### PR TITLE
#161 case-insensitive regex matching should be based on unicode

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SimpleEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SimpleEvaluationStrategy.java
@@ -1445,6 +1445,7 @@ public class SimpleEvaluationStrategy implements EvaluationStrategy, UUIDable {
 						break;
 					case 'i':
 						f |= Pattern.CASE_INSENSITIVE;
+						f |= Pattern.UNICODE_CASE;
 						break;
 					case 'x':
 						f |= Pattern.COMMENTS;

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -1104,6 +1104,22 @@ public abstract class ComplexSPARQLQueryTest {
 	}
 
 	@Test
+	public void testRegexCaseNonAscii()
+		throws Exception
+	{
+		String query = "ask {filter (regex(\"Валовой\", \"валовой\", \"i\")) }";
+
+		assertTrue("case-insensitive match on Cyrillic should succeed",
+				conn.prepareBooleanQuery(query).evaluate());
+
+		query = "ask {filter (regex(\"Валовой\", \"валовой\")) }";
+
+		assertFalse("case-sensitive match on Cyrillic should fail",
+				conn.prepareBooleanQuery(query).evaluate());
+
+	}
+
+	@Test
 	public void testValuesInOptional()
 		throws Exception
 	{


### PR DESCRIPTION
This PR addresses GitHub issue: #161

Briefly describe the changes proposed in this PR:

- minor fix in evaluation of regular expression: do Unicode-based case matching when matching case-insensitively
- added compliance test that demonestrates expected behavior.

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>