### PR TITLE
Fix #834 : Add NamespaceAware interface

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/Model.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/Model.java
@@ -28,7 +28,7 @@ import org.eclipse.rdf4j.model.util.Models;
  * @see org.eclipse.rdf4j.model.util.Models the Models utility class
  */
 @SuppressWarnings("deprecation")
-public interface Model extends Graph, Set<Statement>, Serializable {
+public interface Model extends Graph, Set<Statement>, Serializable, NamespaceAware {
 
 	/**
 	 * Returns an unmodifiable view of this model. This method provides "read-only" access to this model.
@@ -39,25 +39,6 @@ public interface Model extends Graph, Set<Statement>, Serializable {
 	 * @return an unmodifiable view of the specified set.
 	 */
 	public Model unmodifiable();
-
-	/**
-	 * Gets the map that contains the assigned namespaces.
-	 * 
-	 * @return Map of prefix to namespace
-	 */
-	public Set<Namespace> getNamespaces();
-
-	/**
-	 * Gets the namespace that is associated with the specified prefix, if any.
-	 * 
-	 * @param prefix
-	 *        A namespace prefix.
-	 * @return The namespace name that is associated with the specified prefix, or {@link Optional#empty()} if
-	 *         there is no such namespace.
-	 */
-	public default Optional<Namespace> getNamespace(String prefix) {
-		return getNamespaces().stream().filter(t -> t.getPrefix().equals(prefix)).findAny();
-	}
 
 	/**
 	 * Sets the prefix for a namespace. This will replace any existing namespace associated to the prefix.

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/NamespaceAware.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/NamespaceAware.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eclipse RDF4J contributors and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * An interface that is used to signify that something is able to provide {@link Namespace} information, in
+ * addition to {@link Statement}s.
+ * 
+ * @author Peter Ansell
+ */
+@FunctionalInterface
+public interface NamespaceAware {
+
+	/**
+	 * Gets the set that contains the assigned namespaces.
+	 * 
+	 * @return A {@link Set} containing the {@link Namespace} objects that are available.
+	 */
+	public Set<Namespace> getNamespaces();
+
+	/**
+	 * Gets the namespace that is associated with the specified prefix, if any. If multiple namespaces match
+	 * the given prefix, the result may not be consistent over successive calls to this method.
+	 * 
+	 * @param prefix
+	 *        A namespace prefix.
+	 * @return The namespace name that is associated with the specified prefix, or {@link Optional#empty()} if
+	 *         there is no such namespace.
+	 */
+	public default Optional<Namespace> getNamespace(String prefix) {
+		return getNamespaces().stream().filter(t -> t.getPrefix().equals(prefix)).findAny();
+	}
+
+}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/Rio.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/Rio.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.NamespaceAware;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -415,8 +416,8 @@ public class Rio {
 	{
 		writer.startRDF();
 
-		if (model instanceof Model) {
-			for (Namespace nextNamespace : ((Model)model).getNamespaces()) {
+		if (model instanceof NamespaceAware) {
+			for (Namespace nextNamespace : ((NamespaceAware)model).getNamespaces()) {
 				writer.handleNamespace(nextNamespace.getPrefix(), nextNamespace.getName());
 			}
 		}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/ContextStatementCollector.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/ContextStatementCollector.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.eclipse.rdf4j.OpenRDFUtil;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.NamespaceAware;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -59,8 +60,8 @@ public class ContextStatementCollector extends AbstractRDFHandler {
 			Resource... contexts)
 	{
 		OpenRDFUtil.verifyContextNotNull(contexts);
-		if (statements instanceof Model) {
-			this.namespaces = Namespaces.wrap(((Model)statements).getNamespaces());
+		if (statements instanceof NamespaceAware) {
+			this.namespaces = Namespaces.wrap(((NamespaceAware)statements).getNamespaces());
 		}
 		else {
 			this.namespaces = new LinkedHashMap<String, String>();

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDInternalRDFParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDInternalRDFParser.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.NamespaceAware;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
@@ -95,8 +96,8 @@ class JSONLDInternalRDFParser implements com.github.jsonldjava.core.RDFParser {
 			handleStatement(result, (Statement)input);
 		}
 		else if (input instanceof Graph) {
-			if (input instanceof Model) {
-				final Set<Namespace> namespaces = ((Model)input).getNamespaces();
+			if (input instanceof NamespaceAware) {
+				final Set<Namespace> namespaces = ((NamespaceAware)input).getNamespaces();
 				for (final Namespace nextNs : namespaces) {
 					result.setNamespace(nextNs.getName(), nextNs.getPrefix());
 				}


### PR DESCRIPTION
This PR addresses GitHub issue: #834 .

Briefly describe the changes proposed in this PR:

* Adds a new NamespaceAware interface to abstract out the Model.getNamespace and Model.getNamespaces methods so code can check for NamespaceAware rather than Model

This allows users of Rio.write, in particular, to submit their own collections without having to override Model, and have namespaces preserved in the output.
