### PR TITLE
Issues/#286 queryresultio error handling

### DIFF
--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLParserCustomTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLParserCustomTest.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqlxml;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
+import org.eclipse.rdf4j.query.resultio.QueryResultParser;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
+import org.eclipse.rdf4j.rio.ParserConfig;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.eclipse.rdf4j.rio.helpers.XMLParserSettings;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Custom tests for SPARQL/XML Parser.
+ * 
+ * @author Michael Grove
+ * @author Peter Ansell
+ */
+public class SPARQLXMLParserCustomTest {
+
+    /**
+     * Test with the default ParserConfig settings. Ie, setParserConfig is not
+     * called.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testEntityExpansionDefaultSettings() throws Exception {
+        QueryResultCollector handler = new QueryResultCollector();
+        ParseErrorCollector errorCollector = new ParseErrorCollector();
+        QueryResultParser aParser = QueryResultIO.createTupleParser(TupleQueryResultFormat.SPARQL)
+                .setQueryResultHandler(handler).setParseErrorListener(errorCollector);
+
+        try {
+            // this should trigger a SAX parse exception that will blow up at
+            // the 64k entity limit rather than OOMing
+            aParser.parseQueryResult(this.getClass()
+                    .getResourceAsStream("/sparqlxml/bad-entity-expansion-limit.srx"));
+            fail("Parser did not throw an exception");
+        } catch (QueryResultParseException e) {
+            // assertTrue(e.getMessage().contains(
+            // "The parser has encountered more than \"64,000\" entity
+            // expansions in this document; this is the limit imposed by the
+            // "));
+        }
+        assertEquals(0, errorCollector.getWarnings().size());
+        assertEquals(0, errorCollector.getErrors().size());
+        assertEquals(1, errorCollector.getFatalErrors().size());
+    }
+
+    /**
+     * Test with unrelated ParserConfig settings
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testEntityExpansionUnrelatedSettings() throws Exception {
+        ParserConfig config = new ParserConfig();
+        QueryResultCollector handler = new QueryResultCollector();
+        ParseErrorCollector errorCollector = new ParseErrorCollector();
+        QueryResultParser aParser = QueryResultIO.createTupleParser(TupleQueryResultFormat.SPARQL)
+                .setQueryResultHandler(handler).setParserConfig(config)
+                .setParseErrorListener(errorCollector);
+
+        try {
+            // this should trigger a SAX parse exception that will blow up at
+            // the 64k entity limit rather than OOMing
+            aParser.parseQueryResult(this.getClass()
+                    .getResourceAsStream("/sparqlxml/bad-entity-expansion-limit.srx"));
+            fail("Parser did not throw an exception");
+        } catch (QueryResultParseException e) {
+            // assertTrue(e.getMessage().contains(
+            // "The parser has encountered more than \"64,000\" entity
+            // expansions in this document; this is the limit imposed by the
+            // "));
+        }
+        assertEquals(0, errorCollector.getWarnings().size());
+        assertEquals(0, errorCollector.getErrors().size());
+        assertEquals(1, errorCollector.getFatalErrors().size());
+    }
+
+    /**
+     * Test with Secure processing setting on.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testEntityExpansionSecureProcessing() throws Exception {
+        QueryResultCollector handler = new QueryResultCollector();
+        ParseErrorCollector errorCollector = new ParseErrorCollector();
+        QueryResultParser aParser = QueryResultIO.createTupleParser(TupleQueryResultFormat.SPARQL)
+                .setQueryResultHandler(handler).set(XMLParserSettings.SECURE_PROCESSING, true)
+                .setParseErrorListener(errorCollector);
+
+        try {
+            // this should trigger a SAX parse exception that will blow up at
+            // the 64k entity limit rather than OOMing
+            aParser.parseQueryResult(this.getClass()
+                    .getResourceAsStream("/sparqlxml/bad-entity-expansion-limit.srx"));
+            fail("Parser did not throw an exception");
+        } catch (QueryResultParseException e) {
+            // assertTrue(e.getMessage().contains(
+            // "The parser has encountered more than \"64,000\" entity
+            // expansions in this document; this is the limit imposed by the
+            // "));
+        }
+        assertEquals(0, errorCollector.getWarnings().size());
+        assertEquals(0, errorCollector.getErrors().size());
+        assertEquals(1, errorCollector.getFatalErrors().size());
+    }
+
+    /**
+     * Test with Secure processing setting off.
+     * <p>
+     * IMPORTANT: Only turn this on to verify it is still working, as there is
+     * no way to safely perform this test.
+     * <p>
+     * WARNING: This test will cause an OutOfMemoryException when it eventually
+     * fails, as it will eventually fail.
+     * 
+     * @throws Exception
+     */
+    @Ignore
+    @Test(timeout = 10000)
+    public void testEntityExpansionNoSecureProcessing() throws Exception {
+        QueryResultCollector handler = new QueryResultCollector();
+        ParseErrorCollector errorCollector = new ParseErrorCollector();
+        QueryResultParser aParser = QueryResultIO.createTupleParser(TupleQueryResultFormat.SPARQL)
+                .setQueryResultHandler(handler).set(XMLParserSettings.SECURE_PROCESSING, false)
+                .setParseErrorListener(errorCollector);
+
+        try {
+            // IMPORTANT: This will not use the entity limit
+            aParser.parseQueryResult(this.getClass()
+                    .getResourceAsStream("/sparqlxml/bad-entity-expansion-limit.srx"));
+            fail("Parser did not throw an exception");
+        } catch (QueryResultParseException e) {
+            // assertTrue(e.getMessage().contains(
+            // "The parser has encountered more than \"64,000\" entity
+            // expansions in this document; this is the limit imposed by the"));
+        }
+        assertEquals(0, errorCollector.getWarnings().size());
+        assertEquals(0, errorCollector.getErrors().size());
+        assertEquals(1, errorCollector.getFatalErrors().size());
+    }
+
+    @Test
+    public void testSupportedSettings() throws Exception {
+        assertTrue(QueryResultIO.createTupleParser(TupleQueryResultFormat.SPARQL)
+                .getSupportedSettings().size() > 0);
+    }
+}

--- a/compliance/queryresultio/src/test/resources/sparqlxml/bad-entity-expansion-limit.srx
+++ b/compliance/queryresultio/src/test/resources/sparqlxml/bad-entity-expansion-limit.srx
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE sparql:sparql [
+ <!ENTITY lol "lol">
+ <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+ <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+ <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+ <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+ <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+ <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+ <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<sparql:sparql xmlns:sparql="http://www.w3.org/2005/sparql-results#">
+  <sparql:head>
+    <sparql:variable name="z"/>
+  </sparql:head>
+  <sparql:results>
+    <sparql:result>
+      <sparql:binding name="z">
+        <sparql:literal datatype="http://www.w3.org/2001/XMLSchema#integer">&lol9;</sparql:literal>
+      </sparql:binding>
+    </sparql:result>
+  </sparql:results>
+</sparql:sparql>

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserCustomTest.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.rio.helpers.XMLParserSettings;
 import org.junit.Ignore;
@@ -42,13 +43,13 @@ public class RDFXMLParserCustomTest {
 		throws Exception
 	{
 		final Model aGraph = new LinkedHashModel();
-		RDFParser aParser = Rio.createParser(RDFFormat.RDFXML);
-		aParser.setRDFHandler(new StatementCollector(aGraph));
+		ParseErrorCollector errorCollector = new ParseErrorCollector();
+		RDFParser aParser = Rio.createParser(RDFFormat.RDFXML).setRDFHandler(
+				new StatementCollector(aGraph)).setParseErrorListener(errorCollector);
 
 		try {
 			// this should trigger a SAX parse exception that will blow up at the
-			// 64k
-			// entity limit rather than OOMing
+			// 64k entity limit rather than OOMing
 			aParser.parse(
 					this.getClass().getResourceAsStream(
 							"/testcases/rdfxml/openrdf/bad-entity-expansion-limit.rdf"),
@@ -59,6 +60,9 @@ public class RDFXMLParserCustomTest {
 			// assertTrue(e.getMessage().contains(
 			// "The parser has encountered more than \"64,000\" entity expansions in this document; this is the limit imposed by the "));
 		}
+		assertEquals(0, errorCollector.getWarnings().size());
+		assertEquals(0, errorCollector.getErrors().size());
+		assertEquals(1, errorCollector.getFatalErrors().size());
 	}
 
 	/**
@@ -71,11 +75,10 @@ public class RDFXMLParserCustomTest {
 		throws Exception
 	{
 		final Model aGraph = new LinkedHashModel();
-		RDFParser aParser = Rio.createParser(RDFFormat.RDFXML);
-		aParser.setRDFHandler(new StatementCollector(aGraph));
-
+		ParseErrorCollector errorCollector = new ParseErrorCollector();
 		ParserConfig config = new ParserConfig();
-		aParser.setParserConfig(config);
+		RDFParser aParser = Rio.createParser(RDFFormat.RDFXML).setRDFHandler(
+				new StatementCollector(aGraph)).setParserConfig(config).setParseErrorListener(errorCollector);
 
 		try {
 			// this should trigger a SAX parse exception that will blow up at the
@@ -90,6 +93,9 @@ public class RDFXMLParserCustomTest {
 			// assertTrue(e.getMessage().contains(
 			// "The parser has encountered more than \"64,000\" entity expansions in this document; this is the limit imposed by the "));
 		}
+		assertEquals(0, errorCollector.getWarnings().size());
+		assertEquals(0, errorCollector.getErrors().size());
+		assertEquals(1, errorCollector.getFatalErrors().size());
 	}
 
 	/**
@@ -102,12 +108,10 @@ public class RDFXMLParserCustomTest {
 		throws Exception
 	{
 		final Model aGraph = new LinkedHashModel();
-		RDFParser aParser = Rio.createParser(RDFFormat.RDFXML);
-		aParser.setRDFHandler(new StatementCollector(aGraph));
-
-		ParserConfig config = new ParserConfig();
-		config.set(XMLParserSettings.SECURE_PROCESSING, true);
-		aParser.setParserConfig(config);
+		ParseErrorCollector errorCollector = new ParseErrorCollector();
+		RDFParser aParser = Rio.createParser(RDFFormat.RDFXML).setRDFHandler(
+				new StatementCollector(aGraph)).set(XMLParserSettings.SECURE_PROCESSING,
+						true).setParseErrorListener(errorCollector);
 
 		try {
 			// this should trigger a SAX parse exception that will blow up at the
@@ -122,6 +126,9 @@ public class RDFXMLParserCustomTest {
 			// assertTrue(e.getMessage().contains(
 			// "The parser has encountered more than \"64,000\" entity expansions in this document; this is the limit imposed by the "));
 		}
+		assertEquals(0, errorCollector.getWarnings().size());
+		assertEquals(0, errorCollector.getErrors().size());
+		assertEquals(1, errorCollector.getFatalErrors().size());
 	}
 
 	/**
@@ -141,12 +148,10 @@ public class RDFXMLParserCustomTest {
 		throws Exception
 	{
 		final Model aGraph = new LinkedHashModel();
-		RDFParser aParser = Rio.createParser(RDFFormat.RDFXML);
-		aParser.setRDFHandler(new StatementCollector(aGraph));
-
-		ParserConfig config = new ParserConfig();
-		config.set(XMLParserSettings.SECURE_PROCESSING, false);
-		aParser.setParserConfig(config);
+		ParseErrorCollector errorCollector = new ParseErrorCollector();
+		RDFParser aParser = Rio.createParser(RDFFormat.RDFXML).setRDFHandler(
+				new StatementCollector(aGraph)).set(XMLParserSettings.SECURE_PROCESSING,
+						false).setParseErrorListener(errorCollector);
 
 		try {
 			// IMPORTANT: This will not use the entity limit
@@ -160,6 +165,9 @@ public class RDFXMLParserCustomTest {
 			// assertTrue(e.getMessage().contains(
 			// "The parser has encountered more than \"64,000\" entity expansions in this document; this is the limit imposed by the"));
 		}
+		assertEquals(0, errorCollector.getWarnings().size());
+		assertEquals(0, errorCollector.getErrors().size());
+		assertEquals(1, errorCollector.getFatalErrors().size());
 	}
 
 	@Test

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultParser.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultParser.java
@@ -13,7 +13,10 @@ import java.util.Collections;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.QueryResultHandler;
+import org.eclipse.rdf4j.rio.ParseErrorListener;
+import org.eclipse.rdf4j.rio.ParseLocationListener;
 import org.eclipse.rdf4j.rio.ParserConfig;
+import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
@@ -35,7 +38,20 @@ public abstract class AbstractQueryResultParser implements QueryResultParser {
 	 */
 	protected QueryResultHandler handler;
 
-	private ParserConfig parserConfig = new ParserConfig();
+	/**
+	 * A collection of configuration options for this parser.
+	 */
+	private ParserConfig parserConfig;
+
+	/**
+	 * An optional ParseErrorListener to report parse errors to.
+	 */
+	private ParseErrorListener errListener;
+
+	/**
+	 * An optional ParseLocationListener to report parse progress in the form of line- and column numbers to.
+	 */
+	private ParseLocationListener locationListener;
 
 	/*--------------*
 	 * Constructors *
@@ -54,6 +70,7 @@ public abstract class AbstractQueryResultParser implements QueryResultParser {
 	 */
 	public AbstractQueryResultParser(ValueFactory valueFactory) {
 		setValueFactory(valueFactory);
+		setParserConfig(new ParserConfig());
 	}
 
 	/*---------*
@@ -61,23 +78,46 @@ public abstract class AbstractQueryResultParser implements QueryResultParser {
 	 *---------*/
 
 	@Override
-	public void setValueFactory(ValueFactory valueFactory) {
+	public QueryResultParser setValueFactory(ValueFactory valueFactory) {
 		this.valueFactory = valueFactory;
+		return this;
 	}
 
 	@Override
-	public void setQueryResultHandler(QueryResultHandler handler) {
+	public QueryResultParser setQueryResultHandler(QueryResultHandler handler) {
 		this.handler = handler;
+		return this;
 	}
 
 	@Override
-	public void setParserConfig(ParserConfig config) {
+	public QueryResultParser setParserConfig(ParserConfig config) {
 		this.parserConfig = config;
+		return this;
 	}
 
 	@Override
 	public ParserConfig getParserConfig() {
 		return this.parserConfig;
+	}
+
+	@Override
+	public QueryResultParser setParseErrorListener(ParseErrorListener el) {
+		errListener = el;
+		return this;
+	}
+
+	public ParseErrorListener getParseErrorListener() {
+		return errListener;
+	}
+
+	@Override
+	public QueryResultParser setParseLocationListener(ParseLocationListener el) {
+		locationListener = el;
+		return this;
+	}
+
+	public ParseLocationListener getParseLocationListener() {
+		return locationListener;
 	}
 
 	/*
@@ -86,5 +126,11 @@ public abstract class AbstractQueryResultParser implements QueryResultParser {
 	@Override
 	public Collection<RioSetting<?>> getSupportedSettings() {
 		return Collections.emptyList();
+	}
+
+	@Override
+	public <T> QueryResultParser set(RioSetting<T> setting, T value) {
+		getParserConfig().set(setting, value);
+		return this;
 	}
 }

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultParseException.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultParseException.java
@@ -27,9 +27,9 @@ public class QueryResultParseException extends RDF4JException {
 	 * Variables *
 	 *-----------*/
 
-	private int lineNo = -1;
+	private long lineNo = -1L;
 
-	private int columnNo = -1;
+	private long columnNo = -1L;
 
 	/*--------------*
 	 * Constructors *
@@ -67,7 +67,7 @@ public class QueryResultParseException extends RDF4JException {
 	 * @param columnNo
 	 *        A column number associated with the message.
 	 */
-	public QueryResultParseException(String msg, int lineNo, int columnNo) {
+	public QueryResultParseException(String msg, long lineNo, long columnNo) {
 		super(msg);
 		this.lineNo = lineNo;
 		this.columnNo = columnNo;
@@ -95,7 +95,7 @@ public class QueryResultParseException extends RDF4JException {
 	 * @param columnNo
 	 *        A column number associated with the message.
 	 */
-	public QueryResultParseException(Throwable t, int lineNo, int columnNo) {
+	public QueryResultParseException(Throwable t, long lineNo, long columnNo) {
 		super(t);
 		this.lineNo = lineNo;
 		this.columnNo = columnNo;
@@ -110,7 +110,7 @@ public class QueryResultParseException extends RDF4JException {
 	 * 
 	 * @return A line number, or <tt>-1</tt> if no line number is available or applicable.
 	 */
-	public int getLineNumber() {
+	public long getLineNumber() {
 		return lineNo;
 	}
 
@@ -119,7 +119,7 @@ public class QueryResultParseException extends RDF4JException {
 	 * 
 	 * @return A column number, or <tt>-1</tt> if no column number is available or applicable.
 	 */
-	public int getColumnNumber() {
+	public long getColumnNumber() {
 		return columnNo;
 	}
 }

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultParser.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultParser.java
@@ -50,25 +50,25 @@ public interface QueryResultParser {
 	 */
 	QueryResultParser setValueFactory(ValueFactory valueFactory);
 
-    /**
-     * Sets the ParseErrorListener that will be notified of any errors that this parser finds during parsing.
-     * 
-     * @param el
-     *        The ParseErrorListener that will be notified of errors or warnings.
-     * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
-     *         calls.
-     */
-    QueryResultParser setParseErrorListener(ParseErrorListener el);
+	/**
+	 * Sets the ParseErrorListener that will be notified of any errors that this parser finds during parsing.
+	 * 
+	 * @param el
+	 *        The ParseErrorListener that will be notified of errors or warnings.
+	 * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
+	 *         calls.
+	 */
+	QueryResultParser setParseErrorListener(ParseErrorListener el);
 
-    /**
-     * Sets the ParseLocationListener that will be notified of the parser's progress during the parse process.
-     * 
-     * @param ll
-     *        The ParseLocationListener that will be notified of the parser's progress.
-     * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
-     *         calls.
-     */
-    QueryResultParser setParseLocationListener(ParseLocationListener ll);
+	/**
+	 * Sets the ParseLocationListener that will be notified of the parser's progress during the parse process.
+	 * 
+	 * @param ll
+	 *        The ParseLocationListener that will be notified of the parser's progress.
+	 * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
+	 *         calls.
+	 */
+	QueryResultParser setParseLocationListener(ParseLocationListener ll);
 
 	/**
 	 * Parse the query results out of the given {@link InputStream} into the handler setup using
@@ -107,16 +107,16 @@ public interface QueryResultParser {
 	 */
 	Collection<RioSetting<?>> getSupportedSettings();
 
-    /**
-     * Set a setting on the parser, and return this parser object to allow chaining.
-     * 
-     * @param setting
-     *        The setting to change.
-     * @param value
-     *        The value to change.
-     * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
-     *         calls.
-     */
-    <T> QueryResultParser set(RioSetting<T> setting, T value);
+	/**
+	 * Set a setting on the parser, and return this parser object to allow chaining.
+	 * 
+	 * @param setting
+	 *        The setting to change.
+	 * @param value
+	 *        The value to change.
+	 * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
+	 *         calls.
+	 */
+	<T> QueryResultParser set(RioSetting<T> setting, T value);
 
 }

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultParser.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultParser.java
@@ -14,6 +14,8 @@ import java.util.Collection;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.QueryResultHandler;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
+import org.eclipse.rdf4j.rio.ParseErrorListener;
+import org.eclipse.rdf4j.rio.ParseLocationListener;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RioSetting;
 
@@ -38,7 +40,7 @@ public interface QueryResultParser {
 	 * @param handler
 	 *        The {@link QueryResultHandler} to use for handling results.
 	 */
-	void setQueryResultHandler(QueryResultHandler handler);
+	QueryResultParser setQueryResultHandler(QueryResultHandler handler);
 
 	/**
 	 * Sets the ValueFactory that the parser will use to create Value objects for the parsed query result.
@@ -46,7 +48,27 @@ public interface QueryResultParser {
 	 * @param valueFactory
 	 *        The value factory that the parser should use.
 	 */
-	void setValueFactory(ValueFactory valueFactory);
+	QueryResultParser setValueFactory(ValueFactory valueFactory);
+
+    /**
+     * Sets the ParseErrorListener that will be notified of any errors that this parser finds during parsing.
+     * 
+     * @param el
+     *        The ParseErrorListener that will be notified of errors or warnings.
+     * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
+     *         calls.
+     */
+    QueryResultParser setParseErrorListener(ParseErrorListener el);
+
+    /**
+     * Sets the ParseLocationListener that will be notified of the parser's progress during the parse process.
+     * 
+     * @param ll
+     *        The ParseLocationListener that will be notified of the parser's progress.
+     * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
+     *         calls.
+     */
+    QueryResultParser setParseLocationListener(ParseLocationListener ll);
 
 	/**
 	 * Parse the query results out of the given {@link InputStream} into the handler setup using
@@ -71,18 +93,30 @@ public interface QueryResultParser {
 	 * @param config
 	 *        a parser configuration object.
 	 */
-	public void setParserConfig(ParserConfig config);
+	QueryResultParser setParserConfig(ParserConfig config);
 
 	/**
 	 * Retrieves the current parser configuration as a single object.
 	 * 
 	 * @return a parser configuration object representing the current configuration of the parser.
 	 */
-	public ParserConfig getParserConfig();
+	ParserConfig getParserConfig();
 
 	/**
 	 * @return A collection of {@link RioSetting}s that are supported by this QueryResultParser.
 	 */
-	public Collection<RioSetting<?>> getSupportedSettings();
+	Collection<RioSetting<?>> getSupportedSettings();
+
+    /**
+     * Set a setting on the parser, and return this parser object to allow chaining.
+     * 
+     * @param setting
+     *        The setting to change.
+     * @param value
+     *        The value to change.
+     * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method
+     *         calls.
+     */
+    <T> QueryResultParser set(RioSetting<T> setting, T value);
 
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #286 

Briefly describe the changes proposed in this PR:

- Adds capability to receive error messages from QueryResultParser's
- Resolves the FIXME notes that I added to the SPARQL/XML parser in pull request #282 so non-fatal SAX exceptions are not swallowed by a noop ErrorHandler
- Ports the fluent configuration style from RDFParser to QueryResultParser
- Fixes entity expansion limit security issue for SPARQL/XML in the same way as RDF/XML
- Fixes use of int instead of long for line/column numbers in QueryResultParseException, to match RDFParseException API

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

Even though this is a large set of changes, there are several API changes that would need to be done before the first 2.0 release or else wait until 3.0 due to not being able to make them backwards compatible, so targeting at 2.0 rather than 2.1.

This builds on the changes that were done to bring Tuple and Boolean parsing together in the past and hopefully makes it simpler in future to pull together the QueryResultParser and RDFParser interfaces in the future to reduce code duplication.