### PR TITLE
Fix #662: eclipse copyright header code template

### DIFF
--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/MemoryEvaluationStrategyTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/MemoryEvaluationStrategyTest.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail.memory;
 
 import org.eclipse.rdf4j.repository.EvaluationStrategyTest;

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/nativerdf/NativeEvaluationStrategyTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/nativerdf/NativeEvaluationStrategyTest.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail.nativerdf;
 
 import org.eclipse.rdf4j.repository.EvaluationStrategyTest;

--- a/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/SetParametersTest.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.console;
 
 import static org.junit.Assert.assertEquals;

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.http.server.repository.transaction;
 
 import java.util.UUID;

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.http.server.repository.transaction;
 
 import java.io.IOException;

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/ModelBuilder.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/ModelBuilder.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
 import java.util.Date;

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/SKOSXL.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/SKOSXL.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.model.vocabulary;
 
 import org.eclipse.rdf4j.model.IRI;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
 import org.eclipse.rdf4j.query.Dataset;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/xsd/CastFunction.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/xsd/CastFunction.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.xsd;
 
 import org.eclipse.rdf4j.model.IRI;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import org.eclipse.rdf4j.model.Value;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SimpleEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SimpleEvaluationStrategy.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import org.eclipse.rdf4j.query.Dataset;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/TupleFunctionEvaluationStatistics.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/TupleFunctionEvaluationStatistics.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/filters/AccurateRepositoryBloomFilter.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/filters/AccurateRepositoryBloomFilter.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.repository.filters;
 
 import org.eclipse.rdf4j.model.IRI;

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/filters/InaccurateRepositoryBloomFilter.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/filters/InaccurateRepositoryBloomFilter.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.repository.filters;
 
 import org.eclipse.rdf4j.model.IRI;

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/filters/RepositoryBloomFilter.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/filters/RepositoryBloomFilter.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.repository.filters;
 
 import org.eclipse.rdf4j.model.IRI;

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/SimpleParseLocationListener.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/SimpleParseLocationListener.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
 import org.eclipse.rdf4j.rio.ParseLocationListener;

--- a/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/BloomFilterFederationQueryTest.java
+++ b/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/BloomFilterFederationQueryTest.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.federation;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/core/sail/spin/src/test/java/org/eclipse/rdf4j/sail/spin/EvaluationModeTest.java
+++ b/core/sail/spin/src/test/java/org/eclipse/rdf4j/sail/spin/EvaluationModeTest.java
@@ -1,10 +1,10 @@
-/**
- * Copyright (c) 2015 Eclipse RDF4J contributors.
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.spin;
 
 import static org.hamcrest.CoreMatchers.hasItems;

--- a/eclipse-settings/codetemplates.xml
+++ b/eclipse-settings/codetemplates.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="false" context="filecomment_context" deleted="false" description="Comment for created Java files" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.filecomment" name="filecomment">/**
- * Copyright (c) 2016 Eclipse RDF4J contributors.
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="false" context="filecomment_context" deleted="false" description="Comment for created Java files" enabled="true" id="org.eclipse.jdt.ui.text.codetemplates.filecomment" name="filecomment">/*******************************************************************************
+ * Copyright (c) ${year} Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */</template></templates>
+ *******************************************************************************/</template></templates>

--- a/testsuites/store/src/main/java/org/eclipse/rdf4j/repository/EvaluationStrategyTest.java
+++ b/testsuites/store/src/main/java/org/eclipse/rdf4j/repository/EvaluationStrategyTest.java
@@ -1,10 +1,10 @@
-/**
+/*******************************************************************************
  * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- */
+ *******************************************************************************/
 package org.eclipse.rdf4j.repository;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This PR addresses GitHub issue: #662 .

Briefly describe the changes proposed in this PR:

* fixed eclipse copyright header template 
* global search-and-replace to make existing files use the corrected header

Please all update your eclipse settings with the correct header template ASAP. 