### PR TITLE
#173 set default empty value for hudson.rdf4j.proxy.opts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,8 @@
 		<httpcore.version>4.4.4</httpcore.version>
 		<jackson.version>2.6.2</jackson.version>
 		<jsonldjava.version>0.7.0</jsonldjava.version>
+		<!-- default empty value to avoid errors in intregation test execution -->
+		<hudson.rdf4j.proxy.opts/>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
This PR addresses GitHub issue: #173

This ensures the failsafe plugin does not stop with an error when executing integration tests on a developer workstation (i.e. when running `mvn verify`). The empty value is overridden with the correct proxy when the eclipse-hudson-rdf4j profile is activated (which only happens on the Hudson CI server).

Ran `mvn verify` locally, verified this fixes the issue. Also double-checked that override on profile activation works as expected. 