### PR TITLE
Fix #652: Keep BOM updated so they are valid dependencies

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -43,6 +43,7 @@
 				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-http-server</artifactId>
 				<version>${project.version}</version>
+				<type>war</type>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
@@ -53,6 +54,7 @@
 				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-http-workbench</artifactId>
 				<version>${project.version}</version>
+				<type>war</type>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
@@ -246,12 +248,12 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-sail-federation</artifactId>
+				<artifactId>rdf4j-sail-base</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-sail-inferencer</artifactId>
+				<artifactId>rdf4j-sail-federation</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -271,22 +273,12 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-sail-lucene-test</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-sail-lucene4</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-sail-lucenesail</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-sail-solr</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.rdf4j</groupId>
+				<artifactId>rdf4j-sail-inferencer</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -296,12 +288,12 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-sail-nativerdf</artifactId>
+				<artifactId>rdf4j-sail-model</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-sail-rdbms</artifactId>
+				<artifactId>rdf4j-sail-nativerdf</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -326,6 +318,7 @@
 				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-http-compliance</artifactId>
 				<version>${project.version}</version>
+				<type>war</type>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
@@ -351,6 +344,7 @@
 				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-sparql-compliance</artifactId>
 				<version>${project.version}</version>
+				<type>war</type>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
@@ -361,10 +355,21 @@
 				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-store-compliance</artifactId>
 				<version>${project.version}</version>
+				<type>war</type>
 			</dependency>
 
 			<!-- reusable test suites -->
 
+			<dependency>
+				<groupId>org.eclipse.rdf4j</groupId>
+				<artifactId>rdf4j-geosparql-testsuite</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.rdf4j</groupId>
+				<artifactId>rdf4j-lucene-testsuite</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-model-testsuite</artifactId>
@@ -388,11 +393,6 @@
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-sparql-testsuite</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-geosparql-testsuite</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: #652.

Briefly describe the changes proposed in this PR:

* specify <type>war</type> were needed (thus the `<dependencies>` could also be used outside `<dependencyManagement>`
* remove now missing rdf4j-sail-lucene4 etc.
* Reordered some dependencies to be closer to file system alhabetical

This avoids problems with maven site plugin when using the BOM, which would otherwise log various errors from the dependency plugin.

Signed-off-by: Stian Soiland-Reyes <stain@apache.org>