### PR TITLE
issue#281 : Further use of ErrorHandler to prevent fatal errors emitted to console

### DIFF
--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
@@ -128,10 +128,7 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 	 * Creates a new RDFXMLParser that will use a {@link SimpleValueFactory} to create RDF model objects.
 	 */
 	public RDFXMLParser() {
-		super();
-
-		// SAXFilter does some filtering and verifying of SAX events
-		saxFilter = new SAXFilter(this);
+		this(SimpleValueFactory.getInstance());
 	}
 
 	/**

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
@@ -163,6 +163,7 @@ class SAXFilter implements ContentHandler {
 	 * Methods from interface ContentHandler *
 	 *---------------------------------------*/
 
+	@Override
 	public void setDocumentLocator(Locator loc) {
 		locator = loc;
 
@@ -172,6 +173,7 @@ class SAXFilter implements ContentHandler {
 		}
 	}
 
+	@Override
 	public void startDocument()
 		throws SAXException
 	{
@@ -186,6 +188,7 @@ class SAXFilter implements ContentHandler {
 		}
 	}
 
+	@Override
 	public void endDocument()
 		throws SAXException
 	{
@@ -200,6 +203,7 @@ class SAXFilter implements ContentHandler {
 		}
 	}
 
+	@Override
 	public void startPrefixMapping(String prefix, String uri)
 		throws SAXException
 	{
@@ -228,12 +232,14 @@ class SAXFilter implements ContentHandler {
 		}
 	}
 
+	@Override
 	public void endPrefixMapping(String prefix) {
 		if (parseLiteralMode) {
 			xmlLiteralPrefixes.remove(prefix);
 		}
 	}
 
+	@Override
 	public void startElement(String namespaceURI, String localName, String qName, Attributes attributes)
 		throws SAXException
 	{
@@ -323,6 +329,7 @@ class SAXFilter implements ContentHandler {
 		deferredElement = null;
 	}
 
+	@Override
 	public void endElement(String namespaceURI, String localName, String qName)
 		throws SAXException
 	{
@@ -420,6 +427,7 @@ class SAXFilter implements ContentHandler {
 		}
 	}
 
+	@Override
 	public void characters(char[] ch, int start, int length)
 		throws SAXException
 	{
@@ -463,16 +471,19 @@ class SAXFilter implements ContentHandler {
 		}
 	}
 
+	@Override
 	public void ignorableWhitespace(char[] ch, int start, int length) {
 		if (parseLiteralMode) {
 			charBuf.append(ch, start, length);
 		}
 	}
 
+	@Override
 	public void processingInstruction(String target, String data) {
 		// ignore
 	}
 
+	@Override
 	public void skippedEntity(String name) {
 		// ignore
 	}

--- a/core/rio/trix/pom.xml
+++ b/core/rio/trix/pom.xml
@@ -45,6 +45,16 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/core/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
+++ b/core/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trix;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DC;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TriXParserTest {
+
+	private ValueFactory vf;
+
+	private RDFParser parser;
+
+	private StatementCollector sc;
+
+	private ParseErrorCollector el;
+
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		vf = SimpleValueFactory.getInstance();
+		parser = new TriXParser();
+		sc = new StatementCollector();
+		parser.setRDFHandler(sc);
+		el = new ParseErrorCollector();
+		parser.setParseErrorListener(el);
+	}
+
+	@Test
+	public void testFatalErrorPrologContent()
+		throws Exception
+	{
+		// Temporarily override System.err to verify that nothing is being printed to it for this test
+		PrintStream oldErr = System.err;
+		ByteArrayOutputStream tempErr = new ByteArrayOutputStream();
+		System.setErr(new PrintStream(tempErr));
+		PrintStream oldOut = System.out;
+		ByteArrayOutputStream tempOut = new ByteArrayOutputStream();
+		System.setOut(new PrintStream(tempOut));
+		try (final InputStream in = this.getClass().getResourceAsStream(
+				"/org/eclipse/rdf4j/rio/trix/not-a-trix-file.trix");)
+		{
+			parser.parse(in, "");
+		}
+		catch (RDFParseException e) {
+			assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
+		}
+		finally {
+			// Reset System Error output to ensure that we don't interfere with other tests
+			System.setErr(oldErr);
+			// Reset System Out output to ensure that we don't interfere with other tests
+			System.setOut(oldOut);
+		}
+		// Verify nothing was printed to System.err during test
+		assertEquals(0, tempErr.size());
+		// Verify nothing was printed to System.out during test
+		assertEquals(0, tempOut.size());
+		assertEquals(0, el.getWarnings().size());
+		assertEquals(0, el.getErrors().size());
+		assertEquals(1, el.getFatalErrors().size());
+		assertEquals("[Rio fatal] Content is not allowed in prolog. (1, 1)", el.getFatalErrors().get(0));
+	}
+}

--- a/core/rio/trix/src/test/resources/org/eclipse/rdf4j/rio/trix/not-a-trix-file.trix
+++ b/core/rio/trix/src/test/resources/org/eclipse/rdf4j/rio/trix/not-a-trix-file.trix
@@ -1,0 +1,1 @@
+# rdf:RDF should not make this an RDF file, and it should fail to parse as one even with <rdf:RDF> or </rdf:RDF> in this comment

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/xml/SimpleSAXParser.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/xml/SimpleSAXParser.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
@@ -77,6 +78,11 @@ public class SimpleSAXParser {
 	 */
 	private boolean preserveWhitespace = false;
 
+	/**
+	 * A Locator indicating a position in the text that is currently being parsed by the SAX parser.
+	 */
+	private Locator locator;
+
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
@@ -134,6 +140,10 @@ public class SimpleSAXParser {
 	 */
 	public SimpleSAXListener getListener() {
 		return listener;
+	}
+
+	public Locator getLocator() {
+		return locator;
 	}
 
 	/**
@@ -204,7 +214,7 @@ public class SimpleSAXParser {
 	 * @param inputSource
 	 *        An <tt>InputSource</tt> containing XML data.
 	 */
-	private synchronized void parse(InputSource inputSource)
+	public synchronized void parse(InputSource inputSource)
 		throws SAXException, IOException
 	{
 		xmlReader.setContentHandler(new SimpleSAXDefaultHandler());
@@ -328,6 +338,11 @@ public class SimpleSAXParser {
 
 			// Clear character buffer
 			charBuf.setLength(0);
+		}
+
+		@Override
+		public void setDocumentLocator(Locator loc) {
+			locator = loc;
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #281 

Briefly describe the changes proposed in this PR:

- Ensure that all XMLReader instances have ErrorHandler objects attached to them to prevent fatal errors being emitted to the Console 
- Adds Locator to SimpleSaxParser so that error messages and exceptions for parsers using it can have line and column numbers attached to them.
- Adds regression test for TriXParser to ensure it doesn't start emitting error messages to the System.err or System.out in future

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

Note that queryresultio doesn't have any formal infrastructure for reporting errors to users in a friendly fashion as rio does with ParseErrorListener, so only supporting fatal error exception rethrowing for SAXExceptions passing through the SPARQL/XML parser at this stage.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>