### PR TITLE
#91 using secondary cache for maintenance

### DIFF
--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
@@ -231,7 +231,7 @@ public enum ActiveTransactionRegistry {
 			throw new RepositoryException(
 					"transaction with id " + transactionId + " is no longer registered!");
 		}
-		bumpSecondaryCache(transactionId, entry);
+		updateSecondaryCache(transactionId, entry);
 
 		return entry.getConnection();
 	}
@@ -246,7 +246,7 @@ public enum ActiveTransactionRegistry {
 	public void returnTransactionConnection(UUID transactionId) {
 		final CacheEntry entry = primaryCache.getIfPresent(transactionId);
 		if (entry != null) {
-			bumpSecondaryCache(transactionId, entry);
+			updateSecondaryCache(transactionId, entry);
 			final ReentrantLock txnLock = entry.getLock();
 			if (txnLock.isHeldByCurrentThread()) {
 				txnLock.unlock();
@@ -256,14 +256,14 @@ public enum ActiveTransactionRegistry {
 
 	/**
 	 * Checks if the given transaction entry is still in the secondary cache (resetting its last access time
-	 * in the process) and if not reinsert it.
+	 * in the process) and if not reinserts it.
 	 * 
 	 * @param transactionId
 	 *        the id for the transaction to check
 	 * @param entry
 	 *        the cache entry to insert if necessary.
 	 */
-	private void bumpSecondaryCache(UUID transactionId, final CacheEntry entry) {
+	private void updateSecondaryCache(UUID transactionId, final CacheEntry entry) {
 		try {
 			secondaryCache.get(transactionId, new Callable<CacheEntry>() {
 

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
@@ -59,8 +59,8 @@ public enum ActiveTransactionRegistry {
 
 	/**
 	 * The secondary cache does automatic cleanup of its entries based on the configured timeout. If an
-	 * expired entry no longer has an active lock (meaning no operation is currently active on the connection,
-	 * and the transaction is therefore considered "orphaned"), it also discarded from the primary cache.
+	 * expired entry no longer is no longer handed out to an actual server-side operation, it is considered
+	 * "orphaned" and discarded from the primary cache.
 	 */
 	private final Cache<UUID, CacheEntry> secondaryCache;
 

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
@@ -134,6 +134,10 @@ public enum ActiveTransactionRegistry {
 							primaryCache.invalidate(transactionId);
 							logger.warn("deregistered expired transaction {}", transactionId);
 						}
+						else {
+							// operation still active. Reinsert in secondary cache.
+							secondaryCache.put(transactionId, entry);
+						}
 					}
 				}
 			}

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
@@ -8,6 +8,8 @@
 package org.eclipse.rdf4j.http.server.repository.transaction;
 
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -39,23 +41,36 @@ public enum ActiveTransactionRegistry {
 	private final Logger logger = LoggerFactory.getLogger(ActiveTransactionRegistry.class);
 
 	/**
-	 * Configurable system property {@code sesame.server.txn.registry.timeout} for specifying the transaction
+	 * Configurable system property {@code rdf4j.server.txn.registry.timeout} for specifying the transaction
 	 * cache timeout (in seconds).
 	 */
-	public static final String CACHE_TIMEOUT_PROPERTY = "sesame.server.txn.registry.timeout";
+	public static final String CACHE_TIMEOUT_PROPERTY = "rdf4j.server.txn.registry.timeout";
 
 	/**
 	 * Default timeout setting for transaction cache entries (in seconds).
 	 */
 	public final static int DEFAULT_TIMEOUT = 60;
 
-	private final Cache<UUID, CacheEntry> activeConnections;
+	/**
+	 * primary cache for transactions, accessible via transaction ID. Cache entries are kept until a
+	 * transaction signals it has ended, or until the secondary cache finds an "orphaned" transaction entry.
+	 */
+	private final Cache<UUID, CacheEntry> primaryCache;
+
+	/**
+	 * The secondary cache does automatic cleanup of its entries based on the configured timeout. If an
+	 * expired entry no longer has an active lock (meaning no operation is currently active on the connection,
+	 * and the transaction is therefore considered "orphaned"), it also discarded from the primary cache.
+	 */
+	private final Cache<UUID, CacheEntry> secondaryCache;
 
 	static class CacheEntry {
 
 		private final RepositoryConnection connection;
 
-		private final Lock lock = new ReentrantLock();
+		private final ReentrantLock lock = new ReentrantLock();
+
+		private boolean handedOut;
 
 		public CacheEntry(RepositoryConnection connection) {
 			this.connection = connection;
@@ -71,8 +86,25 @@ public enum ActiveTransactionRegistry {
 		/**
 		 * @return Returns the lock.
 		 */
-		public Lock getLock() {
+		public ReentrantLock getLock() {
 			return lock;
+		}
+
+		/**
+		 * Indicates if the entry is currently handed out to a thread
+		 * 
+		 * @return true iff the entry is handed out to a thread, false otherwise.
+		 */
+		public boolean isHandedOut() {
+			return handedOut;
+		}
+
+		/**
+		 * @param handedOut
+		 *        the handedOut to set
+		 */
+		public void setHandedOut(boolean handedOut) {
+			this.handedOut = handedOut;
 		}
 
 	}
@@ -94,30 +126,38 @@ public enum ActiveTransactionRegistry {
 			}
 		}
 
-		activeConnections = initializeCache(timeout, TimeUnit.SECONDS);
-	}
+		primaryCache = CacheBuilder.newBuilder().removalListener(new RemovalListener<UUID, CacheEntry>() {
 
-	private final Cache<UUID, CacheEntry> initializeCache(int timeout, TimeUnit unit) {
-		return CacheBuilder.newBuilder().removalListener(new RemovalListener<UUID, CacheEntry>() {
+			@Override
+			public void onRemoval(RemovalNotification<UUID, CacheEntry> notification) {
+				CacheEntry entry = notification.getValue();
+				try {
+					entry.getConnection().close();
+				}
+				catch (RepositoryException e) {
+					// fall through
+				}
+			}
+		}).build();
+
+		secondaryCache = CacheBuilder.newBuilder().removalListener(new RemovalListener<UUID, CacheEntry>() {
 
 			@Override
 			public void onRemoval(RemovalNotification<UUID, CacheEntry> notification) {
 				if (RemovalCause.EXPIRED.equals(notification.getCause())) {
-					logger.warn("transaction registry item {} removed after expiry", notification.getKey());
-					CacheEntry entry = notification.getValue();
-					try {
-						entry.getConnection().close();
+					final UUID transactionId = notification.getKey();
+					final CacheEntry entry = notification.getValue();
+					synchronized (primaryCache) {
+						if (!entry.isHandedOut()) {
+							// no operation active, we can decommission this entry
+							primaryCache.invalidate(transactionId);
+							logger.warn("deregistered expired transaction {}", transactionId);
+						}
 					}
-					catch (RepositoryException e) {
-						// fall through
-					}
-				}
-				else {
-					logger.debug("transaction {} removed from registry. cause: {}", notification.getKey(),
-							notification.getCause());
 				}
 			}
-		}).expireAfterAccess(timeout, unit).build();
+		}).expireAfterAccess(timeout, TimeUnit.SECONDS).build();
+
 	}
 
 	/**
@@ -133,9 +173,11 @@ public enum ActiveTransactionRegistry {
 	public void register(UUID transactionId, RepositoryConnection conn)
 		throws RepositoryException
 	{
-		synchronized (activeConnections) {
-			if (activeConnections.getIfPresent(transactionId) == null) {
-				activeConnections.put(transactionId, new CacheEntry(conn));
+		synchronized (primaryCache) {
+			if (primaryCache.getIfPresent(transactionId) == null) {
+				final CacheEntry cacheEntry = new CacheEntry(conn);
+				primaryCache.put(transactionId, cacheEntry);
+				secondaryCache.put(transactionId, cacheEntry);
 				logger.debug("registered transaction {} ", transactionId);
 			}
 			else {
@@ -157,16 +199,15 @@ public enum ActiveTransactionRegistry {
 	public void deregister(UUID transactionId)
 		throws RepositoryException
 	{
-		synchronized (activeConnections) {
-			CacheEntry entry = activeConnections.getIfPresent(transactionId);
+		synchronized (primaryCache) {
+			CacheEntry entry = primaryCache.getIfPresent(transactionId);
 			if (entry == null) {
 				throw new RepositoryException(
 						"transaction with id " + transactionId.toString() + " not registered.");
 			}
 			else {
-				activeConnections.invalidate(transactionId);
-				final Lock txnLock = entry.getLock();
-				txnLock.unlock();
+				primaryCache.invalidate(transactionId);
+				secondaryCache.invalidate(transactionId);
 				logger.debug("deregistered transaction {}", transactionId);
 			}
 		}
@@ -188,8 +229,8 @@ public enum ActiveTransactionRegistry {
 		throws RepositoryException, InterruptedException
 	{
 		Lock txnLock = null;
-		synchronized (activeConnections) {
-			CacheEntry entry = activeConnections.getIfPresent(transactionId);
+		synchronized (primaryCache) {
+			CacheEntry entry = primaryCache.getIfPresent(transactionId);
 			if (entry == null) {
 				throw new RepositoryException(
 						"transaction with id " + transactionId.toString() + " not registered.");
@@ -200,11 +241,14 @@ public enum ActiveTransactionRegistry {
 
 		txnLock.lockInterruptibly();
 		/* Another thread might have deregistered the transaction while we were acquiring the lock */
-		final CacheEntry entry = activeConnections.getIfPresent(transactionId);
+		final CacheEntry entry = primaryCache.getIfPresent(transactionId);
 		if (entry == null) {
 			throw new RepositoryException(
 					"transaction with id " + transactionId + " is no longer registered!");
 		}
+		bumpSecondaryCache(transactionId, entry);
+		entry.setHandedOut(true);
+
 		return entry.getConnection();
 	}
 
@@ -216,12 +260,40 @@ public enum ActiveTransactionRegistry {
 	 *        a transaction identifier.
 	 */
 	public void returnTransactionConnection(UUID transactionId) {
-
-		final CacheEntry entry = activeConnections.getIfPresent(transactionId);
-
+		final CacheEntry entry = primaryCache.getIfPresent(transactionId);
 		if (entry != null) {
-			final Lock txnLock = entry.getLock();
-			txnLock.unlock();
+			bumpSecondaryCache(transactionId, entry);
+			final ReentrantLock txnLock = entry.getLock();
+			if (txnLock.isHeldByCurrentThread()) {
+				txnLock.unlock();
+			}
+			entry.setHandedOut(false);
+		}
+	}
+
+	/**
+	 * Checks if the given transaction entry is still in the secondary cache (resetting its last access time
+	 * in the process) and if not reinsert it.
+	 * 
+	 * @param transactionId
+	 *        the id for the transaction to check
+	 * @param entry
+	 *        the cache entry to insert if necessary.
+	 */
+	private void bumpSecondaryCache(UUID transactionId, final CacheEntry entry) {
+		try {
+			secondaryCache.get(transactionId, new Callable<CacheEntry>() {
+
+				@Override
+				public CacheEntry call()
+					throws Exception
+				{
+					return entry;
+				}
+			});
+		}
+		catch (ExecutionException e) {
+			throw new RuntimeException(e);
 		}
 	}
 }

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -775,13 +775,26 @@ public class TransactionController extends AbstractController {
 			IRI predicate = SESAME.WILDCARD.equals(st.getPredicate()) ? null : st.getPredicate();
 			Value object = SESAME.WILDCARD.equals(st.getObject()) ? null : st.getObject();
 
+			// use the RepositoryConnection.clear operation if we're removing all statements
+			final boolean clearAllTriples = subject == null && predicate == null && object == null;
+
 			try {
 				Resource context = st.getContext();
 				if (context != null) {
-					conn.remove(subject, predicate, object, st.getContext());
+					if (clearAllTriples) {
+						conn.clear(context);
+					}
+					else {
+						conn.remove(subject, predicate, object, context);
+					}
 				}
 				else {
-					conn.remove(subject, predicate, object);
+					if (clearAllTriples) {
+						conn.clear();
+					}
+					else {
+						conn.remove(subject, predicate, object);
+					}
 				}
 			}
 			catch (RepositoryException e) {

--- a/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
@@ -93,8 +93,8 @@ public class TestActiveTransactionRegistry {
 					done.countDown();
 				}
 				catch (RepositoryException | InterruptedException e) {
-					// TODO Auto-generated catch block
 					e.printStackTrace();
+					fail(e.getMessage());
 				}
 			}
 		};
@@ -107,8 +107,8 @@ public class TestActiveTransactionRegistry {
 					txn1registered.await();
 				}
 				catch (InterruptedException e) {
-					// TODO Auto-generated catch block
 					e.printStackTrace();
+					fail(e.getMessage());
 				}
 
 				try {
@@ -119,8 +119,8 @@ public class TestActiveTransactionRegistry {
 					done.countDown();
 				}
 				catch (RepositoryException | InterruptedException e) {
-					// TODO Auto-generated catch block
 					e.printStackTrace();
+					fail(e.getMessage());
 				}
 			}
 		};
@@ -134,8 +134,8 @@ public class TestActiveTransactionRegistry {
 					registry.deregister(txnId1);
 				}
 				catch (InterruptedException e) {
-					// TODO Auto-generated catch block
 					e.printStackTrace();
+					fail(e.getMessage());
 				}
 			}
 		};
@@ -147,6 +147,14 @@ public class TestActiveTransactionRegistry {
 		t3.start();
 		t2.start();
 		t1.start();
+
+		try {
+			t3.join(5000);
+		}
+		catch (InterruptedException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
 	}
 
 }

--- a/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2015 Eclipse RDF4J contributors, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.http.server.repository.transaction;
+
+import static org.junit.Assert.fail;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestActiveTransactionRegistry {
+
+	private static final Logger logger = LoggerFactory.getLogger(TestActiveTransactionRegistry.class);
+
+	private ActiveTransactionRegistry registry;
+
+	private RepositoryConnection conn;
+
+	private UUID txnId1;
+
+	private UUID txnId2;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		System.setProperty(ActiveTransactionRegistry.CACHE_TIMEOUT_PROPERTY, "1");
+		registry = ActiveTransactionRegistry.INSTANCE;
+		conn = Mockito.mock(RepositoryConnection.class);
+		txnId1 = UUID.randomUUID();
+		txnId2 = UUID.randomUUID();
+
+	}
+
+	@Test
+	public void testTimeoutRepeatedAccess()
+		throws Exception
+	{
+		registry.register(txnId2, conn);
+
+		int count = 0;
+		while (count++ < 2) {
+			logger.debug("pass {}", count);
+			registry.getTransactionConnection(txnId2);
+			Thread.sleep(1200);
+			registry.returnTransactionConnection(txnId2);
+		}
+
+		registry.deregister(txnId2);
+		try {
+			registry.getTransactionConnection(txnId2);
+			fail("should be deregistered");
+		}
+		catch (RepositoryException e) {
+			// fall through, expected
+		}
+	}
+
+	@Test
+	public void testMultithreadedAccess() {
+
+		CountDownLatch txn1registered = new CountDownLatch(1);
+
+		CountDownLatch done = new CountDownLatch(2);
+
+		Runnable r1 = new Runnable() {
+
+			@Override
+			public void run() {
+				registry.register(txnId1, conn);
+				txn1registered.countDown();
+
+				try {
+					registry.getTransactionConnection(txnId1);
+					Thread.sleep(700);
+					registry.returnTransactionConnection(txnId1);
+
+					done.countDown();
+				}
+				catch (RepositoryException | InterruptedException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+		};
+
+		Runnable r2 = new Runnable() {
+
+			@Override
+			public void run() {
+				try {
+					txn1registered.await();
+				}
+				catch (InterruptedException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+
+				try {
+					registry.getTransactionConnection(txnId1);
+					Thread.sleep(500);
+					registry.returnTransactionConnection(txnId1);
+
+					done.countDown();
+				}
+				catch (RepositoryException | InterruptedException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+		};
+
+		Runnable r3 = new Runnable() {
+
+			@Override
+			public void run() {
+				try {
+					done.await();
+					registry.deregister(txnId1);
+				}
+				catch (InterruptedException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+		};
+
+		Thread t1 = new Thread(r1, "r1");
+		Thread t2 = new Thread(r2, "r2");
+		Thread t3 = new Thread(r3, "r3");
+
+		t3.start();
+		t2.start();
+		t1.start();
+	}
+
+}

--- a/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
@@ -149,7 +149,7 @@ public class TestActiveTransactionRegistry {
 		t1.start();
 
 		try {
-			t3.join(5000);
+			t3.join();
 		}
 		catch (InterruptedException e) {
 			e.printStackTrace();

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -373,7 +373,12 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 		throws RepositoryException
 	{
 		try {
-			sailConnection.removeStatements(subject, predicate, object, contexts);
+			if (subject == null && predicate == null && object == null) {
+				sailConnection.clear(contexts);
+			}
+			else {
+				sailConnection.removeStatements(subject, predicate, object, contexts);
+			}
 		}
 		catch (SailReadOnlyException e) {
 			throw new RepositoryReadOnlyException(e.getMessage(), e);


### PR DESCRIPTION
This PR addresses GitHub issue: #91

Briefly describe the changes proposed in this PR:

- primary cache in txn registry no longer has a timeout
- secondary cache with timeout verifies if entry is still actively used server-side. If not, entry is also removed from primary cache.
- added unit tests which verify expected behavior. 

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

