### PR TITLE
Issue #544: reimplement 'set log' for Logback

### DIFF
--- a/core/console/pom.xml
+++ b/core/console/pom.xml
@@ -54,7 +54,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<scope>runtime</scope>
+			<scope>compile</scope>
 		</dependency>
 		
 		<dependency>

--- a/core/console/src/main/java/org/eclipse/rdf4j/console/SetParameters.java
+++ b/core/console/src/main/java/org/eclipse/rdf4j/console/SetParameters.java
@@ -7,11 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableBiMap.Builder;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -21,16 +21,17 @@ import ch.qos.logback.classic.Logger;
  */
 public class SetParameters implements Command {
 
-	private static final Map<String, Level> LOG_LEVELS;
+	private static final BiMap<String, Level> LOG_LEVELS;
 
 	static {
-		Map<String, Level> logLevels = new LinkedHashMap<String, Level>();
+		Builder<String, Level> logLevels = ImmutableBiMap.<String, Level> builder();
+
 		logLevels.put("none", Level.OFF);
 		logLevels.put("error", Level.ERROR);
 		logLevels.put("warning", Level.WARN);
 		logLevels.put("info", Level.INFO);
 		logLevels.put("debug", Level.DEBUG);
-		LOG_LEVELS = Collections.unmodifiableMap(logLevels);
+		LOG_LEVELS = logLevels.build();
 	}
 
 	private final ConsoleIO consoleIO;
@@ -95,14 +96,8 @@ public class SetParameters implements Command {
 
 		if (value == null) {
 			Level currentLevel = logbackRootLogger.getLevel();
-			String levelString = currentLevel.levelStr;
 
-			for (Map.Entry<String, Level> entry : LOG_LEVELS.entrySet()) {
-				if (entry.getValue().equals(currentLevel)) {
-					levelString = entry.getKey();
-					break;
-				}
-			}
+			String levelString = LOG_LEVELS.inverse().getOrDefault(currentLevel, currentLevel.levelStr);
 
 			consoleIO.writeln("log: " + levelString);
 

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
@@ -1,10 +1,10 @@
-/*******************************************************************************
+/**
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- *******************************************************************************/
+ */
 package org.eclipse.rdf4j.console;
 
 import static org.junit.Assert.assertEquals;

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
@@ -63,8 +63,28 @@ public class SetParametersTest {
 		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 		logger.setLevel(Level.DEBUG);
 
-		setParameters.execute("set", "log", "warning");
+		setParameters.execute("set", "log=warning");
 
 		assertEquals(Level.WARN, logger.getLevel());
 	}
+
+	@Test
+	public void settingUnknownLevelIsLoggedAsError() {
+		setParameters.execute("set", "log=chatty");
+
+		verify(consoleIo).writeError("unknown logging level: chatty");
+		verifyNoMoreInteractions(consoleIo);
+	}
+
+	@Test
+	public void levelsThatDoNotMatchSlf4jAreMapped() {
+		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		logger.setLevel(Level.WARN);
+
+		setParameters.execute("set", "log");
+
+		verify(consoleIo).writeln("log: warning");
+		verifyNoMoreInteractions(consoleIo);
+	}
+
 }

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.console;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+
+public class SetParametersTest {
+
+	@Rule
+	public MockitoRule rule = MockitoJUnit.rule();
+
+	@Mock
+	ConsoleIO consoleIo;
+
+	@InjectMocks
+	SetParameters setParameters;
+
+	@After
+	public void setLogLevelBackToDebug() {
+		((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
+	}
+
+	@Test
+	public void unknownParametersAreErrors() {
+		setParameters.execute("set", "unknown");
+
+		verify(consoleIo).writeError("unknown parameter: unknown");
+		verifyNoMoreInteractions(consoleIo);
+	}
+
+	@Test
+	public void noValueShowsCurrentLevel() {
+		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		logger.setLevel(Level.INFO);
+
+		setParameters.execute("set", "log");
+
+		verify(consoleIo).writeln("log: info");
+		verifyNoMoreInteractions(consoleIo);
+	}
+
+	@Test
+	public void settingLogChangesLevel() {
+		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		logger.setLevel(Level.DEBUG);
+
+		setParameters.execute("set", "log", "warning");
+
+		assertEquals(Level.WARN, logger.getLevel());
+	}
+}

--- a/eclipse-settings/codetemplates.xml
+++ b/eclipse-settings/codetemplates.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="false" context="filecomment_context" deleted="false" description="Comment for created Java files" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.filecomment" name="filecomment">/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
This PR addresses GitHub issue: #544.

* Add tests for 'set log'
* Bring back the previous JDK logging implementation and adjust for Logback.
