### PR TITLE
upgrade to jsonld-java 0.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 		<httpclient.version>4.5.2</httpclient.version>
 		<httpcore.version>4.4.4</httpcore.version>
 		<jackson.version>2.6.2</jackson.version>
-		<jsonldjava.version>0.7.0</jsonldjava.version>
+		<jsonldjava.version>0.8.3</jsonldjava.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
This PR addresses GitHub issue: #138

Briefly describe the changes proposed in this PR:

- included version of jsonld-java upgraded to 0.8.3.

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied

