### PR TITLE
 #13 set version number for Java 8 release branch to 2.0M1-SNAPSHOT

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-bom</artifactId>

--- a/compliance/geosparql/pom.xml
+++ b/compliance/geosparql/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-geosparql-compliance</artifactId>

--- a/compliance/http/pom.xml
+++ b/compliance/http/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-http-compliance</artifactId>

--- a/compliance/model/pom.xml
+++ b/compliance/model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-model-compliance</artifactId>

--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-compliance</artifactId>

--- a/compliance/queryresultio/pom.xml
+++ b/compliance/queryresultio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryresultio-compliance</artifactId>

--- a/compliance/rio/pom.xml
+++ b/compliance/rio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-compliance</artifactId>

--- a/compliance/serql/pom.xml
+++ b/compliance/serql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-serql-compliance</artifactId>

--- a/compliance/sparql/pom.xml
+++ b/compliance/sparql/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sparql-compliance</artifactId>

--- a/compliance/store/pom.xml
+++ b/compliance/store/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-store-compliance</artifactId>

--- a/core/assembly/pom.xml
+++ b/core/assembly/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-assembly</artifactId>

--- a/core/config/pom.xml
+++ b/core/config/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-config</artifactId>

--- a/core/console/pom.xml
+++ b/core/console/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-console</artifactId>

--- a/core/http/client/pom.xml
+++ b/core/http/client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-http</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-http-client</artifactId>

--- a/core/http/pom.xml
+++ b/core/http/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-http</artifactId>

--- a/core/http/protocol/pom.xml
+++ b/core/http/protocol/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-http</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-http-protocol</artifactId>

--- a/core/http/server-spring/pom.xml
+++ b/core/http/server-spring/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-http</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-http-server-spring</artifactId>

--- a/core/http/server/pom.xml
+++ b/core/http/server/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-http</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-http-server</artifactId>

--- a/core/http/workbench/pom.xml
+++ b/core/http/workbench/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-http</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-http-workbench</artifactId>

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-model</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-core</artifactId>

--- a/core/query/pom.xml
+++ b/core/query/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-query</artifactId>

--- a/core/queryalgebra/evaluation/pom.xml
+++ b/core/queryalgebra/evaluation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryalgebra</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryalgebra-evaluation</artifactId>

--- a/core/queryalgebra/geosparql/pom.xml
+++ b/core/queryalgebra/geosparql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryalgebra</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryalgebra-geosparql</artifactId>

--- a/core/queryalgebra/model/pom.xml
+++ b/core/queryalgebra/model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryalgebra</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryalgebra-model</artifactId>

--- a/core/queryalgebra/pom.xml
+++ b/core/queryalgebra/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryalgebra</artifactId>

--- a/core/queryparser/api/pom.xml
+++ b/core/queryparser/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryparser</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryparser-api</artifactId>

--- a/core/queryparser/pom.xml
+++ b/core/queryparser/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryparser</artifactId>

--- a/core/queryparser/serql/pom.xml
+++ b/core/queryparser/serql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryparser</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryparser-serql</artifactId>

--- a/core/queryparser/sparql/pom.xml
+++ b/core/queryparser/sparql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryparser</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryparser-sparql</artifactId>

--- a/core/queryrender/pom.xml
+++ b/core/queryrender/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryrender</artifactId>

--- a/core/queryresultio/api/pom.xml
+++ b/core/queryresultio/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryresultio-api</artifactId>

--- a/core/queryresultio/binary/pom.xml
+++ b/core/queryresultio/binary/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryresultio-binary</artifactId>

--- a/core/queryresultio/pom.xml
+++ b/core/queryresultio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryresultio</artifactId>

--- a/core/queryresultio/sparqljson/pom.xml
+++ b/core/queryresultio/sparqljson/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryresultio-sparqljson</artifactId>

--- a/core/queryresultio/sparqlxml/pom.xml
+++ b/core/queryresultio/sparqlxml/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryresultio-sparqlxml</artifactId>

--- a/core/queryresultio/text/pom.xml
+++ b/core/queryresultio/text/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryresultio-text</artifactId>

--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository-api</artifactId>

--- a/core/repository/contextaware/pom.xml
+++ b/core/repository/contextaware/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository-contextaware</artifactId>

--- a/core/repository/dataset/pom.xml
+++ b/core/repository/dataset/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository-dataset</artifactId>

--- a/core/repository/event/pom.xml
+++ b/core/repository/event/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository-event</artifactId>

--- a/core/repository/http/pom.xml
+++ b/core/repository/http/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository-http</artifactId>

--- a/core/repository/manager/pom.xml
+++ b/core/repository/manager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository-manager</artifactId>

--- a/core/repository/pom.xml
+++ b/core/repository/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository</artifactId>

--- a/core/repository/sail/pom.xml
+++ b/core/repository/sail/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository-sail</artifactId>

--- a/core/repository/sparql/pom.xml
+++ b/core/repository/sparql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-repository-sparql</artifactId>

--- a/core/rio/api/pom.xml
+++ b/core/rio/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-api</artifactId>

--- a/core/rio/binary/pom.xml
+++ b/core/rio/binary/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-binary</artifactId>

--- a/core/rio/datatypes/pom.xml
+++ b/core/rio/datatypes/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-datatypes</artifactId>

--- a/core/rio/jsonld/pom.xml
+++ b/core/rio/jsonld/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-jsonld</artifactId>

--- a/core/rio/languages/pom.xml
+++ b/core/rio/languages/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-languages</artifactId>

--- a/core/rio/n3/pom.xml
+++ b/core/rio/n3/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-n3</artifactId>

--- a/core/rio/nquads/pom.xml
+++ b/core/rio/nquads/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-nquads</artifactId>

--- a/core/rio/ntriples/pom.xml
+++ b/core/rio/ntriples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-ntriples</artifactId>

--- a/core/rio/pom.xml
+++ b/core/rio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio</artifactId>

--- a/core/rio/rdfjson/pom.xml
+++ b/core/rio/rdfjson/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-rdfjson</artifactId>

--- a/core/rio/rdfxml/pom.xml
+++ b/core/rio/rdfxml/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-rdfxml</artifactId>

--- a/core/rio/trig/pom.xml
+++ b/core/rio/trig/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-trig</artifactId>

--- a/core/rio/trix/pom.xml
+++ b/core/rio/trix/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-trix</artifactId>

--- a/core/rio/turtle/pom.xml
+++ b/core/rio/turtle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-turtle</artifactId>

--- a/core/runtime-osgi/pom.xml
+++ b/core/runtime-osgi/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-runtime-osgi</artifactId>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-runtime</artifactId>

--- a/core/sail/api/pom.xml
+++ b/core/sail/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-api</artifactId>

--- a/core/sail/base/pom.xml
+++ b/core/sail/base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-base</artifactId>

--- a/core/sail/federation/pom.xml
+++ b/core/sail/federation/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-federation</artifactId>

--- a/core/sail/fts/elasticsearch/pom.xml
+++ b/core/sail/fts/elasticsearch/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail-fts</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-elasticsearch</artifactId>

--- a/core/sail/fts/lucene-api/pom.xml
+++ b/core/sail/fts/lucene-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail-fts</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-lucene-api</artifactId>

--- a/core/sail/fts/lucene/pom.xml
+++ b/core/sail/fts/lucene/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail-fts</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-lucene</artifactId>

--- a/core/sail/fts/pom.xml
+++ b/core/sail/fts/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-fts</artifactId>

--- a/core/sail/fts/solr/pom.xml
+++ b/core/sail/fts/solr/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail-fts</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-solr</artifactId>

--- a/core/sail/inferencer/pom.xml
+++ b/core/sail/inferencer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-inferencer</artifactId>

--- a/core/sail/memory/pom.xml
+++ b/core/sail/memory/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-memory</artifactId>

--- a/core/sail/model/pom.xml
+++ b/core/sail/model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-model</artifactId>

--- a/core/sail/nativerdf/pom.xml
+++ b/core/sail/nativerdf/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-nativerdf</artifactId>

--- a/core/sail/pom.xml
+++ b/core/sail/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail</artifactId>

--- a/core/sail/spin/pom.xml
+++ b/core/sail/spin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sail-spin</artifactId>

--- a/core/spin/pom.xml
+++ b/core/spin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-spin</artifactId>

--- a/core/util/pom.xml
+++ b/core/util/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-util</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.eclipse.rdf4j</groupId>
 	<artifactId>rdf4j</artifactId>
-	<version>1.0M1-SNAPSHOT</version>
+	<version>2.0M1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>RDF4J</name>

--- a/testsuites/geosparql/pom.xml
+++ b/testsuites/geosparql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-geosparql-testsuite</artifactId>

--- a/testsuites/lucene/pom.xml
+++ b/testsuites/lucene/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-lucene-testsuite</artifactId>

--- a/testsuites/model/pom.xml
+++ b/testsuites/model/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-model-testsuite</artifactId>

--- a/testsuites/pom.xml
+++ b/testsuites/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-testsuites</artifactId>

--- a/testsuites/queryresultio/pom.xml
+++ b/testsuites/queryresultio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-queryresultio-testsuite</artifactId>

--- a/testsuites/rio/pom.xml
+++ b/testsuites/rio/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-rio-testsuite</artifactId>

--- a/testsuites/serql/pom.xml
+++ b/testsuites/serql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-serql-testsuite</artifactId>

--- a/testsuites/sparql/pom.xml
+++ b/testsuites/sparql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-sparql-testsuite</artifactId>

--- a/testsuites/store/pom.xml
+++ b/testsuites/store/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>1.0M1-SNAPSHOT</version>
+		<version>2.0M1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>rdf4j-store-testsuite</artifactId>


### PR DESCRIPTION
The Java 8 release of RDF4J will be numbered 2.0. When we are ready to release a Java 7 backport we'll use 1.0 for that release branch. 

Unless someone has a better idea.