### PR TITLE
Fix #239, second try

### DIFF
--- a/core/sail/spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
+++ b/core/sail/spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
@@ -1,12 +1,15 @@
-/*******************************************************************************
+/**
+ * *****************************************************************************
  * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- *******************************************************************************/
+ ******************************************************************************
+ */
 package org.eclipse.rdf4j.sail.spin;
 
+import com.google.common.collect.Lists;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -16,9 +19,11 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
 import java.util.Locale;
 
 import org.eclipse.rdf4j.OpenRDFException;
+import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -36,6 +41,7 @@ import org.eclipse.rdf4j.sail.inferencer.fc.DedupingInferencer;
 import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingRDFSInferencer;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -261,5 +267,35 @@ public class SpifSailTest {
 				"prefix spif: <http://spinrdf.org/spif#> "
 						+ "ask where {filter(spif:canInvoke(spif:indexOf, 'foobar', 2))}");
 		assertFalse(bq.evaluate());
+	}
+
+	@Test
+	public void testConcat()
+		throws Exception
+	{
+		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+				"prefix apf: <http://jena.hpl.hp.com/ARQ/property#>\n" + "\n" + "select ?text where {\n"
+						+ "   ?text apf:concat (\"very\" \"sour\" \"berry\") . }");
+		TupleQueryResult tqresult = tq.evaluate();
+
+		Assert.assertEquals("verysourberry", tqresult.next().getValue("text").stringValue());
+	}
+
+	@Test
+	public void testStrSplit()
+		throws Exception
+	{
+		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL,
+				"prefix apf: <http://jena.hpl.hp.com/ARQ/property#>\n" + "\n" + "select ?text where {\n"
+						+ "   ?text apf:strSplit (\"very:sour:berry\" \":\") . }");
+		TupleQueryResult tqr = tq.evaluate();
+
+		List<BindingSet> resultList = Iterations.asList(tqr);
+		List<String> resultStringList = Lists.transform(resultList,
+				(BindingSet input) -> input.getValue("text").stringValue());
+
+		Assert.assertArrayEquals(new String[] { "very", "sour", "berry" },
+				resultStringList.toArray(new String[] {}));
+
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #239 

Briefly describe the changes proposed in this PR:

- Second try to fix issue #239 
- Replacement of PR eclipse/rdf4j#240

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

    
More information at eclipse/rdf4j/pull/240
Signed-off-by:Jacek Grzebyta <grzebyta.dev@gmail.com>