### PR TITLE
Fix #181: federation scoping of joins from different graphs

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSPARQL10QueryTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSPARQL10QueryTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.federation;
+
+import junit.framework.Test;
+
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQL10ManifestTest;
+import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQLQueryTest;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.dataset.DatasetRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+
+public class FederationSPARQL10QueryTest extends SPARQLQueryTest {
+
+	public static Test suite()
+		throws Exception
+	{
+		return SPARQL10ManifestTest.suite(new Factory() {
+
+			public FederationSPARQL10QueryTest createSPARQLQueryTest(String testURI, String name,
+					String queryFileURL, String resultFileURL, Dataset dataSet, boolean laxCardinality)
+			{
+				return createSPARQLQueryTest(testURI, name, queryFileURL, resultFileURL, dataSet,
+						laxCardinality, false);
+			}
+
+			public FederationSPARQL10QueryTest createSPARQLQueryTest(String testURI, String name,
+					String queryFileURL, String resultFileURL, Dataset dataSet, boolean laxCardinality,
+					boolean checkOrder)
+			{
+				String[] ignoredTests = {
+						// incompatible with SPARQL 1.1 - syntax for decimals was modified
+						"Basic - Term 6",
+						// incompatible with SPARQL 1.1 - syntax for decimals was modified
+						"Basic - Term 7",
+						// Test is incorrect: assumes timezoned date is comparable with non-timezoned
+						"date-2"};
+
+				return new FederationSPARQL10QueryTest(testURI, name, queryFileURL, resultFileURL, dataSet,
+						laxCardinality, checkOrder, ignoredTests);
+			}
+		});
+
+	}
+
+	protected FederationSPARQL10QueryTest(String testURI, String name, String queryFileURL,
+			String resultFileURL, Dataset dataSet, boolean laxCardinality, String... ignoredTests)
+	{
+		this(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality, false, ignoredTests);
+	}
+
+	protected FederationSPARQL10QueryTest(String testURI, String name, String queryFileURL,
+			String resultFileURL, Dataset dataSet, boolean laxCardinality, boolean checkOrder,
+			String... ignoredTests)
+	{
+		super(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality, checkOrder, ignoredTests);
+	}
+
+	protected Repository newRepository() {
+		Federation sail = new Federation();
+		sail.addMember(new SailRepository(new MemoryStore()));
+		sail.addMember(new SailRepository(new MemoryStore()));
+		sail.addMember(new SailRepository(new MemoryStore()));
+		return new DatasetRepository(new SailRepository(sail));
+	}
+}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSPARQL11QueryTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSPARQL11QueryTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.federation;
+
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQL11ManifestTest;
+import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQLQueryTest;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.dataset.DatasetRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+
+import junit.framework.Test;
+
+public class FederationSPARQL11QueryTest extends SPARQLQueryTest {
+
+	public static Test suite()
+		throws Exception
+	{
+		return SPARQL11ManifestTest.suite(new Factory() {
+
+			public SPARQLQueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
+					String resultFileURL, Dataset dataSet, boolean laxCardinality)
+			{
+				return new FederationSPARQL11QueryTest(testURI, name, queryFileURL, resultFileURL, dataSet,
+						laxCardinality);
+			}
+
+			public SPARQLQueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
+					String resultFileURL, Dataset dataSet, boolean laxCardinality, boolean checkOrder)
+			{
+				String[] ignoredTests = {
+						// test case incompatible with RDF 1.1 - see
+						// http://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0006.html
+						"STRDT   TypeErrors",
+						// test case incompatible with RDF 1.1 - see
+						// http://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0006.html
+						"STRLANG   TypeErrors",
+						// known issue: SES-937
+						"sq03 - Subquery within graph pattern, graph variable is not bound",
+						};
+
+				return new FederationSPARQL11QueryTest(testURI, name, queryFileURL, resultFileURL, dataSet,
+						laxCardinality, checkOrder, ignoredTests);
+			}
+			// skip 'service' tests for now since they require presence of remote sparql endpoints.
+		}, true, true, false, "service");
+	}
+
+	public FederationSPARQL11QueryTest(String testURI, String name, String queryFileURL, String resultFileURL,
+			Dataset dataSet, boolean laxCardinality, String... ignoredTests)
+	{
+		super(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality, ignoredTests);
+	}
+
+	public FederationSPARQL11QueryTest(String testURI, String name, String queryFileURL, String resultFileURL,
+			Dataset dataSet, boolean laxCardinality, boolean checkOrder, String... ignoredTests)
+	{
+		super(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality, checkOrder, ignoredTests);
+	}
+
+	@Override
+	protected Repository newRepository() {
+		Federation sail = new Federation();
+		sail.addMember(new SailRepository(new MemoryStore()));
+		sail.addMember(new SailRepository(new MemoryStore()));
+		sail.addMember(new SailRepository(new MemoryStore()));
+		return new DatasetRepository(new SailRepository(sail));
+	}
+}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -7,69 +7,46 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.federation;
 
-import org.eclipse.rdf4j.query.Dataset;
-import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQL11ManifestTest;
-import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQLQueryTest;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.dataset.DatasetRepository;
+import static org.junit.Assert.assertFalse;
+
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Test;
 
-import junit.framework.Test;
+public class FederationSparqlTest {
 
-public class FederationSparqlTest extends SPARQLQueryTest {
-
-	public static Test suite()
+	@Test
+	public void quickTest()
 		throws Exception
 	{
-		return SPARQL11ManifestTest.suite(new Factory() {
+		SailRepository repo1 = new SailRepository(new MemoryStore());
+		SailRepository repo2 = new SailRepository(new MemoryStore());
+		Federation fed = new Federation();
+		fed.addMember(repo1);
+		fed.addMember(repo2);
+		SailRepository repoFed = new SailRepository(fed);
+		repoFed.initialize();
 
-			public SPARQLQueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
-					String resultFileURL, Dataset dataSet, boolean laxCardinality)
-			{
-				return new FederationSparqlTest(testURI, name, queryFileURL, resultFileURL, dataSet,
-						laxCardinality);
-			}
+		try (RepositoryConnection conn = repo1.getConnection()) {
+			conn.add(getClass().getResource("/testcases-sparql-1.0-w3c/data-r2/algebra/var-scope-join-1.ttl"),
+					null, null, conn.getValueFactory().createIRI("http://example/g1"));
+		}
+		try (RepositoryConnection conn = repo2.getConnection()) {
+			conn.add(getClass().getResource("/testcases-sparql-1.0-w3c/data-r2/algebra/var-scope-join-1.ttl"),
+					null, null, conn.getValueFactory().createIRI("http://example/g2"));
+		}
 
-			public SPARQLQueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
-					String resultFileURL, Dataset dataSet, boolean laxCardinality, boolean checkOrder)
-			{
-				String[] ignoredTests = {
-						// test case incompatible with RDF 1.1 - see
-						// http://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0006.html
-						"STRDT   TypeErrors",
-						// test case incompatible with RDF 1.1 - see
-						// http://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0006.html
-						"STRLANG   TypeErrors",
-						// known issue: SES-937
-						"sq03 - Subquery within graph pattern, graph variable is not bound",
-						};
-
-				return new FederationSparqlTest(testURI, name, queryFileURL, resultFileURL, dataSet,
-						laxCardinality, checkOrder, ignoredTests);
-			}
-			// skip 'service' tests for now since they require presence of remote sparql endpoints.
-		}, true, true, false, "service");
-	}
-
-	public FederationSparqlTest(String testURI, String name, String queryFileURL, String resultFileURL,
-			Dataset dataSet, boolean laxCardinality, String... ignoredTests)
-	{
-		super(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality, ignoredTests);
-	}
-
-	public FederationSparqlTest(String testURI, String name, String queryFileURL, String resultFileURL,
-			Dataset dataSet, boolean laxCardinality, boolean checkOrder, String... ignoredTests)
-	{
-		super(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality, checkOrder, ignoredTests);
-	}
-
-	@Override
-	protected Repository newRepository() {
-		Federation sail = new Federation();
-		sail.addMember(new SailRepository(new MemoryStore()));
-		sail.addMember(new SailRepository(new MemoryStore()));
-		sail.addMember(new SailRepository(new MemoryStore()));
-		return new DatasetRepository(new SailRepository(sail));
+		String query = "PREFIX : <http://example/> SELECT * { graph :g1 {?X  :name 'paul'} { graph :g2 {?Y :name 'george' . OPTIONAL { ?X :email ?Z } } } }";
+		boolean hasResults;
+		try (RepositoryConnection conn = repoFed.getConnection()) {
+			TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
+			TupleQueryResult tqr = tq.evaluate();
+			hasResults = tqr.hasNext();
+		}
+		assertFalse(hasResults);
 	}
 }

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 public class FederationSparqlTest {
 
 	@Test
-	public void quickTest()
+	public void test181Issue()
 		throws Exception
 	{
 		SailRepository repo1 = new SailRepository(new MemoryStore());

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/algebra/OwnedTupleExpr.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/algebra/OwnedTupleExpr.java
@@ -55,6 +55,10 @@ public class OwnedTupleExpr extends UnaryTupleOperator {
 		this.variables = bindings;
 	}
 
+	public TupleQuery getQuery() {
+		return query;
+	}
+
 	public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(Dataset dataset,
 			BindingSet bindings)
 		throws QueryEvaluationException

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/algebra/OwnedTupleExpr.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/algebra/OwnedTupleExpr.java
@@ -55,8 +55,8 @@ public class OwnedTupleExpr extends UnaryTupleOperator {
 		this.variables = bindings;
 	}
 
-	public TupleQuery getQuery() {
-		return query;
+	public boolean hasQuery() {
+		return query != null;
 	}
 
 	public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(Dataset dataset,

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
@@ -91,7 +91,9 @@ public class FederationStrategy extends StrictEvaluationStrategy {
 		for (int i = 1, n = join.getNumberOfArguments(); i < n; i++) {
 
 			TupleExpr rightArg = join.getArg(i);
-			if (TupleExprs.containsProjection(rightArg)) {
+			if (TupleExprs.containsProjection(rightArg)
+					|| (rightArg instanceof OwnedTupleExpr && ((OwnedTupleExpr)rightArg).getQuery() != null))
+			{
 				TupleExpr leftArg = join.getArg(i - 1);
 				collectedBindingNames.addAll(leftArg.getBindingNames());
 				result = new HashJoinIteration(this, result, collectedBindingNames,

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
@@ -92,7 +92,7 @@ public class FederationStrategy extends StrictEvaluationStrategy {
 
 			TupleExpr rightArg = join.getArg(i);
 			if (TupleExprs.containsProjection(rightArg)
-					|| (rightArg instanceof OwnedTupleExpr && ((OwnedTupleExpr)rightArg).getQuery() != null))
+					|| (rightArg instanceof OwnedTupleExpr && ((OwnedTupleExpr)rightArg).hasQuery()))
 			{
 				TupleExpr leftArg = join.getArg(i - 1);
 				collectedBindingNames.addAll(leftArg.getBindingNames());


### PR DESCRIPTION
This PR addresses GitHub issue: #181  .

Briefly describe the changes proposed in this PR:

* Better naming to Federation compliance tests.
* Test case for #181.
* Fix for #181.
