### PR TITLE
Issue #468: Don't wrap exceptions that can be thrown directly.

### DIFF
--- a/core/http/workbench/src/main/java/org/eclipse/rdf4j/workbench/base/TransformationServlet.java
+++ b/core/http/workbench/src/main/java/org/eclipse/rdf4j/workbench/base/TransformationServlet.java
@@ -99,7 +99,7 @@ public abstract class TransformationServlet extends AbstractRepositoryServlet {
 				service(wreq, resp, xslPath);
 			}
 		}
-		catch (RuntimeException e) {
+		catch (RuntimeException | ServletException | IOException e) {
 			throw e;
 		}
 		catch (Exception e) {


### PR DESCRIPTION
This PR addresses GitHub issue: #468 .

Signed-off-by: Joseph Walton <joe@kafsemo.org>