### PR TITLE
Fix #79: Use null binding for unbound variable solutions

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSet.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSet.java
@@ -86,7 +86,6 @@ public class QueryBindingSet extends AbstractBindingSet {
 	}
 
 	public void setBinding(String name, Value value) {
-		assert value != null : "null value for variable " + name;
 		bindings.put(name, value);
 	}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -348,7 +348,7 @@ public class StrictEvaluationStrategy
 		if (serviceRef.hasValue())
 			serviceUri = serviceRef.getValue().stringValue();
 		else {
-			if (bindings != null && bindings.hasBinding(serviceRef.getName())) {
+			if (bindings != null && bindings.getValue(serviceRef.getName()) != null) {
 				serviceUri = bindings.getBinding(serviceRef.getName()).getValue().stringValue();
 			}
 			else {
@@ -468,6 +468,13 @@ public class StrictEvaluationStrategy
 		CloseableIteration<? extends Statement, QueryEvaluationException> stIter2 = null;
 		CloseableIteration<? extends Statement, QueryEvaluationException> stIter3 = null;
 		ConvertingIteration<Statement, BindingSet, QueryEvaluationException> result = null;
+
+		if (isUnbound(subjVar, bindings) || isUnbound(predVar, bindings) || isUnbound(objVar, bindings)
+				|| isUnbound(conVar, bindings))
+		{
+			// the variable must remain unbound for this solution see https://www.w3.org/TR/sparql11-query/#assignment
+			return new EmptyIteration<BindingSet, QueryEvaluationException>();
+		}
 
 		boolean allGood = false;
 		try {
@@ -650,6 +657,15 @@ public class StrictEvaluationStrategy
 					}
 				}
 			}
+		}
+	}
+
+	protected boolean isUnbound(Var var, BindingSet bindings) {
+		if (var == null) {
+			return false;
+		}
+		else {
+			return bindings.hasBinding(var.getName()) && bindings.getValue(var.getName()) == null;
 		}
 	}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ExtensionIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ExtensionIterator.java
@@ -57,7 +57,10 @@ public class ExtensionIterator extends ConvertingIteration<BindingSet, BindingSe
 				}
 				catch (ValueExprEvaluationException e) {
 					// silently ignore type errors in extension arguments. They should not cause the 
-					// query to fail but just result in no additional binding.
+					// query to fail but result in no bindings for this solution
+					// see https://www.w3.org/TR/sparql11-query/#assignment
+					// use null as place holder for unbound variables that must remain so
+					targetBindings.setBinding(extElem.getName(), null);
 				}
 			}
 		}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
@@ -261,7 +261,11 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 		throws QueryEvaluationException
 	{
 
-		if (currentLength == 0L) {
+		if (isUnbound(startVar, bindings) || isUnbound(endVar, bindings)) {
+			// the variable must remain unbound for this solution see https://www.w3.org/TR/sparql11-query/#assignment
+			currentIter = new EmptyIteration<BindingSet, QueryEvaluationException>();
+		}
+		else if (currentLength == 0L) {
 			ZeroLengthPath zlp = new ZeroLengthPath(scope, startVar, endVar, contextVar);
 			currentIter = this.evaluationStrategyImpl.evaluate(zlp, bindings);
 			currentLength++;
@@ -331,6 +335,15 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 			}
 			currentLength++;
 
+		}
+	}
+
+	protected boolean isUnbound(Var var, BindingSet bindings) {
+		if (var == null) {
+			return false;
+		}
+		else {
+			return bindings.hasBinding(var.getName()) && bindings.getValue(var.getName()) == null;
 		}
 	}
 

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLQueryBindingSet.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLQueryBindingSet.java
@@ -88,7 +88,6 @@ public class SPARQLQueryBindingSet extends AbstractBindingSet {
 	}
 
 	public void setBinding(String name, Value value) {
-		assert value != null : "null value for variable " + name;
 		bindings.put(name, value);
 	}
 


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #79 .

* Uses a binding with value null for unbound solutions that must remain so
* hasBinding will return true, but getValue will return null
* Query strategies need to check if binding already has a solution AND
* if the solution for the variable is to remain unbound
