### PR TITLE
Fix #646: included vars from VALUES clauses and BIND clause in service vars

### DIFF
--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Service.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Service.java
@@ -217,8 +217,19 @@ public class Service extends UnaryTupleOperator {
 				if (!node.hasValue() && !node.isAnonymous())
 					res.add(node.getName());
 			}
+			
+			@Override
+			public void meet(BindingSetAssignment bsa) {
+				res.addAll(bsa.getAssuredBindingNames());
+			}
+			
+			@Override
+			public void meet(Extension e) {
+				for (ExtensionElem elem: e.getElements()) {
+					res.add(elem.getName());
+				}
+			}
 			// TODO maybe stop tree traversal in nested SERVICE?
-			// TODO special case handling for BIND
 		});
 		return res;
 	}


### PR DESCRIPTION
This PR addresses GitHub issue: #646 .

Briefly describe the changes proposed in this PR:

* vars introduced by BIND or VALUES now included in service vars
* added unit test to check for regression

@damyan-ognyanov 