### PR TITLE
Fix #539: made automated use of known ns prefixes in queries the default.

### DIFF
--- a/core/console/src/main/java/org/eclipse/rdf4j/console/Console.java
+++ b/core/console/src/main/java/org/eclipse/rdf4j/console/Console.java
@@ -77,7 +77,7 @@ public class Console implements ConsoleState, ConsoleParameters {
 
 	private boolean showPrefix = true;
 
-	private boolean queryPrefix = false;
+	private boolean queryPrefix = true;
 
 	/*----------------*
 	 * Static methods *


### PR DESCRIPTION
This PR addresses GitHub issue: #539 .

Briefly describe the changes proposed in this PR:

* trivial fix to make automatic inclusion of namespace prefixes known in the repository the default.
