### PR TITLE
Fix #639: line number error reporting in INSERT/DELETE DATA updates

### DIFF
--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/DeleteData.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/DeleteData.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.query.algebra;
 public class DeleteData extends AbstractQueryModelNode implements UpdateExpr {
 
 	private final String dataBlock;
+	private int lineNumberOffset;
 
 	public DeleteData(String dataBlock) {
 		this.dataBlock = dataBlock;
@@ -53,4 +54,14 @@ public class DeleteData extends AbstractQueryModelNode implements UpdateExpr {
 		return false;
 	}
 
+	/**
+	 * @return the lineNumberCorrection
+	 */
+	public int getLineNumberOffset() {
+		return lineNumberOffset;
+	}
+	
+	public void setLineNumberOffset(int lineNumberOffset) {
+		this.lineNumberOffset = lineNumberOffset;
+	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/InsertData.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/InsertData.java
@@ -14,6 +14,8 @@ public class InsertData extends AbstractQueryModelNode implements UpdateExpr {
 
 	private final String dataBlock;
 
+	private int lineNumberCorrection;
+	
 	public InsertData(String dataBlock) {
 		this.dataBlock = dataBlock;
 	}
@@ -51,6 +53,17 @@ public class InsertData extends AbstractQueryModelNode implements UpdateExpr {
 	@Override
 	public boolean isSilent() {
 		return false;
+	}
+
+	/**
+	 * @return the lineNumberCorrection
+	 */
+	public int getLineNumberOffset() {
+		return lineNumberCorrection;
+	}
+	
+	public void setLineNumberOffset(int lineNumberOffset) {
+		this.lineNumberCorrection = lineNumberOffset;
 	}
 
 }

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/PrefixDeclProcessor.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/PrefixDeclProcessor.java
@@ -71,12 +71,12 @@ public class PrefixDeclProcessor {
 		}
 
 		// insert some default prefixes (if not explicitly defined in the query)
-		insertDefaultPrefix(prefixMap, "rdf", RDF.NAMESPACE);
-		insertDefaultPrefix(prefixMap, "rdfs", RDFS.NAMESPACE);
-		insertDefaultPrefix(prefixMap, "sesame", SESAME.NAMESPACE);
-		insertDefaultPrefix(prefixMap, "owl", OWL.NAMESPACE);
-		insertDefaultPrefix(prefixMap, "xsd", XMLSchema.NAMESPACE);
-		insertDefaultPrefix(prefixMap, "fn", FN.NAMESPACE);
+		final int defaultPrefixesAdded = insertDefaultPrefix(prefixMap, "rdf", RDF.NAMESPACE)
+				+ insertDefaultPrefix(prefixMap, "rdfs", RDFS.NAMESPACE)
+				+ insertDefaultPrefix(prefixMap, "sesame", SESAME.NAMESPACE)
+				+ insertDefaultPrefix(prefixMap, "owl", OWL.NAMESPACE)
+				+ insertDefaultPrefix(prefixMap, "xsd", XMLSchema.NAMESPACE)
+				+ insertDefaultPrefix(prefixMap, "fn", FN.NAMESPACE);
 
 		ASTUnparsedQuadDataBlock dataBlock = null;
 		if (qc.getOperation() instanceof ASTInsertData) {
@@ -91,6 +91,7 @@ public class PrefixDeclProcessor {
 
 		if (dataBlock != null) {
 			String prefixes = createPrefixesInSPARQLFormat(prefixMap);
+			dataBlock.setAddedDefaultPrefixes(defaultPrefixesAdded);
 			// TODO optimize string concat?
 			dataBlock.setDataBlock(prefixes + dataBlock.getDataBlock());
 		}
@@ -107,10 +108,12 @@ public class PrefixDeclProcessor {
 		return prefixMap;
 	}
 
-	private static void insertDefaultPrefix(Map<String, String> prefixMap, String prefix, String namespace) {
+	private static int insertDefaultPrefix(Map<String, String> prefixMap, String prefix, String namespace) {
 		if (!prefixMap.containsKey(prefix) && !prefixMap.containsValue(namespace)) {
 			prefixMap.put(prefix, namespace);
+			return 1;
 		}
+		return 0;
 	}
 
 	private static String createPrefixesInSPARQLFormat(Map<String, String> prefixMap) {

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
@@ -82,7 +82,10 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 		throws VisitorException
 	{
 		ASTUnparsedQuadDataBlock dataBlock = node.jjtGetChild(ASTUnparsedQuadDataBlock.class);
-		return new InsertData(dataBlock.getDataBlock());
+		InsertData insertData = new InsertData(dataBlock.getDataBlock());
+		
+		insertData.setLineNumberOffset(dataBlock.getAddedDefaultPrefixes());
+		return insertData;
 	}
 
 	@Override
@@ -91,7 +94,10 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 	{
 
 		ASTUnparsedQuadDataBlock dataBlock = node.jjtGetChild(ASTUnparsedQuadDataBlock.class);
-		return new DeleteData(dataBlock.getDataBlock());
+		DeleteData deleteData = new DeleteData(dataBlock.getDataBlock());
+		
+		deleteData.setLineNumberOffset(dataBlock.getAddedDefaultPrefixes());
+		return deleteData;
 
 	}
 

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTUnparsedQuadDataBlock.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTUnparsedQuadDataBlock.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.query.parser.sparql.ast;
 public class ASTUnparsedQuadDataBlock extends SimpleNode {
 
 	private String dataBlock;
+	private int addedDefaultPrefixes;
 
 	public ASTUnparsedQuadDataBlock(int id) {
 		super(id);
@@ -34,6 +35,17 @@ public class ASTUnparsedQuadDataBlock extends SimpleNode {
 		throws VisitorException
 	{
 		return visitor.visit(this, data);
+	}
+
+	/**
+	 * @param defaultPrefixesAdded
+	 */
+	public void setAddedDefaultPrefixes(int defaultPrefixesAdded) {
+		this.addedDefaultPrefixes = defaultPrefixesAdded;
+	}
+	
+	public int getAddedDefaultPrefixes() {
+		return addedDefaultPrefixes;
 	}
 }
 /* JavaCC - OriginalChecksum=0f8443c5fea151a421f76d4230035cd9 (do not edit this line) */

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -13,7 +13,9 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.Order;
@@ -25,6 +27,7 @@ import org.eclipse.rdf4j.query.parser.ParsedBooleanQuery;
 import org.eclipse.rdf4j.query.parser.ParsedGraphQuery;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.query.parser.ParsedUpdate;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,7 +75,37 @@ public class SPARQLParserTest {
 		assertNotNull(q);
 		assertEquals(simpleSparqlQuery, q.getSourceString());
 	}
+	
+	
+	@Test 
+	public void testInsertDataLineNumberReporting() throws Exception
+	{
+		String insertDataString = "INSERT DATA {\n incorrect reference }";
 
+		try {
+			ParsedUpdate u = parser.parseUpdate(insertDataString, null);
+			fail("should have resulted in parse exception");
+		}
+		catch (MalformedQueryException e) {
+			assertTrue(e.getMessage().contains("line 2,"));
+		}
+		
+	}
+	
+	@Test 
+	public void testDeleteDataLineNumberReporting() throws Exception
+	{
+		String deleteDataString = "DELETE DATA {\n incorrect reference }";
+
+		try {
+			ParsedUpdate u = parser.parseUpdate(deleteDataString, null);
+			fail("should have resulted in parse exception");
+		}
+		catch (MalformedQueryException e) {
+			assertTrue(e.getMessage().contains("line 2,"));
+		}
+	}
+	
 	@Test
 	public void testSES1922PathSequenceWithValueConstant()
 		throws Exception

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SPARQLUpdateDataBlockParser.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SPARQLUpdateDataBlockParser.java
@@ -37,6 +37,7 @@ import org.eclipse.rdf4j.rio.trig.TriGParser;
 public class SPARQLUpdateDataBlockParser extends TriGParser {
 
 	private boolean allowBlankNodes = true;
+	private int lineNumberOffset;
 
 	/*--------------*
 	 * Constructors *
@@ -117,6 +118,11 @@ public class SPARQLUpdateDataBlockParser extends TriGParser {
 		this.allowBlankNodes = allowBlankNodes;
 	}
 
+	@Override
+	protected int getLineNumber() {
+		return super.getLineNumber() - this.lineNumberOffset; 
+	}
+	
 	private void skipOptionalPeriod()
 		throws RDFHandlerException, IOException
 	{
@@ -125,5 +131,12 @@ public class SPARQLUpdateDataBlockParser extends TriGParser {
 		if (c == '.') {
 			readCodePoint();
 		}
+	}
+
+	/**
+	 * @param lineNumberOffset
+	 */
+	public void setLineNumberOffset(int lineNumberOffset) {
+			this.lineNumberOffset = lineNumberOffset;
 	}
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
@@ -453,6 +453,7 @@ public class SailUpdateExecutor {
 			handler = new TimeLimitRDFHandler(handler, 1000L * maxExecutionTime);
 		}
 		parser.setRDFHandler(handler);
+		parser.setLineNumberOffset(insertDataExpr.getLineNumberOffset());
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES);
 		try {
@@ -480,8 +481,8 @@ public class SailUpdateExecutor {
 	{
 
 		SPARQLUpdateDataBlockParser parser = new SPARQLUpdateDataBlockParser(vf);
-		parser.setAllowBlankNodes(false); // no blank nodes allowed in DELETE
-											// DATA.
+		parser.setLineNumberOffset(deleteDataExpr.getLineNumberOffset());
+		parser.setAllowBlankNodes(false); // no blank nodes allowed in DELETE DATA.
 		RDFHandler handler = new RDFSailRemover(con, vf, uc);
 		if (maxExecutionTime > 0) {
 			handler = new TimeLimitRDFHandler(handler, 1000L * maxExecutionTime);


### PR DESCRIPTION
This PR addresses GitHub issue: #639 .

Briefly describe the changes proposed in this PR:

* InsertData and DeleteData have lineNumberOffset getter/setter 
* update data block parser overrides getLineNumber to process reported offset. 
* added unit tests. 
