### PR TITLE
Issue: #630 TransactionController threading 

### DIFF
--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/QueryResultView.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/QueryResultView.java
@@ -12,13 +12,11 @@ import static org.eclipse.rdf4j.http.protocol.Protocol.QUERY_PARAM_NAME;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Map;
-import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.rdf4j.common.lang.FileFormat;
-import org.eclipse.rdf4j.http.server.repository.transaction.ActiveTransactionRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.View;
@@ -63,16 +61,7 @@ public abstract class QueryResultView implements View {
 	public final void render(Map model, HttpServletRequest request, HttpServletResponse response)
 		throws IOException
 	{
-		UUID txnId = null;
-		try {
-			txnId = (UUID)model.get(TRANSACTION_ID_KEY);
-			renderInternal(model, request, response);
-		}
-		finally {
-			if (txnId != null) {
-				ActiveTransactionRegistry.INSTANCE.returnTransactionConnection(txnId);
-			}
-		}
+		renderInternal(model, request, response);
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
@@ -1,0 +1,475 @@
+/**
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.http.server.repository.transaction;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.eclipse.rdf4j.IsolationLevel;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.SESAME;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.Query;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.util.RDFInserter;
+import org.eclipse.rdf4j.rio.ParserConfig;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+
+/**
+ * A transaction encapsulates a single {@link Thread} and a {@link RepositoryConnection}, to enable executing
+ * all operations that are part of the transaction from a single, dedicated thread. This is necessary because
+ * {@link RepositoryConnection} is not guaranteed thread-safe and we may run into concurrency issues if we
+ * attempt to share it between the various HTTP Request worker threads.
+ * 
+ * @author Jeen Broekstra
+ */
+class Transaction {
+
+	private final UUID id;
+
+	private final Repository rep;
+
+	private final RepositoryConnection txnConnection;
+
+	private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+	private final List<Future<?>> futures = new ArrayList<>();
+
+	/**
+	 * Create a new Transaction for the given {@link Repository}.
+	 * 
+	 * @param repository
+	 *        the {@link Repository} on which to open a transaction.
+	 * @throws InterruptedException
+	 *         if the transaction thread is interrupted while opening a connection.
+	 * @throws ExecutionException
+	 *         if an error occurs while opening the connection.
+	 */
+	Transaction(Repository repository)
+		throws InterruptedException, ExecutionException
+	{
+		this.id = UUID.randomUUID();
+		this.rep = repository;
+		this.txnConnection = getTransactionConnection();
+	}
+
+	/**
+	 * The identifier of this transaction object.
+	 * 
+	 * @return a {@link UUID} that identifies this Transaction.
+	 */
+	UUID getID() {
+		return id;
+	}
+
+
+
+	/**
+	 * Start the transaction.
+	 * 
+	 * @param level
+	 *        the {@link IsolationLevel} to use for this transction.
+	 * @throws InterruptedException
+	 *         if the transaction thread is interrupted
+	 * @throws ExecutionException
+	 *         if an error occurs while starting the transaction.
+	 */
+	void begin(IsolationLevel level)
+		throws InterruptedException, ExecutionException
+	{
+		Future<Boolean> result = executor.submit(() -> {
+			txnConnection.begin(level);
+			return true;
+		});
+
+		futures.add(result);
+		result.get();
+	}
+
+	/**
+	 * Rolls back all updates in the transaction.
+	 * 
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 */
+	void rollback()
+		throws InterruptedException, ExecutionException
+	{
+		Future<Boolean> result = executor.submit(() -> {
+			txnConnection.rollback();
+			return true;
+		});
+	
+		futures.add(result);
+		result.get();
+	}
+
+	/**
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 */
+	void commit()
+		throws InterruptedException, ExecutionException
+	{
+		Future<Boolean> result = executor.submit(() -> {
+			txnConnection.commit();
+			return true;
+		});
+	
+		futures.add(result);
+	
+		result.get();
+	}
+
+	/**
+	 * Prepares a query for evaluation on this transaction.
+	 * 
+	 * @param ql
+	 *        The {@link QueryLanguage query language} in which the query is formulated.
+	 * @param query
+	 *        The query string.
+	 * @param baseURI
+	 *        The base URI to resolve any relative URIs that are in the query against, can be <tt>null</tt> if
+	 *        the query does not contain any relative URIs.
+	 * @return A query ready to be evaluated on this repository.
+	 * @throws InterruptedException
+	 *         if the transaction thread is interrupted
+	 * @throws ExecutionException
+	 *         if an error occurs while executing the operation.
+	 */
+	Query prepareQuery(QueryLanguage queryLn, String queryStr, String baseURI)
+		throws InterruptedException, ExecutionException
+	{
+		Future<Query> result = executor.submit(() -> txnConnection.prepareQuery(queryLn, queryStr, baseURI));
+
+		futures.add(result);
+		return result.get();
+	}
+
+	/**
+	 * Evaluate a TupleQuery in this transaction and return the result.
+	 * 
+	 * @param tQuery
+	 *        a {@link TupleQuery} prepared on this transaction.
+	 * @return a {@link TupleQueryResult}
+	 * @throws InterruptedException
+	 *         if the transaction thread is interrupted
+	 * @throws ExecutionException
+	 *         if an error occurs while executing the operation.
+	 */
+	TupleQueryResult evaluate(TupleQuery tQuery)
+		throws InterruptedException, ExecutionException
+	{
+		Future<TupleQueryResult> result = executor.submit(() -> tQuery.evaluate());
+		futures.add(result);
+		return result.get();
+	}
+
+	/**
+	 * Evaluate a {@link GraphQuery} in this transaction and return the result.
+	 * 
+	 * @param gQuery
+	 *        a {@link GraphQuery} prepared on this transaction.
+	 * @return a {@link GraphQueryResult}
+	 * @throws InterruptedException
+	 *         if the transaction thread is interrupted
+	 * @throws ExecutionException
+	 *         if an error occurs while executing the operation.
+	 */
+	GraphQueryResult evaluate(GraphQuery gQuery)
+		throws InterruptedException, ExecutionException
+	{
+		Future<GraphQueryResult> result = executor.submit(() -> gQuery.evaluate());
+		futures.add(result);
+		return result.get();
+	}
+
+	/**
+	 * Evaluate a {@link BooleanQuery} in this transaction and return the result.
+	 * 
+	 * @param bQuery
+	 *        a {@link BooleanQuery} prepared on this transaction.
+	 * @return the query result as a boolean
+	 * @throws InterruptedException
+	 *         if the transaction thread is interrupted
+	 * @throws ExecutionException
+	 *         if an error occurs while executing the operation.
+	 */
+	boolean evaluate(BooleanQuery bQuery)
+		throws InterruptedException, ExecutionException
+	{
+		Future<Boolean> result = executor.submit(() -> bQuery.evaluate());
+		futures.add(result);
+		return result.get();
+	}
+
+	/**
+	 * @param subj
+	 * @param pred
+	 * @param obj
+	 * @param useInferencing
+	 * @param rdfWriter
+	 * @param contexts
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 */
+	void exportStatements(Resource subj, IRI pred, Value obj, boolean useInferencing,
+			RDFWriter rdfWriter, Resource... contexts)
+		throws InterruptedException, ExecutionException
+	{
+		Future<Boolean> result = executor.submit(() -> {
+			txnConnection.exportStatements(subj, pred, obj, useInferencing, rdfWriter, contexts);
+			return true;
+		});
+	
+		futures.add(result);
+		result.get();
+	}
+
+	/**
+	 * Returns the number of (explicit) statements that are in the specified contexts in this transaction.
+	 * 
+	 * @param contexts
+	 *        The context(s) to get the data from. Note that this parameter is a vararg and as such is
+	 *        optional. If no contexts are supplied the method operates on the entire repository.
+	 * @return The number of explicit statements from the specified contexts in this transaction.
+	 */
+	long getSize(Resource[] contexts)
+		throws InterruptedException, ExecutionException
+	{
+		Future<Long> result = executor.submit(() -> txnConnection.size(contexts));
+		futures.add(result);
+		return result.get();
+	}
+
+	/**
+	 * Adds RDF data from an {@link InputStream} to the transaction.
+	 * 
+	 * @param inputStream
+	 * @param baseURI
+	 * @param format
+	 * @param contexts
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 */
+	void add(InputStream inputStream, String baseURI, RDFFormat format, boolean preserveBNodes,
+			Resource... contexts)
+		throws InterruptedException, ExecutionException
+	{
+		Future<Boolean> result = executor.submit(() -> {
+			try {
+				if (preserveBNodes) {
+					// create a reconfigured parser + inserter instead of relying on standard
+					// repositoryconn add method.
+					RDFParser parser = Rio.createParser(format);
+					parser.getParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
+					RDFInserter inserter = new RDFInserter(txnConnection);
+					inserter.setPreserveBNodeIDs(true);
+					if (contexts.length > 0) {
+						inserter.enforceContext(contexts);
+					}
+					parser.setRDFHandler(inserter);
+					parser.parse(inputStream, baseURI);
+				}
+				else {
+					txnConnection.add(inputStream, baseURI, format, contexts);
+				}
+				return true;
+			}
+			catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+
+		futures.add(result);
+		result.get();
+	}
+
+	/**
+	 * @param contentType
+	 * @param inputStream
+	 * @param baseURI
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 */
+	void delete(RDFFormat contentType, InputStream inputStream, String baseURI)
+		throws InterruptedException, ExecutionException
+	{
+		Future<Boolean> exception = executor.submit(() -> {
+			RDFParser parser = Rio.createParser(contentType, txnConnection.getValueFactory());
+
+			parser.setRDFHandler(new WildcardRDFRemover(txnConnection));
+			parser.getParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
+			try {
+				parser.parse(inputStream, baseURI);
+				return true;
+			}
+			catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+
+		futures.add(exception);
+
+		exception.get();
+	}
+
+	/**
+	 * @param queryLn
+	 * @param sparqlUpdateString
+	 * @param baseURI
+	 * @param includeInferred
+	 * @param dataset
+	 * @param bindings
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 */
+	void executeUpdate(QueryLanguage queryLn, String sparqlUpdateString, String baseURI,
+			boolean includeInferred, Dataset dataset, Map<String, Value> bindings)
+		throws InterruptedException, ExecutionException
+	{
+		Future<Boolean> result = executor.submit(() -> {
+			Update update = txnConnection.prepareUpdate(queryLn, sparqlUpdateString);
+			update.setIncludeInferred(includeInferred);
+			if (dataset != null) {
+				update.setDataset(dataset);
+			}
+			for (String bindingName : bindings.keySet()) {
+				update.setBinding(bindingName, bindings.get(bindingName));
+			}
+
+			update.execute();
+			return true;
+		});
+
+		futures.add(result);
+		result.get();
+	}
+
+	boolean hasActiveOperations() {
+		for (Future future : futures) {
+			if (!future.isDone()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Close this transaction.
+	 * 
+	 * @throws InterruptedException
+	 * @throws ExecutionException
+	 */
+	void close()
+		throws InterruptedException, ExecutionException
+	{
+		try {
+			Future<Boolean> result = executor.submit(() -> {
+				txnConnection.close();
+				return true;
+			});
+	
+			futures.add(result);
+			result.get();
+		}
+		finally {
+			executor.shutdown();
+		}
+	}
+
+	private RepositoryConnection getTransactionConnection()
+			throws InterruptedException, ExecutionException
+		{
+			// create a new RepositoryConnection with correct parser settings
+			Future<RepositoryConnection> future = executor.submit(() -> {
+				RepositoryConnection conn = rep.getConnection();
+				ParserConfig config = conn.getParserConfig();
+				config.set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
+				config.addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
+				config.addNonFatalError(BasicParserSettings.VERIFY_LANGUAGE_TAGS);
+
+				return conn;
+			});
+
+			futures.add(future);
+			return future.get();
+		}
+
+	private static class WildcardRDFRemover extends AbstractRDFHandler {
+	
+		private final RepositoryConnection conn;
+	
+		public WildcardRDFRemover(RepositoryConnection conn) {
+			super();
+			this.conn = conn;
+		}
+	
+		@Override
+		public void handleStatement(Statement st)
+			throws RDFHandlerException
+		{
+			Resource subject = SESAME.WILDCARD.equals(st.getSubject()) ? null : st.getSubject();
+			IRI predicate = SESAME.WILDCARD.equals(st.getPredicate()) ? null : st.getPredicate();
+			Value object = SESAME.WILDCARD.equals(st.getObject()) ? null : st.getObject();
+	
+			// use the RepositoryConnection.clear operation if we're removing all statements
+			final boolean clearAllTriples = subject == null && predicate == null && object == null;
+	
+			try {
+				Resource context = st.getContext();
+				if (context != null) {
+					if (clearAllTriples) {
+						conn.clear(context);
+					}
+					else {
+						conn.remove(subject, predicate, object, context);
+					}
+				}
+				else {
+					if (clearAllTriples) {
+						conn.clear();
+					}
+					else {
+						conn.remove(subject, predicate, object);
+					}
+				}
+			}
+			catch (RepositoryException e) {
+				throw new RDFHandlerException(e);
+			}
+		}
+	
+	}
+}

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -30,6 +30,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -52,13 +53,11 @@ import org.eclipse.rdf4j.http.server.repository.GraphQueryResultView;
 import org.eclipse.rdf4j.http.server.repository.QueryResultView;
 import org.eclipse.rdf4j.http.server.repository.RepositoryInterceptor;
 import org.eclipse.rdf4j.http.server.repository.TupleQueryResultView;
-import org.eclipse.rdf4j.http.server.repository.statements.ExportStatementsView;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.SESAME;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.BooleanQuery;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -68,23 +67,16 @@ import org.eclipse.rdf4j.query.QueryInterruptedException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.UnsupportedQueryLanguageException;
-import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.query.UpdateExecutionException;
 import org.eclipse.rdf4j.query.impl.SimpleDataset;
 import org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriterRegistry;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterRegistry;
 import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
-import org.eclipse.rdf4j.repository.util.RDFInserter;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
 import org.eclipse.rdf4j.rio.RDFWriterRegistry;
 import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
-import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContextException;
@@ -117,13 +109,13 @@ public class TransactionController extends AbstractController {
 		UUID transactionId = getTransactionID(request);
 		logger.debug("transaction id: {}", transactionId);
 		logger.debug("request content type: {}", request.getContentType());
-		RepositoryConnection connection = ActiveTransactionRegistry.INSTANCE.getTransactionConnection(
-				transactionId);
 
-		if (connection == null) {
-			logger.warn("could not find connection for transaction id {}", transactionId);
+		Transaction transaction = ActiveTransactionRegistry.INSTANCE.getTransaction(transactionId);
+
+		if (transaction == null) {
+			logger.warn("could not find transaction for transaction id {}", transactionId);
 			throw new ClientHTTPException(SC_BAD_REQUEST,
-					"unable to find registerd connection for transaction id '" + transactionId + "'");
+					"unable to find registerd transaction for transaction id '" + transactionId + "'");
 		}
 
 		// if no action is specified in the request, it's a rollback (since it's
@@ -138,7 +130,7 @@ public class TransactionController extends AbstractController {
 				// PUT is allowed.
 				if ("PUT".equals(reqMethod) || METHOD_POST.equals(reqMethod)) {
 					logger.info("{} txn query request", reqMethod);
-					result = processQuery(connection, transactionId, request, response);
+					result = processQuery(transaction, request, response);
 					logger.info("{} txn query request finished", reqMethod);
 				}
 				else {
@@ -149,7 +141,7 @@ public class TransactionController extends AbstractController {
 			case GET:
 				if ("PUT".equals(reqMethod) || METHOD_POST.equals(reqMethod)) {
 					logger.info("{} txn get/export statements request", reqMethod);
-					result = getExportStatementsResult(connection, transactionId, request, response);
+					result = getExportStatementsResult(transaction, request, response);
 					logger.info("{} txn get/export statements request finished", reqMethod);
 				}
 				else {
@@ -160,7 +152,7 @@ public class TransactionController extends AbstractController {
 			case SIZE:
 				if ("PUT".equals(reqMethod) || METHOD_POST.equals(reqMethod)) {
 					logger.info("{} txn size request", reqMethod);
-					result = getSize(connection, transactionId, request, response);
+					result = getSize(transaction, request, response);
 					logger.info("{} txn size request finished", reqMethod);
 				}
 				else {
@@ -169,38 +161,31 @@ public class TransactionController extends AbstractController {
 				}
 				break;
 			default:
-				// modification operations - we can process these and then
-				// immediately release the connection back to the registry.
-				try {
-					// TODO Action.ROLLBACK check is for backward compatibility with
-					// older 2.8.x releases only. It's not in the protocol spec.
-					if ("DELETE".equals(reqMethod) || (action.equals(Action.ROLLBACK)
-							&& ("PUT".equals(reqMethod) || METHOD_POST.equals(reqMethod))))
-					{
-						logger.info("transaction rollback");
-						try {
-							connection.rollback();
-						}
-						finally {
-							ActiveTransactionRegistry.INSTANCE.deregister(transactionId);
-							connection.close();
-						}
-						result = new ModelAndView(EmptySuccessView.getInstance());
-						logger.info("transaction rollback request finished.");
+				// TODO Action.ROLLBACK check is for backward compatibility with
+				// older 2.8.x releases only. It's not in the protocol spec.
+				if ("DELETE".equals(reqMethod) || (action.equals(Action.ROLLBACK)
+						&& ("PUT".equals(reqMethod) || METHOD_POST.equals(reqMethod))))
+				{
+					logger.info("transaction rollback");
+					try {
+						transaction.rollback();
 					}
-					else if ("PUT".equals(reqMethod) || METHOD_POST.equals(reqMethod)) {
-						// TODO filter for appropriate PUT operations
-						logger.info("{} txn operation", reqMethod);
-						result = processModificationOperation(connection, action, request, response);
-						logger.info("PUT txn operation request finished.");
+					finally {
+						ActiveTransactionRegistry.INSTANCE.deregister(transaction);
+						transaction.close();
 					}
-					else {
-						throw new ClientHTTPException(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
-								"Method not allowed: " + reqMethod);
-					}
+					result = new ModelAndView(EmptySuccessView.getInstance());
+					logger.info("transaction rollback request finished.");
 				}
-				finally {
-					ActiveTransactionRegistry.INSTANCE.returnTransactionConnection(transactionId);
+				else if ("PUT".equals(reqMethod) || METHOD_POST.equals(reqMethod)) {
+					// TODO filter for appropriate PUT operations
+					logger.info("{} txn operation", reqMethod);
+					result = processModificationOperation(transaction, action, request, response);
+					logger.info("PUT txn operation request finished.");
+				}
+				else {
+					throw new ClientHTTPException(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+							"Method not allowed: " + reqMethod);
 				}
 				break;
 		}
@@ -235,7 +220,7 @@ public class TransactionController extends AbstractController {
 		return txnID;
 	}
 
-	private ModelAndView processModificationOperation(RepositoryConnection conn, Action action,
+	private ModelAndView processModificationOperation(Transaction transaction, Action action,
 			HttpServletRequest request, HttpServletResponse response)
 		throws IOException, HTTPException
 	{
@@ -249,50 +234,31 @@ public class TransactionController extends AbstractController {
 		}
 
 		final Resource[] contexts = ProtocolUtil.parseContextParam(request, CONTEXT_PARAM_NAME,
-				conn.getValueFactory());
+				SimpleValueFactory.getInstance());
 
 		final boolean preserveNodeIds = ProtocolUtil.parseBooleanParam(request,
 				Protocol.PRESERVE_BNODE_ID_PARAM_NAME, false);
 
 		try {
+			RDFFormat format = null;
 			switch (action) {
 				case ADD:
-					final RDFFormat format = Rio.getParserFormatForMIMEType(
-							request.getContentType()).orElseThrow(
-									Rio.unsupportedFormat(request.getContentType()));
-
-					if (preserveNodeIds) {
-						// create a reconfigured parser + inserter instead of relying on standard
-						// repositoryconn add method.
-						RDFParser parser = Rio.createParser(format);
-						parser.getParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
-						RDFInserter inserter = new RDFInserter(conn);
-						inserter.setPreserveBNodeIDs(true);
-						if (contexts.length > 0) {
-							inserter.enforceContext(contexts);
-						}
-						parser.setRDFHandler(inserter);
-						parser.parse(request.getInputStream(), baseURI);
-					}
-					else {
-						conn.add(request.getInputStream(), baseURI, format, contexts);
-					}
+					format = Rio.getParserFormatForMIMEType(request.getContentType()).orElseThrow(
+							Rio.unsupportedFormat(request.getContentType()));
+					transaction.add(request.getInputStream(), baseURI, format, preserveNodeIds, contexts);
 					break;
 				case DELETE:
-					RDFParser parser = Rio.createParser(
-							Rio.getParserFormatForMIMEType(request.getContentType()).orElseThrow(
-									Rio.unsupportedFormat(request.getContentType())),
-							conn.getValueFactory());
-					parser.setRDFHandler(new WildcardRDFRemover(conn));
-					parser.getParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
-					parser.parse(request.getInputStream(), baseURI);
+					format = Rio.getParserFormatForMIMEType(request.getContentType()).orElseThrow(
+							Rio.unsupportedFormat(request.getContentType()));
+					transaction.delete(format, request.getInputStream(), baseURI);
+
 					break;
 				case UPDATE:
-					return getSparqlUpdateResult(conn, request, response);
+					return getSparqlUpdateResult(transaction, request, response);
 				case COMMIT:
-					conn.commit();
-					conn.close();
-					ActiveTransactionRegistry.INSTANCE.deregister(getTransactionID(request));
+					transaction.commit();
+					transaction.close();
+					ActiveTransactionRegistry.INSTANCE.deregister(transaction);
 					break;
 				default:
 					logger.warn("transaction modification action '{}' not recognized", action);
@@ -313,39 +279,33 @@ public class TransactionController extends AbstractController {
 		}
 	}
 
-	private ModelAndView getSize(RepositoryConnection conn, UUID txnId, HttpServletRequest request,
+	private ModelAndView getSize(Transaction transaction, HttpServletRequest request,
 			HttpServletResponse response)
 		throws HTTPException
 	{
-		try {
-			ProtocolUtil.logRequestParameters(request);
+		ProtocolUtil.logRequestParameters(request);
 
-			Map<String, Object> model = new HashMap<String, Object>();
-			final boolean headersOnly = METHOD_HEAD.equals(request.getMethod());
+		Map<String, Object> model = new HashMap<String, Object>();
+		final boolean headersOnly = METHOD_HEAD.equals(request.getMethod());
 
-			if (!headersOnly) {
-				Repository repository = RepositoryInterceptor.getRepository(request);
+		if (!headersOnly) {
+			Repository repository = RepositoryInterceptor.getRepository(request);
 
-				ValueFactory vf = repository.getValueFactory();
-				Resource[] contexts = ProtocolUtil.parseContextParam(request, Protocol.CONTEXT_PARAM_NAME,
-						vf);
+			ValueFactory vf = repository.getValueFactory();
+			Resource[] contexts = ProtocolUtil.parseContextParam(request, Protocol.CONTEXT_PARAM_NAME, vf);
 
-				long size = -1;
+			long size = -1;
 
-				try {
-					size = conn.size(contexts);
-				}
-				catch (RepositoryException e) {
-					throw new ServerHTTPException("Repository error: " + e.getMessage(), e);
-				}
-				model.put(SimpleResponseView.CONTENT_KEY, String.valueOf(size));
+			try {
+				size = transaction.getSize(contexts);
 			}
+			catch (RepositoryException | InterruptedException | ExecutionException e) {
+				throw new ServerHTTPException("Repository error: " + e.getMessage(), e);
+			}
+			model.put(SimpleResponseView.CONTENT_KEY, String.valueOf(size));
+		}
 
-			return new ModelAndView(SimpleResponseView.getInstance(), model);
-		}
-		finally {
-			ActiveTransactionRegistry.INSTANCE.returnTransactionConnection(txnId);
-		}
+		return new ModelAndView(SimpleResponseView.getInstance(), model);
 	}
 
 	/**
@@ -353,13 +313,13 @@ public class TransactionController extends AbstractController {
 	 * 
 	 * @return a model and view for exporting the statements.
 	 */
-	private ModelAndView getExportStatementsResult(RepositoryConnection conn, UUID txnId,
-			HttpServletRequest request, HttpServletResponse response)
+	private ModelAndView getExportStatementsResult(Transaction transaction, HttpServletRequest request,
+			HttpServletResponse response)
 		throws ClientHTTPException
 	{
 		ProtocolUtil.logRequestParameters(request);
 
-		ValueFactory vf = conn.getValueFactory();
+		ValueFactory vf = SimpleValueFactory.getInstance();
 
 		Resource subj = ProtocolUtil.parseResourceParam(request, SUBJECT_PARAM_NAME, vf);
 		IRI pred = ProtocolUtil.parseURIParam(request, PREDICATE_PARAM_NAME, vf);
@@ -371,16 +331,16 @@ public class TransactionController extends AbstractController {
 				RDFWriterRegistry.getInstance());
 
 		Map<String, Object> model = new HashMap<String, Object>();
-		model.put(ExportStatementsView.SUBJECT_KEY, subj);
-		model.put(ExportStatementsView.PREDICATE_KEY, pred);
-		model.put(ExportStatementsView.OBJECT_KEY, obj);
-		model.put(ExportStatementsView.CONTEXTS_KEY, contexts);
-		model.put(ExportStatementsView.USE_INFERENCING_KEY, Boolean.valueOf(useInferencing));
-		model.put(ExportStatementsView.FACTORY_KEY, rdfWriterFactory);
-		model.put(ExportStatementsView.HEADERS_ONLY, METHOD_HEAD.equals(request.getMethod()));
-		model.put(ExportStatementsView.CONNECTION_KEY, conn);
-		model.put(ExportStatementsView.TRANSACTION_ID_KEY, txnId);
-		return new ModelAndView(ExportStatementsView.getInstance(), model);
+		model.put(TransactionExportStatementsView.SUBJECT_KEY, subj);
+		model.put(TransactionExportStatementsView.PREDICATE_KEY, pred);
+		model.put(TransactionExportStatementsView.OBJECT_KEY, obj);
+		model.put(TransactionExportStatementsView.CONTEXTS_KEY, contexts);
+		model.put(TransactionExportStatementsView.USE_INFERENCING_KEY, Boolean.valueOf(useInferencing));
+		model.put(TransactionExportStatementsView.FACTORY_KEY, rdfWriterFactory);
+		model.put(TransactionExportStatementsView.HEADERS_ONLY, METHOD_HEAD.equals(request.getMethod()));
+
+		model.put(TransactionExportStatementsView.TRANSACTION_KEY, transaction);
+		return new ModelAndView(TransactionExportStatementsView.getInstance(), model);
 	}
 
 	/**
@@ -388,7 +348,7 @@ public class TransactionController extends AbstractController {
 	 * {@link QueryResultView} will take care of correctly releasing the connection back to the
 	 * {@link ActiveTransactionRegistry}, after fully rendering the query result for sending over the wire.
 	 */
-	private ModelAndView processQuery(RepositoryConnection conn, UUID txnId, HttpServletRequest request,
+	private ModelAndView processQuery(Transaction txn, HttpServletRequest request,
 			HttpServletResponse response)
 		throws IOException, HTTPException
 	{
@@ -403,31 +363,31 @@ public class TransactionController extends AbstractController {
 			queryStr = request.getParameter(QUERY_PARAM_NAME);
 		}
 
-		Query query = getQuery(conn, queryStr, request, response);
-
 		View view;
 		Object queryResult;
 		FileFormatServiceRegistry<? extends FileFormat, ?> registry;
 
 		try {
+			Query query = getQuery(txn, queryStr, request, response);
+
 			if (query instanceof TupleQuery) {
 				TupleQuery tQuery = (TupleQuery)query;
 
-				queryResult = tQuery.evaluate();
+				queryResult = txn.evaluate(tQuery);
 				registry = TupleQueryResultWriterRegistry.getInstance();
 				view = TupleQueryResultView.getInstance();
 			}
 			else if (query instanceof GraphQuery) {
 				GraphQuery gQuery = (GraphQuery)query;
 
-				queryResult = gQuery.evaluate();
+				queryResult = txn.evaluate(gQuery);
 				registry = RDFWriterRegistry.getInstance();
 				view = GraphQueryResultView.getInstance();
 			}
 			else if (query instanceof BooleanQuery) {
 				BooleanQuery bQuery = (BooleanQuery)query;
 
-				queryResult = bQuery.evaluate();
+				queryResult = txn.evaluate(bQuery);
 				registry = BooleanQueryResultWriterRegistry.getInstance();
 				view = BooleanQueryResultView.getInstance();
 			}
@@ -436,14 +396,12 @@ public class TransactionController extends AbstractController {
 						"Unsupported query type: " + query.getClass().getName());
 			}
 		}
-		catch (QueryInterruptedException e) {
+		catch (QueryInterruptedException | InterruptedException | ExecutionException e) {
 			logger.info("Query interrupted", e);
-			ActiveTransactionRegistry.INSTANCE.returnTransactionConnection(txnId);
-			throw new ServerHTTPException(SC_SERVICE_UNAVAILABLE, "Query evaluation took too long");
+			throw new ServerHTTPException(SC_SERVICE_UNAVAILABLE, "Query execution interrupted");
 		}
 		catch (QueryEvaluationException e) {
 			logger.info("Query evaluation error", e);
-			ActiveTransactionRegistry.INSTANCE.returnTransactionConnection(txnId);
 			if (e.getCause() != null && e.getCause() instanceof HTTPException) {
 				// custom signal from the backend, throw as HTTPException
 				// directly (see SES-1016).
@@ -461,13 +419,13 @@ public class TransactionController extends AbstractController {
 		model.put(QueryResultView.FACTORY_KEY, factory);
 		model.put(QueryResultView.HEADERS_ONLY, false); // TODO needed for HEAD
 														// requests.
-		model.put(QueryResultView.TRANSACTION_ID_KEY, txnId);
+		model.put(QueryResultView.TRANSACTION_ID_KEY, txn.getID());
 		return new ModelAndView(view, model);
 	}
 
-	private Query getQuery(RepositoryConnection repositoryCon, String queryStr, HttpServletRequest request,
+	private Query getQuery(Transaction txn, String queryStr, HttpServletRequest request,
 			HttpServletResponse response)
-		throws IOException, ClientHTTPException
+		throws IOException, ClientHTTPException, InterruptedException, ExecutionException
 	{
 		Query result = null;
 
@@ -514,7 +472,7 @@ public class TransactionController extends AbstractController {
 					try {
 						IRI uri = null;
 						if (!"null".equals(defaultGraphURI)) {
-							uri = repositoryCon.getValueFactory().createIRI(defaultGraphURI);
+							uri = SimpleValueFactory.getInstance().createIRI(defaultGraphURI);
 						}
 						dataset.addDefaultGraph(uri);
 					}
@@ -530,7 +488,7 @@ public class TransactionController extends AbstractController {
 					try {
 						IRI uri = null;
 						if (!"null".equals(namedGraphURI)) {
-							uri = repositoryCon.getValueFactory().createIRI(namedGraphURI);
+							uri = SimpleValueFactory.getInstance().createIRI(namedGraphURI);
 						}
 						dataset.addNamedGraph(uri);
 					}
@@ -543,12 +501,11 @@ public class TransactionController extends AbstractController {
 		}
 
 		try {
-			result = repositoryCon.prepareQuery(queryLn, queryStr, baseURI);
-
+			result = txn.prepareQuery(queryLn, queryStr, baseURI);
 			result.setIncludeInferred(includeInferred);
 
 			if (maxQueryTime > 0) {
-				result.setMaxQueryTime(maxQueryTime);
+				result.setMaxExecutionTime(maxQueryTime);
 			}
 
 			if (dataset != null) {
@@ -567,7 +524,7 @@ public class TransactionController extends AbstractController {
 				{
 					String bindingName = parameterName.substring(BINDING_PREFIX.length());
 					Value bindingValue = ProtocolUtil.parseValueParam(request, parameterName,
-							repositoryCon.getValueFactory());
+							SimpleValueFactory.getInstance());
 					result.setBinding(bindingName, bindingValue);
 				}
 			}
@@ -588,7 +545,7 @@ public class TransactionController extends AbstractController {
 		return result;
 	}
 
-	private ModelAndView getSparqlUpdateResult(RepositoryConnection conn, HttpServletRequest request,
+	private ModelAndView getSparqlUpdateResult(Transaction transaction, HttpServletRequest request,
 			HttpServletResponse response)
 		throws ServerHTTPException, ClientHTTPException, HTTPException
 	{
@@ -644,7 +601,7 @@ public class TransactionController extends AbstractController {
 				try {
 					IRI uri = null;
 					if (!"null".equals(graphURI)) {
-						uri = conn.getValueFactory().createIRI(graphURI);
+						uri = SimpleValueFactory.getInstance().createIRI(graphURI);
 					}
 					dataset.addDefaultRemoveGraph(uri);
 				}
@@ -660,7 +617,7 @@ public class TransactionController extends AbstractController {
 			try {
 				IRI uri = null;
 				if (!"null".equals(graphURI)) {
-					uri = conn.getValueFactory().createIRI(graphURI);
+					uri = SimpleValueFactory.getInstance().createIRI(graphURI);
 				}
 				dataset.setDefaultInsertGraph(uri);
 			}
@@ -675,7 +632,7 @@ public class TransactionController extends AbstractController {
 				try {
 					IRI uri = null;
 					if (!"null".equals(defaultGraphURI)) {
-						uri = conn.getValueFactory().createIRI(defaultGraphURI);
+						uri = SimpleValueFactory.getInstance().createIRI(defaultGraphURI);
 					}
 					dataset.addDefaultGraph(uri);
 				}
@@ -691,7 +648,7 @@ public class TransactionController extends AbstractController {
 				try {
 					IRI uri = null;
 					if (!"null".equals(namedGraphURI)) {
-						uri = conn.getValueFactory().createIRI(namedGraphURI);
+						uri = SimpleValueFactory.getInstance().createIRI(namedGraphURI);
 					}
 					dataset.addNamedGraph(uri);
 				}
@@ -703,18 +660,11 @@ public class TransactionController extends AbstractController {
 		}
 
 		try {
-			Update update = conn.prepareUpdate(queryLn, sparqlUpdateString, baseURI);
-
-			update.setIncludeInferred(includeInferred);
-
-			if (dataset != null) {
-				update.setDataset(dataset);
-			}
-
 			// determine if any variable bindings have been set on this update.
 			@SuppressWarnings("unchecked")
 			Enumeration<String> parameterNames = request.getParameterNames();
 
+			Map<String, Value> bindings = new HashMap<>();
 			while (parameterNames.hasMoreElements()) {
 				String parameterName = parameterNames.nextElement();
 
@@ -723,16 +673,17 @@ public class TransactionController extends AbstractController {
 				{
 					String bindingName = parameterName.substring(BINDING_PREFIX.length());
 					Value bindingValue = ProtocolUtil.parseValueParam(request, parameterName,
-							conn.getValueFactory());
-					update.setBinding(bindingName, bindingValue);
+							SimpleValueFactory.getInstance());
+					bindings.put(bindingName, bindingValue);
 				}
 			}
 
-			update.execute();
+			transaction.executeUpdate(queryLn, sparqlUpdateString, baseURI, includeInferred, dataset,
+					bindings);
 
 			return new ModelAndView(EmptySuccessView.getInstance());
 		}
-		catch (UpdateExecutionException e) {
+		catch (UpdateExecutionException | InterruptedException | ExecutionException e) {
 			if (e.getCause() != null && e.getCause() instanceof HTTPException) {
 				// custom signal from the backend, throw as HTTPException directly
 				// (see SES-1016).
@@ -758,49 +709,4 @@ public class TransactionController extends AbstractController {
 		}
 	}
 
-	private static class WildcardRDFRemover extends AbstractRDFHandler {
-
-		private final RepositoryConnection conn;
-
-		public WildcardRDFRemover(RepositoryConnection conn) {
-			super();
-			this.conn = conn;
-		}
-
-		@Override
-		public void handleStatement(Statement st)
-			throws RDFHandlerException
-		{
-			Resource subject = SESAME.WILDCARD.equals(st.getSubject()) ? null : st.getSubject();
-			IRI predicate = SESAME.WILDCARD.equals(st.getPredicate()) ? null : st.getPredicate();
-			Value object = SESAME.WILDCARD.equals(st.getObject()) ? null : st.getObject();
-
-			// use the RepositoryConnection.clear operation if we're removing all statements
-			final boolean clearAllTriples = subject == null && predicate == null && object == null;
-
-			try {
-				Resource context = st.getContext();
-				if (context != null) {
-					if (clearAllTriples) {
-						conn.clear(context);
-					}
-					else {
-						conn.remove(subject, predicate, object, context);
-					}
-				}
-				else {
-					if (clearAllTriples) {
-						conn.clear();
-					}
-					else {
-						conn.remove(subject, predicate, object);
-					}
-				}
-			}
-			catch (RepositoryException e) {
-				throw new RDFHandlerException(e);
-			}
-		}
-
-	}
 }

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -172,7 +172,6 @@ public class TransactionController extends AbstractController {
 					}
 					finally {
 						ActiveTransactionRegistry.INSTANCE.deregister(transaction);
-						transaction.close();
 					}
 					result = new ModelAndView(EmptySuccessView.getInstance());
 					logger.info("transaction rollback request finished.");
@@ -256,9 +255,12 @@ public class TransactionController extends AbstractController {
 				case UPDATE:
 					return getSparqlUpdateResult(transaction, request, response);
 				case COMMIT:
-					transaction.commit();
-					transaction.close();
-					ActiveTransactionRegistry.INSTANCE.deregister(transaction);
+					try {
+						transaction.commit();
+					}
+					finally {
+						ActiveTransactionRegistry.INSTANCE.deregister(transaction);
+					}
 					break;
 				default:
 					logger.warn("transaction modification action '{}' not recognized", action);

--- a/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.fail;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
+import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.junit.Before;
@@ -26,7 +27,7 @@ public class TestActiveTransactionRegistry {
 
 	private ActiveTransactionRegistry registry;
 
-	private RepositoryConnection conn;
+	private Repository repository;
 
 	private UUID txnId1;
 
@@ -41,120 +42,8 @@ public class TestActiveTransactionRegistry {
 	{
 		System.setProperty(ActiveTransactionRegistry.CACHE_TIMEOUT_PROPERTY, "1");
 		registry = ActiveTransactionRegistry.INSTANCE;
-		conn = Mockito.mock(RepositoryConnection.class);
-		txnId1 = UUID.randomUUID();
-		txnId2 = UUID.randomUUID();
-
+		repository = Mockito.mock(Repository.class);
 	}
 
-	@Test
-	public void testTimeoutRepeatedAccess()
-		throws Exception
-	{
-		registry.register(txnId2, conn);
-
-		int count = 0;
-		while (count++ < 2) {
-			logger.debug("pass {}", count);
-			registry.getTransactionConnection(txnId2);
-			Thread.sleep(1200);
-			registry.returnTransactionConnection(txnId2);
-		}
-
-		registry.deregister(txnId2);
-		try {
-			registry.getTransactionConnection(txnId2);
-			fail("should be deregistered");
-		}
-		catch (RepositoryException e) {
-			// fall through, expected
-		}
-	}
-
-	@Test
-	public void testMultithreadedAccess() {
-
-		CountDownLatch txn1registered = new CountDownLatch(1);
-
-		CountDownLatch done = new CountDownLatch(2);
-
-		Runnable r1 = new Runnable() {
-
-			@Override
-			public void run() {
-				registry.register(txnId1, conn);
-				txn1registered.countDown();
-
-				try {
-					registry.getTransactionConnection(txnId1);
-					Thread.sleep(700);
-					registry.returnTransactionConnection(txnId1);
-
-					done.countDown();
-				}
-				catch (RepositoryException | InterruptedException e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}
-			}
-		};
-
-		Runnable r2 = new Runnable() {
-
-			@Override
-			public void run() {
-				try {
-					txn1registered.await();
-				}
-				catch (InterruptedException e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}
-
-				try {
-					registry.getTransactionConnection(txnId1);
-					Thread.sleep(500);
-					registry.returnTransactionConnection(txnId1);
-
-					done.countDown();
-				}
-				catch (RepositoryException | InterruptedException e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}
-			}
-		};
-
-		Runnable r3 = new Runnable() {
-
-			@Override
-			public void run() {
-				try {
-					done.await();
-					registry.deregister(txnId1);
-				}
-				catch (InterruptedException e) {
-					e.printStackTrace();
-					fail(e.getMessage());
-				}
-			}
-		};
-
-		Thread t1 = new Thread(r1, "r1");
-		Thread t2 = new Thread(r2, "r2");
-		Thread t3 = new Thread(r3, "r3");
-
-		t3.start();
-		t2.start();
-		t1.start();
-
-		try {
-			t3.join();
-		}
-		catch (InterruptedException e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
 
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #630 .

Briefly describe the changes proposed in this PR:

* new class Transaction ensures single-threaded access to RepositoryConnection: it encapsulates both a RepositoryConnection and a dedicated Thread (provided by an ExecutorService)
* Drastically simplified concurrency handling: ActiveTransactionRegistry now keeps tracks of Transactions instead of RepositoryConnections - no longer any need for locking access to the RepositoryConnection

All integration/compliance tests succeed, and I have manually verified that this fix also fixes the IllegalMonitorStateException described in #630. 
