### PR TITLE
issue #759 : Use fixed Locale.ENGLISH for XML error verification

### DIFF
--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
@@ -18,6 +18,7 @@ import java.io.PrintStream;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Locale;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
@@ -31,6 +32,7 @@ import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,16 +46,28 @@ public class RDFXMLParserTest {
 
 	private ParseErrorCollector el;
 
+	private Locale platformLocale;
+
 	@Before
 	public void setUp()
 		throws Exception
 	{
+		platformLocale = Locale.getDefault();
+		
+		Locale.setDefault(Locale.ENGLISH);
 		vf = SimpleValueFactory.getInstance();
 		parser = new RDFXMLParser();
 		sc = new StatementCollector();
 		parser.setRDFHandler(sc);
 		el = new ParseErrorCollector();
 		parser.setParseErrorListener(el);
+	}
+
+	@After
+	public void tearDown()
+		throws Exception
+	{
+		Locale.setDefault(platformLocale);
 	}
 
 	@Test
@@ -121,7 +135,8 @@ public class RDFXMLParserTest {
 	public void testFatalErrorPrologContent()
 		throws Exception
 	{
-		// Temporarily override System.err to verify that nothing is being printed to it for this test
+		// Temporarily override System.err to verify that nothing is being
+		// printed to it for this test
 		PrintStream oldErr = System.err;
 		ByteArrayOutputStream tempErr = new ByteArrayOutputStream();
 		System.setErr(new PrintStream(tempErr));
@@ -134,13 +149,14 @@ public class RDFXMLParserTest {
 			parser.parse(in, "");
 		}
 		catch (RDFParseException e) {
-			// FIXME exact error message is locale-dependent. Just fall through, error is expected. See #280.
-			//			assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
+			assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
 		}
 		finally {
-			// Reset System Error output to ensure that we don't interfere with other tests
+			// Reset System Error output to ensure that we don't interfere with
+			// other tests
 			System.setErr(oldErr);
-			// Reset System Out output to ensure that we don't interfere with other tests
+			// Reset System Out output to ensure that we don't interfere with
+			// other tests
 			System.setOut(oldOut);
 		}
 		// Verify nothing was printed to System.err during test

--- a/core/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
+++ b/core/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.Locale;
 
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -19,6 +20,7 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,10 +34,15 @@ public class TriXParserTest {
 
 	private ParseErrorCollector el;
 
+	private Locale platformLocale;
+
 	@Before
 	public void setUp()
 		throws Exception
 	{
+		platformLocale = Locale.getDefault();
+
+		Locale.setDefault(Locale.ENGLISH);
 		vf = SimpleValueFactory.getInstance();
 		parser = new TriXParser();
 		sc = new StatementCollector();
@@ -44,11 +51,19 @@ public class TriXParserTest {
 		parser.setParseErrorListener(el);
 	}
 
+	@After
+	public void tearDown()
+		throws Exception
+	{
+		Locale.setDefault(platformLocale);
+	}
+
 	@Test
 	public void testFatalErrorPrologContent()
 		throws Exception
 	{
-		// Temporarily override System.err to verify that nothing is being printed to it for this test
+		// Temporarily override System.err to verify that nothing is being
+		// printed to it for this test
 		PrintStream oldErr = System.err;
 		ByteArrayOutputStream tempErr = new ByteArrayOutputStream();
 		System.setErr(new PrintStream(tempErr));
@@ -61,13 +76,14 @@ public class TriXParserTest {
 			parser.parse(in, "");
 		}
 		catch (RDFParseException e) {
-			// FIXME exact error message is locale-dependent. Just fall through, error is expected. See #280.
-			// assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
+			assertEquals("Content is not allowed in prolog. [line 1, column 1]", e.getMessage());
 		}
 		finally {
-			// Reset System Error output to ensure that we don't interfere with other tests
+			// Reset System Error output to ensure that we don't interfere with
+			// other tests
 			System.setErr(oldErr);
-			// Reset System Out output to ensure that we don't interfere with other tests
+			// Reset System Out output to ensure that we don't interfere with
+			// other tests
 			System.setOut(oldOut);
 		}
 		// Verify nothing was printed to System.err during test


### PR DESCRIPTION
This PR addresses GitHub issue: #759 .

Briefly describe the changes proposed in this PR:

* Use fixed Locale.ENGLISH for XML error verification in tests. If this turns out not to work, the message verification can be easily removed, but prefer if the tests were specific to the error they are attempting to test
