### PR TITLE
SPARQL endpoint url length threshold lowered and made configurable

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
@@ -120,10 +120,16 @@ public class SparqlSession implements HttpClientDependent {
 	protected static final Charset UTF8 = Charset.forName("UTF-8");
 
 	/**
-	 * The default threshold for URL length, beyond which we use the POST method. The default is based on the
-	 * lowest common denominator for various web servers.
+	 * The default value of the threshold for URL length, beyond which we use the POST method. The default is
+	 * based on the lowest common denominator for various web servers.
 	 */
 	public static final int DEFAULT_MAXIMUM_URL_LENGTH = 4083;
+
+	/**
+	 * @deprecated use {@link #DEFAULT_MAXIMUM_URL_LENGTH} instead.
+	 */
+	@Deprecated
+	public static final int MAXIMUM_URL_LENGTH = DEFAULT_MAXIMUM_URL_LENGTH;
 
 	/**
 	 * System property for configuration of URL length threshold: rdf4j.sparql.url.maxlength
@@ -131,7 +137,7 @@ public class SparqlSession implements HttpClientDependent {
 	public static final String MAXIMUM_URL_LENGTH_PARAM = "rdf4j.sparql.url.maxlength";
 
 	/**
-	 * The default threshold for URL length, beyond which we use the POST method.
+	 * The threshold for URL length, beyond which we use the POST method.
 	 */
 	private final int maximumUrlLength;
 

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SparqlSession.java
@@ -53,6 +53,7 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
+import org.eclipse.rdf4j.RDF4JConfigException;
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.http.protocol.UnauthorizedException;
@@ -120,8 +121,8 @@ public class SparqlSession implements HttpClientDependent {
 	protected static final Charset UTF8 = Charset.forName("UTF-8");
 
 	/**
-	 * The default value of the threshold for URL length, beyond which we use the POST method. The default is
-	 * based on the lowest common denominator for various web servers.
+	 * The default value of the threshold for URL length, beyond which we use the POST method for SPARQL query
+	 * requests. The default is based on the lowest common denominator for various web servers.
 	 */
 	public static final int DEFAULT_MAXIMUM_URL_LENGTH = 4083;
 
@@ -132,12 +133,15 @@ public class SparqlSession implements HttpClientDependent {
 	public static final int MAXIMUM_URL_LENGTH = DEFAULT_MAXIMUM_URL_LENGTH;
 
 	/**
-	 * System property for configuration of URL length threshold: rdf4j.sparql.url.maxlength
+	 * System property for configuration of URL length threshold: {@code rdf4j.sparql.url.maxlength}. A
+	 * threshold of 0 (or a negative value) means that the POST method is used for <strong>every</strong>
+	 * SPARQL query request.
 	 */
 	public static final String MAXIMUM_URL_LENGTH_PARAM = "rdf4j.sparql.url.maxlength";
 
 	/**
-	 * The threshold for URL length, beyond which we use the POST method.
+	 * The threshold for URL length, beyond which we use the POST method. A threshold of 0 (or a negative
+	 * value) means that the POST method is used for <strong>every</strong> SPARQL query request.
 	 */
 	private final int maximumUrlLength;
 
@@ -197,12 +201,8 @@ public class SparqlSession implements HttpClientDependent {
 				maximumUrlLength = Integer.parseInt(propertyValue);
 			}
 			catch (NumberFormatException e) {
-				throw new RDF4JException("integer value expected for property " + MAXIMUM_URL_LENGTH_PARAM,
-						e)
-				{
-
-					private static final long serialVersionUID = 1L;
-				};
+				throw new RDF4JConfigException(
+						"integer value expected for property " + MAXIMUM_URL_LENGTH_PARAM, e);
 			}
 		}
 		this.maximumUrlLength = maximumUrlLength;

--- a/core/model/src/main/java/org/eclipse/rdf4j/RDF4JConfigException.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/RDF4JConfigException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2015 Eclipse RDF4J contributors, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j;
+
+/**
+ * Exception indicating a configuration problem in an RDF4J component.
+ * 
+ * @author Jeen Broekstra
+ */
+public class RDF4JConfigException extends RDF4JException {
+
+	private static final long serialVersionUID = -8121506409791182977L;
+
+	public RDF4JConfigException() {
+		super();
+	}
+
+	public RDF4JConfigException(String message) {
+		super(message);
+	}
+
+	public RDF4JConfigException(Throwable t) {
+		super(t);
+	}
+
+	public RDF4JConfigException(String msg, Throwable t) {
+		super(msg, t);
+	}
+}

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigException.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigException.java
@@ -7,14 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
-import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.RDF4JConfigException;
 
 /**
  * Exception indicating a repository configuration problem.
  * 
  * @author Arjohn Kampman
  */
-public class RepositoryConfigException extends RDF4JException {
+public class RepositoryConfigException extends RDF4JConfigException {
 
 	private static final long serialVersionUID = -6643040675968955429L;
 

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigException.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigException.java
@@ -7,14 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.config;
 
-import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.RDF4JConfigException;
 
 /**
  * Exception indicating a sail configuration problem.
  * 
  * @author Arjohn Kampman
  */
-public class SailConfigException extends RDF4JException {
+public class SailConfigException extends RDF4JConfigException {
 
 	private static final long serialVersionUID = 185213210952981723L;
 


### PR DESCRIPTION
This PR addresses GitHub issue: #255

Briefly describe the changes proposed in this PR:

- default value of url length threshold set to 4083
- threshold now configurable via system property 'rdf4j.sparql.url.maxlength'

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [ ] tests are included
- [x] all tests succeed
