### PR TITLE
Fix #859: Use config.ttl files instead of SYSTEM repository

### DIFF
--- a/core/console/src/test/java/org/eclipse/rdf4j/console/AbstractCommandTest.java
+++ b/core/console/src/test/java/org/eclipse/rdf4j/console/AbstractCommandTest.java
@@ -19,14 +19,13 @@ import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
-import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
@@ -81,8 +80,7 @@ public class AbstractCommandTest {
 	protected void addRepository(InputStream configStream, URL data)
 		throws UnsupportedEncodingException, IOException, RDF4JException
 	{
-		Repository systemRepo = manager.getSystemRepository();
-		RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE, systemRepo.getValueFactory());
+		RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE, SimpleValueFactory.getInstance());
 		Model graph = new LinkedHashModel();
 		rdfParser.setRDFHandler(new StatementCollector(graph));
 		rdfParser.parse(new StringReader(IOUtil.readString(new InputStreamReader(configStream, "UTF-8"))),
@@ -93,7 +91,7 @@ public class AbstractCommandTest {
 						() -> new RepositoryConfigException("could not find subject resource"));
 		RepositoryConfig repoConfig = RepositoryConfig.create(graph, repositoryNode);
 		repoConfig.validate();
-		RepositoryConfigUtil.updateRepositoryConfigs(systemRepo, repoConfig);
+		manager.addRepositoryConfig(repoConfig);
 		if (null != data) { // null if we didn't provide a data file
 			final String repId = Models.objectLiteral(
 					graph.filter(repositoryNode, RepositoryConfigSchema.REPOSITORYID, null)).orElseThrow(

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryConfigRepository.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryConfigRepository.java
@@ -1,0 +1,369 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
+import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.impl.TreeModel;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.Query;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.RepositoryResult;
+import org.eclipse.rdf4j.repository.UnknownTransactionStateException;
+import org.eclipse.rdf4j.repository.base.AbstractRepository;
+import org.eclipse.rdf4j.repository.base.AbstractRepositoryConnection;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
+import org.eclipse.rdf4j.rio.RDFHandler;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+
+/**
+ * {@link Repository} implementation that saves {@link RepositoryConfig} RDF to a {@link RepositoryManager}.
+ *
+ * @author James Leigh
+ */
+public class RepositoryConfigRepository extends AbstractRepository {
+
+	/**
+	 * The repository identifier for the system repository that contains the configuration data.
+	 */
+	public static final String ID = "SYSTEM";
+
+	private final RepositoryManager manager;
+
+	public RepositoryConfigRepository(RepositoryManager manager) {
+		this.manager = manager;
+	}
+
+	@Override
+	public void setDataDir(File dataDir) {
+		// no-op
+	}
+
+	@Override
+	public File getDataDir() {
+		return null;
+	}
+
+	@Override
+	public boolean isWritable()
+		throws RepositoryException
+	{
+		return true;
+	}
+
+	@Override
+	public ValueFactory getValueFactory() {
+		return SimpleValueFactory.getInstance();
+	}
+
+	@Override
+	protected void initializeInternal()
+		throws RepositoryException
+	{
+	}
+
+	@Override
+	protected void shutDownInternal()
+		throws RepositoryException
+	{
+	}
+
+	@Override
+	public RepositoryConnection getConnection()
+		throws RepositoryException
+	{
+		return new AbstractRepositoryConnection(this) {
+
+			private boolean active = false;
+
+			private Model committed = loadModel();
+
+			private Model added = new TreeModel();
+
+			private Model removed = new TreeModel();
+
+			@Override
+			public RepositoryResult<Resource> getContextIDs()
+				throws RepositoryException
+			{
+				Set<Resource> contextIDs = new LinkedHashSet<>();
+				manager.getRepositoryIDs().forEach(id -> {
+					contextIDs.add(getContext(id));
+				});
+				CloseableIteration<Resource, RepositoryException> iter;
+				iter = new CloseableIteratorIteration<>(contextIDs.iterator());
+				return new RepositoryResult<>(iter);
+			}
+
+			@Override
+			public RepositoryResult<Statement> getStatements(Resource subj, IRI pred, Value obj,
+					boolean includeInferred, Resource... contexts)
+				throws RepositoryException
+			{
+				Model model = committed.filter(subj, pred, obj, contexts);
+				CloseableIteration<Statement, RepositoryException> iter;
+				iter = new CloseableIteratorIteration<>(model.iterator());
+				return new RepositoryResult<>(iter);
+			}
+
+			@Override
+			public void exportStatements(Resource subj, IRI pred, Value obj, boolean includeInferred,
+					RDFHandler handler, Resource... contexts)
+				throws RepositoryException,
+				RDFHandlerException
+			{
+				Model model = committed.filter(subj, pred, obj, contexts);
+				handler.startRDF();
+				model.getNamespaces().forEach(ns -> {
+					handler.handleNamespace(ns.getPrefix(), ns.getName());
+				});
+				model.forEach(st -> {
+					handler.handleStatement(st);
+				});
+				handler.endRDF();
+			}
+
+			@Override
+			public long size(Resource... contexts)
+				throws RepositoryException
+			{
+				return committed.filter(null, null, null, contexts).size();
+			}
+
+			@Override
+			public boolean isActive()
+				throws UnknownTransactionStateException,
+				RepositoryException
+			{
+				return active;
+			}
+
+			@Override
+			public void begin()
+				throws RepositoryException
+			{
+				active = true;
+			}
+
+			@Override
+			public void commit()
+				throws RepositoryException
+			{
+				Set<String> ids = new LinkedHashSet<>();
+				ids.addAll(manager.getRepositoryIDs());
+				ids.addAll(RepositoryConfigUtil.getRepositoryIDs(added));
+				ids.forEach(id -> {
+					Resource ctx = getContext(id);
+					Model less = removed.filter(null, null, null, ctx);
+					Model more = added.filter(null, null, null, ctx);
+					Model alt = RepositoryConfigUtil.getRepositoryConfigModel(added, id);
+					if (!less.isEmpty() || !more.isEmpty() || alt != null) {
+						Model model = new TreeModel(committed.filter(null, null, null, getContext(id)));
+						model.removeAll(less);
+						removed.getNamespaces().forEach(ns -> {
+							model.removeNamespace(ns.getPrefix());
+						});
+						added.getNamespaces().forEach(ns -> {
+							model.setNamespace(ns);
+						});
+						model.addAll(more);
+						if (alt != null) {
+							model.addAll(alt);
+						}
+						if (model.isEmpty()) {
+							manager.removeRepository(id);
+						}
+						else {
+							manager.addRepositoryConfig(RepositoryConfigUtil.getRepositoryConfig(model, id));
+						}
+					}
+				});
+				committed = loadModel();
+				rollback();
+			}
+
+			@Override
+			public void rollback()
+				throws RepositoryException
+			{
+				added.clear();
+				added.getNamespaces().clear();
+				removed.clear();
+				removed.getNamespaces().clear();
+				active = false;
+			}
+
+			@Override
+			public RepositoryResult<Namespace> getNamespaces()
+				throws RepositoryException
+			{
+				CloseableIteration<Namespace, RepositoryException> iter;
+				iter = new CloseableIteratorIteration<>(committed.getNamespaces().iterator());
+				return new RepositoryResult<>(iter);
+			}
+
+			@Override
+			public String getNamespace(String prefix)
+				throws RepositoryException
+			{
+				Optional<Namespace> ns = committed.getNamespace(prefix);
+				if (ns.isPresent()) {
+					return ns.get().getName();
+				}
+				else {
+					return null;
+				}
+			}
+
+			@Override
+			public void setNamespace(String prefix, String name)
+				throws RepositoryException
+			{
+				removed.removeNamespace(prefix);
+				added.setNamespace(prefix, name);
+			}
+
+			@Override
+			public void removeNamespace(String prefix)
+				throws RepositoryException
+			{
+				added.removeNamespace(prefix);
+				Optional<Namespace> ns = committed.getNamespace(prefix);
+				if (ns.isPresent()) {
+					removed.setNamespace(ns.get());
+				}
+			}
+
+			@Override
+			public void clearNamespaces()
+				throws RepositoryException
+			{
+				added.getNamespaces().clear();
+				committed.getNamespaces().forEach(ns -> {
+					removed.setNamespace(ns);
+				});
+			}
+
+			@Override
+			public Query prepareQuery(QueryLanguage ql, String query, String baseURI)
+				throws RepositoryException,
+				MalformedQueryException
+			{
+				throw unsupported();
+			}
+
+			@Override
+			public TupleQuery prepareTupleQuery(QueryLanguage ql, String query, String baseURI)
+				throws RepositoryException,
+				MalformedQueryException
+			{
+				throw unsupported();
+			}
+
+			@Override
+			public GraphQuery prepareGraphQuery(QueryLanguage ql, String query, String baseURI)
+				throws RepositoryException,
+				MalformedQueryException
+			{
+				throw unsupported();
+			}
+
+			@Override
+			public BooleanQuery prepareBooleanQuery(QueryLanguage ql, String query, String baseURI)
+				throws RepositoryException,
+				MalformedQueryException
+			{
+				throw unsupported();
+			}
+
+			@Override
+			public Update prepareUpdate(QueryLanguage ql, String update, String baseURI)
+				throws RepositoryException,
+				MalformedQueryException
+			{
+				throw unsupported();
+			}
+
+			@Override
+			protected void addWithoutCommit(Resource subj, IRI pred, Value obj, Resource... contexts)
+				throws RepositoryException
+			{
+				added.add(subj, pred, obj, contexts);
+			}
+
+			@Override
+			protected void removeWithoutCommit(Resource subj, IRI pred, Value obj, Resource... contexts)
+				throws RepositoryException
+			{
+				Model model = committed.filter(subj, pred, obj, contexts);
+				removed.addAll(model);
+			}
+
+			private Model loadModel() {
+				Model model = new TreeModel();
+				manager.getRepositoryIDs().forEach(id -> {
+					Resource ctx = getContext(id);
+					RepositoryConfig config = manager.getRepositoryConfig(id);
+					Model cfg = new TreeModel();
+					config.export(cfg, ctx);
+					cfg.getNamespaces().forEach(ns -> {
+						model.setNamespace(ns);
+					});
+					cfg.forEach(st -> {
+						model.add(st.getSubject(), st.getPredicate(), st.getObject(), ctx);
+					});
+				});
+				return model;
+			}
+
+			private Resource getContext(String repositoryID) {
+				String location;
+				try {
+					location = manager.getLocation().toURI().toString();
+				}
+				catch (MalformedURLException | URISyntaxException e) {
+					assert false;
+					location = "urn:" + repositoryID;
+				}
+				String url = Protocol.getRepositoryLocation(location, repositoryID);
+				return getValueFactory().createIRI(url + "#" + repositoryID);
+			}
+
+			private UnsupportedOperationException unsupported() {
+				return new UnsupportedOperationException(
+						"Query operations are not supported on the SYSTEM repository");
+			}
+		};
+	}
+
+}

--- a/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryInterceptor.java
+++ b/core/http/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryInterceptor.java
@@ -102,7 +102,11 @@ public class RepositoryInterceptor extends ServerInterceptor {
 		throws ClientHTTPException, ServerHTTPException
 	{
 		String nextRepositoryID = repositoryID;
-		if (nextRepositoryID != null) {
+		if (RepositoryConfigRepository.ID.equals(nextRepositoryID)) {
+			request.setAttribute(REPOSITORY_ID_KEY, nextRepositoryID);
+			request.setAttribute(REPOSITORY_KEY, new RepositoryConfigRepository(repositoryManager));
+		}
+		else if (nextRepositoryID != null) {
 			try {
 				Repository repository = repositoryManager.getRepository(nextRepositoryID);
 

--- a/core/http/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/CreateServlet.java
+++ b/core/http/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/CreateServlet.java
@@ -22,15 +22,14 @@ import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
-import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.ConfigTemplate;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
-import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 import org.eclipse.rdf4j.repository.manager.RepositoryInfo;
 import org.eclipse.rdf4j.repository.manager.SystemRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -125,9 +124,8 @@ public class CreateServlet extends TransformationServlet {
 	private RepositoryConfig updateRepositoryConfig(final String configString)
 		throws IOException, RDF4JException
 	{
-		final Repository systemRepo = manager.getSystemRepository();
 		final Model graph = new LinkedHashModel();
-		final RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE, systemRepo.getValueFactory());
+		final RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE, SimpleValueFactory.getInstance());
 		rdfParser.setRDFHandler(new StatementCollector(graph));
 		rdfParser.parse(new StringReader(configString), RepositoryConfigSchema.NAMESPACE);
 
@@ -137,7 +135,7 @@ public class CreateServlet extends TransformationServlet {
 								"could not find instance of Repository class in config"));
 		final RepositoryConfig repConfig = RepositoryConfig.create(graph, res);
 		repConfig.validate();
-		RepositoryConfigUtil.updateRepositoryConfigs(systemRepo, repConfig);
+		manager.addRepositoryConfig(repConfig);
 		return repConfig;
 	}
 

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
+import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORY;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYID;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYIMPL;
@@ -19,6 +20,7 @@ import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 
 /**
  * @author Arjohn Kampman
@@ -131,6 +133,9 @@ public class RepositoryConfig {
 	 */
 	public void export(Model model, Resource repositoryNode) {
 		ValueFactory vf = SimpleValueFactory.getInstance();
+		model.setNamespace(RDFS.NS);
+		model.setNamespace(XMLSchema.NS);
+		model.setNamespace("rep", NAMESPACE);
 		model.add(repositoryNode, RDF.TYPE, REPOSITORY);
 
 		if (id != null) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -11,8 +11,6 @@ import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSIT
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYID;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYIMPL;
 
-import org.eclipse.rdf4j.model.BNode;
-import org.eclipse.rdf4j.model.Graph;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -114,11 +112,25 @@ public class RepositoryConfig {
 		implConfig.validate();
 	}
 
+	/**
+	 * @deprecated use {@link #export(Model, Resource)}
+	 */
+	@Deprecated
 	public void export(Model model) {
 		ValueFactory vf = SimpleValueFactory.getInstance();
+		export(model, vf.createBNode());
+	}
 
-		BNode repositoryNode = vf.createBNode();
-
+	/**
+	 * Exports the configuration into RDF using the given repositoryNode
+	 *
+	 * @param model
+	 *        target RDF collection
+	 * @param repositoryNode
+	 * @since 2.3
+	 */
+	public void export(Model model, Resource repositoryNode) {
+		ValueFactory vf = SimpleValueFactory.getInstance();
 		model.add(repositoryNode, RDF.TYPE, REPOSITORY);
 
 		if (id != null) {
@@ -152,7 +164,7 @@ public class RepositoryConfig {
 
 	/**
 	 * Creates a new {@link RepositoryConfig} object and initializes it by supplying the {@code model} and
-	 * {@code repositoryNode} to its {@link #parse(Graph, Resource) parse} method.
+	 * {@code repositoryNode} to its {@link #parse(Model, Resource) parse} method.
 	 * 
 	 * @param model
 	 *        the {@link Model} to read initialization data from.

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.repository.Repository;
@@ -30,6 +31,56 @@ import org.eclipse.rdf4j.repository.RepositoryResult;
 
 public class RepositoryConfigUtil {
 
+	public static RepositoryConfig getRepositoryConfig(Model model, String repositoryID) {
+		Statement idStatement = getIDStatement(model, repositoryID);
+		if (idStatement == null) {
+			// No such config
+			return null;
+		}
+		Resource repositoryNode = idStatement.getSubject();
+		Resource context = idStatement.getContext();
+		Model contextGraph = model.filter(null, null, null, context);
+		return RepositoryConfig.create(contextGraph, repositoryNode);
+	}
+
+	public static Model getRepositoryConfigModel(Model model, String repositoryID) {
+		Statement idStatement = getIDStatement(model, repositoryID);
+		if (idStatement == null) {
+			// No such config
+			return null;
+		}
+		return model.filter(null, null, null, idStatement.getContext());
+	}
+
+	public static Set<String> getRepositoryIDs(Model model)
+		throws RepositoryException
+	{
+		Set<String> idSet = new LinkedHashSet<String>();
+		model.filter(null, REPOSITORYID, null).forEach(idStatement -> {
+			if (idStatement.getObject() instanceof Literal) {
+				Literal idLiteral = (Literal)idStatement.getObject();
+				idSet.add(idLiteral.getLabel());
+			}
+		});
+		return idSet;
+	}
+
+	private static Statement getIDStatement(Model model, String repositoryID) {
+		Literal idLiteral = SimpleValueFactory.getInstance().createLiteral(repositoryID);
+		Model idStatementList = model.filter(null, REPOSITORYID, idLiteral);
+
+		if (idStatementList.size() == 1) {
+			return idStatementList.iterator().next();
+		}
+		else if (idStatementList.isEmpty()) {
+			return null;
+		}
+		else {
+			throw new RepositoryConfigException("Multiple ID-statements for repository ID " + repositoryID);
+		}
+	}
+
+	@Deprecated
 	public static Set<String> getRepositoryIDs(Repository repository)
 		throws RepositoryException
 	{
@@ -71,6 +122,7 @@ public class RepositoryConfigUtil {
 	 *         if an error occurred while trying to retrieve information from the (system) repository
 	 * @throws RepositoryConfigException
 	 */
+	@Deprecated
 	public static boolean hasRepositoryConfig(Repository repository, String repositoryID)
 		throws RepositoryException, RepositoryConfigException
 	{
@@ -83,6 +135,7 @@ public class RepositoryConfigUtil {
 		}
 	}
 
+	@Deprecated
 	public static RepositoryConfig getRepositoryConfig(Repository repository, String repositoryID)
 		throws RepositoryConfigException, RepositoryException
 	{
@@ -125,6 +178,7 @@ public class RepositoryConfigUtil {
 	 *         When access to the Repository's RepositoryConnection causes a RepositoryException.
 	 * @throws RepositoryConfigException
 	 */
+	@Deprecated
 	public static void updateRepositoryConfigs(Repository repository, RepositoryConfig... configs)
 		throws RepositoryException, RepositoryConfigException
 	{
@@ -152,6 +206,7 @@ public class RepositoryConfigUtil {
 	 * @throws RepositoryException
 	 * @throws RepositoryConfigException
 	 */
+	@Deprecated
 	public static void updateRepositoryConfigs(RepositoryConnection con, RepositoryConfig... configs)
 		throws RepositoryException, RepositoryConfigException
 	{
@@ -191,6 +246,7 @@ public class RepositoryConfigUtil {
 	 *         Whenever access to the Repository's RepositoryConnection causes a RepositoryException.
 	 * @throws RepositoryConfigException
 	 */
+	@Deprecated
 	public static boolean removeRepositoryConfigs(Repository repository, String... repositoryIDs)
 		throws RepositoryException, RepositoryConfigException
 	{
@@ -218,6 +274,7 @@ public class RepositoryConfigUtil {
 		return changed;
 	}
 
+	@Deprecated
 	public static Resource getContext(RepositoryConnection con, String repositoryID)
 		throws RepositoryException, RepositoryConfigException
 	{

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.http.config;
 
+import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.NAMESPACE;
 import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.PASSWORD;
 import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.REPOSITORYURL;
 import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.USERNAME;
@@ -78,6 +79,7 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (url != null) {
+			graph.setNamespace("http", NAMESPACE);
 			graph.add(implNode, REPOSITORYURL, SimpleValueFactory.getInstance().createIRI(url));
 		}
 		// if (username != null) {

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
@@ -11,10 +11,16 @@ import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSIT
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORY_CONTEXT;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -27,9 +33,12 @@ import org.eclipse.rdf4j.http.client.HttpClientDependent;
 import org.eclipse.rdf4j.http.client.SessionManagerDependent;
 import org.eclipse.rdf4j.http.client.SharedHttpClientSessionManager;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
@@ -49,6 +58,8 @@ import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryRegistry;
 import org.eclipse.rdf4j.repository.event.base.RepositoryConnectionListenerAdapter;
 import org.eclipse.rdf4j.repository.sail.config.RepositoryResolverClient;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
 
 /**
  * An implementation of the {@link RepositoryManager} interface that operates directly on the repository data
@@ -64,6 +75,10 @@ public class LocalRepositoryManager extends RepositoryManager {
 
 	public static final String REPOSITORIES_DIR = "repositories";
 
+	private static final RDFFormat CONFIG_FORMAT = RDFFormat.TURTLE;
+
+	private static final String CFG_FILE = "config." + CONFIG_FORMAT.getDefaultFileExtension();
+
 	/*-----------*
 	 * Variables *
 	 *-----------*/
@@ -78,6 +93,8 @@ public class LocalRepositoryManager extends RepositoryManager {
 
 	/** dependent life cycle */
 	private volatile FederatedServiceResolverImpl serviceResolver;
+
+	private boolean upgraded;
 
 	/*--------------*
 	 * Constructors *
@@ -100,6 +117,7 @@ public class LocalRepositoryManager extends RepositoryManager {
 	 *---------*/
 
 	@Override
+	@Deprecated
 	protected SystemRepository createSystemRepository()
 		throws RepositoryException
 	{
@@ -219,12 +237,18 @@ public class LocalRepositoryManager extends RepositoryManager {
 	@Override
 	@Deprecated
 	public SystemRepository getSystemRepository() {
-		return (SystemRepository)super.getSystemRepository();
+		if (getRepositoryDir(SystemRepository.ID).isDirectory()) {
+			return (SystemRepository)super.getSystemRepository();
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override
 	protected Repository createRepository(String id)
-		throws RepositoryConfigException, RepositoryException
+		throws RepositoryConfigException,
+		RepositoryException
 	{
 		Repository repository = null;
 
@@ -288,58 +312,167 @@ public class LocalRepositoryManager extends RepositoryManager {
 	}
 
 	@Override
-	public RepositoryInfo getRepositoryInfo(String id)
-		throws RepositoryException
-	{
-		try {
-			RepositoryConfig config = null;
-			if (id.equals(SystemRepository.ID)) {
-				config = new RepositoryConfig(id, new SystemRepositoryConfig());
+	public synchronized RepositoryConfig getRepositoryConfig(String id) {
+		File dataDir = getRepositoryDir(id);
+		if (new File(dataDir, CFG_FILE).exists()) {
+			File configFile = new File(dataDir, CFG_FILE);
+			try (InputStream input = new FileInputStream(configFile)) {
+				Model model = Rio.parse(input, configFile.toURI().toString(), CONFIG_FORMAT);
+				Set<String> repositoryIDs = RepositoryConfigUtil.getRepositoryIDs(model);
+				if (repositoryIDs.isEmpty()) {
+					throw new RepositoryConfigException("No repository ID in configuration: " + configFile);
+				}
+				else if (repositoryIDs.size() != 1) {
+					throw new RepositoryConfigException(
+							"Multiple repository IDs in configuration: " + configFile);
+				}
+				String repositoryID = repositoryIDs.iterator().next();
+				if (!id.equals(repositoryID) && !getRepositoryDir(repositoryID).getCanonicalFile().equals(
+						dataDir.getCanonicalFile()))
+				{
+					throw new RepositoryConfigException(
+							"Wrong repository ID in configuration: " + configFile);
+				}
+				return RepositoryConfigUtil.getRepositoryConfig(model, repositoryID);
 			}
-			else {
-				config = getRepositoryConfig(id);
+			catch (IOException e) {
+				throw new RepositoryConfigException(e);
 			}
-
-			RepositoryInfo repInfo = new RepositoryInfo();
-			repInfo.setId(id);
-			repInfo.setDescription(config.getTitle());
-			try {
-				repInfo.setLocation(getRepositoryDir(id).toURI().toURL());
-			}
-			catch (MalformedURLException mue) {
-				throw new RepositoryException("Location of repository does not resolve to a valid URL", mue);
-			}
-
-			repInfo.setReadable(true);
-			repInfo.setWritable(true);
-
-			return repInfo;
 		}
-		catch (RepositoryConfigException e) {
-			// FIXME: don't fetch info through config parsing
-			throw new RepositoryException("Unable to read repository configuration", e);
+		else if (id.equals(SystemRepository.ID)) {
+			return new RepositoryConfig(id, new SystemRepositoryConfig());
 		}
-	}
-
-	public Set<String> getRepositoryIDs()
-		throws RepositoryException
-	{
-		return RepositoryConfigUtil.getRepositoryIDs(getSystemRepository());
+		else {
+			return super.getRepositoryConfig(id);
+		}
 	}
 
 	@Override
-	public List<RepositoryInfo> getAllRepositoryInfos(boolean skipSystemRepo)
+	public RepositoryInfo getRepositoryInfo(String id) {
+		RepositoryConfig config = getRepositoryConfig(id);
+		if (config == null) {
+			return null;
+		}
+		RepositoryInfo repInfo = new RepositoryInfo();
+		repInfo.setId(config.getID());
+		repInfo.setDescription(config.getTitle());
+		try {
+			repInfo.setLocation(getRepositoryDir(config.getID()).toURI().toURL());
+		}
+		catch (MalformedURLException mue) {
+			throw new RepositoryException("Location of repository does not resolve to a valid URL", mue);
+		}
+		repInfo.setReadable(true);
+		repInfo.setWritable(true);
+		return repInfo;
+	}
+
+	@Override
+	public synchronized List<RepositoryInfo> getAllRepositoryInfos(boolean skipSystemRepo)
 		throws RepositoryException
 	{
-		List<RepositoryInfo> result = new ArrayList<RepositoryInfo>();
+		File repositoriesDir = resolvePath(REPOSITORIES_DIR);
+		String[] dirs = repositoriesDir.list(new FilenameFilter() {
 
-		for (String id : getRepositoryIDs()) {
-			if (!skipSystemRepo || !id.equals(SystemRepository.ID)) {
-				result.add(getRepositoryInfo(id));
+			public boolean accept(File repositories, String name) {
+				File dataDir = new File(repositories, name);
+				return dataDir.isDirectory() && new File(dataDir, CFG_FILE).exists();
+			}
+		});
+		if (dirs == null || dirs.length == 0) {
+			SystemRepository systemRepository = getSystemRepository();
+			if (systemRepository != null) {
+				dirs = RepositoryConfigUtil.getRepositoryIDs(systemRepository).toArray(new String[0]);
 			}
 		}
-
+		if (dirs == null) {
+			return Collections.emptyList();
+		}
+		List<RepositoryInfo> result = new ArrayList<RepositoryInfo>();
+		for (String name : dirs) {
+			RepositoryInfo repInfo = getRepositoryInfo(name);
+			if (!skipSystemRepo || !repInfo.getId().equals(SystemRepository.ID)) {
+				result.add(repInfo);
+			}
+		}
 		return result;
+	}
+
+	@Override
+	public synchronized void addRepositoryConfig(RepositoryConfig config)
+		throws RepositoryException,
+		RepositoryConfigException
+	{
+		File dataDir = getRepositoryDir(config.getID());
+		if (!dataDir.exists()) {
+			dataDir.mkdirs();
+		}
+		if (!dataDir.isDirectory()) {
+			throw new RepositoryConfigException("Could not create directory: " + dataDir);
+		}
+		File configFile = new File(dataDir, CFG_FILE);
+		if (!upgraded && !configFile.exists()) {
+			upgraded = true;
+			upgrade();
+		}
+		Model model = new TreeModel();
+		String ns = configFile.toURI().toString() + "#";
+		config.export(model, SimpleValueFactory.getInstance().createIRI(ns, config.getID()));
+		File part = new File(configFile.getParentFile(), configFile.getName() + ".part");
+		try (OutputStream output = new FileOutputStream(part)) {
+			Rio.write(model, output, CONFIG_FORMAT);
+		}
+		catch (IOException e) {
+			throw new RepositoryConfigException(e);
+		}
+		super.addRepositoryConfig(config);
+		part.renameTo(configFile);
+	}
+
+	@Override
+	public synchronized boolean removeRepository(String repositoryID)
+		throws RepositoryException,
+		RepositoryConfigException
+	{
+		boolean removed = super.removeRepository(repositoryID);
+		File dataDir = getRepositoryDir(repositoryID);
+		if (dataDir.isDirectory()) {
+			logger.debug("Cleaning up data dir {} for repository {}", dataDir.getAbsolutePath(),
+					repositoryID);
+			try {
+				FileUtil.deleteDir(dataDir);
+			}
+			catch (IOException e) {
+				throw new RepositoryConfigException(e);
+			}
+		}
+		return removed;
+	}
+
+	private synchronized void upgrade() {
+		File repositoriesDir = resolvePath(REPOSITORIES_DIR);
+		String[] dirs = repositoriesDir.list(new FilenameFilter() {
+
+			public boolean accept(File repositories, String name) {
+				File dataDir = new File(repositories, name);
+				return dataDir.isDirectory() && new File(dataDir, CFG_FILE).exists();
+			}
+		});
+		if (dirs != null && dirs.length > 0) {
+			return; // already upgraded
+		}
+		SystemRepository systemRepository = getSystemRepository();
+		if (systemRepository == null) {
+			return; // no legacy SYSTEM
+		}
+		Set<String> ids = RepositoryConfigUtil.getRepositoryIDs(systemRepository);
+		List<RepositoryConfig> configs = new ArrayList<RepositoryConfig>();
+		for (String id : ids) {
+			configs.add(getRepositoryConfig(id));
+		}
+		for (RepositoryConfig config : configs) {
+			addRepositoryConfig(config);
+		}
 	}
 
 	class ConfigChangeListener extends RepositoryConnectionListenerAdapter {
@@ -508,19 +641,6 @@ public class LocalRepositoryManager extends RepositoryManager {
 			}
 
 			return result;
-		}
-	}
-
-	@Override
-	protected void cleanUpRepository(String repositoryID)
-		throws IOException
-	{
-		File dataDir = getRepositoryDir(repositoryID);
-
-		if (dataDir.isDirectory()) {
-			logger.debug("Cleaning up data dir {} for repository {}", dataDir.getAbsolutePath(),
-					repositoryID);
-			FileUtil.deleteDir(dataDir);
 		}
 	}
 }

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RepositoryManager.java
@@ -253,7 +253,7 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	{
 		// update SYSTEM repository if there is one for 2.2 compatibility
 		Repository systemRepository = getSystemRepository();
-		if (systemRepository != null) {
+		if (systemRepository != null && !SystemRepository.ID.equals(config.getID())) {
 			RepositoryConfigUtil.updateRepositoryConfigs(systemRepository, config);
 		}
 	}

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RepositoryManager.java
@@ -15,13 +15,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.http.client.HttpClient;
 import org.eclipse.rdf4j.http.client.HttpClientDependent;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
@@ -53,6 +56,8 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	 *-----------*/
 
 	protected Map<String, Repository> initializedRepositories;
+
+	private boolean initialized;
 
 	/*--------------*
 	 * Constructors *
@@ -86,10 +91,7 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	 * @return true iff the repository manager has been initialized.
 	 */
 	public boolean isInitialized() {
-		synchronized (initializedRepositories) {
-			Repository repo = initializedRepositories.get(SystemRepository.ID);
-			return repo != null && repo.isInitialized();
-		}
+		return initialized;
 	}
 
 	/**
@@ -114,15 +116,15 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	public void initialize()
 		throws RepositoryException
 	{
-		Repository systemRepository = createSystemRepository();
-
-		synchronized (initializedRepositories) {
-			initializedRepositories.put(SystemRepository.ID, systemRepository);
-		}
+		initialized = true;
 	}
 
-	protected abstract Repository createSystemRepository()
-		throws RepositoryException;
+	@Deprecated
+	protected Repository createSystemRepository()
+		throws RepositoryException
+	{
+		return null;
+	}
 
 	/**
 	 * Gets the SYSTEM repository.
@@ -133,7 +135,15 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 			throw new IllegalStateException("Repository Manager is not initialized");
 		}
 		synchronized (initializedRepositories) {
-			return initializedRepositories.get(SystemRepository.ID);
+			Repository systemRepository = initializedRepositories.get(SystemRepository.ID);
+			if (systemRepository != null && systemRepository.isInitialized()) {
+				return systemRepository;
+			}
+			systemRepository = createSystemRepository();
+			if (systemRepository != null) {
+				initializedRepositories.put(SystemRepository.ID, systemRepository);
+			}
+			return systemRepository;
 		}
 	}
 
@@ -198,19 +208,29 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	public Set<String> getRepositoryIDs()
 		throws RepositoryException
 	{
-		return RepositoryConfigUtil.getRepositoryIDs(getSystemRepository());
+		Set<String> idSet = new LinkedHashSet<String>();
+		getAllRepositoryInfos(false).forEach(info -> {
+			idSet.add(info.getId());
+		});
+		return idSet;
 	}
 
 	public boolean hasRepositoryConfig(String repositoryID)
 		throws RepositoryException, RepositoryConfigException
 	{
-		return RepositoryConfigUtil.hasRepositoryConfig(getSystemRepository(), repositoryID);
+		return getRepositoryInfo(repositoryID) != null;
 	}
 
 	public RepositoryConfig getRepositoryConfig(String repositoryID)
 		throws RepositoryConfigException, RepositoryException
 	{
-		return RepositoryConfigUtil.getRepositoryConfig(getSystemRepository(), repositoryID);
+		Repository systemRepository = getSystemRepository();
+		if (systemRepository == null) {
+			return null;
+		}
+		else {
+			return RepositoryConfigUtil.getRepositoryConfig(systemRepository, repositoryID);
+		}
 	}
 
 	/**
@@ -231,7 +251,11 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	public void addRepositoryConfig(RepositoryConfig config)
 		throws RepositoryException, RepositoryConfigException
 	{
-		RepositoryConfigUtil.updateRepositoryConfigs(getSystemRepository(), config);
+		// update SYSTEM repository if there is one for 2.2 compatibility
+		Repository systemRepository = getSystemRepository();
+		if (systemRepository != null) {
+			RepositoryConfigUtil.updateRepositoryConfigs(systemRepository, config);
+		}
 	}
 
 	/**
@@ -254,10 +278,14 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 		throws RepositoryException, RepositoryConfigException
 	{
 		logger.debug("Removing repository configuration for {}.", repositoryID);
-		boolean isRemoved = false;
+		boolean isRemoved = hasRepositoryConfig(repositoryID);
 
 		synchronized (initializedRepositories) {
-			isRemoved = RepositoryConfigUtil.removeRepositoryConfigs(getSystemRepository(), repositoryID);
+			// update SYSTEM repository if there is one for 2.2 compatibility
+			Repository systemRepository = getSystemRepository();
+			if (systemRepository != null) {
+				RepositoryConfigUtil.removeRepositoryConfigs(systemRepository, repositoryID);
+			}
 
 			if (isRemoved) {
 				logger.debug("Shutdown repository {} after removal of configuration.", repositoryID);
@@ -292,14 +320,16 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	public boolean isSafeToRemove(String repositoryID)
 		throws RepositoryException
 	{
-		RepositoryConnection connection = this.getSystemRepository().getConnection();
-		try {
-			return !connection.hasStatement(null, ProxyRepositorySchema.PROXIED_ID,
-					connection.getValueFactory().createLiteral(repositoryID), false);
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+		for (String id : getRepositoryIDs()) {
+			RepositoryConfig config = getRepositoryConfig(id);
+			Model model = new LinkedHashModel();
+			config.export(model, vf.createBNode());
+			if (model.contains(null, ProxyRepositorySchema.PROXIED_ID, vf.createLiteral(repositoryID))) {
+				return false;
+			}
 		}
-		finally {
-			connection.close();
-		}
+		return true;
 	}
 
 	/**
@@ -321,10 +351,14 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 		throws RepositoryException, RepositoryConfigException
 	{
 		logger.debug("Removing repository {}.", repositoryID);
-		boolean isRemoved = false;
+		boolean isRemoved = hasRepositoryConfig(repositoryID);
 
 		synchronized (initializedRepositories) {
-			isRemoved = RepositoryConfigUtil.removeRepositoryConfigs(getSystemRepository(), repositoryID);
+			// update SYSTEM repository if there is one for 2.2 compatibility
+			Repository systemRepository = getSystemRepository();
+			if (systemRepository != null) {
+				RepositoryConfigUtil.removeRepositoryConfigs(systemRepository, repositoryID);
+			}
 
 			if (isRemoved) {
 				logger.debug("Shutdown repository {} after removal of configuration.", repositoryID);
@@ -372,6 +406,9 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 				result = null;
 			}
 
+			if (result == null && SystemRepository.ID.equals(identity)) {
+				result = getSystemRepository();
+			}
 			if (result == null) {
 				// First call (or old object thrown away), create and initialize the
 				// repository.
@@ -493,8 +530,17 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	 * @throws RepositoryException
 	 *         When not able to retrieve existing configurations
 	 */
-	public abstract RepositoryInfo getRepositoryInfo(String id)
-		throws RepositoryException;
+	public RepositoryInfo getRepositoryInfo(String id)
+		throws RepositoryException
+	{
+		for (RepositoryInfo repInfo : getAllRepositoryInfos()) {
+			if (repInfo.getId().equals(id)) {
+				return repInfo;
+			}
+		}
+
+		return null;
+	}
 
 	public Collection<RepositoryInfo> getAllRepositoryInfos()
 		throws RepositoryException
@@ -568,6 +614,7 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 			}
 
 			initializedRepositories.clear();
+			initialized = false;
 		}
 	}
 
@@ -617,8 +664,11 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	 *        the ID of the repository to clean up
 	 * @throws IOException
 	 */
-	protected abstract void cleanUpRepository(String repositoryID)
-		throws IOException;
+	@Deprecated
+	protected void cleanUpRepository(String repositoryID)
+		throws IOException
+	{
+	}
 
 	/**
 	 * Gets the URL of the server or directory.

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/SystemRepository.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/SystemRepository.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
  * @author Herko ter Horst
  * @author Arjohn Kampman
  */
+@Deprecated
 public class SystemRepository extends NotifyingRepositoryWrapper {
 
 	/*-----------*

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/SystemRepository.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/SystemRepository.java
@@ -56,12 +56,27 @@ public class SystemRepository extends NotifyingRepositoryWrapper {
 		throws RepositoryException
 	{
 		super();
-		super.setDelegate(new SailRepository(new MemoryStore(systemDir)));
+		setDataDir(systemDir);
+	}
+
+	SystemRepository()
+		throws RepositoryException
+	{
+		super();
 	}
 
 	/*---------*
 	 * Methods *
 	 *---------*/
+
+	@Override
+	public void setDataDir(File systemDir) {
+		Repository delegate = super.getDelegate();
+		if (delegate != null) {
+			delegate.shutDown();
+		}
+		super.setDelegate(new SailRepository(new MemoryStore(systemDir)));
+	}
 
 	@Override
 	public void initialize()

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/SystemRepositoryFactory.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/SystemRepositoryFactory.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.manager;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryFactory;
+import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
+
+public class SystemRepositoryFactory implements RepositoryFactory {
+
+	@Override
+	public String getRepositoryType() {
+		return SystemRepository.REPOSITORY_TYPE;
+	}
+
+	@Override
+	public RepositoryImplConfig getConfig() {
+		return new SystemRepositoryConfig();
+	}
+
+	@Override
+	public Repository getRepository(RepositoryImplConfig config)
+		throws RepositoryConfigException
+	{
+		return new SystemRepository();
+	}
+
+}

--- a/core/repository/manager/src/main/resources/META-INF/services/org.eclipse.rdf4j.repository.config.RepositoryFactory
+++ b/core/repository/manager/src/main/resources/META-INF/services/org.eclipse.rdf4j.repository.config.RepositoryFactory
@@ -1,0 +1,1 @@
+org.eclipse.rdf4j.repository.manager.SystemRepositoryFactory

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
@@ -50,6 +50,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 	public Resource export(Model model) {
 		Resource implNode = super.export(model);
 		if (null != this.proxiedID) {
+			model.setNamespace("proxy", ProxyRepositorySchema.NAMESPACE);
 			model.add(implNode, ProxyRepositorySchema.PROXIED_ID,
 					SimpleValueFactory.getInstance().createLiteral(this.proxiedID));
 		}

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail.config;
 
+import static org.eclipse.rdf4j.repository.sail.config.SailRepositorySchema.NAMESPACE;
 import static org.eclipse.rdf4j.repository.sail.config.SailRepositorySchema.SAILIMPL;
 import static org.eclipse.rdf4j.sail.config.SailConfigSchema.SAILTYPE;
 
@@ -69,6 +70,7 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource repImplNode = super.export(model);
 
 		if (sailImplConfig != null) {
+			model.setNamespace("sr", NAMESPACE);
 			Resource sailImplNode = sailImplConfig.export(model);
 			model.add(repImplNode, SAILIMPL, sailImplNode);
 		}

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
@@ -26,6 +26,8 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
+	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/sparql#";
+
 	public static final IRI QUERY_ENDPOINT = vf.createIRI(
 			"http://www.openrdf.org/config/repository/sparql#query-endpoint");
 
@@ -80,6 +82,7 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
 
+		m.setNamespace("sparql", NAMESPACE);
 		if (getQueryEndpointUrl() != null) {
 			m.add(implNode, QUERY_ENDPOINT, vf.createIRI(getQueryEndpointUrl()));
 		}

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
@@ -63,6 +63,7 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 		ValueFactory vf = SimpleValueFactory.getInstance();
 		BNode implNode = vf.createBNode();
 
+		m.setNamespace("sail", SailConfigSchema.NAMESPACE);
 		if (type != null) {
 			m.add(implNode, SAILTYPE, vf.createLiteral(type));
 		}

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
@@ -55,6 +55,7 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (evalStratFactoryClassName != null) {
+			graph.setNamespace("sb", NAMESPACE);
 			graph.add(implNode, EVALUATION_STRATEGY_FACTORY,
 					SimpleValueFactory.getInstance().createLiteral(evalStratFactoryClassName));
 		}

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/config/FederationConfig.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/config/FederationConfig.java
@@ -109,6 +109,7 @@ public class FederationConfig extends AbstractSailImplConfig {
 	public Resource export(Model model) {
 		ValueFactory valueFactory = SimpleValueFactory.getInstance();
 		Resource self = super.export(model);
+		model.setNamespace("sf", NAMESPACE);
 		for (RepositoryImplConfig member : getMembers()) {
 			model.add(self, MEMBER, member.export(model));
 		}

--- a/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/AbstractLuceneSailConfig.java
+++ b/core/sail/fts/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/AbstractLuceneSailConfig.java
@@ -83,6 +83,7 @@ public abstract class AbstractLuceneSailConfig extends AbstractDelegatingSailImp
 		Resource implNode = super.export(m);
 
 		ValueFactory vf = SimpleValueFactory.getInstance();
+		m.setNamespace("sl", LuceneSailConfigSchema.NAMESPACE);
 		if (indexDir != null) {
 			m.add(implNode, INDEX_DIR, SimpleValueFactory.getInstance().createLiteral(indexDir));
 		}

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerConfig.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerConfig.java
@@ -162,6 +162,7 @@ public final class CustomGraphQueryInferencerConfig extends AbstractDelegatingSa
 	@Override
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
+		m.setNamespace("cgqi", CustomGraphQueryInferencerSchema.NAMESPACE);
 		if (null != language) {
 			m.add(implNode, QUERY_LANGUAGE,
 					SimpleValueFactory.getInstance().createLiteral(language.getName()));

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory.config;
 
+import static org.eclipse.rdf4j.sail.memory.config.MemoryStoreSchema.NAMESPACE;
 import static org.eclipse.rdf4j.sail.memory.config.MemoryStoreSchema.PERSIST;
 import static org.eclipse.rdf4j.sail.memory.config.MemoryStoreSchema.SYNC_DELAY;
 
@@ -62,6 +63,7 @@ public class MemoryStoreConfig extends BaseSailConfig {
 	public Resource export(Model graph) {
 		Resource implNode = super.export(graph);
 
+		graph.setNamespace("ms", NAMESPACE);
 		if (persist) {
 			graph.add(implNode, PERSIST, BooleanLiteral.TRUE);
 		}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.sail.nativerdf.config;
 
 import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.FORCE_SYNC;
+import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.NAMESPACE;
 import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.NAMESPACE_CACHE_SIZE;
 import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.NAMESPACE_ID_CACHE_SIZE;
 import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.TRIPLE_INDEXES;
@@ -119,6 +120,7 @@ public class NativeStoreConfig extends BaseSailConfig {
 		Resource implNode = super.export(m);
 		ValueFactory vf = SimpleValueFactory.getInstance();
 
+		m.setNamespace("ns", NAMESPACE);
 		if (tripleIndexes != null) {
 			m.add(implNode, TRIPLE_INDEXES, vf.createLiteral(tripleIndexes));
 		}


### PR DESCRIPTION
This PR addresses GitHub issue: #859 .

* RepositoryConifg is stored in config.ttl files (SYSTEM repository is updated if it already exists)
* RepositoryManager does not lock configs and can be used by multiple processes
* http-server uses a pseudo SYSTEM repository that does not support queries and limited isolation levels
