### PR TITLE
fixed compilation failures after sniffer-annotations removal

### DIFF
--- a/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
+++ b/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
@@ -9,7 +9,6 @@ package org.eclipse.rdf4j.sail.lucene;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -69,7 +68,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.util.Bits;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;

--- a/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexNIOFS.java
+++ b/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexNIOFS.java
@@ -13,7 +13,6 @@ import java.util.Properties;
 
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.NIOFSDirectory;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**
  * LuceneIndex which uses a NIOFSDirectory instead of MMapDirectory to avoid the JVM crash (see
@@ -25,9 +24,6 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 public class LuceneIndexNIOFS extends LuceneIndex {
 
 	@Override
-	// this method uses java.nio.Path which is a Java 7 feature. We ignore this as the Lucene modules 
-	// are marked as an exception to the rule that we are Java 6-compatible.
-	@IgnoreJRERequirement
 	protected Directory createDirectory(Properties parameters)
 		throws IOException
 	{


### PR DESCRIPTION
This PR addresses GitHub issue: #267

Overlooked further usage (and import declarations), removed now. 

Compilation succeeds locally. 