### PR TITLE
Fix #673 : Add utility for BCP47 normalisation

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.model.util;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
+import java.util.IllformedLocaleException;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -553,7 +554,8 @@ public class Literals {
 	public static boolean canCreateLiteral(Object object) {
 		if (object == null) {
 			// Cannot create a literal from a null
-			// Avoid throwing a NullPointerException here to enable universal usage
+			// Avoid throwing a NullPointerException here to enable universal
+			// usage
 			// of this method
 			return false;
 		}
@@ -578,6 +580,22 @@ public class Literals {
 	 */
 	public static boolean isLanguageLiteral(Literal literal) {
 		return Objects.requireNonNull(literal, "Literal cannot be null").getLanguage().isPresent();
+	}
+
+	/**
+	 * Normalises the given <a href="https://tools.ietf.org/html/bcp47">BCP47</a> language tag according to
+	 * the rules defined by the JDK in the {@link Locale} API.
+	 * 
+	 * @param languageTag
+	 *        An unnormalised, valid, language tag
+	 * @return A normalised version of the given language tag
+	 * @throws IllformedLocaleException
+	 *         If the given language tag is illformed according to the rules specified in BCP47.
+	 */
+	public static String normaliseBCP47Tag(String languageTag)
+		throws IllformedLocaleException
+	{
+		return new Locale.Builder().setLanguageTag(languageTag).build().toLanguageTag().intern();
 	}
 
 	protected Literals() {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -583,16 +583,16 @@ public class Literals {
 	}
 
 	/**
-	 * Normalises the given <a href="https://tools.ietf.org/html/bcp47">BCP47</a> language tag according to
+	 * Normalizes the given <a href="https://tools.ietf.org/html/bcp47">BCP47</a> language tag according to
 	 * the rules defined by the JDK in the {@link Locale} API.
 	 * 
 	 * @param languageTag
-	 *        An unnormalised, valid, language tag
-	 * @return A normalised version of the given language tag
+	 *        An unnormalized, valid, language tag
+	 * @return A normalized version of the given language tag
 	 * @throws IllformedLocaleException
-	 *         If the given language tag is illformed according to the rules specified in BCP47.
+	 *         If the given language tag is ill-formed according to the rules specified in BCP47.
 	 */
-	public static String normaliseBCP47Tag(String languageTag)
+	public static String normalizeLanguageTag(String languageTag)
 		throws IllformedLocaleException
 	{
 		return new Locale.Builder().setLanguageTag(languageTag).build().toLanguageTag().intern();

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -410,7 +410,9 @@ public class Literals {
 	 *        a fallback value for the locale
 	 * @return the Locale, or the fallback if a suitable Locale could not be constructed for the language tag.
 	 * @see <a href="http://www.ietf.org/rfc/rfc3066.txt">RFC 3066</a>
+	 * @deprecated Use {@link Literals#normalizeLanguageTag(String) instead}
 	 */
+	@Deprecated
 	public static Locale getLocale(Literal l, Locale fallback) {
 		Locale result = fallback;
 

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/IanaLanguageTag.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/IanaLanguageTag.java
@@ -16,13 +16,17 @@ package org.eclipse.rdf4j.model.util.language;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.rdf4j.model.util.Literals;
+
 /**
  * Language codes registered by IANA. An encapsulation of the IANA language registry found at <a href=
  * " http://www.iana.org/assignments/language-tags"> http://www.iana.org/assignments/language-tags</a>. The
  * values were updated on 8th July 2002 from a file dated 7th July 2002.
  * 
  * @author jjc
+ * @deprecated Use {@link Literals#normalizeLanguageTag(String) instead}
  */
+@Deprecated
 public class IanaLanguageTag extends LanguageTag {
 
 	static final Map<String, IanaLanguageTag[]> all = new HashMap<String, IanaLanguageTag[]>();

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/Iso3166.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/Iso3166.java
@@ -16,6 +16,8 @@ package org.eclipse.rdf4j.model.util.language;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.rdf4j.model.util.Literals;
+
 /**
  * Country code names from ISO 3166.
  * <p>
@@ -24,7 +26,9 @@ import java.util.Map;
  * nabd/iso3166ma/codlstp1/db_en.html</a>
  * 
  * @author jjc
+ * @deprecated Use {@link Literals#normalizeLanguageTag(String) instead}
  */
+@Deprecated
 public class Iso3166 {
 
 	static final Map<String, Iso3166> all = new HashMap<String, Iso3166>();

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/Iso639.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/Iso639.java
@@ -16,6 +16,8 @@ package org.eclipse.rdf4j.model.util.language;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.rdf4j.model.util.Literals;
+
 /**
  * Language codes from ISO639-1 and ISO639-2.
  * <p>
@@ -24,8 +26,9 @@ import java.util.Map;
  * englangn.html</a> on the 24th July 2001, and dated 12th October 2000.
  * 
  * @author jjc
+ * @deprecated Use {@link Literals#normalizeLanguageTag(String) instead}
  */
-
+@Deprecated
 public class Iso639 implements LanguageTagCodes {
 
 	static final Map<String, Iso639> all = new HashMap<String, Iso639>();

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/LanguageTag.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/LanguageTag.java
@@ -17,11 +17,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.rdf4j.model.util.Literals;
+
 /**
  * RFC 3066, "Tags for the Identification of Languages".
  * 
  * @author jjc
+ * 
+ * @deprecated Use {@link Literals#normalizeLanguageTag(String) instead}
  */
+@Deprecated
 public class LanguageTag implements LanguageTagCodes {
 
 	String subtags[];

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/LanguageTagCodes.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/LanguageTagCodes.java
@@ -13,11 +13,15 @@
 
 package org.eclipse.rdf4j.model.util.language;
 
+import org.eclipse.rdf4j.model.util.Literals;
+
 /**
  * Informational values about language codes. Values to be OR-ed together.
  * 
  * @author jjc
+ * @deprecated Use {@link Literals#normalizeLanguageTag(String) instead}
  */
+@Deprecated
 public interface LanguageTagCodes {
 
 	/**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/LanguageTagSyntaxException.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/language/LanguageTagSyntaxException.java
@@ -13,11 +13,15 @@
 
 package org.eclipse.rdf4j.model.util.language;
 
+import org.eclipse.rdf4j.model.util.Literals;
+
 /**
  * A LanguageTag did not conform to RFC3066. This exception is for the syntactic rules of RFC3066 section 2.1.
  * 
  * @author jjc
+ * @deprecated Use {@link Literals#normalizeLanguageTag(String) instead}
  */
+@Deprecated
 public class LanguageTagSyntaxException extends java.lang.Exception {
 
 	/**

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -948,4 +948,21 @@ public class LiteralsTest {
 
 	}
 
+	/**
+	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#normaliseBCP47Tag(String)} .
+	 */
+	@Test
+	public void testNormaliseBCP47Tag()
+		throws Exception
+	{
+		assertEquals("en", Literals.normaliseBCP47Tag("en"));
+		assertEquals("en-AU", Literals.normaliseBCP47Tag("en-AU"));
+		assertEquals("en-AU", Literals.normaliseBCP47Tag("en-au"));
+		assertEquals("en-AU", Literals.normaliseBCP47Tag("EN-AU"));
+		assertEquals("en-AU", Literals.normaliseBCP47Tag("EN-au"));
+		assertEquals("fr-FR", Literals.normaliseBCP47Tag("fr-FR"));
+		assertEquals("fr-FR", Literals.normaliseBCP47Tag("fr-fr"));
+		assertEquals("fr-FR", Literals.normaliseBCP47Tag("FR-FR"));
+		assertEquals("fr-FR", Literals.normaliseBCP47Tag("FR-fr"));
+	}
 }

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -949,20 +949,20 @@ public class LiteralsTest {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#normaliseBCP47Tag(String)} .
+	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#normalizeLanguageTag(String)} .
 	 */
 	@Test
 	public void testNormaliseBCP47Tag()
 		throws Exception
 	{
-		assertEquals("en", Literals.normaliseBCP47Tag("en"));
-		assertEquals("en-AU", Literals.normaliseBCP47Tag("en-AU"));
-		assertEquals("en-AU", Literals.normaliseBCP47Tag("en-au"));
-		assertEquals("en-AU", Literals.normaliseBCP47Tag("EN-AU"));
-		assertEquals("en-AU", Literals.normaliseBCP47Tag("EN-au"));
-		assertEquals("fr-FR", Literals.normaliseBCP47Tag("fr-FR"));
-		assertEquals("fr-FR", Literals.normaliseBCP47Tag("fr-fr"));
-		assertEquals("fr-FR", Literals.normaliseBCP47Tag("FR-FR"));
-		assertEquals("fr-FR", Literals.normaliseBCP47Tag("FR-fr"));
+		assertEquals("en", Literals.normalizeLanguageTag("en"));
+		assertEquals("en-AU", Literals.normalizeLanguageTag("en-AU"));
+		assertEquals("en-AU", Literals.normalizeLanguageTag("en-au"));
+		assertEquals("en-AU", Literals.normalizeLanguageTag("EN-AU"));
+		assertEquals("en-AU", Literals.normalizeLanguageTag("EN-au"));
+		assertEquals("fr-FR", Literals.normalizeLanguageTag("fr-FR"));
+		assertEquals("fr-FR", Literals.normalizeLanguageTag("fr-fr"));
+		assertEquals("fr-FR", Literals.normalizeLanguageTag("FR-FR"));
+		assertEquals("fr-FR", Literals.normalizeLanguageTag("FR-fr"));
 	}
 }

--- a/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
+++ b/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
@@ -39,7 +39,7 @@ public class BCP47LanguageHandler implements LanguageHandler {
 		Objects.requireNonNull(languageTag, "Language tag cannot be null");
 
 		try {
-			Literals.normaliseBCP47Tag(languageTag);
+			Literals.normalizeLanguageTag(languageTag);
 		}
 		catch (IllformedLocaleException e) {
 			return false;
@@ -71,7 +71,7 @@ public class BCP47LanguageHandler implements LanguageHandler {
 		Objects.requireNonNull(literalValue, "Literal value cannot be null");
 
 		try {
-			return valueFactory.createLiteral(literalValue, Literals.normaliseBCP47Tag(languageTag));
+			return valueFactory.createLiteral(literalValue, Literals.normalizeLanguageTag(languageTag));
 		}
 		catch (IllformedLocaleException e) {
 			throw new LiteralUtilException("Could not normalize BCP47 language tag", e);

--- a/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
+++ b/core/rio/languages/src/main/java/org/eclipse/rdf4j/rio/languages/BCP47LanguageHandler.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.util.LiteralUtilException;
+import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.rio.LanguageHandler;
 
 /**
@@ -38,7 +39,7 @@ public class BCP47LanguageHandler implements LanguageHandler {
 		Objects.requireNonNull(languageTag, "Language tag cannot be null");
 
 		try {
-			parseAsBCP47(languageTag);
+			Literals.normaliseBCP47Tag(languageTag);
 		}
 		catch (IllformedLocaleException e) {
 			return false;
@@ -70,9 +71,7 @@ public class BCP47LanguageHandler implements LanguageHandler {
 		Objects.requireNonNull(literalValue, "Literal value cannot be null");
 
 		try {
-			Locale asBCP47 = parseAsBCP47(languageTag);
-			
-			return valueFactory.createLiteral(literalValue, asBCP47.toLanguageTag().intern());
+			return valueFactory.createLiteral(literalValue, Literals.normaliseBCP47Tag(languageTag));
 		}
 		catch (IllformedLocaleException e) {
 			throw new LiteralUtilException("Could not normalize BCP47 language tag", e);
@@ -83,11 +82,4 @@ public class BCP47LanguageHandler implements LanguageHandler {
 	public String getKey() {
 		return LanguageHandler.BCP47;
 	}
-
-	private Locale parseAsBCP47(String languageTag)
-		throws IllformedLocaleException
-	{
-		return new Locale.Builder().setLanguageTag(languageTag).build();
-	}
-
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #673 .

Briefly describe the changes proposed in this PR:

* Adds a utility function for the steps required for BCP47 language tag normalisation
* Converts BCP47LanguageHandler to use the utility function

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>