### PR TITLE
issue#273 : Use non-deprecated methods to be compatible with jackson2.7+

### DIFF
--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -33,8 +33,9 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Lf2SpacesIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter;
 
 /**
  * {@link RDFWriter} implementation for the RDF/JSON format
@@ -67,14 +68,14 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	{
 		try {
 			if (this.writer != null) {
-				final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createJsonGenerator(this.writer);
+				final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createGenerator(this.writer);
 				RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
 
 				jg.close();
 				this.writer.flush();
 			}
 			else if (this.outputStream != null) {
-				final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createJsonGenerator(this.outputStream);
+				final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createGenerator(this.outputStream);
 				RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
 
 				jg.close();
@@ -213,7 +214,7 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	{
 		if (writerConfig.get(BasicWriterSettings.PRETTY_PRINT)) {
 			// SES-2011: Always use \n for consistency
-			Lf2SpacesIndenter indenter = Lf2SpacesIndenter.instance.withLinefeed("\n");
+			Indenter indenter = DefaultIndenter.SYSTEM_LINEFEED_INSTANCE;
 			// By default Jackson does not pretty print, so enable this unless
 			// PRETTY_PRINT setting is disabled
 			DefaultPrettyPrinter pp = new DefaultPrettyPrinter().withArrayIndenter(

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -68,18 +68,22 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	{
 		try {
 			if (this.writer != null) {
-				final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createGenerator(this.writer);
-				RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
-
-				jg.close();
-				this.writer.flush();
+				try (final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createGenerator(this.writer);) {
+					RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
+				}
+				finally {
+					this.writer.flush();
+				}
 			}
 			else if (this.outputStream != null) {
-				final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createGenerator(this.outputStream);
-				RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
-
-				jg.close();
-				this.outputStream.flush();
+				try (final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createGenerator(
+						this.outputStream);)
+				{
+					RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
+				}
+				finally {
+					this.outputStream.flush();
+				}
 			}
 			else {
 				throw new IllegalStateException("The output stream and the writer were both null.");


### PR DESCRIPTION
This PR addresses GitHub issue: #273 

Briefly describe the changes proposed in this PR:

- Fix use of deprecated Jackson public API methods/variables including one that was removed in 2.7

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [n/a] tests are included
- [x] all tests succeed

Lf2SpacesIndenter was removed in 2.7, so to be compatible with
2.7/2.8/etc. changing here to use the new name for it. There is no need to update to Jackson-2.7/2.8 at this point, other than to get bug fixes, but this will make it possible to interoperate with other libraries that do depend on features added there.

The previous pull request was targeted at master, but I would like this to be fixed in 2.0 given it is a small change.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>