### PR TITLE
Fix #255 Lower MAXIMUM_URL_LENGTH

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
@@ -123,7 +123,7 @@ public class SparqlSession implements HttpClientDependent {
 	 * The threshold for URL length, beyond which we use the POST method based on the lowest common
 	 * denominator for various web servers
 	 */
-	public static final int MAXIMUM_URL_LENGTH = 8192;
+	public static final int MAXIMUM_URL_LENGTH = 4083;
 
 	final Logger logger = LoggerFactory.getLogger(this.getClass());
 


### PR DESCRIPTION
This PR addresses GitHub issue: #255 

Improves compatibility with SPARQL endpoints by lowering thresh-hold for when a GET request should become a POST