### PR TITLE
Fix #719: build configuration tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ branches:
   only:
   - master
   - /^releases.*$/
+env:
+  - MAVEN_OPTS=-Xmx1024M

--- a/pom.xml
+++ b/pom.xml
@@ -659,7 +659,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>3.0.2</version>
+					<version>2.3.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -610,12 +610,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>2.4.1</version>
+					<version>3.0.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.3.2</version>
+					<version>3.6.0</version>
 					<configuration>
 						<fork>true</fork>
 						<source>1.8</source>
@@ -659,7 +659,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.3.1</version>
+					<version>3.0.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -682,7 +682,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.17</version>
+					<version>2.19.1</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 						<argLine>-Xmx1024M ${hudson.rdf4j.proxy.opts}</argLine>
@@ -691,7 +691,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.17</version>
+					<version>2.19.1</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 						<forkCount>1</forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -683,6 +683,10 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.17</version>
+					<configuration>
+						<encoding>UTF-8</encoding>
+						<argLine>-Xmx1024M ${hudson.rdf4j.proxy.opts}</argLine>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -692,7 +696,7 @@
 						<encoding>UTF-8</encoding>
 						<forkCount>1</forkCount>
 						<reuseForks>false</reuseForks>
-						<argLine>-Xmx1024M -XX:MaxPermSize=256M ${hudson.rdf4j.proxy.opts}</argLine>
+						<argLine>-Xmx1024M ${hudson.rdf4j.proxy.opts}</argLine>
 						<includes>
 							<include>**/*Test.java</include>
 						</includes>


### PR DESCRIPTION
This PR addresses GitHub issue: #719 .

Briefly describe the changes proposed in this PR:

* maven failsafe and surefire plugins both use increased heap space for forked jvms 
* obsolete MaxPermSize parameter removed
* bumped versions of various core build / test plugins (compiler, jar, clean, failsafe, surefire). 
* travis environment tweaked to set default maven heap size to 1G 
