### PR TITLE
#29 fix subquery evaluation in FederationSail due to wrong join order

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
@@ -43,8 +43,7 @@ public class FederationSparqlTest extends SPARQLQueryTest {
 						"STRLANG   TypeErrors",
 						// known issue: SES-937
 						"sq03 - Subquery within graph pattern, graph variable is not bound",
-						// fails in federationsail setup. 
-						"sq14 - limit by resource" };
+						};
 
 				return new FederationSparqlTest(testURI, name, queryFileURL, resultFileURL, dataSet,
 						laxCardinality, checkOrder, ignoredTests);

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/optimizers/EvaluationStatistics.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/optimizers/EvaluationStatistics.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.LeftJoin;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.SingletonSet;
+import org.eclipse.rdf4j.query.algebra.Slice;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
@@ -72,6 +73,11 @@ public class EvaluationStatistics {
 		@Override
 		public void meet(StatementPattern pattern) {
 			cardinality = getCardinality(pattern);
+		}
+		
+		@Override
+		public void meet(Slice slice) {
+			cardinality = 1;
 		}
 
 		protected double getCardinality(StatementPattern pattern) {


### PR DESCRIPTION
This PR addresses GitHub issue: #29 

The evaluation of subqueries in FederationSail was not correct as
revealed by W3C test sq14. This is caused by an unsuitable join order,
where the sub select is processed using the results of a graph pattern
as intermediate result.

The simplest fix for this case is to set the cardinality hints for the
optimizer for SLICE algebra nodes to 1 such that they are executed as
left join argument with high probability.

The full fix (which will be done in another change) could be to use a hash
based join strategy.