### PR TITLE
Add rdf4j-rio-jsonld to rdf4j-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -181,6 +181,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
+				<artifactId>rdf4j-rio-jsonld</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-rio-languages</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: #189

Briefly describe the changes proposed in this PR:

- specifies version of rdf4j-rio-jsonld in bom pom.xml

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [yes] RDF4J code formatting has been applied
- [n/a] tests are included
- [n/a] all tests succeed

