### PR TITLE
issue #684 : More reliably clean up for InterruptedException in BackgroundTupleResult

### DIFF
--- a/compliance/http/src/test/java/org/eclipse/rdf4j/http/server/ProtocolTest.java
+++ b/compliance/http/src/test/java/org/eclipse/rdf4j/http/server/ProtocolTest.java
@@ -58,6 +58,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.opencsv.CSVReader;
 
 public class ProtocolTest {
@@ -485,7 +486,8 @@ public class ProtocolTest {
 		// "Test-NativeStore");
 		String repositoryLocation = TestServer.REPOSITORY_URL;
 
-		ExecutorService threadPool = Executors.newFixedThreadPool(20);
+		ExecutorService threadPool = Executors.newFixedThreadPool(20,
+				new ThreadFactoryBuilder().setNameFormat("rdf4j-protocoltest-%d").build());
 
 		for (int count = 0; count < limitCount; count++) {
 			final int number = count;
@@ -598,8 +600,9 @@ public class ProtocolTest {
 
 		int responseCode = conn.getResponseCode();
 
-		if (responseCode != HttpURLConnection.HTTP_OK && // 200 OK
-				responseCode != HttpURLConnection.HTTP_NO_CONTENT) // 204 NO CONTENT
+		// HTTP 200 or 204
+		if (responseCode != HttpURLConnection.HTTP_OK && 
+				responseCode != HttpURLConnection.HTTP_NO_CONTENT)
 		{
 			String response = "location " + location + " responded: " + conn.getResponseMessage() + " ("
 					+ responseCode + ")";
@@ -621,8 +624,9 @@ public class ProtocolTest {
 
 		int responseCode = conn.getResponseCode();
 
-		if (responseCode != HttpURLConnection.HTTP_OK && // 200 OK
-				responseCode != HttpURLConnection.HTTP_NO_CONTENT) // 204 NO CONTENT
+		// HTTP 200 or 204
+		if (responseCode != HttpURLConnection.HTTP_OK &&
+				responseCode != HttpURLConnection.HTTP_NO_CONTENT) 
 		{
 			String response = "location " + location + " responded: " + conn.getResponseMessage() + " ("
 					+ responseCode + ")";
@@ -662,8 +666,9 @@ public class ProtocolTest {
 
 		int responseCode = conn.getResponseCode();
 
-		if (responseCode != HttpURLConnection.HTTP_OK && // 200 OK
-				responseCode != HttpURLConnection.HTTP_NO_CONTENT) // 204 NO CONTENT
+		// HTTP 200 or 204
+		if (responseCode != HttpURLConnection.HTTP_OK &&
+				responseCode != HttpURLConnection.HTTP_NO_CONTENT)
 		{
 			String response = "location " + location + " responded: " + conn.getResponseMessage() + " ("
 					+ responseCode + ")";
@@ -682,8 +687,9 @@ public class ProtocolTest {
 
 		int responseCode = conn.getResponseCode();
 
-		if (responseCode != HttpURLConnection.HTTP_OK && // 200 OK
-				responseCode != HttpURLConnection.HTTP_NO_CONTENT) // 204 NO CONTENT
+		// HTTP 200 or 204
+		if (responseCode != HttpURLConnection.HTTP_OK &&
+				responseCode != HttpURLConnection.HTTP_NO_CONTENT)
 		{
 			String response = "location " + location + " responded: " + conn.getResponseMessage() + " ("
 					+ responseCode + ")";
@@ -707,6 +713,7 @@ public class ProtocolTest {
 
 		try {
 			int responseCode = conn.getResponseCode();
+			// HTTP 200
 			if (responseCode == HttpURLConnection.HTTP_OK) {
 				// Process query results
 				return QueryResultIO.parseTuple(conn.getInputStream(), TupleQueryResultFormat.SPARQL);

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/http/HTTPTupleQueryResultTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/http/HTTPTupleQueryResultTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.TupleQueryResultTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class HTTPTupleQueryResultTest extends TupleQueryResultTest {
+
+	private static HTTPMemServer server;
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+	}
+
+	@Override
+	protected Repository newRepository() {
+		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+	}
+
+}

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SesameClientImpl.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SesameClientImpl.java
@@ -7,8 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.utils.HttpClientUtils;
@@ -16,6 +18,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.eclipse.rdf4j.http.client.util.HttpClientBuilders;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
  * Uses {@link HttpClient} to manage HTTP connections.
@@ -25,47 +29,62 @@ import org.eclipse.rdf4j.http.client.util.HttpClientBuilders;
 public class SesameClientImpl implements SesameClient, HttpClientDependent {
 
 	/** independent life cycle */
-	private HttpClient httpClient;
+	private volatile HttpClient httpClient;
 
 	/** dependent life cycle */
-	private CloseableHttpClient dependentClient;
+	private volatile CloseableHttpClient dependentClient;
 
-	private ExecutorService executor = null;
+	private final ExecutorService executor;
 
 	/**
 	 * Optional {@link HttpClientBuilder} to create the inner {@link #httpClient} (if not provided externally)
 	 */
-	private HttpClientBuilder httpClientBuilder;
+	private volatile HttpClientBuilder httpClientBuilder;
 
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
 
 	public SesameClientImpl() {
-		initialize();
+		this.executor = Executors.newCachedThreadPool(
+				new ThreadFactoryBuilder().setNameFormat("rdf4j-sesameclientimpl-%d").build());
 	}
 
 	public SesameClientImpl(CloseableHttpClient dependentClient, ExecutorService dependentExecutorService) {
-		this.httpClient = this.dependentClient = dependentClient;
-		this.executor = dependentExecutorService;
+		this.httpClient = this.dependentClient = Objects.requireNonNull(dependentClient,
+				"HTTP client was null");
+		this.executor = Objects.requireNonNull(dependentExecutorService, "Executor service was null");
 	}
 
-	/**
-	 * @return Returns the httpClient.
-	 */
-	public synchronized HttpClient getHttpClient() {
-		if (httpClient == null) {
-			httpClient = dependentClient = createHttpClient();
+	@Override
+	public HttpClient getHttpClient() {
+		HttpClient result = httpClient;
+		if (result == null) {
+			synchronized (this) {
+				result = httpClient;
+				if (result == null) {
+					result = httpClient = dependentClient = createHttpClient();
+				}
+			}
 		}
-		return httpClient;
+		return result;
 	}
 
 	/**
 	 * @param httpClient
 	 *        The httpClient to use for remote/service calls.
 	 */
-	public synchronized void setHttpClient(HttpClient httpClient) {
-		this.httpClient = httpClient;
+	public void setHttpClient(HttpClient httpClient) {
+		synchronized (this) {
+			this.httpClient = Objects.requireNonNull(httpClient, "HTTP Client cannot be null");
+			// If they set a client, we need to check whether we need to
+			// close any existing dependentClient
+			CloseableHttpClient toCloseDependentClient = dependentClient;
+			dependentClient = null;
+			if (toCloseDependentClient != null) {
+				HttpClientUtils.closeQuietly(toCloseDependentClient);
+			}
+		}
 	}
 
 	/**
@@ -76,19 +95,20 @@ public class SesameClientImpl implements SesameClient, HttpClientDependent {
 	 *        the builder for the managed HttpClient
 	 * @see HttpClientBuilders
 	 */
-	public synchronized void setHttpClientBuilder(HttpClientBuilder httpClientBuilder) {
+	public void setHttpClientBuilder(HttpClientBuilder httpClientBuilder) {
 		this.httpClientBuilder = httpClientBuilder;
 	}
 
 	private CloseableHttpClient createHttpClient() {
-		if (this.httpClientBuilder != null) {
-			return httpClientBuilder.build();
+		HttpClientBuilder nextHttpClientBuilder = httpClientBuilder;
+		if (nextHttpClientBuilder != null) {
+			return nextHttpClientBuilder.build();
 		}
 		return HttpClients.createSystem();
 	}
 
 	@Override
-	public synchronized SparqlSession createSparqlSession(String queryEndpointUrl, String updateEndpointUrl) {
+	public SparqlSession createSparqlSession(String queryEndpointUrl, String updateEndpointUrl) {
 		SparqlSession session = new SparqlSession(getHttpClient(), executor);
 		session.setQueryURL(queryEndpointUrl);
 		session.setUpdateURL(updateEndpointUrl);
@@ -96,7 +116,7 @@ public class SesameClientImpl implements SesameClient, HttpClientDependent {
 	}
 
 	@Override
-	public synchronized SesameSession createSesameSession(String serverURL) {
+	public SesameSession createSesameSession(String serverURL) {
 		SesameSession session = new SesameSession(getHttpClient(), executor);
 		session.setServerURL(serverURL);
 		return session;
@@ -107,25 +127,38 @@ public class SesameClientImpl implements SesameClient, HttpClientDependent {
 	 *-----------------*/
 
 	@Override
-	public synchronized void shutDown() {
-		if (executor != null) {
-			executor.shutdown();
-			executor = null;
-		}
-		if (dependentClient != null) {
-			HttpClientUtils.closeQuietly(dependentClient);
+	public void shutDown() {
+		try {
+			CloseableHttpClient toCloseDependentClient = dependentClient;
 			dependentClient = null;
+			if (toCloseDependentClient != null) {
+				HttpClientUtils.closeQuietly(toCloseDependentClient);
+			}
+		}
+		finally {
+			try {
+				executor.shutdown();
+				executor.awaitTermination(10, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException e) {
+				// Preserve the interrupt status so others can check it as necessary
+				Thread.currentThread().interrupt();
+			}
+			finally {
+				if (!executor.isTerminated()) {
+					executor.shutdownNow();
+				}
+			}
 		}
 	}
 
 	/**
-	 * (re)initializes the connection manager and HttpClient (if not already done), for example after a
-	 * shutdown has been invoked earlier. Invoking this method multiple times will have no effect.
+	 * No-op
+	 * 
+	 * @deprecated Create a new instance instead of trying to reactivate an old instance.
 	 */
-	public synchronized void initialize() {
-		if (executor == null) {
-			executor = Executors.newCachedThreadPool();
-		}
+	@Deprecated
+	public void initialize() {
 	}
 
 }

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/BackgroundGraphResultHangTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/BackgroundGraphResultHangTest.java
@@ -63,11 +63,10 @@ public class BackgroundGraphResultHangTest {
 				new ByteArrayInputStream(data.getBytes(Charset.forName("UTF-8"))), Charset.forName("UTF-8"),
 				"http://base.org");
 
-		gRes.run();
-
-		gRes.getNamespaces();
-
 		thrown.expect(QueryEvaluationException.class);
+		gRes.run();
+		gRes.getNamespaces();
 		gRes.hasNext();
 	}
+
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/JoinExecutorBase.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/JoinExecutorBase.java
@@ -98,6 +98,7 @@ public abstract class JoinExecutorBase<T> extends LookAheadIteration<T, QueryEva
 			rightQueue.put(res);
 		}
 		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 			throw new RuntimeException("Error adding element to right queue", e);
 		}
 	}

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/AbstractRepository.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/AbstractRepository.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractRepository implements Repository {
 
-	// "volatile" guarantees access ordering in JDK5+
 	private volatile boolean initialized = false;
 
 	private final Object initLock = new Object();

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/ParallelJoinCursor.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/ParallelJoinCursor.java
@@ -69,6 +69,7 @@ public class ParallelJoinCursor extends LookAheadIteration<BindingSet, QueryEval
 	 * Methods *
 	 *---------*/
 
+	@Override
 	public void run() {
 		evaluationThread = Thread.currentThread();
 		try {
@@ -80,7 +81,7 @@ public class ParallelJoinCursor extends LookAheadIteration<BindingSet, QueryEval
 			rightQueue.toss(e);
 		}
 		catch (InterruptedException e) {
-			// stop
+			Thread.currentThread().interrupt();
 		}
 		finally {
 			evaluationThread = null; // NOPMD

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/ParallelLeftJoinCursor.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/ParallelLeftJoinCursor.java
@@ -81,6 +81,7 @@ public class ParallelLeftJoinCursor extends LookAheadIteration<BindingSet, Query
 	 * Methods *
 	 *---------*/
 
+	@Override
 	public void run() {
 		evaluationThread = Thread.currentThread();
 		try {
@@ -94,7 +95,7 @@ public class ParallelLeftJoinCursor extends LookAheadIteration<BindingSet, Query
 			rightQueue.toss(e);
 		}
 		catch (InterruptedException e) {
-			// stop
+			Thread.currentThread().interrupt();
 		}
 		finally {
 			evaluationThread = null; // NOPMD

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/QueueCursor.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/QueueCursor.java
@@ -121,6 +121,7 @@ public class QueueCursor<E> extends LookAheadIteration<E, QueryEvaluationExcepti
 			return take;
 		}
 		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 			checkException();
 			throw new QueryEvaluationException(e);
 		}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -331,6 +331,7 @@ class MemorySailStore implements SailStore {
 							cleanSnapshots();
 						}
 						catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
 							logger.warn("snapshot cleanup interrupted");
 						}
 					}

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/AbstractCloseableIteration.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/AbstractCloseableIteration.java
@@ -40,7 +40,8 @@ public abstract class AbstractCloseableIteration<E, X extends Exception> impleme
 	}
 
 	/**
-	 * Calls {@link #handleClose()} upon first call and makes sure this method gets called only once.
+	 * Calls {@link #handleClose()} upon first call and makes sure the resource closures are only executed
+	 * once.
 	 */
 	@Override
 	public final void close()

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/LookAheadIteration.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/LookAheadIteration.java
@@ -49,9 +49,7 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 		if (isClosed()) {
 			return false;
 		}
-		lookAhead();
-
-		boolean result = nextElement != null;
+		boolean result = (lookAhead() != null);
 		if (!result) {
 			close();
 		}
@@ -65,9 +63,7 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 		if (isClosed()) {
 			throw new NoSuchElementException("The iteration has been closed.");
 		}
-		lookAhead();
-
-		E result = nextElement;
+		E result = lookAhead();
 
 		if (result != null) {
 			nextElement = null;
@@ -82,9 +78,11 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 	/**
 	 * Fetches the next element if it hasn't been fetched yet and stores it in {@link #nextElement}.
 	 * 
+	 * @return The next element, or null if there are no more results.
 	 * @throws X
+	 *         If there is an issue getting the next element or closing the iteration.
 	 */
-	private void lookAhead()
+	private E lookAhead()
 		throws X
 	{
 		E checkElement = nextElement;
@@ -95,6 +93,7 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 				close();
 			}
 		}
+		return checkElement;
 	}
 
 	/**

--- a/testsuites/store/src/main/java/org/eclipse/rdf4j/repository/GraphQueryResultTest.java
+++ b/testsuites/store/src/main/java/org/eclipse/rdf4j/repository/GraphQueryResultTest.java
@@ -62,11 +62,14 @@ public abstract class GraphQueryResultTest {
 	public void tearDown()
 		throws Exception
 	{
-		con.close();
-		con = null;
-
-		rep.shutDown();
-		rep = null;
+		try {
+			con.close();
+			con = null;
+		}
+		finally {
+			rep.shutDown();
+			rep = null;
+		}
 	}
 
 	protected Repository createRepository()

--- a/testsuites/store/src/main/java/org/eclipse/rdf4j/repository/TupleQueryResultTest.java
+++ b/testsuites/store/src/main/java/org/eclipse/rdf4j/repository/TupleQueryResultTest.java
@@ -12,12 +12,18 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.CoreMatchers.is;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -55,11 +61,14 @@ public abstract class TupleQueryResultTest {
 	public void tearDown()
 		throws Exception
 	{
-		con.close();
-		con = null;
-
-		rep.shutDown();
-		rep = null;
+		try {
+			con.close();
+			con = null;
+		}
+		finally {
+			rep.shutDown();
+			rep = null;
+		}
 	}
 
 	protected Repository createRepository()
@@ -176,6 +185,46 @@ public abstract class TupleQueryResultTest {
 		}
 		finally {
 			result.close();
+		}
+	}
+
+	@Test
+	public void testStreaming()
+		throws Exception
+	{
+		ValueFactory vf = con.getValueFactory();
+		int subjectIndex = 0;
+		int predicateIndex = 100;
+		int objectIndex = 1000;
+		int testStatementCount = 1000;
+		int count = 0;
+		con.begin();
+		while (count < testStatementCount) {
+			con.add(vf.createIRI("urn:test:" + subjectIndex), vf.createIRI("urn:test:" + predicateIndex),
+					vf.createIRI("urn:test:" + objectIndex));
+			if(Math.round(Math.random()) > 0) {
+				subjectIndex++;
+			}
+			if(Math.round(Math.random()) > 0) {
+				predicateIndex++;
+			}
+			if(Math.round(Math.random()) > 0) {
+				objectIndex++;
+			}
+			count++;
+		}
+		con.commit();
+		
+		for(int evaluateCount = 0; evaluateCount < 1000; evaluateCount++) {
+			try (ByteArrayOutputStream stream = new ByteArrayOutputStream();
+					RepositoryConnection nextCon = rep.getConnection();) {
+				TupleQueryResultWriter sparqlWriter = QueryResultIO.createTupleWriter(
+						TupleQueryResultFormat.SPARQL, stream);
+				TupleQuery tupleQuery = nextCon.prepareTupleQuery(QueryLanguage.SPARQL,
+						"SELECT ?s ?p ?o WHERE { ?s ?p ?o . }");
+				tupleQuery.setIncludeInferred(false);
+				tupleQuery.evaluate(sparqlWriter);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #684 .

Briefly describe the changes proposed in this PR:

* Cleans up more reliably in BackgroundTupleResult when InterruptedException occurs
* Removes internal synchronisation in QueueCursor for exceptions so it now uses ConcurrentLinkedQueue instead of LinkedList.

All tests pass for me after the changes.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>