### PR TITLE
Issues/#276 rdfxml sax errorhandler

### DIFF
--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
@@ -265,7 +265,7 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 			}
 
 			xmlReader.setContentHandler(saxFilter);
-			xmlReader.setErrorHandler(this);
+			//xmlReader.setErrorHandler(this);
 
 			// Set all compulsory feature settings, using the defaults if they are
 			// not explicitly set

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
@@ -265,7 +265,7 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 			}
 
 			xmlReader.setContentHandler(saxFilter);
-			//xmlReader.setErrorHandler(this);
+			xmlReader.setErrorHandler(this);
 
 			// Set all compulsory feature settings, using the defaults if they are
 			// not explicitly set

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
@@ -12,7 +12,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Iterator;
@@ -23,7 +25,9 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
@@ -32,30 +36,39 @@ import org.junit.Test;
 
 public class RDFXMLParserTest {
 
-    private ValueFactory vf;
-    private RDFParser parser;
-    private StatementCollector sc;
+	private ValueFactory vf;
 
-    @Before
-    public void setUp() throws Exception {
-        vf = SimpleValueFactory.getInstance();
-        parser = new RDFXMLParser();
-        sc = new StatementCollector();
-        parser.setRDFHandler(sc);
-    }
-    
+	private RDFParser parser;
+
+	private StatementCollector sc;
+
+	private ParseErrorCollector el;
+
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		vf = SimpleValueFactory.getInstance();
+		parser = new RDFXMLParser();
+		sc = new StatementCollector();
+		parser.setRDFHandler(sc);
+		el = new ParseErrorCollector();
+		parser.setParseErrorListener(el);
+	}
+
 	@Test
 	public void rdfXmlLoadedFromInsideAJarResolvesRelativeUris()
 		throws Exception
 	{
-		URL zipfileUrl = this.getClass().getResource("/org/eclipse/rdf4j/rio/rdfxml/sample-with-rdfxml-data.zip");
+		URL zipfileUrl = this.getClass().getResource(
+				"/org/eclipse/rdf4j/rio/rdfxml/sample-with-rdfxml-data.zip");
 
 		assertNotNull("The sample-data.zip file must be present for this test", zipfileUrl);
 
 		String url = "jar:" + zipfileUrl + "!/index.rdf";
 
-		try(final InputStream in = new URL(url).openStream();) {
-		    parser.parse(in, url);
+		try (final InputStream in = new URL(url).openStream();) {
+			parser.parse(in, url);
 		}
 
 		Collection<Statement> stmts = sc.getStatements();
@@ -70,7 +83,7 @@ public class RDFXMLParserTest {
 		assertEquals(vf.createIRI("http://www.example.com/#"), stmt1.getSubject());
 		assertEquals(vf.createIRI("http://www.example.com/ns/#document-about"), stmt1.getPredicate());
 		assertTrue(stmt1.getObject() instanceof IRI);
-		
+
 		IRI res = (IRI)stmt1.getObject();
 
 		String resourceUrl = res.stringValue();
@@ -80,23 +93,62 @@ public class RDFXMLParserTest {
 		URL javaUrl = new URL(resourceUrl);
 		assertEquals("jar", javaUrl.getProtocol());
 
-		try(InputStream uc = javaUrl.openStream();) {
-		    assertEquals("The resource stream should be empty", -1, uc.read());
+		try (InputStream uc = javaUrl.openStream();) {
+			assertEquals("The resource stream should be empty", -1, uc.read());
 		}
 
 		assertEquals(res, stmt2.getSubject());
 		assertEquals(DC.TITLE, stmt2.getPredicate());
 		assertEquals(vf.createLiteral("Empty File"), stmt2.getObject());
 	}
-		
-    @Test
-    public void testRDFXMLWhitespace() throws Exception {
-        try(final InputStream in = this.getClass().getResourceAsStream("/org/eclipse/rdf4j/rio/rdfxml/rdfxml-whitespace-literal.rdf");) {
-            parser.parse(in, "");
-        }
-        Statement stmt1 = sc.getStatements().iterator().next();
-        assertEquals(1, sc.getStatements().size());
+
+	@Test
+	public void testRDFXMLWhitespace()
+		throws Exception
+	{
+		try (final InputStream in = this.getClass().getResourceAsStream(
+				"/org/eclipse/rdf4j/rio/rdfxml/rdfxml-whitespace-literal.rdf");)
+		{
+			parser.parse(in, "");
+		}
+		Statement stmt1 = sc.getStatements().iterator().next();
+		assertEquals(1, sc.getStatements().size());
 		assertEquals(RDFS.LABEL, stmt1.getPredicate());
 		assertEquals(vf.createLiteral("  Literal with whitespace  "), stmt1.getObject());
+	}
+
+	@Test
+	public void testFatalErrorPrologContent()
+		throws Exception
+	{
+		// Temporarily override System.err to verify that nothing is being printed to it for this test
+		PrintStream oldErr = System.err;
+		ByteArrayOutputStream tempErr = new ByteArrayOutputStream();
+		System.setErr(new PrintStream(tempErr));
+		PrintStream oldOut = System.out;
+		ByteArrayOutputStream tempOut = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(tempOut));
+		try (final InputStream in = this.getClass().getResourceAsStream(
+				"/org/eclipse/rdf4j/rio/rdfxml/not-an-rdfxml-file.rdf");)
+		{
+			parser.parse(in, "");
+		}
+		catch (RDFParseException e) {
+			assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
+		}
+		finally {
+			// Reset System Error output to ensure that we don't interfere with other tests
+			System.setErr(oldErr);
+			// Reset System Out output to ensure that we don't interfere with other tests
+			System.setOut(oldOut);
+		}
+		// Verify nothing was printed to System.err during test
+		assertEquals(0, tempErr.size());
+		// Verify nothing was printed to System.out during test
+		assertEquals(0, tempOut.size());
+		assertEquals(0, el.getWarnings().size());
+		assertEquals(0, el.getErrors().size());
+		assertEquals(1, el.getFatalErrors().size());
+		assertEquals("[Rio fatal] Content is not allowed in prolog. (1, 1)", el.getFatalErrors().get(0));
 	}
 }

--- a/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/not-an-rdfxml-file.rdf
+++ b/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/not-an-rdfxml-file.rdf
@@ -1,0 +1,1 @@
+# rdf:RDF should not make this an RDF file, and it should fail to parse as one even with <rdf:RDF> or </rdf:RDF> in this comment

--- a/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/rdfxml-whitespace-literal.rdf
+++ b/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/rdfxml-whitespace-literal.rdf
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8'?>
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+
+ <rdf:Description rdf:about='urn:test:empty-literal'>
+  <label xmlns='http://www.w3.org/2000/01/rdf-schema#'>  Literal with whitespace  </label>
+ </rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
This PR addresses GitHub issue: #276 

Briefly describe the changes proposed in this PR:

- Add regression test for issue #276 (tracked in previous tracker as SES-666), relating to the SAX parser printing errors to System.err
- Fix the RDF/XML whitespace test that was bundled into an opaque unrelated ZIP file during a previous pull request

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed
