### PR TITLE
 #16 moved github templates to hidden dir, added PR template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,13 +9,13 @@ RDF4J is a project governed by the [Eclipse Foundation](http://www.eclipse.org/)
 
 In order for any contributions to RDF4J to be accepted, you MUST do the following things:
 
-1. Sign the [Eclipse Foundation Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
+1. Digitally sign the [Eclipse Foundation Contributor License Agreement](http://www.eclipse.org/legal/CLA.php).
 To sign the Eclipse CLA you need to:
 
   * Obtain an Eclipse Foundation userid. If you already use Eclipse Bugzilla or Gerrit you already have one of those. If you don’t, you need to
 [register](https://dev.eclipse.org/site_login/createaccount.php).
 
-  * Login into the [projects portal](https://projects.eclipse.org/), select “My Account”, and then the “Contributor License Agreement” tab.
+  * Login into the [projects portal](https://projects.eclipse.org/), select “My Account”, and then the “Contributor License Agreement” tab. Read through, then sign.
 
 2. Add your github username in your Eclipse Foundation account settings. Log in it to Eclipse and go to account settings.
 
@@ -26,16 +26,19 @@ You do this by adding the `-s` flag when you make the commit(s).
 
 ## Developer Guidelines
 
-RDF4J feature development takes place on the `master` branch, which is a branch for the next minor or major release. In addition, each minor release has its own release branch (e.g. `releases/2.8.x`, and `releases/4.0.x`), on which hotfixes/patches are done.
+RDF4J feature development takes place off of the `master` branch. In addition,
+each minor release has its own release branch (e.g. `releases/1.0.x`, and
+`releases/2.0.x`), on which hotfixes/patches are done.
 
-Every issue, no matter how small, gets its own branch. New features are usually
+Every issue, no matter how small, gets its own feature branch. New features are usually
 developed on branches from the master branch. Patches or hotfixes for existing
 releases are developed on a branch split off from the releveant release branch.
 Issue branch names are always prefixed with `issues/`, followed by the issue
 number in the [GitHub issue tracker](https://github.com/eclipse/rdf4j/issues),
-followed by one or two dash-separated keywords for the issue. For example:
-`issues/#6-sparql-npe` is the branch for a fix for GitHub issue #6, which has
-to do with SPARQL and a NullPointerException.
+followed by one or two dash-separated keywords for the issue. 
+
+For example (fictional): `issues/#6-sparql-npe` is the branch for a fix for
+GitHub issue #6, which has to do with SPARQL and a NullPointerException.
 
 If you're unsure on which branch a contribution should be made, please ask!
 
@@ -50,20 +53,22 @@ Eclipse workspace and make sure they are applied to your code contributions.
 Once the legalities are out of the way and you're up-to-date on developer guidelines, you can 
 start coding. Here's how:
 
-1. Fork the repository on GitHub
-2. Create a new branch for your changes (see the Developer Guidelines above for details)
-3. Make your changes
-4. Make sure you include tests
-5. Make sure the test suite passes after your changes
-6. Commit your changes into that branch
-7. Use descriptive and meaningful commit messages. Reference the issue number in the commit message (for example " #6 added null check")
-9. Sign off every commit you do, as explained above.
-10. Optionally squash your commits (not necessary, but if you want to clean your commit history a bit, _this_ is the point to do it).
+1. Create an issue in the [RDF4J GitHub issue tracker](https://github.com/eclipse/rdf4j/issues) that describes your improvement, new feature, or bug fix. Alternatively, comment on an existing issue to indicate you're keen to help solve it.
+2. Fork the repository on GitHub
+3. Create a new branch for your changes (see the Developer Guidelines above for details - please make sure you pick the correct and up-to-date starting branch!)
+4. Make your changes
+5. Make sure you include tests
+6. Make sure the test suite passes after your changes
+7. Commit your changes into the branch. Please use descriptive and meaningful commit messages. Reference the issue number in the commit message (for example " #6 added null check")
+8. Sign off every commit you do, as explained above.
+9. Optionally squash your commits (not necessary, but if you want to clean your commit history a bit, _this_ is the point to do it).
 10. Push your changes to your branch in your forked repository
 
 ## Submitting the changes
 
-You can use GitHub to submit a pull request (PR) for your contribution.
+Once you are satisfied your changes are in good shape, you can use GitHub to
+submit a pull request (PR) for your contribution back to the central RDF4J
+repository.
  
 Once you have submitted your PR, do not use your branch for any other
 development (unless asked to do so by the reviewers of your PR). If you do, any

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,5 @@ Briefly describe the changes proposed in this PR:
 Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):
 
 - [ ] RDF4J code formatting has been applied
-- [ ] tests are included and all succeed
+- [ ] tests are included
 - [ ] all tests succeed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,8 @@ Briefly describe the changes proposed in this PR:
 - ...
 - ...
 
-Make sure the following is taken care of before submitting your PR (please mark as ticked to indicate you've taken care of them):
+Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):
 
-- [ ] RDF4J code formatting applied
-- [ ] tests included
-- [ ] tests greenline
+- [ ] RDF4J code formatting has been applied
+- [ ] tests are included and all succeed
+- [ ] all tests succeed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 
-This PR addresses GitHub issue: # 
+This PR addresses GitHub issue: #
 
 Briefly describe the changes proposed in this PR:
 
@@ -7,8 +7,7 @@ Briefly describe the changes proposed in this PR:
 - ...
 - ...
 
-Make sure the following is taken care of before submitting your PR (please mark
-as ticked to indicate you've taken care of them):
+Make sure the following is taken care of before submitting your PR (please mark as ticked to indicate you've taken care of them):
 
 - [ ] RDF4J code formatting applied
 - [ ] tests included

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+
+This PR addresses GitHub issue: # 
+
+Briefly describe the changes proposed in this PR:
+
+- ...
+- ...
+- ...
+
+Make sure the following is taken care of before submitting your PR (please mark
+as ticked to indicate you've taken care of them):
+
+- [ ] RDF4J code formatting applied
+- [ ] tests included
+- [ ] tests greenline


### PR DESCRIPTION
This PR addresses GitHub issue: #16 

Briefly describe the changes proposed in this PR:

- moved github templates to hidden dir
- added Pull request template

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed
