### PR TITLE
Fixes #655 by introducing synchronization when setting contentsChange…

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
@@ -381,7 +381,9 @@ public class MemoryStore extends AbstractNotifyingSail implements FederatedServi
 	@Override
 	public void notifySailChanged(SailChangedEvent event) {
 		super.notifySailChanged(event);
-		contentsChanged = true;
+		synchronized (syncSemaphore) {
+			contentsChanged = true;
+		}
 	}
 
 	protected void scheduleSyncTask()


### PR DESCRIPTION
This PR addresses GitHub issue: #655  .

A very simple fix that wraps contentsChanged = true into a synchronized (syncSemaphor) block. As I couldn't come up with a reliable test case I didn't write any.

Signed-off-by: Pavel Mihaylov <pavel@ontotext.com>