### PR TITLE
Fix #703: service clause bind clause varname fix + unit test

### DIFF
--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Service.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Service.java
@@ -214,8 +214,9 @@ public class Service extends UnaryTupleOperator {
 				throws RuntimeException
 			{
 				// take only real vars, i.e. ignore blank nodes
-				if (!node.hasValue() && !node.isAnonymous())
+				if (!node.hasValue() && !node.isAnonymous()) {
 					res.add(node.getName());
+				}
 			}
 			
 			@Override
@@ -225,6 +226,7 @@ public class Service extends UnaryTupleOperator {
 			
 			@Override
 			public void meet(Extension e) {
+				super.meet(e);
 				for (ExtensionElem elem: e.getElements()) {
 					res.add(elem.getName());
 				}


### PR DESCRIPTION
This PR addresses GitHub issue: #703 .

Briefly describe the changes proposed in this PR:

* `Service.computeServiceVars` now also visits all descendents of `Extension` objects.
* added unit test, greenlines after fix.
* update test case javadoc
