### PR TITLE
 #58 disabled SPIN compliance tests due to performance/stability

### DIFF
--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/SpinMemoryRepositoryConnectionTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/SpinMemoryRepositoryConnectionTest.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.sail.spin.SpinSail;
 import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore("#58 - disabled spin compliance tests due to being slow and unstable. Manually execute when modifying SPIN functionality")
 public class SpinMemoryRepositoryConnectionTest extends RepositoryConnectionTest {
 
 	public SpinMemoryRepositoryConnectionTest(IsolationLevel level) {
@@ -33,7 +34,6 @@ public class SpinMemoryRepositoryConnectionTest extends RepositoryConnectionTest
 	{
 		return new SailRepository(new SpinSail(new MemoryStore()));
 	}
-	
 
 	@Ignore
 	@Test

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/SpinRDFSMemoryRepositoryConnectionTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/SpinRDFSMemoryRepositoryConnectionTest.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.sail.spin.SpinSail;
 import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore("#58 - disabled spin compliance tests due to being slow and unstable. Manually execute when modifying SPIN functionality")
 public class SpinRDFSMemoryRepositoryConnectionTest extends RepositoryConnectionTest {
 
 	public SpinRDFSMemoryRepositoryConnectionTest(IsolationLevel level) {
@@ -36,7 +37,6 @@ public class SpinRDFSMemoryRepositoryConnectionTest extends RepositoryConnection
 		return new SailRepository(
 				new SpinSail(new ForwardChainingRDFSInferencer(new DedupingInferencer(new MemoryStore()))));
 	}
-	
 
 	@Ignore
 	@Test


### PR DESCRIPTION
This PR addresses GitHub issue: #

Briefly describe the changes proposed in this PR:

- disabled tests

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [ ] RDF4J code formatting has been applied
- [ ] tests are included
- [ ] all tests succeed

Manually re-enable when working on fixes for SPIN functionality. 
