### PR TITLE
#227 fixed use of getLanguage() return value

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -812,7 +812,7 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 
 				if (Literals.isLanguageLiteral(lit)) {
 					qb.append("@");
-					qb.append(lit.getLanguage());
+					qb.append(lit.getLanguage().get());
 				}
 				else {
 					qb.append("^^<" + lit.getDatatype().stringValue() + ">");
@@ -938,9 +938,9 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 				qb.append(SPARQLUtil.encodeString(lit.getLabel()));
 				qb.append("\"");
 
-				if (Literals.isLanguageLiteral(lit)) {
+				if (lit.getLanguage().isPresent()) {
 					qb.append("@");
-					qb.append(lit.getLanguage());
+					qb.append(lit.getLanguage().get());
 				}
 				else {
 					qb.append("^^<" + lit.getDatatype().stringValue() + ">");

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLOperation.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLOperation.java
@@ -159,7 +159,7 @@ public abstract class SPARQLOperation implements Operation {
 
 		if (Literals.isLanguageLiteral(lit)) {
 			sb.append('@');
-			sb.append(lit.getLanguage());
+			sb.append(lit.getLanguage().get());
 		}
 		else {
 			sb.append("^^<");

--- a/core/spin/src/main/java/org/eclipse/rdf4j/spin/function/Concat.java
+++ b/core/spin/src/main/java/org/eclipse/rdf4j/spin/function/Concat.java
@@ -50,7 +50,7 @@ public class Concat implements Function {
 					if (languageTag == null) {
 						languageTag = lit.getLanguage().get();
 					}
-					else if (!languageTag.equals(lit.getLanguage())) {
+					else if (!languageTag.equals(lit.getLanguage().get())) {
 						languageTag = null;
 						useLanguageTag = false;
 					}


### PR DESCRIPTION
This PR addresses GitHub issue: #227

Briefly describe the changes proposed in this PR:

-    getLanguage() returns an Optional, if it has been verified to be non-empty, use getLanguage().get() (or getLanguage.orElse(null)) to retrieve the actual string value.

Make sure you've followed the Contributor Guidelines. In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x]   all tests succeed

