### PR TITLE
issue #262: switch to opencsv to parse the server response in the com…

### DIFF
--- a/compliance/http/pom.xml
+++ b/compliance/http/pom.xml
@@ -137,7 +137,12 @@
 			<artifactId>httpmime</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>com.opencsv</groupId>
+			<artifactId>opencsv</artifactId>
+			<version>3.2</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
This PR addresses GitHub issue: #262 

Briefly describe the changes proposed in this PR:

- as suggested, I switched to use opencsv to parse the server response in the compliance test

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed (in fact, I executed only the tests specific to this issue)