### PR TITLE
Fix #676: revert changes to hashcode of AbstractBindingSet

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/AbstractBindingSet.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/AbstractBindingSet.java
@@ -52,12 +52,11 @@ public abstract class AbstractBindingSet implements BindingSet {
 
 	@Override
 	public final int hashCode() {
-		int hashCode = 5;
+		int hashCode = 0;
 
 		for (Binding binding : this) {
-			hashCode = 37 * hashCode + binding.hashCode();
+			hashCode ^= binding.getName().hashCode() ^ binding.getValue().hashCode();
 		}
-
 		return hashCode;
 	}
 

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/BindingSetTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/BindingSetTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for BindingSet implementations.
+ * 
+ * @author jeen
+ */
+public abstract class BindingSetTest<T extends BindingSet> {
+
+	/**
+	 * Verifies that the BindingSet implementation honors the API spec for {@link BindingSet#equals(Object)}
+	 * and {@link BindingSet#hashCode()}.
+	 */
+	@Test
+	public void testEqualsHashcode() {
+
+		T[] bindingSets = createEqualBindingSets();
+
+		T bs1 = bindingSets[0];
+		T bs2 = bindingSets[1];
+
+		assertEquals(bs1, bs2);
+
+		assertEquals(bs1.hashCode(), bs2.hashCode());
+	}
+
+	/**
+	 * Creates two equal, but differently ordered, BindingSet objects.
+	 * 
+	 * @return an array of two equal but differently ordered BindingSets.
+	 */
+	protected abstract T[] createEqualBindingSets();
+}

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/BindingSetTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/BindingSetTest.java
@@ -25,7 +25,7 @@ public abstract class BindingSetTest<T extends BindingSet> {
 	@Test
 	public void testEqualsHashcode() {
 
-		T[] bindingSets = createEqualBindingSets();
+		T[] bindingSets = createTwoEqualReorderedBindingSets();
 
 		T bs1 = bindingSets[0];
 		T bs2 = bindingSets[1];
@@ -40,5 +40,5 @@ public abstract class BindingSetTest<T extends BindingSet> {
 	 * 
 	 * @return an array of two equal but differently ordered BindingSets.
 	 */
-	protected abstract T[] createEqualBindingSets();
+	protected abstract T[] createTwoEqualReorderedBindingSets();
 }

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/impl/ListBindingSetTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/impl/ListBindingSetTest.java
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.query.BindingSetTest;
 public class ListBindingSetTest extends BindingSetTest<ListBindingSet> {
 
 	@Override
-	protected ListBindingSet[] createEqualBindingSets() {
+	protected ListBindingSet[] createTwoEqualReorderedBindingSets() {
 
 		List<String> names1 = Arrays.asList(new String[] { "x", "y", "z" });
 		List<String> names2 = Arrays.asList(new String[] { "y", "z", "x" });

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/impl/ListBindingSetTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/impl/ListBindingSetTest.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.impl;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSetTest;
+
+/**
+ * Unit tests for {@link ListBindingSet}
+ * 
+ * @author Jeen Broekstra
+ */
+public class ListBindingSetTest extends BindingSetTest<ListBindingSet> {
+
+	@Override
+	protected ListBindingSet[] createEqualBindingSets() {
+
+		List<String> names1 = Arrays.asList(new String[] { "x", "y", "z" });
+		List<String> names2 = Arrays.asList(new String[] { "y", "z", "x" });
+
+		ListBindingSet bindingSet1 = new ListBindingSet(names1, RDF.ALT, RDF.BAG, RDF.FIRST);
+		ListBindingSet bindingSet2 = new ListBindingSet(names2, RDF.BAG, RDF.FIRST, RDF.ALT);
+		return new ListBindingSet[] { bindingSet1, bindingSet2 };
+	}
+
+}

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/impl/MapBindingSetTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/impl/MapBindingSetTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.impl;
+
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSetTest;
+
+/**
+ * Unit tests for {@link MapBindingSet}
+ * 
+ * @author Jeen Broekstra
+ */
+public class MapBindingSetTest extends BindingSetTest<MapBindingSet> {
+
+	@Override
+	protected MapBindingSet[] createEqualBindingSets() {
+
+		MapBindingSet bindingSet1 = new MapBindingSet();
+		MapBindingSet bindingSet2 = new MapBindingSet();
+
+		bindingSet1.addBinding("x", RDF.ALT);
+		bindingSet1.addBinding("y", RDF.BAG);
+		bindingSet1.addBinding("z", RDF.FIRST);
+
+		bindingSet2.addBinding("y", RDF.BAG);
+		bindingSet2.addBinding("x", RDF.ALT);
+		bindingSet2.addBinding("z", RDF.FIRST);
+
+		return new MapBindingSet[] { bindingSet1, bindingSet2 };
+	}
+
+}

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/impl/MapBindingSetTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/impl/MapBindingSetTest.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.query.BindingSetTest;
 public class MapBindingSetTest extends BindingSetTest<MapBindingSet> {
 
 	@Override
-	protected MapBindingSet[] createEqualBindingSets() {
+	protected MapBindingSet[] createTwoEqualReorderedBindingSets() {
 
 		MapBindingSet bindingSet1 = new MapBindingSet();
 		MapBindingSet bindingSet2 = new MapBindingSet();

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSetTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSetTest.java
@@ -12,33 +12,34 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.ValueFactoryImpl;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.junit.Before;
 import org.junit.Test;
 
-public class QueryBindingSetTest {
+public class QueryBindingSetTest{
 
 	private final MapBindingSet mbs = new MapBindingSet();
-
 	private final QueryBindingSet qbs = new QueryBindingSet();
 
-	private ValueFactory vf = ValueFactoryImpl.getInstance();
+	private ValueFactory vf = SimpleValueFactory.getInstance();
 
 	@Before
 	public void setup() {
-		qbs.addBinding("foo", vf.createURI("urn:foo"));
-		mbs.addBinding("foo", vf.createURI("urn:foo"));
+		qbs.addBinding("foo", vf.createIRI("urn:foo"));
+		mbs.addBinding("foo", vf.createIRI("urn:foo"));
 	}
 
 	@Test
-	public void testEqualsObject() {
+	public void testEqualsMapBindingSet() {
 
 		QueryBindingSet bs = new QueryBindingSet();
 		assertFalse(bs.equals(qbs));
 		assertFalse(bs.equals(mbs));
 
-		bs.addBinding("foo", vf.createURI("urn:foo"));
+		bs.addBinding("foo", vf.createIRI("urn:foo"));
 
 		assertEquals(bs, qbs);
 		assertEquals(bs, mbs);
@@ -46,11 +47,31 @@ public class QueryBindingSetTest {
 	}
 
 	@Test
-	public void testHashCode() {
+	public void testHashcodeMapBindingSet() {
 		assertTrue(qbs.equals(mbs));
 		assertTrue(mbs.equals(qbs));
 		assertEquals("objects that return true on their equals() method must have identical hash codes",
 				qbs.hashCode(), mbs.hashCode());
 	}
 
+	/**
+	 * Verifies that the BindingSet implementation honors the API spec for {@link BindingSet#equals(Object)}
+	 * and {@link BindingSet#hashCode()}.
+	 */
+	@Test
+	public void testEqualsHashcode() {
+		QueryBindingSet bs1 = new QueryBindingSet();
+		QueryBindingSet bs2 = new QueryBindingSet();
+		
+		bs1.addBinding("x", RDF.ALT);
+		bs1.addBinding("y", RDF.BAG);
+		bs1.addBinding("z", RDF.FIRST);
+		
+		bs2.addBinding("y", RDF.BAG);
+		bs2.addBinding("x", RDF.ALT);
+		bs2.addBinding("z", RDF.FIRST);
+		assertEquals(bs1, bs2);
+		assertEquals(bs1.hashCode(), bs2.hashCode());
+	}
+	
 }

--- a/core/repository/sparql/pom.xml
+++ b/core/repository/sparql/pom.xml
@@ -42,6 +42,11 @@ The SPARQL Repository provides a RDF4J Repository interface to any SPARQL end-po
 			<artifactId>rdf4j-queryresultio-sparqlxml</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	
 </project>

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLQueryBindingSetTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLQueryBindingSetTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql.query;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.junit.Test;
+
+/**
+ * @author jeen
+ *
+ */
+public class SPARQLQueryBindingSetTest {
+
+
+	/**
+	 * Verifies that the BindingSet implementation honors the API spec for {@link BindingSet#equals(Object)}
+	 * and {@link BindingSet#hashCode()}.
+	 */
+	@Test
+	public void testEqualsHashcode() {
+		SPARQLQueryBindingSet bs1 = new SPARQLQueryBindingSet();
+		SPARQLQueryBindingSet bs2 = new SPARQLQueryBindingSet();
+		
+		bs1.addBinding("x", RDF.ALT);
+		bs1.addBinding("y", RDF.BAG);
+		bs1.addBinding("z", RDF.FIRST);
+		
+		bs2.addBinding("y", RDF.BAG);
+		bs2.addBinding("x", RDF.ALT);
+		bs2.addBinding("z", RDF.FIRST);
+		
+		assertEquals(bs1, bs2);
+		assertEquals(bs1.hashCode(), bs2.hashCode());
+	}
+
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #676 .

Briefly describe the changes proposed in this PR:

* reverted changed hashcode impl back to be API-conformant 
* add regression tests for all BindingSet implementations 

