### PR TITLE
upgraded servlet-api (provided) dep to 3.0.1

### DIFF
--- a/core/http/server-spring/pom.xml
+++ b/core/http/server-spring/pom.xml
@@ -32,7 +32,7 @@
  
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet.jsp</groupId>

--- a/core/http/server-spring/src/test/java/org/eclipse/rdf4j/common/webapp/util/HttpServerUtilTest.java
+++ b/core/http/server-spring/src/test/java/org/eclipse/rdf4j/common/webapp/util/HttpServerUtilTest.java
@@ -15,15 +15,24 @@ import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.Part;
 
 import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.common.lang.service.FileFormatServiceRegistry;
@@ -417,6 +426,141 @@ public class HttpServerUtilTest {
 		public boolean isRequestedSessionIdFromUrl() {
 			// TODO Auto-generated method stub
 			return false;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.ServletRequest#getServletContext()
+		 */
+		@Override
+		public ServletContext getServletContext() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.ServletRequest#startAsync()
+		 */
+		@Override
+		public AsyncContext startAsync()
+			throws IllegalStateException
+		{
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.ServletRequest#startAsync(javax.servlet.ServletRequest,
+		 * javax.servlet.ServletResponse)
+		 */
+		@Override
+		public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+			throws IllegalStateException
+		{
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.ServletRequest#isAsyncStarted()
+		 */
+		@Override
+		public boolean isAsyncStarted() {
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.ServletRequest#isAsyncSupported()
+		 */
+		@Override
+		public boolean isAsyncSupported() {
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.ServletRequest#getAsyncContext()
+		 */
+		@Override
+		public AsyncContext getAsyncContext() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.ServletRequest#getDispatcherType()
+		 */
+		@Override
+		public DispatcherType getDispatcherType() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.http.HttpServletRequest#authenticate(javax.servlet.http.HttpServletResponse)
+		 */
+		@Override
+		public boolean authenticate(HttpServletResponse response)
+			throws IOException, ServletException
+		{
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.http.HttpServletRequest#login(java.lang.String, java.lang.String)
+		 */
+		@Override
+		public void login(String username, String password)
+			throws ServletException
+		{
+			// TODO Auto-generated method stub
+
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.http.HttpServletRequest#logout()
+		 */
+		@Override
+		public void logout()
+			throws ServletException
+		{
+			// TODO Auto-generated method stub
+
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.http.HttpServletRequest#getParts()
+		 */
+		@Override
+		public Collection<Part> getParts()
+			throws IOException, ServletException
+		{
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see javax.servlet.http.HttpServletRequest#getPart(java.lang.String)
+		 */
+		@Override
+		public Part getPart(String name)
+			throws IOException, ServletException
+		{
+			// TODO Auto-generated method stub
+			return null;
 		}
 
 	}

--- a/core/http/workbench/pom.xml
+++ b/core/http/workbench/pom.xml
@@ -93,7 +93,7 @@
 		
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
 
 		<!-- Required for CommonsMultipartResolver from the Spring Framework -->

--- a/pom.xml
+++ b/pom.xml
@@ -320,8 +320,8 @@
 			<!-- Java Enterprise Edition -->
 			<dependency>
 				<groupId>javax.servlet</groupId>
-				<artifactId>servlet-api</artifactId>
-				<version>2.5</version>
+				<artifactId>javax.servlet-api</artifactId>
+				<version>3.0.1</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: #206

Briefly describe the changes proposed in this PR:

- servlet api depency upgraded to 3.0.1 to enable future use of spring-test mock classes (which rely on servlet 3.0). 
- extended internal stub class in HttpServerUtilTest to conform to extended interface in new api

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed
