### PR TITLE
Issue #573 fix for group by behaviour + unit test.

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
@@ -214,9 +214,13 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 			Map<Key, Entry> entries = new LinkedHashMap<Key, Entry>();
 
 			if (!iter.hasNext()) {
-				// no solutions, still need to process aggregates to produce a
+				// no solutions, but if aggregates are present we still need to process them to produce a
 				// zero-result.
-				entries.put(new Key(EmptyBindingSet.getInstance()), new Entry(EmptyBindingSet.getInstance()));
+				final Entry entry = new Entry(null);
+				if (!entry.getAggregates().isEmpty()) {
+					entry.addSolution(EmptyBindingSet.getInstance());
+					entries.put(new Key(EmptyBindingSet.getInstance()), entry);
+				}
 			}
 
 			// long count = 0;

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -571,6 +571,17 @@ public abstract class ComplexSPARQLQueryTest {
 		assertTrue(result.contains(urn4, blank, null));
 	}
 
+	
+	@Test 
+	public void testGroupByEmpty() throws Exception {
+		// see issue https://github.com/eclipse/rdf4j/issues/573
+		String query = "select ?x where {?x ?p ?o} group by ?x";
+		
+		TupleQueryResult result = conn.prepareTupleQuery(query).evaluate();
+		assertNotNull(result);
+		assertFalse(result.hasNext());
+	}
+	
 	@Test
 	public void testGroupConcatDistinct()
 		throws Exception


### PR DESCRIPTION
This PR addresses GitHub issue: #573 .

Briefly describe the changes proposed in this PR:

* GroupIterator now only inserts empty BindingSet in solution if actual aggregate operators are present
* added test case to ComplexSPARQLQueryTest to verify expected behavior
* all SPARQL compliance tests (including test cases for aggregate/grouping behavior) greenline


Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>