### PR TITLE
#180 trivial fix in getUnionArgs

### DIFF
--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/optimizers/FederationJoinOptimizer.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/optimizers/FederationJoinOptimizer.java
@@ -748,7 +748,7 @@ public class FederationJoinOptimizer extends AbstractQueryModelVisitor<Repositor
 	private List<TupleExpr> getUnionArgs(TupleExpr union, List<TupleExpr> list) {
 		if (union instanceof Union) {
 			getUnionArgs(((Union)union).getLeftArg(), list);
-			getUnionArgs(((Union)union).getLeftArg(), list);
+			getUnionArgs(((Union)union).getRightArg(), list);
 		}
 		else {
 			list.add(union);


### PR DESCRIPTION
This PR addresses GitHub issue: #180

Briefly describe the changes proposed in this PR:

- trivial fix in getUnionArgs method to retrieve args from _both_ sides of the union

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] all tests succeed

Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>