### PR TITLE
#597 bumped to spatial4j 0.6.

### DIFF
--- a/core/queryalgebra/geosparql/pom.xml
+++ b/core/queryalgebra/geosparql/pom.xml
@@ -20,7 +20,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.spatial4j</groupId>
+			<groupId>org.locationtech.spatial4j</groupId>
 			<artifactId>spatial4j</artifactId>
 		</dependency>
 

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Boundary.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Boundary.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:boundary, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Buffer.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Buffer.java
@@ -17,8 +17,8 @@ import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:buffer, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/ConvexHull.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/ConvexHull.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:convexHull, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultSpatialAlgebra.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultSpatialAlgebra.java
@@ -10,11 +10,11 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import java.util.Arrays;
 import java.util.Collections;
 
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.ShapeCollection;
-import com.spatial4j.core.shape.SpatialRelation;
-import com.spatial4j.core.shape.impl.BufferedLineString;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.ShapeCollection;
+import org.locationtech.spatial4j.shape.SpatialRelation;
+import org.locationtech.spatial4j.shape.impl.BufferedLineString;
 
 final class DefaultSpatialAlgebra implements SpatialAlgebra {
 

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultWktWriter.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultWktWriter.java
@@ -9,10 +9,10 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import java.io.IOException;
 
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.ShapeCollection;
-import com.spatial4j.core.shape.impl.BufferedLineString;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.ShapeCollection;
+import org.locationtech.spatial4j.shape.impl.BufferedLineString;
 
 final class DefaultWktWriter implements WktWriter {
 

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Difference.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Difference.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:difference, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Distance.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Distance.java
@@ -14,8 +14,8 @@ import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Point;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Point;
 
 /**
  * The GeoSPARQL {@link Function} geof:distance, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhContains.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhContains.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehContains, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCoveredBy.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCoveredBy.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehCoveredBy, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCovers.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCovers.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehCovers, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhDisjoint.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhDisjoint.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehDisjoint, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhEquals.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhEquals.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehEquals, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhInside.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhInside.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehInside, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhMeet.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhMeet.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehMeet, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhOverlap.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhOverlap.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehOverlap, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Envelope.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Envelope.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:envelope, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/FunctionArguments.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/FunctionArguments.java
@@ -18,10 +18,10 @@ import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.distance.DistanceUtils;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.distance.DistanceUtils;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
 
 class FunctionArguments {
 

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunction.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunction.java
@@ -15,8 +15,8 @@ import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 abstract class GeometricBinaryFunction implements Function {
 

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunction.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunction.java
@@ -12,8 +12,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 abstract class GeometricRelationFunction implements Function {
 

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunction.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunction.java
@@ -15,8 +15,8 @@ import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 abstract class GeometricUnaryFunction implements Function {
 

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Intersection.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Intersection.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:intersection, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8DC.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8DC.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8dc, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EC.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EC.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8ec, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EQ.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EQ.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8eq, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPP.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPP.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8ntpp, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPPI.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPPI.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8ntppi, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8PO.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8PO.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8po, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPP.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPP.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8tpp, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPPI.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPPI.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8tppi, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Relate.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Relate.java
@@ -13,8 +13,8 @@ import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:relate, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfContains.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfContains.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfContains, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfCrosses.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfCrosses.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfCrosses, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfDisjoint.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfDisjoint.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfDisjoint, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfEquals.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfEquals.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfEquals, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfIntersects.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfIntersects.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfIntersects, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfOverlaps.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfOverlaps.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfOverlaps, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfTouches.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfTouches.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfTouches, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfWithin.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfWithin.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfWithin, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialAlgebra.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialAlgebra.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 public interface SpatialAlgebra {
 

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialSupport.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialSupport.java
@@ -10,18 +10,18 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.SpatialContextFactory;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.context.SpatialContextFactory;
 
 /**
- * This class is responsible for creating the {@link com.spatial4j.core.context.SpatialContext},
+ * This class is responsible for creating the {@link org.locationtech.spatial4j.context.SpatialContext},
  * {@link SpatialAlegbra} and {@link WktWriter} that will be used. It will first try to load a subclass of
  * itself called "org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql.SpatialSupportInitializer" .
  * This is not provided, and is primarily intended as a way to inject JTS support. If this fails then the
  * following fall-backs are used:
  * <ul>
  * <li>a SpatialContext created by passing system properties with the prefix "spatialSupport." to
- * {@link com.spatial4j.core.context.SpatialContextFactory} . The prefix is stripped from the system property
+ * {@link org.locationtech.spatial4j.context.SpatialContextFactory} . The prefix is stripped from the system property
  * name to form the SpatialContextFactory argument name.</li>
  * <li>a SpatialAlgebra that does not support any operation.</li>
  * <li>a WktWriter that only supports points</li>.

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SymmetricDifference.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SymmetricDifference.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:symDifference, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Union.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Union.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:union, as defined in

--- a/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/WktWriter.java
+++ b/core/queryalgebra/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/WktWriter.java
@@ -9,7 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import java.io.IOException;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 public interface WktWriter {
 

--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocument.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocument.java
@@ -21,9 +21,9 @@ import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.search.SearchHit;
 
 import com.google.common.base.Function;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.core.context.SpatialContext;
+import org.locationtech.spatial4j.core.shape.Point;
+import org.locationtech.spatial4j.core.shape.Shape;
 
 public class ElasticsearchDocument implements SearchDocument {
 

--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentDistance.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentDistance.java
@@ -17,8 +17,8 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.search.SearchHit;
 
 import com.google.common.base.Function;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.distance.DistanceUtils;
+import org.locationtech.spatial4j.core.context.SpatialContext;
+import org.locationtech.spatial4j.core.distance.DistanceUtils;
 
 public class ElasticsearchDocumentDistance extends ElasticsearchDocumentResult implements DocumentDistance {
 

--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentResult.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentResult.java
@@ -12,7 +12,7 @@ import org.eclipse.rdf4j.sail.lucene.SearchDocument;
 import org.elasticsearch.search.SearchHit;
 
 import com.google.common.base.Function;
-import com.spatial4j.core.context.SpatialContext;
+import org.locationtech.spatial4j.core.context.SpatialContext;
 
 public class ElasticsearchDocumentResult implements DocumentResult {
 

--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentScore.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentScore.java
@@ -17,7 +17,7 @@ import org.elasticsearch.search.highlight.HighlightField;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.spatial4j.core.context.SpatialContext;
+import org.locationtech.spatial4j.core.context.SpatialContext;
 
 public class ElasticsearchDocumentScore extends ElasticsearchDocumentResult implements DocumentScore {
 

--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -70,11 +70,11 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.Iterables;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.SpatialContextFactory;
-import com.spatial4j.core.distance.DistanceUtils;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.core.context.SpatialContext;
+import org.locationtech.spatial4j.core.context.SpatialContextFactory;
+import org.locationtech.spatial4j.core.distance.DistanceUtils;
+import org.locationtech.spatial4j.core.shape.Point;
+import org.locationtech.spatial4j.core.shape.Shape;
 
 /**
  * @see LuceneSail

--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSpatialSupport.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSpatialSupport.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.core.shape.Shape;
 
 /**
  * This class will try to load a subclass of itself called

--- a/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractSearchIndex.java
+++ b/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractSearchIndex.java
@@ -41,9 +41,9 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.core.context.SpatialContext;
+import org.locationtech.spatial4j.core.shape.Point;
+import org.locationtech.spatial4j.core.shape.Shape;
 
 public abstract class AbstractSearchIndex implements SearchIndex {
 

--- a/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/util/GeoUnits.java
+++ b/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/util/GeoUnits.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.sail.lucene.util;
 import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 
-import com.spatial4j.core.distance.DistanceUtils;
+import org.locationtech.spatial4j.core.distance.DistanceUtils;
 
 public final class GeoUnits {
 

--- a/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocument.java
+++ b/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocument.java
@@ -18,7 +18,7 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.spatial.SpatialStrategy;
 
 import com.google.common.base.Function;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.core.shape.Shape;
 
 public class LuceneDocument implements SearchDocument {
 

--- a/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocumentDistance.java
+++ b/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocumentDistance.java
@@ -16,8 +16,8 @@ import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.sail.lucene.util.GeoUnits;
 
 import com.google.common.collect.Sets;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.core.shape.Point;
+import org.locationtech.spatial4j.core.shape.Shape;
 
 public class LuceneDocumentDistance extends LuceneDocumentResult implements DocumentDistance {
 

--- a/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
+++ b/core/sail/fts/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
@@ -84,10 +84,10 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.SpatialContextFactory;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.core.context.SpatialContext;
+import org.locationtech.spatial4j.core.context.SpatialContextFactory;
+import org.locationtech.spatial4j.core.shape.Point;
+import org.locationtech.spatial4j.core.shape.Shape;
 
 /**
  * A LuceneIndex is a one-stop-shop abstraction of a Lucene index. It takes care of proper synchronization of

--- a/core/sail/fts/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
+++ b/core/sail/fts/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
@@ -47,12 +47,12 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.Iterables;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.SpatialContextFactory;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Rectangle;
-import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.SpatialRelation;
+import org.locationtech.spatial4j.core.context.SpatialContext;
+import org.locationtech.spatial4j.core.context.SpatialContextFactory;
+import org.locationtech.spatial4j.core.shape.Point;
+import org.locationtech.spatial4j.core.shape.Rectangle;
+import org.locationtech.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.core.shape.SpatialRelation;
 
 /**
  * @see LuceneSail

--- a/pom.xml
+++ b/pom.xml
@@ -312,9 +312,9 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>com.spatial4j</groupId>
+				<groupId>org.locationtech.spatial4j</groupId>
 				<artifactId>spatial4j</artifactId>
-				<version>0.4.1</version>
+				<version>0.6</version>
 			</dependency>
 
 			<!-- Java Enterprise Edition -->


### PR DESCRIPTION
This PR addresses GitHub issue: #597 .

Briefly describe the changes proposed in this PR:

* dependency changed to org.locationtech.spatial4j release 0.6 in poms
* fixed imports

Executed geosparql compliance tests, which greenline. 

@pulquero I'd appreciate your feedback on this. 

Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>