### PR TITLE
 #50 fixed assembly descriptors, poms, and scripts

### DIFF
--- a/core/assembly/pom.xml
+++ b/core/assembly/pom.xml
@@ -260,7 +260,7 @@
 					<plugin>
 						<artifactId>maven-assembly-plugin</artifactId>
 						<configuration>
-							<finalName>openrdf-sesame-${project.version}</finalName>
+							<finalName>eclipse-rdf4j-${project.version}</finalName>
 							<attach>false</attach>
 							<descriptors>
 								<descriptor>src/main/assembly/sdk.xml</descriptor>
@@ -286,10 +286,10 @@
 									<include>org.eclipse.rdf4j:*</include>
 								</includes>
 								<excludes>
-									<exclude>org.eclipse.rdf4j:sesame-runtime-osgi</exclude>
+									<exclude>org.eclipse.rdf4j:rdf4j-runtime-osgi</exclude>
 								</excludes>
 							</artifactSet>
-							<outputFile>target/openrdf-sesame-${project.version}-onejar.jar</outputFile>
+							<outputFile>target/eclipse-rdf4j-${project.version}-onejar.jar</outputFile>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<shadedArtifactAttached>false</shadedArtifactAttached>
 							<transformers>

--- a/core/assembly/src/main/assembly/sdk.xml
+++ b/core/assembly/src/main/assembly/sdk.xml
@@ -6,7 +6,7 @@
 		<format>zip</format>
 	</formats>
 
-	<baseDirectory>openrdf-sesame-${project.version}</baseDirectory>
+	<baseDirectory>eclipse-rdf4j-${project.version}</baseDirectory>
 
 	<dependencySets>
 	    <dependencySet>
@@ -33,11 +33,11 @@
 
 	<files>
 		<file>
-		    <source>../http/server/target/openrdf-sesame.war</source>
+		    <source>../http/server/target/rdf4j-server.war</source>
 			<outputDirectory>war</outputDirectory>
 		</file>
 		<file>
-		    <source>../http/workbench/target/openrdf-workbench.war</source>
+		    <source>../http/workbench/target/rdf4j-workbench.war</source>
 			<outputDirectory>war</outputDirectory>
 		</file>
 

--- a/core/assembly/src/main/dist/bin/console.bat
+++ b/core/assembly/src/main/dist/bin/console.bat
@@ -48,13 +48,13 @@ goto end
 IF ERRORLEVEL 1 goto java6
 rem use java.ext.dirs hack
 rem echo Using java.ext.dirs to set classpath
-"%JAVA%" -Djava.ext.dirs="%LIB_DIR%" org.openrdf.console.Console %CMD_LINE_ARGS%
+"%JAVA%" -Djava.ext.dirs="%LIB_DIR%" org.eclipse.rdf4j.console.Console %CMD_LINE_ARGS%
 goto end
 
 :java6
 rem use java 6 wildcard feature
 rem echo Using wildcard to set classpath
-"%JAVA%" -cp "%LIB_DIR%\*" org.openrdf.console.Console %CMD_LINE_ARGS%
+"%JAVA%" -cp "%LIB_DIR%\*" org.eclipse.rdf4j.console.Console %CMD_LINE_ARGS%
 goto end
 
 :end

--- a/core/assembly/src/main/dist/bin/console.sh
+++ b/core/assembly/src/main/dist/bin/console.sh
@@ -10,4 +10,4 @@
 JAVA_OPT=-mx512m
 
 lib="$(dirname "${0}")/../lib"
-java $JAVA_OPT -cp "$lib/$(ls "$lib"|xargs |sed "s; ;:$lib/;g")" org.openrdf.console.Console $*
+java $JAVA_OPT -cp "$lib/$(ls "$lib"|xargs |sed "s; ;:$lib/;g")" org.eclipse.rdf4j.console.Console $*

--- a/core/console/pom.xml
+++ b/core/console/pom.xml
@@ -88,8 +88,8 @@
 				<configuration>
 					<archive>
 						<manifest>
-							<mainClass>org.openrdf.console.Console</mainClass>
-							<packageName>org.openrdf.console</packageName>
+							<mainClass>org.eclipse.rdf4j.console.Console</mainClass>
+							<packageName>org.eclipse.rdf4j.console</packageName>
 							<addClasspath>true</addClasspath>
 							<addExtensions />
 							<classpathPrefix />


### PR DESCRIPTION
This PR addresses GitHub issue: #50

Briefly describe the changes proposed in this PR:

- assembly descriptor updated
- sdk and onejar files now renamed
- console startup scripts fixed to use new package names. 

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

