### PR TITLE
Fixes #296 by closing the embedded iteration.

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/CrossProductIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/CrossProductIteration.java
@@ -7,14 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
-import java.util.Iterator;
-import java.util.List;
-
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Iteration which forms the cross product of a list of materialized input bindings with each result obtained
@@ -72,7 +72,11 @@ public class CrossProductIteration extends LookAheadIteration<BindingSet, QueryE
 	protected void handleClose()
 		throws QueryEvaluationException
 	{
-		super.handleClose();
-		resultIteration.close();
+		try {
+			super.handleClose();
+		}
+		finally {
+			resultIteration.close();
+		}
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/CrossProductIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/CrossProductIteration.java
@@ -67,4 +67,12 @@ public class CrossProductIteration extends LookAheadIteration<BindingSet, QueryE
 
 		return null;
 	}
+
+	@Override
+	protected void handleClose()
+		throws QueryEvaluationException
+	{
+		super.handleClose();
+		resultIteration.close();
+	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #296 

Briefly describe the changes proposed in this PR:

- Closes the embedded iteration in handleClose().

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [ ] RDF4J code formatting has been applied
- [ ] tests are included
- [ ] all tests succeed

Signed-off-by: Pavel Mihaylov <pavel@ontotext.com>