### PR TITLE
Fix #710: skip install step in travis, added ‘clean’ goal for extra insurance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+install: true
 language: java
 jdk:
   - oraclejdk8
-script: mvn verify
+script: mvn clean verify
 branches:
   only:
   - master


### PR DESCRIPTION
This PR addresses GitHub issue: #710 .

Briefly describe the changes proposed in this PR:

* disabled execution of pre-build install step since this is automatically handled by the build/verify command
* added 'clean' goal to build command (not strictly necessary but a bit more future-proof)

