### PR TITLE
issue #262: add a test and fix the issue in the HTTP server with empt…

### DIFF
--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
@@ -52,8 +52,7 @@ public class NamespaceController extends AbstractController {
 		throws Exception
 	{
 		String pathInfoStr = request.getPathInfo();
-		String[] pathInfo = pathInfoStr.substring(1).split("/");
-		String prefix = pathInfo[pathInfo.length - 1];
+		String prefix = pathInfoStr.substring(pathInfoStr.lastIndexOf('/') + 1);
 
 		String reqMethod = request.getMethod();
 


### PR DESCRIPTION
This PR addresses GitHub issue: #262 

Briefly describe the changes proposed in this PR:

- Use of String.lastIndexOf to find the index of the last slash "/" in the request path, in order to determine where the prefix starts

As the original code, the proposed modification accepts URLs that are not strictly conforming to the specified request format: e.g. any number of intermediate components are silently ignored.

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed (in fact, because of a problem with locale-dependent tests, I was not able to run all tests, but I've executed the tests for the affected module)