### PR TITLE
Issue #300: added Literals.getDurationValue and XMLDatatypeUtil.parseDuration

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -14,6 +14,7 @@ import java.util.StringTokenizer;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
@@ -1902,6 +1903,25 @@ public class XMLDatatypeUtil {
 	 */
 	public static XMLGregorianCalendar parseCalendar(String s) {
 		return dtFactory.newXMLGregorianCalendar(s);
+	}
+
+	/**
+	 * Parses the supplied xsd:duration value string and returns its value.
+	 * 
+	 * @param s
+	 *        A string representation of an xsd:duration value.
+	 * @return The {@link Duration} value represented by the supplied string argument.
+	 * @throws IllegalArgumentException
+	 *         If the supplied string is not a valid xsd:duration value.
+	 * @throws UnsupportedOperationException
+	 *         If implementation cannot support requested values. The XML Schema specification states that
+	 *         values can be of an arbitrary size. Implementations may chose not to or be incapable of
+	 *         supporting arbitrarily large and/or small values. An UnsupportedOperationException will be
+	 *         thrown with a message indicating implementation limits if implementation capacities are
+	 *         exceeded.
+	 */
+	public static Duration parseDuration(String s) {
+		return dtFactory.newDuration(s);
 	}
 
 	/**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -15,10 +15,12 @@ import java.util.Objects;
 import java.util.Optional;
 
 import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.datatype.Duration;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.util.language.LanguageTag;
 import org.eclipse.rdf4j.model.util.language.LanguageTagSyntaxException;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
@@ -356,6 +358,25 @@ public class Literals {
 			return l.calendarValue();
 		}
 		catch (IllegalArgumentException e) {
+			return fallback;
+		}
+	}
+
+	/**
+	 * Gets the {@link Duration} value of the supplied literal. The fallback value is returned in case
+	 * {@link XMLDatatypeUtil#parseDuration(String)} throws an exception.
+	 * 
+	 * @param l
+	 *        The literal to get the {@link Duration} value for.
+	 * @param fallback
+	 *        The value to fall back to in case no Duration value could gotten from the literal.
+	 * @return Either the literal's Duration value, or the fallback value.
+	 */
+	public static Duration getDurationValue(Literal l, Duration fallback) {
+		try {
+			return XMLDatatypeUtil.parseDuration(l.getLabel());
+		}
+		catch (IllegalArgumentException | UnsupportedOperationException e) {
 			return fallback;
 		}
 	}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -18,8 +18,10 @@ import java.util.GregorianCalendar;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.Duration;
 
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.junit.Ignore;
@@ -31,6 +33,9 @@ import org.junit.Test;
  * @author Peter Ansell
  */
 public class LiteralsTest {
+
+	private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
 
 	/**
 	 * Test method for
@@ -303,6 +308,21 @@ public class LiteralsTest {
 		throws Exception
 	{
 		fail("Not yet implemented"); // TODO
+	}
+
+	@Test
+	public final void testGetDurationValueLiteralDuration()
+		throws Exception
+	{
+		DatatypeFactory dtFactory = DatatypeFactory.newInstance();
+		
+		Duration fallback = dtFactory.newDuration(true, 1, 1, 1, 1, 1, 1);
+		
+		Duration result = Literals.getDurationValue(vf.createLiteral("P5Y"), fallback);
+		
+		assertNotNull(result);
+		assertFalse(result.equals(fallback));
+		assertEquals(5, result.getYears());
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses GitHub issue: #300 .

Briefly describe the changes proposed in this PR:

* added `Literals.getDurationValue` method to extract a java `Duration` object from a literal
* added `XMLDatatypeUtil.parseDuration` for parsing a lexical representation into a Duration object.
* added simple unit test
