### PR TITLE
Fix #774: Change all SailSourceModel fields to be synchronized

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/SailSourceModel.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/SailSourceModel.java
@@ -239,7 +239,7 @@ class SailSourceModel extends AbstractModel {
 		if (subj == null || pred == null || obj == null)
 			throw new UnsupportedOperationException("Incomplete statement");
 		try {
-			if (contains(dataset, subj, pred, obj, contexts)) {
+			if (contains(subj, pred, obj, contexts)) {
 				logger.trace("already contains statement {} {} {} {}", subj, pred, obj, contexts);
 				return false;
 			}
@@ -383,7 +383,7 @@ class SailSourceModel extends AbstractModel {
 		}
 	}
 
-	private SailSink sink()
+	private synchronized SailSink sink()
 		throws SailException
 	{
 		if (sink == null) {
@@ -392,7 +392,7 @@ class SailSourceModel extends AbstractModel {
 		return sink;
 	}
 
-	private SailDataset dataset()
+	private synchronized SailDataset dataset()
 		throws SailException
 	{
 		if (sink != null) {


### PR DESCRIPTION
Models can only be modified when exactly one thread is accessing it, but can be accessed by multiple threads when no changes are made. The Changesets use Models to store the delta against the finalized state. These are modified by a connection (in a single thread) and when the connection is committed, but not yet finalized (due to other open connections), the changesets are shared among other connections that need access to these changes (via a SailSourceBranch). With large non-finalized changes against the NativeRdfStore a SailSourceModel is used (backed by another nativerdf store). Unlike other in-memory Models, the SailSourceModel delays sink modifications until they are needed. In the event when a nativerdf connection makes bulk changes, but does not do any read operations before commit, the SailSourceModel may have outstanding sink operations that still need to be flushed when it is made available to other connections via a branch. The next connection that does any read operations may force a SailSourceModel to flush and if it two or more connections try to read the non-finalized changes at the same time, a race condition may occur if the SailSourceModel is not correctly synchronized. This PR synchronizes this process so only one connection will trigger the SailSourceModel to flush.


Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #774