### PR TITLE
issue #732 : Add support for japicmp to core modules

### DIFF
--- a/compliance/store/pom.xml
+++ b/compliance/store/pom.xml
@@ -89,16 +89,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-http-protocol</artifactId>
 			<version>${project.version}</version>
@@ -109,11 +99,6 @@
 			<artifactId>rdf4j-repository-manager</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
-		<!--<dependency>
-			<groupId>info.aduna.appbase</groupId>
-			<artifactId>aduna-appbase-logging-file</artifactId>
-		</dependency>-->
 
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>

--- a/core/http/client/pom.xml
+++ b/core/http/client/pom.xml
@@ -79,5 +79,13 @@
 		</dependency>
 
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -24,5 +24,12 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
-
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/core/query/pom.xml
+++ b/core/query/pom.xml
@@ -31,5 +31,13 @@
 		</dependency>
 		
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/queryalgebra/evaluation/pom.xml
+++ b/core/queryalgebra/evaluation/pom.xml
@@ -69,5 +69,13 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/queryalgebra/model/pom.xml
+++ b/core/queryalgebra/model/pom.xml
@@ -30,5 +30,12 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/core/queryparser/api/pom.xml
+++ b/core/queryparser/api/pom.xml
@@ -34,5 +34,13 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/queryresultio/api/pom.xml
+++ b/core/queryresultio/api/pom.xml
@@ -35,5 +35,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -46,5 +46,12 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/core/repository/http/pom.xml
+++ b/core/repository/http/pom.xml
@@ -66,5 +66,12 @@
 			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
-
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/core/repository/manager/pom.xml
+++ b/core/repository/manager/pom.xml
@@ -82,5 +82,12 @@
 		</dependency>
 		
 	</dependencies>
-
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/core/repository/sail/pom.xml
+++ b/core/repository/sail/pom.xml
@@ -88,5 +88,13 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/repository/sparql/pom.xml
+++ b/core/repository/sparql/pom.xml
@@ -48,5 +48,13 @@ The SPARQL Repository provides a RDF4J Repository interface to any SPARQL end-po
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 	
 </project>

--- a/core/rio/api/pom.xml
+++ b/core/rio/api/pom.xml
@@ -29,5 +29,12 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
-
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/core/sail/api/pom.xml
+++ b/core/sail/api/pom.xml
@@ -40,5 +40,13 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/sail/base/pom.xml
+++ b/core/sail/base/pom.xml
@@ -55,5 +55,13 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/sail/inferencer/pom.xml
+++ b/core/sail/inferencer/pom.xml
@@ -71,5 +71,13 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/sail/memory/pom.xml
+++ b/core/sail/memory/pom.xml
@@ -68,5 +68,12 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/core/sail/model/pom.xml
+++ b/core/sail/model/pom.xml
@@ -20,5 +20,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 
 </project>

--- a/core/sail/nativerdf/pom.xml
+++ b/core/sail/nativerdf/pom.xml
@@ -66,5 +66,12 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
-
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/core/util/pom.xml
+++ b/core/util/pom.xml
@@ -30,5 +30,12 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>com.github.siom79.japicmp</groupId>
+                                <artifactId>japicmp-maven-plugin</artifactId>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
 		<httpcore.version>4.4.4</httpcore.version>
 		<jackson.version>2.8.2</jackson.version>
 		<jsonldjava.version>0.8.3</jsonldjava.version>
+		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
 	</properties>
 
 	<dependencyManagement>
@@ -414,32 +415,6 @@
 						<artifactId>commons-logging</artifactId>
 					</exclusion>
 				</exclusions>
-			</dependency>
-
-			<!-- Compliance tests -->
-			<dependency>
-				<groupId>edu.lehigh.swat.bench</groupId>
-				<artifactId>uba</artifactId>
-				<version>1.7</version>
-			</dependency>
-			<dependency>
-				<groupId>edu.lehigh.swat.bench</groupId>
-				<artifactId>ubt</artifactId>
-				<version>1.1</version>
-			</dependency>
-
-			<!-- JDBC Drivers -->
-
-			<dependency>
-				<groupId>postgresql</groupId>
-				<artifactId>postgresql</artifactId>
-				<version>9.1-901.jdbc4</version>
-			</dependency>
-
-			<dependency>
-				<groupId>mysql</groupId>
-				<artifactId>mysql-connector-java</artifactId>
-				<version>5.1.31</version>
 			</dependency>
 
 			<!-- various -->
@@ -715,21 +690,66 @@
 					<artifactId>tomcat7-maven-plugin</artifactId>
 					<version>2.2</version>
 				</plugin>
+				<plugin>
+					<groupId>com.github.siom79.japicmp</groupId>
+					<artifactId>japicmp-maven-plugin</artifactId>
+					<version>0.9.3</version>
+					<configuration>
+						<oldVersion>
+							<dependency>
+								<groupId>${project.groupId}</groupId>
+								<artifactId>${project.artifactId}</artifactId>
+								<version>${last.japicmp.compare.version}</version>
+								<type>jar</type>
+							</dependency>
+						</oldVersion>
+						<newVersion>
+							<file>
+								<path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
+							</file>
+						</newVersion>
+						<parameter>
+							<onlyModified>true</onlyModified>
+						</parameter>
+					</configuration>
+					<executions>
+						<execution>
+							<phase>verify</phase>
+							<goals>
+								<goal>cmp</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
 		<plugins>
-			<!-- disabled since no java8 signature is available yet <plugin> <groupId>org.codehaus.mojo</groupId> 
-				<artifactId>animal-sniffer-maven-plugin</artifactId> <version>1.14</version> 
-				<executions> <execution> <phase>test</phase> <goals> <goal>check</goal> </goals> 
-				</execution> </executions> <configuration> <signature> <groupId>org.codehaus.mojo.signature</groupId> 
-				<artifactId>java16</artifactId> <version>1.1</version> </signature> </configuration> 
-				</plugin> -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>1.14</version>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<signature>
+						<groupId>org.codehaus.mojo.signature</groupId>
+						<artifactId>java18</artifactId>
+						<version>1.0</version>
+					</signature>
+				</configuration>
+			</plugin>
 			<plugin>
 				<!-- verify all bytecode (including third party libs) is Java 8 max -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.3.1</version>
+				<version>1.4.1</version>
 				<executions>
 					<execution>
 						<id>enforce-bytecode-version</id>
@@ -750,13 +770,12 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.0-beta-3</version>
+						<version>1.0-beta-6</version>
 					</dependency>
 				</dependencies>
 			</plugin>
 
 		</plugins>
-
 
 		<extensions>
 			<extension>


### PR DESCRIPTION
This PR addresses GitHub issue: #732 .

Briefly describe the changes proposed in this PR:

* Add japicmp maven plugin to core modules to start gathering knowledge about the scope of our likely public API for #619
* Reenables animal sniffer with the java-8 signatures. This will be useful with Java-9 betas being used more regularly for experimentation.
* Removes some unused managed dependencies

The japicmp inclusions may not be all of the eventual public API modules, but it forms a likely base. The japicmp plugin does not yet have aggregation support, so each of the individual modules that will make up the public API need to have the plugin added to them manually.

Notably, none of the rio or queryresultio modules need to be in the public API IMO, as they are all accessible as services by all of our core APIs solely using rio-api and queryresultio-api.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>