### PR TITLE
Fix problem with logger

### DIFF
--- a/core/sail/fts/elasticsearch/src/test/resources/logback-test.xml
+++ b/core/sail/fts/elasticsearch/src/test/resources/logback-test.xml
@@ -3,13 +3,11 @@
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %msg%n</pattern>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{10}: %msg%n</pattern>
 		</encoder>
 	</appender>
 	
-        <logger name="org.eclipse.rdf4j.sail.elasticsearch.ElasticsearchSailTest">
-            <level value="debug"/>
-        </logger>
+        <logger name="org.eclipse.rdf4j.sail.elasticsearch.ElasticsearchSailTest" level="debug"/>
         
 	<root>
 		<level value="info" />


### PR DESCRIPTION
This PR addresses GitHub issue: #578  .

Briefly describe the changes proposed in this PR:

I found that logger's level in the config file should be declared in different way:

```
<logger name="my.superclass.full.of.errors.Foo" level="debug" />
```
* Change logger's definition according to documentation
* Change logging layout
