### PR TITLE
#164 critical pre-release hotfix in native and memory store strategy selection

### DIFF
--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/MemoryEvaluationStrategyTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/MemoryEvaluationStrategyTest.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.repository.sail.memory;
+
+import org.eclipse.rdf4j.repository.EvaluationStrategyTest;
+import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
+import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
+
+
+/**
+ * @author jeen
+ *
+ */
+public class MemoryEvaluationStrategyTest extends EvaluationStrategyTest {
+
+	@Override
+	protected BaseSailConfig getBaseSailConfig() {
+		return new MemoryStoreConfig(false);
+	}
+
+}

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/nativerdf/NativeEvaluationStrategyTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/nativerdf/NativeEvaluationStrategyTest.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.repository.sail.nativerdf;
+
+import org.eclipse.rdf4j.repository.EvaluationStrategyTest;
+import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
+import org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreConfig;
+
+
+/**
+ * @author jeen
+ *
+ */
+public class NativeEvaluationStrategyTest extends EvaluationStrategyTest {
+
+	@Override
+	protected BaseSailConfig getBaseSailConfig() {
+		return new NativeStoreConfig();
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
@@ -25,4 +25,22 @@ public interface EvaluationStrategyFactory {
 	 * @return an EvaluationStrategy.
 	 */
 	EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource);
+
+	/**
+	 * Returns the {@link EvaluationStrategy} to use to evaluate queries for the given {@link Dataset} and
+	 * {@link TripleSource}.
+	 * 
+	 * @param dataset
+	 *        the DataSet to evaluate queries against.
+	 * @param tripleSource
+	 *        the TripleSource to evaluate queries against.
+	 * @param iterationCacheSyncThreshold
+	 *        the number of query solutions the {@link EvaluationStrategy} can keep in main memory before it
+	 *        should sync to a temporary disk cache. If set to 0, no disk caching occurs.
+	 *        {@link EvaluationStrategy} implementations that provide no disk caching are free to ignore this
+	 *        parameter.
+	 * @return an EvaluationStrategy.
+	 */
+	EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+			long iterationCacheSyncThreshold);
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
@@ -15,6 +15,24 @@ import org.eclipse.rdf4j.query.Dataset;
 public interface EvaluationStrategyFactory {
 
 	/**
+	 * Set the number of query solutions the {@link EvaluationStrategy} will keep in main memory before it
+	 * attempts to sync to a temporary disk cache. If set to 0, no disk caching will occur.
+	 * EvaluationStrategies that provide no disk caching functionality are free to ignore this parameter.
+	 * 
+	 * @param threshold
+	 *        the number of query solutions that the EvaluationStrategy can cache in main memory before
+	 *        attempting disk sync.
+	 */
+	void setQuerySolutionCacheThreshold(long threshold);
+
+	/**
+	 * Get the number of query solutions the {@link EvaluationStrategy} will keep in main memory before it
+	 * attempts to sync to a temporary disk cache. If set to 0, no disk caching will occur.
+	 * EvaluationStrategies that provide no disk caching functionality are free to ignore this parameter.
+	 */
+	long getQuerySolutionCacheThreshold();
+
+	/**
 	 * Returns the {@link EvaluationStrategy} to use to evaluate queries for the given {@link Dataset} and
 	 * {@link TripleSource}.
 	 * 
@@ -26,21 +44,4 @@ public interface EvaluationStrategyFactory {
 	 */
 	EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource);
 
-	/**
-	 * Returns the {@link EvaluationStrategy} to use to evaluate queries for the given {@link Dataset} and
-	 * {@link TripleSource}.
-	 * 
-	 * @param dataset
-	 *        the DataSet to evaluate queries against.
-	 * @param tripleSource
-	 *        the TripleSource to evaluate queries against.
-	 * @param iterationCacheSyncThreshold
-	 *        the number of query solutions the {@link EvaluationStrategy} can keep in main memory before it
-	 *        should sync to a temporary disk cache. If set to 0, no disk caching occurs.
-	 *        {@link EvaluationStrategy} implementations that provide no disk caching are free to ignore this
-	 *        parameter.
-	 * @return an EvaluationStrategy.
-	 */
-	EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
-			long iterationCacheSyncThreshold);
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
+
+/**
+ * Abstract base class for {@link ExtendedEvaluationStrategy}.
+ * 
+ * @author Jeen Broekstra
+ */
+public abstract class AbstractEvaluationStrategyFactory implements EvaluationStrategyFactory {
+
+	private long querySolutionCacheThreshold;
+
+	@Override
+	public void setQuerySolutionCacheThreshold(long threshold) {
+		this.querySolutionCacheThreshold = threshold;
+	}
+
+	@Override
+	public long getQuerySolutionCacheThreshold() {
+		return querySolutionCacheThreshold;
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
@@ -27,9 +27,9 @@ import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
 public class ExtendedEvaluationStrategy extends TupleFunctionEvaluationStrategy {
 
 	public ExtendedEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
-			FederatedServiceResolver serviceResolver)
+			FederatedServiceResolver serviceResolver, long iterationCacheSyncThreshold)
 	{
-		super(tripleSource, dataset, serviceResolver);
+		super(tripleSource, dataset, serviceResolver, iterationCacheSyncThreshold);
 	}
 
 	@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategyFactory.java
@@ -14,7 +14,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
 
-public class ExtendedEvaluationStrategyFactory
+public class ExtendedEvaluationStrategyFactory extends AbstractEvaluationStrategyFactory
 		implements EvaluationStrategyFactory, FederatedServiceResolverClient
 {
 
@@ -37,15 +37,10 @@ public class ExtendedEvaluationStrategyFactory
 	}
 
 	@Override
-	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
-			long iterationCacheSyncThreshold)
+	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource)
 	{
 		return new ExtendedEvaluationStrategy(tripleSource, dataset, serviceResolver,
-				iterationCacheSyncThreshold);
+				getQuerySolutionCacheThreshold());
 	}
 
-	@Override
-	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		return createEvaluationStrategy(dataset, tripleSource, 0);
-	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategyFactory.java
@@ -37,7 +37,15 @@ public class ExtendedEvaluationStrategyFactory
 	}
 
 	@Override
+	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+			long iterationCacheSyncThreshold)
+	{
+		return new ExtendedEvaluationStrategy(tripleSource, dataset, serviceResolver,
+				iterationCacheSyncThreshold);
+	}
+
+	@Override
 	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		return new ExtendedEvaluationStrategy(tripleSource, dataset, serviceResolver);
+		return createEvaluationStrategy(dataset, tripleSource, 0);
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
@@ -14,7 +14,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
 
-public class StrictEvaluationStrategyFactory
+public class StrictEvaluationStrategyFactory extends AbstractEvaluationStrategyFactory
 		implements EvaluationStrategyFactory, FederatedServiceResolverClient
 {
 
@@ -37,15 +37,9 @@ public class StrictEvaluationStrategyFactory
 	}
 
 	@Override
-	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		return createEvaluationStrategy(dataset, tripleSource, 0);
-	}
-
-	@Override
-	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
-			long iterationCacheSyncThreshold)
+	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource)
 	{
 		return new StrictEvaluationStrategy(tripleSource, dataset, serviceResolver,
-				iterationCacheSyncThreshold);
+				getQuerySolutionCacheThreshold());
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
@@ -38,6 +38,14 @@ public class StrictEvaluationStrategyFactory
 
 	@Override
 	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		return new StrictEvaluationStrategy(tripleSource, dataset, serviceResolver);
+		return createEvaluationStrategy(dataset, tripleSource, 0);
+	}
+
+	@Override
+	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+			long iterationCacheSyncThreshold)
+	{
+		return new StrictEvaluationStrategy(tripleSource, dataset, serviceResolver,
+				iterationCacheSyncThreshold);
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/TupleFunctionEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/TupleFunctionEvaluationStrategy.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.AbstractFederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.TupleFunction;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.TupleFunctionRegistry;
@@ -52,6 +53,12 @@ public class TupleFunctionEvaluationStrategy extends StrictEvaluationStrategy {
 	{
 		super(tripleSource, dataset, serviceResolver, iterationCacheSyncThreshold);
 		this.tupleFuncRegistry = tupleFuncRegistry;
+	}
+
+	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
+			AbstractFederatedServiceResolver serviceResolver, TupleFunctionRegistry tupleFunctionRegistry)
+	{
+		this(tripleSource, dataset, serviceResolver, tupleFunctionRegistry, 0);
 	}
 
 	@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/TupleFunctionEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/TupleFunctionEvaluationStrategy.java
@@ -37,14 +37,20 @@ public class TupleFunctionEvaluationStrategy extends StrictEvaluationStrategy {
 	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
 			FederatedServiceResolver serviceResolver)
 	{
-		this(tripleSource, dataset, serviceResolver, TupleFunctionRegistry.getInstance());
+		this(tripleSource, dataset, serviceResolver, 0);
 	}
 
 	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
-			FederatedServiceResolver serviceResolver,
-			TupleFunctionRegistry tupleFuncRegistry)
+			FederatedServiceResolver serviceResolver, long iterationCacheSyncThreshold)
 	{
-		super(tripleSource, dataset, serviceResolver);
+		this(tripleSource, dataset, serviceResolver, TupleFunctionRegistry.getInstance(), iterationCacheSyncThreshold);
+	}
+	
+	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
+			FederatedServiceResolver serviceResolver,
+			TupleFunctionRegistry tupleFuncRegistry, long iterationCacheSyncThreshold)
+	{
+		super(tripleSource, dataset, serviceResolver, iterationCacheSyncThreshold);
 		this.tupleFuncRegistry = tupleFuncRegistry;
 	}
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
@@ -195,6 +195,7 @@ public class MemoryStore extends AbstractNotifyingSail implements FederatedServi
 		if (evalStratFactory == null) {
 			evalStratFactory = new StrictEvaluationStrategyFactory(getFederatedServiceResolver());
 		}
+		evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
 		return evalStratFactory;
 	}
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
@@ -11,11 +11,6 @@ package org.eclipse.rdf4j.sail.memory;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.query.Dataset;
-import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
-import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
-import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
 import org.eclipse.rdf4j.sail.base.SailSourceConnection;
@@ -114,16 +109,6 @@ public class MemoryStoreConnection extends SailSourceConnection {
 		boolean ret = super.removeInferredStatement(subj, pred, obj, contexts);
 		sailChangedEvent.setStatementsRemoved(true);
 		return ret;
-	}
-
-	@Override
-	protected EvaluationStrategy getEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		EvaluationStrategy strategy = this.sail.getEvaluationStrategyFactory().createEvaluationStrategy(dataset, tripleSource,
-				sail.getIterationCacheSyncThreshold());
-		if (getFederatedServiceResolver() != null && strategy instanceof FederatedServiceResolverClient) {
-			((FederatedServiceResolverClient)strategy).setFederatedServiceResolver(getFederatedServiceResolver());
-		}
-		return strategy;
 	}
 
 	@Override

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
@@ -117,8 +118,12 @@ public class MemoryStoreConnection extends SailSourceConnection {
 
 	@Override
 	protected EvaluationStrategy getEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		return new StrictEvaluationStrategy(tripleSource, dataset, getFederatedServiceResolver(),
+		EvaluationStrategy strategy = this.sail.getEvaluationStrategyFactory().createEvaluationStrategy(dataset, tripleSource,
 				sail.getIterationCacheSyncThreshold());
+		if (getFederatedServiceResolver() != null && strategy instanceof FederatedServiceResolverClient) {
+			((FederatedServiceResolverClient)strategy).setFederatedServiceResolver(getFederatedServiceResolver());
+		}
+		return strategy;
 	}
 
 	@Override

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
@@ -180,6 +180,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 		if (evalStratFactory == null) {
 			evalStratFactory = new StrictEvaluationStrategyFactory(getFederatedServiceResolver());
 		}
+		evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
 		return evalStratFactory;
 	}
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnection.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnection.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
@@ -150,8 +151,12 @@ public class NativeStoreConnection extends SailSourceConnection {
 
 	@Override
 	protected EvaluationStrategy getEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		return new StrictEvaluationStrategy(tripleSource, dataset, getFederatedServiceResolver(),
+		EvaluationStrategy strategy = this.nativeStore.getEvaluationStrategyFactory().createEvaluationStrategy(dataset, tripleSource,
 				nativeStore.getIterationCacheSyncThreshold());
+		if (getFederatedServiceResolver() != null && strategy instanceof FederatedServiceResolverClient) {
+			((FederatedServiceResolverClient)strategy).setFederatedServiceResolver(getFederatedServiceResolver());
+		}
+		return strategy;
 	}
 
 	@Override

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnection.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnection.java
@@ -13,11 +13,6 @@ import org.eclipse.rdf4j.common.concurrent.locks.Lock;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.query.Dataset;
-import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
-import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
-import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
 import org.eclipse.rdf4j.sail.base.SailSourceConnection;
@@ -147,16 +142,6 @@ public class NativeStoreConnection extends SailSourceConnection {
 		boolean ret = super.removeInferredStatement(subj, pred, obj, contexts);
 		sailChangedEvent.setStatementsRemoved(true);
 		return ret;
-	}
-
-	@Override
-	protected EvaluationStrategy getEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		EvaluationStrategy strategy = this.nativeStore.getEvaluationStrategyFactory().createEvaluationStrategy(dataset, tripleSource,
-				nativeStore.getIterationCacheSyncThreshold());
-		if (getFederatedServiceResolver() != null && strategy instanceof FederatedServiceResolverClient) {
-			((FederatedServiceResolverClient)strategy).setFederatedServiceResolver(getFederatedServiceResolver());
-		}
-		return strategy;
 	}
 
 	@Override

--- a/testsuites/store/src/main/java/org/eclipse/rdf4j/repository/EvaluationStrategyTest.java
+++ b/testsuites/store/src/main/java/org/eclipse/rdf4j/repository/EvaluationStrategyTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.repository;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.ExtendedEvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.ExtendedEvaluationStrategyFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
+import org.eclipse.rdf4j.repository.manager.RepositoryProvider;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
+import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test cases for behavior of {@link StrictEvaluationStrategy} and {@link ExtendedEvaluationStrategy} on base
+ * Sail implementations.
+ * 
+ * @author Jeen Broekstra
+ */
+public abstract class EvaluationStrategyTest {
+
+	private Repository strictRepo;
+
+	private Repository extendedRepo;
+
+	private RepositoryManager manager;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		manager = RepositoryProvider.getRepositoryManager(FileUtils.getTempDirectory());
+
+		BaseSailConfig strictStoreConfig = getBaseSailConfig();
+		strictStoreConfig.setEvaluationStrategyFactoryClassName(
+				StrictEvaluationStrategyFactory.class.getName());
+
+		strictRepo = createRepo(strictStoreConfig, "test-strict");
+
+		BaseSailConfig extendedStoreConfig = getBaseSailConfig();
+		extendedStoreConfig.setEvaluationStrategyFactoryClassName(
+				ExtendedEvaluationStrategyFactory.class.getName());
+
+		extendedRepo = createRepo(extendedStoreConfig, "test-extended");
+	}
+
+	private Repository createRepo(BaseSailConfig config, String id) {
+		RepositoryImplConfig ric = new SailRepositoryConfig(config);
+		manager.addRepositoryConfig(new RepositoryConfig(id, ric));
+
+		return manager.getRepository(id);
+	}
+
+	@Test
+	public void testDatetimeSubtypesStrict() {
+		ValueFactory vf = strictRepo.getValueFactory();
+
+		try (RepositoryConnection conn = strictRepo.getConnection()) {
+			Literal l1 = vf.createLiteral("2009", XMLSchema.GYEAR);
+			Literal l2 = vf.createLiteral("2009-01", XMLSchema.GYEARMONTH);
+			IRI s1 = vf.createIRI("urn:s1");
+			IRI s2 = vf.createIRI("urn:s2");
+			conn.add(s1, RDFS.LABEL, l1);
+			conn.add(s2, RDFS.LABEL, l2);
+
+			String query = "SELECT * WHERE { ?s rdfs:label ?l . FILTER(?l >= \"2008\"^^xsd:gYear) }";
+
+			List<BindingSet> result = QueryResults.asList(conn.prepareTupleQuery(query).evaluate());
+			assertEquals(1, result.size());
+		}
+	}
+
+	@Test
+	public void testDatetimeSubtypesExtended() {
+		ValueFactory vf = extendedRepo.getValueFactory();
+
+		try (RepositoryConnection conn = extendedRepo.getConnection()) {
+			Literal l1 = vf.createLiteral("2009", XMLSchema.GYEAR);
+			Literal l2 = vf.createLiteral("2009-01", XMLSchema.GYEARMONTH);
+			IRI s1 = vf.createIRI("urn:s1");
+			IRI s2 = vf.createIRI("urn:s2");
+			conn.add(s1, RDFS.LABEL, l1);
+			conn.add(s2, RDFS.LABEL, l2);
+
+			String query = "SELECT * WHERE { ?s rdfs:label ?l . FILTER(?l >= \"2008\"^^xsd:gYear) }";
+
+			List<BindingSet> result = QueryResults.asList(conn.prepareTupleQuery(query).evaluate());
+			assertEquals(2, result.size());
+		}
+	}
+
+	/**
+	 * Gets a configuration object for the base Sail that should be tested.
+	 * 
+	 * @return a {@link BaseSailConfig}.
+	 */
+	protected abstract BaseSailConfig getBaseSailConfig();
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #164 .

Briefly describe the changes proposed in this PR:

* hotfix/workaround for issue with configuration of evaluation strategy in memory and native stores.
* both stores now use the provided Factory to create an EvaluationStrategy.
* EvaluationStrategy interface extended to allow passing through of `iterationCacheSyncThreshold` param.

We may want to revisit the design later, as it all is a bit tightly coupled. However, this is a hotfix and unless somehow has strong objections I'd like this merged in so we can proceed with release.

@pulquero, @ansell , your feedback in particular is appreciated. 
