### PR TITLE
Fixes #620: Comments in federated queries lead to invalid SPARQL

### DIFF
--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Service.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Service.java
@@ -240,7 +240,7 @@ public class Service extends UnaryTupleOperator {
 		else {
 			sb.append("SELECT %PROJECTION_VARS% WHERE { ");
 			sb.append(serviceExpressionString);
-			sb.append(" }");
+			sb.append("\n}");
 		}
 		preparedSelectQueryString = sb.toString();
 


### PR DESCRIPTION
This PR addresses GitHub issue: #620  .

Trivial fix by inserting a new line before the closing "}".

Signed-off-by: Pavel Mihaylov <pavel@ontotext.com>