### PR TITLE
Fix #678: removed hashcode implementation details from javadoc

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/BNode.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/BNode.java
@@ -32,12 +32,14 @@ public interface BNode extends Resource {
 	 * @return <tt>true</tt> if the other object is an instance of {@link BNode} and their IDs are equal,
 	 *         <tt>false</tt> otherwise.
 	 */
+	@Override
 	public boolean equals(Object o);
 
 	/**
-	 * The hash code of a blank node.
+	 * Returns the hash code value of the blank node.
 	 * 
 	 * @return A hash code for the blank node.
 	 */
+	@Override
 	public int hashCode();
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/BNode.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/BNode.java
@@ -35,7 +35,7 @@ public interface BNode extends Resource {
 	public boolean equals(Object o);
 
 	/**
-	 * The hash code of a blank node is defined as the hash code of its identifier: <tt>id.hashCode()</tt>.
+	 * The hash code of a blank node.
 	 * 
 	 * @return A hash code for the blank node.
 	 */

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/IRI.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/IRI.java
@@ -60,12 +60,14 @@ public interface IRI extends URI, Resource {
 	 * @return <tt>true</tt> if the other object is an instance of {@link IRI} and their
 	 *         String-representations are equal, <tt>false</tt> otherwise.
 	 */
+	@Override
 	public boolean equals(Object o);
 
 	/**
-	 * The hash code of an IRI.
+	 * Returns the hash code value of the IRI.
 	 * 
 	 * @return A hash code for the IRI.
 	 */
+	@Override
 	public int hashCode();
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/IRI.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/IRI.java
@@ -63,8 +63,7 @@ public interface IRI extends URI, Resource {
 	public boolean equals(Object o);
 
 	/**
-	 * The hash code of an IRI is defined as the hash code of its String-representation:
-	 * <tt>toString().hashCode</tt>.
+	 * The hash code of an IRI.
 	 * 
 	 * @return A hash code for the IRI.
 	 */

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/Literal.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/Literal.java
@@ -60,7 +60,7 @@ public interface Literal extends Value {
 	public boolean equals(Object other);
 
 	/**
-	 * Returns the literal's hash code. 
+	 * Returns hash code value of the Literal. 
 	 * 
 	 * @return A hash code for the literal.
 	 */

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/Literal.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/Literal.java
@@ -60,8 +60,7 @@ public interface Literal extends Value {
 	public boolean equals(Object other);
 
 	/**
-	 * Returns the literal's hash code. The hash code of a literal is defined as the hash code of its label:
-	 * <tt>label.hashCode()</tt>.
+	 * Returns the literal's hash code. 
 	 * 
 	 * @return A hash code for the literal.
 	 */

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/Statement.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/Statement.java
@@ -52,12 +52,14 @@ public interface Statement extends Serializable {
 	 * @return <tt>true</tt> if the other object is an instance of {@link Statement} and if their subjects,
 	 *         predicates, objects and contexts are equal.
 	 */
+	@Override
 	public boolean equals(Object other);
 
 	/**
-	 * The hash code of a statement.
+	 * Return a hash code value for the statement.
 	 * 
 	 * @return A hash code for the statement.
 	 */
+	@Override
 	public int hashCode();
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/URI.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/URI.java
@@ -54,8 +54,7 @@ public interface URI extends Resource {
 	public boolean equals(Object o);
 
 	/**
-	 * The hash code of an URI is defined as the hash code of its String-representation:
-	 * <tt>toString().hashCode</tt>.
+	 * The hash code of an URI.
 	 * 
 	 * @return A hash code for the URI.
 	 */

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/Value.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/Value.java
@@ -16,7 +16,7 @@ public interface Value extends Serializable {
 
 	/**
 	 * Returns the String-value of a <tt>Value</tt> object. This returns either a {@link Literal}'s label, a
-	 * {@link IRI}'s URI or a {@link BNode}'s ID.
+	 * {@link IRI}'s full string-representation or a {@link BNode}'s ID.
 	 */
 	public String stringValue();
 }

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/BindingSet.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/BindingSet.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.model.Value;
 /**
  * A BindingSet is a set of named value bindings, which is used a.o. to represent a single query solution.
  * Values are indexed by name of the binding which typically corresponds to the names of the variables used in
- * the projection of the orginal query.
+ * the projection of the original query.
  */
 public interface BindingSet extends Iterable<Binding>, Serializable {
 
@@ -78,13 +78,17 @@ public interface BindingSet extends Iterable<Binding>, Serializable {
 	 * @return <tt>true</tt> if the other object is an instance of {@link BindingSet} and it contains the same
 	 *         set of bindings (disregarding order), <tt>false</tt> otherwise.
 	 */
+	@Override
 	public boolean equals(Object o);
 
 	/**
-	 * The hash code of a {@link BindingSet}. Note: the calculated hash code intentionally does not depend on
-	 * the order in which the bindings are iterated over.
+	 * Returns the hash code value of the {@link BindingSet}.
+	 * <p/>
+	 * The calculated hash code intentionally does not depend on the order in which the bindings are iterated
+	 * over.
 	 * 
 	 * @return A hash code for the BindingSet.
 	 */
+	@Override
 	public int hashCode();
 }

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/BindingSet.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/BindingSet.java
@@ -81,18 +81,8 @@ public interface BindingSet extends Iterable<Binding>, Serializable {
 	public boolean equals(Object o);
 
 	/**
-	 * The hash code of a binding is defined as the bit-wise XOR of the hash codes of its bindings:
-	 * 
-	 * <pre>
-	 * int hashCode = 0;
-	 *
-	 * for (Binding binding : this) {
-	 * 	hashCode &circ;= binding.getName().hashCode() &circ; binding.getValue().hashCode();
-	 * }
-	 * </pre>
-	 * 
-	 * Note: the calculated hash code intentionally does not depend on the order in which the bindings are
-	 * iterated over.
+	 * The hash code of a {@link BindingSet}. Note: the calculated hash code intentionally does not depend on
+	 * the order in which the bindings are iterated over.
 	 * 
 	 * @return A hash code for the BindingSet.
 	 */


### PR DESCRIPTION
This PR addresses GitHub issue: #678 .

Briefly describe the changes proposed in this PR:

* javadoc for model objects (and `BindingSet`) cleaned up: implementation details of hashcode algorithms removed, added override annotations, reformatted where necessary. 
