### PR TITLE
workarounds in unit tests to account for different platform locales.

### DIFF
--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
@@ -7,10 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfxml;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -134,7 +134,8 @@ public class RDFXMLParserTest {
 			parser.parse(in, "");
 		}
 		catch (RDFParseException e) {
-			assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
+			// FIXME exact error message is locale-dependent. Just fall through, error is expected. See #280.
+			//			assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
 		}
 		finally {
 			// Reset System Error output to ensure that we don't interfere with other tests

--- a/core/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
+++ b/core/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
@@ -7,30 +7,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trix;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.net.URL;
-import java.util.Collection;
-import java.util.Iterator;
 
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.DC;
-import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -73,7 +61,8 @@ public class TriXParserTest {
 			parser.parse(in, "");
 		}
 		catch (RDFParseException e) {
-			assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
+			// FIXME exact error message is locale-dependent. Just fall through, error is expected. See #280.
+			// assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
 		}
 		finally {
 			// Reset System Error output to ensure that we don't interfere with other tests

--- a/core/sail/spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
+++ b/core/sail/spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
@@ -48,7 +48,11 @@ public class SpifSailTest {
 
 	private RepositoryConnection conn;
 
-	private Locale locale;
+	/**
+	 * Temporary storage of platform locale. See #280 . Some tests (e.g. test involving spif:dateFormat)
+	 * require English locale to succeed, instead of platform locale.
+	 */
+	private Locale platformLocale;
 
 	@Before
 	public void setup()
@@ -62,7 +66,7 @@ public class SpifSailTest {
 		repo.initialize();
 		conn = repo.getConnection();
 
-		locale = Locale.getDefault();
+		platformLocale = Locale.getDefault();
 
 		/*
 		 * FIXME See #280 . Some tests (e.g. test involving spif:dateFormat) require English locale to
@@ -75,7 +79,7 @@ public class SpifSailTest {
 	public void tearDown()
 		throws RepositoryException
 	{
-		Locale.setDefault(locale);
+		Locale.setDefault(platformLocale);
 		if (conn != null) {
 			conn.close();
 		}

--- a/core/sail/spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
+++ b/core/sail/spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Locale;
 
 import org.eclipse.rdf4j.OpenRDFException;
 import org.eclipse.rdf4j.model.Literal;
@@ -47,6 +48,8 @@ public class SpifSailTest {
 
 	private RepositoryConnection conn;
 
+	private Locale locale;
+
 	@Before
 	public void setup()
 		throws RepositoryException
@@ -58,18 +61,28 @@ public class SpifSailTest {
 		repo = new SailRepository(spinSail);
 		repo.initialize();
 		conn = repo.getConnection();
+
+		locale = Locale.getDefault();
+
+		/*
+		 * FIXME See #280 . Some tests (e.g. test involving spif:dateFormat) require English locale to
+		 * succeed, instead of platform locale.
+		 */
+		Locale.setDefault(Locale.ENGLISH);
 	}
 
 	@After
 	public void tearDown()
 		throws RepositoryException
 	{
+		Locale.setDefault(locale);
 		if (conn != null) {
 			conn.close();
 		}
 		if (repo != null) {
 			repo.shutDown();
 		}
+
 	}
 
 	@Test


### PR DESCRIPTION
This PR addresses GitHub issue: #280

Briefly describe the changes proposed in this PR:

- SPIN unit tests now force English locale for test execution
- TriX and RDF/XML parser tests do not verify exact error message anymore.

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

