### PR TITLE
Issue #623: notification before scheduling sync.

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
@@ -63,8 +63,8 @@ public class MemoryStoreConnection extends SailSourceConnection {
 	{
 		super.commitInternal();
 
-		sail.scheduleSyncTask();
 		sail.notifySailChanged(sailChangedEvent);
+		sail.scheduleSyncTask();
 
 		// create a fresh event object.
 		sailChangedEvent = new DefaultSailChangedEvent(sail);


### PR DESCRIPTION
This PR addresses GitHub issue: #623 .

Briefly describe the changes proposed in this PR:

* trivial fix in internal commit: send change notification _before_ scheduling sync. 

Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>