### PR TITLE
Clean up tests using deprecated methods

### DIFF
--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
@@ -13,10 +13,10 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Collections;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.NamespaceImpl;
@@ -40,13 +40,13 @@ import org.junit.rules.Timeout;
 
 /**
  * Custom tests for Turtle Parser
- * 
+ *
  * @author Peter Ansell
  */
 public class CustomTurtleParserTest {
 
 	@Rule
-	public Timeout timeout = new Timeout(1000000);
+	public Timeout timeout = Timeout.millis(1000000);
 
 	private ValueFactory vf;
 
@@ -183,8 +183,8 @@ public class CustomTurtleParserTest {
 		String okLiteralString = "Literal \n without \n new line at the beginning. \n ";
 		String errLiteralString = "\n Literal \n with \n new line at the beginning. \n ";
 
-		URI mySubject = vf.createURI(namespace, "Subject");
-		URI myPredicate = vf.createURI(namespace, "Predicate");
+		IRI mySubject = vf.createIRI(namespace, "Subject");
+		IRI myPredicate = vf.createIRI(namespace, "Predicate");
 		Literal myOkObject = vf.createLiteral(okLiteralString);
 		Literal myErrObject = vf.createLiteral(errLiteralString);
 
@@ -301,7 +301,7 @@ public class CustomTurtleParserTest {
 		Model model = Rio.parse(new StringReader("<urn:a> a _:c2; <urn:b> <urn:c> ."), "", RDFFormat.TURTLE);
 
 		assertEquals(2, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), vf.createURI("urn:b"), vf.createURI("urn:c")));
+		assertTrue(model.contains(vf.createIRI("urn:a"), vf.createIRI("urn:b"), vf.createIRI("urn:c")));
 	}
 
 	@Test
@@ -311,7 +311,7 @@ public class CustomTurtleParserTest {
 		Model model = Rio.parse(new StringReader("<urn:a> a _:c2;<urn:b> <urn:c> ."), "", RDFFormat.TURTLE);
 
 		assertEquals(2, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), vf.createURI("urn:b"), vf.createURI("urn:c")));
+		assertTrue(model.contains(vf.createIRI("urn:a"), vf.createIRI("urn:b"), vf.createIRI("urn:c")));
 	}
 
 	@Test
@@ -411,8 +411,8 @@ public class CustomTurtleParserTest {
 				RDFFormat.TURTLE);
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), vf.createURI("urn:b"),
-				vf.createLiteral("testliteral", vf.createURI("urn:datatype"))));
+		assertTrue(model.contains(vf.createIRI("urn:a"), vf.createIRI("urn:b"),
+				vf.createLiteral("testliteral", vf.createIRI("urn:datatype"))));
 	}
 
 	@Test
@@ -423,8 +423,8 @@ public class CustomTurtleParserTest {
 				RDFFormat.TURTLE);
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), vf.createURI("urn:b"),
-				vf.createLiteral("testliteral", vf.createURI("urn:datatype"))));
+		assertTrue(model.contains(vf.createIRI("urn:a"), vf.createIRI("urn:b"),
+				vf.createLiteral("testliteral", vf.createIRI("urn:datatype"))));
 	}
 
 	@Test
@@ -435,8 +435,8 @@ public class CustomTurtleParserTest {
 				RDFFormat.TURTLE);
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), vf.createURI("urn:b"),
-				vf.createLiteral("testliteral", vf.createURI("urn:datatype"))));
+		assertTrue(model.contains(vf.createIRI("urn:a"), vf.createIRI("urn:b"),
+				vf.createLiteral("testliteral", vf.createIRI("urn:datatype"))));
 	}
 
 	@Test
@@ -447,8 +447,8 @@ public class CustomTurtleParserTest {
 				RDFFormat.TURTLE);
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), vf.createURI("urn:b"),
-				vf.createLiteral("testliteral", vf.createURI("urn:datatype"))));
+		assertTrue(model.contains(vf.createIRI("urn:a"), vf.createIRI("urn:b"),
+				vf.createLiteral("testliteral", vf.createIRI("urn:datatype"))));
 	}
 
 	@Test
@@ -460,8 +460,8 @@ public class CustomTurtleParserTest {
 				RDFFormat.TURTLE);
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), vf.createURI("urn:b"),
-				vf.createLiteral("testliteral", vf.createURI("urn:datatype"))));
+		assertTrue(model.contains(vf.createIRI("urn:a"), vf.createIRI("urn:b"),
+				vf.createLiteral("testliteral", vf.createIRI("urn:datatype"))));
 	}
 
 	@Test
@@ -504,7 +504,7 @@ public class CustomTurtleParserTest {
 				RDFFormat.TURTLE, aConfig, vf, new ParseErrorLogger());
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), vf.createURI("urn:not_skos:broader"),
-				vf.createURI("urn:b")));
+		assertTrue(model.contains(vf.createIRI("urn:a"), vf.createIRI("urn:not_skos:broader"),
+				vf.createIRI("urn:b")));
 	}
 }

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/AbstractModelTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/AbstractModelTest.java
@@ -33,7 +33,7 @@ import org.junit.rules.Timeout;
 public abstract class AbstractModelTest {
 
 	@Rule
-	public Timeout timeout = new Timeout(10000);
+	public Timeout timeout = Timeout.millis(10000);
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();

--- a/core/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedURITest.java
+++ b/core/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedURITest.java
@@ -61,7 +61,6 @@ public class ParsedURITest {
 	@Test
 	public void jarUriWithFileStringifiesToOriginalForm() {
 		ParsedURI uri = new ParsedURI("jar:file:///some-file.jar!/another-file");
-		System.out.println(uri.getScheme());
 		assertEquals("jar:file:///some-file.jar!/another-file", uri.toString());
 	}
 

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -12,9 +12,11 @@ import static org.junit.Assert.fail;
 
 import java.io.InputStream;
 import java.io.StringReader;
+import java.util.Collections;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -24,12 +26,11 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Unit tests for N-Triples Parser.
- * 
+ *
  * @author Peter Ansell
  */
 public abstract class AbstractNTriplesParserUnitTest {
@@ -189,7 +190,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 						"<urn:test:subject> <urn:test:predicate> \" \\t \\b \\n \\r \\f \\\" \\' \\\\ \" . "),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals(" \t \b \n \r \f \" \' \\ ", model.objectLiteral().get().getLabel());
+		assertEquals(" \t \b \n \r \f \" \' \\ ", Models.objectLiteral(model).get().getLabel());
 	}
 
 	@Test
@@ -204,7 +205,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 						"<urn:test:subject> <urn:test:predicate> <urn:test:object> .#endoflinecomment\n"),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals("urn:test:object", model.objectString().get());
+		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
 	}
 
 	@Test
@@ -219,7 +220,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 						"<urn:test:subject> <urn:test:predicate> <urn:test:object> . #endoflinecomment\n"),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals("urn:test:object", model.objectString().get());
+		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
 	}
 
 	@Test
@@ -234,7 +235,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 						"<urn:test:subject> <urn:test:predicate> <urn:test:object> .# endoflinecomment\n"),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals("urn:test:object", model.objectString().get());
+		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
 	}
 
 	@Test
@@ -249,7 +250,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 						"<urn:test:subject> <urn:test:predicate> <urn:test:object> . # endoflinecomment\n"),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals("urn:test:object", model.objectString().get());
+		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
 	}
 
 	@Test
@@ -319,7 +320,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 				new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> .#\n"),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals("urn:test:object", model.objectString().get());
+		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
 	}
 
 	@Test
@@ -333,7 +334,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 				new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> . #\n"),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals("urn:test:object", model.objectString().get());
+		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
 	}
 
 	@Test
@@ -347,7 +348,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 				new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> .# \n"),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals("urn:test:object", model.objectString().get());
+		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
 	}
 
 	@Test
@@ -361,7 +362,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 				new StringReader("<urn:test:subject> <urn:test:predicate> <urn:test:object> . # \n"),
 				"http://example/");
 		assertEquals(1, model.size());
-		assertEquals("urn:test:object", model.objectString().get());
+		assertEquals(Collections.singleton("urn:test:object"), Models.objectStrings(model));
 	}
 
 	@Test


### PR DESCRIPTION
This PR addresses GitHub issue: #748.

Briefly describe the changes proposed in this PR:

Ahead of removing deprecated methods from Model, fix the tests that still use those methods.
