### PR TITLE
Fix #787: CookieHandlers now check for empty context path string instead of null

### DIFF
--- a/core/http/workbench/src/main/java/org/eclipse/rdf4j/workbench/proxy/CookieHandler.java
+++ b/core/http/workbench/src/main/java/org/eclipse/rdf4j/workbench/proxy/CookieHandler.java
@@ -60,7 +60,7 @@ public class CookieHandler {
 
 	private void initCookie(final Cookie cookie, final HttpServletRequest req) {
 		final String context = req.getContextPath();
-		cookie.setPath(null == context ? "/" : context);
+		cookie.setPath(context.isEmpty() ? "/" : context);
 		if (maxAge != null) {
 			cookie.setMaxAge(Integer.parseInt(maxAge));
 		}

--- a/core/http/workbench/src/main/java/org/eclipse/rdf4j/workbench/util/CookieHandler.java
+++ b/core/http/workbench/src/main/java/org/eclipse/rdf4j/workbench/util/CookieHandler.java
@@ -58,7 +58,7 @@ public class CookieHandler {
 		LOGGER.info("name: {}\nvalue: {}", name, value);
 		LOGGER.info("un-encoded value: {}\n--", raw);
 		final Cookie cookie = new Cookie(name, value);
-		if (null == req.getContextPath()) {
+		if (req.getContextPath().isEmpty()) {
 			cookie.setPath("/");
 		}
 		else {
@@ -96,7 +96,7 @@ public class CookieHandler {
 
 	public void addCookie(WorkbenchRequest req, HttpServletResponse resp, String name, String value) {
 		final Cookie cookie = new Cookie(name, value);
-		if (null == req.getContextPath()) {
+		if (req.getContextPath().isEmpty()) {
 			cookie.setPath("/");
 		}
 		else {


### PR DESCRIPTION
This PR addresses GitHub issue: #787` .

Briefly describe the changes proposed in this PR:

* as per documented in the Java Servlet API, getContextPath return an empty string rather than null if the context path is the root. 

As part of this I discovered that we have two separate CookieHandler classes, for some reason. Something worth investigating in a followup. 