### PR TITLE
Fix #747: Don't encode TSV literals in quotes unless needed

### DIFF
--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleBackgroundTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleBackgroundTest.java
@@ -81,10 +81,10 @@ public class SPARQLTSVTupleBackgroundTest extends AbstractQueryResultIOTupleTest
 		assertRegex(
 				"\\?a\n" + "<foo:bar>\n"
 						+ "(2.0(E0)?|\"2.0\"\\^\\^<http://www.w3.org/2001/XMLSchema#double>)\n" + "_:bnode3\n"
-						+ "\"''single-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"?''single-quoted string(\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\n"
 						+ "\"\\\\\"\\\\\"double-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
-						+ "\"space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
-						+ "\"space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"?space at the end         (\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\n"
+						+ "\"?space at the end         (\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\n"
 						+ "\"\\\\\"\\\\\"double-quoted string with no datatype\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
 						+ "\"newline at the end \\\\n\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n?",
 				toString(createTupleSingleVarMultipleBindingSets()));
@@ -96,11 +96,11 @@ public class SPARQLTSVTupleBackgroundTest extends AbstractQueryResultIOTupleTest
 	{
 		assertRegex(
 				"\\?a\t\\?b\t\\?c\n"
-						+ "<foo:bar>\t_:bnode\t\"baz\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "<foo:bar>\t_:bnode\t(baz|\"baz\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)\n"
 						+ "(1|\"1\"\\^\\^<http://www.w3.org/2001/XMLSchema#integer>)\t\t\"Hello World!\"@en\n"
-						+ "<http://example.org/test/ns/bindingA>\t\"http://example.com/other/ns/bindingB\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t<http://example.com/other/ns/binding,C>\n"
-						+ "\"string with newline at the end       \\\\n\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"string with space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"    \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
-						+ "\"''single-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"\\\\\"\\\\\"double-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"\\\\t\\\\tunencoded tab characters followed by encoded \\\\t\\\\t\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n?",
+						+ "<http://example.org/test/ns/bindingA>\t\"?http://example.com/other/ns/bindingB(\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\t<http://example.com/other/ns/binding,C>\n"
+						+ "\"string with newline at the end       \\\\n\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"?string with space at the end         (\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\t\"?    (\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\n"
+						+ "\"?''single-quoted string(\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\t\"\\\\\"\\\\\"double-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"\\\\t\\\\tunencoded tab characters followed by encoded \\\\t\\\\t\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n?",
 				toString(createTupleMultipleBindingSets()));
 	}
 

--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleTest.java
@@ -70,10 +70,10 @@ public class SPARQLTSVTupleTest extends AbstractQueryResultIOTupleTest {
 		assertRegex(
 				"\\?a\n" + "<foo:bar>\n"
 						+ "(2.0(E0)?|\"2.0\"\\^\\^<http://www.w3.org/2001/XMLSchema#double>)\n" + "_:bnode3\n"
-						+ "\"''single-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"?''single-quoted string(\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\n"
 						+ "\"\\\\\"\\\\\"double-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
-						+ "\"space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
-						+ "\"space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "\"?space at the end         (\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\n"
+						+ "\"?space at the end         (\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\n"
 						+ "\"\\\\\"\\\\\"double-quoted string with no datatype\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
 						+ "\"newline at the end \\\\n\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n?",
 				toString(createTupleSingleVarMultipleBindingSets()));
@@ -85,11 +85,11 @@ public class SPARQLTSVTupleTest extends AbstractQueryResultIOTupleTest {
 	{
 		assertRegex(
 				"\\?a\t\\?b\t\\?c\n"
-						+ "<foo:bar>\t_:bnode\t\"baz\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
+						+ "<foo:bar>\t_:bnode\t(baz|\"baz\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)\n"
 						+ "(1|\"1\"\\^\\^<http://www.w3.org/2001/XMLSchema#integer>)\t\t\"Hello World!\"@en\n"
-						+ "<http://example.org/test/ns/bindingA>\t\"http://example.com/other/ns/bindingB\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t<http://example.com/other/ns/binding,C>\n"
-						+ "\"string with newline at the end       \\\\n\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"string with space at the end         \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"    \"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n"
-						+ "\"''single-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"\\\\\"\\\\\"double-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"\\\\t\\\\tunencoded tab characters followed by encoded \\\\t\\\\t\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n?",
+						+ "<http://example.org/test/ns/bindingA>\t\"?http://example.com/other/ns/bindingB(\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\t<http://example.com/other/ns/binding,C>\n"
+						+ "\"string with newline at the end       \\\\n\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"?string with space at the end         (\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\t\"?    (\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\n"
+						+ "\"?''single-quoted string(\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?)?\t\"\\\\\"\\\\\"double-quoted string\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\t\"\\\\t\\\\tunencoded tab characters followed by encoded \\\\t\\\\t\"(\\^\\^<http://www.w3.org/2001/XMLSchema#string>)?\n?",
 				toString(createTupleMultipleBindingSets()));
 	}
 

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
@@ -187,21 +187,35 @@ public class SPARQLResultsTSVWriter extends AbstractQueryResultWriter implements
 			}
 		}
 
-		writer.write("\"");
+		String encoded = encodeString(label);
 
-		writer.write(encodeString(label));
-
-		writer.write("\"");
 
 		if (Literals.isLanguageLiteral(lit)) {
+			writer.write("\"");
+			writer.write(encoded);
+			writer.write("\"");
 			// Append the literal's language
 			writer.write("@");
 			writer.write(lit.getLanguage().get());
 		}
 		else if (!XMLSchema.STRING.equals(datatype) || !xsdStringToPlainLiteral()) {
+			writer.write("\"");
+			writer.write(encoded);
+			writer.write("\"");
 			// Append the literal's datatype
 			writer.write("^^");
 			writeURI(datatype);
+		}
+		else if (encoded.equals(label) && label.charAt(0) != '<' && label.charAt(0) != '_'
+				&& !label.matches("^[\\+\\-]?[\\d\\.].*"))
+		{
+			// no need to include double quotes
+			writer.write(encoded);
+		}
+		else {
+			writer.write("\"");
+			writer.write(encoded);
+			writer.write("\"");
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #747 .