### PR TITLE
Fix #695: Don't treat path modifiers as subqueries

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -202,7 +202,7 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 			List<TupleExpr> subselects = new ArrayList<TupleExpr>();
 
 			for (TupleExpr expr : expressions) {
-				if (TupleExprs.containsProjection(expr)) {
+				if (TupleExprs.containsSubquery(expr)) {
 					subselects.add(expr);
 				}
 			}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -911,7 +911,7 @@ public class StrictEvaluationStrategy
 			return new ServiceJoinIterator(leftIter, (Service)join.getRightArg(), bindings, this);
 		}
 
-		if (TupleExprs.containsProjection(join.getRightArg())) {
+		if (TupleExprs.containsSubquery(join.getRightArg())) {
 			return new HashJoinIteration(this, join, bindings);
 		}
 		else {
@@ -923,7 +923,7 @@ public class StrictEvaluationStrategy
 			final BindingSet bindings)
 		throws QueryEvaluationException
 	{
-		if (TupleExprs.containsProjection(leftJoin.getRightArg())) {
+		if (TupleExprs.containsSubquery(leftJoin.getRightArg())) {
 			return new HashJoinIteration(this, leftJoin, bindings);
 		}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/limited/LimitedSizeEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/limited/LimitedSizeEvaluationStrategy.java
@@ -152,7 +152,7 @@ public class LimitedSizeEvaluationStrategy extends StrictEvaluationStrategy {
 			return new ServiceJoinIterator(leftIter, (Service)join.getRightArg(), bindings, this);
 		}
 
-		if (TupleExprs.containsProjection(join.getRightArg())) {
+		if (TupleExprs.containsSubquery(join.getRightArg())) {
 			return new LimitedSizeHashJoinIteration(this, join, bindings, used, maxSize);
 		}
 		else {

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Join.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Join.java
@@ -42,7 +42,7 @@ public class Join extends BinaryTupleOperator {
 	 */
 	@Deprecated
 	public boolean hasSubSelectInRightArg() {
-		return TupleExprs.containsProjection(rightArg);
+		return TupleExprs.containsSubquery(rightArg);
 	}
 
 	public Set<String> getBindingNames() {

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Projection.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Projection.java
@@ -22,6 +22,8 @@ public class Projection extends UnaryTupleOperator {
 
 	private Var projectionContext = null;
 
+	private boolean subquery = true;
+
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
@@ -36,6 +38,11 @@ public class Projection extends UnaryTupleOperator {
 	public Projection(TupleExpr arg, ProjectionElemList elements) {
 		this(arg);
 		setProjectionElemList(elements);
+	}
+
+	public Projection(TupleExpr arg, ProjectionElemList elements, boolean subquery) {
+		this(arg, elements);
+		this.subquery = subquery;
 	}
 
 	/*---------*
@@ -121,6 +128,14 @@ public class Projection extends UnaryTupleOperator {
 	 */
 	public void setProjectionContext(Var projectionContext) {
 		this.projectionContext = projectionContext;
+	}
+
+	public boolean isSubquery() {
+		return subquery;
+	}
+
+	public void setSubquery(boolean subquery) {
+		this.subquery = subquery;
 	}
 
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprs.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprs.java
@@ -29,6 +29,36 @@ import org.eclipse.rdf4j.query.algebra.Var;
 public class TupleExprs {
 
 	/**
+	 * Verifies if the supplied {@link TupleExpr} contains a {@link Projection} with the subquery flag set to
+	 * true (default). If the supplied TupleExpr is a {@link Join} or contains a {@link Join}, projections
+	 * inside that Join's arguments will not be taken into account.
+	 *
+	 * @param t
+	 *        a tuple expression.
+	 * @return <code>true</code> if the TupleExpr contains a subquery projection (outside of a Join),
+	 *         <code>false</code> otherwise.
+	 */
+	public static boolean containsSubquery(TupleExpr t) {
+		Deque<TupleExpr> queue = new ArrayDeque<>();
+		queue.add(t);
+		while (!queue.isEmpty()) {
+			TupleExpr n = queue.removeFirst();
+			if (n instanceof Projection && ((Projection)n).isSubquery()) {
+				return true;
+			}
+			else if (n instanceof Join) {
+				// projections already inside a Join need not be
+				// taken into account
+				return false;
+			}
+			else {
+				queue.addAll(getChildren(n));
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Verifies if the supplied {@link TupleExpr} contains a {@link Projection}. If the supplied TupleExpr is
 	 * a {@link Join} or contains a {@link Join}, projections inside that Join's arguments will not be taken
 	 * into account.
@@ -37,7 +67,9 @@ public class TupleExprs {
 	 *        a tuple expression.
 	 * @return <code>true</code> if the TupleExpr contains a projection (outside of a Join),
 	 *         <code>false</code> otherwise.
+	 * @deprecated Since 2.3. Use {@link TupleExprs#containsSubQuery(TupleExpr)} instead.
 	 */
+	@Deprecated
 	public static boolean containsProjection(TupleExpr t) {
 		Deque<TupleExpr> queue = new ArrayDeque<>();
 		queue.add(t);

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -1700,7 +1700,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 						pelist.addElement(pe);
 					}
 
-					result = new Distinct(new Projection(union, pelist));
+					result = new Distinct(new Projection(union, pelist, false));
 				}
 				else {
 					// upperbound is abitrary-length

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/FederationStrategy.java
@@ -91,7 +91,7 @@ public class FederationStrategy extends StrictEvaluationStrategy {
 		for (int i = 1, n = join.getNumberOfArguments(); i < n; i++) {
 
 			TupleExpr rightArg = join.getArg(i);
-			if (TupleExprs.containsProjection(rightArg)
+			if (TupleExprs.containsSubquery(rightArg)
 					|| (rightArg instanceof OwnedTupleExpr && ((OwnedTupleExpr)rightArg).hasQuery()))
 			{
 				TupleExpr leftArg = join.getArg(i - 1);


### PR DESCRIPTION
This PR uses LH join bindings to eval zero or one path modifiers and greatly improves the performance. Previously zero or one path modifiers were treated like a subqueries and used a hash join operation. Note that zero or more path modifiers were already improved with #689


Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #695 .