### PR TITLE
Issues/#264 turtle line numbers

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/SimpleParseLocationListener.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/SimpleParseLocationListener.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.rio.helpers;
+
+import org.eclipse.rdf4j.rio.ParseLocationListener;
+
+/**
+ * A simple implementation of {@link ParseLocationListener}.
+ * 
+ * @author Peter Ansell
+ */
+public class SimpleParseLocationListener implements ParseLocationListener {
+
+	private long lineNo = 0;
+
+	private long columnNo = 0;
+
+	@Override
+	public void parseLocationUpdate(long lineNo, long columnNo) {
+		this.lineNo = lineNo;
+		this.columnNo = columnNo;
+	}
+
+	/**
+	 * @return The last reported line number, -1 if the line number was not available when the location was
+	 *         updated, or 0 if none have been reported.
+	 */
+	public long getLineNo() {
+		return lineNo;
+	}
+
+	/**
+	 * @return The last reported column number, -1 if the column number was not available when the location
+	 *         was updated, or 0 if none have been reported.
+	 */
+	public long getColumnNo() {
+		return columnNo;
+	}
+}

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -1238,6 +1238,7 @@ public class TurtleParser extends AbstractRDFParser {
 				// we only count line feeds (LF), not carriage return (CR), as
 				// normally a CR is immediately followed by a LF.
 				lineNumber++;
+				reportLocation();
 			}
 
 			c = readCodePoint();

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -1405,7 +1405,7 @@ public class TurtleParser extends AbstractRDFParser {
 		throw new RDFParseException("Unexpected end of file");
 	}
 
-	private int getLineNumber() {
+	protected int getLineNumber() {
 		return lineNumber;
 	}
 }

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -1263,10 +1263,15 @@ public class TurtleParser extends AbstractRDFParser {
 			c = readCodePoint();
 		}
 
+		if (c == 0xA) {
+			lineNumber++;
+		}
+		
 		// c is equal to -1, \r or \n.
 		// In case c is equal to \r, we should also read a following \n.
 		if (c == 0xD) {
 			c = readCodePoint();
+			lineNumber++;
 
 			if (c != 0xA) {
 				unread(c);

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TestTurtleParser.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TestTurtleParser.java
@@ -228,6 +228,54 @@ public class TestTurtleParser {
 	}
 
 	@Test
+	public void testLineNumberReportingOnlySingleCommentNoEndline()
+		throws Exception
+	{
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("# This is just a comment");
+		parser.parse(in, baseURI);
+		assertEquals(1, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
+	}
+
+	@Test
+	public void testLineNumberReportingOnlySingleCommentEndline()
+		throws Exception
+	{
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("# This is just a comment\n");
+		parser.parse(in, baseURI);
+		assertEquals(2, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
+	}
+
+	@Test
+	public void testLineNumberReportingOnlySingleCommentCarriageReturn()
+		throws Exception
+	{
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("# This is just a comment\r");
+		parser.parse(in, baseURI);
+		assertEquals(2, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
+	}
+
+	@Test
+	public void testLineNumberReportingOnlySingleCommentCarriageReturnNewline()
+		throws Exception
+	{
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("# This is just a comment\r\n");
+		parser.parse(in, baseURI);
+		assertEquals(2, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
+	}
+
+	@Test
 	public void testParseBooleanLiteralComma()
 		throws Exception
 	{

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TestTurtleParser.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TestTurtleParser.java
@@ -33,6 +33,7 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
@@ -56,6 +57,8 @@ public class TestTurtleParser {
 
 	private final String baseURI = "http://example.org/";
 
+	private SimpleParseLocationListener locationListener = new SimpleParseLocationListener();
+
 	/**
 	 * @throws java.lang.Exception
 	 */
@@ -66,6 +69,7 @@ public class TestTurtleParser {
 		parser = new TurtleParser();
 		parser.setParseErrorListener(errorCollector);
 		parser.setRDFHandler(statementCollector);
+		parser.setParseLocationListener(locationListener);
 	}
 
 	@Test
@@ -170,7 +174,57 @@ public class TestTurtleParser {
 			final String error = errorCollector.getFatalErrors().get(0);
 			// expected to fail at line 9.
 			assertTrue(error.contains("(9,"));
+			assertEquals(9, locationListener.getLineNo());
+			assertEquals(-1, locationListener.getColumnNo());
 		}
+	}
+
+	@Test
+	public void testLineNumberReportingNoErrorsSingleLine()
+		throws Exception
+	{
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("<urn:a> <urn:b> <urn:c>.");
+		parser.parse(in, baseURI);
+		assertEquals(1, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
+	}
+
+	@Test
+	public void testLineNumberReportingNoErrorsSingleLineEndNewline()
+		throws Exception
+	{
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("<urn:a> <urn:b> <urn:c>.\n");
+		parser.parse(in, baseURI);
+		assertEquals(2, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
+	}
+
+	@Test
+	public void testLineNumberReportingNoErrorsMultipleLinesNoEndNewline()
+		throws Exception
+	{
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("<urn:a> <urn:b> <urn:c>.\n<urn:a> <urn:b> <urn:d>.");
+		parser.parse(in, baseURI);
+		assertEquals(2, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
+	}
+
+	@Test
+	public void testLineNumberReportingNoErrorsMultipleLinesEndNewline()
+		throws Exception
+	{
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("<urn:a> <urn:b> <urn:c>.\n<urn:a> <urn:b> <urn:d>.\n");
+		parser.parse(in, baseURI);
+		assertEquals(3, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
 	}
 
 	@Test

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
@@ -32,6 +32,7 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
+import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.junit.After;
 import org.junit.Assert;
@@ -666,18 +667,11 @@ public abstract class AbstractNQuadsParserUnitTest {
 		rdfHandler.assertHandler(1);
 	}
 
-	private class TestParseLocationListener implements ParseLocationListener {
-
-		private long lastRow, lastCol;
-
-		public void parseLocationUpdate(long r, long c) {
-			lastRow = r;
-			lastCol = c;
-		}
+	private class TestParseLocationListener extends SimpleParseLocationListener {
 
 		private void assertListener(int row, int col) {
-			Assert.assertEquals("Unexpected last row", row, lastRow);
-			Assert.assertEquals("Unexpected last col", col, lastCol);
+			Assert.assertEquals("Unexpected last row", row, this.getLineNo());
+			Assert.assertEquals("Unexpected last col", col, this.getColumnNo());
 		}
 
 	}


### PR DESCRIPTION
This PR addresses GitHub issue: #264

Briefly describe the changes proposed in this PR:

- TurtleParser does not report when lines tick over to the location listener
- TurtleParser does not increment line numbers for lines with comments
- TurtleParser does not allow subclasses, of which we have two internally and external users have more, to get the lineNumber information without using reportLocation that is fairly roundabout

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed
