### PR TITLE
Fix #25: Execute each sequence of update operations in a single transaction

### DIFF
--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailUpdate.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailUpdate.java
@@ -54,7 +54,7 @@ public class SailUpdate extends AbstractParserUpdate {
 
 		boolean localTransaction = false;
 		try {
-			if (isLocalTransaction()) {
+			if (!getConnection().isActive()) {
 				localTransaction = true;
 				beginLocalTransaction();
 			}
@@ -90,12 +90,6 @@ public class SailUpdate extends AbstractParserUpdate {
 				rollbackLocalTransaction();
 			}
 		}
-	}
-
-	private boolean isLocalTransaction()
-		throws RepositoryException
-	{
-		return !getConnection().isActive();
 	}
 
 	private void beginLocalTransaction()

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailUpdate.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailUpdate.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * @author Jeen Broekstra
+ * @author James Leigh
  */
 public class SailUpdate extends AbstractParserUpdate {
 
@@ -51,34 +52,42 @@ public class SailUpdate extends AbstractParserUpdate {
 		SailUpdateExecutor executor = new SailUpdateExecutor(con.getSailConnection(), con.getValueFactory(),
 				con.getParserConfig());
 
-		for (UpdateExpr updateExpr : updateExprs) {
+		boolean localTransaction = false;
+		try {
+			if (isLocalTransaction()) {
+				localTransaction = true;
+				beginLocalTransaction();
+			}
+			for (UpdateExpr updateExpr : updateExprs) {
 
-			Dataset activeDataset = getMergedDataset(datasetMapping.get(updateExpr));
+				Dataset activeDataset = getMergedDataset(datasetMapping.get(updateExpr));
 
-			try {
-				boolean localTransaction = isLocalTransaction();
-				if (localTransaction) {
-					beginLocalTransaction();
+				try {
+					executor.executeUpdate(updateExpr, activeDataset, getBindings(), getIncludeInferred(),
+							getMaxExecutionTime());
 				}
-
-				executor.executeUpdate(updateExpr, activeDataset, getBindings(), getIncludeInferred(),
-						getMaxExecutionTime());
-
-				if (localTransaction) {
-					commitLocalTransaction();
+				catch (RDF4JException e) {
+					logger.warn("exception during update execution: ", e);
+					if (!updateExpr.isSilent()) {
+						throw new UpdateExecutionException(e);
+					}
+				}
+				catch (IOException e) {
+					logger.warn("exception during update execution: ", e);
+					if (!updateExpr.isSilent()) {
+						throw new UpdateExecutionException(e);
+					}
 				}
 			}
-			catch (RDF4JException e) {
-				logger.warn("exception during update execution: ", e);
-				if (!updateExpr.isSilent()) {
-					throw new UpdateExecutionException(e);
-				}
+
+			if (localTransaction) {
+				commitLocalTransaction();
+				localTransaction = false;
 			}
-			catch (IOException e) {
-				logger.warn("exception during update execution: ", e);
-				if (!updateExpr.isSilent()) {
-					throw new UpdateExecutionException(e);
-				}
+		}
+		finally {
+			if (localTransaction) {
+				rollbackLocalTransaction();
 			}
 		}
 	}
@@ -99,6 +108,13 @@ public class SailUpdate extends AbstractParserUpdate {
 		throws RepositoryException
 	{
 		getConnection().commit();
+
+	}
+
+	private void rollbackLocalTransaction()
+		throws RepositoryException
+	{
+		getConnection().rollback();
 
 	}
 }


### PR DESCRIPTION
Fix #25: Execute each sequence of update operations in a single transaction

Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #25 .

* If an error is detected it ignores subsequent operations
* If an error is detected all operations are rolledback
