### PR TITLE
issue #698 : Remove shared test directory for elastic search tests

### DIFF
--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -137,9 +137,9 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
-	private Node node;
+	private volatile Node node;
 
-	private Client client;
+	private volatile Client client;
 
 	private String clusterName;
 
@@ -316,14 +316,19 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 	public void shutDown()
 		throws IOException
 	{
-		if (client != null) {
-			client.close();
+		try {
+			Client toCloseClient = client;
 			client = null;
+			if (toCloseClient != null) {
+				toCloseClient.close();
+			}
 		}
-
-		if (node != null) {
-			node.close();
+		finally {
+			Node toCloseNode = node;
 			node = null;
+			if (toCloseNode != null) {
+				toCloseNode.close();
+			}
 		}
 	}
 

--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.URI;
@@ -173,7 +174,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		throws Exception
 	{
 		super.initialize(parameters);
-		indexName = parameters.getProperty(INDEX_NAME_KEY, DEFAULT_INDEX_NAME);
+		indexName = parameters.getProperty(INDEX_NAME_KEY, UUID.randomUUID().toString());
 		documentType = parameters.getProperty(DOCUMENT_TYPE_KEY, DEFAULT_DOCUMENT_TYPE);
 		analyzer = parameters.getProperty(LuceneSail.ANALYZER_CLASS_KEY, DEFAULT_ANALYZER);
 		// slightly hacky cast to cope with the fact that Properties is

--- a/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/core/sail/fts/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -174,7 +174,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		throws Exception
 	{
 		super.initialize(parameters);
-		indexName = parameters.getProperty(INDEX_NAME_KEY, UUID.randomUUID().toString());
+		indexName = parameters.getProperty(INDEX_NAME_KEY, DEFAULT_INDEX_NAME);
 		documentType = parameters.getProperty(DOCUMENT_TYPE_KEY, DEFAULT_DOCUMENT_TYPE);
 		analyzer = parameters.getProperty(LuceneSail.ANALYZER_CLASS_KEY, DEFAULT_ANALYZER);
 		// slightly hacky cast to cope with the fact that Properties is

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -113,9 +114,9 @@ public class ElasticsearchIndexTest {
 		throws Exception
 	{
 		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
+		testDir = tempDir.newFolder("es-index-test").toPath();
 		Properties sailProperties = new Properties();
 		sailProperties.put(ElasticsearchIndex.INDEX_NAME_KEY, ElasticsearchTestUtils.getNextTestIndexName());
-		testDir = tempDir.newFolder("elasticsearchindextest").toPath();
 		sailProperties.put(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		index = new ElasticsearchIndex();
 		index.initialize(sailProperties);

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
@@ -16,12 +16,14 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.Semaphore;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -44,11 +46,16 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class ElasticsearchIndexTest {
 
-	private static final String DATA_DIR = "target/test-data";
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+
+	private Path testDir;
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
@@ -107,9 +114,11 @@ public class ElasticsearchIndexTest {
 	public void setUp()
 		throws Exception
 	{
-		index = new ElasticsearchIndex();
+		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
 		Properties sailProperties = new Properties();
-		sailProperties.put(LuceneSail.LUCENE_DIR_KEY, DATA_DIR);
+		testDir = tempDir.newFolder("elasticsearchindextest").toPath();
+		sailProperties.put(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
+		index = new ElasticsearchIndex();
 		index.initialize(sailProperties);
 		node = NodeBuilder.nodeBuilder().loadConfigSettings(false).client(true).local(true).clusterName(
 				index.getClusterName()).node();
@@ -120,10 +129,27 @@ public class ElasticsearchIndexTest {
 	public void tearDown()
 		throws Exception
 	{
-		client.close();
-		node.close();
-		index.shutDown();
-		FileSystemUtils.deleteRecursively(new File(DATA_DIR));
+		try {
+			client.close();
+		}
+		finally {
+			try {
+				node.close();
+			}
+			finally {
+				try {
+					index.shutDown();
+				}
+				finally {
+					try {
+						FileSystemUtils.deleteRecursively(testDir.toFile());
+					}
+					finally {
+						ElasticsearchTestUtils.TEST_SEMAPHORE.release();
+					}
+				}
+			}
+		}
 	}
 
 	@Test
@@ -159,7 +185,8 @@ public class ElasticsearchIndexTest {
 		index.addStatement(statement12);
 		index.commit();
 
-		// See if everything remains consistent. We must create a new IndexReader
+		// See if everything remains consistent. We must create a new
+		// IndexReader
 		// in order to be able to see the updates
 		count = client.prepareCount(index.getIndexName()).setTypes(
 				index.getTypes()).execute().actionGet().getCount();
@@ -194,7 +221,8 @@ public class ElasticsearchIndexTest {
 		index.removeStatement(statement11);
 		index.commit();
 
-		// check that that statement is actually removed and that the other still
+		// check that that statement is actually removed and that the other
+		// still
 		// exists
 		count = client.prepareCount(index.getIndexName()).setTypes(
 				index.getTypes()).execute().actionGet().getCount();
@@ -315,8 +343,7 @@ public class ElasticsearchIndexTest {
 
 		// now add the statements through the repo
 		// add statements with context
-		SailRepositoryConnection connection = repository.getConnection();
-		try {
+		try (SailRepositoryConnection connection = repository.getConnection();) {
 			connection.begin();
 			connection.add(statementContext111, statementContext111.getContext());
 			connection.add(statementContext121, statementContext121.getContext());
@@ -344,7 +371,6 @@ public class ElasticsearchIndexTest {
 		}
 		finally {
 			// close repo
-			connection.close();
 			repository.shutDown();
 		}
 	}
@@ -373,8 +399,7 @@ public class ElasticsearchIndexTest {
 
 		// now add the statements through the repo
 		// add statements with context
-		SailRepositoryConnection connection = repository.getConnection();
-		try {
+		try (SailRepositoryConnection connection = repository.getConnection();) {
 			connection.begin();
 			connection.add(statementContext111, statementContext111.getContext());
 			connection.add(statementContext121, statementContext121.getContext());
@@ -402,7 +427,6 @@ public class ElasticsearchIndexTest {
 		}
 		finally {
 			// close repo
-			connection.close();
 			repository.shutDown();
 		}
 	}

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.UUID;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -115,7 +114,7 @@ public class ElasticsearchIndexTest {
 	{
 		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
 		Properties sailProperties = new Properties();
-		sailProperties.put(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
+		sailProperties.put(ElasticsearchIndex.INDEX_NAME_KEY, ElasticsearchTestUtils.getNextTestIndexName());
 		testDir = tempDir.newFolder("elasticsearchindextest").toPath();
 		sailProperties.put(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		index = new ElasticsearchIndex();

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashSet;
@@ -23,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.Semaphore;
+import java.util.UUID;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -116,6 +115,7 @@ public class ElasticsearchIndexTest {
 	{
 		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
 		Properties sailProperties = new Properties();
+		sailProperties.put(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
 		testDir = tempDir.newFolder("elasticsearchindextest").toPath();
 		sailProperties.put(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		index = new ElasticsearchIndex();

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -17,16 +18,20 @@ import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailGeoSPARQLTest;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class ElasticsearchSailGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLTest {
 
-	private static final String DATA_DIR = "target/test-data";
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+	private Path testDir;
 
 	@Override
 	protected void configure(LuceneSail sail) {
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
-		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, DATA_DIR);
+		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_NODES_KEY, ">=1");
 	}
@@ -50,10 +55,27 @@ public class ElasticsearchSailGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLT
 	}
 
 	@Override
+	public void setUp()
+		throws Exception
+	{
+		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
+		testDir = tempDir.newFolder("elasticsearch-geosparqltest").toPath();
+		super.setUp();
+	}
+
+	@Override
 	public void tearDown()
 		throws IOException, RepositoryException
 	{
-		super.tearDown();
-		FileSystemUtils.deleteRecursively(new File(DATA_DIR));
+		try {
+			super.tearDown();
+		}
+		finally {
+			try {
+				FileSystemUtils.deleteRecursively(testDir.toFile());
+			} finally {
+				ElasticsearchTestUtils.TEST_SEMAPHORE.release();
+			}
+		}
 	}
 }

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
@@ -9,7 +9,6 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.UUID;
 
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -30,7 +29,7 @@ public class ElasticsearchSailGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLT
 
 	@Override
 	protected void configure(LuceneSail sail) {
-		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
+		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, ElasticsearchTestUtils.getNextTestIndexName());
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
@@ -59,7 +59,7 @@ public class ElasticsearchSailGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLT
 		throws Exception
 	{
 		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
-		testDir = tempDir.newFolder("elasticsearch-geosparqltest").toPath();
+		testDir = tempDir.newFolder("es-gs-test").toPath();
 		super.setUp();
 	}
 

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
@@ -7,9 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearch;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.UUID;
 
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -30,6 +30,7 @@ public class ElasticsearchSailGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLT
 
 	@Override
 	protected void configure(LuceneSail sail) {
+		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
@@ -9,7 +9,6 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailIndexedPropertiesTest;
@@ -27,7 +26,7 @@ public class ElasticsearchSailIndexedPropertiesTest extends AbstractLuceneSailIn
 
 	@Override
 	protected void configure(LuceneSail sail) {
-		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
+		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, ElasticsearchTestUtils.getNextTestIndexName());
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 	}

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
@@ -36,7 +36,7 @@ public class ElasticsearchSailIndexedPropertiesTest extends AbstractLuceneSailIn
 		throws Exception
 	{
 		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
-		testDir = tempDir.newFolder("elasticsearch-indexedpropertiestest").toPath();
+		testDir = tempDir.newFolder("es-ip-test").toPath();
 		super.setUp();
 	}
 

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailIndexedPropertiesTest;
@@ -26,6 +27,7 @@ public class ElasticsearchSailIndexedPropertiesTest extends AbstractLuceneSailIn
 
 	@Override
 	protected void configure(LuceneSail sail) {
+		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 	}

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailSpinTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailSpinTest.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
-import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailSpinTest;
@@ -54,7 +53,7 @@ public class ElasticsearchSailSpinTest extends AbstractLuceneSailSpinTest {
 
 	@Override
 	protected void configure(Properties parameters) {
-		parameters.setProperty(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
+		parameters.setProperty(ElasticsearchIndex.INDEX_NAME_KEY, ElasticsearchTestUtils.getNextTestIndexName());
 		parameters.setProperty(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		parameters.setProperty(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		parameters.setProperty(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailSpinTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailSpinTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
+import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailSpinTest;
@@ -53,6 +54,7 @@ public class ElasticsearchSailSpinTest extends AbstractLuceneSailSpinTest {
 
 	@Override
 	protected void configure(Properties parameters) {
+		parameters.setProperty(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
 		parameters.setProperty(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		parameters.setProperty(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		parameters.setProperty(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailSpinTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailSpinTest.java
@@ -30,7 +30,7 @@ public class ElasticsearchSailSpinTest extends AbstractLuceneSailSpinTest {
 		throws Exception
 	{
 		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
-		testDir = tempDir.newFolder("elasticsearch-sailspintest").toPath();
+		testDir = tempDir.newFolder("es-ss-test").toPath();
 		super.setUp();
 	}
 

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailSpinTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailSpinTest.java
@@ -7,32 +7,54 @@
  */
 package org.eclipse.rdf4j.sail.elasticsearch;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Properties;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailSpinTest;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.elasticsearch.common.io.FileSystemUtils;
-import org.junit.After;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class ElasticsearchSailSpinTest extends AbstractLuceneSailSpinTest {
 
-	private static final String DATA_DIR = "target/test-data";
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
 
-	@After
+	private Path testDir;
+
+	@Override
+	public void setUp()
+		throws Exception
+	{
+		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
+		testDir = tempDir.newFolder("elasticsearch-sailspintest").toPath();
+		super.setUp();
+	}
+
+	@Override
 	public void tearDown()
 		throws RepositoryException, IOException
 	{
-		super.tearDown();
-		FileSystemUtils.deleteRecursively(new File(DATA_DIR));
+		try {
+			super.tearDown();
+		}
+		finally {
+			try {
+				FileSystemUtils.deleteRecursively(testDir.toFile());
+			}
+			finally {
+				ElasticsearchTestUtils.TEST_SEMAPHORE.release();
+			}
+		}
 	}
 
 	@Override
 	protected void configure(Properties parameters) {
 		parameters.setProperty(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
-		parameters.setProperty(LuceneSail.LUCENE_DIR_KEY, DATA_DIR);
+		parameters.setProperty(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		parameters.setProperty(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");
 		parameters.setProperty(ElasticsearchIndex.WAIT_FOR_NODES_KEY, ">=1");
 	}

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
@@ -9,7 +9,6 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTest;
@@ -31,7 +30,7 @@ public class ElasticsearchSailTest extends AbstractLuceneSailTest {
 
 	@Override
 	protected void configure(LuceneSail sail) {
-		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
+		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, ElasticsearchTestUtils.getNextTestIndexName());
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTest;
@@ -30,6 +31,7 @@ public class ElasticsearchSailTest extends AbstractLuceneSailTest {
 
 	@Override
 	protected void configure(LuceneSail sail) {
+		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
@@ -7,36 +7,60 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearch;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTest;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.elasticsearch.common.io.FileSystemUtils;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ElasticsearchSailTest extends AbstractLuceneSailTest {
 
-	private static final String DATA_DIR = "target/test-data";
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
 
-        private Logger log = LoggerFactory.getLogger(getClass());
+	private Path testDir;
+
+	private Logger log = LoggerFactory.getLogger(getClass());
 
 	@Override
 	protected void configure(LuceneSail sail) {
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
-		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, DATA_DIR);
+		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_NODES_KEY, ">=1");
-		log.debug("******* \t Data dir: {}", DATA_DIR);
+		log.debug("******* \t Data dir: {}", testDir.toAbsolutePath().toString());
+	}
+
+	@Override
+	public void setUp()
+		throws Exception
+	{
+		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
+		testDir = tempDir.newFolder("elasticsearch-sailspintest").toPath();
+		super.setUp();
 	}
 
 	@Override
 	public void tearDown()
-		throws IOException, RepositoryException
+		throws RepositoryException, IOException
 	{
-		super.tearDown();
-		FileSystemUtils.deleteRecursively(new File(DATA_DIR));
+		try {
+			super.tearDown();
+		}
+		finally {
+			try {
+				FileSystemUtils.deleteRecursively(testDir.toFile());
+			}
+			finally {
+				ElasticsearchTestUtils.TEST_SEMAPHORE.release();
+			}
+		}
 	}
+
 }

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
@@ -43,7 +43,7 @@ public class ElasticsearchSailTest extends AbstractLuceneSailTest {
 		throws Exception
 	{
 		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
-		testDir = tempDir.newFolder("elasticsearch-sailspintest").toPath();
+		testDir = tempDir.newFolder("es-sail-test").toPath();
 		super.setUp();
 	}
 

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTupleFunctionTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTupleFunctionTest.java
@@ -29,7 +29,7 @@ public class ElasticsearchSailTupleFunctionTest extends AbstractLuceneSailTupleF
 		throws Exception
 	{
 		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
-		testDir = tempDir.newFolder("elasticsearch-sailspintest").toPath();
+		testDir = tempDir.newFolder("es-stf-test").toPath();
 		super.setUp();
 	}
 

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTupleFunctionTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTupleFunctionTest.java
@@ -7,34 +7,53 @@
  */
 package org.eclipse.rdf4j.sail.elasticsearch;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTupleFunctionTest;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.elasticsearch.common.io.FileSystemUtils;
-import org.junit.After;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class ElasticsearchSailTupleFunctionTest extends AbstractLuceneSailTupleFunctionTest {
 
-	private static final String DATA_DIR = "target/test-data";
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
 
-	private Logger log = LoggerFactory.getLogger(getClass());
+	private Path testDir;
 
-	@After
+	@Override
+	public void setUp()
+		throws Exception
+	{
+		ElasticsearchTestUtils.TEST_SEMAPHORE.acquire();
+		testDir = tempDir.newFolder("elasticsearch-sailspintest").toPath();
+		super.setUp();
+	}
+
+	@Override
 	public void tearDown()
 		throws RepositoryException, IOException
 	{
-		super.tearDown();
-		FileSystemUtils.deleteRecursively(new File(DATA_DIR));
+		try {
+			super.tearDown();
+		}
+		finally {
+			try {
+				FileSystemUtils.deleteRecursively(testDir.toFile());
+			}
+			finally {
+				ElasticsearchTestUtils.TEST_SEMAPHORE.release();
+			}
+		}
 	}
 
 	@Override
 	protected void configure(LuceneSail sail) {
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
-		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, DATA_DIR);
+		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_NODES_KEY, ">=1");
 	}

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTupleFunctionTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTupleFunctionTest.java
@@ -9,7 +9,6 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTupleFunctionTest;
@@ -53,7 +52,7 @@ public class ElasticsearchSailTupleFunctionTest extends AbstractLuceneSailTupleF
 
 	@Override
 	protected void configure(LuceneSail sail) {
-		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
+		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, ElasticsearchTestUtils.getNextTestIndexName());
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTupleFunctionTest.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTupleFunctionTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTupleFunctionTest;
@@ -52,6 +53,7 @@ public class ElasticsearchSailTupleFunctionTest extends AbstractLuceneSailTupleF
 
 	@Override
 	protected void configure(LuceneSail sail) {
+		sail.setParameter(ElasticsearchIndex.INDEX_NAME_KEY, UUID.randomUUID().toString());
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, ElasticsearchIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, testDir.toAbsolutePath().toString());
 		sail.setParameter(ElasticsearchIndex.WAIT_FOR_STATUS_KEY, "green");

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchTestUtils.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchTestUtils.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ElasticsearchTestUtils {
 
@@ -15,6 +16,14 @@ public class ElasticsearchTestUtils {
 	 * ElasticSearch shares/exposes a number of services at the JVM level. This Semaphore ensures that only a
 	 * single one of our tests is attempting to work with the ElasticSearch APIs at one time.
 	 */
-	public static Semaphore TEST_SEMAPHORE = new Semaphore(1);
+	public static final Semaphore TEST_SEMAPHORE = new Semaphore(1);
 
+	/**
+	 * Counter used to uniquely name test indexes without using UUID's that may be causing path length issues.
+	 */
+	private static final AtomicLong TEST_COUNTER = new AtomicLong(0);
+	
+	public static String getNextTestIndexName() {
+		return "rdf4j-elasticsearch-testindex-" + TEST_COUNTER.incrementAndGet();
+	}
 }

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchTestUtils.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchTestUtils.java
@@ -24,6 +24,6 @@ public class ElasticsearchTestUtils {
 	private static final AtomicLong TEST_COUNTER = new AtomicLong(0);
 	
 	public static String getNextTestIndexName() {
-		return "rdf4j-elasticsearch-testindex-" + TEST_COUNTER.incrementAndGet();
+		return "rdf4j-es-testindex-" + TEST_COUNTER.incrementAndGet();
 	}
 }

--- a/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchTestUtils.java
+++ b/core/sail/fts/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchTestUtils.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.elasticsearch;
+
+import java.util.concurrent.Semaphore;
+
+public class ElasticsearchTestUtils {
+
+	/**
+	 * ElasticSearch shares/exposes a number of services at the JVM level. This Semaphore ensures that only a
+	 * single one of our tests is attempting to work with the ElasticSearch APIs at one time.
+	 */
+	public static Semaphore TEST_SEMAPHORE = new Semaphore(1);
+
+}

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 
 	@Before
 	public void setUp()
-		throws IOException, RepositoryException
+		throws Exception
 	{
 		// setup a LuceneSail
 		MemoryStore memoryStore = new MemoryStore();

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
@@ -127,11 +127,15 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 	public void tearDown()
 		throws IOException, RepositoryException
 	{
-		if (connection != null) {
-			connection.close();
+		try {
+			if (connection != null) {
+				connection.close();
+			}
 		}
-		if (repository != null) {
-			repository.shutDown();
+		finally {
+			if (repository != null) {
+				repository.shutDown();
+			}
 		}
 	}
 

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailIndexedPropertiesTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailIndexedPropertiesTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractLuceneSailIndexedPropertiesTest {
 
 	@Before
 	public void setUp()
-		throws IOException, RepositoryException
+		throws Exception
 	{
 		// setup a LuceneSail
 		MemoryStore memoryStore = new MemoryStore();

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailIndexedPropertiesTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailIndexedPropertiesTest.java
@@ -125,8 +125,16 @@ public abstract class AbstractLuceneSailIndexedPropertiesTest {
 	public void tearDown()
 		throws IOException, RepositoryException
 	{
-		connection.close();
-		repository.shutDown();
+		try {
+			if (connection != null) {
+				connection.close();
+			}
+		}
+		finally {
+			if (repository != null) {
+				repository.shutDown();
+			}
+		}
 	}
 
 	@Test

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailSpinTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailSpinTest.java
@@ -60,6 +60,8 @@ public abstract class AbstractLuceneSailSpinTest {
 
 	private RepositoryConnection connection;
 
+	private SearchIndex searchIndex;
+
 	@Before
 	public void setUp()
 		throws Exception
@@ -74,7 +76,7 @@ public abstract class AbstractLuceneSailSpinTest {
 		// add Lucene support
 		Properties parameters = new Properties();
 		configure(parameters);
-		SearchIndex searchIndex = LuceneSail.createSearchIndex(parameters);
+		searchIndex = LuceneSail.createSearchIndex(parameters);
 		spin.addQueryContextInitializer(new SearchIndexQueryContextInitializer(searchIndex));
 		repository = new SailRepository(spin);
 		repository.initialize();
@@ -98,8 +100,15 @@ public abstract class AbstractLuceneSailSpinTest {
 			}
 		}
 		finally {
-			if (repository != null) {
-				repository.shutDown();
+			try {
+				if (repository != null) {
+					repository.shutDown();
+				}
+			}
+			finally {
+				if (searchIndex != null) {
+					searchIndex.shutDown();
+				}
 			}
 		}
 	}

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailSpinTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailSpinTest.java
@@ -92,8 +92,12 @@ public abstract class AbstractLuceneSailSpinTest {
 	public void tearDown()
 		throws IOException, RepositoryException
 	{
-		connection.close();
-		repository.shutDown();
+		try {
+			connection.close();
+		}
+		finally {
+			repository.shutDown();
+		}
 	}
 
 	protected abstract void configure(Properties parameters);

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailSpinTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailSpinTest.java
@@ -93,10 +93,14 @@ public abstract class AbstractLuceneSailSpinTest {
 		throws IOException, RepositoryException
 	{
 		try {
-			connection.close();
+			if (connection != null) {
+				connection.close();
+			}
 		}
 		finally {
-			repository.shutDown();
+			if (repository != null) {
+				repository.shutDown();
+			}
 		}
 	}
 

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
@@ -108,7 +108,7 @@ public abstract class AbstractLuceneSailTest {
 
 	@Before
 	public void setUp()
-		throws IOException, RepositoryException
+		throws Exception
 	{
 		// set logging, uncomment this to get better logging for debugging
 		// org.apache.log4j.BasicConfigurator.configure();

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
@@ -147,11 +147,15 @@ public abstract class AbstractLuceneSailTest {
 	public void tearDown()
 		throws IOException, RepositoryException
 	{
-		if (connection != null) {
-			connection.close();
+		try {
+			if (connection != null) {
+				connection.close();
+			}
 		}
-		if (repository != null) {
-			repository.shutDown();
+		finally {
+			if (repository != null) {
+				repository.shutDown();
+			}
 		}
 	}
 

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTupleFunctionTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTupleFunctionTest.java
@@ -92,8 +92,12 @@ public abstract class AbstractLuceneSailTupleFunctionTest {
 	public void tearDown()
 		throws IOException, RepositoryException
 	{
-		connection.close();
-		repository.shutDown();
+		try {
+			connection.close();
+		}
+		finally {
+			repository.shutDown();
+		}
 	}
 
 	protected abstract void configure(LuceneSail sail);

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTupleFunctionTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTupleFunctionTest.java
@@ -93,10 +93,14 @@ public abstract class AbstractLuceneSailTupleFunctionTest {
 		throws IOException, RepositoryException
 	{
 		try {
-			connection.close();
+			if (connection != null) {
+				connection.close();
+			}
 		}
 		finally {
-			repository.shutDown();
+			if (repository != null) {
+				repository.shutDown();
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR addresses GitHub issue: #698 .

Briefly describe the changes proposed in this PR:

* Fix the use of shared directories across all elastic search tests
* Add a global semaphore to ensure that JUnit never runs multiple tests through at once, given the use of global JVM state by the ElasticSearch libraries
* Use try-finally to reliably attempt to clean up resources

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>