### PR TITLE
create single Accept header with comma-separated values for formats

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
@@ -97,6 +97,8 @@ import org.eclipse.rdf4j.rio.helpers.ParseErrorLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Joiner;
+
 /**
  * The SparqlSession provides low level HTTP methods for the HTTP communication of the SPARQL repository as
  * well as the HTTP Repository. All methods are compliant to the SPARQL 1.1 protocol. For both Tuple and Graph
@@ -763,7 +765,9 @@ public class SparqlSession implements HttpClientDependent {
 		throws RepositoryException, IOException, QueryInterruptedException, MalformedQueryException
 	{
 
+		final List<String> acceptValues = new ArrayList<String>(tqrFormats.size());
 		for (QueryResultFormat format : tqrFormats) {
+
 			// Determine a q-value that reflects the user specified preference
 			int qValue = 10;
 
@@ -778,10 +782,11 @@ public class SparqlSession implements HttpClientDependent {
 				if (qValue < 10) {
 					acceptParam += ";q=0." + qValue;
 				}
-
-				method.addHeader(ACCEPT_PARAM_NAME, acceptParam);
+				acceptValues.add(acceptParam);
 			}
 		}
+
+		method.addHeader(ACCEPT_PARAM_NAME, Joiner.on(", ").join(acceptValues));
 
 		try {
 			return executeOK(method);
@@ -911,9 +916,8 @@ public class SparqlSession implements HttpClientDependent {
 
 		List<String> acceptParams = RDFFormat.getAcceptParams(rdfFormats, requireContext,
 				getPreferredRDFFormat());
-		for (String acceptParam : acceptParams) {
-			method.addHeader(ACCEPT_PARAM_NAME, acceptParam);
-		}
+
+		method.addHeader(ACCEPT_PARAM_NAME, Joiner.on(", ").join(acceptParams));
 
 		try {
 			return executeOK(method);
@@ -972,6 +976,8 @@ public class SparqlSession implements HttpClientDependent {
 		throws IOException, RDF4JException
 	{
 
+		final List<String> acceptValues = new ArrayList<>(booleanFormats.size());
+
 		for (QueryResultFormat format : booleanFormats) {
 			// Determine a q-value that reflects the user specified preference
 			int qValue = 10;
@@ -988,9 +994,11 @@ public class SparqlSession implements HttpClientDependent {
 					acceptParam += ";q=0." + qValue;
 				}
 
-				method.addHeader(ACCEPT_PARAM_NAME, acceptParam);
+				acceptValues.add(acceptParam);
 			}
 		}
+
+		method.addHeader(ACCEPT_PARAM_NAME, Joiner.on(", ").join(acceptValues));
 
 		return executeOK(method);
 	}

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
@@ -129,6 +129,11 @@ public class SparqlSession implements HttpClientDependent {
 
 	final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+	/**
+	 * shared instance of a {@link Joiner} for creating a comma-separated string.
+	 */
+	private static final Joiner commaJoiner = Joiner.on(", ");
+
 	/*-----------*
 	 * Variables *
 	 *-----------*/
@@ -786,7 +791,7 @@ public class SparqlSession implements HttpClientDependent {
 			}
 		}
 
-		method.addHeader(ACCEPT_PARAM_NAME, Joiner.on(", ").join(acceptValues));
+		method.addHeader(ACCEPT_PARAM_NAME, commaJoiner.join(acceptValues));
 
 		try {
 			return executeOK(method);
@@ -917,7 +922,7 @@ public class SparqlSession implements HttpClientDependent {
 		List<String> acceptParams = RDFFormat.getAcceptParams(rdfFormats, requireContext,
 				getPreferredRDFFormat());
 
-		method.addHeader(ACCEPT_PARAM_NAME, Joiner.on(", ").join(acceptParams));
+		method.addHeader(ACCEPT_PARAM_NAME, commaJoiner.join(acceptParams));
 
 		try {
 			return executeOK(method);
@@ -998,7 +1003,7 @@ public class SparqlSession implements HttpClientDependent {
 			}
 		}
 
-		method.addHeader(ACCEPT_PARAM_NAME, Joiner.on(", ").join(acceptValues));
+		method.addHeader(ACCEPT_PARAM_NAME, commaJoiner.join(acceptValues));
 
 		return executeOK(method);
 	}


### PR DESCRIPTION
This PR addresses GitHub issue: #228

Briefly describe the changes proposed in this PR:

- http query requests now send single, comma-separated Accept header 

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [ ] tests are included
- [x] all tests succeed

Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>