### PR TITLE
Fix #725: Don't always deregister the connection on commit

### DIFF
--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -255,12 +255,8 @@ public class TransactionController extends AbstractController {
 				case UPDATE:
 					return getSparqlUpdateResult(transaction, request, response);
 				case COMMIT:
-					try {
-						transaction.commit();
-					}
-					finally {
-						ActiveTransactionRegistry.INSTANCE.deregister(transaction);
-					}
+					transaction.commit();
+					ActiveTransactionRegistry.INSTANCE.deregister(transaction);
 					break;
 				default:
 					logger.warn("transaction modification action '{}' not recognized", action);

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -256,6 +256,8 @@ public class TransactionController extends AbstractController {
 					return getSparqlUpdateResult(transaction, request, response);
 				case COMMIT:
 					transaction.commit();
+					// If commit fails with an exception, deregister should be skipped so the user
+					// has a chance to do a proper rollback. See #725.
 					ActiveTransactionRegistry.INSTANCE.deregister(transaction);
 					break;
 				default:


### PR DESCRIPTION
This PR addresses GitHub issue: #725 .
