### PR TITLE
issue #819: Missing type for SPARQL repo config

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
@@ -41,6 +41,7 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	}
 
 	public SPARQLRepositoryConfig(String queryEndpointUrl) {
+		this();
 		setQueryEndpointUrl(queryEndpointUrl);
 	}
 

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfigTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfigTest.java
@@ -1,0 +1,32 @@
+package org.eclipse.rdf4j.repository.sparql.config;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link SPARQLRepositoryConfig}.
+ *
+ * @author infgeoax
+ */
+public class SPARQLRepositoryConfigTest {
+
+	private static final String QUERY_ENDPOINT_URL = "http://example.com/sparql";
+
+	private static final String UPDATE_ENDPOINT_URL = "http://example.com/update";
+
+	@Test public void testConstructorWithSPARQLEndpoint() {
+		SPARQLRepositoryConfig config = new SPARQLRepositoryConfig(QUERY_ENDPOINT_URL);
+		assertEquals(QUERY_ENDPOINT_URL, config.getQueryEndpointUrl());
+		assertNull(config.getUpdateEndpointUrl());
+		assertEquals(SPARQLRepositoryFactory.REPOSITORY_TYPE, config.getType());
+	}
+
+	@Test public void testConstructorWithQueryAndUpdateEndpoints() {
+		SPARQLRepositoryConfig config = new SPARQLRepositoryConfig(QUERY_ENDPOINT_URL, UPDATE_ENDPOINT_URL);
+		assertEquals(QUERY_ENDPOINT_URL, config.getQueryEndpointUrl());
+		assertEquals(UPDATE_ENDPOINT_URL, config.getUpdateEndpointUrl());
+		assertEquals(SPARQLRepositoryFactory.REPOSITORY_TYPE, config.getType());
+	}
+}


### PR DESCRIPTION
Constructors that take SPARQL query and/or update endpoints did not set the type field properly. Repository managers could not retrieve the config information from the system repository without the type statement later, causing getRepository to fail with an exception:

org.eclipse.rdf4j.repository.config.RepositoryConfigException: Repository implementation for repository missing

Signed-off-by: Xiaofeng Li <luke.the.coder@gmail.com>


This PR addresses GitHub issue: #819  .

Briefly describe the changes proposed in this PR:

Call default constructor in constructors that take endpoint parameters.