### PR TITLE
Fix #689: bug in ZeroLengthPathIteration + cost estimate improvement in planner

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import java.util.Collection;
+import java.util.UUID;
 
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.BinaryTupleOperator;
@@ -103,12 +104,14 @@ public class EvaluationStatistics {
 
 		@Override
 		public void meet(ArbitraryLengthPath node) {
-
-			// actual cardinality = count(union(subjs, objs))
-			// but might require getting all statements
-			// so due to the lower actual cardinality we value it in preference to a fully unbound statement pattern.
-			cardinality = getSubjectCardinality(node.getSubjectVar())
-					* getObjectCardinality(node.getObjectVar()) * getContextCardinality(node.getContextVar());
+			final Var pathVar = new Var("_anon_" + UUID.randomUUID().toString().replaceAll("-", "_"));
+			pathVar.setAnonymous(true);
+			// cardinality of ALP is determined based on the cost of a 
+			// single ?s ?p ?o ?c pattern where ?p is unbound, compensating for the fact that
+			// the length of the path is unknown but expected to be _at least_ twice that of a normal 
+			// statement pattern.
+			cardinality = 2.0 * getCardinality(new StatementPattern(node.getSubjectVar(), pathVar,
+					node.getObjectVar(), node.getContextVar()));
 		}
 
 		@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIteration.java
@@ -98,7 +98,7 @@ public class ZeroLengthPathIteration extends LookAheadIteration<BindingSet, Quer
 				Value v = bs.getValue(endpointVarName);
 
 				if (add(reportedValues, v)) {
-					QueryBindingSet next = new QueryBindingSet();
+					QueryBindingSet next = new QueryBindingSet(bindings);
 					next.addBinding(subjectVar.getName(), v);
 					next.addBinding(objVar.getName(), v);
 					if (contextVar != null) {

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIterationTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIterationTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
+import org.eclipse.rdf4j.query.impl.MapBindingSet;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author jeen
+ */
+public class ZeroLengthPathIterationTest {
+
+	private final ValueFactory vf = SimpleValueFactory.getInstance();
+
+	private EvaluationStrategy evaluator;
+
+	@Before
+	public void setUp() {
+		Model m = new LinkedHashModel();
+		m.add(RDF.ALT, RDF.TYPE, RDFS.CLASS);
+		m.add(RDF.BAG, RDF.TYPE, RDFS.CLASS);
+
+		TripleSource ts = new TripleSource() {
+
+			@Override
+			public CloseableIteration<? extends Statement, QueryEvaluationException> getStatements(
+					Resource subj, IRI pred, Value obj, Resource... contexts)
+				throws QueryEvaluationException
+			{
+				return new CloseableIteratorIteration<Statement, QueryEvaluationException>(
+						m.filter(subj, pred, obj, contexts).iterator());
+			}
+
+			@Override
+			public ValueFactory getValueFactory() {
+				return vf;
+			}
+		};
+		evaluator = new StrictEvaluationStrategy(ts, null);
+	}
+
+	@Test
+	public void testRetainInputBindings() {
+
+		MapBindingSet bindings = new MapBindingSet();
+		bindings.addBinding("a", RDF.FIRST);
+
+		Var subjectVar = new Var("x");
+		Var objVar = new Var("y");
+		ZeroLengthPathIteration zlp = new ZeroLengthPathIteration(evaluator, subjectVar, objVar, null, null,
+				null, bindings);
+		try {
+			BindingSet result = zlp.getNextElement();
+
+			assertTrue(result.hasBinding("a"));
+			assertTrue(result.hasBinding("x"));
+			assertTrue(result.hasBinding("y"));
+		}
+		finally {
+			zlp.close();
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIterationTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIterationTest.java
@@ -65,6 +65,10 @@ public class ZeroLengthPathIterationTest {
 		evaluator = new StrictEvaluationStrategy(ts, null);
 	}
 
+	/**
+	 * Verify that evaluation of a {@link ZeroLengthPathIteration} does not discard input bindings. 
+	 * @see https://github.com/eclipse/rdf4j/issues/689
+	 */
 	@Test
 	public void testRetainInputBindings() {
 
@@ -78,9 +82,9 @@ public class ZeroLengthPathIterationTest {
 		try {
 			BindingSet result = zlp.getNextElement();
 
-			assertTrue(result.hasBinding("a"));
-			assertTrue(result.hasBinding("x"));
-			assertTrue(result.hasBinding("y"));
+			assertTrue("zlp evaluation should have retained unrelated input binding", result.hasBinding("a"));
+			assertTrue("zlp evaluation should binding for subject var", result.hasBinding("x"));
+			assertTrue("zlp evaluation should binding for object var", result.hasBinding("y"));
 		}
 		finally {
 			zlp.close();


### PR DESCRIPTION
This PR addresses GitHub issue: #689 .

Briefly describe the changes proposed in this PR:

* QueryJoinOptimizer incorrectly reorganized joins involving ArbitraryLengthPaths due to too-low estimate of cost.
* cost estimate now based on store estimate of single statement pattern involving the ALP's subject and object, and an unknown predicate, times 2 (we estimate an ALP's path length will be at least 2). 
* Tested manually that the bug is specifically caused by the optimizer, not by the execution engine: if the optimizer is completely disabled, the engine does compute the correct query result. 
