### PR TITLE
issue#301 : Work on tightening the contract for lucene sail components

### DIFF
--- a/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneIndex.java
+++ b/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneIndex.java
@@ -8,8 +8,8 @@
 package org.eclipse.rdf4j.sail.lucene;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 
 public abstract class AbstractLuceneIndex extends AbstractSearchIndex {
 
@@ -17,7 +17,7 @@ public abstract class AbstractLuceneIndex extends AbstractSearchIndex {
 	 * keep a lit of old monitors that are still iterating but not closed (open iterators), will be all closed
 	 * on shutdown items are removed from list by ReaderMnitor.endReading() when closing
 	 */
-	protected final Collection<AbstractReaderMonitor> oldmonitors = new LinkedList<AbstractReaderMonitor>();
+	protected final Collection<AbstractReaderMonitor> oldmonitors = new ArrayList<AbstractReaderMonitor>();
 
 	protected abstract AbstractReaderMonitor getCurrentMonitor();
 

--- a/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractReaderMonitor.java
+++ b/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractReaderMonitor.java
@@ -33,14 +33,22 @@ public abstract class AbstractReaderMonitor {
 		this.index = index;
 	}
 
-	public int getReadingCount() {
+	public final int getReadingCount() {
 		return readingCount.get();
 	}
 
 	/**
 	 * 
 	 */
-	public void beginReading() {
+	public final synchronized void beginReading() {
+		if (closed.get()) {
+			throw new IllegalStateException("Cannot begin reading as we have been closed.");
+		}
+		// We cannot allow any more readers to be open at this stage, as any
+		// decrements towards zero on readingCount could trigger closure/removal
+		if (doClose.get()) {
+			throw new IllegalStateException("Cannot begin reading as we have moved into closing stages.");
+		}
 		readingCount.incrementAndGet();
 	}
 
@@ -49,16 +57,17 @@ public abstract class AbstractReaderMonitor {
 	 * 
 	 * @throws IOException
 	 */
-	public void endReading()
+	public final synchronized void endReading()
 		throws IOException
 	{
-		if (readingCount.decrementAndGet() == 0 && doClose.get()) {
-			// when endReading is called on CurrentMonitor and it should be closed,
-			// close it
-			close();// close Lucene index remove them self from Lucene index
+		if (readingCount.decrementAndGet() <= 0 && doClose.get()) {
+			// when endReading is called on CurrentMonitor and it should be
+			// closed, close it
+			close();
+			// close Lucene index remove them self from Lucene index
 			synchronized (index.oldmonitors) {
-				index.oldmonitors.remove(this); // if its not in the list, then this
-												// is a no-operation
+				// if its not in the list, then this is a no-operation
+				index.oldmonitors.remove(this);
 			}
 		}
 	}
@@ -69,7 +78,7 @@ public abstract class AbstractReaderMonitor {
 	 * @return <code>true</code> if the close succeeded, <code>false</code> otherwise.
 	 * @throws IOException
 	 */
-	public boolean closeWhenPossible()
+	public final synchronized boolean closeWhenPossible()
 		throws IOException
 	{
 		doClose.set(true);
@@ -79,10 +88,10 @@ public abstract class AbstractReaderMonitor {
 		return closed.get();
 	}
 
-	public void close()
+	public final void close()
 		throws IOException
 	{
-		if (!closed.getAndSet(true)) {
+		if (closed.compareAndSet(false, true)) {
 			handleClose();
 		}
 	}

--- a/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
@@ -253,13 +254,13 @@ public class LuceneSail extends NotifyingSailWrapper {
 	/**
 	 * The LuceneIndex holding the indexed literals.
 	 */
-	private SearchIndex luceneIndex;
+	private volatile SearchIndex luceneIndex;
 
 	protected final Properties parameters = new Properties();
 
-	private String reindexQuery = "SELECT ?s ?p ?o ?c WHERE {{?s ?p ?o} UNION {GRAPH ?c {?s ?p ?o.}}} ORDER BY ?s";
+	private volatile String reindexQuery = "SELECT ?s ?p ?o ?c WHERE {{?s ?p ?o} UNION {GRAPH ?c {?s ?p ?o.}}} ORDER BY ?s";
 
-	private boolean incompleteQueryFails = true;
+	private volatile boolean incompleteQueryFails = true;
 
 	private Set<IRI> indexedFields;
 
@@ -267,6 +268,8 @@ public class LuceneSail extends NotifyingSailWrapper {
 
 	private IndexableStatementFilter filter = null;
 
+	private final AtomicBoolean closed = new AtomicBoolean(false);
+	
 	public void setLuceneIndex(SearchIndex luceneIndex) {
 		this.luceneIndex = luceneIndex;
 	}
@@ -286,18 +289,22 @@ public class LuceneSail extends NotifyingSailWrapper {
 	public void shutDown()
 		throws SailException
 	{
-		try {
-			if (luceneIndex != null) {
-				luceneIndex.shutDown();
+		if(closed.compareAndSet(false, true)) {
+			try {
+				SearchIndex toShutDownLuceneIndex = luceneIndex;
+				luceneIndex = null;
+				if (toShutDownLuceneIndex != null) {
+					toShutDownLuceneIndex.shutDown();
+				}
 			}
-		}
-		catch (IOException e) {
-			throw new SailException(e);
-		}
-		finally {
-			// ensure that super is also invoked when the LuceneIndex causes an
-			// IOException
-			super.shutDown();
+			catch (IOException e) {
+				throw new SailException(e);
+			}
+			finally {
+				// ensure that super is also invoked when the LuceneIndex causes an
+				// IOException
+				super.shutDown();
+			}
 		}
 	}
 
@@ -492,27 +499,33 @@ public class LuceneSail extends NotifyingSailWrapper {
 	}
 
 	protected boolean acceptStatementToIndex(Statement s) {
-		return (filter != null) ? filter.accept(s) : true;
+		IndexableStatementFilter nextFilter = filter;
+		return (nextFilter != null) ? nextFilter.accept(s) : true;
 	}
 
 	public Statement mapStatement(Statement statement) {
 		IRI p = statement.getPredicate();
 		boolean predicateChanged = false;
-		if (indexedFieldsMapping != null) {
-			IRI res = indexedFieldsMapping.get(p);
+		Map<IRI, IRI> nextIndexedFieldsMapping = indexedFieldsMapping;
+		if (nextIndexedFieldsMapping != null) {
+			IRI res = nextIndexedFieldsMapping.get(p);
 			if (res != null) {
 				p = res;
 				predicateChanged = true;
 			}
 		}
-		if (this.indexedFields != null && !this.indexedFields.contains(p))
+		Set<IRI> nextIndexedFields = indexedFields;
+		if (nextIndexedFields != null && !nextIndexedFields.contains(p)) {
 			return null;
+		}
 
-		if (predicateChanged)
+		if (predicateChanged) {
 			return getValueFactory().createStatement(statement.getSubject(), p, statement.getObject(),
 					statement.getContext());
-		else
+		}
+		else {
 			return statement;
+		}
 	}
 
 	protected Collection<SearchQueryInterpreter> getSearchQueryInterpreters() {


### PR DESCRIPTION
This PR addresses GitHub issue: #301 

Briefly describe the changes proposed in this PR:

- Adds more checks and sychronisation to avoid calling into Lucene API at unexpected times

Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):

- [x] RDF4J code formatting has been applied
- [x] tests are included
- [x] all tests succeed

Lock more Lucene methods. The internal Lucene API isn't stable for long term threaded access so external synchronisation is necessary.

Add checks on calls after closure

With these changes I have not been able to replicate the issue after several (30+) invocations of the testsuite. Previously I was getting the error about 1 in every 10 runs through LuceneSailTest.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>