### PR TITLE
Fix #680: concurrent requests over http IllegalMonitorException

### DIFF
--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
@@ -148,13 +148,13 @@ public class RepositoryController extends AbstractController {
 			}
 
 			try {
-				// we need to forcibly close the default repository connection
-				// opened for this repository by
-				// the interceptor.
-				RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-				synchronized (repositoryCon) {
-					repositoryCon.close();
-				}
+				//				// we need to forcibly close the default repository connection
+				//				// opened for this repository by
+				//				// the interceptor.
+				//				RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
+				//				synchronized (repositoryCon) {
+				//					repositoryCon.close();
+				//				}
 
 				boolean success = repositoryManager.removeRepository(repId);
 				if (success) {
@@ -196,7 +196,7 @@ public class RepositoryController extends AbstractController {
 
 		if (queryStr != null) {
 			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-			synchronized (repositoryCon) {
+			try {
 				Query query = getQuery(repository, repositoryCon, queryStr, request, response);
 
 				View view;
@@ -269,8 +269,13 @@ public class RepositoryController extends AbstractController {
 				model.put(QueryResultView.QUERY_RESULT_KEY, queryResult);
 				model.put(QueryResultView.FACTORY_KEY, factory);
 				model.put(QueryResultView.HEADERS_ONLY, headersOnly);
+				model.put(QueryResultView.CONNECTION_KEY, repositoryCon);
 
 				return new ModelAndView(view, model);
+			}
+			catch (Exception e) {
+				repositoryCon.close();
+				throw e;
 			}
 		}
 		else {

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
@@ -148,14 +148,6 @@ public class RepositoryController extends AbstractController {
 			}
 
 			try {
-				//				// we need to forcibly close the default repository connection
-				//				// opened for this repository by
-				//				// the interceptor.
-				//				RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-				//				synchronized (repositoryCon) {
-				//					repositoryCon.close();
-				//				}
-
 				boolean success = repositoryManager.removeRepository(repId);
 				if (success) {
 					logger.info("DELETE request successfully completed");
@@ -274,6 +266,7 @@ public class RepositoryController extends AbstractController {
 				return new ModelAndView(view, model);
 			}
 			catch (Exception e) {
+				// only close the connection when an exception occurs. Otherwise, the QueryResultView will take care of closing it.
 				repositoryCon.close();
 				throw e;
 			}

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryInterceptor.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryInterceptor.java
@@ -55,8 +55,6 @@ public class RepositoryInterceptor extends ServerInterceptor {
 
 	private volatile String repositoryID;
 
-	//	private volatile RepositoryConnection repositoryCon;
-
 	/*---------*
 	 * Methods *
 	 *---------*/

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryInterceptor.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryInterceptor.java
@@ -29,8 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Interceptor for repository requests. Handles the opening and closing of connections to the repository
- * specified in the request. Should not be a singleton bean! Configure as inner bean in openrdf-servlet.xml
+ * Interceptor for repository requests. Should not be a singleton bean! Configure as inner bean in
+ * openrdf-servlet.xml
  * 
  * @author Herko ter Horst
  * @author Arjohn Kampman
@@ -47,8 +47,6 @@ public class RepositoryInterceptor extends ServerInterceptor {
 
 	private static final String REPOSITORY_KEY = "repository";
 
-	private static final String REPOSITORY_CONNECTION_KEY = "repositoryConnection";
-
 	/*-----------*
 	 * Variables *
 	 *-----------*/
@@ -57,7 +55,7 @@ public class RepositoryInterceptor extends ServerInterceptor {
 
 	private volatile String repositoryID;
 
-	private volatile RepositoryConnection repositoryCon;
+	//	private volatile RepositoryConnection repositoryCon;
 
 	/*---------*
 	 * Methods *
@@ -114,54 +112,11 @@ public class RepositoryInterceptor extends ServerInterceptor {
 					throw new ClientHTTPException(SC_NOT_FOUND, "Unknown repository: " + nextRepositoryID);
 				}
 
-				RepositoryConnection nextRepositoryCon = repositoryCon;
-				if (nextRepositoryCon == null) {
-					synchronized (this) {
-						nextRepositoryCon = repositoryCon;
-						if (nextRepositoryCon == null) {
-							nextRepositoryCon = repositoryCon = repository.getConnection();
-							// SES-1834 by default, the Sesame server should not
-							// treat datatype or language value verification
-							// errors as fatal. This is to be graceful, by
-							// default, about accepting "dirty" data.
-							// FIXME SES-1833 this should be configurable by the
-							// user.
-							nextRepositoryCon.getParserConfig().addNonFatalError(
-									BasicParserSettings.VERIFY_DATATYPE_VALUES);
-							nextRepositoryCon.getParserConfig().addNonFatalError(
-									BasicParserSettings.VERIFY_LANGUAGE_TAGS);
-
-							// FIXME: hack for repositories that return
-							// connections that are not in auto-commit mode by
-							// default
-							if (!nextRepositoryCon.isAutoCommit()) {
-								nextRepositoryCon.setAutoCommit(true);
-							}
-						}
-					}
-				}
-
 				request.setAttribute(REPOSITORY_ID_KEY, nextRepositoryID);
 				request.setAttribute(REPOSITORY_KEY, repository);
-				request.setAttribute(REPOSITORY_CONNECTION_KEY, nextRepositoryCon);
 			}
 			catch (RepositoryConfigException e) {
 				throw new ServerHTTPException(e.getMessage(), e);
-			}
-			catch (RepositoryException e) {
-				throw new ServerHTTPException(e.getMessage(), e);
-			}
-		}
-	}
-
-	@Override
-	protected void cleanUpResources()
-		throws ServerHTTPException
-	{
-		RepositoryConnection nextRepositoryCon = repositoryCon;
-		if (nextRepositoryCon != null) {
-			try {
-				nextRepositoryCon.close();
 			}
 			catch (RepositoryException e) {
 				throw new ServerHTTPException(e.getMessage(), e);
@@ -177,7 +132,19 @@ public class RepositoryInterceptor extends ServerInterceptor {
 		return (Repository)request.getAttribute(REPOSITORY_KEY);
 	}
 
+	/**
+	 * Obtain a new {@link RepositoryConnection} with suitable parser/writer configuration for handling the
+	 * incoming HTTP request. The caller of this method is responsible for closing the connection.
+	 * 
+	 * @param request
+	 *        the {@link HttpServletRequest} for which a {@link RepositoryConnection} is to be returned
+	 * @return a configured {@link RepositoryConnection}
+	 */
 	public static RepositoryConnection getRepositoryConnection(HttpServletRequest request) {
-		return (RepositoryConnection)request.getAttribute(REPOSITORY_CONNECTION_KEY);
+		Repository repo = getRepository(request);
+		RepositoryConnection conn = repo.getConnection();
+		conn.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
+		conn.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_LANGUAGE_TAGS);
+		return conn;
 	}
 }

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/graph/GraphController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/graph/GraphController.java
@@ -183,23 +183,20 @@ public class GraphController extends AbstractController {
 		}
 
 		InputStream in = request.getInputStream();
-		try {
-			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-			synchronized (repositoryCon) {
-				boolean localTransaction = !repositoryCon.isActive();
+		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
+			boolean localTransaction = !repositoryCon.isActive();
 
-				if (localTransaction) {
-					repositoryCon.begin();
-				}
+			if (localTransaction) {
+				repositoryCon.begin();
+			}
 
-				if (replaceCurrent) {
-					repositoryCon.clear(graph);
-				}
-				repositoryCon.add(in, baseURI.stringValue(), rdfFormat, graph);
+			if (replaceCurrent) {
+				repositoryCon.clear(graph);
+			}
+			repositoryCon.add(in, baseURI.stringValue(), rdfFormat, graph);
 
-				if (localTransaction) {
-					repositoryCon.commit();
-				}
+			if (localTransaction) {
+				repositoryCon.commit();
 			}
 
 			return new ModelAndView(EmptySuccessView.getInstance());
@@ -233,11 +230,8 @@ public class GraphController extends AbstractController {
 
 		IRI graph = getGraphName(request, vf);
 
-		try {
-			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-			synchronized (repositoryCon) {
-				repositoryCon.clear(graph);
-			}
+		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
+			repositoryCon.clear(graph);
 
 			return new ModelAndView(EmptySuccessView.getInstance());
 		}

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
@@ -84,13 +84,10 @@ public class NamespaceController extends AbstractController {
 	private ModelAndView getExportNamespaceResult(HttpServletRequest request, String prefix)
 		throws ServerHTTPException, ClientHTTPException
 	{
-		try {
+		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
 			String namespace = null;
 
-			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-			synchronized (repositoryCon) {
-				namespace = repositoryCon.getNamespace(prefix);
-			}
+			namespace = repositoryCon.getNamespace(prefix);
 
 			if (namespace == null) {
 				throw new ClientHTTPException(SC_NOT_FOUND, "Undefined prefix: " + prefix);
@@ -117,11 +114,8 @@ public class NamespaceController extends AbstractController {
 		}
 		// FIXME: perform some sanity checks on the namespace string
 
-		try {
-			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-			synchronized (repositoryCon) {
-				repositoryCon.setNamespace(prefix, namespace);
-			}
+		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
+			repositoryCon.setNamespace(prefix, namespace);
 		}
 		catch (RepositoryException e) {
 			throw new ServerHTTPException("Repository error: " + e.getMessage(), e);
@@ -133,11 +127,8 @@ public class NamespaceController extends AbstractController {
 	private ModelAndView getRemoveNamespaceResult(HttpServletRequest request, String prefix)
 		throws ServerHTTPException
 	{
-		try {
-			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-			synchronized (repositoryCon) {
-				repositoryCon.removeNamespace(prefix);
-			}
+		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
+			repositoryCon.removeNamespace(prefix);
 		}
 		catch (RepositoryException e) {
 			throw new ServerHTTPException("Repository error: " + e.getMessage(), e);

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
@@ -85,9 +85,7 @@ public class NamespaceController extends AbstractController {
 		throws ServerHTTPException, ClientHTTPException
 	{
 		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
-			String namespace = null;
-
-			namespace = repositoryCon.getNamespace(prefix);
+			String namespace = repositoryCon.getNamespace(prefix);
 
 			if (namespace == null) {
 				throw new ClientHTTPException(SC_NOT_FOUND, "Undefined prefix: " + prefix);

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespacesController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespacesController.java
@@ -87,8 +87,9 @@ public class NamespacesController extends AbstractController {
 			List<String> columnNames = Arrays.asList("prefix", "namespace");
 			List<BindingSet> namespaces = new ArrayList<BindingSet>();
 
-			RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-			synchronized (repositoryCon) {
+			try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(
+					request))
+			{
 				final ValueFactory vf = repositoryCon.getValueFactory();
 				try {
 					CloseableIteration<? extends Namespace, RepositoryException> iter = repositoryCon.getNamespaces();
@@ -126,19 +127,19 @@ public class NamespacesController extends AbstractController {
 		return new ModelAndView(TupleQueryResultView.getInstance(), model);
 	}
 
+
 	private ModelAndView getClearNamespacesResult(HttpServletRequest request, HttpServletResponse response)
 		throws ServerHTTPException
 	{
-		RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-		synchronized (repositoryCon) {
+		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
 			try {
 				repositoryCon.clearNamespaces();
 			}
 			catch (RepositoryException e) {
 				throw new ServerHTTPException("Repository error: " + e.getMessage(), e);
 			}
-		}
 
-		return new ModelAndView(EmptySuccessView.getInstance());
+			return new ModelAndView(EmptySuccessView.getInstance());
+		}
 	}
 }

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/size/SizeController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/size/SizeController.java
@@ -57,11 +57,10 @@ public class SizeController extends AbstractController {
 
 			long size = -1;
 
-			try {
-				RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request);
-				synchronized (repositoryCon) {
-					size = repositoryCon.size(contexts);
-				}
+			try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(
+					request))
+			{
+				size = repositoryCon.size(contexts);
 			}
 			catch (RepositoryException e) {
 				throw new ServerHTTPException("Repository error: " + e.getMessage(), e);

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/ExportStatementsView.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/ExportStatementsView.java
@@ -77,7 +77,6 @@ public class ExportStatementsView implements View {
 		Value obj = (Value)model.get(OBJECT_KEY);
 		Resource[] contexts = (Resource[])model.get(CONTEXTS_KEY);
 		boolean useInferencing = (Boolean)model.get(USE_INFERENCING_KEY);
-		RepositoryConnection conn = (RepositoryConnection)model.get(CONNECTION_KEY);
 
 		boolean headersOnly = (Boolean)model.get(HEADERS_ONLY);
 
@@ -105,10 +104,7 @@ public class ExportStatementsView implements View {
 			response.setHeader("Content-Disposition", "attachment; filename=" + filename);
 
 			if (!headersOnly) {
-				if (conn == null) {
-					conn = RepositoryInterceptor.getRepositoryConnection(request);
-				}
-				synchronized (conn) {
+				try (RepositoryConnection conn = RepositoryInterceptor.getRepositoryConnection(request)) {
 					conn.exportStatements(subj, pred, obj, useInferencing, rdfWriter, contexts);
 				}
 			}

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.rdf4j.IsolationLevel;
@@ -61,7 +60,7 @@ import org.slf4j.LoggerFactory;
 class Transaction {
 
 	private static final Logger logger = LoggerFactory.getLogger(Transaction.class);
-	
+
 	private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
 	private final UUID id;
@@ -70,19 +69,7 @@ class Transaction {
 
 	private final RepositoryConnection txnConnection;
 
-	private final ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
-		
-		int count = 0;
-		
-		@Override
-		public Thread newThread(Runnable r) {
-			count++;
-			if (count > 1) {
-				logger.warn("creating more than one thread for SingleThreadExecutor. Txn: {}", id);
-			}
-			return new Thread(r, "txn-" + id);
-		}
-	});
+	private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
 	private final List<Future<?>> futures = new ArrayList<>();
 

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -421,7 +421,7 @@ public class TransactionController extends AbstractController {
 		model.put(QueryResultView.FACTORY_KEY, factory);
 		model.put(QueryResultView.HEADERS_ONLY, false); // TODO needed for HEAD
 														// requests.
-		model.put(QueryResultView.TRANSACTION_ID_KEY, txn.getID());
+//		model.put(QueryResultView.TRANSACTION_ID_KEY, txn.getID());
 		return new ModelAndView(view, model);
 	}
 

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -421,7 +421,6 @@ public class TransactionController extends AbstractController {
 		model.put(QueryResultView.FACTORY_KEY, factory);
 		model.put(QueryResultView.HEADERS_ONLY, false); // TODO needed for HEAD
 														// requests.
-//		model.put(QueryResultView.TRANSACTION_ID_KEY, txn.getID());
 		return new ModelAndView(view, model);
 	}
 

--- a/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
+++ b/core/http/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
@@ -12,7 +12,10 @@ import java.nio.charset.StandardCharsets;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.rio.ParserConfig;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
@@ -40,13 +43,17 @@ public class TestStatementsController {
 		request.setContent(updateString.getBytes(StandardCharsets.UTF_8));
 
 		// prepare mocks
-		final RepositoryConnection connection = Mockito.mock(RepositoryConnection.class);
+		final Repository repMock = Mockito.mock(Repository.class);
+		final RepositoryConnection connectionMock = Mockito.mock(RepositoryConnection.class);
+		final ParserConfig parserConfigMock = Mockito.mock(ParserConfig.class);
 		final Update updateMock = Mockito.mock(Update.class);
-		Mockito.when(connection.prepareUpdate(QueryLanguage.SPARQL, updateString, null)).thenReturn(
+		Mockito.when(repMock.getConnection()).thenReturn(connectionMock);
+		Mockito.when(connectionMock.prepareUpdate(QueryLanguage.SPARQL, updateString, null)).thenReturn(
 				updateMock);
+		Mockito.when(connectionMock.getParserConfig()).thenReturn(parserConfigMock);
 
 		// repository interceptor uses this attribute
-		request.setAttribute("repositoryConnection", connection);
+		request.setAttribute("repository", repMock);
 
 		//act
 		controller.handleRequest(request, new MockHttpServletResponse());

--- a/testsuites/store/src/main/java/org/eclipse/rdf4j/sail/RDFStoreTest.java
+++ b/testsuites/store/src/main/java/org/eclipse/rdf4j/sail/RDFStoreTest.java
@@ -18,6 +18,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.Iteration;
@@ -47,6 +48,7 @@ import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -62,7 +64,7 @@ public abstract class RDFStoreTest {
 	 * Timeout all individual tests after 1 minute.
 	 */
 	@Rule
-	public Timeout to = new Timeout(60000);
+	public Timeout to = new Timeout(60, TimeUnit.SECONDS);
 
 	/*-----------*
 	 * Constants *
@@ -168,8 +170,14 @@ public abstract class RDFStoreTest {
 	{
 		try {
 			if (con.isOpen()) {
-				con.rollback();
-				con.close();
+				try {
+					if (con.isActive()) {
+						con.rollback();
+					}
+				}
+				finally {
+					con.close();
+				}
 			}
 		}
 		finally {
@@ -718,6 +726,7 @@ public abstract class RDFStoreTest {
 	}
 
 	@Test
+	@Ignore("test is fundamentelly flawed as it uses multithreaded access on the same connection")
 	public void testMultiThreadedAccess() {
 
 		Runnable runnable = new Runnable() {

--- a/testsuites/store/src/main/java/org/eclipse/rdf4j/sail/RDFStoreTest.java
+++ b/testsuites/store/src/main/java/org/eclipse/rdf4j/sail/RDFStoreTest.java
@@ -727,6 +727,7 @@ public abstract class RDFStoreTest {
 
 	@Test
 	@Ignore("test is fundamentelly flawed as it uses multithreaded access on the same connection")
+	@Deprecated
 	public void testMultiThreadedAccess() {
 
 		Runnable runnable = new Runnable() {


### PR DESCRIPTION
This PR addresses GitHub issue: #680 .

Briefly describe the changes proposed in this PR:

* RepositoryInterceptor in RDF4J Server no longer keeps a shared RepositoryConnection, instead it creates a new, pre-configured connection whenever needed. Callers are responsible for closing the connection when done.
* Native store internal locking simplified 

These fixes have been tested in combination with the test case provided in #680, and it seems to resolve the issue. In addition all existing tests greenline.

I will look into adding the provided test case to our suite as a regression test. 
