### PR TITLE
issue #745 : Clear parser state before/after parsing

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -365,11 +365,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 */
 	@Deprecated
 	protected void clearBNodeIDMap() {
-		baseURI = null;
-		nextBNodePrefix = createUniqueBNodePrefix();
-		namespaceTable.clear();
-
-		initializeNamespaceTableFromConfiguration();
+		clear();
 	}
 
 	/**

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.rio.helpers;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
@@ -360,10 +361,15 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 * the document has been parsed completely, but subclasses can clear the map at other moments too, for
 	 * example when a bnode scope ends.
 	 * 
-	 * @deprecated Map is no longer used.
+	 * @deprecated Map is no longer used, call {@link #clear()} instead.
 	 */
 	@Deprecated
 	protected void clearBNodeIDMap() {
+		baseURI = null;
+		nextBNodePrefix = createUniqueBNodePrefix();
+		namespaceTable.clear();
+
+		initializeNamespaceTableFromConfiguration();
 	}
 
 	/**
@@ -431,8 +437,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 		throws RDFParseException
 	{
 		// If we are preserving blank node ids then we do not prefix them to
-		// make
-		// them globally unique
+		// make them globally unique
 		if (preserveBNodeIDs()) {
 			return valueFactory.createBNode(nodeID);
 		}
@@ -446,13 +451,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 			if (nodeID.length() > 32) {
 				// we only hash the node ID if it is longer than the hash string
 				// itself would be.
-				byte[] chars = null;
-				try {
-					chars = nodeID.getBytes("UTF-8");
-				}
-				catch (UnsupportedEncodingException e) {
-					throw new RuntimeException(e);
-				}
+				byte[] chars = nodeID.getBytes(StandardCharsets.UTF_8);
 
 				// we use an MD5 hash rather than the node ID itself to get a
 				// fixed-length generated id, rather than

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFParser.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFParser.java
@@ -65,30 +65,32 @@ public class BinaryRDFParser extends AbstractRDFParser {
 	public void parse(InputStream in, String baseURI)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		if (in == null) {
-			throw new IllegalArgumentException("Input stream must not be null");
-		}
-
-		this.in = new DataInputStream(new BufferedInputStream(in));
-
-		// Check magic number
-		byte[] magicNumber = IOUtil.readBytes(in, MAGIC_NUMBER.length);
-		if (!Arrays.equals(magicNumber, MAGIC_NUMBER)) {
-			reportFatalError("File does not contain a binary RDF document");
-		}
-
-		// Check format version (parser is backward-compatible with version 1 and
-		// version 2)
-		int formatVersion = this.in.readInt();
-		if (formatVersion != FORMAT_VERSION) {
-			reportFatalError("Incompatible format version: " + formatVersion);
-		}
-
-		if (rdfHandler != null) {
-			rdfHandler.startRDF();
-		}
-
+		clear();
+		
 		try {
+			if (in == null) {
+				throw new IllegalArgumentException("Input stream must not be null");
+			}
+
+			this.in = new DataInputStream(new BufferedInputStream(in));
+
+			// Check magic number
+			byte[] magicNumber = IOUtil.readBytes(in, MAGIC_NUMBER.length);
+			if (!Arrays.equals(magicNumber, MAGIC_NUMBER)) {
+				reportFatalError("File does not contain a binary RDF document");
+			}
+
+			// Check format version (parser is backward-compatible with version 1 and
+			// version 2)
+			int formatVersion = this.in.readInt();
+			if (formatVersion != FORMAT_VERSION) {
+				reportFatalError("Incompatible format version: " + formatVersion);
+			}
+
+			if (rdfHandler != null) {
+				rdfHandler.startRDF();
+			}
+
 			loop: while (true) {
 				int recordType = this.in.readByte();
 

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -58,13 +58,16 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 	public void parse(final InputStream in, final String baseURI)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		final JSONLDInternalTripleCallback callback = new JSONLDInternalTripleCallback(getRDFHandler(),
-				valueFactory, getParserConfig(), getParseErrorListener());
-
-		final JsonLdOptions options = new JsonLdOptions(baseURI);
-		options.useNamespaces = true;
+		clear();
 
 		try {
+			final JSONLDInternalTripleCallback callback = new JSONLDInternalTripleCallback(getRDFHandler(),
+					valueFactory, getParserConfig(), getParseErrorListener(), nodeID -> createBNode(nodeID),
+					() -> createBNode());
+
+			final JsonLdOptions options = new JsonLdOptions(baseURI);
+			options.useNamespaces = true;
+
 			JsonLdProcessor.toRDF(JsonUtils.fromInputStream(in), callback, options);
 		}
 		catch (final JsonLdError e) {
@@ -79,19 +82,25 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 			}
 			throw e;
 		}
+		finally {
+			clear();
+		}
 	}
 
 	@Override
 	public void parse(final Reader reader, final String baseURI)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		final JSONLDInternalTripleCallback callback = new JSONLDInternalTripleCallback(getRDFHandler(),
-				valueFactory, getParserConfig(), getParseErrorListener());
-
-		final JsonLdOptions options = new JsonLdOptions(baseURI);
-		options.useNamespaces = true;
+		clear();
 
 		try {
+			final JSONLDInternalTripleCallback callback = new JSONLDInternalTripleCallback(getRDFHandler(),
+					valueFactory, getParserConfig(), getParseErrorListener(), nodeID -> createBNode(nodeID),
+					() -> createBNode());
+
+			final JsonLdOptions options = new JsonLdOptions(baseURI);
+			options.useNamespaces = true;
+
 			JsonLdProcessor.toRDF(JsonUtils.fromReader(reader), callback, options);
 		}
 		catch (final JsonLdError e) {
@@ -105,6 +114,9 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 				throw (RDFParseException)e.getCause();
 			}
 			throw e;
+		}
+		finally {
+			clear();
 		}
 	}
 

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDInternalTripleCallbackTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDInternalTripleCallbackTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.Iterator;
 
-import org.eclipse.rdf4j.model.Graph;
+import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -40,12 +40,13 @@ public class JSONLDInternalTripleCallbackTest {
 		final String expectedString = "(http://nonexistent.com/abox#Document1823812, http://www.w3.org/1999/02/22-rdf-syntax-ns#type, http://nonexistent.com/tbox#Document) [null]";
 		final Object input = JsonUtils.fromString(inputstring);
 
-		final Graph graph = new LinkedHashModel();
+		final Model graph = new LinkedHashModel();
 		final ParseErrorCollector parseErrorListener = new ParseErrorCollector();
 		final ParserConfig parserConfig = new ParserConfig();
 		final JSONLDInternalTripleCallback callback = new JSONLDInternalTripleCallback(
 				new StatementCollector(graph), SimpleValueFactory.getInstance(), parserConfig,
-				parseErrorListener);
+				parseErrorListener, nodeID -> SimpleValueFactory.getInstance().createBNode(nodeID),
+				() -> SimpleValueFactory.getInstance().createBNode());
 
 		JsonLdProcessor.toRDF(input, callback);
 

--- a/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
+++ b/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
@@ -62,23 +62,25 @@ public class NQuadsParser extends NTriplesParser {
 	public synchronized void parse(final Reader reader, final String baseURI)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		if (reader == null) {
-			throw new IllegalArgumentException("Reader can not be 'null'");
-		}
-		if (baseURI == null) {
-			throw new IllegalArgumentException("base URI can not be 'null'");
-		}
-
-		if (rdfHandler != null) {
-			rdfHandler.startRDF();
-		}
-
-		this.reader = reader;
-		lineNo = 1;
-
-		reportLocation(lineNo, 1);
-
+		clear();
+		
 		try {
+			if (reader == null) {
+				throw new IllegalArgumentException("Reader can not be 'null'");
+			}
+			if (baseURI == null) {
+				throw new IllegalArgumentException("base URI can not be 'null'");
+			}
+
+			if (rdfHandler != null) {
+				rdfHandler.startRDF();
+			}
+
+			this.reader = reader;
+			lineNo = 1;
+
+			reportLocation(lineNo, 1);
+
 			int c = readCodePoint();
 			c = skipWhitespace(c);
 

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -141,23 +141,25 @@ public class NTriplesParser extends AbstractRDFParser {
 	public synchronized void parse(Reader reader, String baseURI)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		if (reader == null) {
-			throw new IllegalArgumentException("Reader can not be 'null'");
-		}
-		if (baseURI == null) {
-			throw new IllegalArgumentException("base URI can not be 'null'");
-		}
-
-		if (rdfHandler != null) {
-			rdfHandler.startRDF();
-		}
-
-		this.reader = reader;
-		lineNo = 1;
-
-		reportLocation(lineNo, 1);
-
+		clear();
+		
 		try {
+			if (reader == null) {
+				throw new IllegalArgumentException("Reader can not be 'null'");
+			}
+			if (baseURI == null) {
+				throw new IllegalArgumentException("base URI can not be 'null'");
+			}
+
+			if (rdfHandler != null) {
+				rdfHandler.startRDF();
+			}
+
+			this.reader = reader;
+			lineNo = 1;
+
+			reportLocation(lineNo, 1);
+
 			int c = readCodePoint();
 			c = skipWhitespace(c);
 

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
@@ -69,13 +69,15 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 	public void parse(final InputStream inputStream, final String baseUri)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		if (this.rdfHandler != null) {
-			this.rdfHandler.startRDF();
-		}
-
 		JsonParser jp = null;
 
+		clear();
+		
 		try {
+			if (this.rdfHandler != null) {
+				this.rdfHandler.startRDF();
+			}
+
 			jp = RDFJSONUtility.JSON_FACTORY.createParser(new BOMInputStream(inputStream, false));
 			rdfJsonToHandlerInternal(this.rdfHandler, this.valueFactory, jp);
 		}
@@ -198,7 +200,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 			final String subjStr = jp.getCurrentName();
 			Resource subject = null;
 
-			subject = subjStr.startsWith("_:") ? vf.createBNode(subjStr.substring(2)) : vf.createIRI(subjStr);
+			subject = subjStr.startsWith("_:") ? createBNode(subjStr.substring(2)) : vf.createIRI(subjStr);
 			if (jp.nextToken() != JsonToken.START_OBJECT) {
 				reportFatalError("Expected subject value to start with an Object", jp.getCurrentLocation());
 			}
@@ -336,7 +338,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 							reportFatalError("Datatype was attached to a blank node object: subject="
 									+ subjStr + " predicate=" + predStr, jp.getCurrentLocation());
 						}
-						object = vf.createBNode(nextValue.substring(2));
+						object = createBNode(nextValue.substring(2));
 					}
 					else if (RDFJSONUtility.URI.equals(nextType)) {
 						if (nextLanguage != null) {
@@ -359,7 +361,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 								context = null;
 							}
 							else if(nextContext.startsWith("_:")) {
-								context = vf.createBNode(nextContext.substring(2));
+								context = createBNode(nextContext.substring(2));
 							}
 							else {
 								context = vf.createIRI(nextContext);

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
@@ -72,7 +72,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 		JsonParser jp = null;
 
 		clear();
-		
+
 		try {
 			if (this.rdfHandler != null) {
 				this.rdfHandler.startRDF();
@@ -156,12 +156,15 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 	public void parse(final Reader reader, final String baseUri)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		if (rdfHandler != null) {
-			rdfHandler.startRDF();
-		}
 		JsonParser jp = null;
 
+		clear();
+
 		try {
+			if (this.rdfHandler != null) {
+				this.rdfHandler.startRDF();
+			}
+
 			jp = RDFJSONUtility.JSON_FACTORY.createParser(reader);
 			rdfJsonToHandlerInternal(rdfHandler, valueFactory, jp);
 		}
@@ -174,6 +177,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 			}
 		}
 		finally {
+			clear();
 			if (jp != null) {
 				try {
 					jp.close();
@@ -356,11 +360,11 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 					if (!nextContexts.isEmpty()) {
 						for (final String nextContext : nextContexts) {
 							final Resource context;
-							
-							if(nextContext.equals(RDFJSONUtility.NULL)) {
+
+							if (nextContext.equals(RDFJSONUtility.NULL)) {
 								context = null;
 							}
-							else if(nextContext.startsWith("_:")) {
+							else if (nextContext.startsWith("_:")) {
 								context = createBNode(nextContext.substring(2));
 							}
 							else {

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
@@ -243,6 +243,8 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 	private void parse(InputSource inputSource)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
+		clear();
+		
 		try {
 			documentURI = inputSource.getSystemId();
 

--- a/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXParser.java
+++ b/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXParser.java
@@ -163,11 +163,13 @@ public class TriXParser extends AbstractRDFParser implements ErrorHandler {
 	private void parse(InputSource inputStreamOrReader)
 		throws IOException, RDFParseException, RDFHandlerException
 	{
-		if (rdfHandler != null) {
-			rdfHandler.startRDF();
-		}
-
+		clear();
+		
 		try {
+			if (rdfHandler != null) {
+				rdfHandler.startRDF();
+			}
+
 			XMLReader xmlReader;
 
 			if (getParserConfig().isSet(XMLParserSettings.CUSTOM_XML_READER)) {

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -13,6 +13,7 @@ import java.io.InputStreamReader;
 import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -140,7 +141,7 @@ public class TurtleParser extends AbstractRDFParser {
 		// Note: baseURI will be checked in parse(Reader, String)
 
 		try {
-			parse(new InputStreamReader(new BOMInputStream(in, false), "UTF-8"), baseURI);
+			parse(new InputStreamReader(new BOMInputStream(in, false), StandardCharsets.UTF_8), baseURI);
 		} catch (UnsupportedEncodingException e) {
 			// Every platform should support the UTF-8 encoding...
 			throw new RuntimeException(e);
@@ -170,29 +171,31 @@ public class TurtleParser extends AbstractRDFParser {
 	 */
 	public synchronized void parse(Reader reader, String baseURI)
 			throws IOException, RDFParseException, RDFHandlerException {
-		if (reader == null) {
-			throw new IllegalArgumentException("Reader must not be 'null'");
-		}
-		if (baseURI == null) {
-			throw new IllegalArgumentException("base URI must not be 'null'");
-		}
-
-		if (rdfHandler != null) {
-			rdfHandler.startRDF();
-		}
-
-		// Start counting lines at 1:
-		lineNumber = 1;
-
-		// Allow at most 8 characters to be pushed back:
-		this.reader = new PushbackReader(reader, 8);
-
-		// Store normalized base URI
-		setBaseURI(baseURI);
-
-		reportLocation();
-
+		clear();
+		
 		try {
+			if (reader == null) {
+				throw new IllegalArgumentException("Reader must not be 'null'");
+			}
+			if (baseURI == null) {
+				throw new IllegalArgumentException("base URI must not be 'null'");
+			}
+
+			if (rdfHandler != null) {
+				rdfHandler.startRDF();
+			}
+
+			// Start counting lines at 1:
+			lineNumber = 1;
+
+			// Allow at most 8 characters to be pushed back:
+			this.reader = new PushbackReader(reader, 8);
+
+			// Store normalized base URI
+			setBaseURI(baseURI);
+
+			reportLocation();
+
 			int c = skipWSC();
 
 			while (c != -1) {
@@ -1326,14 +1329,18 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Appends the characters from codepoint into the string builder. This is the same
-	 * as Character#toChars but prevents the additional char array garbage for BMP codepoints.
-	 * @param dst the destination in which to append the characters
-	 * @param codePoint the codepoint to be appended
+	 * Appends the characters from codepoint into the string builder. This is
+	 * the same as Character#toChars but prevents the additional char array
+	 * garbage for BMP codepoints.
+	 * 
+	 * @param dst
+	 *            the destination in which to append the characters
+	 * @param codePoint
+	 *            the codepoint to be appended
 	 */
 	private static void appendCodepoint(StringBuilder dst, int codePoint) {
 		if (Character.isBmpCodePoint(codePoint)) {
-			dst.append((char)codePoint);
+			dst.append((char) codePoint);
 		} else if (Character.isValidCodePoint(codePoint)) {
 			dst.append(Character.highSurrogate(codePoint));
 			dst.append(Character.lowSurrogate(codePoint));

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -1650,4 +1650,25 @@ public abstract class RDFWriterTest {
 		assertTrue(parsedOutput.contains(uri1, uri1, uri2));
 		assertEquals(1, parsedOutput.contexts().size());
 	}
+	
+	@Test
+	public void testSuccessBNodeParsesAreDistinct() throws Exception
+	{
+		ByteArrayOutputStream outputWriter = new ByteArrayOutputStream();
+		RDFWriter rdfWriter = rdfWriterFactory.getWriter(outputWriter);
+		setupWriterConfig(rdfWriter.getWriterConfig());
+		rdfWriter.startRDF();
+		rdfWriter.handleStatement(vf.createStatement(uri1, uri1, bnode));
+		rdfWriter.endRDF();
+		ByteArrayInputStream inputReader = new ByteArrayInputStream(outputWriter.toByteArray());
+		RDFParser rdfParser = rdfParserFactory.getParser();
+		setupParserConfig(rdfParser.getParserConfig());
+		Model parsedOutput = new LinkedHashModel();
+		rdfParser.setRDFHandler(new StatementCollector(parsedOutput));
+		rdfParser.parse(inputReader, "");
+		assertEquals(1, parsedOutput.size());
+		ByteArrayInputStream inputReader2 = new ByteArrayInputStream(outputWriter.toByteArray());
+		rdfParser.parse(inputReader2, "");
+		assertEquals(2, parsedOutput.size());
+	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #745 .

Briefly describe the changes proposed in this PR:

* Consistently call AbstractRDFParser.clear before and after parsing to ensure state is consistent with the API goals of safely (not concurrently, just in serial) reusing RDFParser instances within the RDF-1.1 Abstract Model expectations
* Adds a test to ensure that the same blank node is parsed as two distinct objects by the same RDFParser across successive calls to RDFParser.parse

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>