### PR TITLE
issue #647: Disable automatic retries in client

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -106,7 +106,7 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 		if (nextHttpClientBuilder != null) {
 			return nextHttpClientBuilder.build();
 		}
-		return HttpClients.createSystem();
+		return HttpClientBuilder.create().useSystemProperties().disableAutomaticRetries().build();
 	}
 
 	@Override


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #647 

It is generally not a good idea to retry HTTP requests against a database service. This change forces the original HTTP error to be returned and doesn't try anything more.