### PR TITLE
#167 removed fundamentally flawed test

### DIFF
--- a/compliance/http/src/test/java/org/eclipse/rdf4j/http/server/ProtocolTest.java
+++ b/compliance/http/src/test/java/org/eclipse/rdf4j/http/server/ProtocolTest.java
@@ -32,7 +32,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleIRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQueryResult;
@@ -272,51 +271,6 @@ public class ProtocolTest {
 				String response = "location " + location + " responded: " + conn.getResponseMessage() + " ("
 						+ responseCode + ")";
 				fail(response);
-			}
-		}
-		finally {
-			conn.disconnect();
-		}
-	}
-
-	/**
-	 * Checks that a suitable RDF content type is returned when accept header not explicitly set.
-	 */
-	@Test
-	public void testContentTypeForGraphQuery3_GET()
-		throws Exception
-	{
-		String query = "DESCRIBE <foo:bar>";
-		String location = TestServer.REPOSITORY_URL;
-		location += "?query=" + URLEncoder.encode(query, "UTF-8");
-
-		URL url = new URL(location);
-
-		HttpURLConnection conn = (HttpURLConnection)url.openConnection();
-
-		conn.connect();
-
-		try {
-			int responseCode = conn.getResponseCode();
-			if (responseCode == HttpURLConnection.HTTP_OK) {
-				String contentType = conn.getHeaderField("Content-Type");
-				assertNotNull(contentType);
-
-				// snip off optional charset declaration
-				int charPos = contentType.indexOf(";");
-				if (charPos > -1) {
-					contentType = contentType.substring(0, charPos);
-				}
-
-				RDFFormat format = Rio.getParserFormatForMIMEType(contentType).orElseThrow(
-						Rio.unsupportedFormat(contentType));
-				assertNotNull(format);
-			}
-			else {
-				String response = "location " + location + " responded: " + conn.getResponseMessage() + " ("
-						+ responseCode + ")";
-				fail(response);
-				throw new RuntimeException(response);
 			}
 		}
 		finally {


### PR DESCRIPTION
This PR addresses GitHub issue: #167

Briefly describe the changes proposed in this PR:

Flawed test removed. Note that test failure was only intermittent and depends on runtime preference of server for RDF syntax formats. 

Test can never be guaranteed to succeed as server may send an RDF syntax
format that is simply not supported by the client - but this does not
mean a breach of protocol since the test's intent was to check what
happens when no Accept header is set. 

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed



Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>