### PR TITLE
#29 fix suqbquery evaluation in FederationSail (use hash join)

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
@@ -87,6 +87,20 @@ public class HashJoinIteration extends LookAheadIteration<BindingSet, QueryEvalu
 
 		this.leftJoin = leftJoin;
 	}
+	
+	public HashJoinIteration(EvaluationStrategy strategy, CloseableIteration<BindingSet, QueryEvaluationException> leftIter, 
+			Set<String> leftBindingNames, TupleExpr right, BindingSet bindings, boolean leftJoin)
+		throws QueryEvaluationException
+	{
+		this.leftIter = leftIter;
+		rightIter = strategy.evaluate(right, bindings);
+
+		Set<String> joinAttributeNames = leftBindingNames;
+		joinAttributeNames.retainAll(right.getBindingNames());
+		joinAttributes = joinAttributeNames.toArray(new String[joinAttributeNames.size()]);
+
+		this.leftJoin = leftJoin;
+	}
 
 	/*---------*
 	 * Methods *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
@@ -78,25 +78,21 @@ public class HashJoinIteration extends LookAheadIteration<BindingSet, QueryEvalu
 			BindingSet bindings, boolean leftJoin)
 		throws QueryEvaluationException
 	{
-		leftIter = strategy.evaluate(left, bindings);
-		rightIter = strategy.evaluate(right, bindings);
-
-		Set<String> joinAttributeNames = left.getBindingNames();
-		joinAttributeNames.retainAll(right.getBindingNames());
-		joinAttributes = joinAttributeNames.toArray(new String[joinAttributeNames.size()]);
-
-		this.leftJoin = leftJoin;
+		this(strategy, strategy.evaluate(left, bindings), left.getBindingNames(),
+				strategy.evaluate(right, bindings), right.getBindingNames(), leftJoin);	
 	}
 	
-	public HashJoinIteration(EvaluationStrategy strategy, CloseableIteration<BindingSet, QueryEvaluationException> leftIter, 
-			Set<String> leftBindingNames, TupleExpr right, BindingSet bindings, boolean leftJoin)
-		throws QueryEvaluationException
+	public HashJoinIteration(EvaluationStrategy strategy,
+			CloseableIteration<BindingSet, QueryEvaluationException> leftIter, Set<String> leftBindingNames,
+			CloseableIteration<BindingSet, QueryEvaluationException> rightIter, Set<String> rightBindingNames,
+			boolean leftJoin)
+				throws QueryEvaluationException
 	{
 		this.leftIter = leftIter;
-		rightIter = strategy.evaluate(right, bindings);
+		this.rightIter = rightIter;
 
 		Set<String> joinAttributeNames = leftBindingNames;
-		joinAttributeNames.retainAll(right.getBindingNames());
+		joinAttributeNames.retainAll(rightBindingNames);
 		joinAttributes = joinAttributeNames.toArray(new String[joinAttributeNames.size()]);
 
 		this.leftJoin = leftJoin;

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
@@ -94,10 +94,12 @@ public class FederationStrategy extends SimpleEvaluationStrategy {
 			if (TupleExprs.containsProjection(rightArg)) {
 				TupleExpr leftArg = join.getArg(i - 1);
 				collectedBindingNames.addAll(leftArg.getBindingNames());
-				result = new HashJoinIteration(this, result, collectedBindingNames, rightArg, bindings, false);
-			} else {
+				result = new HashJoinIteration(this, result, collectedBindingNames,
+						evaluate(rightArg, bindings), rightArg.getBindingNames(), false);
+			}
+			else {
 				result = new ParallelJoinCursor(this, result, join.getArg(i)); // NOPMD
-				executor.execute((Runnable) result);
+				executor.execute((Runnable)result);
 				collectedBindingNames.addAll(rightArg.getBindingNames());
 			}
 		}

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
@@ -25,6 +25,8 @@ import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.SimpleEvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.iterator.BadlyDesignedLeftJoinIterator;
+import org.eclipse.rdf4j.query.algebra.evaluation.iterator.HashJoinIteration;
+import org.eclipse.rdf4j.query.algebra.helpers.TupleExprs;
 import org.eclipse.rdf4j.sail.federation.algebra.NaryJoin;
 import org.eclipse.rdf4j.sail.federation.algebra.OwnedTupleExpr;
 
@@ -84,9 +86,20 @@ public class FederationStrategy extends SimpleEvaluationStrategy {
 	{
 		assert join.getNumberOfArguments() > 0;
 		CloseableIteration<BindingSet, QueryEvaluationException> result = evaluate(join.getArg(0), bindings);
+		Set<String> collectedBindingNames = new HashSet<>();
+		collectedBindingNames.addAll(join.getArg(0).getBindingNames());
 		for (int i = 1, n = join.getNumberOfArguments(); i < n; i++) {
-			result = new ParallelJoinCursor(this, result, join.getArg(i)); // NOPMD
-			executor.execute((Runnable)result);
+
+			TupleExpr rightArg = join.getArg(i);
+			if (TupleExprs.containsProjection(rightArg)) {
+				TupleExpr leftArg = join.getArg(i - 1);
+				collectedBindingNames.addAll(leftArg.getBindingNames());
+				result = new HashJoinIteration(this, result, collectedBindingNames, rightArg, bindings, false);
+			} else {
+				result = new ParallelJoinCursor(this, result, join.getArg(i)); // NOPMD
+				executor.execute((Runnable) result);
+				collectedBindingNames.addAll(rightArg.getBindingNames());
+			}
 		}
 		return result;
 	}


### PR DESCRIPTION
This PR addresses GitHub issue: #29 

In certain cases the nested loop join approach is not applicable (e.g.,
if the right argument is a sub-select with ORDER BY or LIMIT, see sq14).

This change now applies a HashJoin strategy in such cases.

Note that the HashJoinIteration has to be extended such that the left
intermediate result iteration can be passed to it.