### PR TITLE
fix issue #258

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ pom.xml.versionsBackup
 
 # Mac nonsense
 .DS_Store
+
+# NetBean files
+**/nb-configuration.xml
+**/nbactions*.xml


### PR DESCRIPTION
This PR addresses GitHub issue: #258 

Briefly describe the changes proposed in this PR:

- added NetBeans files patterns to .gitignore

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x ] RDF4J code formatting has been applied
- tests are included   :: **NA**
- all tests succeed   **NA**

ignore NetBeans IDE files
Signed-off-by:Jacek Grzebyta <grzebyta.dev@gmail.com>