### PR TITLE
issue #614 : Console Federate command broken by log level debug

### DIFF
--- a/core/console/src/main/java/org/eclipse/rdf4j/console/Federate.java
+++ b/core/console/src/main/java/org/eclipse/rdf4j/console/Federate.java
@@ -77,34 +77,32 @@ public class Federate implements Command {
 		if (LOGGER.isDebugEnabled()) {
 			logCallDetails(distinct, readonly, fedID, memberIDs);
 		}
-		else {
-			RepositoryManager manager = state.getManager();
-			try {
-				if (manager.hasRepositoryConfig(fedID)) {
-					cio.writeError(fedID + " already exists.");
-				}
-				else if (validateMembers(manager, readonly, memberIDs)) {
-					String description = cio.readln("Federation Description (optional):");
-					RepositoryManagerFederator rmf = new RepositoryManagerFederator(manager);
-					rmf.addFed(fedID, description, memberIDs, readonly, distinct);
-					cio.writeln("Federation created.");
-				}
+		RepositoryManager manager = state.getManager();
+		try {
+			if (manager.hasRepositoryConfig(fedID)) {
+				cio.writeError(fedID + " already exists.");
 			}
-			catch (RepositoryConfigException rce) {
-				cio.writeError(rce.getMessage());
+			else if (validateMembers(manager, readonly, memberIDs)) {
+				String description = cio.readln("Federation Description (optional):");
+				RepositoryManagerFederator rmf = new RepositoryManagerFederator(manager);
+				rmf.addFed(fedID, description, memberIDs, readonly, distinct);
+				cio.writeln("Federation created.");
 			}
-			catch (RepositoryException re) {
-				cio.writeError(re.getMessage());
-			}
-			catch (MalformedURLException mue) {
-				cio.writeError(mue.getMessage());
-			}
-			catch (RDF4JException ore) {
-				cio.writeError(ore.getMessage());
-			}
-			catch (IOException ioe) {
-				cio.writeError(ioe.getMessage());
-			}
+		}
+		catch (RepositoryConfigException rce) {
+			cio.writeError(rce.getMessage());
+		}
+		catch (RepositoryException re) {
+			cio.writeError(re.getMessage());
+		}
+		catch (MalformedURLException mue) {
+			cio.writeError(mue.getMessage());
+		}
+		catch (RDF4JException ore) {
+			cio.writeError(ore.getMessage());
+		}
+		catch (IOException ioe) {
+			cio.writeError(ioe.getMessage());
 		}
 	}
 

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/AbstractCommandTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/AbstractCommandTest.java
@@ -45,9 +45,11 @@ public class AbstractCommandTest {
 
 	/*
 	 * Switch off .silent() to debug specific tests and reenable it afterwards.
+	 * 
+	 * Note, .silent() was added in Mockito 2, so has been removed until we update.
 	 */
 	@Rule
-	public MockitoRule abstractCommandTestMockitoRule = MockitoJUnit.rule().silent();
+	public MockitoRule abstractCommandTestMockitoRule = MockitoJUnit.rule(); //.silent();
 
 	protected RepositoryManager manager;
 

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/AbstractCommandTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/AbstractCommandTest.java
@@ -7,8 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -34,15 +32,39 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.After;
+import org.junit.Rule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 /**
  * @author Dale Visser
  */
 public class AbstractCommandTest {
 
+	/*
+	 * Switch off .silent() to debug specific tests and reenable it afterwards.
+	 */
+	@Rule
+	public MockitoRule abstractCommandTestMockitoRule = MockitoJUnit.rule().silent();
+
 	protected RepositoryManager manager;
 
-	protected ConsoleIO streams = mock(ConsoleIO.class);
+	@Mock
+	protected ConsoleIO mockConsoleIO;
+
+	@Mock
+	protected ConsoleState mockConsoleState;
+
+	@After
+	public void tearDown()
+		throws Exception
+	{
+		if (manager != null) {
+			manager.shutDown();
+		}
+	}
 
 	protected final void addRepositories(String... identities)
 		throws UnsupportedEncodingException, IOException, RDF4JException

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/DropTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/DropTest.java
@@ -56,13 +56,14 @@ public class DropTest extends AbstractCommandTest {
 				new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));
 		ConsoleState state = mock(ConsoleState.class);
 		when(state.getManager()).thenReturn(manager);
-		drop = new Drop(streams, state, new Close(streams, state), new LockRemover(streams));
+		drop = new Drop(mockConsoleIO, state, new Close(mockConsoleIO, state),
+				new LockRemover(mockConsoleIO));
 	}
 
 	private void setUserDropConfirm(boolean confirm)
 		throws IOException
 	{
-		when(streams.askProceed(startsWith("WARNING: you are about to drop repository '"),
+		when(mockConsoleIO.askProceed(startsWith("WARNING: you are about to drop repository '"),
 				anyBoolean())).thenReturn(confirm);
 	}
 
@@ -80,10 +81,10 @@ public class DropTest extends AbstractCommandTest {
 		setUserDropConfirm(true);
 		assertThat(manager.isSafeToRemove(PROXY_ID), is(equalTo(true)));
 		drop.execute("drop", PROXY_ID);
-		verify(streams).writeln("Dropped repository '" + PROXY_ID + "'");
+		verify(mockConsoleIO).writeln("Dropped repository '" + PROXY_ID + "'");
 		assertThat(manager.isSafeToRemove(MEMORY_MEMBER_ID1), is(equalTo(true)));
 		drop.execute("drop", MEMORY_MEMBER_ID1);
-		verify(streams).writeln("Dropped repository '" + MEMORY_MEMBER_ID1 + "'");
+		verify(mockConsoleIO).writeln("Dropped repository '" + MEMORY_MEMBER_ID1 + "'");
 	}
 
 	@Test
@@ -92,10 +93,10 @@ public class DropTest extends AbstractCommandTest {
 	{
 		setUserDropConfirm(true);
 		assertThat(manager.isSafeToRemove(MEMORY_MEMBER_ID1), is(equalTo(false)));
-		when(streams.askProceed(startsWith("WARNING: dropping this repository may break"),
+		when(mockConsoleIO.askProceed(startsWith("WARNING: dropping this repository may break"),
 				anyBoolean())).thenReturn(false);
 		drop.execute("drop", MEMORY_MEMBER_ID1);
-		verify(streams).writeln("Drop aborted");
+		verify(mockConsoleIO).writeln("Drop aborted");
 	}
 
 	@Test
@@ -104,8 +105,8 @@ public class DropTest extends AbstractCommandTest {
 	{
 		setUserDropConfirm(false);
 		drop.execute("drop", MEMORY_MEMBER_ID1);
-		verify(streams, never()).askProceed(startsWith("WARNING: dropping this repository may break"),
+		verify(mockConsoleIO, never()).askProceed(startsWith("WARNING: dropping this repository may break"),
 				anyBoolean());
-		verify(streams).writeln("Drop aborted");
+		verify(mockConsoleIO).writeln("Drop aborted");
 	}
 }

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/FederateTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/FederateTest.java
@@ -11,23 +11,17 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.eclipse.rdf4j.repository.RepositoryException;
-import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
 import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryConfig;
 import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryFactory;
@@ -43,6 +37,11 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.InjectMocks;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 
 /**
  * Unit tests for {@link Federate}.
@@ -67,34 +66,45 @@ public class FederateTest extends AbstractCommandTest {
 
 	private static final String FED_DESCRIPTION = "Test Federation Title";
 
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+
+	@InjectMocks
 	private Federate federate;
 
-	@Rule
-	public final TemporaryFolder LOCATION = new TemporaryFolder();
+	private Level originalLevel;
 
 	@Before
-	public void prepareManager()
-		throws UnsupportedEncodingException, IOException, RDF4JException
+	public void setUp()
+		throws Exception
 	{
-		manager = new LocalRepositoryManager(LOCATION.getRoot());
+		originalLevel = ((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).getLevel();
+
+		// Start all tests assuming a base of Debug logging, then revert after the test
+		((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
+
+		manager = new LocalRepositoryManager(tempDir.newFolder("federate-test-repository-manager"));
 		manager.initialize();
 		addRepositories(MEMORY_MEMBER_ID1, MEMORY_MEMBER_ID2, HTTP_MEMBER_ID, HTTP2_MEMBER_ID,
 				SPARQL_MEMBER_ID, SPARQL2_MEMBER_ID);
-		ConsoleState state = mock(ConsoleState.class);
-		when(state.getManager()).thenReturn(manager);
-		when(streams.readln("Federation Description (optional):")).thenReturn(FED_DESCRIPTION);
-		federate = new Federate(streams, state);
+		when(mockConsoleState.getManager()).thenReturn(manager);
+		when(mockConsoleIO.readln("Federation Description (optional):")).thenReturn(FED_DESCRIPTION);
 	}
 
 	@After
 	public void tearDown()
-		throws RDF4JException
+		throws Exception
 	{
-		manager.shutDown();
+		try {
+			super.tearDown();
+		}
+		finally {
+			((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(originalLevel);
+		}
 	}
 
 	private void execute(String... args)
-		throws IOException
+		throws Exception
 	{
 		List<String> execArgs = new ArrayList<String>(args.length + 1);
 		execArgs.add("federate");
@@ -103,56 +113,56 @@ public class FederateTest extends AbstractCommandTest {
 	}
 
 	@Test
-	public void noArgumentsPrintsHelp()
-		throws IOException, RDF4JException
+	public void testNoArgumentsPrintsHelp()
+		throws Exception
 	{
 		execute();
-		verify(streams).writeln(PrintHelp.FEDERATE);
+		verify(mockConsoleIO).writeln(PrintHelp.FEDERATE);
 	}
 
 	@Test
-	public void oneArgumentPrintsHelp()
-		throws IOException, RDF4JException
+	public void testOneArgumentPrintsHelp()
+		throws Exception
 	{
 		execute(FED_ID);
-		verify(streams).writeln(PrintHelp.FEDERATE);
+		verify(mockConsoleIO).writeln(PrintHelp.FEDERATE);
 	}
 
 	@Test
-	public void twoArgumentsPrintsHelp()
-		throws IOException, RDF4JException
+	public void testTwoArgumentsPrintsHelp()
+		throws Exception
 	{
 		execute(FED_ID, MEMORY_MEMBER_ID1);
-		verify(streams).writeln(PrintHelp.FEDERATE);
+		verify(mockConsoleIO).writeln(PrintHelp.FEDERATE);
 	}
 
 	@Test
-	public void invalidArgumentPrintsError()
-		throws IOException, RDF4JException
+	public void testInvalidArgumentPrintsError()
+		throws Exception
 	{
 		execute("type=memory", FED_ID, MEMORY_MEMBER_ID1, MEMORY_MEMBER_ID2);
 		verifyFailure();
 	}
 
 	@Test
-	public void duplicateMembersPrintsError()
-		throws IOException, RDF4JException
+	public void testDuplicateMembersPrintsError()
+		throws Exception
 	{
 		execute(FED_ID, MEMORY_MEMBER_ID1, MEMORY_MEMBER_ID1);
 		verifyFailure();
 	}
 
 	@Test
-	public void fedSameAsMemberPrintsError()
-		throws IOException, RDF4JException
+	public void testFedSameAsMemberPrintsError()
+		throws Exception
 	{
 		execute(FED_ID, MEMORY_MEMBER_ID1, FED_ID, MEMORY_MEMBER_ID1);
 		verifyFailure();
 	}
 
 	@Test
-	public void sparqlAndNotReadOnlyPrintsError()
-		throws IOException, RDF4JException
+	public void testSparqlAndNotReadOnlyPrintsError()
+		throws Exception
 	{
 		execute("readonly=false", FED_ID, SPARQL_MEMBER_ID, SPARQL2_MEMBER_ID);
 		verifyFailure(SPARQL_MEMBER_ID + " is read-only.");
@@ -160,24 +170,24 @@ public class FederateTest extends AbstractCommandTest {
 	}
 
 	@Test
-	public void fedAlreadyExistsPrintsSpecificError()
-		throws IOException, RDF4JException
+	public void testFedAlreadyExistsPrintsSpecificError()
+		throws Exception
 	{
 		execute(MEMORY_MEMBER_ID1, FED_ID, MEMORY_MEMBER_ID2);
 		verifyFailure(MEMORY_MEMBER_ID1 + " already exists.");
 	}
 
 	@Test
-	public void nonexistentMemberPrintsSpecificError()
-		throws IOException, RDF4JException
+	public void testNonexistentMemberPrintsSpecificError()
+		throws Exception
 	{
 		execute(FED_ID, MEMORY_MEMBER_ID1, "FreeLunch");
 		verifyFailure("FreeLunch does not exist.");
 	}
 
 	@Test
-	public void federateMemoryMembersSuccess()
-		throws UnsupportedEncodingException, IOException, RepositoryException, RepositoryConfigException
+	public void testFederateMemoryMembersSuccess()
+		throws Exception
 	{
 		execute(FED_ID, MEMORY_MEMBER_ID1, MEMORY_MEMBER_ID2);
 		verifySuccess(ProxyRepositoryFactory.REPOSITORY_TYPE, ProxyRepositoryFactory.REPOSITORY_TYPE);
@@ -186,7 +196,7 @@ public class FederateTest extends AbstractCommandTest {
 	}
 
 	private long getSize(String memberID)
-		throws RepositoryException, RepositoryConfigException
+		throws Exception
 	{
 		RepositoryConnection connection = manager.getRepository(memberID).getConnection();
 		try {
@@ -198,32 +208,32 @@ public class FederateTest extends AbstractCommandTest {
 	}
 
 	@Test
-	public void federateSucceedsWithHTTPandSPARQLmembers()
-		throws UnsupportedEncodingException, IOException, RDF4JException
+	public void testFederateSucceedsWithHTTPandSPARQLmembers()
+		throws Exception
 	{
 		execute(FED_ID, HTTP_MEMBER_ID, SPARQL_MEMBER_ID);
 		verifySuccess(HTTPRepositoryFactory.REPOSITORY_TYPE, SPARQLRepositoryFactory.REPOSITORY_TYPE);
 	}
 
 	@Test
-	public void federateHTTPtypeSucceeds()
-		throws IOException, RDF4JException
+	public void testFederateHTTPtypeSucceeds()
+		throws Exception
 	{
 		execute(FED_ID, HTTP_MEMBER_ID, HTTP2_MEMBER_ID);
 		verifySuccess(HTTPRepositoryFactory.REPOSITORY_TYPE, HTTPRepositoryFactory.REPOSITORY_TYPE);
 	}
 
 	@Test
-	public void federateSPARQLtypeSucceeds()
-		throws IOException, RDF4JException
+	public void testFederateSPARQLtypeSucceeds()
+		throws Exception
 	{
 		execute(FED_ID, SPARQL_MEMBER_ID, SPARQL2_MEMBER_ID);
 		verifySuccess(SPARQLRepositoryFactory.REPOSITORY_TYPE, SPARQLRepositoryFactory.REPOSITORY_TYPE);
 	}
 
 	@Test
-	public void successWithNonDefaultReadonlyAndDistinct()
-		throws IOException, RepositoryException, RepositoryConfigException
+	public void testSuccessWithNonDefaultReadonlyAndDistinct()
+		throws Exception
 	{
 		execute(FED_ID, "distinct=true", "readonly=false", MEMORY_MEMBER_ID1, MEMORY_MEMBER_ID2);
 		verifySuccess(false, true, ProxyRepositoryFactory.REPOSITORY_TYPE,
@@ -233,8 +243,8 @@ public class FederateTest extends AbstractCommandTest {
 	}
 
 	@Test
-	public void fullyHeterogeneousSuccess()
-		throws IOException, RepositoryException, RepositoryConfigException
+	public void testFullyHeterogeneousSuccess()
+		throws Exception
 	{
 		execute(FED_ID, SPARQL_MEMBER_ID, MEMORY_MEMBER_ID1, HTTP_MEMBER_ID);
 		verifySuccess(SPARQLRepositoryFactory.REPOSITORY_TYPE, ProxyRepositoryFactory.REPOSITORY_TYPE,
@@ -242,18 +252,18 @@ public class FederateTest extends AbstractCommandTest {
 	}
 
 	private void verifySuccess(String... memberTypes)
-		throws RepositoryException, RepositoryConfigException, IOException
+		throws Exception
 	{
 		verifySuccess(true, false, memberTypes);
 	}
 
 	private void verifySuccess(boolean readonly, boolean distinct, String... memberTypes)
-		throws RepositoryException, RepositoryConfigException, IOException
+		throws Exception
 	{
 		assertThat(manager.hasRepositoryConfig(FED_ID), is(equalTo(true)));
-		verify(streams, times(1)).writeln("Federation created.");
-		verify(streams, never()).writeError(anyString());
-		verify(streams, times(1)).readln("Federation Description (optional):");
+		verify(mockConsoleIO, times(1)).readln("Federation Description (optional):");
+		verify(mockConsoleIO, times(1)).writeln("Federation created.");
+		verify(mockConsoleIO, never()).writeError(anyString());
 		assertThat(manager.getRepositoryInfo(FED_ID).getDescription(), is(equalTo(FED_DESCRIPTION)));
 		SailRepositoryConfig sailRepoConfig = (SailRepositoryConfig)manager.getRepositoryConfig(
 				FED_ID).getRepositoryImplConfig();
@@ -282,13 +292,13 @@ public class FederateTest extends AbstractCommandTest {
 	}
 
 	private void verifyFailure(String... error)
-		throws RepositoryException, RepositoryConfigException
+		throws Exception
 	{
 		if (error.length > 0) {
-			verify(streams).writeError(error[0]);
+			verify(mockConsoleIO).writeError(error[0]);
 		}
 		else {
-			verify(streams).writeError(anyString());
+			verify(mockConsoleIO).writeError(anyString());
 		}
 		assertThat(manager.hasRepositoryConfig(FED_ID), is(equalTo(false)));
 	}

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/FederateTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/FederateTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
@@ -13,24 +13,18 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 
-public class SetParametersTest {
-
-	@Rule
-	public MockitoRule rule = MockitoJUnit.rule();
+public class SetParametersTest extends AbstractCommandTest {
 
 	@Mock
-	ConsoleIO consoleIo;
+	ConsoleParameters consoleParameters;
 
 	@InjectMocks
 	SetParameters setParameters;
@@ -38,36 +32,46 @@ public class SetParametersTest {
 	private Level originalLevel;
 
 	@Before
-	public void storeOriginalLogLevel() {
+	public void setUp() {
 		originalLevel = ((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).getLevel();
+		
+		// Start all tests assuming a base of Debug logging, then revert after the test
+		((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
 	}
 
 	@After
-	public void setLogLevelBackToOriginalLevel() {
-		((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(originalLevel);
+	public void tearDown()
+		throws Exception
+	{
+		try {
+			super.tearDown();
+		}
+		finally {
+			((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(originalLevel);
+		}
 	}
 
 	@Test
-	public void unknownParametersAreErrors() {
+	public void testUnknownParametersAreErrors() {
 		setParameters.execute("set", "unknown");
 
-		verify(consoleIo).writeError("unknown parameter: unknown");
-		verifyNoMoreInteractions(consoleIo);
+		verify(mockConsoleIO).writeError("unknown parameter: unknown");
+		verifyNoMoreInteractions(mockConsoleIO);
 	}
 
 	@Test
-	public void noValueShowsCurrentLevel() {
+	public void testNoValueShowsCurrentLevel() {
 		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 		logger.setLevel(Level.INFO);
 
 		setParameters.execute("set", "log");
 
-		verify(consoleIo).writeln("log: info");
-		verifyNoMoreInteractions(consoleIo);
+		verify(mockConsoleIO).writeln("log: info");
+		verifyNoMoreInteractions(mockConsoleIO);
 	}
 
 	@Test
-	public void settingLogChangesLevel() {
+	public void testSettingLogChangesLevel() {
 		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 		logger.setLevel(Level.DEBUG);
 
@@ -77,22 +81,30 @@ public class SetParametersTest {
 	}
 
 	@Test
-	public void settingUnknownLevelIsLoggedAsError() {
+	public void testSettingUnknownLevelIsLoggedAsError() {
 		setParameters.execute("set", "log=chatty");
 
-		verify(consoleIo).writeError("unknown logging level: chatty");
-		verifyNoMoreInteractions(consoleIo);
+		verify(mockConsoleIO).writeError("unknown logging level: chatty");
+		verifyNoMoreInteractions(mockConsoleIO);
 	}
 
 	@Test
-	public void levelsThatDoNotMatchSlf4jAreMapped() {
+	public void testLevelsThatDoNotMatchSlf4jAreMapped() {
 		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 		logger.setLevel(Level.WARN);
 
 		setParameters.execute("set", "log");
 
-		verify(consoleIo).writeln("log: warning");
-		verifyNoMoreInteractions(consoleIo);
+		verify(mockConsoleIO).writeln("log: warning");
+		verifyNoMoreInteractions(mockConsoleIO);
+	}
+
+	@Test
+	public void testShowWidth() {
+		setParameters.execute("set", "width");
+		// Mocks have int's setup to be 0, so not actually testing the real behaviour here which would be a positive value
+		verify(mockConsoleIO).writeln("width: 0");
+		verifyNoMoreInteractions(mockConsoleIO);
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<slf4j.version>1.7.10</slf4j.version>
-		<logback.version>1.1.2</logback.version>
+		<logback.version>1.1.7</logback.version>
 		<spring.version>4.2.1.RELEASE</spring.version>
 		<httpclient.version>4.5.2</httpclient.version>
 		<httpcore.version>4.4.4</httpcore.version>
@@ -510,7 +510,7 @@
 				<!-- needs extra dependencies: objenesis & hamcrest -->
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.10.19</version>
+				<version>2.2.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -682,12 +682,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.17</version>
+					<version>2.19.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.17</version>
+					<version>2.19.1</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 						<forkCount>1</forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<slf4j.version>1.7.10</slf4j.version>
-		<logback.version>1.1.7</logback.version>
+		<logback.version>1.1.2</logback.version>
 		<spring.version>4.2.1.RELEASE</spring.version>
 		<httpclient.version>4.5.2</httpclient.version>
 		<httpcore.version>4.4.4</httpcore.version>
@@ -510,7 +510,7 @@
 				<!-- needs extra dependencies: objenesis & hamcrest -->
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>2.2.0</version>
+				<version>1.10.19</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -682,12 +682,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.19.1</version>
+					<version>2.17</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.19.1</version>
+					<version>2.17</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 						<forkCount>1</forkCount>


### PR DESCRIPTION
This PR addresses GitHub issue: #614 .

Briefly describe the changes proposed in this PR:

* The Console Federate command was using log level for control flow, resulting in federation failing to occur if the log level was debug or finer.

Debugging this involved updating Mockito to 2.2.0 and Logback to 1.1.7, but those changes don't seem to be related to the solution so they have been backed out due to the close release time.

Debugging also involved refactoring SetParametersTest to reuse AbstractCommandTest as designed, and included refactoring to use MockitoRule, @Mock and @InjectMocks to verify they were not related and can be maintained in future.

There is now a known baseline log level of debug setup for both FederateTest and SetParametersTest, based on their need to consistently verify console IO messages that may be affected by the log level and should function properly even at the debug log level. This is reset after each test so the global base logging level will still be able to be manipulated through a configuration file as necessary for other tests.

Fixes #614

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>