### PR TITLE
Fix #872: Move guava dependency from util to sail-model

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -94,8 +94,6 @@ import org.eclipse.rdf4j.rio.helpers.ParseErrorLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Joiner;
-
 /**
  * The SPARQLProtocolSession provides low level HTTP methods for communication with SPARQL endpoints. All
  * methods are compliant to the <a href="https://www.w3.org/TR/sparql11-protocol/">SPARQL 1.1 Protocol W3C
@@ -150,11 +148,6 @@ public class SPARQLProtocolSession implements HttpClientDependent {
 	private final int maximumUrlLength;
 
 	final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-	/**
-	 * shared instance of a {@link Joiner} for creating a comma-separated string.
-	 */
-	private static final Joiner commaJoiner = Joiner.on(", ");
 
 	/*-----------*
 	 * Variables *
@@ -828,7 +821,7 @@ public class SPARQLProtocolSession implements HttpClientDependent {
 			}
 		}
 
-		method.addHeader(ACCEPT_PARAM_NAME, commaJoiner.join(acceptValues));
+		method.addHeader(ACCEPT_PARAM_NAME, String.join(", ", acceptValues));
 
 		try {
 			return executeOK(method);
@@ -966,7 +959,7 @@ public class SPARQLProtocolSession implements HttpClientDependent {
 		List<String> acceptParams = RDFFormat.getAcceptParams(rdfFormats, requireContext,
 				getPreferredRDFFormat());
 
-		method.addHeader(ACCEPT_PARAM_NAME, commaJoiner.join(acceptParams));
+		method.addHeader(ACCEPT_PARAM_NAME, String.join(", ", acceptParams));
 
 		try {
 			return executeOK(method);
@@ -1047,7 +1040,7 @@ public class SPARQLProtocolSession implements HttpClientDependent {
 			}
 		}
 
-		method.addHeader(ACCEPT_PARAM_NAME, commaJoiner.join(acceptValues));
+		method.addHeader(ACCEPT_PARAM_NAME, String.join(", ", acceptValues));
 
 		return executeOK(method);
 	}

--- a/core/sail/model/pom.xml
+++ b/core/sail/model/pom.xml
@@ -19,6 +19,10 @@
 			<artifactId>rdf4j-sail-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+		</dependency>
 	</dependencies>
         <build>
                 <plugins>

--- a/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/NonSerializables.java
+++ b/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/NonSerializables.java
@@ -5,10 +5,12 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.util;
+package org.eclipse.rdf4j.sail.model;
 
 import java.util.Map;
 import java.util.UUID;
+
+import org.eclipse.rdf4j.util.UUIDable;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;

--- a/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/SailModel.java
+++ b/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/SailModel.java
@@ -33,7 +33,6 @@ import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import org.eclipse.rdf4j.util.NonSerializables;
 
 /**
  * Model implementation for a {@link org.eclipse.rdf4j.sail.SailConnection}. All

--- a/core/util/pom.xml
+++ b/core/util/pom.xml
@@ -15,11 +15,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #872 .

* Use java7 String.join
* Create custom ThreadFactory
* Move NonSerializables to sail-model
