### PR TITLE
update DOAP.java with default prefix

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DCAT.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DCAT.java
@@ -23,15 +23,15 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 public class DCAT {
 
 	/**
-	 * The DCAT namespace: http://www.w3.org/ns/dcat#
-	 */
-	public static final String NAMESPACE = "http://www.w3.org/ns/dcat#";
-
-	/**
 	 * Recommended prefix for the Data Catalog Vocabulary namespace: "dcat"
 	 */
 	public static final String PREFIX = "dcat";
 
+	/**
+	 * The DCAT namespace: http://www.w3.org/ns/dcat#
+	 */
+	public static final String NAMESPACE = "http://www.w3.org/ns/dcat#";
+	
 	/**
 	 * An immutable {@link Namespace} constant that represents the Data Catalog Vocabulary namespace.
 	 */

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DOAP.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DOAP.java
@@ -8,7 +8,9 @@
 package org.eclipse.rdf4j.model.vocabulary;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DOAP.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DOAP.java
@@ -16,8 +16,21 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
  */
 public class DOAP {
 
+	/**
+	 * The recommended prefix for the DOAP namespace: "doap"
+	 */
+	public static final String PREFIX = "doap";
+	
+	/**
+	 * The DOAP namespace: http://usefulinc.com/ns/doap#
+	 */
 	public static final String NAMESPACE = "http://usefulinc.com/ns/doap#";
 
+	/**
+	 * An immutable {@link Namespace} constant that represents the DOAP namespace.
+	 */
+	public static final Namespace NS = new SimpleNamespace(PREFIX, NAMESPACE);
+	
 	/**
 	 * Classes
 	 */

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DOAP.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/DOAP.java
@@ -8,9 +8,13 @@
 package org.eclipse.rdf4j.model.vocabulary;
 
 import org.eclipse.rdf4j.model.IRI;
+
 import org.eclipse.rdf4j.model.Namespace;
+
 import org.eclipse.rdf4j.model.ValueFactory;
+
 import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**


### PR DESCRIPTION
added reccommended prefix for doap, as in [http://prefix.cc/doap](http://prefix.cc/doap)


This PR addresses GitHub issue: #866 .

Briefly describe the changes proposed in this PR:

* added PREFIX / NS constants for the vocabulary DOAP, to make it compliant with the others provided, which usually expose `NS(PREFIX,NAMESPACE)` constants
