### PR TITLE
Fixes issue #249 Clarify the conceptual relationship to RDF-1.1

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/BNode.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/BNode.java
@@ -8,9 +8,12 @@
 package org.eclipse.rdf4j.model;
 
 /**
- * A blank node (aka <em>bnode</em>, aka <em>anonymous node</em>). A blank node has an identifier to be able
- * to compare it to other blank nodes internally. Please note that, conceptually, blank node equality can only
- * be determined by examining the statements that refer to them.
+ * An RDF-1.1 blank node (aka <em>bnode</em>, aka <em>anonymous node</em>). A blank node has an identifier to
+ * be able to compare it to other blank nodes internally. Please note that, conceptually, blank node equality
+ * can only be determined by examining the statements that refer to them.
+ * 
+ * @see <a href="http://www.w3.org/TR/rdf11-concepts/#section-blank-nodes">RDF-1.1 Concepts and Abstract
+ *      Syntax</a>
  */
 public interface BNode extends Resource {
 

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/Literal.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/Literal.java
@@ -14,11 +14,14 @@ import java.util.Optional;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 
 /**
- * An RDF literal consisting of a label (the lexical value), a datatype, and optionally a language tag.
+ * An RDF-1.1 literal consisting of a label (the lexical value), a datatype, and optionally a language tag.
  * 
  * @author Arjohn Kampman
+ * @see <a href="http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal">RDF-1.1 Concepts and Abstract
+ *      Syntax</a>
  */
 public interface Literal extends Value {
 
@@ -37,10 +40,11 @@ public interface Literal extends Value {
 	public Optional<String> getLanguage();
 
 	/**
-	 * Gets the datatype for this literal.
+	 * Gets the datatype for this literal. If {@link #getLanguage()} returns a non-empty value than this must
+	 * return {@link RDF#LANGSTRING}. If no datatype was assigned to this literal by the creator, then this
+	 * method must return {@link XMLSchema#STRING}.
 	 * 
-	 * @return The datatype for this literal. If {@link #getLanguage()} returns a non-empty value than this
-	 *         must return {@link RDF#LANGSTRING}.
+	 * @return The datatype for this literal.
 	 */
 	public IRI getDatatype();
 

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -13,11 +13,15 @@ import java.util.Date;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+
 /**
  * A factory for creating {@link IRI IRIs}, {@link BNode blank nodes}, {@link Literal literals} and
- * {@link Statement statements}.
+ * {@link Statement statements} based on the RDF-1.1 Concepts and Abstract Syntax, a W3C Recommendation.
  * 
  * @author Arjohn Kampman
+ * @see <a href="http://www.w3.org/TR/rdf11-concepts/">RDF-1.1 Concepts and Abstract Syntax</a>
  */
 public interface ValueFactory {
 
@@ -40,7 +44,7 @@ public interface ValueFactory {
 	 * @return An object representing the URI.
 	 * @throws IlllegalArgumentException
 	 *         If the supplied string does not resolve to a legal (absolute) URI.
-	 * @deprecated since 4.0. Use {{@link #createIRI(String)} instead.
+	 * @deprecated Use {{@link #createIRI(String)} instead.
 	 */
 	@Deprecated
 	public default URI createURI(String uri) {
@@ -71,7 +75,7 @@ public interface ValueFactory {
 	 * @return An object representing the URI.
 	 * @throws IlllegalArgumentException
 	 *         If the supplied string does not resolve to a legal (absolute) URI.
-	 * @deprecated since 4.0. Use {{@link #createIRI(String, String)} instead.
+	 * @deprecated Use {{@link #createIRI(String, String)} instead.
 	 */
 	@Deprecated
 	public default URI createURI(String namespace, String localName) {
@@ -95,20 +99,22 @@ public interface ValueFactory {
 	public BNode createBNode(String nodeID);
 
 	/**
-	 * Creates a new literal with the supplied label.
+	 * Creates a new literal with the supplied label. The return value of {@link Literal#getDatatype()} for
+	 * the returned object must be {@link XMLSchema#STRING}.
 	 * 
 	 * @param label
-	 *        The literal's label.
+	 *        The literal's label, must not be <tt>null</tt>.
 	 */
 	public Literal createLiteral(String label);
 
 	/**
-	 * Creates a new literal with the supplied label and language attribute.
+	 * Creates a new literal with the supplied label and language attribute. The return value of
+	 * {@link Literal#getDatatype()} for the returned object must be {@link RDF#LANGSTRING}.
 	 * 
 	 * @param label
-	 *        The literal's label.
+	 *        The literal's label, must not be <tt>null</tt>.
 	 * @param language
-	 *        The literal's language attribute, or <tt>null</tt> if the literal doesn't have a language.
+	 *        The literal's language attribute, must not be <tt>null</tt>.
 	 */
 	public Literal createLiteral(String label, String language);
 
@@ -116,9 +122,10 @@ public interface ValueFactory {
 	 * Creates a new literal with the supplied label and datatype.
 	 * 
 	 * @param label
-	 *        The literal's label.
+	 *        The literal's label, must not be <tt>null</tt>.
 	 * @param datatype
-	 *        The literal's datatype, or <tt>null</tt> if the literal doesn't have a datatype.
+	 *        The literal's datatype. If it is null, the datatype {@link XMLSchema#STRING} will be assigned to
+	 *        this literal.
 	 */
 	public Literal createLiteral(String label, IRI datatype);
 
@@ -128,8 +135,9 @@ public interface ValueFactory {
 	 * @param label
 	 *        The literal's label.
 	 * @param datatype
-	 *        The literal's datatype, or <tt>null</tt> if the literal doesn't have a datatype.
-	 * @deprecated since 4.0. Use {@link #createLiteral(String, IRI)} instead.
+	 *        The literal's datatype. If it is null, the datatype {@link XMLSchema#STRING} will be assigned to
+	 *        this literal.
+	 * @deprecated Use {@link #createLiteral(String, IRI)} instead.
 	 */
 	@Deprecated
 	public default Literal createLiteral(String label, URI datatype) {
@@ -250,7 +258,7 @@ public interface ValueFactory {
 	 * @param object
 	 *        The statement's object.
 	 * @return The created statement.
-	 * @deprecated since 4.0. Use {@link #createStatement(Resource, IRI, Value)} instead.
+	 * @deprecated Use {@link #createStatement(Resource, IRI, Value)} instead.
 	 */
 	@Deprecated
 	public default Statement createStatement(Resource subject, URI predicate, Value object) {
@@ -282,7 +290,7 @@ public interface ValueFactory {
 	 * @param object
 	 *        The statement's object.
 	 * @return The created statement.
-	 * @deprecated since 4.0. Use {@link #createStatement(Resource, IRI, Value, Resource)} instead.
+	 * @deprecated Use {@link #createStatement(Resource, IRI, Value, Resource)} instead.
 	 */
 	@Deprecated
 	public default Statement createStatement(Resource subject, URI predicate, Value object,


### PR DESCRIPTION
This PR addresses GitHub issue: #249

Briefly describe the changes proposed in this PR:

- Clarify the relationship to the RDF-1.1 specification. In particular, clarify the status of Literal.getDatatype that cannot be null or empty in RDF-1.1 as it could be in RDF-1.0.

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [ ] tests are included
- [ ] all tests succeed

No code or contract changes, just clarifications in javadoc of the contracts that the existing RDF4J code already follows.