### PR TITLE
Issue #544: Restore same log level.

### DIFF
--- a/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -34,9 +35,16 @@ public class SetParametersTest {
 	@InjectMocks
 	SetParameters setParameters;
 
+	private Level originalLevel;
+
+	@Before
+	public void storeOriginalLogLevel() {
+		originalLevel = ((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).getLevel();
+	}
+
 	@After
-	public void setLogLevelBackToDebug() {
-		((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
+	public void setLogLevelBackToOriginalLevel() {
+		((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(originalLevel);
 	}
 
 	@Test


### PR DESCRIPTION
This PR addresses the build break from merging #591.

Restore the same log level from the start of the test, rather
than assuming that it's DEBUG.

If I run the tests using a more recent Surefire and `-Dsurefire.runOrder=random`, the tests fail before this change, and pass afterwards.