### PR TITLE
issue #799 : Use Jackson BoM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,13 +162,30 @@
 		<spring.version>4.2.1.RELEASE</spring.version>
 		<httpclient.version>4.5.2</httpclient.version>
 		<httpcore.version>4.4.4</httpcore.version>
-		<jackson.version>2.8.2</jackson.version>
+		<jackson.version>2.8.8</jackson.version>
 		<jsonldjava.version>0.8.3</jsonldjava.version>
 		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
 	</properties>
 
 	<dependencyManagement>
 		<dependencies>
+			<!-- Jackson Bill-of-Materials -->
+			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${jackson.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<!-- Annotations is designed to be fixed at the 2.x.0 minor version level, 
+			     but in practice is still being released for 2.8.x patch versions.
+			     See https://github.com/FasterXML/jackson-bom/issues/4 -->
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-annotations</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			
 			<!-- Apache Commons -->
 			<dependency>
 				<groupId>commons-cli</groupId>
@@ -509,26 +526,6 @@
 				<version>${jsonldjava.version}</version>
 				<type>test-jar</type>
 				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.dataformat</groupId>
-				<artifactId>jackson-dataformat-csv</artifactId>
-				<version>${jackson.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
This PR addresses GitHub issue: #799 .

Briefly describe the changes proposed in this PR:

* Reuse the recently introduced jackson-bom to make versioning of jackson family libraries consistent

Deviates from the Jackson BoM in the case of jackson-annotations which for 2.8.x is still being released for each patch (although it isn't intended to have changes on patch versions). This is to avoid having users misunderstand the situation regarding jackson-annotations versioning. From 2.9.0 the situation for jackson-annotations is planned to be changed so that 2.9.0 is a fixed version for it. When the occurs the exception for jackson-annotations can be removed and only jackson-bom included.

More details on the jackson-annotations issue available at https://github.com/FasterXML/jackson-bom/issues/4

Note this bumps jackson to 2.8.8 so there would need to be an Eclipse legal review before merging. The version needed to be bumped as the earliest jackson-bom is 2.8.3 which was already past the current 2.8.2 version.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>