### PR TITLE
Fix #697: only report if actual statements inferred

### DIFF
--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/AbstractForwardChainingInferencerConnection.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/AbstractForwardChainingInferencerConnection.java
@@ -174,7 +174,9 @@ public abstract class AbstractForwardChainingInferencerConnection extends Infere
 			logger.debug("iteration " + iteration + " done; inferred " + nofInferred + " new statements");
 			totalInferred += nofInferred;
 		}
-		logger.info("{} inferred {} new statements", this.getClass().getName(), totalInferred);
+		if (totalInferred > 0) {
+			logger.info("{} inferred {} new statements", this.getClass().getName(), totalInferred);
+		}
 	}
 
 	/**

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/AbstractForwardChainingInferencerConnection.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/AbstractForwardChainingInferencerConnection.java
@@ -166,16 +166,16 @@ public abstract class AbstractForwardChainingInferencerConnection extends Infere
 
 		while (hasNewStatements()) {
 			iteration++;
-			logger.debug("starting iteration " + iteration);
+			logger.trace("starting iteration " + iteration);
 			Model newThisIteration = prepareIteration();
 
 			int nofInferred = applyRules(newThisIteration);
 
-			logger.debug("iteration " + iteration + " done; inferred " + nofInferred + " new statements");
+			logger.trace("iteration " + iteration + " done; inferred " + nofInferred + " new statements");
 			totalInferred += nofInferred;
 		}
 		if (totalInferred > 0) {
-			logger.info("{} inferred {} new statements", this.getClass().getName(), totalInferred);
+			logger.debug("{} inferred {} new statements", this.getClass().getName(), totalInferred);
 		}
 	}
 


### PR DESCRIPTION
This PR addresses GitHub issue: #697 .

Briefly describe the changes proposed in this PR:

* only report info-level log if actual statements inferred
