### PR TITLE
Fix #729: processing of sesame:nil virtual graph name for DELETE WHERE operations

### DIFF
--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -23,6 +24,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
@@ -536,11 +538,17 @@ public class SailUpdateExecutor {
 	}
 
 	private IRI[] getDefaultRemoveGraphs(Dataset dataset) {
-		if (dataset == null)
+		if (dataset == null) {
 			return new IRI[0];
-		Set<IRI> set = dataset.getDefaultRemoveGraphs();
-		if (set == null || set.isEmpty())
+		}
+		Set<IRI> set = new HashSet<>(dataset.getDefaultRemoveGraphs());
+		if (set.isEmpty()) {
 			return new IRI[0];
+		}
+		if (set.remove(SESAME.NIL)) {
+			set.add(null);
+		}
+
 		return set.toArray(new IRI[set.size()]);
 	}
 
@@ -672,7 +680,12 @@ public class SailUpdateExecutor {
 				}
 
 				if (context != null) {
-					con.removeStatement(uc, subject, predicate, object, context);
+					if (SESAME.NIL.equals(context)) {
+						con.removeStatement(uc, subject, predicate, object, (Resource)null);
+					}
+					else {
+						con.removeStatement(uc, subject, predicate, object, context);
+					}
 				}
 				else {
 					IRI[] remove = getDefaultRemoveGraphs(uc.getDataset());

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateTest.java
@@ -115,93 +115,108 @@ public abstract class SPARQLUpdateTest {
 	/* test methods */
 
 	@Test
-	public void testDeleteFromDefaultGraph() throws Exception {
-		
+	public void testDeleteFromDefaultGraph()
+		throws Exception
+	{
+
 		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST);
 		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST, RDF.ALT);
 		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST, RDF.BAG);
-		
+
 		StringBuilder update = new StringBuilder();
 		update.append(getNamespaceDeclarations());
 		update.append("DELETE { GRAPH sesame:nil { ?s ?p ?o } } WHERE { GRAPH rdf:Alt { ?s ?p ?o } }");
-		
+
 		Update operation = con.prepareUpdate(QueryLanguage.SPARQL, update.toString());
 		operation.execute();
 
-		assertTrue(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, RDF.ALT));
-		assertTrue(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, RDF.BAG));
-		assertFalse(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, SESAME.NIL));
-		assertFalse(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, (Resource)null));
+		assertTrue(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF.ALT));
+		assertTrue(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF.BAG));
+		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, SESAME.NIL));
+		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, (Resource)null));
 	}
-	
+
 	@Test
-	public void testDeleteFromDefaultGraphUsingWith() throws Exception {
-		
+	public void testDeleteFromDefaultGraphUsingWith()
+		throws Exception
+	{
+
 		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST);
 		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST, RDF.ALT);
 		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST, RDF.BAG);
-		
+
 		StringBuilder update = new StringBuilder();
 		update.append(getNamespaceDeclarations());
 		update.append("WITH sesame:nil DELETE { ?s ?p ?o  } WHERE { ?s ?p ?o }");
-		
+
 		Update operation = con.prepareUpdate(QueryLanguage.SPARQL, update.toString());
 		operation.execute();
 
-		assertTrue(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, RDF.ALT));
-		assertTrue(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, RDF.BAG));
-		assertFalse(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, SESAME.NIL));
-		assertFalse(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, (Resource)null));
+		assertTrue(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF.ALT));
+		assertTrue(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF.BAG));
+		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, SESAME.NIL));
+		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, (Resource)null));
 	}
-	
+
 	@Test
-	public void testInsertWhereInvalidTriple() throws Exception {
+	public void testInsertWhereInvalidTriple()
+		throws Exception
+	{
 		StringBuilder update = new StringBuilder();
 		update.append(getNamespaceDeclarations());
 		update.append("INSERT {?name a foaf:Person. ?x a <urn:TestSubject>. } WHERE { ?x foaf:name ?name }");
-		
+
 		Update operation = con.prepareUpdate(QueryLanguage.SPARQL, update.toString());
-		
+
 		try {
 			operation.execute();
-		} catch (ClassCastException e) {
+		}
+		catch (ClassCastException e) {
 			fail("subject-literal triple pattern should be silently ignored");
 		}
-		
-		assertTrue(con.hasStatement((Resource)null, RDF.TYPE, con.getValueFactory().createIRI("urn:TestSubject"), true));
+
+		assertTrue(con.hasStatement((Resource)null, RDF.TYPE,
+				con.getValueFactory().createIRI("urn:TestSubject"), true));
 	}
-	
+
 	@Test
-	public void testDeleteWhereInvalidTriple() throws Exception {
+	public void testDeleteWhereInvalidTriple()
+		throws Exception
+	{
 		StringBuilder update = new StringBuilder();
 		update.append(getNamespaceDeclarations());
 		update.append("DELETE {?name a foaf:Person. ?x foaf:name ?name } WHERE { ?x foaf:name ?name }");
-		
+
 		Update operation = con.prepareUpdate(QueryLanguage.SPARQL, update.toString());
-		
+
 		try {
 			operation.execute();
-		} catch (ClassCastException e) {
+		}
+		catch (ClassCastException e) {
 			fail("subject-literal triple pattern should be silently ignored");
 		}
 		assertFalse(con.hasStatement(null, FOAF.NAME, null, true));
 	}
-	
+
 	@Test
-	public void testDeleteInsertWhereInvalidTriple() throws Exception {
+	public void testDeleteInsertWhereInvalidTriple()
+		throws Exception
+	{
 		StringBuilder update = new StringBuilder();
 		update.append(getNamespaceDeclarations());
-		update.append("DELETE {?name a foaf:Person} INSERT {?name a foaf:Agent} WHERE { ?x foaf:name ?name }");
-		
+		update.append(
+				"DELETE {?name a foaf:Person} INSERT {?name a foaf:Agent} WHERE { ?x foaf:name ?name }");
+
 		Update operation = con.prepareUpdate(QueryLanguage.SPARQL, update.toString());
-		
+
 		try {
 			operation.execute();
-		} catch (ClassCastException e) {
+		}
+		catch (ClassCastException e) {
 			fail("subject-literal triple pattern should be silently ignored");
 		}
 	}
-	
+
 	@Test
 	public void testInsertWhere()
 		throws Exception

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateTest.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryLanguage;
@@ -113,6 +114,46 @@ public abstract class SPARQLUpdateTest {
 
 	/* test methods */
 
+	@Test
+	public void testDeleteFromDefaultGraph() throws Exception {
+		
+		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST);
+		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST, RDF.ALT);
+		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST, RDF.BAG);
+		
+		StringBuilder update = new StringBuilder();
+		update.append(getNamespaceDeclarations());
+		update.append("DELETE { GRAPH sesame:nil { ?s ?p ?o } } WHERE { GRAPH rdf:Alt { ?s ?p ?o } }");
+		
+		Update operation = con.prepareUpdate(QueryLanguage.SPARQL, update.toString());
+		operation.execute();
+
+		assertTrue(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, RDF.ALT));
+		assertTrue(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, RDF.BAG));
+		assertFalse(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, SESAME.NIL));
+		assertFalse(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, (Resource)null));
+	}
+	
+	@Test
+	public void testDeleteFromDefaultGraphUsingWith() throws Exception {
+		
+		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST);
+		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST, RDF.ALT);
+		con.add(RDF.FIRST, RDF.FIRST, RDF.FIRST, RDF.BAG);
+		
+		StringBuilder update = new StringBuilder();
+		update.append(getNamespaceDeclarations());
+		update.append("WITH sesame:nil DELETE { ?s ?p ?o  } WHERE { ?s ?p ?o }");
+		
+		Update operation = con.prepareUpdate(QueryLanguage.SPARQL, update.toString());
+		operation.execute();
+
+		assertTrue(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, RDF.ALT));
+		assertTrue(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, RDF.BAG));
+		assertFalse(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, SESAME.NIL));
+		assertFalse(con.hasStatement(RDF.FIRST,  RDF.FIRST,  RDF.FIRST, true, (Resource)null));
+	}
+	
 	@Test
 	public void testInsertWhereInvalidTriple() throws Exception {
 		StringBuilder update = new StringBuilder();


### PR DESCRIPTION
This PR addresses GitHub issue: #729 .

Briefly describe the changes proposed in this PR:

* SailUpdateExecutor now checks presence of `sesame:nil` value as graph name for DELETE clause, and replaces with `null` value.
* added test cases for `DELETE { GRAPH sesame:nil {....` and `WITH sesame:nil DELETE {....` variants.
