### PR TITLE
Issue #299 added downgrading of RDF/XML q-value for accept headers

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
@@ -264,14 +264,22 @@ public class RDFFormat extends FileFormat {
 				qValue -= 1;
 			}
 
-			for (String mimeType : format.getMIMETypes()) {
-				String acceptParam = mimeType;
+			if (RDFXML.equals(format)) {
+				// We explicitly dislike RDF/XML as it has limitations in what it can serialize. See #299.
+				qValue -= 4;
+			}
 
-				if (qValue < 10) {
-					acceptParam += ";q=0." + qValue;
+			// if the qValue did not go negative, we add this format to the accept params.
+			if (qValue > 0) { 
+				for (String mimeType : format.getMIMETypes()) {
+					String acceptParam = mimeType;
+
+					if (qValue < 10) {
+						acceptParam += ";q=0." + qValue;
+					}
+
+					acceptParams.add(acceptParam);
 				}
-
-				acceptParams.add(acceptParam);
 			}
 		}
 

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
@@ -269,17 +269,17 @@ public class RDFFormat extends FileFormat {
 				qValue -= 4;
 			}
 
-			// if the qValue did not go negative, we add this format to the accept params.
-			if (qValue > 0) { 
-				for (String mimeType : format.getMIMETypes()) {
-					String acceptParam = mimeType;
+			// ensure q-value does not go below 0.1.
+			qValue = Math.max(1, qValue);
+			
+			for (String mimeType : format.getMIMETypes()) {
+				String acceptParam = mimeType;
 
-					if (qValue < 10) {
-						acceptParam += ";q=0." + qValue;
-					}
-
-					acceptParams.add(acceptParam);
+				if (qValue < 10) {
+					acceptParam += ";q=0." + qValue;
 				}
+
+				acceptParams.add(acceptParam);
 			}
 		}
 


### PR DESCRIPTION
This PR addresses GitHub issue: #299  .

Briefly describe the changes proposed in this PR:

* q-value for RDF/XML is downgraded by 0.4 (so best-case scenario is it becomes 0.6)
* added failsafe to completely skip a format if the q-value goes below 0.1.
