### PR TITLE
Issue #626: show dir being written to when error occurs in disk overflow

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowModel.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowModel.java
@@ -262,7 +262,8 @@ abstract class MemoryOverflowModel extends AbstractModel {
 			memory = new TreeModel(memory.getNamespaces());
 		}
 		catch (IOException | SailException e) {
-			logger.error("Error while writing to overflow directory " + dataDir.getAbsolutePath(), e);
+			String path = dataDir != null? dataDir.getAbsolutePath() : "(unknown)";
+			logger.error("Error while writing to overflow directory " + path, e);
 		}
 	}
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowModel.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowModel.java
@@ -261,11 +261,8 @@ abstract class MemoryOverflowModel extends AbstractModel {
 			disk.addAll(memory);
 			memory = new TreeModel(memory.getNamespaces());
 		}
-		catch (IOException e) {
-			logger.error(e.toString(), e);
-		}
-		catch (SailException e) {
-			logger.error(e.toString(), e);
+		catch (IOException | SailException e) {
+			logger.error("Error while writing to overflow directory " + dataDir.getAbsolutePath(), e);
 		}
 	}
 


### PR DESCRIPTION
This PR addresses GitHub issue: #626 .

Briefly describe the changes proposed in this PR:

* trivial change in error logging: include datadir (if known) when error occurs in disk sync.

Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>