### PR TITLE
issue #449 : Add support for BCP47, and use by default

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/LanguageHandler.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/LanguageHandler.java
@@ -23,7 +23,7 @@ import org.eclipse.rdf4j.model.util.LiteralUtilException;
 public interface LanguageHandler {
 
 	/**
-	 * Identifier for the language tag format defined by RFC3066, which is referenced by the RDF
+	 * Identifier for the language tag format defined by RFC3066, which is referenced by the RDF-1.0
 	 * specification.
 	 */
 	public static final String RFC3066 = "org.eclipse.rdf4j.rio.languages.RFC3066";
@@ -33,6 +33,12 @@ public interface LanguageHandler {
 	 * referenced by the RDF specification.
 	 */
 	public static final String RFC4646 = "org.eclipse.rdf4j.rio.languages.RFC4646";
+
+	/**
+	 * Identifier for the language tag format defined by BCP47, which is referenced by the RDF-1.1
+	 * specification.
+	 */
+	public static final String BCP47 = "org.eclipse.rdf4j.rio.languages.BCP47";
 
 	/**
 	 * Checks if the given language tag is recognized by this language handler, including cases where the

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -242,18 +242,18 @@ public class BasicParserSettings {
 			_DEFAULT_PREFIX);
 
 	static {
-		List<DatatypeHandler> defaultDatatypeHandlers = new ArrayList<DatatypeHandler>(5);
+		List<DatatypeHandler> defaultDatatypeHandlers = new ArrayList<>(5);
 		try {
 			DatatypeHandlerRegistry registry = DatatypeHandlerRegistry.getInstance();
-			for (String nextHandler : Arrays.asList(DatatypeHandler.XMLSCHEMA, DatatypeHandler.RDFDATATYPES,
+			for (String nextDatatype : Arrays.asList(DatatypeHandler.XMLSCHEMA, DatatypeHandler.RDFDATATYPES,
 					DatatypeHandler.DBPEDIA, DatatypeHandler.VIRTUOSOGEOMETRY, DatatypeHandler.GEOSPARQL))
 			{
-				Optional<DatatypeHandler> nextdt = registry.get(nextHandler);
-				if (nextdt.isPresent()) {
-					defaultDatatypeHandlers.add(nextdt.get());
+				Optional<DatatypeHandler> nextDatatypeHandler = registry.get(nextDatatype);
+				if (nextDatatypeHandler.isPresent()) {
+					defaultDatatypeHandlers.add(nextDatatypeHandler.get());
 				}
 				else {
-					log.warn("Could not find DatatypeHandler : {}", nextHandler);
+					log.warn("Could not find DatatypeHandler : {}", nextDatatype);
 				}
 			}
 		}
@@ -263,20 +263,20 @@ public class BasicParserSettings {
 			log.warn("Found an error loading DatatypeHandler services", e);
 		}
 
-		DATATYPE_HANDLERS = new RioSettingImpl<List<DatatypeHandler>>(
-				"org.eclipse.rdf4j.rio.datatypehandlers", "Datatype Handlers",
-				Collections.unmodifiableList(defaultDatatypeHandlers));
+		DATATYPE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.datatypehandlers",
+				"Datatype Handlers", Collections.unmodifiableList(defaultDatatypeHandlers));
 
-		List<LanguageHandler> defaultLanguageHandlers = new ArrayList<LanguageHandler>(1);
+		List<LanguageHandler> defaultLanguageHandlers = new ArrayList<>(1);
 		try {
 			LanguageHandlerRegistry registry = LanguageHandlerRegistry.getInstance();
-			for (String nextHandler : Arrays.asList(LanguageHandler.BCP47)) {
-				Optional<LanguageHandler> nextlang = registry.get(nextHandler);
-				if (nextlang.isPresent()) {
-					defaultLanguageHandlers.add(nextlang.get());
+			String nextLanguageTagScheme = LanguageHandler.BCP47;
+			if (registry.has(nextLanguageTagScheme)) {
+				Optional<LanguageHandler> nextLanguageHandler = registry.get(nextLanguageTagScheme);
+				if (nextLanguageHandler.isPresent()) {
+					defaultLanguageHandlers.add(nextLanguageHandler.get());
 				}
 				else {
-					log.warn("Could not find LanguageHandler : {}", nextHandler);
+					log.warn("Could not find LanguageHandler : {}", nextLanguageTagScheme);
 				}
 			}
 		}
@@ -286,9 +286,8 @@ public class BasicParserSettings {
 			log.warn("Found an error loading LanguageHandler services", e);
 		}
 
-		LANGUAGE_HANDLERS = new RioSettingImpl<List<LanguageHandler>>(
-				"org.eclipse.rdf4j.rio.languagehandlers", "Language Handlers",
-				Collections.unmodifiableList(defaultLanguageHandlers));
+		LANGUAGE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.languagehandlers",
+				"Language Handlers", Collections.unmodifiableList(defaultLanguageHandlers));
 	}
 
 	/**

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -270,7 +270,7 @@ public class BasicParserSettings {
 		List<LanguageHandler> defaultLanguageHandlers = new ArrayList<LanguageHandler>(1);
 		try {
 			LanguageHandlerRegistry registry = LanguageHandlerRegistry.getInstance();
-			for (String nextHandler : Arrays.asList(LanguageHandler.RFC3066)) {
+			for (String nextHandler : Arrays.asList(LanguageHandler.BCP47)) {
 				Optional<LanguageHandler> nextlang = registry.get(nextHandler);
 				if (nextlang.isPresent()) {
 					defaultLanguageHandlers.add(nextlang.get());

--- a/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
+++ b/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2015 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
+++ b/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
@@ -9,7 +9,7 @@ package org.eclipse.rdf4j.rio.languages;
 
 import java.util.IllformedLocaleException;
 import java.util.Locale;
-import java.util.regex.Pattern;
+import java.util.Objects;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -35,9 +35,7 @@ public class BCP47LanguageHandler implements LanguageHandler {
 
 	@Override
 	public boolean isRecognizedLanguage(String languageTag) {
-		if (languageTag == null) {
-			throw new NullPointerException("Language tag cannot be null");
-		}
+		Objects.requireNonNull(languageTag, "Language tag cannot be null");
 
 		try {
 			parseAsBCP47(languageTag);
@@ -53,11 +51,10 @@ public class BCP47LanguageHandler implements LanguageHandler {
 	public boolean verifyLanguage(String literalValue, String languageTag)
 		throws LiteralUtilException
 	{
+		Objects.requireNonNull(languageTag, "Language tag cannot be null");
+		Objects.requireNonNull(literalValue, "Literal value cannot be null");
+		
 		if (isRecognizedLanguage(languageTag)) {
-			if (literalValue == null) {
-				throw new NullPointerException("Literal value cannot be null");
-			}
-
 			// Language tag syntax already checked in isRecognizedLanguage
 			return true;
 		}
@@ -69,17 +66,12 @@ public class BCP47LanguageHandler implements LanguageHandler {
 	public Literal normalizeLanguage(String literalValue, String languageTag, ValueFactory valueFactory)
 		throws LiteralUtilException
 	{
-		if (languageTag == null) {
-			throw new NullPointerException("Language tag cannot be null");
-		}
+		Objects.requireNonNull(languageTag, "Language tag cannot be null");
+		Objects.requireNonNull(literalValue, "Literal value cannot be null");
 
 		try {
 			Locale asBCP47 = parseAsBCP47(languageTag);
 			
-			if (literalValue == null) {
-				throw new NullPointerException("Literal value cannot be null");
-			}
-
 			return valueFactory.createLiteral(literalValue, asBCP47.toLanguageTag().intern());
 		}
 		catch (IllformedLocaleException e) {

--- a/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/RFC3066LanguageHandler.java
+++ b/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/RFC3066LanguageHandler.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.languages;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.eclipse.rdf4j.model.Literal;
@@ -38,9 +39,7 @@ public class RFC3066LanguageHandler implements LanguageHandler {
 
 	@Override
 	public boolean isRecognizedLanguage(String languageTag) {
-		if (languageTag == null) {
-			throw new NullPointerException("Language tag cannot be null");
-		}
+		Objects.requireNonNull(languageTag, "Language tag cannot be null");
 
 		// language tag is RFC3066-conformant if it matches this regex:
 		// [a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*
@@ -53,11 +52,10 @@ public class RFC3066LanguageHandler implements LanguageHandler {
 	public boolean verifyLanguage(String literalValue, String languageTag)
 		throws LiteralUtilException
 	{
+		Objects.requireNonNull(languageTag, "Language tag cannot be null");
+		Objects.requireNonNull(literalValue, "Literal value cannot be null");
+		
 		if (isRecognizedLanguage(languageTag)) {
-			if (literalValue == null) {
-				throw new NullPointerException("Literal value cannot be null");
-			}
-
 			// Language tag syntax already checked in isRecognizedLanguage
 			return true;
 		}
@@ -69,12 +67,10 @@ public class RFC3066LanguageHandler implements LanguageHandler {
 	public Literal normalizeLanguage(String literalValue, String languageTag, ValueFactory valueFactory)
 		throws LiteralUtilException
 	{
+		Objects.requireNonNull(languageTag, "Language tag cannot be null");
+		Objects.requireNonNull(literalValue, "Literal value cannot be null");
+		
 		if (isRecognizedLanguage(languageTag)) {
-			if (literalValue == null) {
-				throw new NullPointerException("Literal value cannot be null");
-			}
-
-			// TODO Implement normalisation more effectively than this
 			return valueFactory.createLiteral(literalValue, languageTag.toLowerCase().intern());
 		}
 

--- a/core/rio/languages/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.LanguageHandler
+++ b/core/rio/languages/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.LanguageHandler
@@ -1,1 +1,2 @@
 org.eclipse.rdf4j.rio.languages.RFC3066LanguageHandler
+org.eclipse.rdf4j.rio.languages.BCP47LanguageHandler

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
@@ -114,15 +115,45 @@ public abstract class AbstractParserHandlingTest {
 	protected abstract InputStream getUnknownDatatypeStream(Model unknownDatatypeStatements)
 		throws Exception;
 
+	/**
+	 * Returns an {@link InputStream} containing the given RDF statements in a format that is recognised by
+	 * the RDFParser returned by {@link #getParser()}.
+	 * 
+	 * @param knownDatatypeStatements
+	 *        A {@link Model} containing statements which all contain known datatypes.
+	 * @return An InputStream based on the given parameters.
+	 */
 	protected abstract InputStream getKnownDatatypeStream(Model knownDatatypeStatements)
 		throws Exception;
 
+	/**
+	 * Returns an {@link InputStream} containing the given RDF statements in a format that is recognised by
+	 * the RDFParser returned by {@link #getParser()}.
+	 * 
+	 * @param unknownLanguageStatements
+	 *        A {@link Model} containing statements which all contain unknown language tags.
+	 * @return An InputStream based on the given parameters.
+	 */
 	protected abstract InputStream getUnknownLanguageStream(Model unknownLanguageStatements)
 		throws Exception;
 
+	/**
+	 * Returns an {@link InputStream} containing the given RDF statements in a format that is recognised by
+	 * the RDFParser returned by {@link #getParser()}.
+	 * 
+	 * @param knownLanguageStatements
+	 *        A {@link Model} containing statements which all contain known language tags.
+	 * @return An InputStream based on the given parameters.
+	 */
 	protected abstract InputStream getKnownLanguageStream(Model knownLanguageStatements)
 		throws Exception;
 
+	/**
+	 * Concrete test classes must override this to return a new instance of the RDFParser that is being
+	 * tested.
+	 * 
+	 * @return A new instance of the RDFParser that is being tested.
+	 */
 	protected abstract RDFParser getParser();
 
 	/**
@@ -839,6 +870,46 @@ public abstract class AbstractParserHandlingTest {
 		throws Exception
 	{
 		Model expectedModel = getTestModel(KNOWN_LANGUAGE_VALUE, KNOWN_LANGUAGE_TAG);
+		InputStream input = getKnownLanguageStream(expectedModel);
+
+		testParser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);
+
+		testParser.parse(input, BASE_URI);
+
+		assertErrorListener(0, 0, 0);
+		assertModel(expectedModel);
+	}
+
+	/**
+	 * Tests whether an known language with the message which generates a failure if the uppercased version of
+	 * the language is unknown.
+	 */
+	@Test
+	public final void testKnownLanguageWithMessageWhereUnknownWouldFailCase2()
+		throws Exception
+	{
+		Model expectedModel = getTestModel(KNOWN_LANGUAGE_VALUE,
+				KNOWN_LANGUAGE_TAG.toUpperCase(Locale.ENGLISH));
+		InputStream input = getKnownLanguageStream(expectedModel);
+
+		testParser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);
+
+		testParser.parse(input, BASE_URI);
+
+		assertErrorListener(0, 0, 0);
+		assertModel(expectedModel);
+	}
+
+	/**
+	 * Tests whether an known language with the message which generates a failure if the lowercased version of
+	 * the language is unknown.
+	 */
+	@Test
+	public final void testKnownLanguageWithMessageWhereUnknownWouldFailCase3()
+		throws Exception
+	{
+		Model expectedModel = getTestModel(KNOWN_LANGUAGE_VALUE,
+				KNOWN_LANGUAGE_TAG.toLowerCase(Locale.ENGLISH));
 		InputStream input = getKnownLanguageStream(expectedModel);
 
 		testParser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);


### PR DESCRIPTION
This PR addresses GitHub issue: #449 to support BCP47.

Briefly describe the changes proposed in this PR:

* Adds implementation of BCP47 based on Java-7+ Locale
* Switches BasicParserSettings to use BCP47 by default, per our reliance on RDF-1.1

RFC3066 is now only used if it is specifically setup in parser settings, or referenced directly.

The use of BCP47 is required for RDF-1.1, where RFC3066 was required for RDF-1.0. Since we have changed to RDF-1.1, we need to change the default language tag handler to match.

I still want to add some regression tests related to issue #665 and other language tag case-sensitivity issues to verify and preserve the new BCP47 behaviour unless we change the regression test, but the core implementation of BCP47 ```new Locale.Builder().setLanguageTag(languageTag).build().toLanguageTag()```, is done.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>