### PR TITLE
issue#254 : Change TriG parser to not assume "GRAPH" is the SPARQL Keyword

### DIFF
--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
@@ -70,9 +70,10 @@ public class TriGParserCustomTest {
 	public void testSPARQLGraphKeyword()
 		throws Exception
 	{
-		Model model = Rio.parse(new StringReader("GRAPH <urn:a> { [] <http://www.example.net/test> \"Foo\" }"), "",
+		Model model = Rio.parse(
+				new StringReader("GRAPH <urn:a> { [] <http://www.example.net/test> \"Foo\" }"), "",
 				RDFFormat.TRIG);
-		
+
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
 		assertEquals("urn:a", model.contexts().iterator().next().stringValue());
@@ -87,7 +88,7 @@ public class TriGParserCustomTest {
 	{
 		Model model = Rio.parse(new StringReader("<urn:a> { [] <http://www.example.net/test> \"Foo\" }"), "",
 				RDFFormat.TRIG);
-		
+
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
 		assertEquals("urn:a", model.contexts().iterator().next().stringValue());
@@ -100,9 +101,11 @@ public class TriGParserCustomTest {
 	public void testGraphLocalNameGraph()
 		throws Exception
 	{
-		Model model = Rio.parse(new StringReader("@prefix graph: <urn:> .\n graph:a { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
-		
+		Model model = Rio.parse(
+				new StringReader(
+						"@prefix graph: <urn:> .\n graph:a { [] <http://www.example.net/test> \"Foo\" }"),
+				"", RDFFormat.TRIG);
+
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
 		assertEquals("urn:a", model.contexts().iterator().next().stringValue());
@@ -110,14 +113,16 @@ public class TriGParserCustomTest {
 		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
 		assertEquals("Foo", model.objects().iterator().next().stringValue());
 	}
-	
+
 	@Test
 	public void testGraphLocalNameIntegerGraph()
 		throws Exception
 	{
-		Model model = Rio.parse(new StringReader("@prefix graph: <urn:> .\n graph:1 { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
-		
+		Model model = Rio.parse(
+				new StringReader(
+						"@prefix graph: <urn:> .\n graph:1 { [] <http://www.example.net/test> \"Foo\" }"),
+				"", RDFFormat.TRIG);
+
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
 		assertEquals("urn:1", model.contexts().iterator().next().stringValue());
@@ -125,14 +130,15 @@ public class TriGParserCustomTest {
 		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
 		assertEquals("Foo", model.objects().iterator().next().stringValue());
 	}
-	
+
 	@Test
 	public void testGraphLocalNameNotGraph()
 		throws Exception
 	{
-		Model model = Rio.parse(new StringReader("@prefix ex: <urn:> .\n ex:a { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
-		
+		Model model = Rio.parse(
+				new StringReader("@prefix ex: <urn:> .\n ex:a { [] <http://www.example.net/test> \"Foo\" }"),
+				"", RDFFormat.TRIG);
+
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
 		assertEquals("urn:a", model.contexts().iterator().next().stringValue());
@@ -140,14 +146,15 @@ public class TriGParserCustomTest {
 		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
 		assertEquals("Foo", model.objects().iterator().next().stringValue());
 	}
-	
+
 	@Test
 	public void testGraphLocalNameIntegerNotGraph()
 		throws Exception
 	{
-		Model model = Rio.parse(new StringReader("@prefix ex: <urn:> .\n ex:1 { [] <http://www.example.net/test> \"Foo\" }"), "",
-				RDFFormat.TRIG);
-		
+		Model model = Rio.parse(
+				new StringReader("@prefix ex: <urn:> .\n ex:1 { [] <http://www.example.net/test> \"Foo\" }"),
+				"", RDFFormat.TRIG);
+
 		assertEquals(1, model.size());
 		assertNotNull(model.contexts().iterator().next());
 		assertEquals("urn:1", model.contexts().iterator().next().stringValue());
@@ -155,7 +162,7 @@ public class TriGParserCustomTest {
 		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
 		assertEquals("Foo", model.objects().iterator().next().stringValue());
 	}
-	
+
 	@Test
 	public void testTrailingSemicolon()
 		throws Exception

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
@@ -10,7 +10,10 @@ package org.eclipse.rdf4j.rio.trig;
 import static org.junit.Assert.*;
 
 import java.io.StringReader;
+import java.util.concurrent.TimeUnit;
 
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -35,7 +38,7 @@ import org.junit.rules.Timeout;
 public class TriGParserCustomTest {
 
 	@Rule
-	public Timeout timeout = new Timeout(1000000);
+	public Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
 
 	private ValueFactory vf;
 
@@ -67,10 +70,62 @@ public class TriGParserCustomTest {
 	public void testSPARQLGraphKeyword()
 		throws Exception
 	{
-		Rio.parse(new StringReader("GRAPH <urn:a> { [] <http://www.example.net/test> \"Foo\" }"), "",
+		Model model = Rio.parse(new StringReader("GRAPH <urn:a> { [] <http://www.example.net/test> \"Foo\" }"), "",
 				RDFFormat.TRIG);
+		
+		assertEquals(1, model.size());
+		assertNotNull(model.contexts().iterator().next());
+		assertEquals("urn:a", model.contexts().iterator().next().stringValue());
+		assertTrue(model.subjects().iterator().next() instanceof BNode);
+		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
+		assertEquals("Foo", model.objects().iterator().next().stringValue());
 	}
 
+	@Test
+	public void testGraph()
+		throws Exception
+	{
+		Model model = Rio.parse(new StringReader("<urn:a> { [] <http://www.example.net/test> \"Foo\" }"), "",
+				RDFFormat.TRIG);
+		
+		assertEquals(1, model.size());
+		assertNotNull(model.contexts().iterator().next());
+		assertEquals("urn:a", model.contexts().iterator().next().stringValue());
+		assertTrue(model.subjects().iterator().next() instanceof BNode);
+		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
+		assertEquals("Foo", model.objects().iterator().next().stringValue());
+	}
+
+	@Test
+	public void testGraphLocalName()
+		throws Exception
+	{
+		Model model = Rio.parse(new StringReader("@prefix graph: <urn:> .\n graph:a { [] <http://www.example.net/test> \"Foo\" }"), "",
+				RDFFormat.TRIG);
+		
+		assertEquals(1, model.size());
+		assertNotNull(model.contexts().iterator().next());
+		assertEquals("urn:a", model.contexts().iterator().next().stringValue());
+		assertTrue(model.subjects().iterator().next() instanceof BNode);
+		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
+		assertEquals("Foo", model.objects().iterator().next().stringValue());
+	}
+	
+	@Test
+	public void testGraphLocalNameInteger()
+		throws Exception
+	{
+		Model model = Rio.parse(new StringReader("@prefix graph: <urn:> .\n graph:1 { [] <http://www.example.net/test> \"Foo\" }"), "",
+				RDFFormat.TRIG);
+		
+		assertEquals(1, model.size());
+		assertNotNull(model.contexts().iterator().next());
+		assertEquals("urn:1", model.contexts().iterator().next().stringValue());
+		assertTrue(model.subjects().iterator().next() instanceof BNode);
+		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
+		assertEquals("Foo", model.objects().iterator().next().stringValue());
+	}
+	
 	@Test
 	public void testTrailingSemicolon()
 		throws Exception

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
@@ -97,7 +97,7 @@ public class TriGParserCustomTest {
 	}
 
 	@Test
-	public void testGraphLocalName()
+	public void testGraphLocalNameGraph()
 		throws Exception
 	{
 		Model model = Rio.parse(new StringReader("@prefix graph: <urn:> .\n graph:a { [] <http://www.example.net/test> \"Foo\" }"), "",
@@ -112,10 +112,40 @@ public class TriGParserCustomTest {
 	}
 	
 	@Test
-	public void testGraphLocalNameInteger()
+	public void testGraphLocalNameIntegerGraph()
 		throws Exception
 	{
 		Model model = Rio.parse(new StringReader("@prefix graph: <urn:> .\n graph:1 { [] <http://www.example.net/test> \"Foo\" }"), "",
+				RDFFormat.TRIG);
+		
+		assertEquals(1, model.size());
+		assertNotNull(model.contexts().iterator().next());
+		assertEquals("urn:1", model.contexts().iterator().next().stringValue());
+		assertTrue(model.subjects().iterator().next() instanceof BNode);
+		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
+		assertEquals("Foo", model.objects().iterator().next().stringValue());
+	}
+	
+	@Test
+	public void testGraphLocalNameNotGraph()
+		throws Exception
+	{
+		Model model = Rio.parse(new StringReader("@prefix ex: <urn:> .\n ex:a { [] <http://www.example.net/test> \"Foo\" }"), "",
+				RDFFormat.TRIG);
+		
+		assertEquals(1, model.size());
+		assertNotNull(model.contexts().iterator().next());
+		assertEquals("urn:a", model.contexts().iterator().next().stringValue());
+		assertTrue(model.subjects().iterator().next() instanceof BNode);
+		assertEquals("http://www.example.net/test", model.predicates().iterator().next().stringValue());
+		assertEquals("Foo", model.objects().iterator().next().stringValue());
+	}
+	
+	@Test
+	public void testGraphLocalNameIntegerNotGraph()
+		throws Exception
+	{
+		Model model = Rio.parse(new StringReader("@prefix ex: <urn:> .\n ex:1 { [] <http://www.example.net/test> \"Foo\" }"), "",
 				RDFFormat.TRIG);
 		
 		assertEquals(1, model.size());

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParser.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParser.java
@@ -22,14 +22,12 @@ import org.eclipse.rdf4j.rio.turtle.TurtleParser;
 import org.eclipse.rdf4j.rio.turtle.TurtleUtil;
 
 /**
- * RDF parser for <a href="http://www.wiwiss.fu-berlin.de/suhl/bizer/TriG/Spec/">TriG</a> files. This parser
- * is not thread-safe, therefore its public methods are synchronized.
- * <p>
- * This implementation is based on the 2005/06/06 version of the TriG specification, but implemented as an
- * extension of the <a href="http://www.dajobe.org/2004/01/turtle/">Turtle</a> specification of 2006/01/02.
+ * RDF parser for <a href="https://www.w3.org/TR/trig/">RDF-1.1 TriG</a> files. This parser is not
+ * thread-safe, therefore its public methods are synchronized.
  * 
- * @see TurtleParser
  * @author Arjohn Kampman
+ * @author Peter Ansell
+ * @see TurtleParser
  */
 public class TriGParser extends TurtleParser {
 
@@ -100,6 +98,14 @@ public class TriGParser extends TurtleParser {
 			parseDirective(directive);
 			skipWSC();
 			// SPARQL BASE and PREFIX lines do not end in .
+		}
+		else if (directive.length() >= 6 && directive.substring(0, 5).equalsIgnoreCase("GRAPH")
+				&& directive.substring(5, 6).equals(":"))
+		{
+			// If there was a colon immediately after the graph keyword then
+			// assume it was a pname and not the SPARQL GRAPH keyword
+			unread(directive);
+			parseGraph();
 		}
 		else if (directive.length() >= 5 && directive.substring(0, 5).equalsIgnoreCase("GRAPH")) {
 			// Do not unread the directive if it was SPARQL GRAPH
@@ -190,7 +196,8 @@ public class TriGParser extends TurtleParser {
 		else {
 			setContext(null);
 
-			// Did not turn out to be a graph, so assign it to subject instead and
+			// Did not turn out to be a graph, so assign it to subject instead
+			// and
 			// parse from here to triples
 			if (foundContextOrSubject) {
 				subject = contextOrSubject;
@@ -233,7 +240,8 @@ public class TriGParser extends TurtleParser {
 			c = peekCodePoint();
 
 			// if this is not the end of the statement, recurse into the list of
-			// predicate and objects, using the subject parsed above as the subject
+			// predicate and objects, using the subject parsed above as the
+			// subject
 			// of the statement.
 			if (c != '.' && c != '}') {
 				parsePredicateObjectList();

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -39,22 +39,21 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.TurtleParserSettings;
 
 /**
- * RDF parser for <a href="http://www.dajobe.org/2004/01/turtle/">Turtle</a> files. This parser is not
- * thread-safe, therefore its public methods are synchronized.
+ * RDF parser for <a href="https://www.w3.org/TR/turtle/">RDF-1.1 Turtle</a>
+ * files. This parser is not thread-safe, therefore its public methods are
+ * synchronized.
  * <p>
- * This implementation is based on the 2006/01/02 version of the Turtle specification, with slight deviations:
- * <ul>
- * <li>Normalization of integer, floating point and boolean values is dependent on the specified datatype
- * handling. According to the specification, integers and booleans should be normalized, but floats don't.
- * </li>
- * <li>Comments can be used anywhere in the document, and extend to the end of the line. The Turtle grammar
- * doesn't allow comments to be used inside triple constructs that extend over multiple lines, but the
- * author's own parser deviates from this too.</li>
- * <li>The localname part of a prefixed named is allowed to start with a number (cf.
- * <a href="http://www.w3.org/TR/turtle/">the W3C Turtle Working Draft</a> ).</li>
+ * <li>Normalization of integer, floating point and boolean values is dependent
+ * on the specified datatype handling. According to the specification, integers
+ * and booleans should be normalized, but floats don't.</li>
+ * <li>Comments can be used anywhere in the document, and extend to the end of
+ * the line. The Turtle grammar doesn't allow comments to be used inside triple
+ * constructs that extend over multiple lines, but the author's own parser
+ * deviates from this too.</li>
  * </ul>
  * 
  * @author Arjohn Kampman
+ * @author Peter Ansell
  */
 public class TurtleParser extends AbstractRDFParser {
 
@@ -77,17 +76,19 @@ public class TurtleParser extends AbstractRDFParser {
 	 *--------------*/
 
 	/**
-	 * Creates a new TurtleParser that will use a {@link SimpleValueFactory} to create RDF model objects.
+	 * Creates a new TurtleParser that will use a {@link SimpleValueFactory} to
+	 * create RDF model objects.
 	 */
 	public TurtleParser() {
 		super();
 	}
 
 	/**
-	 * Creates a new TurtleParser that will use the supplied ValueFactory to create RDF model objects.
+	 * Creates a new TurtleParser that will use the supplied ValueFactory to
+	 * create RDF model objects.
 	 * 
 	 * @param valueFactory
-	 *        A ValueFactory.
+	 *            A ValueFactory.
 	 */
 	public TurtleParser(ValueFactory valueFactory) {
 		super(valueFactory);
@@ -109,25 +110,29 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Implementation of the <tt>parse(InputStream, String)</tt> method defined in the RDFParser interface.
+	 * Implementation of the <tt>parse(InputStream, String)</tt> method defined
+	 * in the RDFParser interface.
 	 * 
 	 * @param in
-	 *        The InputStream from which to read the data, must not be <tt>null</tt>. The InputStream is
-	 *        supposed to contain UTF-8 encoded Unicode characters, as per the Turtle specification.
+	 *            The InputStream from which to read the data, must not be
+	 *            <tt>null</tt>. The InputStream is supposed to contain UTF-8
+	 *            encoded Unicode characters, as per the Turtle specification.
 	 * @param baseURI
-	 *        The URI associated with the data in the InputStream, must not be <tt>null</tt>.
+	 *            The URI associated with the data in the InputStream, must not
+	 *            be <tt>null</tt>.
 	 * @throws IOException
-	 *         If an I/O error occurred while data was read from the InputStream.
+	 *             If an I/O error occurred while data was read from the
+	 *             InputStream.
 	 * @throws RDFParseException
-	 *         If the parser has found an unrecoverable parse error.
+	 *             If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException
-	 *         If the configured statement handler encountered an unrecoverable error.
+	 *             If the configured statement handler encountered an
+	 *             unrecoverable error.
 	 * @throws IllegalArgumentException
-	 *         If the supplied input stream or base URI is <tt>null</tt>.
+	 *             If the supplied input stream or base URI is <tt>null</tt>.
 	 */
 	public synchronized void parse(InputStream in, String baseURI)
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+			throws IOException, RDFParseException, RDFHandlerException {
 		if (in == null) {
 			throw new IllegalArgumentException("Input stream must not be 'null'");
 		}
@@ -135,32 +140,35 @@ public class TurtleParser extends AbstractRDFParser {
 
 		try {
 			parse(new InputStreamReader(new BOMInputStream(in, false), "UTF-8"), baseURI);
-		}
-		catch (UnsupportedEncodingException e) {
+		} catch (UnsupportedEncodingException e) {
 			// Every platform should support the UTF-8 encoding...
 			throw new RuntimeException(e);
 		}
 	}
 
 	/**
-	 * Implementation of the <tt>parse(Reader, String)</tt> method defined in the RDFParser interface.
+	 * Implementation of the <tt>parse(Reader, String)</tt> method defined in
+	 * the RDFParser interface.
 	 * 
 	 * @param reader
-	 *        The Reader from which to read the data, must not be <tt>null</tt>.
+	 *            The Reader from which to read the data, must not be
+	 *            <tt>null</tt>.
 	 * @param baseURI
-	 *        The URI associated with the data in the Reader, must not be <tt>null</tt>.
+	 *            The URI associated with the data in the Reader, must not be
+	 *            <tt>null</tt>.
 	 * @throws IOException
-	 *         If an I/O error occurred while data was read from the InputStream.
+	 *             If an I/O error occurred while data was read from the
+	 *             InputStream.
 	 * @throws RDFParseException
-	 *         If the parser has found an unrecoverable parse error.
+	 *             If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException
-	 *         If the configured statement handler encountered an unrecoverable error.
+	 *             If the configured statement handler encountered an
+	 *             unrecoverable error.
 	 * @throws IllegalArgumentException
-	 *         If the supplied reader or base URI is <tt>null</tt>.
+	 *             If the supplied reader or base URI is <tt>null</tt>.
 	 */
 	public synchronized void parse(Reader reader, String baseURI)
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+			throws IOException, RDFParseException, RDFHandlerException {
 		if (reader == null) {
 			throw new IllegalArgumentException("Reader must not be 'null'");
 		}
@@ -190,8 +198,7 @@ public class TurtleParser extends AbstractRDFParser {
 				parseStatement();
 				c = skipWSC();
 			}
-		}
-		finally {
+		} finally {
 			clear();
 		}
 
@@ -200,9 +207,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseStatement()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parseStatement() throws IOException, RDFParseException, RDFHandlerException {
 
 		StringBuilder sb = new StringBuilder(8);
 
@@ -215,22 +220,18 @@ public class TurtleParser extends AbstractRDFParser {
 				break;
 			}
 			sb.append(Character.toChars(codePoint));
-		}
-		while (sb.length() < 8);
+		} while (sb.length() < 8);
 
 		String directive = sb.toString();
 
-		if (directive.startsWith("@") || directive.equalsIgnoreCase("prefix")
-				|| directive.equalsIgnoreCase("base"))
-		{
+		if (directive.startsWith("@") || directive.equalsIgnoreCase("prefix") || directive.equalsIgnoreCase("base")) {
 			parseDirective(directive);
 			skipWSC();
 			// SPARQL BASE and PREFIX lines do not end in .
 			if (directive.startsWith("@")) {
 				verifyCharacterOrFail(readCodePoint(), ".");
 			}
-		}
-		else {
+		} else {
 			unread(directive);
 			parseTriples();
 			skipWSC();
@@ -238,66 +239,54 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseDirective(String directive)
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parseDirective(String directive) throws IOException, RDFParseException, RDFHandlerException {
 		if (directive.length() >= 7 && directive.substring(0, 7).equals("@prefix")) {
 			if (directive.length() > 7) {
 				unread(directive.substring(7));
 			}
 			parsePrefixID();
-		}
-		else if (directive.length() >= 5 && directive.substring(0, 5).equals("@base")) {
+		} else if (directive.length() >= 5 && directive.substring(0, 5).equals("@base")) {
 			if (directive.length() > 5) {
 				unread(directive.substring(5));
 			}
 			parseBase();
-		}
-		else if (directive.length() >= 6 && directive.substring(0, 6).equalsIgnoreCase("prefix")) {
-			// SPARQL doesn't require whitespace after directive, so must unread if
+		} else if (directive.length() >= 6 && directive.substring(0, 6).equalsIgnoreCase("prefix")) {
+			// SPARQL doesn't require whitespace after directive, so must unread
+			// if
 			// we found part of the prefixID
 			if (directive.length() > 6) {
 				unread(directive.substring(6));
 			}
 			parsePrefixID();
-		}
-		else if ((directive.length() >= 4 && directive.substring(0, 4).equalsIgnoreCase("base"))) {
+		} else if ((directive.length() >= 4 && directive.substring(0, 4).equalsIgnoreCase("base"))) {
 			if (directive.length() > 4) {
 				unread(directive.substring(4));
 			}
 			parseBase();
-		}
-		else if (directive.length() >= 7 && directive.substring(0, 7).equalsIgnoreCase("@prefix")) {
+		} else if (directive.length() >= 7 && directive.substring(0, 7).equalsIgnoreCase("@prefix")) {
 			if (!this.getParserConfig().get(TurtleParserSettings.CASE_INSENSITIVE_DIRECTIVES)) {
-				reportFatalError(
-						"Cannot strictly support case-insensitive @prefix directive in compliance mode.");
+				reportFatalError("Cannot strictly support case-insensitive @prefix directive in compliance mode.");
 			}
 			if (directive.length() > 7) {
 				unread(directive.substring(7));
 			}
 			parsePrefixID();
-		}
-		else if (directive.length() >= 5 && directive.substring(0, 5).equalsIgnoreCase("@base")) {
+		} else if (directive.length() >= 5 && directive.substring(0, 5).equalsIgnoreCase("@base")) {
 			if (!this.getParserConfig().get(TurtleParserSettings.CASE_INSENSITIVE_DIRECTIVES)) {
-				reportFatalError(
-						"Cannot strictly support case-insensitive @base directive in compliance mode.");
+				reportFatalError("Cannot strictly support case-insensitive @base directive in compliance mode.");
 			}
 			if (directive.length() > 5) {
 				unread(directive.substring(5));
 			}
 			parseBase();
-		}
-		else if (directive.length() == 0) {
+		} else if (directive.length() == 0) {
 			reportFatalError("Directive name is missing, expected @prefix or @base");
-		}
-		else {
+		} else {
 			reportFatalError("Unknown directive \"" + directive + "\"");
 		}
 	}
 
-	protected void parsePrefixID()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parsePrefixID() throws IOException, RDFParseException, RDFHandlerException {
 		skipWSC();
 
 		// Read prefix ID (e.g. "rdf:" or ":")
@@ -309,11 +298,9 @@ public class TurtleParser extends AbstractRDFParser {
 			if (c == ':') {
 				unread(c);
 				break;
-			}
-			else if (TurtleUtil.isWhitespace(c)) {
+			} else if (TurtleUtil.isWhitespace(c)) {
 				break;
-			}
-			else if (c == -1) {
+			} else if (c == -1) {
 				throwEOFException();
 			}
 
@@ -340,9 +327,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseBase()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parseBase() throws IOException, RDFParseException, RDFHandlerException {
 		skipWSC();
 
 		IRI baseURI = parseURI();
@@ -350,9 +335,7 @@ public class TurtleParser extends AbstractRDFParser {
 		setBaseURI(baseURI.toString());
 	}
 
-	protected void parseTriples()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parseTriples() throws IOException, RDFParseException, RDFHandlerException {
 		int c = peekCodePoint();
 
 		// If the first character is an open bracket we need to decide which of
@@ -366,8 +349,7 @@ public class TurtleParser extends AbstractRDFParser {
 				subject = createBNode();
 				skipWSC();
 				parsePredicateObjectList();
-			}
-			else {
+			} else {
 				unread('[');
 				subject = parseImplicitBlank();
 			}
@@ -375,13 +357,13 @@ public class TurtleParser extends AbstractRDFParser {
 			c = peekCodePoint();
 
 			// if this is not the end of the statement, recurse into the list of
-			// predicate and objects, using the subject parsed above as the subject
+			// predicate and objects, using the subject parsed above as the
+			// subject
 			// of the statement.
 			if (c != '.') {
 				parsePredicateObjectList();
 			}
-		}
-		else {
+		} else {
 			parseSubject();
 			skipWSC();
 			parsePredicateObjectList();
@@ -392,9 +374,7 @@ public class TurtleParser extends AbstractRDFParser {
 		object = null;
 	}
 
-	protected void parsePredicateObjectList()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parsePredicateObjectList() throws IOException, RDFParseException, RDFHandlerException {
 		predicate = parsePredicate();
 
 		skipWSC();
@@ -407,12 +387,12 @@ public class TurtleParser extends AbstractRDFParser {
 			int c = skipWSC();
 
 			if (c == '.' || // end of triple
-					c == ']' || c == '}') // end of predicateObjectList inside blank
-									// node
+					c == ']' || c == '}') // end of predicateObjectList inside
+											// blank
+			// node
 			{
 				break;
-			}
-			else if (c == ';') {
+			} else if (c == ';') {
 				// empty predicateObjectList, skip to next
 				continue;
 			}
@@ -425,9 +405,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseObjectList()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parseObjectList() throws IOException, RDFParseException, RDFHandlerException {
 		parseObject();
 
 		while (skipWSC() == ',') {
@@ -437,32 +415,25 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseSubject()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parseSubject() throws IOException, RDFParseException, RDFHandlerException {
 		int c = peekCodePoint();
 
 		if (c == '(') {
 			subject = parseCollection();
-		}
-		else if (c == '[') {
+		} else if (c == '[') {
 			subject = parseImplicitBlank();
-		}
-		else {
+		} else {
 			Value value = parseValue();
 
 			if (value instanceof Resource) {
-				subject = (Resource)value;
-			}
-			else if (value != null) {
+				subject = (Resource) value;
+			} else if (value != null) {
 				reportFatalError("Illegal subject value: " + value);
 			}
 		}
 	}
 
-	protected IRI parsePredicate()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected IRI parsePredicate() throws IOException, RDFParseException, RDFHandlerException {
 		// Check if the short-cut 'a' is used
 		int c1 = readCodePoint();
 
@@ -482,26 +453,21 @@ public class TurtleParser extends AbstractRDFParser {
 		// Predicate is a normal resource
 		Value predicate = parseValue();
 		if (predicate instanceof IRI) {
-			return (IRI)predicate;
-		}
-		else {
+			return (IRI) predicate;
+		} else {
 			reportFatalError("Illegal predicate value: " + predicate);
 			return null;
 		}
 	}
 
-	protected void parseObject()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected void parseObject() throws IOException, RDFParseException, RDFHandlerException {
 		int c = peekCodePoint();
 
 		if (c == '(') {
 			object = parseCollection();
-		}
-		else if (c == '[') {
+		} else if (c == '[') {
 			object = parseImplicitBlank();
-		}
-		else {
+		} else {
 			object = parseValue();
 		}
 
@@ -511,9 +477,7 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses a collection, e.g. <tt>( item1 item2 item3 )</tt>.
 	 */
-	protected Resource parseCollection()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected Resource parseCollection() throws IOException, RDFParseException, RDFHandlerException {
 		verifyCharacterOrFail(readCodePoint(), "(");
 
 		int c = skipWSC();
@@ -522,8 +486,7 @@ public class TurtleParser extends AbstractRDFParser {
 			// Empty list
 			readCodePoint();
 			return RDF.NIL;
-		}
-		else {
+		} else {
 			BNode listRoot = createBNode();
 
 			// Remember current subject and predicate
@@ -564,12 +527,10 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses an implicit blank node. This method parses the token <tt>[]</tt> and predicateObjectLists that
-	 * are surrounded by square brackets.
+	 * Parses an implicit blank node. This method parses the token <tt>[]</tt>
+	 * and predicateObjectLists that are surrounded by square brackets.
 	 */
-	protected Resource parseImplicitBlank()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected Resource parseImplicitBlank() throws IOException, RDFParseException, RDFHandlerException {
 		verifyCharacterOrFail(readCodePoint(), "[");
 
 		BNode bNode = createBNode();
@@ -604,50 +565,41 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses an RDF value. This method parses uriref, qname, node ID, quoted literal, integer, double and
-	 * boolean.
+	 * Parses an RDF value. This method parses uriref, qname, node ID, quoted
+	 * literal, integer, double and boolean.
 	 */
-	protected Value parseValue()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected Value parseValue() throws IOException, RDFParseException, RDFHandlerException {
 		int c = peekCodePoint();
 
 		if (c == '<') {
 			// uriref, e.g. <foo://bar>
 			return parseURI();
-		}
-		else if (c == ':' || TurtleUtil.isPrefixStartChar(c)) {
+		} else if (c == ':' || TurtleUtil.isPrefixStartChar(c)) {
 			// qname or boolean
 			return parseQNameOrBoolean();
-		}
-		else if (c == '_') {
+		} else if (c == '_') {
 			// node ID, e.g. _:n1
 			return parseNodeID();
-		}
-		else if (c == '"' || c == '\'') {
+		} else if (c == '"' || c == '\'') {
 			// quoted literal, e.g. "foo" or """foo""" or 'foo' or '''foo'''
 			return parseQuotedLiteral();
-		}
-		else if (ASCIIUtil.isNumber(c) || c == '.' || c == '+' || c == '-') {
+		} else if (ASCIIUtil.isNumber(c) || c == '.' || c == '+' || c == '-') {
 			// integer or double, e.g. 123 or 1.2e3
 			return parseNumber();
-		}
-		else if (c == -1) {
+		} else if (c == -1) {
 			throwEOFException();
 			return null;
-		}
-		else {
+		} else {
 			reportFatalError("Expected an RDF value here, found '" + new String(Character.toChars(c)) + "'");
 			return null;
 		}
 	}
 
 	/**
-	 * Parses a quoted string, optionally followed by a language tag or datatype.
+	 * Parses a quoted string, optionally followed by a language tag or
+	 * datatype.
 	 */
-	protected Literal parseQuotedLiteral()
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+	protected Literal parseQuotedLiteral() throws IOException, RDFParseException, RDFHandlerException {
 		String label = parseQuotedString();
 
 		// Check for presence of a language tag or datatype
@@ -674,9 +626,12 @@ public class TurtleParser extends AbstractRDFParser {
 
 			c = readCodePoint();
 			while (!TurtleUtil.isWhitespace(c)) {
-				// SES-1887 : Flexibility introduced for SES-1985 and SES-1821 needs
-				// to be counterbalanced against legitimate situations where Turtle
-				// language tags do not need whitespace following the language tag
+				// SES-1887 : Flexibility introduced for SES-1985 and SES-1821
+				// needs
+				// to be counterbalanced against legitimate situations where
+				// Turtle
+				// language tags do not need whitespace following the language
+				// tag
 				if (c == '.' || c == ';' || c == ',' || c == ')' || c == ']' || c == -1) {
 					break;
 				}
@@ -691,8 +646,7 @@ public class TurtleParser extends AbstractRDFParser {
 			unread(c);
 
 			return createLiteral(label, lang.toString(), null, getLineNumber(), -1);
-		}
-		else if (c == '^') {
+		} else if (c == '^') {
 			readCodePoint();
 
 			// next character should be another '^'
@@ -703,24 +657,21 @@ public class TurtleParser extends AbstractRDFParser {
 			// Read datatype
 			Value datatype = parseValue();
 			if (datatype instanceof IRI) {
-				return createLiteral(label, null, (IRI)datatype, getLineNumber(), -1);
-			}
-			else {
+				return createLiteral(label, null, (IRI) datatype, getLineNumber(), -1);
+			} else {
 				reportFatalError("Illegal datatype value: " + datatype);
 				return null;
 			}
-		}
-		else {
+		} else {
 			return createLiteral(label, null, null, getLineNumber(), -1);
 		}
 	}
 
 	/**
-	 * Parses a quoted string, which is either a "normal string" or a """long string""".
+	 * Parses a quoted string, which is either a "normal string" or a """long
+	 * string""".
 	 */
-	protected String parseQuotedString()
-		throws IOException, RDFParseException
-	{
+	protected String parseQuotedString() throws IOException, RDFParseException {
 		String result = null;
 
 		int c1 = readCodePoint();
@@ -735,8 +686,7 @@ public class TurtleParser extends AbstractRDFParser {
 		if ((c1 == '"' && c2 == '"' && c3 == '"') || (c1 == '\'' && c2 == '\'' && c3 == '\'')) {
 			// Long string
 			result = parseLongString(c2);
-		}
-		else {
+		} else {
 			// Normal string
 			unread(c3);
 			unread(c2);
@@ -747,8 +697,7 @@ public class TurtleParser extends AbstractRDFParser {
 		// Unescape any escape sequences
 		try {
 			result = TurtleUtil.decodeString(result);
-		}
-		catch (IllegalArgumentException e) {
+		} catch (IllegalArgumentException e) {
 			reportError(e.getMessage(), BasicParserSettings.VERIFY_DATATYPE_VALUES);
 		}
 
@@ -756,11 +705,10 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses a "normal string". This method requires that the opening character has already been parsed.
+	 * Parses a "normal string". This method requires that the opening character
+	 * has already been parsed.
 	 */
-	protected String parseString(int closingCharacter)
-		throws IOException, RDFParseException
-	{
+	protected String parseString(int closingCharacter) throws IOException, RDFParseException {
 		StringBuilder sb = new StringBuilder(32);
 
 		while (true) {
@@ -768,8 +716,7 @@ public class TurtleParser extends AbstractRDFParser {
 
 			if (c == closingCharacter) {
 				break;
-			}
-			else if (c == -1) {
+			} else if (c == -1) {
 				throwEOFException();
 			}
 
@@ -789,12 +736,10 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses a """long string""". This method requires that the first three characters have already been
-	 * parsed.
+	 * Parses a """long string""". This method requires that the first three
+	 * characters have already been parsed.
 	 */
-	protected String parseLongString(int closingCharacter)
-		throws IOException, RDFParseException
-	{
+	protected String parseLongString(int closingCharacter) throws IOException, RDFParseException {
 		StringBuilder sb = new StringBuilder(1024);
 
 		int doubleQuoteCount = 0;
@@ -805,11 +750,9 @@ public class TurtleParser extends AbstractRDFParser {
 
 			if (c == -1) {
 				throwEOFException();
-			}
-			else if (c == closingCharacter) {
+			} else if (c == closingCharacter) {
 				doubleQuoteCount++;
-			}
-			else {
+			} else {
 				doubleQuoteCount = 0;
 			}
 
@@ -828,9 +771,7 @@ public class TurtleParser extends AbstractRDFParser {
 		return sb.substring(0, sb.length() - 3);
 	}
 
-	protected Literal parseNumber()
-		throws IOException, RDFParseException
-	{
+	protected Literal parseNumber() throws IOException, RDFParseException {
 		StringBuilder value = new StringBuilder(8);
 		IRI datatype = XMLSchema.INTEGER;
 
@@ -853,10 +794,10 @@ public class TurtleParser extends AbstractRDFParser {
 			if (c == '.') {
 
 				if (TurtleUtil.isWhitespace(peekCodePoint())) {
-					// We're parsing an integer that did not have a space before the
+					// We're parsing an integer that did not have a space before
+					// the
 					// period to end the statement
-				}
-				else {
+				} else {
 					value.append(Character.toChars(c));
 
 					c = readCodePoint();
@@ -874,8 +815,7 @@ public class TurtleParser extends AbstractRDFParser {
 					// We're parsing a decimal or a double
 					datatype = XMLSchema.DECIMAL;
 				}
-			}
-			else {
+			} else {
 				if (value.length() == 0) {
 					// We've only parsed an 'e' or 'E'
 					reportFatalError("Object for statement missing");
@@ -926,9 +866,7 @@ public class TurtleParser extends AbstractRDFParser {
 		return createLiteral(value.toString(), null, datatype, getLineNumber(), -1);
 	}
 
-	protected IRI parseURI()
-		throws IOException, RDFParseException
-	{
+	protected IRI parseURI() throws IOException, RDFParseException {
 		StringBuilder uriBuf = new StringBuilder(100);
 
 		// First character should be '<'
@@ -942,14 +880,12 @@ public class TurtleParser extends AbstractRDFParser {
 
 			if (c == '>') {
 				break;
-			}
-			else if (c == -1) {
+			} else if (c == -1) {
 				throwEOFException();
 			}
 
 			if (c == ' ') {
-				reportError("IRI included an unencoded space: '" + c + "'",
-						BasicParserSettings.VERIFY_URI_SYNTAX);
+				reportError("IRI included an unencoded space: '" + c + "'", BasicParserSettings.VERIFY_URI_SYNTAX);
 				uriIsIllegal = true;
 			}
 
@@ -962,8 +898,7 @@ public class TurtleParser extends AbstractRDFParser {
 					throwEOFException();
 				}
 				if (c != 'u' && c != 'U') {
-					reportError("IRI includes string escapes: '\\" + c + "'",
-							BasicParserSettings.VERIFY_URI_SYNTAX);
+					reportError("IRI includes string escapes: '\\" + c + "'", BasicParserSettings.VERIFY_URI_SYNTAX);
 					uriIsIllegal = true;
 				}
 				uriBuf.append(Character.toChars(c));
@@ -982,12 +917,12 @@ public class TurtleParser extends AbstractRDFParser {
 
 			// Unescape any escape sequences
 			try {
-				// FIXME: The following decodes \n and similar in URIs, which should
+				// FIXME: The following decodes \n and similar in URIs, which
+				// should
 				// be
 				// invalid according to test <turtle-syntax-bad-uri-04.ttl>
 				uri = TurtleUtil.decodeString(uri);
-			}
-			catch (IllegalArgumentException e) {
+			} catch (IllegalArgumentException e) {
 				reportError(e.getMessage(), BasicParserSettings.VERIFY_DATATYPE_VALUES);
 			}
 
@@ -998,11 +933,10 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses qnames and boolean values, which have equivalent starting characters.
+	 * Parses qnames and boolean values, which have equivalent starting
+	 * characters.
 	 */
-	protected Value parseQNameOrBoolean()
-		throws IOException, RDFParseException
-	{
+	protected Value parseQNameOrBoolean() throws IOException, RDFParseException {
 		// First character should be a ':' or a letter
 		int c = readCodePoint();
 		if (c == -1) {
@@ -1018,8 +952,7 @@ public class TurtleParser extends AbstractRDFParser {
 		if (c == ':') {
 			// qname using default namespace
 			namespace = getNamespace("");
-		}
-		else {
+		} else {
 			// c is the first letter of the prefix
 			StringBuilder prefix = new StringBuilder(8);
 			prefix.append(Character.toChars(c));
@@ -1040,10 +973,10 @@ public class TurtleParser extends AbstractRDFParser {
 					unread(c);
 					return createLiteral(value, null, XMLSchema.BOOLEAN, getLineNumber(), -1);
 				}
-			}
-			else {
+			} else {
 				if (previousChar == '.') {
-					// '.' is a legal prefix name char, but can not appear at the end
+					// '.' is a legal prefix name char, but can not appear at
+					// the end
 					reportFatalError("prefix can not end with with '.'");
 				}
 			}
@@ -1059,8 +992,7 @@ public class TurtleParser extends AbstractRDFParser {
 		if (TurtleUtil.isNameStartChar(c)) {
 			if (c == '\\') {
 				localName.append(readLocalEscapedChar());
-			}
-			else {
+			} else {
 				localName.append(Character.toChars(c));
 			}
 
@@ -1069,8 +1001,7 @@ public class TurtleParser extends AbstractRDFParser {
 			while (TurtleUtil.isNameChar(c)) {
 				if (c == '\\') {
 					localName.append(readLocalEscapedChar());
-				}
-				else {
+				} else {
 					localName.append(Character.toChars(c));
 				}
 				previousChar = c;
@@ -1081,13 +1012,13 @@ public class TurtleParser extends AbstractRDFParser {
 			unread(c);
 
 			if (previousChar == '.') {
-				// '.' is a legal name char, but can not appear at the end, so is
+				// '.' is a legal name char, but can not appear at the end, so
+				// is
 				// not actually part of the name
 				unread(previousChar);
 				localName.deleteCharAt(localName.length() - 1);
 			}
-		}
-		else {
+		} else {
 			// Unread last character
 			unread(c);
 		}
@@ -1097,8 +1028,7 @@ public class TurtleParser extends AbstractRDFParser {
 		for (int i = 0; i < localNameString.length(); i++) {
 			if (localNameString.charAt(i) == '%') {
 				if (i > localNameString.length() - 3 || !ASCIIUtil.isHex(localNameString.charAt(i + 1))
-						|| !ASCIIUtil.isHex(localNameString.charAt(i + 2)))
-				{
+						|| !ASCIIUtil.isHex(localNameString.charAt(i + 2))) {
 					reportFatalError("Found incomplete percent-encoded sequence: " + localNameString);
 				}
 			}
@@ -1112,15 +1042,12 @@ public class TurtleParser extends AbstractRDFParser {
 		return createURI(namespace + localNameString);
 	}
 
-	private char readLocalEscapedChar()
-		throws RDFParseException, IOException
-	{
+	private char readLocalEscapedChar() throws RDFParseException, IOException {
 		int c = readCodePoint();
 
 		if (TurtleUtil.isLocalEscapedChar(c)) {
-			return (char)c;
-		}
-		else {
+			return (char) c;
+		} else {
 			throw new RDFParseException("found '" + new String(Character.toChars(c)) + "', expected one of: "
 					+ Arrays.toString(TurtleUtil.LOCAL_ESCAPED_CHARS));
 		}
@@ -1129,9 +1056,7 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses a blank node ID, e.g. <tt>_:node1</tt>.
 	 */
-	protected BNode parseNodeID()
-		throws IOException, RDFParseException
-	{
+	protected BNode parseNodeID() throws IOException, RDFParseException {
 		// Node ID should start with "_:"
 		verifyCharacterOrFail(readCodePoint(), "_");
 		verifyCharacterOrFail(readCodePoint(), ":");
@@ -1140,9 +1065,8 @@ public class TurtleParser extends AbstractRDFParser {
 		int c = readCodePoint();
 		if (c == -1) {
 			throwEOFException();
-		}
-		else if (!TurtleUtil.isBLANK_NODE_LABEL_StartChar(c)) {
-			reportError("Expected a letter, found '" + (char)c + "'", BasicParserSettings.PRESERVE_BNODE_IDS);
+		} else if (!TurtleUtil.isBLANK_NODE_LABEL_StartChar(c)) {
+			reportError("Expected a letter, found '" + (char) c + "'", BasicParserSettings.PRESERVE_BNODE_IDS);
 		}
 
 		StringBuilder name = new StringBuilder(32);
@@ -1165,7 +1089,7 @@ public class TurtleParser extends AbstractRDFParser {
 				unread(previous);
 				break;
 			}
-			name.append((char)previous);
+			name.append((char) previous);
 			if (!TurtleUtil.isBLANK_NODE_LABEL_Char(c)) {
 				unread(c);
 			}
@@ -1174,9 +1098,7 @@ public class TurtleParser extends AbstractRDFParser {
 		return createBNode(name.toString());
 	}
 
-	protected void reportStatement(Resource subj, IRI pred, Value obj)
-		throws RDFParseException, RDFHandlerException
-	{
+	protected void reportStatement(Resource subj, IRI pred, Value obj) throws RDFParseException, RDFHandlerException {
 		if (subj != null && pred != null && obj != null) {
 			Statement st = createStatement(subj, pred, obj);
 			if (rdfHandler != null) {
@@ -1186,13 +1108,11 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Verifies that the supplied character code point <tt>codePoint</tt> is one of the expected characters
-	 * specified in <tt>expected</tt>. This method will throw a <tt>ParseException</tt> if this is not the
-	 * case.
+	 * Verifies that the supplied character code point <tt>codePoint</tt> is one
+	 * of the expected characters specified in <tt>expected</tt>. This method
+	 * will throw a <tt>ParseException</tt> if this is not the case.
 	 */
-	protected void verifyCharacterOrFail(int codePoint, String expected)
-		throws RDFParseException
-	{
+	protected void verifyCharacterOrFail(int codePoint, String expected) throws RDFParseException {
 		if (codePoint == -1) {
 			throwEOFException();
 		}
@@ -1219,22 +1139,21 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Consumes any white space characters (space, tab, line feed, newline) and comments (#-style) from
-	 * <tt>reader</tt>. After this method has been called, the first character that is returned by
-	 * <tt>reader</tt> is either a non-ignorable character, or EOF. For convenience, this character is also
-	 * returned by this method.
+	 * Consumes any white space characters (space, tab, line feed, newline) and
+	 * comments (#-style) from <tt>reader</tt>. After this method has been
+	 * called, the first character that is returned by <tt>reader</tt> is either
+	 * a non-ignorable character, or EOF. For convenience, this character is
+	 * also returned by this method.
 	 * 
-	 * @return The next character code point that will be returned by <tt>reader</tt>.
+	 * @return The next character code point that will be returned by
+	 *         <tt>reader</tt>.
 	 */
-	protected int skipWSC()
-		throws IOException, RDFHandlerException
-	{
+	protected int skipWSC() throws IOException, RDFHandlerException {
 		int c = readCodePoint();
 		while (TurtleUtil.isWhitespace(c) || c == '#') {
 			if (c == '#') {
 				processComment();
-			}
-			else if (c == '\n') {
+			} else if (c == '\n') {
 				// we only count line feeds (LF), not carriage return (CR), as
 				// normally a CR is immediately followed by a LF.
 				lineNumber++;
@@ -1249,12 +1168,10 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Consumes characters from reader until the first EOL has been read. This line of text is then passed to
-	 * the {@link #rdfHandler} as a comment.
+	 * Consumes characters from reader until the first EOL has been read. This
+	 * line of text is then passed to the {@link #rdfHandler} as a comment.
 	 */
-	protected void processComment()
-		throws IOException, RDFHandlerException
-	{
+	protected void processComment() throws IOException, RDFHandlerException {
 		StringBuilder comment = new StringBuilder(64);
 		int c = readCodePoint();
 		while (c != -1 && c != 0xD && c != 0xA) {
@@ -1280,74 +1197,69 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Reads the next Unicode code point.
 	 * 
-	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
+	 * @return the next Unicode code point, or -1 if the end of the stream has
+	 *         been reached.
 	 * @throws IOException
 	 */
-	protected int readCodePoint()
-		throws IOException
-	{
+	protected int readCodePoint() throws IOException {
 		int next = reader.read();
-		if (Character.isHighSurrogate((char)next)) {
-			next = Character.toCodePoint((char)next, (char)reader.read());
+		if (Character.isHighSurrogate((char) next)) {
+			next = Character.toCodePoint((char) next, (char) reader.read());
 		}
 		return next;
 	}
 
 	/**
-	 * Pushes back a single code point by copying it to the front of the buffer. After this method returns, a
-	 * call to {@link #readCodePoint()} will return the same code point c again.
+	 * Pushes back a single code point by copying it to the front of the buffer.
+	 * After this method returns, a call to {@link #readCodePoint()} will return
+	 * the same code point c again.
 	 * 
 	 * @param codePoint
-	 *        a single Unicode code point.
+	 *            a single Unicode code point.
 	 * @throws IOException
 	 */
-	protected void unread(int codePoint)
-		throws IOException
-	{
+	protected void unread(int codePoint) throws IOException {
 		if (codePoint != -1) {
 			if (Character.isSupplementaryCodePoint(codePoint)) {
 				final char[] surrogatePair = Character.toChars(codePoint);
 				reader.unread(surrogatePair);
-			}
-			else {
+			} else {
 				reader.unread(codePoint);
 			}
 		}
 	}
 
 	/**
-	 * Pushes back the supplied string by copying it to the front of the buffer. After this method returns,
-	 * successive calls to {@link #readCodePoint()} will return the code points in the supplied string again,
-	 * starting at the first in the String..
+	 * Pushes back the supplied string by copying it to the front of the buffer.
+	 * After this method returns, successive calls to {@link #readCodePoint()}
+	 * will return the code points in the supplied string again, starting at the
+	 * first in the String..
 	 * 
 	 * @param string
-	 *        the string to un-read.
+	 *            the string to un-read.
 	 * @throws IOException
 	 */
-	protected void unread(String string)
-		throws IOException
-	{
+	protected void unread(String string) throws IOException {
 		for (int i = string.codePointCount(0, string.length()); i >= 1; i--) {
 			final int codePoint = string.codePointBefore(i);
 			if (Character.isSupplementaryCodePoint(codePoint)) {
 				final char[] surrogatePair = Character.toChars(codePoint);
 				reader.unread(surrogatePair);
-			}
-			else {
+			} else {
 				reader.unread(codePoint);
 			}
 		}
 	}
 
 	/**
-	 * Peeks at the next Unicode code point without advancing the reader, and returns its value.
+	 * Peeks at the next Unicode code point without advancing the reader, and
+	 * returns its value.
 	 * 
-	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
+	 * @return the next Unicode code point, or -1 if the end of the stream has
+	 *         been reached.
 	 * @throws IOException
 	 */
-	protected int peekCodePoint()
-		throws IOException
-	{
+	protected int peekCodePoint() throws IOException {
 		int result = readCodePoint();
 		unread(result);
 		return result;
@@ -1358,7 +1270,8 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Overrides {@link AbstractRDFParser#reportWarning(String)}, adding line number information to the error.
+	 * Overrides {@link AbstractRDFParser#reportWarning(String)}, adding line
+	 * number information to the error.
 	 */
 	@Override
 	protected void reportWarning(String msg) {
@@ -1366,41 +1279,33 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Overrides {@link AbstractRDFParser#reportError(String, RioSetting)}, adding line number information to
-	 * the error.
+	 * Overrides {@link AbstractRDFParser#reportError(String, RioSetting)},
+	 * adding line number information to the error.
 	 */
 	@Override
-	protected void reportError(String msg, RioSetting<Boolean> setting)
-		throws RDFParseException
-	{
+	protected void reportError(String msg, RioSetting<Boolean> setting) throws RDFParseException {
 		reportError(msg, getLineNumber(), -1, setting);
 	}
 
 	/**
-	 * Overrides {@link AbstractRDFParser#reportFatalError(String)}, adding line number information to the
-	 * error.
+	 * Overrides {@link AbstractRDFParser#reportFatalError(String)}, adding line
+	 * number information to the error.
 	 */
 	@Override
-	protected void reportFatalError(String msg)
-		throws RDFParseException
-	{
+	protected void reportFatalError(String msg) throws RDFParseException {
 		reportFatalError(msg, getLineNumber(), -1);
 	}
 
 	/**
-	 * Overrides {@link AbstractRDFParser#reportFatalError(Exception)}, adding line number information to the
-	 * error.
+	 * Overrides {@link AbstractRDFParser#reportFatalError(Exception)}, adding
+	 * line number information to the error.
 	 */
 	@Override
-	protected void reportFatalError(Exception e)
-		throws RDFParseException
-	{
+	protected void reportFatalError(Exception e) throws RDFParseException {
 		reportFatalError(e, getLineNumber(), -1);
 	}
 
-	protected void throwEOFException()
-		throws RDFParseException
-	{
+	protected void throwEOFException() throws RDFParseException {
 		throw new RDFParseException("Unexpected end of file");
 	}
 


### PR DESCRIPTION
This PR addresses GitHub issue: #254 

Briefly describe the changes proposed in this PR:

- Add regression test for issue#254 to confirm bug
- Change the TriG parser to not assume that "GRAPH" is the SPARQL keyword if there is a colon immediately following it, as it could have been used as a pname in that case

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

