### PR TITLE
Added dcat:theme

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DCAT.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DCAT.java
@@ -80,6 +80,9 @@ public class DCAT {
 	
 	/** dcat:record */	
 	public static final IRI HAS_RECORD;
+
+	/** dcat:theme */
+	public static final IRI THEME;
 	
 	/** dcat:themeTaxonomy */
 	public static final IRI THEME_TAXONOMY;
@@ -102,6 +105,7 @@ public class DCAT {
 		LANDING_PAGE = factory.createIRI(NAMESPACE, "landingPage");
 		MEDIA_TYPE = factory.createIRI(NAMESPACE, "mediaType");
 		HAS_RECORD = factory.createIRI(NAMESPACE, "record");
+		THEME = factory.createIRI(NAMESPACE, "theme");
 		THEME_TAXONOMY = factory.createIRI(NAMESPACE, "themeTaxonomy");
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #283 

Briefly describe the changes proposed in this PR:

- trivial change: added dcat:theme property / IRI in the vocab class

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [X] RDF4J code formatting has been applied
- [ ] tests are included
- [ ] all tests succeed

Signed-off-by:Bart Hanssens <bart.hanssens@fedict.be>