### PR TITLE
Use repositories over TLS.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<organization>
 		<name>Eclipse Foundation</name>
-		<url>http://www.eclipse.org/</url>
+		<url>https://www.eclipse.org/</url>
 	</organization>
 
 	<developers>
@@ -762,7 +762,7 @@
 		<repository>
 			<id>maven-restlet</id>
 			<name>Public online Restlet repository</name>
-			<url>http://maven.restlet.org</url>
+			<url>https://maven.restlet.com</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Use an HTTPS URL for Restlet, so code isn't fetched over an insecure connection. Switch to their current preferred TLD of .com rather than .org (they redirect .org to .com over HTTP, but not HTTPS).

Adjust the Eclipse link at the same time.
