### PR TITLE
#575 added limit and offset as optional HTTP request params

### DIFF
--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
@@ -96,6 +96,10 @@ public abstract class Protocol {
 	 */
 	public static final String QUERY_PARAM_NAME = "query";
 
+	public static final String LIMIT_PARAM_NAME = "limit";
+	
+	public static final String OFFSET_PARAM_NAME = "offset";
+	
 	/**
 	 * Parameter name for the query language parameter.
 	 */

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/ProtocolUtil.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/ProtocolUtil.java
@@ -120,6 +120,24 @@ public class ProtocolUtil {
 		}
 	}
 
+	public static long parseLongParam(HttpServletRequest request, String paramName, long defaultValue)
+		throws ClientHTTPException
+	{
+		String paramValue = request.getParameter(paramName);
+		if (paramValue == null) {
+			return defaultValue;
+		}
+		else {
+			try {
+				return Long.parseLong(paramValue);
+			}
+			catch (IllegalArgumentException e) {
+				throw new ClientHTTPException(SC_BAD_REQUEST,
+						"Invalid value for parameter '" + paramName + "': " + e.getMessage());
+			}
+		}
+	}
+
 	/**
 	 * Logs all request parameters of the supplied request.
 	 */

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
@@ -29,6 +29,9 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.LimitIteration;
+import org.eclipse.rdf4j.common.iteration.OffsetIteration;
 import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.common.lang.service.FileFormatServiceRegistry;
 import org.eclipse.rdf4j.common.webapp.util.HttpServerUtil;
@@ -193,21 +196,44 @@ public class RepositoryController extends AbstractController {
 				Query query = getQuery(repository, repositoryCon, queryStr, request, response);
 
 				View view;
-				Object queryResult;
+				Object queryResult = null;
 				FileFormatServiceRegistry<? extends FileFormat, ?> registry;
 
 				try {
 					if (query instanceof TupleQuery) {
-						TupleQuery tQuery = (TupleQuery)query;
+						if (!headersOnly) {
+							TupleQuery tQuery = (TupleQuery)query;
+							long limit = ProtocolUtil.parseLongParam(request, Protocol.LIMIT_PARAM_NAME, 0);
+							long offset = ProtocolUtil.parseLongParam(request, Protocol.OFFSET_PARAM_NAME, 0);
+							boolean distinct = ProtocolUtil.parseBooleanParam(request,
+									Protocol.DISTINCT_PARAM_NAME, false);
 
-						queryResult = headersOnly ? null : tQuery.evaluate();
+							QueryResult<?> tqr = tQuery.evaluate();
+							if (distinct) {
+								tqr = distinct(tqr);
+							}
+
+							queryResult = paginated(tqr, limit, offset);
+						}
 						registry = TupleQueryResultWriterRegistry.getInstance();
 						view = TupleQueryResultView.getInstance();
 					}
 					else if (query instanceof GraphQuery) {
-						GraphQuery gQuery = (GraphQuery)query;
+						if (!headersOnly) {
+							GraphQuery gQuery = (GraphQuery)query;
+							long limit = ProtocolUtil.parseLongParam(request, Protocol.LIMIT_PARAM_NAME, 0);
+							long offset = ProtocolUtil.parseLongParam(request, Protocol.OFFSET_PARAM_NAME, 0);
 
-						queryResult = headersOnly ? null : gQuery.evaluate();
+							boolean distinct = ProtocolUtil.parseBooleanParam(request,
+									Protocol.DISTINCT_PARAM_NAME, false);
+
+							QueryResult<?> gqr = gQuery.evaluate();
+							if (distinct) {
+								gqr = distinct(gqr);
+							}
+
+							queryResult = paginated(gqr, limit, offset);
+						}
 						registry = RDFWriterRegistry.getInstance();
 						view = GraphQueryResultView.getInstance();
 					}
@@ -236,14 +262,6 @@ public class RepositoryController extends AbstractController {
 					}
 					else {
 						throw new ServerHTTPException("Query evaluation error: " + e.getMessage());
-					}
-				}
-
-				if (queryResult instanceof QueryResult<?>) {
-					boolean distinct = ProtocolUtil.parseBooleanParam(request, Protocol.DISTINCT_PARAM_NAME,
-							false);
-					if (distinct) {
-						queryResult = distinct((QueryResult<?>)queryResult);
 					}
 				}
 
@@ -379,7 +397,7 @@ public class RepositoryController extends AbstractController {
 
 	private static QueryResult<?> distinct(QueryResult<?> qr) {
 		if (qr instanceof TupleQueryResult) {
-			TupleQueryResult tqr = (TupleQueryResult) qr;
+			TupleQueryResult tqr = (TupleQueryResult)qr;
 			return QueryResults.distinctResults(tqr);
 		}
 		else if (qr instanceof GraphQueryResult) {
@@ -389,5 +407,19 @@ public class RepositoryController extends AbstractController {
 		else {
 			return qr;
 		}
+	}
+
+	private static <T> CloseableIteration<T, QueryEvaluationException> paginated(QueryResult<T> qr,
+			long limit, long offset)
+	{
+		CloseableIteration<T, QueryEvaluationException> result = qr;
+		if (offset > 0) {
+			result = new OffsetIteration<>(result, offset);
+		}
+		if (limit > 0) {
+			result = new LimitIteration<>(result, limit);
+		}
+
+		return result;
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #575 .

Briefly describe the changes proposed in this PR:

* added limit and offset params to REST protocol
* added util method `ProtocolUtil.parseLongParam`
* `RepositoryController` now applies optional limit and offset to query results (by wrapping iteration)


Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>