### PR TITLE
Fix #740: New background results API

### DIFF
--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/binary/SPARQLBinaryTupleBackgroundTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/binary/SPARQLBinaryTupleBackgroundTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.binary;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
+import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.UnsupportedQueryResultFormatException;
+
+/**
+ * @author Peter Ansell
+ */
+public class SPARQLBinaryTupleBackgroundTest extends AbstractQueryResultIOTupleTest {
+
+	@Override
+	protected String getFileName() {
+		return "test.brt";
+	}
+
+	@Override
+	protected TupleQueryResultFormat getTupleFormat() {
+		return TupleQueryResultFormat.BINARY;
+	}
+
+	@Override
+	protected BooleanQueryResultFormat getMatchingBooleanFormatOrNull() {
+		return null;
+	}
+
+	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in)
+		throws IOException, QueryResultParseException, TupleQueryResultHandlerException,
+		UnsupportedQueryResultFormatException
+	{
+		return QueryResultIO.parseTupleBackground(in, format);
+	}
+
+}

--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleBackgroundTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleBackgroundTest.java
@@ -1,0 +1,284 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqljson;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
+import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.UnsupportedQueryResultFormatException;
+import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
+import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONParser;
+import org.junit.Test;
+
+/**
+ * @author Peter Ansell
+ * @author Sebastian Schaffert
+ */
+public class SPARQLJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTest {
+
+	@Override
+	protected String getFileName() {
+		return "test.srj";
+	}
+
+	@Override
+	protected TupleQueryResultFormat getTupleFormat() {
+		return TupleQueryResultFormat.JSON;
+	}
+
+	@Override
+	protected BooleanQueryResultFormat getMatchingBooleanFormatOrNull() {
+		return BooleanQueryResultFormat.JSON;
+	}
+
+	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in)
+		throws IOException, QueryResultParseException, TupleQueryResultHandlerException,
+		UnsupportedQueryResultFormatException
+	{
+		return QueryResultIO.parseTupleBackground(in, format);
+	}
+
+	@Test
+	public void testBindings1()
+		throws Exception
+	{
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/bindings1.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		// there must be two variables
+		assertEquals(2, handler.getBindingNames().size());
+
+		// first must be called "book", the second "title"
+		assertEquals("book", handler.getBindingNames().get(0));
+		assertEquals("title", handler.getBindingNames().get(1));
+
+		// should be 7 solutions alltogether
+		assertEquals(7, handler.getBindingSets().size());
+
+		// Results are ordered, so first should be book6
+		assertEquals("http://example.org/book/book6",
+				handler.getBindingSets().get(0).getValue("book").stringValue());
+
+		for (BindingSet b : handler.getBindingSets()) {
+			assertNotNull(b.getValue("book"));
+			assertNotNull(b.getValue("title"));
+			assertTrue(b.getValue("book") instanceof IRI);
+			assertTrue(b.getValue("title") instanceof Literal);
+
+			IRI book = (IRI)b.getValue("book");
+			if (book.stringValue().equals("http://example.org/book/book6")) {
+				assertEquals("Harry Potter and the Half-Blood Prince", b.getValue("title").stringValue());
+			}
+			else if (book.stringValue().equals("http://example.org/book/book7")) {
+				assertEquals("Harry Potter and the Deathly Hallows", b.getValue("title").stringValue());
+			}
+			else if (book.stringValue().equals("http://example.org/book/book5")) {
+				assertEquals("Harry Potter and the Order of the Phoenix", b.getValue("title").stringValue());
+			}
+			else if (book.stringValue().equals("http://example.org/book/book4")) {
+				assertEquals("Harry Potter and the Goblet of Fire", b.getValue("title").stringValue());
+			}
+			else if (book.stringValue().equals("http://example.org/book/book2")) {
+				assertEquals("Harry Potter and the Chamber of Secrets", b.getValue("title").stringValue());
+			}
+			else if (book.stringValue().equals("http://example.org/book/book3")) {
+				assertEquals("Harry Potter and the Prisoner Of Azkaban", b.getValue("title").stringValue());
+			}
+			else if (book.stringValue().equals("http://example.org/book/book1")) {
+				assertEquals("Harry Potter and the Philosopher's Stone", b.getValue("title").stringValue());
+			}
+			else {
+				fail("Found unexpected binding set in result: " + b.toString());
+			}
+		}
+
+	}
+
+	@Test
+	public void testBindings2()
+		throws Exception
+	{
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/bindings2.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		// there must be 7 variables
+		assertEquals(7, handler.getBindingNames().size());
+
+		// first must be called "x", etc.,
+		assertEquals("x", handler.getBindingNames().get(0));
+		assertEquals("hpage", handler.getBindingNames().get(1));
+		assertEquals("name", handler.getBindingNames().get(2));
+		assertEquals("mbox", handler.getBindingNames().get(3));
+		assertEquals("age", handler.getBindingNames().get(4));
+		assertEquals("blurb", handler.getBindingNames().get(5));
+		assertEquals("friend", handler.getBindingNames().get(6));
+
+		// 2 results
+		assertEquals(2, handler.getBindingSets().size());
+
+		// Results are ordered, so first should be alice
+		assertEquals("http://work.example.org/alice/",
+				handler.getBindingSets().get(0).getValue("hpage").stringValue());
+
+		for (BindingSet b : handler.getBindingSets()) {
+
+			assertNotNull(b.getValue("x"));
+			assertNotNull(b.getValue("hpage"));
+			assertNotNull(b.getValue("name"));
+			assertNotNull(b.getValue("mbox"));
+			assertNotNull(b.getValue("friend"));
+
+			assertTrue(b.getValue("x") instanceof BNode);
+			assertTrue(b.getValue("hpage") instanceof IRI);
+			assertTrue(b.getValue("name") instanceof Literal);
+			assertTrue(b.getValue("friend") instanceof BNode);
+
+			BNode value = (BNode)b.getValue("x");
+
+			if (value.getID().equals("r1")) {
+				assertNotNull(b.getValue("blurb"));
+
+				assertTrue(b.getValue("mbox") instanceof Literal);
+				assertTrue(b.getValue("blurb") instanceof Literal);
+
+				assertEquals("http://work.example.org/alice/", b.getValue("hpage").stringValue());
+
+				Literal name = (Literal)b.getValue("name");
+				assertEquals("Alice", name.stringValue());
+				assertFalse(name.getLanguage().isPresent());
+				assertEquals(XMLSchema.STRING, name.getDatatype());
+
+				Literal mbox = (Literal)b.getValue("mbox");
+				assertEquals("", mbox.stringValue());
+				assertFalse(mbox.getLanguage().isPresent());
+				assertEquals(XMLSchema.STRING, mbox.getDatatype());
+
+				Literal blurb = (Literal)b.getValue("blurb");
+				assertEquals("<p xmlns=\"http://www.w3.org/1999/xhtml\">My name is <b>alice</b></p>",
+						blurb.stringValue());
+				assertFalse(blurb.getLanguage().isPresent());
+				assertEquals(RDF.XMLLITERAL, blurb.getDatatype());
+			}
+			else if (value.getID().equals("r2")) {
+				assertNull(b.getValue("blurb"));
+
+				assertTrue(b.getValue("mbox") instanceof IRI);
+
+				assertEquals("http://work.example.org/bob/", b.getValue("hpage").stringValue());
+
+				Literal name = (Literal)b.getValue("name");
+				assertEquals("Bob", name.stringValue());
+				assertEquals("en", name.getLanguage().orElse(null));
+				assertEquals(RDF.LANGSTRING, name.getDatatype());
+
+				assertEquals("mailto:bob@work.example.org", b.getValue("mbox").stringValue());
+			}
+			else {
+				fail("Found unexpected binding set in result: " + b.toString());
+			}
+		}
+
+		assertEquals(1, handler.getLinks().size());
+		assertEquals("http://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/#example",
+				handler.getLinks().get(0));
+
+	}
+
+	@Test
+	public void testNonStandardDistinct()
+		throws Exception
+	{
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/non-standard-distinct.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		// there must be 1 variable
+		assertEquals(1, handler.getBindingNames().size());
+
+		// first must be called "Concept", etc.,
+		assertEquals("Concept", handler.getBindingNames().get(0));
+
+		// -1 results
+		assertEquals(100, handler.getBindingSets().size());
+	}
+
+	@Test
+	public void testNonStandardOrdered()
+		throws Exception
+	{
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/non-standard-ordered.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		// there must be 1 variable
+		assertEquals(1, handler.getBindingNames().size());
+
+		// first must be called "Concept", etc.,
+		assertEquals("Concept", handler.getBindingNames().get(0));
+
+		// -1 results
+		assertEquals(100, handler.getBindingSets().size());
+	}
+
+	@Test
+	public void testNonStandardDistinctOrdered()
+		throws Exception
+	{
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream(
+				"/sparqljson/non-standard-distinct-ordered.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		// there must be 1 variable
+		assertEquals(1, handler.getBindingNames().size());
+
+		// first must be called "Concept", etc.,
+		assertEquals("Concept", handler.getBindingNames().get(0));
+
+		// -1 results
+		assertEquals(100, handler.getBindingSets().size());
+	}
+}

--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleBackgroundTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleBackgroundTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqlxml;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
+import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.UnsupportedQueryResultFormatException;
+
+/**
+ * @author Peter Ansell
+ */
+public class SPARQLXMLTupleBackgroundTest extends AbstractQueryResultIOTupleTest {
+
+	@Override
+	protected String getFileName() {
+		return "test.srx";
+	}
+
+	@Override
+	protected TupleQueryResultFormat getTupleFormat() {
+		return TupleQueryResultFormat.SPARQL;
+	}
+
+	@Override
+	protected BooleanQueryResultFormat getMatchingBooleanFormatOrNull() {
+		return BooleanQueryResultFormat.SPARQL;
+	}
+
+	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in)
+		throws IOException, QueryResultParseException, TupleQueryResultHandlerException,
+		UnsupportedQueryResultFormatException
+	{
+		return QueryResultIO.parseTupleBackground(in, format);
+	}
+
+}

--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleBackgroundTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleBackgroundTest.java
@@ -1,0 +1,241 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.csv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Binding;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.algebra.Compare;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+import org.junit.Test;
+
+/**
+ * @author Peter Ansell
+ * @author James Leigh
+ */
+public class SPARQLCSVTupleBackgroundTest extends AbstractQueryResultIOTupleTest {
+
+	@Override
+	protected String getFileName() {
+		return "test.csv";
+	}
+
+	@Override
+	protected TupleQueryResultFormat getTupleFormat() {
+		return TupleQueryResultFormat.CSV;
+	}
+
+	@Override
+	protected BooleanQueryResultFormat getMatchingBooleanFormatOrNull() {
+		return null;
+	}
+
+	@Test
+	public void testEndOfLine()
+		throws Exception
+	{
+		TupleQueryResultFormat format = getTupleFormat();
+		ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
+		TupleQueryResultWriter writer = QueryResultIO.createTupleWriter(format, out);
+		writer.startDocument();
+		writer.startHeader();
+		writer.handleLinks(Arrays.<String> asList());
+		QueryResults.report(createTupleNoBindingSets(), writer);
+
+		assertEquals("\r\n", out.toString("UTF-8").replaceAll("\\S+", ""));
+	}
+
+	@Test
+	public void testEmptyResults()
+		throws Exception
+	{
+		TupleQueryResultFormat format = getTupleFormat();
+		ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
+		TupleQueryResultWriter writer = QueryResultIO.createTupleWriter(format, out);
+		writer.startDocument();
+		writer.startHeader();
+		writer.handleLinks(Arrays.<String> asList());
+		QueryResults.report(createTupleNoBindingSets(), writer);
+
+		assertRegex("a,b,c(\r\n)?", out.toString("UTF-8"));
+	}
+
+	@Test
+	public void testSingleVarResults()
+		throws Exception
+	{
+		TupleQueryResultFormat format = getTupleFormat();
+		ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
+		TupleQueryResultWriter writer = QueryResultIO.createTupleWriter(format, out);
+		writer.startDocument();
+		writer.startHeader();
+		writer.handleLinks(Arrays.<String> asList());
+		QueryResults.report(createTupleSingleVarMultipleBindingSets(), writer);
+
+		System.out.println(out.toString("UTF-8"));
+		assertRegex("a\r\n" + "foo:bar\r\n" + "2.0(E0)?\r\n" + "_:bnode3\r\n" + "''single-quoted string\r\n"
+				+ "\"\"\"\"\"double-quoted string\"\r\n" + "space at the end         \r\n"
+				+ "space at the end         \r\n" + "\"\"\"\"\"double-quoted string with no datatype\"\r\n"
+				+ "\"newline at the end \n\"(\r\n)?", out.toString("UTF-8"));
+	}
+
+	@Test
+	public void testmultipleVarResults()
+		throws Exception
+	{
+		TupleQueryResultFormat format = getTupleFormat();
+		ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
+		TupleQueryResultWriter writer = QueryResultIO.createTupleWriter(format, out);
+		writer.startDocument();
+		writer.startHeader();
+		writer.handleLinks(Arrays.<String> asList());
+		QueryResults.report(createTupleMultipleBindingSets(), writer);
+
+		assertRegex(
+				"a,b,c\r\n" + "foo:bar,_:bnode,baz\r\n" + "1,,Hello World!\r\n"
+						+ "http://example.org/test/ns/bindingA,http://example.com/other/ns/bindingB,\"http://example.com/other/ns/binding,C\"\r\n"
+						+ "\"string with newline at the end       \n\",string with space at the end         ,    \r\n"
+						+ "''single-quoted string,\"\"\"\"\"double-quoted string\",\t\tunencoded tab characters followed by encoded \t\t(\r\n)?",
+				out.toString("UTF-8"));
+	}
+
+	private void assertRegex(String pattern, String actual) {
+		if (!Pattern.compile(pattern, Pattern.DOTALL).matcher(actual).matches()) {
+			assertEquals(pattern, actual);
+		}
+	}
+
+	protected void assertQueryResultsEqual(TupleQueryResult tqr1, TupleQueryResult tqr2)
+		throws QueryEvaluationException
+	{
+		List<BindingSet> list1 = Iterations.asList(tqr1);
+		List<BindingSet> list2 = Iterations.asList(tqr2);
+
+		// Compare the number of statements in both sets
+		if (list1.size() != list2.size()) {
+			fail();
+		}
+
+		assertTrue(matchBindingSets(list1, list2, new HashMap<BNode, BNode>(), 0));
+	}
+
+	private boolean matchBindingSets(List<? extends BindingSet> queryResult1,
+			Iterable<? extends BindingSet> queryResult2, Map<BNode, BNode> bNodeMapping, int idx)
+	{
+		boolean result = false;
+
+		if (idx < queryResult1.size()) {
+			BindingSet bs1 = queryResult1.get(idx);
+
+			List<BindingSet> matchingBindingSets = findMatchingBindingSets(bs1, queryResult2, bNodeMapping);
+
+			for (BindingSet bs2 : matchingBindingSets) {
+				// Map bNodes in bs1 to bNodes in bs2
+				Map<BNode, BNode> newBNodeMapping = new HashMap<BNode, BNode>(bNodeMapping);
+
+				for (Binding binding : bs1) {
+					if (binding.getValue() instanceof BNode) {
+						newBNodeMapping.put((BNode)binding.getValue(),
+								(BNode)bs2.getValue(binding.getName()));
+					}
+				}
+
+				// FIXME: this recursive implementation has a high risk of
+				// triggering a stack overflow
+
+				// Enter recursion
+				result = matchBindingSets(queryResult1, queryResult2, newBNodeMapping, idx + 1);
+
+				if (result == true) {
+					// models match, look no further
+					break;
+				}
+			}
+		}
+		else {
+			// All statements have been mapped successfully
+			result = true;
+		}
+
+		return result;
+	}
+
+	private static List<BindingSet> findMatchingBindingSets(BindingSet st,
+			Iterable<? extends BindingSet> model, Map<BNode, BNode> bNodeMapping)
+	{
+		List<BindingSet> result = new ArrayList<BindingSet>();
+
+		for (BindingSet modelSt : model) {
+			if (bindingSetsMatch(st, modelSt, bNodeMapping)) {
+				// All components possibly match
+				result.add(modelSt);
+			}
+		}
+
+		return result;
+	}
+
+	private static boolean bindingSetsMatch(BindingSet bs1, BindingSet bs2, Map<BNode, BNode> bNodeMapping) {
+
+		if (bs1.size() != bs2.size()) {
+			return false;
+		}
+
+		for (Binding binding1 : bs1) {
+			Value value1 = binding1.getValue();
+			Value value2 = bs2.getValue(binding1.getName());
+
+			if (value1 == null && value2 != null) {
+				return false;
+			}
+			else if (value1 != null && value2 == null) {
+				return false;
+			}
+			else if (value1 != null && value2 != null) {
+				if (!equals(value1, value2) && !value1.stringValue().equals(value2.stringValue())) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	protected static boolean equals(Value value1, Value value2) {
+		try {
+			return QueryEvaluationUtil.compare(value1, value2, Compare.CompareOp.EQ);
+		}
+		catch (ValueExprEvaluationException e) {
+			return false;
+		}
+	}
+
+}

--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleBackgroundTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleBackgroundTest.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.tsv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryResultHandlerException;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
+import org.eclipse.rdf4j.query.impl.MutableTupleQueryResult;
+import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+import org.eclipse.rdf4j.query.resultio.UnsupportedQueryResultFormatException;
+import org.junit.Test;
+
+/**
+ * @author Peter Ansell
+ * @author James Leigh
+ */
+public class SPARQLTSVTupleBackgroundTest extends AbstractQueryResultIOTupleTest {
+
+	@Override
+	protected String getFileName() {
+		return "test.tsv";
+	}
+
+	@Override
+	protected TupleQueryResultFormat getTupleFormat() {
+		return TupleQueryResultFormat.TSV;
+	}
+
+	@Override
+	protected BooleanQueryResultFormat getMatchingBooleanFormatOrNull() {
+		return null;
+	}
+
+	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in)
+		throws IOException, QueryResultParseException, TupleQueryResultHandlerException,
+		UnsupportedQueryResultFormatException
+	{
+		return QueryResultIO.parseTupleBackground(in, format);
+	}
+
+	@Test
+	public void testEndOfLine()
+		throws Exception
+	{
+		assertEquals("\n", toString(createTupleNoBindingSets()).replaceAll("\\S+|\t", ""));
+	}
+
+	@Test
+	public void testEmptyResults()
+		throws Exception
+	{
+		assertRegex("\\?a\t\\?b\t\\?c\n?", toString(createTupleNoBindingSets()));
+	}
+
+	@Test
+	public void testSingleVarResults()
+		throws Exception
+	{
+		assertRegex(
+				"\\?a\n" + "<foo:bar>\n"
+						+ "(2.0(E0)?|\"2.0\"\\^\\^<http://www.w3.org/2001/XMLSchema#double>)\n" + "_:bnode3\n"
+						+ "\"''single-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"\\\\\"\\\\\"double-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"\\\\\"\\\\\"double-quoted string with no datatype\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"newline at the end \\\\n\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n?",
+				toString(createTupleSingleVarMultipleBindingSets()));
+	}
+
+	@Test
+	public void testmultipleVarResults()
+		throws Exception
+	{
+		assertRegex(
+				"\\?a\t\\?b\t\\?c\n"
+						+ "<foo:bar>\t_:bnode\t\"baz\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "(1|\"1\"\\^\\^<http://www.w3.org/2001/XMLSchema#integer>)\t\t\"Hello World!\"@en\n"
+						+ "<http://example.org/test/ns/bindingA>\t\"http://example.com/other/ns/bindingB\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t<http://example.com/other/ns/binding,C>\n"
+						+ "\"string with newline at the end       \\\\n\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"string with space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"    \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"''single-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"\\\\\"\\\\\"double-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"\\\\t\\\\tunencoded tab characters followed by encoded \\\\t\\\\t\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n?",
+				toString(createTupleMultipleBindingSets()));
+	}
+
+	private String toString(TupleQueryResult results)
+		throws QueryResultHandlerException, TupleQueryResultHandlerException, QueryEvaluationException,
+		UnsupportedEncodingException
+	{
+		TupleQueryResultFormat format = getTupleFormat();
+		ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
+		TupleQueryResultWriter writer = QueryResultIO.createTupleWriter(format, out);
+		writer.startDocument();
+		writer.startHeader();
+		writer.handleLinks(Arrays.<String> asList());
+		QueryResults.report(results, writer);
+
+		return out.toString("UTF-8");
+	}
+
+	private void assertRegex(String pattern, String actual) {
+		if (!Pattern.compile(pattern, Pattern.DOTALL).matcher(actual).matches()) {
+			assertEquals(pattern, actual);
+		}
+	}
+
+	protected void assertQueryResultsEqual(TupleQueryResult expected, TupleQueryResult output)
+		throws QueryEvaluationException, TupleQueryResultHandlerException, QueryResultHandlerException,
+		UnsupportedEncodingException
+	{
+		MutableTupleQueryResult r1 = new MutableTupleQueryResult(expected);
+		MutableTupleQueryResult r2 = new MutableTupleQueryResult(output);
+		if (!QueryResults.equals(r1, r2)) {
+			r1.beforeFirst();
+			r2.beforeFirst();
+			assertEquals(toString(r1), toString(r2));
+			r2.beforeFirst();
+			fail(toString(r2));
+		}
+	}
+
+}

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.rio.rdfjson;
+package org.eclipse.rdf4j.rio.binary;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,20 +15,18 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONWriterFactory;
+import org.eclipse.rdf4j.rio.binary.BinaryRDFParserFactory;
+import org.eclipse.rdf4j.rio.binary.BinaryRDFWriterFactory;
 
 /**
- * JUnit test for the RDF/JSON parser.
- * 
- * @author Peter Ansell
+ * @author Arjohn Kampman
  */
-public class RDFJSONWriterTest extends RDFWriterTest {
+public class BinaryRDFWriterBackgroundTest extends RDFWriterTest {
 
-	public RDFJSONWriterTest() {
-		super(new RDFJSONWriterFactory(), new RDFJSONParserFactory());
+	public BinaryRDFWriterBackgroundTest() {
+		super(new BinaryRDFWriterFactory(), new BinaryRDFParserFactory());
 	}
-	
+
 	@Override
 	protected Model parse(InputStream reader, String baseURI)
 		throws RDFParseException, RDFHandlerException, IOException
@@ -36,5 +34,4 @@ public class RDFJSONWriterTest extends RDFWriterTest {
 		return QueryResults.asModel(
 				QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat()));
 	}
-	
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.jsonld;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.rio.ParserConfig;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.rio.helpers.JSONLDMode;
+import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.eclipse.rdf4j.rio.jsonld.JSONLDParserFactory;
+import org.eclipse.rdf4j.rio.jsonld.JSONLDWriterFactory;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author Peter Ansell
+ */
+public class JSONLDWriterBackgroundTest extends RDFWriterTest {
+
+	public JSONLDWriterBackgroundTest() {
+		super(new JSONLDWriterFactory(), new JSONLDParserFactory());
+	}
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		super.setupWriterConfig(config);
+		config.set(JSONLDSettings.JSONLD_MODE, JSONLDMode.COMPACT);
+	}
+
+	@Override
+	protected void setupParserConfig(ParserConfig config) {
+		super.setupParserConfig(config);
+		config.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
+		config.set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);
+	}
+
+	@Override
+	protected Model parse(InputStream reader, String baseURI)
+		throws RDFParseException, RDFHandlerException, IOException
+	{
+		return QueryResults.asModel(
+				QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat()));
+	}
+	
+	@Test
+	@Override
+	@Ignore("TODO: Determine why this test is breaking")
+	public void testIllegalPrefix()
+		throws RDFHandlerException, RDFParseException, IOException
+	{
+	}
+
+	@Test
+	public void testRoundTripNamespaces()
+		throws Exception
+	{
+		String exNs = "http://example.org/";
+		IRI uri1 = vf.createIRI(exNs, "uri1");
+		IRI uri2 = vf.createIRI(exNs, "uri2");
+		Literal plainLit = vf.createLiteral("plain", XMLSchema.STRING);
+
+		Statement st1 = vf.createStatement(uri1, uri2, plainLit);
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		RDFWriter rdfWriter = rdfWriterFactory.getWriter(out);
+		rdfWriter.getWriterConfig().set(JSONLDSettings.JSONLD_MODE, JSONLDMode.COMPACT);
+		rdfWriter.handleNamespace("ex", exNs);
+		rdfWriter.startRDF();
+		rdfWriter.handleStatement(st1);
+		rdfWriter.endRDF();
+
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		RDFParser rdfParser = rdfParserFactory.getParser();
+		ParserConfig config = new ParserConfig();
+		config.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
+		config.set(BasicParserSettings.FAIL_ON_UNKNOWN_LANGUAGES, true);
+		rdfParser.setParserConfig(config);
+		rdfParser.setValueFactory(vf);
+		Model model = new LinkedHashModel();
+		rdfParser.setRDFHandler(new StatementCollector(model));
+
+		rdfParser.parse(in, "foo:bar");
+
+		assertEquals("Unexpected number of statements, found " + model.size(), 1, model.size());
+
+		assertTrue("missing namespaced statement", model.contains(st1));
+
+		if (rdfParser.getRDFFormat().supportsNamespaces()) {
+			assertTrue("Expected at least one namespace, found " + model.getNamespaces().size(),
+					model.getNamespaces().size() >= 1);
+			assertEquals(exNs, model.getNamespace("ex").get().getName());
+		}
+	}
+}

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/nquads/NQuadsWriterBackgroundTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/nquads/NQuadsWriterBackgroundTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.rio.rdfjson;
+package org.eclipse.rdf4j.rio.nquads;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,21 +14,16 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONWriterFactory;
+import org.eclipse.rdf4j.rio.nquads.AbstractNQuadsWriterTest;
+import org.eclipse.rdf4j.rio.nquads.NQuadsParserFactory;
+import org.eclipse.rdf4j.rio.nquads.NQuadsWriterFactory;
 
-/**
- * JUnit test for the RDF/JSON parser.
- * 
- * @author Peter Ansell
- */
-public class RDFJSONWriterTest extends RDFWriterTest {
+public class NQuadsWriterBackgroundTest extends AbstractNQuadsWriterTest {
 
-	public RDFJSONWriterTest() {
-		super(new RDFJSONWriterFactory(), new RDFJSONParserFactory());
+	public NQuadsWriterBackgroundTest() {
+		super(new NQuadsWriterFactory(), new NQuadsParserFactory());
 	}
-	
+
 	@Override
 	protected Model parse(InputStream reader, String baseURI)
 		throws RDFParseException, RDFHandlerException, IOException

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterBackgroundTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterBackgroundTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.rio.rdfjson;
+package org.eclipse.rdf4j.rio.ntriples;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,20 +15,20 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONWriterFactory;
+import org.eclipse.rdf4j.rio.ntriples.NTriplesParserFactory;
+import org.eclipse.rdf4j.rio.ntriples.NTriplesWriterFactory;
 
 /**
- * JUnit test for the RDF/JSON parser.
+ * JUnit test for the N-Triples parser/writer combination.
  * 
  * @author Peter Ansell
  */
-public class RDFJSONWriterTest extends RDFWriterTest {
+public class NTriplesWriterBackgroundTest extends RDFWriterTest {
 
-	public RDFJSONWriterTest() {
-		super(new RDFJSONWriterFactory(), new RDFJSONParserFactory());
+	public NTriplesWriterBackgroundTest() {
+		super(new NTriplesWriterFactory(), new NTriplesParserFactory());
 	}
-	
+
 	@Override
 	protected Model parse(InputStream reader, String baseURI)
 		throws RDFParseException, RDFHandlerException, IOException
@@ -36,5 +36,5 @@ public class RDFJSONWriterTest extends RDFWriterTest {
 		return QueryResults.asModel(
 				QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat()));
 	}
-	
+
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterBackgroundTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterBackgroundTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.rdfxml;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.rdfxml.RDFXMLParserFactory;
+import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriterTestCase;
+import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriterFactory;
+import org.junit.Test;
+
+public class RDFXMLPrettyWriterBackgroundTest extends RDFXMLWriterTestCase {
+
+	private static ValueFactory vf = SimpleValueFactory.getInstance();
+
+	public RDFXMLPrettyWriterBackgroundTest() {
+		super(new RDFXMLPrettyWriterFactory(), new RDFXMLParserFactory());
+	}
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(BasicWriterSettings.PRETTY_PRINT, true);
+	}
+
+	@Override
+	protected Model parse(InputStream reader, String baseURI)
+		throws RDFParseException, RDFHandlerException, IOException
+	{
+		return QueryResults.asModel(
+				QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat()));
+	}
+	
+	/**
+	 * Extract lines that start an rdf element so basic assertions can be made.
+	 */
+	private static List<String> rdfOpenTags(String s)
+		throws IOException
+	{
+		String withoutSpaces = Pattern.compile("^\\s+", Pattern.MULTILINE).matcher(s).replaceAll("");
+
+		List<String> rdfLines = new ArrayList<String>();
+
+		for (String l : IOUtils.readLines(new StringReader(withoutSpaces))) {
+			if (l.startsWith("<rdf:")) {
+				rdfLines.add(l.replaceAll(" .*", ""));
+			}
+		}
+
+		return rdfLines;
+	}
+
+	@Test
+	public void sequenceItemsAreAbbreviated()
+		throws RDFHandlerException, IOException
+	{
+		StringWriter writer = new StringWriter();
+		RDFWriter rdfWriter = rdfWriterFactory.getWriter(writer);
+
+		rdfWriter.startRDF();
+
+		Resource res = vf.createIRI("http://example.com/#");
+
+		rdfWriter.handleStatement(vf.createStatement(res, RDF.TYPE, RDF.BAG));
+
+		rdfWriter.handleStatement(vf.createStatement(res, vf.createIRI(RDF.NAMESPACE + "_1"),
+				vf.createIRI("http://example.com/#1")));
+		rdfWriter.handleStatement(vf.createStatement(res, vf.createIRI(RDF.NAMESPACE + "_2"),
+				vf.createIRI("http://example.com/#2")));
+		rdfWriter.endRDF();
+
+		List<String> rdfLines = rdfOpenTags(writer.toString());
+
+		assertEquals(Arrays.asList("<rdf:RDF", "<rdf:Bag", "<rdf:li", "<rdf:li"), rdfLines);
+	}
+
+	@Test
+	public void outOfSequenceItemsAreNotAbbreviated()
+		throws RDFHandlerException, IOException
+	{
+		StringWriter writer = new StringWriter();
+		RDFWriter rdfWriter = rdfWriterFactory.getWriter(writer);
+
+		rdfWriter.startRDF();
+
+		Resource res = vf.createIRI("http://example.com/#");
+
+		rdfWriter.handleStatement(vf.createStatement(res, RDF.TYPE, RDF.BAG));
+
+		rdfWriter.handleStatement(vf.createStatement(res, vf.createIRI(RDF.NAMESPACE + "_0"),
+				vf.createIRI("http://example.com/#0")));
+		rdfWriter.handleStatement(vf.createStatement(res, vf.createIRI(RDF.NAMESPACE + "_2"),
+				vf.createIRI("http://example.com/#2")));
+		rdfWriter.endRDF();
+
+		List<String> rdfLines = rdfOpenTags(writer.toString());
+
+		assertEquals(Arrays.asList("<rdf:RDF", "<rdf:Bag", "<rdf:_0", "<rdf:_2"), rdfLines);
+	}
+
+	@Test
+	public void inSequenceItemsMixedWithOtherElementsAreAbbreviated()
+		throws RDFHandlerException, IOException
+	{
+		StringWriter writer = new StringWriter();
+		RDFWriter rdfWriter = rdfWriterFactory.getWriter(writer);
+
+		rdfWriter.startRDF();
+
+		Resource res = vf.createIRI("http://example.com/#");
+
+		rdfWriter.handleStatement(vf.createStatement(res, RDF.TYPE, RDF.BAG));
+
+		rdfWriter.handleStatement(vf.createStatement(res, vf.createIRI(RDF.NAMESPACE + "_2"),
+				vf.createIRI("http://example.com/#2")));
+		rdfWriter.handleStatement(vf.createStatement(res, vf.createIRI(RDF.NAMESPACE + "_1"),
+				vf.createIRI("http://example.com/#1")));
+		rdfWriter.handleStatement(vf.createStatement(res, vf.createIRI(RDF.NAMESPACE + "_3"),
+				vf.createIRI("http://example.com/#3")));
+		rdfWriter.handleStatement(vf.createStatement(res, vf.createIRI(RDF.NAMESPACE + "_2"),
+				vf.createIRI("http://example.com/#2")));
+		rdfWriter.endRDF();
+
+		List<String> rdfLines = rdfOpenTags(writer.toString());
+
+		assertEquals(Arrays.asList("<rdf:RDF", "<rdf:Bag", "<rdf:_2", "<rdf:li", "<rdf:_3", "<rdf:li"),
+				rdfLines);
+	}
+}

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterBackgroundTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterBackgroundTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.rio.rdfjson;
+package org.eclipse.rdf4j.rio.rdfxml;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,21 +14,23 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONWriterFactory;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.rdfxml.RDFXMLParserFactory;
+import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriterFactory;
+import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriterTestCase;
 
-/**
- * JUnit test for the RDF/JSON parser.
- * 
- * @author Peter Ansell
- */
-public class RDFJSONWriterTest extends RDFWriterTest {
+public class RDFXMLWriterBackgroundTest extends RDFXMLWriterTestCase {
 
-	public RDFJSONWriterTest() {
-		super(new RDFJSONWriterFactory(), new RDFJSONParserFactory());
+	public RDFXMLWriterBackgroundTest() {
+		super(new RDFXMLWriterFactory(), new RDFXMLParserFactory());
 	}
 	
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(BasicWriterSettings.PRETTY_PRINT, false);
+	}
+
 	@Override
 	protected Model parse(InputStream reader, String baseURI)
 		throws RDFParseException, RDFHandlerException, IOException

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGPrettyWriterBackgroundTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGPrettyWriterBackgroundTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.rio.rdfjson;
+package org.eclipse.rdf4j.rio.trig;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,20 +15,27 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONWriterFactory;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.trig.TriGParserFactory;
+import org.eclipse.rdf4j.rio.trig.TriGWriterFactory;
 
 /**
- * JUnit test for the RDF/JSON parser.
+ * Unit tests for the TriG pretty printing functionality
  * 
  * @author Peter Ansell
  */
-public class RDFJSONWriterTest extends RDFWriterTest {
+public class TriGPrettyWriterBackgroundTest extends RDFWriterTest {
 
-	public RDFJSONWriterTest() {
-		super(new RDFJSONWriterFactory(), new RDFJSONParserFactory());
+	public TriGPrettyWriterBackgroundTest() {
+		super(new TriGWriterFactory(), new TriGParserFactory());
 	}
-	
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(BasicWriterSettings.PRETTY_PRINT, true);
+	}
+
 	@Override
 	protected Model parse(InputStream reader, String baseURI)
 		throws RDFParseException, RDFHandlerException, IOException

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGWriterBackgroundTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGWriterBackgroundTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.rio.rdfjson;
+package org.eclipse.rdf4j.rio.trig;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,20 +15,25 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONParserFactory;
-import org.eclipse.rdf4j.rio.rdfjson.RDFJSONWriterFactory;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.trig.TriGParserFactory;
+import org.eclipse.rdf4j.rio.trig.TriGWriterFactory;
 
 /**
- * JUnit test for the RDF/JSON parser.
- * 
- * @author Peter Ansell
+ * @author Arjohn Kampman
  */
-public class RDFJSONWriterTest extends RDFWriterTest {
+public class TriGWriterBackgroundTest extends RDFWriterTest {
 
-	public RDFJSONWriterTest() {
-		super(new RDFJSONWriterFactory(), new RDFJSONParserFactory());
+	public TriGWriterBackgroundTest() {
+		super(new TriGWriterFactory(), new TriGParserFactory());
 	}
-	
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(BasicWriterSettings.PRETTY_PRINT, false);
+	}
+
 	@Override
 	protected Model parse(InputStream reader, String baseURI)
 		throws RDFParseException, RDFHandlerException, IOException

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/BackgroundGraphResult.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/BackgroundGraphResult.java
@@ -7,48 +7,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.charset.Charset;
-import java.util.Collections;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 
-import org.eclipse.rdf4j.common.iteration.IterationWrapper;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.query.GraphQueryResult;
-import org.eclipse.rdf4j.query.QueryEvaluationException;
-import org.eclipse.rdf4j.rio.RDFHandler;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParser;
 
 /**
  * Provides concurrent access to statements as they are being parsed.
  * 
  * @author James Leigh
+ * @deprecated Use {@link org.eclipse.rdf4j.query.impl.BackgroundGraphResult} instead.
  */
-public class BackgroundGraphResult extends IterationWrapper<Statement, QueryEvaluationException>
-		implements GraphQueryResult, Runnable, RDFHandler
+@Deprecated
+public class BackgroundGraphResult extends org.eclipse.rdf4j.query.impl.BackgroundGraphResult
 {
-
-	private final RDFParser parser;
-
-	private final Charset charset;
-
-	private final InputStream in;
-
-	private final String baseURI;
-
-	private final CountDownLatch namespacesReady = new CountDownLatch(1);
-
-	private final Map<String, String> namespaces = new ConcurrentHashMap<String, String>();
-
-	private final QueueCursor<Statement> queue;
-
 	public BackgroundGraphResult(RDFParser parser, InputStream in, Charset charset, String baseURI) {
 		this(new QueueCursor<Statement>(10), parser, in, charset, baseURI);
 	}
@@ -56,188 +29,7 @@ public class BackgroundGraphResult extends IterationWrapper<Statement, QueryEval
 	public BackgroundGraphResult(QueueCursor<Statement> queue, RDFParser parser, InputStream in,
 			Charset charset, String baseURI)
 	{
-		super(queue);
-		this.queue = queue;
-		this.parser = parser;
-		this.in = in;
-		this.charset = charset;
-		this.baseURI = baseURI;
-	}
-
-	@Override
-	public boolean hasNext()
-		throws QueryEvaluationException
-	{
-		if (isClosed()) {
-			return false;
-		}
-		if (Thread.currentThread().isInterrupted()) {
-			close();
-			return false;
-		}
-
-		boolean result = queue.hasNext();
-		if (!result) {
-			close();
-		}
-		return result;
-	}
-
-	@Override
-	public Statement next()
-		throws QueryEvaluationException
-	{
-		if (isClosed()) {
-			throw new NoSuchElementException("The iteration has been closed.");
-		}
-		if (Thread.currentThread().isInterrupted()) {
-			close();
-			throw new NoSuchElementException("The iteration has been closed.");
-		}
-		
-		try {
-			return queue.next();
-		}
-		catch (NoSuchElementException e) {
-			close();
-			throw e;
-		}
-	}
-
-	@Override
-	public void remove()
-		throws QueryEvaluationException
-	{
-		if (isClosed()) {
-			throw new IllegalStateException("The iteration has been closed.");
-		}
-		if (Thread.currentThread().isInterrupted()) {
-			close();
-			throw new IllegalStateException("The iteration has been closed.");
-		}
-
-		try {
-			queue.remove();
-		}
-		catch (IllegalStateException e) {
-			close();
-			throw e;
-		}
-	}
-
-	@Override
-	protected void handleClose()
-		throws QueryEvaluationException
-	{
-		try {
-			try {
-				super.handleClose();
-			}
-			finally {
-				try {
-					// After checking that we ourselves cannot possibly be generating an NPE ourselves, 
-					// attempt to close the input stream we were given
-					InputStream toClose = in;
-					if (toClose != null) {
-						toClose.close();
-					}
-				}
-				catch (NullPointerException e) {
-					// Swallow NullPointerException that Apache HTTPClient is hiding behind a NotThreadSafe annotation
-				}
-			}
-		}
-		catch (IOException e) {
-			throw new QueryEvaluationException(e);
-		}
-		finally {
-			queue.close();
-		}
-	}
-
-	@Override
-	public void run() {
-		try {
-			parser.setRDFHandler(this);
-			if (charset == null) {
-				parser.parse(in, baseURI);
-			}
-			else {
-				parser.parse(new InputStreamReader(in, charset), baseURI);
-			}
-		}
-		catch (RDFHandlerException e) {
-			// parsing was cancelled or interrupted
-			close();
-		}
-		catch (Exception e) {
-			queue.toss(e);
-			close();
-		}
-		finally {
-			queue.done();
-			namespacesReady.countDown();
-		}
-	}
-
-	@Override
-	public void startRDF()
-		throws RDFHandlerException
-	{
-		// no-op
-	}
-
-	@Override
-	public Map<String, String> getNamespaces() {
-		try {
-			namespacesReady.await();
-			// Show the user an unmodifiable view on the map but we can still change it here
-			return Collections.unmodifiableMap(namespaces);
-		}
-		catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			close();
-			throw new UndeclaredThrowableException(e);
-		}
-	}
-
-	@Override
-	public void handleComment(String comment)
-		throws RDFHandlerException
-	{
-		// ignore
-	}
-
-	@Override
-	public void handleNamespace(String prefix, String uri)
-		throws RDFHandlerException
-	{
-		namespaces.put(prefix, uri);
-	}
-
-	@Override
-	public void handleStatement(Statement st)
-		throws RDFHandlerException
-	{
-		namespacesReady.countDown();
-		try {
-			queue.put(st);
-		}
-		catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			close();
-			throw new RDFHandlerException(e);
-		}
-		if (isClosed()) {
-			throw new RDFHandlerException("Result closed");
-		}
-	}
-
-	@Override
-	public void endRDF()
-		throws RDFHandlerException
-	{
-		namespacesReady.countDown();
+		super(queue, parser, in, charset, baseURI);
 	}
 
 }

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/BackgroundTupleResult.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/BackgroundTupleResult.java
@@ -7,41 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 import org.eclipse.rdf4j.query.BindingSet;
-import org.eclipse.rdf4j.query.QueryEvaluationException;
-import org.eclipse.rdf4j.query.QueryResultHandlerException;
-import org.eclipse.rdf4j.query.TupleQueryResultHandler;
-import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
-import org.eclipse.rdf4j.query.impl.IteratingTupleQueryResult;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
 
 /**
  * Provides concurrent access to tuple results as they are being parsed.
  * 
  * @author James Leigh
+ * @deprecated Use {@link org.eclipse.rdf4j.query.resultio.helpers.BackgroundTupleResult} instead.
  */
-public class BackgroundTupleResult extends IteratingTupleQueryResult
-		implements Runnable, TupleQueryResultHandler
+@Deprecated
+public class BackgroundTupleResult extends org.eclipse.rdf4j.query.resultio.helpers.BackgroundTupleResult
 {
-
-	private final TupleQueryResultParser parser;
-
-	private final InputStream in;
-
-	private final QueueCursor<BindingSet> queue;
-
-	private final List<String> bindingNames = new ArrayList<>();
-
-	private final CountDownLatch bindingNamesReady = new CountDownLatch(1);
-
 	public BackgroundTupleResult(TupleQueryResultParser parser, InputStream in) {
 		this(new QueueCursor<BindingSet>(10), parser, in);
 	}
@@ -49,123 +28,7 @@ public class BackgroundTupleResult extends IteratingTupleQueryResult
 	public BackgroundTupleResult(QueueCursor<BindingSet> queue, TupleQueryResultParser parser,
 			InputStream in)
 	{
-		super(Collections.<String> emptyList(), queue);
-		this.queue = queue;
-		this.parser = parser;
-		this.in = in;
+		super(queue, parser, in);
 	}
 
-	@Override
-	protected void handleClose()
-		throws QueryEvaluationException
-	{
-		try {
-			try {
-				super.handleClose();
-			}
-			finally {
-				try {
-					// After checking that we ourselves cannot possibly be generating an NPE ourselves, 
-					// attempt to close the input stream we were given
-					InputStream toClose = in;
-					if (toClose != null) {
-						toClose.close();
-					}
-				}
-				catch (NullPointerException e) {
-					// Swallow NullPointerException that Apache HTTPClient is hiding behind a NotThreadSafe annotation
-				}
-			}
-		}
-		catch (IOException e) {
-			throw new QueryEvaluationException(e);
-		}
-		finally {
-			queue.close();
-		}
-	}
-
-	@Override
-	public List<String> getBindingNames() {
-		try {
-			bindingNamesReady.await();
-			queue.checkException();
-			return bindingNames;
-		}
-		catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			close();
-			throw new UndeclaredThrowableException(e);
-		}
-		catch (QueryEvaluationException e) {
-			close();
-			throw new UndeclaredThrowableException(e);
-		}
-	}
-
-	@Override
-	public void run() {
-		try {
-			parser.setQueryResultHandler(this);
-			parser.parseQueryResult(in);
-		}
-		catch (QueryResultHandlerException e) {
-			// parsing cancelled or interrupted
-			close();
-		}
-		catch (Exception e) {
-			queue.toss(e);
-			close();
-		}
-		finally {
-			queue.done();
-			bindingNamesReady.countDown();
-		}
-	}
-
-	@Override
-	public void startQueryResult(List<String> bindingNames)
-		throws TupleQueryResultHandlerException
-	{
-		this.bindingNames.addAll(bindingNames);
-		bindingNamesReady.countDown();
-	}
-
-	@Override
-	public void handleSolution(BindingSet bindingSet)
-		throws TupleQueryResultHandlerException
-	{
-		try {
-			queue.put(bindingSet);
-		}
-		catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			close();
-			throw new TupleQueryResultHandlerException(e);
-		}
-		if (isClosed()) {
-			throw new TupleQueryResultHandlerException("Result closed");
-		}
-	}
-
-	@Override
-	public void endQueryResult()
-		throws TupleQueryResultHandlerException
-	{
-		// no-op
-	}
-
-	@Override
-	public void handleBoolean(boolean value)
-		throws QueryResultHandlerException
-	{
-		throw new UnsupportedOperationException("Cannot handle boolean results");
-	}
-
-	@Override
-	public void handleLinks(List<String> linkUrls)
-		throws QueryResultHandlerException
-	{
-		// ignore
-	}
 }

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -220,7 +221,7 @@ public class QueryResults extends Iterations {
 				new QueueCursor<>(new LinkedBlockingQueue<>(1)), parser, in, format.getCharset(), baseURI);
 		boolean allGood = false;
 		try {
-			new Thread(result).start();
+			ForkJoinPool.commonPool().submit(result);
 			allGood = true;
 		}
 		finally {

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
@@ -73,10 +73,14 @@ public class QueryResults extends Iterations {
 		throws QueryEvaluationException
 	{
 		Statement singleResult = null;
-		if (result.hasNext()) {
-			singleResult = result.next();
+		try {
+			if (result.hasNext()) {
+				singleResult = result.next();
+			}
 		}
-		result.close();
+		finally {
+			result.close();
+		}
 		return singleResult;
 	}
 
@@ -90,10 +94,14 @@ public class QueryResults extends Iterations {
 		throws QueryEvaluationException
 	{
 		BindingSet singleResult = null;
-		if (result.hasNext()) {
-			singleResult = result.next();
+		try {
+			if (result.hasNext()) {
+				singleResult = result.next();
+			}
 		}
-		result.close();
+		finally {
+			result.close();
+		}
 		return singleResult;
 	}
 

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
@@ -201,8 +201,9 @@ public class QueryResults extends Iterations {
 	/**
 	 * Parses an RDF document and returns it as a GraphQueryResult object, with parsing done on a separate
 	 * thread in the background.<br>
-	 * IMPORTANT: As this method will spawn a new thread in the background, it is vitally important that it be
-	 * closed consistently when it is no longer required, to prevent resource leaks.
+	 * IMPORTANT: As this method will spawn a new thread in the background, it is vitally important that the
+	 * resulting GraphQueryResult be closed consistently when it is no longer required, to prevent resource
+	 * leaks.
 	 * 
 	 * @param in
 	 *        The {@link InputStream} containing the RDF document.
@@ -210,7 +211,8 @@ public class QueryResults extends Iterations {
 	 *        The base URI for the RDF document.
 	 * @param format
 	 *        The {@link RDFFormat} of the RDF document.
-	 * @return A {@link GraphQueryResult} that parses in the background.
+	 * @return A {@link GraphQueryResult} that parses in the background, and must be closed to prevent
+	 *         resource leaks.
 	 */
 	public static GraphQueryResult parseGraphBackground(InputStream in, String baseURI, RDFFormat format)
 		throws UnsupportedRDFormatException

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/BackgroundGraphResult.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/BackgroundGraphResult.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.rdf4j.common.iteration.IterationWrapper;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.rio.RDFHandler;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParser;
+
+/**
+ * Provides concurrent access to statements as they are being parsed when instances of this class are run as
+ * Threads.
+ * 
+ * @author James Leigh
+ */
+public class BackgroundGraphResult extends IterationWrapper<Statement, QueryEvaluationException>
+		implements GraphQueryResult, Runnable, RDFHandler
+{
+
+	private final RDFParser parser;
+
+	private final Charset charset;
+
+	private final InputStream in;
+
+	private final String baseURI;
+
+	private final CountDownLatch namespacesReady = new CountDownLatch(1);
+
+	private final Map<String, String> namespaces = new ConcurrentHashMap<String, String>();
+
+	private final QueueCursor<Statement> queue;
+
+	public BackgroundGraphResult(RDFParser parser, InputStream in, Charset charset, String baseURI) {
+		this(new QueueCursor<Statement>(10), parser, in, charset, baseURI);
+	}
+
+	public BackgroundGraphResult(QueueCursor<Statement> queue, RDFParser parser, InputStream in,
+			Charset charset, String baseURI)
+	{
+		super(queue);
+		this.queue = queue;
+		this.parser = parser;
+		this.in = in;
+		this.charset = charset;
+		this.baseURI = baseURI;
+	}
+
+	@Override
+	public boolean hasNext()
+		throws QueryEvaluationException
+	{
+		if (isClosed()) {
+			return false;
+		}
+		if (Thread.currentThread().isInterrupted()) {
+			close();
+			return false;
+		}
+
+		boolean result = queue.hasNext();
+		if (!result) {
+			close();
+		}
+		return result;
+	}
+
+	@Override
+	public Statement next()
+		throws QueryEvaluationException
+	{
+		if (isClosed()) {
+			throw new NoSuchElementException("The iteration has been closed.");
+		}
+		if (Thread.currentThread().isInterrupted()) {
+			close();
+			throw new NoSuchElementException("The iteration has been closed.");
+		}
+
+		try {
+			return queue.next();
+		}
+		catch (NoSuchElementException e) {
+			close();
+			throw e;
+		}
+	}
+
+	@Override
+	public void remove()
+		throws QueryEvaluationException
+	{
+		if (isClosed()) {
+			throw new IllegalStateException("The iteration has been closed.");
+		}
+		if (Thread.currentThread().isInterrupted()) {
+			close();
+			throw new IllegalStateException("The iteration has been closed.");
+		}
+
+		try {
+			queue.remove();
+		}
+		catch (IllegalStateException e) {
+			close();
+			throw e;
+		}
+	}
+
+	@Override
+	protected void handleClose()
+		throws QueryEvaluationException
+	{
+		try {
+			try {
+				super.handleClose();
+			}
+			finally {
+				try {
+					// After checking that we ourselves cannot possibly be generating an NPE ourselves, 
+					// attempt to close the input stream we were given
+					InputStream toClose = in;
+					if (toClose != null) {
+						toClose.close();
+					}
+				}
+				catch (NullPointerException e) {
+					// Swallow NullPointerException that Apache HTTPClient is hiding behind a NotThreadSafe annotation
+				}
+			}
+		}
+		catch (IOException e) {
+			throw new QueryEvaluationException(e);
+		}
+		finally {
+			queue.close();
+		}
+	}
+
+	@Override
+	public void run() {
+		try {
+			parser.setRDFHandler(this);
+			if (charset == null) {
+				parser.parse(in, baseURI);
+			}
+			else {
+				parser.parse(new InputStreamReader(in, charset), baseURI);
+			}
+		}
+		catch (RDFHandlerException e) {
+			// parsing was cancelled or interrupted
+			close();
+		}
+		catch (Exception e) {
+			queue.toss(e);
+			close();
+		}
+		finally {
+			queue.done();
+			namespacesReady.countDown();
+		}
+	}
+
+	@Override
+	public void startRDF()
+		throws RDFHandlerException
+	{
+		// no-op
+	}
+
+	@Override
+	public Map<String, String> getNamespaces() {
+		try {
+			namespacesReady.await();
+			// Show the user an unmodifiable view on the map but we can still change it here
+			return Collections.unmodifiableMap(namespaces);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			close();
+			throw new UndeclaredThrowableException(e);
+		}
+	}
+
+	@Override
+	public void handleComment(String comment)
+		throws RDFHandlerException
+	{
+		// ignore
+	}
+
+	@Override
+	public void handleNamespace(String prefix, String uri)
+		throws RDFHandlerException
+	{
+		namespaces.put(prefix, uri);
+	}
+
+	@Override
+	public void handleStatement(Statement st)
+		throws RDFHandlerException
+	{
+		namespacesReady.countDown();
+		try {
+			queue.put(st);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			close();
+			throw new RDFHandlerException(e);
+		}
+		if (isClosed()) {
+			throw new RDFHandlerException("Result closed");
+		}
+	}
+
+	@Override
+	public void endRDF()
+		throws RDFHandlerException
+	{
+		namespacesReady.countDown();
+	}
+
+}

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/QueueCursor.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/QueueCursor.java
@@ -5,8 +5,9 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.http.client;
+package org.eclipse.rdf4j.query.impl;
 
+import org.eclipse.rdf4j.common.iteration.QueueIteration;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
 /**
@@ -14,10 +15,8 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
  * automatically converting the exception into a QueryEvaluationException with an appropriate stack trace.
  * 
  * @author James Leigh
- * @deprecated Use {@link org.eclipse.rdf4j.query.impl.QueueCursor} instead
  */
-@Deprecated
-public class QueueCursor<E> extends org.eclipse.rdf4j.query.impl.QueueCursor<E> {
+public class QueueCursor<E> extends QueueIteration<E, QueryEvaluationException> {
 
 	/**
 	 * Creates an <tt>QueueCursor</tt> with the given (fixed) capacity and default access policy.

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/QueueCursor.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/QueueCursor.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.impl;
 
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
 import org.eclipse.rdf4j.common.iteration.QueueIteration;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
@@ -39,6 +42,19 @@ public class QueueCursor<E> extends QueueIteration<E, QueryEvaluationException> 
 	 */
 	public QueueCursor(int capacity, boolean fair) {
 		super(capacity, fair);
+	}
+
+	/**
+	 * Creates an <tt>QueueCursor</tt> with the given {@link BlockingQueue} as its backing queue.<br>
+	 * It may not be threadsafe to modify or access the given {@link BlockingQueue} from other locations. This
+	 * method only enables the default {@link ArrayBlockingQueue} to be overridden.
+	 * 
+	 * @param queue
+	 *        A BlockingQueue that is not used in other locations, but will be used as the backing Queue
+	 *        implementation for this cursor.
+	 */
+	public QueueCursor(BlockingQueue<E> queue) {
+		super(queue);
 	}
 
 	@Override

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultIO.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultIO.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
 
@@ -362,7 +363,7 @@ public class QueryResultIO {
 			// when the BackgroundTupleResult is either closed or interrupted
 			boolean allGood = false;
 			try {
-				new Thread(result).start();
+				ForkJoinPool.commonPool().submit(result);
 				allGood = true;
 			}
 			finally {

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultIO.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultIO.java
@@ -141,6 +141,7 @@ public class QueryResultIO {
 	 * by {@link TupleQueryResultParserRegistry#getInstance()} to get a factory for the specified format and
 	 * uses this factory to create the appropriate parser.
 	 * 
+	 * @return A TupleQueryResultParser matching the given format.
 	 * @throws UnsupportedQueryResultFormatException
 	 *         If no parser is available for the specified tuple query result format.
 	 */
@@ -159,6 +160,7 @@ public class QueryResultIO {
 	 * Convenience methods for creating TupleQueryResultParser objects that use the specified ValueFactory to
 	 * create RDF model objects.
 	 * 
+	 * @return A TupleQueryResultParser matching the given format.
 	 * @throws UnsupportedQueryResultFormatException
 	 *         If no parser is available for the specified tuple query result format.
 	 * @see #createParser(TupleQueryResultFormat)
@@ -178,6 +180,7 @@ public class QueryResultIO {
 	 * by {@link TupleQueryResultWriterRegistry#getInstance()} to get a factory for the specified format and
 	 * uses this factory to create the appropriate writer.
 	 * 
+	 * @return A TupleQueryResultWriter matching the given format.
 	 * @throws UnsupportedQueryResultFormatException
 	 *         If no writer is available for the specified tuple query result format.
 	 */
@@ -197,6 +200,7 @@ public class QueryResultIO {
 	 * returned by {@link BooleanQueryResultParserRegistry#getInstance()} to get a factory for the specified
 	 * format and uses this factory to create the appropriate parser.
 	 * 
+	 * @return A BooleanQueryResultParser matching the given format.
 	 * @throws UnsupportedQueryResultFormatException
 	 *         If no parser is available for the specified boolean query result format.
 	 */
@@ -216,6 +220,7 @@ public class QueryResultIO {
 	 * returned by {@link BooleanQueryResultWriterRegistry#getInstance()} to get a factory for the specified
 	 * format and uses this factory to create the appropriate writer.
 	 * 
+	 * @return A BooleanQueryResultWriter matching the given format.
 	 * @throws UnsupportedQueryResultFormatException
 	 *         If no writer is available for the specified boolean query result format.
 	 */
@@ -235,6 +240,7 @@ public class QueryResultIO {
 	 * {@link TupleQueryResultWriterRegistry#getInstance()} to get a factory for the specified format and uses
 	 * this factory to create the appropriate writer.
 	 * 
+	 * @return A QueryResultWriter matching the given format.
 	 * @throws UnsupportedQueryResultFormatException
 	 *         If no writer is available for the specified tuple query result format.
 	 */
@@ -308,6 +314,7 @@ public class QueryResultIO {
 	 * @param format
 	 *        The query result format of the document to parse. Supported formats are
 	 *        {@link TupleQueryResultFormat#SPARQL} and {@link TupleQueryResultFormat#BINARY}.
+	 * @return A TupleQueryResult containing the query results.
 	 * @throws IOException
 	 *         If an I/O error occured while reading the query result document from the stream.
 	 * @throws TupleQueryResultHandlerException
@@ -326,14 +333,16 @@ public class QueryResultIO {
 	/**
 	 * Parses a query result document and returns it as a TupleQueryResult object, with parsing done on a
 	 * separate thread in the background.<br>
-	 * IMPORTANT: As this method will spawn a new thread in the background, it is vitally important that it be
-	 * closed consistently when it is no longer required, to prevent resource leaks.
+	 * IMPORTANT: As this method may spawn a new thread in the background, it is vitally important that the
+	 * TupleQueryResult be closed consistently when it is no longer required, to prevent resource leaks.
 	 * 
 	 * @param in
 	 *        An InputStream to read the query result document from.
 	 * @param format
 	 *        The query result format of the document to parse. Supported formats are
 	 *        {@link TupleQueryResultFormat#SPARQL} and {@link TupleQueryResultFormat#BINARY}.
+	 * @return A TupleQueryResult containing the query results, which must be closed to prevent resource
+	 *         leaks.
 	 * @throws IOException
 	 *         If an I/O error occured while reading the query result document from the stream.
 	 * @throws TupleQueryResultHandlerException
@@ -375,10 +384,8 @@ public class QueryResultIO {
 		}
 		else {
 			TupleQueryResultBuilder qrBuilder = new TupleQueryResultBuilder();
-			parser.setQueryResultHandler(qrBuilder);
-
 			try {
-				parser.parseQueryResult(in);
+				parser.setQueryResultHandler(qrBuilder).parseQueryResult(in);
 			}
 			catch (QueryResultHandlerException e) {
 				if (e instanceof TupleQueryResultHandlerException) {
@@ -400,6 +407,7 @@ public class QueryResultIO {
 	 *        An InputStream to read the query result document from.
 	 * @param format
 	 *        The file format of the document to parse.
+	 * @return A boolean representing the result of parsing the given InputStream.
 	 * @throws IOException
 	 *         If an I/O error occured while reading the query result document from the stream.
 	 * @throws UnsupportedQueryResultFormatException

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/helpers/BackgroundTupleResult.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/helpers/BackgroundTupleResult.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.helpers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryResultHandlerException;
+import org.eclipse.rdf4j.query.TupleQueryResultHandler;
+import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
+import org.eclipse.rdf4j.query.impl.IteratingTupleQueryResult;
+import org.eclipse.rdf4j.query.impl.QueueCursor;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
+
+/**
+ * Provides concurrent access to tuple results as they are being parsed.
+ * 
+ * @author James Leigh
+ */
+public class BackgroundTupleResult extends IteratingTupleQueryResult
+		implements Runnable, TupleQueryResultHandler
+{
+
+	private final TupleQueryResultParser parser;
+
+	private final InputStream in;
+
+	private final QueueCursor<BindingSet> queue;
+
+	private final List<String> bindingNames = new ArrayList<>();
+
+	private final CountDownLatch bindingNamesReady = new CountDownLatch(1);
+
+	public BackgroundTupleResult(TupleQueryResultParser parser, InputStream in) {
+		this(new QueueCursor<BindingSet>(10), parser, in);
+	}
+
+	public BackgroundTupleResult(QueueCursor<BindingSet> queue, TupleQueryResultParser parser,
+			InputStream in)
+	{
+		super(Collections.<String> emptyList(), queue);
+		this.queue = queue;
+		this.parser = parser;
+		this.in = in;
+	}
+
+	@Override
+	protected void handleClose()
+		throws QueryEvaluationException
+	{
+		try {
+			try {
+				super.handleClose();
+			}
+			finally {
+				try {
+					// After checking that we ourselves cannot possibly be generating an NPE ourselves, 
+					// attempt to close the input stream we were given
+					InputStream toClose = in;
+					if (toClose != null) {
+						toClose.close();
+					}
+				}
+				catch (NullPointerException e) {
+					// Swallow NullPointerException that Apache HTTPClient is hiding behind a NotThreadSafe annotation
+				}
+			}
+		}
+		catch (IOException e) {
+			throw new QueryEvaluationException(e);
+		}
+		finally {
+			queue.close();
+		}
+	}
+
+	@Override
+	public List<String> getBindingNames() {
+		try {
+			bindingNamesReady.await();
+			queue.checkException();
+			return bindingNames;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			close();
+			throw new UndeclaredThrowableException(e);
+		}
+		catch (QueryEvaluationException e) {
+			close();
+			throw new UndeclaredThrowableException(e);
+		}
+	}
+
+	@Override
+	public void run() {
+		try {
+			parser.setQueryResultHandler(this);
+			parser.parseQueryResult(in);
+		}
+		catch (QueryResultHandlerException e) {
+			// parsing cancelled or interrupted
+			close();
+		}
+		catch (Exception e) {
+			queue.toss(e);
+			close();
+		}
+		finally {
+			queue.done();
+			bindingNamesReady.countDown();
+		}
+	}
+
+	@Override
+	public void startQueryResult(List<String> bindingNames)
+		throws TupleQueryResultHandlerException
+	{
+		this.bindingNames.addAll(bindingNames);
+		bindingNamesReady.countDown();
+	}
+
+	@Override
+	public void handleSolution(BindingSet bindingSet)
+		throws TupleQueryResultHandlerException
+	{
+		try {
+			queue.put(bindingSet);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			close();
+			throw new TupleQueryResultHandlerException(e);
+		}
+		if (isClosed()) {
+			throw new TupleQueryResultHandlerException("Result closed");
+		}
+	}
+
+	@Override
+	public void endQueryResult()
+		throws TupleQueryResultHandlerException
+	{
+		// no-op
+	}
+
+	@Override
+	public void handleBoolean(boolean value)
+		throws QueryResultHandlerException
+	{
+		throw new UnsupportedOperationException("Cannot handle boolean results");
+	}
+
+	@Override
+	public void handleLinks(List<String> linkUrls)
+		throws QueryResultHandlerException
+	{
+		// ignore
+	}
+}

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueueCursor.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueueCursor.java
@@ -12,8 +12,7 @@ package org.eclipse.rdf4j.repository.sparql.query;
  * automatically converting the exception into a QueryEvaluationException with an appropriate stack trace.
  * 
  * @author James Leigh
- * @deprecated use {@link org.eclipse.rdf4j.http.client.QueueCursor} instead
- * @see org.eclipse.rdf4j.http.client.QueueCursor
+ * @deprecated Use {@link org.eclipse.rdf4j.query.impl.QueueCursor} instead
  */
 @Deprecated
 public class QueueCursor<E> extends org.eclipse.rdf4j.http.client.QueueCursor<E> {

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueueCursor.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueueCursor.java
@@ -15,6 +15,7 @@ package org.eclipse.rdf4j.repository.sparql.query;
  * @deprecated use {@link org.eclipse.rdf4j.http.client.QueueCursor} instead
  * @see org.eclipse.rdf4j.http.client.QueueCursor
  */
+@Deprecated
 public class QueueCursor<E> extends org.eclipse.rdf4j.http.client.QueueCursor<E> {
 
 	public QueueCursor(int capacity, boolean fair) {

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/QueueCursor.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/QueueCursor.java
@@ -12,7 +12,7 @@ package org.eclipse.rdf4j.sail.federation.evaluation;
  * automatically converting the exception into a QueryEvaluationException with an appropriate stack trace.
  * 
  * @author James Leigh
- * @deprecated Use {@link org.eclipse.rdf4j.http.client.QueueCursor} instead	
+ * @deprecated Use {@link org.eclipse.rdf4j.query.impl.QueueCursor} instead
  */
 @Deprecated
 public class QueueCursor<E> extends org.eclipse.rdf4j.http.client.QueueCursor<E> {

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/QueueCursor.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/QueueCursor.java
@@ -7,33 +7,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.federation.evaluation;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
-import org.eclipse.rdf4j.query.QueryEvaluationException;
-
 /**
  * Makes working with a queue easier by adding the methods {@link #done()} and {@link #toss(Exception)} and
  * automatically converting the exception into a QueryEvaluationException with an appropriate stack trace.
  * 
  * @author James Leigh
+ * @deprecated Use {@link org.eclipse.rdf4j.http.client.QueueCursor} instead	
  */
-public class QueueCursor<E> extends LookAheadIteration<E, QueryEvaluationException> {
-
-	private final AtomicBoolean done = new AtomicBoolean(false);
-
-	private final BlockingQueue<E> queue;
-
-	private final E afterLast = createAfterLast();
-
-	private final Queue<Throwable> exceptions = new LinkedList<Throwable>();
+@Deprecated
+public class QueueCursor<E> extends org.eclipse.rdf4j.http.client.QueueCursor<E> {
 
 	/**
 	 * Creates an <tt>QueueCursor</tt> with the given (fixed) capacity and default access policy.
@@ -55,134 +37,7 @@ public class QueueCursor<E> extends LookAheadIteration<E, QueryEvaluationExcepti
 	 *        in FIFO order; if <tt>false</tt> the access order is unspecified.
 	 */
 	public QueueCursor(int capacity, boolean fair) {
-		super();
-		this.queue = new ArrayBlockingQueue<E>(capacity, fair);
-	}
-
-	/**
-	 * The next time {@link #next()} is called this exception will be thrown. If it is not a
-	 * QueryEvaluationException or RuntimeException it will be wrapped in a QueryEvaluationException.
-	 */
-	public void toss(Exception exception) {
-		synchronized (exceptions) {
-			exceptions.add(exception);
-		}
-	}
-
-	/**
-	 * Adds another item to the queue, blocking while the queue is full.
-	 */
-	public void put(E item)
-		throws InterruptedException
-	{
-		if (!done.get()) {
-			queue.put(item);
-		}
-	}
-
-	/**
-	 * Indicates the method {@link #put(Object)} will not be called in the queue anymore.
-	 */
-	public void done() {
-		// Lazily set here, and then come back in handleClose and use set if necessary
-		done.lazySet(true);
-		try {
-			queue.add(afterLast);
-		}
-		catch (IllegalStateException e) { // NOPMD
-			// no thread is waiting on this queue anyway
-		}
-	}
-
-	/**
-	 * Returns the next item in the queue or throws an exception.
-	 */
-	@Override
-	public E getNextElement()
-		throws QueryEvaluationException
-	{
-		try {
-			checkException();
-			E take;
-			if (done.get()) {
-				take = queue.poll();
-			}
-			else {
-				take = queue.take();
-				if (done.get()) {
-					done(); // in case the queue was full before
-				}
-			}
-			if (isAfterLast(take)) {
-				checkException();
-				done(); // put afterLast back for others
-				take = null; // NOPMD
-			}
-			return take;
-		}
-		catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			checkException();
-			throw new QueryEvaluationException(e);
-		}
-	}
-
-	@Override
-	public void handleClose()
-		throws QueryEvaluationException
-	{
-		try {
-			super.handleClose();
-		}
-		finally {
-			done.set(true);
-			do {
-				queue.clear(); // ensure extra room is available
-			}
-			while (!queue.offer(afterLast));
-			checkException();
-		}
-	}
-
-	public void checkException()
-		throws QueryEvaluationException
-	{
-		synchronized (exceptions) {
-			if (!exceptions.isEmpty()) {
-				try {
-					throw exceptions.remove();
-				}
-				catch (QueryEvaluationException e) {
-					modifyStackTraceAndRethrow(e, 1);
-				}
-				catch (RuntimeException e) {
-					modifyStackTraceAndRethrow(e, 0);
-				}
-				catch (Throwable e) { // NOPMD
-					throw new QueryEvaluationException(e);
-				}
-			}
-		}
-	}
-
-	private <X extends Exception> void modifyStackTraceAndRethrow(X exception, int firstIndex)
-		throws X
-	{
-		List<StackTraceElement> stack = new ArrayList<StackTraceElement>();
-		stack.addAll(Arrays.asList(exception.getStackTrace()));
-		StackTraceElement[] thisStack = new Throwable().getStackTrace(); // NOPMD
-		stack.addAll(Arrays.asList(thisStack).subList(firstIndex, thisStack.length));
-		exception.setStackTrace(stack.toArray(new StackTraceElement[stack.size()]));
-		throw exception;
-	}
-
-	private boolean isAfterLast(E take) {
-		return take == null || take == afterLast; // NOPMD
-	}
-
-	@SuppressWarnings("unchecked")
-	private E createAfterLast() {
-		return (E)new Object();
+		super(capacity, fair);
 	}
 
 }

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/QueueIteration.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/QueueIteration.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.common.iteration;
+
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
+
+/**
+ * Makes working with a queue easier by adding the methods {@link #done()} and {@link #toss(Exception)} and
+ * after converting the Exception to the required type using {@link #convert(Exception)}.
+ * 
+ * @author James Leigh
+ */
+public abstract class QueueIteration<E, T extends Exception> extends LookAheadIteration<E, T> {
+
+	private final AtomicBoolean done = new AtomicBoolean(false);
+
+	private final BlockingQueue<E> queue;
+
+	private final E afterLast = createAfterLast();
+
+	private final Queue<Exception> exceptions = new ConcurrentLinkedQueue<Exception>();
+
+	/**
+	 * Creates an <tt>QueueCursor</tt> with the given (fixed) capacity and default access policy.
+	 * 
+	 * @param capacity
+	 *        the capacity of this queue
+	 */
+	public QueueIteration(int capacity) {
+		this(capacity, false);
+	}
+
+	/**
+	 * Creates an <tt>QueueCursor</tt> with the given (fixed) capacity and the specified access policy.
+	 * 
+	 * @param capacity
+	 *        the capacity of this queue
+	 * @param fair
+	 *        if <tt>true</tt> then queue accesses for threads blocked on insertion or removal, are processed
+	 *        in FIFO order; if <tt>false</tt> the access order is unspecified.
+	 */
+	public QueueIteration(int capacity, boolean fair) {
+		super();
+		this.queue = new ArrayBlockingQueue<E>(capacity, fair);
+	}
+
+	/**
+	 * Converts an exception from the underlying iteration to an exception of type <tt>X</tt>.
+	 */
+	protected abstract T convert(Exception e);
+
+	/**
+	 * The next time {@link #next()} is called this exception will be thrown. If it is not a
+	 * QueryEvaluationException or RuntimeException it will be wrapped in a QueryEvaluationException.
+	 */
+	public void toss(Exception exception) {
+		exceptions.add(exception);
+	}
+
+	/**
+	 * Adds another item to the queue, blocking while the queue is full.
+	 */
+	public void put(E item)
+		throws InterruptedException, T
+	{
+		try {
+			while (!isClosed() && !done.get() && !Thread.currentThread().isInterrupted()
+					&& !queue.offer(item, 1, TimeUnit.SECONDS))
+			{
+				// No body, just iterating regularly through the loop conditions to respond to state changes without a full busy-wait loop
+			}
+			// Proactively close if interruption didn't propagate an exception to the catch clause below
+			if (done.get() || Thread.currentThread().isInterrupted()) {
+				close();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			close();
+			throw e;
+		}
+	}
+
+	/**
+	 * Indicates the method {@link #put(Object)} will not be called in the queue anymore.
+	 */
+	public void done() {
+		// Lazily set here, and then come back in handleClose and use set if necessary
+		done.lazySet(true);
+		boolean offer = queue.offer(afterLast);
+		if (!offer) {
+			// TODO: Log inability to add sentinel at debug level
+			// The sentinel is forced onto the queue during the close method
+		}
+	}
+
+	/**
+	 * Returns the next item in the queue, which may be <tt>null</tt>, or throws an exception.
+	 */
+	@Override
+	public E getNextElement()
+		throws T
+	{
+		if (isClosed()) {
+			return null;
+		}
+		try {
+			checkException();
+			E take;
+			if (done.get()) {
+				take = queue.poll();
+			}
+			else {
+				take = queue.take();
+				if (done.get()) {
+					done(); // in case the queue was full before
+				}
+			}
+			if (isAfterLast(take)) {
+				checkException();
+				done(); // put afterLast back for others
+				return null;
+			}
+			checkException();
+			return take;
+		}
+		catch (InterruptedException e) {
+			checkException();
+			close();
+			throw convert(e);
+		}
+	}
+
+	@Override
+	public void handleClose()
+		throws T
+	{
+		try {
+			super.handleClose();
+		}
+		finally {
+			done.set(true);
+			do {
+				queue.clear(); // ensure extra room is available
+			}
+			while (!queue.offer(afterLast));
+			checkException();
+		}
+	}
+
+	public void checkException()
+		throws T
+	{
+		if (!exceptions.isEmpty()) {
+			try {
+				close();
+				throw exceptions.remove();
+			}
+			catch (Exception e) {
+				throw convert(e);
+			}
+		}
+	}
+
+	private boolean isAfterLast(E take) {
+		return take == null || take == afterLast;
+	}
+
+	@SuppressWarnings("unchecked")
+	private E createAfterLast() {
+		return (E)new Object();
+	}
+
+}

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/QueueIteration.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/QueueIteration.java
@@ -33,7 +33,7 @@ public abstract class QueueIteration<E, T extends Exception> extends LookAheadIt
 	private final Queue<Exception> exceptions = new ConcurrentLinkedQueue<Exception>();
 
 	/**
-	 * Creates an <tt>QueueCursor</tt> with the given (fixed) capacity and default access policy.
+	 * Creates an <tt>QueueIteration</tt> with the given (fixed) capacity and default access policy.
 	 * 
 	 * @param capacity
 	 *        the capacity of this queue
@@ -43,7 +43,7 @@ public abstract class QueueIteration<E, T extends Exception> extends LookAheadIt
 	}
 
 	/**
-	 * Creates an <tt>QueueCursor</tt> with the given (fixed) capacity and the specified access policy.
+	 * Creates an <tt>QueueIteration</tt> with the given (fixed) capacity and the specified access policy.
 	 * 
 	 * @param capacity
 	 *        the capacity of this queue
@@ -54,6 +54,19 @@ public abstract class QueueIteration<E, T extends Exception> extends LookAheadIt
 	public QueueIteration(int capacity, boolean fair) {
 		super();
 		this.queue = new ArrayBlockingQueue<E>(capacity, fair);
+	}
+
+	/**
+	 * Creates an <tt>QueueIteration</tt> with the given {@link BlockingQueue} as its backing queue.<br>
+	 * It may not be threadsafe to modify or access the given {@link BlockingQueue} from other locations. This
+	 * method only enables the default {@link ArrayBlockingQueue} to be overridden.
+	 * 
+	 * @param queue
+	 *        A BlockingQueue that is not used in other locations, but will be used as the backing Queue
+	 *        implementation for this cursor.
+	 */
+	public QueueIteration(BlockingQueue<E> queue) {
+		this.queue = queue;
 	}
 
 	/**

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,6 +73,27 @@ public abstract class AbstractQueryResultIOTest {
 	protected abstract String getFileName();
 
 	protected abstract QueryResultFormat getFormat();
+
+	/**
+	 * Override this to customise how the tuple parsing is performed, particularly to test background and
+	 * other parsing strategies.
+	 * 
+	 * @param format
+	 *        The {@link TupleQueryResultFormat} for the parser.
+	 * @param in
+	 *        The InputStream to parse
+	 * @return A {@link TupleQueryResult} that can be parsed.
+	 * @throws IOException
+	 * @throws QueryResultParseException
+	 * @throws TupleQueryResultHandlerException
+	 * @throws UnsupportedQueryResultFormatException
+	 */
+	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in)
+		throws IOException, QueryResultParseException, TupleQueryResultHandlerException,
+		UnsupportedQueryResultFormatException
+	{
+		return QueryResultIO.parseTuple(in, format);
+	}
 
 	/**
 	 * Test method for
@@ -216,7 +238,7 @@ public abstract class AbstractQueryResultIOTest {
 		// System.out.println("output: " + out.toString("UTF-8"));
 
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+		TupleQueryResult output = parseTupleInternal(format, in);
 
 		assertQueryResultsEqual(expected, output);
 	}
@@ -237,7 +259,7 @@ public abstract class AbstractQueryResultIOTest {
 		// System.out.println("output: " + out.toString("UTF-8"));
 
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+		TupleQueryResult output = parseTupleInternal(format, in);
 
 		assertQueryResultsEqual(expected, output);
 	}
@@ -262,7 +284,7 @@ public abstract class AbstractQueryResultIOTest {
 		// System.out.println("output: " + out.toString("UTF-8"));
 
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+		TupleQueryResult output = parseTupleInternal(format, in);
 
 		assertQueryResultsEqual(expected, output);
 	}
@@ -297,7 +319,7 @@ public abstract class AbstractQueryResultIOTest {
 		// System.out.println("output: " + result);
 
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+		TupleQueryResult output = parseTupleInternal(format, in);
 
 		assertQueryResultsEqual(expected, output);
 
@@ -338,12 +360,13 @@ public abstract class AbstractQueryResultIOTest {
 			assertTrue(result.startsWith(callback + "("));
 			assertTrue(result.endsWith(");"));
 
-			// Strip off the callback function and verify that it contains a valid
+			// Strip off the callback function and verify that it contains a
+			// valid
 			// JSON object containing the correct results
 			result = result.substring(callback.length() + 1, result.length() - 2);
 
 			ByteArrayInputStream in = new ByteArrayInputStream(result.getBytes("UTF-8"));
-			TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+			TupleQueryResult output = parseTupleInternal(format, in);
 
 			assertQueryResultsEqual(expected, output);
 		}
@@ -361,7 +384,7 @@ public abstract class AbstractQueryResultIOTest {
 		// System.out.println("output: " + out.toString("UTF-8"));
 
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+		TupleQueryResult output = parseTupleInternal(format, in);
 
 		assertQueryResultsEqual(expected, output);
 	}
@@ -379,7 +402,7 @@ public abstract class AbstractQueryResultIOTest {
 		// System.out.println("output: " + out.toString("UTF-8"));
 
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+		TupleQueryResult output = parseTupleInternal(format, in);
 
 		assertQueryResultsEqual(expected, output);
 	}
@@ -399,7 +422,7 @@ public abstract class AbstractQueryResultIOTest {
 		// System.out.println("output: " + out.toString("UTF-8"));
 
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+		TupleQueryResult output = parseTupleInternal(format, in);
 
 		assertQueryResultsEqual(expected, output);
 	}
@@ -431,7 +454,7 @@ public abstract class AbstractQueryResultIOTest {
 		// System.out.println("output: " + out.toString("UTF-8"));
 
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-		TupleQueryResult output = QueryResultIO.parseTuple(in, format);
+		TupleQueryResult output = parseTupleInternal(format, in);
 
 		assertQueryResultsEqual(expected, output);
 	}
@@ -496,7 +519,7 @@ public abstract class AbstractQueryResultIOTest {
 		TupleQueryResultParser parser = QueryResultIO.createTupleParser(format);
 		// This should perform a full parse to verify the document, even though
 		// the handler is not set
-		parser.parse(in);
+		parser.parseQueryResult(in);
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses GitHub issue: #740 .

Briefly describe the changes proposed in this PR:

* Move BackgroundGraphResult and BackgroundTupleResult (and QueueCursor) to more accessible locations
* Add new API calls that will use the background methods (QueryResults.parseGraphBackground and QueryResultIO.parseTupleBackground) with a small fixed length BlockingQueue to simulate a pull based parser. Parser will now block (ie, wait) on their respective handle methods until the queue has the capacity to allow it to go further.

This pull request addresses part of #738, in that the internal push-based parsing now has an easy to use push-back mechanism to rate-limit and (almost) short-circuit the parsing based on the consumer. In reality, the capacity of the BlockingQueue used imposes a limit on the amount of short-circuiting in play. In this iteration, the capacity is fixed at 1, but QueueCursor has options for various other limits that users can experiment with themselves if 1 doesn't work for them. In the future we can extend the API to customise the capacity or change the default.

In terms of paging that was referred to in #738, the functionality already exists in the form of QueryResults.limitResults, which can be chained with the result of QueryResults.parseGraphBackground or QueryResultIO.parseTupleBackground.

The reasoning for the slightly odd placement of the helper methods relates to the current sub-optimal module layout, where rdf4j-rio-api is a dependency of rdf4j-query and rdf4j-query is a dependency of rdf4j-queryresultio-api.

In the QueueCursor case, rdf4j-query is a much better module in terms of dependencies compared to rdf4j-http-client, which should make it slightly more accessible for reuse.

In this iteration, ForkJoinPool.commonPool() is used to enable users to configure the maximum number of concurrent threads across calls to the parseGraphBackground/parseTupleBackground methods without having to add a dedicated ExecutorService to rdf4j-query.