### PR TITLE
#751 updated benchmark pom and applied renaming

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.eclipse.rdf4j</groupId>
         <artifactId>rdf4j</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>rdf4j-benchmark</artifactId>

--- a/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/ForwardChainingSchemaCachingRDFSInferencerBenchmark.java
+++ b/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/ForwardChainingSchemaCachingRDFSInferencerBenchmark.java
@@ -9,7 +9,7 @@
 package org.eclipse.rdf4j.benchmark;
 
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingSchemaCachingRDFSInferencer;
+import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencer;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 /**
@@ -19,12 +19,12 @@ public class ForwardChainingSchemaCachingRDFSInferencerBenchmark extends Initial
 
 	@Override
 	SailRepository getSail(SailRepository schema) {
-		return new SailRepository(new ForwardChainingSchemaCachingRDFSInferencer(new MemoryStore(), schema));
+		return new SailRepository(new SchemaCachingRDFSInferencer(new MemoryStore(), schema));
 	}
 
 	@Override
 	Class getSailClass() {
-		return ForwardChainingSchemaCachingRDFSInferencer.class;
+		return SchemaCachingRDFSInferencer.class;
 	}
 
 }

--- a/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/ReasoningBenchmark.java
+++ b/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/ReasoningBenchmark.java
@@ -14,7 +14,7 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingRDFSInferencer;
-import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingSchemaCachingRDFSInferencer;
+import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencer;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -125,7 +125,7 @@ public class ReasoningBenchmark {
 		throws IOException
 	{
 		SailRepository sail = new SailRepository(
-				new ForwardChainingSchemaCachingRDFSInferencer(new MemoryStore()));
+				new SchemaCachingRDFSInferencer(new MemoryStore()));
 		sail.initialize();
 
 		try (SailRepositoryConnection connection = sail.getConnection()) {
@@ -164,7 +164,7 @@ public class ReasoningBenchmark {
 		throws IOException
 	{
 		SailRepository sail = new SailRepository(
-				new ForwardChainingSchemaCachingRDFSInferencer(new MemoryStore()));
+				new SchemaCachingRDFSInferencer(new MemoryStore()));
 		sail.initialize();
 
 		try (SailRepositoryConnection connection = sail.getConnection()) {
@@ -187,7 +187,7 @@ public class ReasoningBenchmark {
 		throws IOException
 	{
 		SailRepository sail = new SailRepository(
-				new ForwardChainingSchemaCachingRDFSInferencer(new MemoryStore(), createSchema()));
+				new SchemaCachingRDFSInferencer(new MemoryStore(), createSchema()));
 		sail.initialize();
 
 		try (SailRepositoryConnection connection = sail.getConnection()) {
@@ -206,7 +206,7 @@ public class ReasoningBenchmark {
 		throws IOException
 	{
 		SailRepository sail = new SailRepository(
-				new ForwardChainingSchemaCachingRDFSInferencer(new MemoryStore(), createSchema()));
+				new SchemaCachingRDFSInferencer(new MemoryStore(), createSchema()));
 		sail.initialize();
 
 		try (SailRepositoryConnection connection = sail.getConnection()) {

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 		<module>testsuites</module>
 		<module>compliance</module>
 		<module>bom</module>
+		<module>benchmark</module>
 	</modules>
 
 	<profiles>


### PR DESCRIPTION
This PR addresses GitHub issue: #751 .

Briefly describe the changes proposed in this PR:

* Fixed version number in the benchmark pom
* Applied the renaming of ForwardChainingSchemaCachingRDFSInferencer to the benchmarking classes
