### PR TITLE
Issue #630 simplified concurrent locking code

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
@@ -322,11 +322,6 @@ class NativeSailStore implements SailStore {
 
 		private final boolean explicit;
 
-		/**
-		 * The exclusive transaction lock held by this connection during transactions.
-		 */
-		private volatile boolean txnLockAcquired;
-
 		public NativeSailSink(boolean explicit)
 			throws SailException
 		{
@@ -335,9 +330,7 @@ class NativeSailStore implements SailStore {
 
 		@Override
 		public synchronized void close() {
-			boolean nextTxnLockAcquired = txnLockAcquired;
-			txnLockAcquired = false;
-			if (nextTxnLockAcquired) {
+			if (txnLockManager.isHeldByCurrentThread()) {
 				txnLockManager.unlock();
 			}
 		}
@@ -355,7 +348,7 @@ class NativeSailStore implements SailStore {
 		{
 			// SES-1949 check necessary to avoid empty/read-only transactions
 			// messing up concurrent transactions
-			if (txnLockAcquired && txnLockManager.getHoldCount() == 1) {
+			if (txnLockManager.isHeldByCurrentThread()) {
 				try {
 					try {
 						valueStore.sync();
@@ -435,23 +428,13 @@ class NativeSailStore implements SailStore {
 		private synchronized void acquireExclusiveTransactionLock()
 			throws SailException
 		{
-			boolean nextTxnLockAcquired = txnLockAcquired;
-			if (!nextTxnLockAcquired) {
-				txnLockManager.lock();
+			if (!txnLockManager.isHeldByCurrentThread()) {
 				try {
-					if (txnLockManager.getHoldCount() == 1) {
-						// first object
-						tripleStore.startTransaction();
-					}
-					nextTxnLockAcquired = txnLockAcquired = true;
+					txnLockManager.lock();
+					tripleStore.startTransaction();
 				}
 				catch (IOException e) {
 					throw new SailException(e);
-				}
-				finally {
-					if (!nextTxnLockAcquired) {
-						txnLockManager.unlock();
-					}
 				}
 			}
 		}


### PR DESCRIPTION
This PR addresses GitHub issue: #630 .

Briefly describe the changes proposed in this PR:

* simplified locking code in NativeSailStore and MemorySailStore: eliminated use of separate boolean value to track locking state 

This is not yet ready for merging, as I need to run further tests to confirm that this is consistent and that it indeed addresses the observed issue in #630. Nevertheless, reviews welcome. 
