### PR TITLE
Fixes #617: Tabs in update with federate query are not parsed correctly.

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SyntaxTreeBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SyntaxTreeBuilder.java
@@ -62,6 +62,11 @@ public class SyntaxTreeBuilder/* @bgen(jjtree) */ implements SyntaxTreeBuilderTr
 		throws TokenMgrError, ParseException
 	{
 		SyntaxTreeBuilder stb = new SyntaxTreeBuilder(new StringReader(sequence));
+
+		// Set size of tab to 1 to force tokenmanager to report correct column
+		// index for substring splitting of service graph pattern.
+		stb.jj_input_stream.setTabSize(1);
+
 		ASTUpdateSequence seq = stb.UpdateSequence();
 		seq.setSourceString(sequence);
 		return seq;

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/sparql.jjt
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/sparql.jjt
@@ -24,15 +24,15 @@ options {
 
 PARSER_BEGIN(SyntaxTreeBuilder)
 
-package org.openrdf.query.parser.sparql.ast;
+package org.eclipse.rdf4j.query.parser.sparql.ast;
 
 import java.io.StringReader;
 
-import org.openrdf.model.IRI;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.model.vocabulary.XMLSchema;
-import org.openrdf.query.algebra.Compare.CompareOp;
-import org.openrdf.query.algebra.MathExpr.MathOp;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.query.algebra.Compare.CompareOp;
+import org.eclipse.rdf4j.query.algebra.MathExpr.MathOp;
 
 public class SyntaxTreeBuilder {
 
@@ -70,6 +70,11 @@ public class SyntaxTreeBuilder {
 		throws TokenMgrError, ParseException
 	{
 		SyntaxTreeBuilder stb = new SyntaxTreeBuilder( new StringReader(sequence) );
+
+		// Set size of tab to 1 to force tokenmanager to report correct column
+		// index for substring splitting of service graph pattern.
+		stb.jj_input_stream.setTabSize(1);
+
 		ASTUpdateSequence seq = stb.UpdateSequence();
 		seq.setSourceString(sequence);
 		return seq;


### PR DESCRIPTION
This PR addresses GitHub issue: #617 .

The fix addresses the issue by setting the tab size to 1 when parsing updates (copied the same code that is applied to parsing queries). I also edited the generated SyntaxTreeBuilder.java instead of rerunning jjtree/javacc on sparql.jjt (although I verified that works).

Also updated package names in sparql.jjt to org.eclipse.rdf4j as they seem to have been forgotten.

Signed-off-by: Pavel Mihaylov <pavel@ontotext.com>