### PR TITLE
Fix #686: parser now processes subselect wildcards in update operations

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParser.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParser.java
@@ -78,6 +78,7 @@ public class SPARQLParser implements QueryParser {
 
 				StringEscapesProcessor.process(uc);
 				BaseDeclProcessor.process(uc, baseURI);
+				WildcardProjectionProcessor.process(uc);
 
 				// do a special dance to handle prefix declarations in sequences: if
 				// the current

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
@@ -37,7 +37,6 @@ import org.eclipse.rdf4j.query.parser.sparql.ast.ASTDeleteData;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTDeleteWhere;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTDrop;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTGraphOrDefault;
-import org.eclipse.rdf4j.query.parser.sparql.ast.ASTGraphPatternGroup;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTGraphRefAll;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTInsertClause;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTInsertData;
@@ -47,11 +46,12 @@ import org.eclipse.rdf4j.query.parser.sparql.ast.ASTMove;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTQuadsNotTriples;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTUnparsedQuadDataBlock;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTUpdate;
+import org.eclipse.rdf4j.query.parser.sparql.ast.ASTWhereClause;
 import org.eclipse.rdf4j.query.parser.sparql.ast.VisitorException;
 
 /**
  * Extension of TupleExprBuilder that builds Update Expressions.
- * 
+ *
  * @author Jeen Broekstra
  */
 public class UpdateExprBuilder extends TupleExprBuilder {
@@ -83,7 +83,7 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 	{
 		ASTUnparsedQuadDataBlock dataBlock = node.jjtGetChild(ASTUnparsedQuadDataBlock.class);
 		InsertData insertData = new InsertData(dataBlock.getDataBlock());
-		
+
 		insertData.setLineNumberOffset(dataBlock.getAddedDefaultPrefixes());
 		return insertData;
 	}
@@ -95,7 +95,7 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 
 		ASTUnparsedQuadDataBlock dataBlock = node.jjtGetChild(ASTUnparsedQuadDataBlock.class);
 		DeleteData deleteData = new DeleteData(dataBlock.getDataBlock());
-		
+
 		deleteData.setLineNumberOffset(dataBlock.getAddedDefaultPrefixes());
 		return deleteData;
 
@@ -312,7 +312,7 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 	public Modify visit(ASTModify node, Object data)
 		throws VisitorException
 	{
-		ASTGraphPatternGroup whereClause = node.getWhereClause();
+		ASTWhereClause whereClause = node.getWhereClause();
 
 		TupleExpr where = null;
 		if (whereClause != null) {

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTModify.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTModify.java
@@ -43,9 +43,5 @@ public class ASTModify extends ASTUpdate {
 		}
 	}
 
-	public ASTGraphPatternGroup getWhereClause() {
-		return jjtGetChild(ASTGraphPatternGroup.class);
-	}
-
 }
 /* JavaCC - OriginalChecksum=9460d42e4f84afaf785d4073d7125899 (do not edit this line) */

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTOperation.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTOperation.java
@@ -33,4 +33,7 @@ public abstract class ASTOperation extends SimpleNode {
 		return jjtGetChildren(ASTDatasetClause.class);
 	}
 
+	public ASTWhereClause getWhereClause() {
+		return jjtGetChild(ASTWhereClause.class);
+	}
 }

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTQuery.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTQuery.java
@@ -17,10 +17,6 @@ public abstract class ASTQuery extends ASTOperation {
 		super(p, id);
 	}
 
-	public ASTWhereClause getWhereClause() {
-		return jjtGetChild(ASTWhereClause.class);
-	}
-
 	public ASTOrderClause getOrderClause() {
 		return jjtGetChild(ASTOrderClause.class);
 	}

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTUnparsedQuadDataBlock.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTUnparsedQuadDataBlock.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.query.parser.sparql.ast;
 public class ASTUnparsedQuadDataBlock extends SimpleNode {
 
 	private String dataBlock;
+
 	private int addedDefaultPrefixes;
 
 	public ASTUnparsedQuadDataBlock(int id) {
@@ -43,7 +44,7 @@ public class ASTUnparsedQuadDataBlock extends SimpleNode {
 	public void setAddedDefaultPrefixes(int defaultPrefixesAdded) {
 		this.addedDefaultPrefixes = defaultPrefixesAdded;
 	}
-	
+
 	public int getAddedDefaultPrefixes() {
 		return addedDefaultPrefixes;
 	}

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SyntaxTreeBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SyntaxTreeBuilder.java
@@ -8010,6 +8010,38 @@ public class SyntaxTreeBuilder/*@bgen(jjtree)*/implements SyntaxTreeBuilderTreeC
     }
   }
 
+/*
+ * WHERE keyword is required in modify operations
+ */
+  final public void ModifyWhereClause() throws ParseException {
+ /*@bgen(jjtree) WhereClause */
+  ASTWhereClause jjtn000 = new ASTWhereClause(JJTWHERECLAUSE);
+  boolean jjtc000 = true;
+  jjtree.openNodeScope(jjtn000);
+    try {
+      jj_consume_token(WHERE);
+      GroupGraphPattern();
+    } catch (Throwable jjte000) {
+           if (jjtc000) {
+             jjtree.clearNodeScope(jjtn000);
+             jjtc000 = false;
+           } else {
+             jjtree.popNode();
+           }
+           if (jjte000 instanceof RuntimeException) {
+             {if (true) throw (RuntimeException)jjte000;}
+           }
+           if (jjte000 instanceof ParseException) {
+             {if (true) throw (ParseException)jjte000;}
+           }
+           {if (true) throw (Error)jjte000;}
+    } finally {
+           if (jjtc000) {
+             jjtree.closeNodeScope(jjtn000, true);
+           }
+    }
+  }
+
   final public void Modify() throws ParseException {
  /*@bgen(jjtree) Modify */
   ASTModify jjtn000 = new ASTModify(JJTMODIFY);
@@ -8056,8 +8088,7 @@ public class SyntaxTreeBuilder/*@bgen(jjtree)*/implements SyntaxTreeBuilderTreeC
         }
         UsingClause();
       }
-      jj_consume_token(WHERE);
-      GroupGraphPattern();
+      ModifyWhereClause();
     } catch (Throwable jjte000) {
       if (jjtc000) {
         jjtree.clearNodeScope(jjtn000);
@@ -8126,6 +8157,16 @@ public class SyntaxTreeBuilder/*@bgen(jjtree)*/implements SyntaxTreeBuilderTreeC
     try { return !jj_3_7(); }
     catch(LookaheadSuccess ls) { return true; }
     finally { jj_save(6, xla); }
+  }
+
+  private boolean jj_3R_61() {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(147)) {
+    jj_scanpos = xsp;
+    if (jj_scan_token(146)) return true;
+    }
+    return false;
   }
 
   private boolean jj_3R_57() {
@@ -8609,16 +8650,6 @@ public class SyntaxTreeBuilder/*@bgen(jjtree)*/implements SyntaxTreeBuilderTreeC
 
   private boolean jj_3R_67() {
     if (jj_scan_token(LBRACK)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_61() {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(147)) {
-    jj_scanpos = xsp;
-    if (jj_scan_token(146)) return true;
-    }
     return false;
   }
 

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/sparql.jjt
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/sparql.jjt
@@ -23,7 +23,6 @@ options {
 }
 
 PARSER_BEGIN(SyntaxTreeBuilder)
-
 package org.eclipse.rdf4j.query.parser.sparql.ast;
 
 import java.io.StringReader;
@@ -1874,10 +1873,19 @@ void WithClause() #DatasetClause :
     <WITH> IRIref()
 }
 
+/*
+ * WHERE keyword is required in modify operations
+ */
+void ModifyWhereClause() #WhereClause :
+{}
+{
+	 <WHERE> GroupGraphPattern()
+}
+
 void Modify() :
 {}
 {
     [ WithClause() ] 
     ( DeleteClause() [InsertClause()] | InsertClause() ) (UsingClause())* 
-    <WHERE> GroupGraphPattern()
+    ModifyWhereClause()
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #686 .

Briefly describe the changes proposed in this PR:

* SPARQLParser now applies WildcardProjectionProcessor to update as well as queries
* SPARQL Grammar adapted so an ASTWhereClause is generated for modify updates
* added regression test
