### PR TITLE
Fix #364: Changed handleConstraintViolation to protected

### DIFF
--- a/core/sail/spin/src/main/java/org/eclipse/rdf4j/sail/spin/SpinSailConnection.java
+++ b/core/sail/spin/src/main/java/org/eclipse/rdf4j/sail/spin/SpinSailConnection.java
@@ -686,7 +686,7 @@ class SpinSailConnection extends AbstractForwardChainingInferencerConnection {
 		}
 	}
 
-	private void handleConstraintViolation(ConstraintViolation violation)
+	protected void handleConstraintViolation(ConstraintViolation violation)
 		throws ConstraintViolationException
 	{
 		switch (violation.getLevel()) {


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@fedict.be>


This PR addresses GitHub issue: #364 .

Briefly describe the changes proposed in this PR:

* Changed handleConstraintViolation from private to protected, so it can be overridden (e.g. to create a fancier report)