### PR TITLE
removed animal-sniffer-annotations dependency

### DIFF
--- a/core/sail/fts/lucene/pom.xml
+++ b/core/sail/fts/lucene/pom.xml
@@ -56,11 +56,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.codehaus.mojo</groupId>
-			<artifactId>animal-sniffer-annotations</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
+++ b/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
@@ -167,10 +167,6 @@ public class LuceneIndex extends AbstractLuceneIndex {
 		postInit();
 	}
 
-	// this method uses java.nio.Path which is a Java 7 feature. We ignore this
-	// as the Lucene modules
-	// are marked as an exception to the rule that we are Java 6-compatible.
-	@IgnoreJRERequirement
 	protected Directory createDirectory(Properties parameters)
 		throws IOException
 	{

--- a/pom.xml
+++ b/pom.xml
@@ -459,12 +459,6 @@
 				<version>1.0.8</version>
 			</dependency>
 
-			<dependency>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>animal-sniffer-annotations</artifactId>
-				<version>1.14</version>
-			</dependency>
-
 			<!-- Logging: SLF4J and logback -->
 			<dependency>
 				<groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR addresses GitHub issue: #267 

Removed animal-sniffer-annotations dependency. This dependency is obsolete since RDF4J moved to Java 7/8.