### PR TITLE
#773 fixed by checking not null insted of null

### DIFF
--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
@@ -154,7 +154,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 	public void parse(final Reader reader, final String baseUri)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		if (rdfHandler == null) {
+		if (rdfHandler != null) {
 			rdfHandler.startRDF();
 		}
 		JsonParser jp = null;

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
@@ -7,18 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Locale;
-
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -28,11 +16,6 @@ import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
-import org.eclipse.rdf4j.rio.DatatypeHandler;
-import org.eclipse.rdf4j.rio.ParserConfig;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
@@ -41,6 +24,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+
+import static org.junit.Assert.*;
 
 /**
  * Abstract tests to confirm consistent behaviour for the datatype and language handling settings.
@@ -951,13 +943,6 @@ public abstract class AbstractParserHandlingTest {
 				vf.createLiteral(languageValue, languageTag)));
 		return result;
 	}
-//
-//	@Test(expected = RDFParseException.class)
-//	public void testNullRdfHandlerReader() throws IOException {
-//
-//		getParser().parse(new InputStreamReader(new ByteArrayInputStream("".getBytes())) , "");
-//
-//	}
 
 	@Test
 	public void testNullRdfHandlerReader(){
@@ -967,7 +952,6 @@ public abstract class AbstractParserHandlingTest {
 			assertTrue("Did not find expected rdfHandler", (!(e instanceof NullPointerException)));
 		}
 	}
-
 
 	@Test
 	public void testNullRdfHandlerInputStream(){

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
@@ -11,7 +11,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -947,5 +950,16 @@ public abstract class AbstractParserHandlingTest {
 		result.add(vf.createStatement(vf.createBNode(), RDFS.COMMENT,
 				vf.createLiteral(languageValue, languageTag)));
 		return result;
+	}
+
+	@Test(expected = RDFParseException.class)
+	public void testNullRdfHandlerReader() throws IOException {
+		getParser().parse(new InputStreamReader(new ByteArrayInputStream("".getBytes())) , "");
+
+	}
+
+	@Test(expected = RDFParseException.class)
+	public void testNullRdfHandlerInputStream() throws IOException {
+		getParser().parse(new ByteArrayInputStream("".getBytes()), "");
 	}
 }

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
@@ -951,15 +951,30 @@ public abstract class AbstractParserHandlingTest {
 				vf.createLiteral(languageValue, languageTag)));
 		return result;
 	}
+//
+//	@Test(expected = RDFParseException.class)
+//	public void testNullRdfHandlerReader() throws IOException {
+//
+//		getParser().parse(new InputStreamReader(new ByteArrayInputStream("".getBytes())) , "");
+//
+//	}
 
-	@Test(expected = RDFParseException.class)
-	public void testNullRdfHandlerReader() throws IOException {
-		getParser().parse(new InputStreamReader(new ByteArrayInputStream("".getBytes())) , "");
-
+	@Test
+	public void testNullRdfHandlerReader(){
+		try {
+			 getParser().parse(new InputStreamReader(new ByteArrayInputStream("".getBytes())), "");
+		}catch (Exception e){
+			assertTrue("Did not find expected rdfHandler", (!(e instanceof NullPointerException)));
+		}
 	}
 
-	@Test(expected = RDFParseException.class)
-	public void testNullRdfHandlerInputStream() throws IOException {
-		getParser().parse(new ByteArrayInputStream("".getBytes()), "");
+
+	@Test
+	public void testNullRdfHandlerInputStream(){
+		try {
+			getParser().parse(new ByteArrayInputStream("".getBytes()), "");
+		}catch (Exception e){
+			assertTrue("Did not find expected rdfHandler", (!(e instanceof NullPointerException)));
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Heshan Jayasinghe <shanujse@gmail.com>

This PR addresses GitHub issue: # 773 .

Briefly describe the changes proposed in this PR:

* fixed 773 by checking not null instead of null in RDFJSONParser class void parse(Reader reader,
String baseURI) method
* added two test-cases to AbstractParserHandlingTest class to test that issue