### PR TITLE
Issue #266: simplified Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,8 @@
 
-This PR addresses GitHub issue: #
+This PR addresses GitHub issue: # .
 
 Briefly describe the changes proposed in this PR:
 
-- ...
-- ...
-- ...
-
-Make sure you've followed the [Contributor Guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md). In particular (please tick to indicate you've taken care of it):
-
-- [ ] RDF4J code formatting has been applied
-- [ ] tests are included
-- [ ] all tests succeed
+- 
+- 
+- 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,6 @@ This PR addresses GitHub issue: # .
 
 Briefly describe the changes proposed in this PR:
 
-- 
-- 
-- 
+* 
+* 
+* 


### PR DESCRIPTION
Got rid of the redundant link to the guidelines (GitHub shows it right at the top itself) and the tick boxes for formatting and tests, etc (nobody really uses them anyway it seems).