### PR TITLE
#773 fixed by checking not null instead of null

### DIFF
--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
@@ -154,7 +154,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 	public void parse(final Reader reader, final String baseUri)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		if (rdfHandler == null) {
+		if (rdfHandler != null) {
 			rdfHandler.startRDF();
 		}
 		JsonParser jp = null;

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
@@ -11,7 +11,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -947,5 +950,16 @@ public abstract class AbstractParserHandlingTest {
 		result.add(vf.createStatement(vf.createBNode(), RDFS.COMMENT,
 				vf.createLiteral(languageValue, languageTag)));
 		return result;
+	}
+
+	@Test(expected = RDFParseException.class)
+	public void testNullRdfHandlerReader() throws IOException {
+		getParser().parse(new InputStreamReader(new ByteArrayInputStream("".getBytes())) , "");
+
+	}
+
+	@Test(expected = RDFParseException.class)
+	public void testNullRdfHandlerInputStream() throws IOException {
+		getParser().parse(new ByteArrayInputStream("".getBytes()), "");
 	}
 }


### PR DESCRIPTION
Signed-off-by: Heshan Jayasinghe <shanujse@gmail.com>
This PR addresses GitHub issue: # 773.

Briefly describe the changes proposed in this PR:

* fixed 773 by checking not null instead of null in RDFJSONParser class void parse(Reader reader,
           String baseURI) method
* added two test-cases to AbstractParserHandlingTest class to test that issue