### PR TITLE
update execution now takes timeout into account

### DIFF
--- a/compliance/http/pom.xml
+++ b/compliance/http/pom.xml
@@ -132,6 +132,11 @@
 			<artifactId>log4j-over-slf4j</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpmime</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 

--- a/compliance/http/src/test/java/org/eclipse/rdf4j/http/server/ProtocolTest.java
+++ b/compliance/http/src/test/java/org/eclipse/rdf4j/http/server/ProtocolTest.java
@@ -17,18 +17,24 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.Charsets;
 import org.apache.http.HttpEntity;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -192,6 +198,31 @@ public class ProtocolTest {
 		CloseableHttpResponse response = httpclient.execute(post);
 
 		System.out.println("Update Direct Post Status: " + response.getStatusLine());
+		int statusCode = response.getStatusLine().getStatusCode();
+		assertEquals(true, statusCode >= 200 && statusCode < 400);
+	}
+
+	/**
+	 * Checks that the server accepts a formencoded POST with an update and a timeout parameter.
+	 */
+	@Test
+	public void testUpdateForm_POST()
+		throws Exception
+	{
+		String update = "delete where { <monkey:pod> ?p ?o . }";
+		String location = Protocol.getStatementsLocation(TestServer.REPOSITORY_URL);
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		HttpPost post = new HttpPost(location);
+		List<NameValuePair> nvps = new ArrayList<NameValuePair>();
+		nvps.add(new BasicNameValuePair(Protocol.UPDATE_PARAM_NAME, update));
+		nvps.add(new BasicNameValuePair(Protocol.TIMEOUT_PARAM_NAME, "1"));
+		UrlEncodedFormEntity entity = new UrlEncodedFormEntity(nvps, Charsets.UTF_8);
+
+		post.setEntity(entity);
+
+		CloseableHttpResponse response = httpclient.execute(post);
+
+		System.out.println("Update Form Post Status: " + response.getStatusLine());
 		int statusCode = response.getStatusLine().getStatusCode();
 		assertEquals(true, statusCode >= 200 && statusCode < 400);
 	}

--- a/core/http/server-spring/pom.xml
+++ b/core/http/server-spring/pom.xml
@@ -75,6 +75,14 @@
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/ProtocolUtil.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/ProtocolUtil.java
@@ -181,6 +181,33 @@ public class ProtocolUtil {
 		}
 	}
 
+	/**
+	 * Reads the {@link Protocol#TIMEOUT_PARAM_NAME} parameter from the request and (if present) parses it
+	 * into an integer value.
+	 * 
+	 * @param request
+	 *        the {@link HttpServletRequest} to read the parameter from
+	 * @return the value of the timeout parameter as an integer (representing the timeout time in seconds), or
+	 *         0 if no timeout parameter is specified in the request.
+	 * @throws ClientHTTPException
+	 *         if the value of the timeout parameter is not a valid integer.
+	 */
+	public static int parseTimeoutParam(HttpServletRequest request)
+		throws ClientHTTPException
+	{
+		final String timeoutParam = request.getParameter(Protocol.TIMEOUT_PARAM_NAME);
+		int maxExecutionTime = 0;
+		if (timeoutParam != null) {
+			try {
+				maxExecutionTime = Integer.parseInt(timeoutParam);
+			}
+			catch (NumberFormatException e) {
+				throw new ClientHTTPException(SC_BAD_REQUEST, "Invalid timeout value: " + timeoutParam);
+			}
+		}
+		return maxExecutionTime;
+	}
+
 	public static void logAcceptableFormats(HttpServletRequest request) {
 		Logger logger = LoggerFactory.getLogger(ProtocolUtil.class);
 		if (logger.isDebugEnabled()) {

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
@@ -275,16 +275,7 @@ public class RepositoryController extends AbstractController {
 		// determine if inferred triples should be included in query evaluation
 		boolean includeInferred = ProtocolUtil.parseBooleanParam(request, INCLUDE_INFERRED_PARAM_NAME, true);
 
-		String timeout = request.getParameter(Protocol.TIMEOUT_PARAM_NAME);
-		int maxQueryTime = 0;
-		if (timeout != null) {
-			try {
-				maxQueryTime = Integer.parseInt(timeout);
-			}
-			catch (NumberFormatException e) {
-				throw new ClientHTTPException(SC_BAD_REQUEST, "Invalid timeout value: " + timeout);
-			}
-		}
+		final int maxQueryTime = ProtocolUtil.parseTimeoutParam(request);
 
 		// build a dataset, if specified
 		String[] defaultGraphURIs = request.getParameterValues(DEFAULT_GRAPH_PARAM_NAME);

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/StatementsController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/StatementsController.java
@@ -248,17 +248,7 @@ public class StatementsController extends AbstractController {
 			}
 		}
 
-		final String timeout = request.getParameter(Protocol.TIMEOUT_PARAM_NAME);
-		int maxQueryTime = 0;
-		if (timeout != null) {
-			try {
-				maxQueryTime = Integer.parseInt(timeout);
-			}
-			catch (NumberFormatException e) {
-				throw new ClientHTTPException(SC_BAD_REQUEST, "Invalid timeout value: " + timeout);
-			}
-		}
-
+		final int maxQueryTime = ProtocolUtil.parseTimeoutParam(request);
 		try {
 			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
 			synchronized (repositoryCon) {

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/StatementsController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/StatementsController.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.http.server.repository.statements;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static javax.servlet.http.HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE;
 import static org.eclipse.rdf4j.http.protocol.Protocol.BASEURI_PARAM_NAME;
 import static org.eclipse.rdf4j.http.protocol.Protocol.BINDING_PREFIX;
@@ -49,6 +50,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.QueryInterruptedException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.query.UpdateExecutionException;
@@ -246,13 +248,24 @@ public class StatementsController extends AbstractController {
 			}
 		}
 
-		try {
+		final String timeout = request.getParameter(Protocol.TIMEOUT_PARAM_NAME);
+		int maxQueryTime = 0;
+		if (timeout != null) {
+			try {
+				maxQueryTime = Integer.parseInt(timeout);
+			}
+			catch (NumberFormatException e) {
+				throw new ClientHTTPException(SC_BAD_REQUEST, "Invalid timeout value: " + timeout);
+			}
+		}
 
+		try {
 			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
 			synchronized (repositoryCon) {
 				Update update = repositoryCon.prepareUpdate(queryLn, sparqlUpdateString, baseURI);
 
 				update.setIncludeInferred(includeInferred);
+				update.setMaxExecutionTime(maxQueryTime);
 
 				if (dataset != null) {
 					update.setDataset(dataset);
@@ -280,6 +293,9 @@ public class StatementsController extends AbstractController {
 			}
 
 			return new ModelAndView(EmptySuccessView.getInstance());
+		}
+		catch (QueryInterruptedException e) {
+			throw new ServerHTTPException(SC_SERVICE_UNAVAILABLE, "update execution took too long");
 		}
 		catch (UpdateExecutionException e) {
 			if (e.getCause() != null && e.getCause() instanceof HTTPException) {

--- a/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
+++ b/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015 Eclipse RDF4J contributors, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.http.server.repository.statements;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author jeen
+ */
+public class TestStatementsController {
+
+	@Test
+	public void shouldUseTimeoutParameterForUpdateQueries()
+		throws Exception
+	{
+		//prepare
+		StatementsController controller = new StatementsController();
+
+		final int maxExecution = 1;
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod(HttpMethod.POST.name());
+		request.setContentType(Protocol.SPARQL_UPDATE_MIME_TYPE);
+		request.addParameter(Protocol.TIMEOUT_PARAM_NAME, String.valueOf(maxExecution));
+		final String updateString = "delete where { <monkey:pod> ?p ?o . }";
+		request.setContent(updateString.getBytes(StandardCharsets.UTF_8));
+
+		// prepare mocks
+		final RepositoryConnection connection = Mockito.mock(RepositoryConnection.class);
+		final Update updateMock = Mockito.mock(Update.class);
+		Mockito.when(connection.prepareUpdate(QueryLanguage.SPARQL, updateString, null)).thenReturn(
+				updateMock);
+
+		// repository interceptor uses this attribute
+		request.setAttribute("repositoryConnection", connection);
+
+		//act
+		controller.handleRequest(request, new MockHttpServletResponse());
+
+		Mockito.verify(updateMock).setMaxExecutionTime(maxExecution);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -403,6 +403,18 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-test</artifactId>
+				<version>${spring.version}</version>
+				<scope>test</scope>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
 
 			<!-- Compliance tests -->
 			<dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: #187 

Briefly describe the changes proposed in this PR:

- timeout parameter now read and used by StatementsController
- added protocol test that verifies form-encoded post for update with timeout param is accepted

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

