### PR TITLE
issue #311 : Update to Jackson-2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
 		<spring.version>4.2.1.RELEASE</spring.version>
 		<httpclient.version>4.5.2</httpclient.version>
 		<httpcore.version>4.4.4</httpcore.version>
-		<jackson.version>2.6.2</jackson.version>
+		<jackson.version>2.8.2</jackson.version>
 		<jsonldjava.version>0.8.3</jsonldjava.version>
 	</properties>
 
@@ -547,6 +547,11 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-csv</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
This PR addresses GitHub issue: #311 .

Briefly describe the changes proposed in this PR:

* Update Jackson to 2.8.2
* Add Jackson Dataformat CSV module to dependency management, but not to any dependencies sections. Usage of this module will be added in near future pull requests.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>