### PR TITLE
 #27 temporarily disabled web.xml schema validation

### DIFF
--- a/core/http/server/src/test/java/org/eclipse/rdf4j/http/server/WebXmlValidationTest.java
+++ b/core/http/server/src/test/java/org/eclipse/rdf4j/http/server/WebXmlValidationTest.java
@@ -15,6 +15,7 @@ import javax.xml.XMLConstants;
 import javax.xml.validation.SchemaFactory;
 
 import org.eclipse.rdf4j.common.xml.DocumentUtil;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
@@ -24,6 +25,7 @@ import org.xml.sax.SAXException;
 public class WebXmlValidationTest {
 
 	@Test
+	@Ignore("temporarily disabled to avoid problems with downloading of XML Schema on Hudson instance")
 	public void testValidXml() throws MalformedURLException, IOException, SAXException {
 		File webXml = new File("src/main/webapp/WEB-INF/web.xml");
 


### PR DESCRIPTION
Hudson instance seems to have trouble downloading the XML Schema,
causing the build to stall.