### PR TITLE
Uses IRI class in all vocabularies

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/APF.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/APF.java
@@ -7,9 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.vocabulary;
 
-import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.ValueFactoryImpl;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
  * http://jena.hpl.hp.com/ARQ/property#.
@@ -26,13 +26,13 @@ public final class APF {
 
 	public static final String PREFIX = "apf";
 
-	public static final URI STR_SPLIT;
+	public static final IRI STR_SPLIT;
 
-	public static final URI CONCAT;
+	public static final IRI CONCAT;
 
 	static {
-		ValueFactory factory = ValueFactoryImpl.getInstance();
-		STR_SPLIT = factory.createURI(NAMESPACE, "strSplit");
-		CONCAT = factory.createURI(NAMESPACE, "concat");
+		ValueFactory factory = SimpleValueFactory.getInstance();
+		STR_SPLIT = factory.createIRI(NAMESPACE, "strSplit");
+		CONCAT = factory.createIRI(NAMESPACE, "concat");
 	}
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/GEO.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/GEO.java
@@ -7,9 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.vocabulary;
 
-import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.ValueFactoryImpl;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
  * @version 1.0
@@ -19,15 +19,15 @@ public class GEO {
 
 	public static final String NAMESPACE = "http://www.opengis.net/ont/geosparql#";
 
-	public static final URI AS_WKT;
+	public static final IRI AS_WKT;
 
-	public static final URI WKT_LITERAL;
+	public static final IRI WKT_LITERAL;
 
 	public static final String DEFAULT_SRID = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
 
 	static {
-		ValueFactory factory = ValueFactoryImpl.getInstance();
-		AS_WKT = factory.createURI(NAMESPACE, "asWKT");
-		WKT_LITERAL = factory.createURI(NAMESPACE, "wktLiteral");
+		ValueFactory factory = SimpleValueFactory.getInstance();
+		AS_WKT = factory.createIRI(NAMESPACE, "asWKT");
+		WKT_LITERAL = factory.createIRI(NAMESPACE, "wktLiteral");
 	}
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/GEOF.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/GEOF.java
@@ -7,9 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.vocabulary;
 
-import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.ValueFactoryImpl;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
  * @see http://www.opengeospatial.org/standards/geosparql
@@ -18,131 +18,131 @@ public class GEOF {
 
 	public static final String NAMESPACE = "http://www.opengis.net/def/function/geosparql/";
 
-	public static final URI DISTANCE;
+	public static final IRI DISTANCE;
 
-	public static final URI BUFFER;
+	public static final IRI BUFFER;
 
-	public static final URI CONVEX_HULL;
+	public static final IRI CONVEX_HULL;
 
-	public static final URI INTERSECTION;
+	public static final IRI INTERSECTION;
 
-	public static final URI UNION;
+	public static final IRI UNION;
 
-	public static final URI DIFFERENCE;
+	public static final IRI DIFFERENCE;
 
-	public static final URI SYM_DIFFERENCE;
+	public static final IRI SYM_DIFFERENCE;
 
-	public static final URI ENVELOPE;
+	public static final IRI ENVELOPE;
 
-	public static final URI BOUNDARY;
+	public static final IRI BOUNDARY;
 
-	public static final URI GET_SRID;
+	public static final IRI GET_SRID;
 
-	public static final URI RELATE;
+	public static final IRI RELATE;
 
-	public static final URI SF_EQUALS;
+	public static final IRI SF_EQUALS;
 
-	public static final URI SF_DISJOINT;
+	public static final IRI SF_DISJOINT;
 
-	public static final URI SF_INTERSECTS;
+	public static final IRI SF_INTERSECTS;
 
-	public static final URI SF_TOUCHES;
+	public static final IRI SF_TOUCHES;
 
-	public static final URI SF_CROSSES;
+	public static final IRI SF_CROSSES;
 
-	public static final URI SF_WITHIN;
+	public static final IRI SF_WITHIN;
 
-	public static final URI SF_CONTAINS;
+	public static final IRI SF_CONTAINS;
 
-	public static final URI SF_OVERLAPS;
+	public static final IRI SF_OVERLAPS;
 
-	public static final URI EH_EQUALS;
+	public static final IRI EH_EQUALS;
 
-	public static final URI EH_DISJOINT;
+	public static final IRI EH_DISJOINT;
 
-	public static final URI EH_MEET;
+	public static final IRI EH_MEET;
 
-	public static final URI EH_OVERLAP;
+	public static final IRI EH_OVERLAP;
 
-	public static final URI EH_COVERS;
+	public static final IRI EH_COVERS;
 
-	public static final URI EH_COVERED_BY;
+	public static final IRI EH_COVERED_BY;
 
-	public static final URI EH_INSIDE;
+	public static final IRI EH_INSIDE;
 
-	public static final URI EH_CONTAINS;
+	public static final IRI EH_CONTAINS;
 
-	public static final URI RCC8_EQ;
+	public static final IRI RCC8_EQ;
 
-	public static final URI RCC8_DC;
+	public static final IRI RCC8_DC;
 
-	public static final URI RCC8_EC;
+	public static final IRI RCC8_EC;
 
-	public static final URI RCC8_PO;
+	public static final IRI RCC8_PO;
 
-	public static final URI RCC8_TPPI;
+	public static final IRI RCC8_TPPI;
 
-	public static final URI RCC8_TPP;
+	public static final IRI RCC8_TPP;
 
-	public static final URI RCC8_NTPP;
+	public static final IRI RCC8_NTPP;
 
-	public static final URI RCC8_NTPPI;
+	public static final IRI RCC8_NTPPI;
 
 	public static final String UOM_NAMESPACE = "http://www.opengis.net/def/uom/OGC/1.0/";
 
-	public static final URI UOM_DEGREE;
+	public static final IRI UOM_DEGREE;
 
-	public static final URI UOM_RADIAN;
+	public static final IRI UOM_RADIAN;
 
-	public static final URI UOM_UNITY;
+	public static final IRI UOM_UNITY;
 
-	public static final URI UOM_METRE;
+	public static final IRI UOM_METRE;
 
 	static {
-		ValueFactory factory = ValueFactoryImpl.getInstance();
-		DISTANCE = factory.createURI(NAMESPACE, "distance");
-		BUFFER = factory.createURI(NAMESPACE, "buffer");
-		CONVEX_HULL = factory.createURI(NAMESPACE, "convexHull");
-		INTERSECTION = factory.createURI(NAMESPACE, "intersection");
-		UNION = factory.createURI(NAMESPACE, "union");
-		DIFFERENCE = factory.createURI(NAMESPACE, "difference");
-		SYM_DIFFERENCE = factory.createURI(NAMESPACE, "symDifference");
-		ENVELOPE = factory.createURI(NAMESPACE, "envelope");
-		BOUNDARY = factory.createURI(NAMESPACE, "boundary");
-		GET_SRID = factory.createURI(NAMESPACE, "getSRID");
+		ValueFactory factory = SimpleValueFactory.getInstance();
+		DISTANCE = factory.createIRI(NAMESPACE, "distance");
+		BUFFER = factory.createIRI(NAMESPACE, "buffer");
+		CONVEX_HULL = factory.createIRI(NAMESPACE, "convexHull");
+		INTERSECTION = factory.createIRI(NAMESPACE, "intersection");
+		UNION = factory.createIRI(NAMESPACE, "union");
+		DIFFERENCE = factory.createIRI(NAMESPACE, "difference");
+		SYM_DIFFERENCE = factory.createIRI(NAMESPACE, "symDifference");
+		ENVELOPE = factory.createIRI(NAMESPACE, "envelope");
+		BOUNDARY = factory.createIRI(NAMESPACE, "boundary");
+		GET_SRID = factory.createIRI(NAMESPACE, "getSRID");
 
-		RELATE = factory.createURI(NAMESPACE, "relate");
+		RELATE = factory.createIRI(NAMESPACE, "relate");
 
-		SF_EQUALS = factory.createURI(NAMESPACE, "sfEquals");
-		SF_DISJOINT = factory.createURI(NAMESPACE, "sfDisjoint");
-		SF_INTERSECTS = factory.createURI(NAMESPACE, "sfIntersects");
-		SF_TOUCHES = factory.createURI(NAMESPACE, "sfTouches");
-		SF_CROSSES = factory.createURI(NAMESPACE, "sfCrosses");
-		SF_WITHIN = factory.createURI(NAMESPACE, "sfWithin");
-		SF_CONTAINS = factory.createURI(NAMESPACE, "sfContains");
-		SF_OVERLAPS = factory.createURI(NAMESPACE, "sfOverlaps");
+		SF_EQUALS = factory.createIRI(NAMESPACE, "sfEquals");
+		SF_DISJOINT = factory.createIRI(NAMESPACE, "sfDisjoint");
+		SF_INTERSECTS = factory.createIRI(NAMESPACE, "sfIntersects");
+		SF_TOUCHES = factory.createIRI(NAMESPACE, "sfTouches");
+		SF_CROSSES = factory.createIRI(NAMESPACE, "sfCrosses");
+		SF_WITHIN = factory.createIRI(NAMESPACE, "sfWithin");
+		SF_CONTAINS = factory.createIRI(NAMESPACE, "sfContains");
+		SF_OVERLAPS = factory.createIRI(NAMESPACE, "sfOverlaps");
 
-		EH_EQUALS = factory.createURI(NAMESPACE, "ehEquals");
-		EH_DISJOINT = factory.createURI(NAMESPACE, "ehDisjoint");
-		EH_MEET = factory.createURI(NAMESPACE, "ehMeet");
-		EH_OVERLAP = factory.createURI(NAMESPACE, "ehOverlap");
-		EH_COVERS = factory.createURI(NAMESPACE, "ehCovers");
-		EH_COVERED_BY = factory.createURI(NAMESPACE, "ehCoveredBy");
-		EH_INSIDE = factory.createURI(NAMESPACE, "ehInside");
-		EH_CONTAINS = factory.createURI(NAMESPACE, "ehContains");
+		EH_EQUALS = factory.createIRI(NAMESPACE, "ehEquals");
+		EH_DISJOINT = factory.createIRI(NAMESPACE, "ehDisjoint");
+		EH_MEET = factory.createIRI(NAMESPACE, "ehMeet");
+		EH_OVERLAP = factory.createIRI(NAMESPACE, "ehOverlap");
+		EH_COVERS = factory.createIRI(NAMESPACE, "ehCovers");
+		EH_COVERED_BY = factory.createIRI(NAMESPACE, "ehCoveredBy");
+		EH_INSIDE = factory.createIRI(NAMESPACE, "ehInside");
+		EH_CONTAINS = factory.createIRI(NAMESPACE, "ehContains");
 
-		RCC8_EQ = factory.createURI(NAMESPACE, "rcc8eq");
-		RCC8_DC = factory.createURI(NAMESPACE, "rcc8dc");
-		RCC8_EC = factory.createURI(NAMESPACE, "rcc8ec");
-		RCC8_PO = factory.createURI(NAMESPACE, "rcc8po");
-		RCC8_TPPI = factory.createURI(NAMESPACE, "rcc8tppi");
-		RCC8_TPP = factory.createURI(NAMESPACE, "rcc8tpp");
-		RCC8_NTPP = factory.createURI(NAMESPACE, "rcc8ntpp");
-		RCC8_NTPPI = factory.createURI(NAMESPACE, "rcc8ntppi");
+		RCC8_EQ = factory.createIRI(NAMESPACE, "rcc8eq");
+		RCC8_DC = factory.createIRI(NAMESPACE, "rcc8dc");
+		RCC8_EC = factory.createIRI(NAMESPACE, "rcc8ec");
+		RCC8_PO = factory.createIRI(NAMESPACE, "rcc8po");
+		RCC8_TPPI = factory.createIRI(NAMESPACE, "rcc8tppi");
+		RCC8_TPP = factory.createIRI(NAMESPACE, "rcc8tpp");
+		RCC8_NTPP = factory.createIRI(NAMESPACE, "rcc8ntpp");
+		RCC8_NTPPI = factory.createIRI(NAMESPACE, "rcc8ntppi");
 
-		UOM_DEGREE = factory.createURI(UOM_NAMESPACE, "degree");
-		UOM_RADIAN = factory.createURI(UOM_NAMESPACE, "radian");
-		UOM_UNITY = factory.createURI(UOM_NAMESPACE, "unity");
-		UOM_METRE = factory.createURI(UOM_NAMESPACE, "metre");
+		UOM_DEGREE = factory.createIRI(UOM_NAMESPACE, "degree");
+		UOM_RADIAN = factory.createIRI(UOM_NAMESPACE, "radian");
+		UOM_UNITY = factory.createIRI(UOM_NAMESPACE, "unity");
+		UOM_METRE = factory.createIRI(UOM_NAMESPACE, "metre");
 	}
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/LIST.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/LIST.java
@@ -7,9 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.vocabulary;
 
-import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.ValueFactoryImpl;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
  * http://jena.hpl.hp.com/ARQ/list#.
@@ -26,16 +26,16 @@ public final class LIST {
 
 	public static final String PREFIX = "list";
 
-	public static final URI MEMBER;
+	public static final IRI MEMBER;
 
-	public static final URI INDEX;
+	public static final IRI INDEX;
 
-	public static final URI LENGTH;
+	public static final IRI LENGTH;
 
 	static {
-		ValueFactory factory = ValueFactoryImpl.getInstance();
-		MEMBER = factory.createURI(NAMESPACE, "member");
-		INDEX = factory.createURI(NAMESPACE, "index");
-		LENGTH = factory.createURI(NAMESPACE, "length");
+		ValueFactory factory = SimpleValueFactory.getInstance();
+		MEMBER = factory.createIRI(NAMESPACE, "member");
+		INDEX = factory.createIRI(NAMESPACE, "index");
+		LENGTH = factory.createIRI(NAMESPACE, "length");
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #171 


It uses IRI instead of URI in all classes in the org.eclipse.rdf4j.model.vocabulary package