### PR TITLE
issue #781: Use hashCode of PathIteration

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/ArbitraryLengthPathTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/ArbitraryLengthPathTest.java
@@ -7,9 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser.sparql;
 
-import junit.framework.TestCase;
-
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 /**
  * @author james
@@ -88,6 +90,35 @@ public class ArbitraryLengthPathTest extends TestCase {
 	{
 		populate(100000);
 		String sparql = "ASK { <urn:test:root> <urn:test:hasChild>* <urn:test:node-end> }";
+		assertTrue(con.prepareBooleanQuery(QueryLanguage.SPARQL, sparql).evaluate());
+	}
+
+	@Test
+	public void testDirection()
+		throws Exception
+	{
+		ValueFactory vf = con.getValueFactory();
+		con.add(vf.createIRI("urn:test:a"), vf.createIRI("urn:test:rel"), vf.createIRI("urn:test:b"));
+		con.add(vf.createIRI("urn:test:b"), vf.createIRI("urn:test:rel"), vf.createIRI("urn:test:a"));
+		String sparql = "ASK { <urn:test:a> <urn:test:rel>* <urn:test:b> . <urn:test:b> <urn:test:rel>* <urn:test:a> }";
+		assertTrue(con.prepareBooleanQuery(QueryLanguage.SPARQL, sparql).evaluate());
+	}
+
+	@Test
+	public void testSimilarPatterns()
+		throws Exception
+	{
+		ValueFactory vf = con.getValueFactory();
+		con.add(vf.createIRI("urn:test:a"), RDF.TYPE, vf.createIRI("urn:test:c"));
+		con.add(vf.createIRI("urn:test:b"), RDF.TYPE, vf.createIRI("urn:test:d"));
+		con.add(vf.createIRI("urn:test:c"), RDFS.SUBCLASSOF, vf.createIRI("urn:test:e"));
+		con.add(vf.createIRI("urn:test:d"), RDFS.SUBCLASSOF, vf.createIRI("urn:test:f"));
+		String sparql = "ASK { \n"
+				+ "   values (?expectedTargetClass55555 ?expectedTargetClass5544T) {(<urn:test:e> <urn:test:f>)}.\n"
+				+ "   <urn:test:a> a ?linkTargetClass55555 .\n"
+				+ "   ?linkTargetClass55555 rdfs:subClassOf* ?expectedTargetClass55555 .\n"
+				+ "   <urn:test:b> a ?linkTargetClass55556 .\n"
+				+ "   ?linkTargetClass55556 rdfs:subClassOf* ?expectedTargetClass5544T . }";
 		assertTrue(con.prepareBooleanQuery(QueryLanguage.SPARQL, sparql).evaluate());
 	}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
@@ -120,12 +120,12 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 
 				if (startVarFixed && endVarFixed && currentLength > 2) {
 					v1 = getVarValue(startVar, startVarFixed, nextElement);
-					v2 = nextElement.getValue("END_" + JOINVAR_PREFIX + pathExpression.hashCode());
+					v2 = nextElement.getValue("END_" + JOINVAR_PREFIX + this.hashCode());
 				}
 				else if (startVarFixed && endVarFixed && currentLength == 2) {
 					v1 = getVarValue(startVar, startVarFixed, nextElement);
 					v2 = nextElement.getValue(
-							JOINVAR_PREFIX + (currentLength - 1) + "-" + pathExpression.hashCode());
+							JOINVAR_PREFIX + (currentLength - 1) + "-" + this.hashCode());
 				}
 				else {
 					v1 = getVarValue(startVar, startVarFixed, nextElement);
@@ -271,7 +271,7 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 
 			if (startVarFixed && endVarFixed) {
 				Var replacement = createAnonVar(
-						JOINVAR_PREFIX + currentLength + "-" + pathExpression.hashCode());
+						JOINVAR_PREFIX + currentLength + "-" + this.hashCode());
 
 				VarReplacer replacer = new VarReplacer(endVar, replacement, 0, false);
 				pathExprClone.visit(replacer);
@@ -290,8 +290,8 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 				if (startVarFixed && endVarFixed) {
 
 					Var startReplacement = createAnonVar(
-							JOINVAR_PREFIX + currentLength + "-" + pathExpression.hashCode());
-					Var endReplacement = createAnonVar("END_" + JOINVAR_PREFIX + pathExpression.hashCode());
+							JOINVAR_PREFIX + currentLength + "-" + this.hashCode());
+					Var endReplacement = createAnonVar("END_" + JOINVAR_PREFIX + this.hashCode());
 					startReplacement.setAnonymous(false);
 					endReplacement.setAnonymous(false);
 
@@ -317,7 +317,7 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 					}
 
 					Var replacement = createAnonVar(
-							JOINVAR_PREFIX + currentLength + "-" + pathExpression.hashCode());
+							JOINVAR_PREFIX + currentLength + "-" + this.hashCode());
 					replacement.setValue(v);
 
 					VarReplacer replacer = new VarReplacer(toBeReplaced, replacement, 0, false);


### PR DESCRIPTION
Use hashCode of PathIteration to identify intermediate variables

Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #781 .
