### PR TITLE
Fix #712: Add ValidatingValueFactory wrapper

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -10,6 +10,8 @@ package org.eclipse.rdf4j.model.datatypes;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URISyntaxException;
+import java.util.IllformedLocaleException;
+import java.util.Locale;
 import java.util.StringTokenizer;
 
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -273,6 +275,9 @@ public class XMLDatatypeUtil {
 		}
 		else if (datatype.equals(XMLSchema.ANYURI)) {
 			result = isValidAnyURI(value);
+		}
+		else if (datatype.equals(XMLSchema.LANGUAGE)) {
+			result = isValidLanguage(value);
 		}
 
 		return result;
@@ -672,6 +677,15 @@ public class XMLDatatypeUtil {
 			return true;
 		}
 		catch (URISyntaxException e) {
+			return false;
+		}
+	}
+
+	public static boolean isValidLanguage(String value) {
+		try {
+			new Locale.Builder().setLanguageTag(value);
+			return true;
+		} catch (IllformedLocaleException e) {
 			return false;
 		}
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -10,8 +10,6 @@ package org.eclipse.rdf4j.model.datatypes;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URISyntaxException;
-import java.util.IllformedLocaleException;
-import java.util.Locale;
 import java.util.StringTokenizer;
 
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -24,6 +22,7 @@ import javax.xml.namespace.QName;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.common.text.ASCIIUtil;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 
 /**
@@ -277,7 +276,7 @@ public class XMLDatatypeUtil {
 			result = isValidAnyURI(value);
 		}
 		else if (datatype.equals(XMLSchema.LANGUAGE)) {
-			result = isValidLanguage(value);
+			result = Literals.isValidLanguageTag(value);
 		}
 
 		return result;
@@ -677,15 +676,6 @@ public class XMLDatatypeUtil {
 			return true;
 		}
 		catch (URISyntaxException e) {
-			return false;
-		}
-	}
-
-	public static boolean isValidLanguage(String value) {
-		try {
-			new Locale.Builder().setLanguageTag(value);
-			return true;
-		} catch (IllformedLocaleException e) {
 			return false;
 		}
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
@@ -24,6 +24,7 @@ import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
+import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.util.URIUtil;
 
 /**
@@ -138,8 +139,8 @@ public class ValidatingValueFactory implements ValueFactory {
 	}
 
 	public Literal createLiteral(String label, String language) {
-		if (!XMLDatatypeUtil.isValidLanguage(language)) {
-			throw new IllegalArgumentException("Not a validate language tag");
+		if (!Literals.isValidLanguageTag(language)) {
+			throw new IllegalArgumentException("Not a validate language tag: " + language);
 		}
 		return delegate.createLiteral(label, language);
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
@@ -1,0 +1,243 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model.impl;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URISyntaxException;
+import java.util.Date;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
+import org.eclipse.rdf4j.model.util.URIUtil;
+
+/**
+ * Validating wrapper to {@link ValueFactory}. Use this class in situations where a caller may be prone to
+ * errors.
+ *
+ * @author James Leigh
+ */
+public class ValidatingValueFactory implements ValueFactory {
+
+	private static final int[][] PN_CHARS_U = {
+			new int[] { '0', '9' },
+			new int[] { '_', '_' },
+			new int[] { 'A', 'Z' },
+			new int[] { 'a', 'z' },
+			new int[] { 0x00C0, 0x00D6 },
+			new int[] { 0x00D8, 0x00F6 },
+			new int[] { 0x00F8, 0x02FF },
+			new int[] { 0x0370, 0x037D },
+			new int[] { 0x037F, 0x1FFF },
+			new int[] { 0x200C, 0x200D },
+			new int[] { 0x2070, 0x218F },
+			new int[] { 0x2C00, 0x2FEF },
+			new int[] { 0x3001, 0xD7FF },
+			new int[] { 0xF900, 0xFDCF },
+			new int[] { 0xFDF0, 0xFFFD },
+			new int[] { 0x10000, 0xEFFFF } };
+
+	private static final int[][] PN_CHARS = {
+			new int[] { '-', '-' },
+			new int[] { 0x00B7, 0x00B7 },
+			new int[] { 0x0300, 0x036F },
+			new int[] { 0x203F, 0x2040 },
+			new int[] { '0', '9' },
+			new int[] { '_', '_' },
+			new int[] { 'A', 'Z' },
+			new int[] { 'a', 'z' },
+			new int[] { 0x00C0, 0x00D6 },
+			new int[] { 0x00D8, 0x00F6 },
+			new int[] { 0x00F8, 0x02FF },
+			new int[] { 0x0370, 0x037D },
+			new int[] { 0x037F, 0x1FFF },
+			new int[] { 0x200C, 0x200D },
+			new int[] { 0x2070, 0x218F },
+			new int[] { 0x2C00, 0x2FEF },
+			new int[] { 0x3001, 0xD7FF },
+			new int[] { 0xF900, 0xFDCF },
+			new int[] { 0xFDF0, 0xFFFD },
+			new int[] { 0x10000, 0xEFFFF } };
+
+	private final ValueFactory delegate;
+
+	public ValidatingValueFactory() {
+		this(SimpleValueFactory.getInstance());
+	}
+
+	public ValidatingValueFactory(ValueFactory delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public IRI createIRI(String iri) {
+		try {
+			if (!new ParsedIRI(iri).isAbsolute()) {
+				throw new IllegalArgumentException("IRI must be absolute");
+			}
+			return delegate.createIRI(iri);
+		}
+		catch (URISyntaxException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	@Override
+	public IRI createIRI(String namespace, String localName) {
+		if (!URIUtil.isCorrectURISplit(namespace, localName)) {
+			return createIRI(namespace + localName);
+		}
+		try {
+			if (!new ParsedIRI(namespace + localName).isAbsolute()) {
+				throw new IllegalArgumentException("Namespace must be absolute");
+			}
+			return delegate.createIRI(namespace, localName);
+		}
+		catch (URISyntaxException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	@Override
+	public BNode createBNode(String nodeID) {
+		if (nodeID.length() < 1) {
+			throw new IllegalArgumentException("Blank node ID cannot be empty");
+		}
+		if (!isMember(PN_CHARS_U, nodeID.codePointAt(0))) {
+			throw new IllegalArgumentException("Blank node ID must start with alphanumber or underscore");
+		}
+		for (int i = 0, n = nodeID.codePointCount(0, nodeID.length()); i < n; i++) {
+			if (!isMember(PN_CHARS, nodeID.codePointAt(nodeID.offsetByCodePoints(0, i)))) {
+				throw new IllegalArgumentException("Illegal blank node ID character");
+			}
+		}
+		return delegate.createBNode(nodeID);
+	}
+
+	@Override
+	public Literal createLiteral(String label, IRI datatype) {
+		if (!XMLDatatypeUtil.isValidValue(label, datatype)) {
+			throw new IllegalArgumentException("Not a validate literal value");
+		}
+		return delegate.createLiteral(label, datatype);
+	}
+
+	public Literal createLiteral(String label, String language) {
+		if (!XMLDatatypeUtil.isValidLanguage(language)) {
+			throw new IllegalArgumentException("Not a validate language tag");
+		}
+		return delegate.createLiteral(label, language);
+	}
+
+	@Override
+	public URI createURI(String uri) {
+		return createIRI(uri);
+	}
+
+	@Override
+	public URI createURI(String namespace, String localName) {
+		return createIRI(namespace, localName);
+	}
+
+	@Override
+	public Literal createLiteral(String label, URI datatype) {
+		if (datatype instanceof IRI) {
+			return createLiteral(label, (IRI)datatype);
+		}
+		else {
+			return createLiteral(label, createIRI(datatype.stringValue()));
+		}
+	}
+
+	public BNode createBNode() {
+		return delegate.createBNode();
+	}
+
+	public Literal createLiteral(String label) {
+		return delegate.createLiteral(label);
+	}
+
+	public Literal createLiteral(boolean value) {
+		return delegate.createLiteral(value);
+	}
+
+	public Literal createLiteral(byte value) {
+		return delegate.createLiteral(value);
+	}
+
+	public Literal createLiteral(short value) {
+		return delegate.createLiteral(value);
+	}
+
+	public Literal createLiteral(int value) {
+		return delegate.createLiteral(value);
+	}
+
+	public Literal createLiteral(long value) {
+		return delegate.createLiteral(value);
+	}
+
+	public Literal createLiteral(float value) {
+		return delegate.createLiteral(value);
+	}
+
+	public Literal createLiteral(double value) {
+		return delegate.createLiteral(value);
+	}
+
+	public Literal createLiteral(BigDecimal bigDecimal) {
+		return delegate.createLiteral(bigDecimal);
+	}
+
+	public Literal createLiteral(BigInteger bigInteger) {
+		return delegate.createLiteral(bigInteger);
+	}
+
+	public Literal createLiteral(XMLGregorianCalendar calendar) {
+		return delegate.createLiteral(calendar);
+	}
+
+	public Literal createLiteral(Date date) {
+		return delegate.createLiteral(date);
+	}
+
+	public Statement createStatement(Resource subject, IRI predicate, Value object) {
+		return delegate.createStatement(subject, predicate, object);
+	}
+
+	public Statement createStatement(Resource subject, IRI predicate, Value object, Resource context) {
+		return delegate.createStatement(subject, predicate, object, context);
+	}
+
+	public Statement createStatement(Resource subject, URI predicate, Value object) {
+		return delegate.createStatement(subject, predicate, object);
+	}
+
+	public Statement createStatement(Resource subject, URI predicate, Value object, Resource context) {
+		return delegate.createStatement(subject, predicate, object, context);
+	}
+
+	private boolean isMember(int[][] set, int cp) {
+		for (int i = 0; i < set.length; i++) {
+			if (set[i][0] <= cp && cp <= set[i][1]) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
@@ -133,14 +133,14 @@ public class ValidatingValueFactory implements ValueFactory {
 	@Override
 	public Literal createLiteral(String label, IRI datatype) {
 		if (!XMLDatatypeUtil.isValidValue(label, datatype)) {
-			throw new IllegalArgumentException("Not a validate literal value");
+			throw new IllegalArgumentException("Not a valid literal value");
 		}
 		return delegate.createLiteral(label, datatype);
 	}
 
 	public Literal createLiteral(String label, String language) {
 		if (!Literals.isValidLanguageTag(language)) {
-			throw new IllegalArgumentException("Not a validate language tag: " + language);
+			throw new IllegalArgumentException("Not a valid language tag: " + language);
 		}
 		return delegate.createLiteral(label, language);
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -15,8 +15,8 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.datatype.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
@@ -598,6 +598,25 @@ public class Literals {
 		throws IllformedLocaleException
 	{
 		return new Locale.Builder().setLanguageTag(languageTag).build().toLanguageTag().intern();
+	}
+
+	/**
+	 * Checks if the given string is a <a href="https://tools.ietf.org/html/bcp47">BCP47</a> language tag
+	 * according to the rules defined by the JDK in the {@link Locale} API.
+	 *
+	 * @param languageTag
+	 *        A language tag
+	 * @return <code>true</code> if the given language tag is well-formed according to the rules specified in
+	 *         BCP47.
+	 */
+	public static boolean isValidLanguageTag(String languageTag) {
+		try {
+			new Locale.Builder().setLanguageTag(languageTag);
+			return true;
+		}
+		catch (IllformedLocaleException e) {
+			return false;
+		}
 	}
 
 	protected Literals() {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/URIUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/URIUtil.java
@@ -103,7 +103,7 @@ public class URIUtil {
 
 		if (lastNsChar == '#') {
 			// correct split if namespace has no other '#'
-			return namespace.lastIndexOf('#', nsLength - 2) == -1;
+			return namespace.lastIndexOf('#', nsLength - 2) == -1 && localName.indexOf('#') == -1;
 		}
 		else if (lastNsChar == '/') {
 			// correct split if local name has no '/' and URI contains no '#'

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/URIUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/URIUtilTest.java
@@ -25,7 +25,7 @@ public class URIUtilTest {
 		assertTrue(URIUtil.isCorrectURISplit("http://www.example.org/page#", "1"));
 		assertTrue(URIUtil.isCorrectURISplit("http://www.example.org/page#", "1/2"));
 		assertTrue(URIUtil.isCorrectURISplit("http://www.example.org/page#", "1:2"));
-		assertTrue(URIUtil.isCorrectURISplit("http://www.example.org/page#", "1#2"));
+		assertFalse(URIUtil.isCorrectURISplit("http://www.example.org/page#", "1#2"));
 		assertTrue(URIUtil.isCorrectURISplit("http://www.example.org/page/", ""));
 		assertTrue(URIUtil.isCorrectURISplit("http://www.example.org/page/", "1"));
 		assertTrue(URIUtil.isCorrectURISplit("http://www.example.org/page/", "1:2"));


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #712 .

* Validates literals with known datatypes, literal languages, blank node IDs, and IRIs before passing the values to the underlying ValueFactory
