### PR TITLE
Fix #876: Add BASE_DIRECTIVE writer config and baseURI parameter to writer interface

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFWriterFactory.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFWriterFactory.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.rio;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.net.URISyntaxException;
 
 /**
  * A RDFWriterFactory returns {@link RDFWriter}s for a specific RDF format.
@@ -31,6 +32,19 @@ public interface RDFWriterFactory {
 	public RDFWriter getWriter(OutputStream out);
 
 	/**
+	 * Returns an RDFWriter instance that will write to the supplied output stream. Using the supplied baseURI
+	 * to relativize IRIs to relative IRIs.
+	 *
+	 * @param out
+	 *        The OutputStream to write the RDF to.
+	 * @param baseURI
+	 *        The URI associated with the data in the InputStream.
+	 * @throws URISyntaxException
+	 */
+	public RDFWriter getWriter(OutputStream out, String baseURI)
+		throws URISyntaxException;
+
+	/**
 	 * Returns an RDFWriter instance that will write to the supplied writer. (Optional operation)
 	 * 
 	 * @param writer
@@ -39,4 +53,19 @@ public interface RDFWriterFactory {
 	 *         if the RDFWriter the specific format does not support writing to a {@link java.io.Writer}
 	 */
 	public RDFWriter getWriter(Writer writer);
+
+	/**
+	 * Returns an RDFWriter instance that will write to the supplied writer. Using the supplied baseURI to
+	 * relativize IRIs to relative IRIs. (Optional operation)
+	 *
+	 * @param writer
+	 *        The Writer to write the RDF to.
+	 * @param baseURI
+	 *        The URI associated with the data in the InputStream.
+	 * @throws URISyntaxException
+	 * @throws UnsupportedOperationException
+	 *         if the RDFWriter the specific format does not support writing to a {@link java.io.Writer}
+	 */
+	public RDFWriter getWriter(Writer writer, String baseURI)
+		throws URISyntaxException;
 }

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/Rio.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/Rio.java
@@ -14,6 +14,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -144,6 +145,26 @@ public class Rio {
 	 * 
 	 * @throws UnsupportedRDFormatException
 	 *         If no writer is available for the specified RDF format.
+	 * @throws URISyntaxException
+	 *         If the baseURI is invalid
+	 */
+	public static RDFWriter createWriter(RDFFormat format, OutputStream out, String baseURI)
+		throws UnsupportedRDFormatException,
+		URISyntaxException
+	{
+		RDFWriterFactory factory = RDFWriterRegistry.getInstance().get(format).orElseThrow(
+				Rio.unsupportedFormat(format));
+
+		return factory.getWriter(out, baseURI);
+	}
+
+	/**
+	 * Convenience methods for creating RDFWriter objects. This method uses the registry returned by
+	 * {@link RDFWriterRegistry#getInstance()} to get a factory for the specified format and uses this factory
+	 * to create the appropriate writer.
+	 * 
+	 * @throws UnsupportedRDFormatException
+	 *         If no writer is available for the specified RDF format.
 	 */
 	public static RDFWriter createWriter(RDFFormat format, Writer writer)
 		throws UnsupportedRDFormatException
@@ -152,6 +173,26 @@ public class Rio {
 				Rio.unsupportedFormat(format));
 
 		return factory.getWriter(writer);
+	}
+
+	/**
+	 * Convenience methods for creating RDFWriter objects. This method uses the registry returned by
+	 * {@link RDFWriterRegistry#getInstance()} to get a factory for the specified format and uses this factory
+	 * to create the appropriate writer.
+	 * 
+	 * @throws UnsupportedRDFormatException
+	 *         If no writer is available for the specified RDF format.
+	 * @throws URISyntaxException
+	 *         If the baseURI is invalid
+	 */
+	public static RDFWriter createWriter(RDFFormat format, Writer writer, String baseURI)
+		throws UnsupportedRDFormatException,
+		URISyntaxException
+	{
+		RDFWriterFactory factory = RDFWriterRegistry.getInstance().get(format).orElseThrow(
+				Rio.unsupportedFormat(format));
+
+		return factory.getWriter(writer, baseURI);
 	}
 
 	/**
@@ -325,6 +366,33 @@ public class Rio {
 	}
 
 	/**
+	 * Writes the given statements to the given {@link OutputStream} in the given format.
+	 * <p>
+	 * If the collection is a {@link Model}, its namespaces will also be written.
+	 * 
+	 * @param model
+	 *        A collection of statements, such as a {@link Model}, to be written.
+	 * @param output
+	 *        The {@link OutputStream} to write the statements to.
+	 * @param baseURI
+	 *        The base URI to relativize IRIs against.
+	 * @param dataFormat
+	 *        The {@link RDFFormat} to use when writing the statements.
+	 * @throws RDFHandlerException
+	 *         Thrown if there is an error writing the statements.
+	 * @throws URISyntaxException
+	 *         If the baseURI is invalid 
+	 * @throws UnsupportedRDFormatException
+	 *         If no {@link RDFWriter} is available for the specified RDF format.
+	 */
+	public static void write(Iterable<Statement> model, OutputStream output, String baseURI,
+			RDFFormat dataFormat)
+		throws RDFHandlerException, UnsupportedRDFormatException, URISyntaxException
+	{
+		write(model, output, baseURI, dataFormat, new WriterConfig());
+	}
+
+	/**
 	 * Writes the given statements to the given {@link Writer} in the given format.
 	 * <p>
 	 * If the collection is a {@link Model}, its namespaces will also be written.
@@ -344,6 +412,32 @@ public class Rio {
 		throws RDFHandlerException
 	{
 		write(model, output, dataFormat, new WriterConfig());
+	}
+
+	/**
+	 * Writes the given statements to the given {@link Writer} in the given format.
+	 * <p>
+	 * If the collection is a {@link Model}, its namespaces will also be written.
+	 * 
+	 * @param model
+	 *        A collection of statements, such as a {@link Model}, to be written.
+	 * @param output
+	 *        The {@link Writer} to write the statements to.
+	 * @param baseURI
+	 *        The base URI to relativize IRIs against.
+	 * @param dataFormat
+	 *        The {@link RDFFormat} to use when writing the statements.
+	 * @throws RDFHandlerException
+	 *         Thrown if there is an error writing the statements.
+	 * @throws URISyntaxException
+	 *         If the baseURI is invalid
+	 * @throws UnsupportedRDFormatException
+	 *         If no {@link RDFWriter} is available for the specified RDF format.
+	 */
+	public static void write(Iterable<Statement> model, Writer output, String baseURI, RDFFormat dataFormat)
+		throws RDFHandlerException, UnsupportedRDFormatException, URISyntaxException
+	{
+		write(model, output, baseURI, dataFormat, new WriterConfig());
 	}
 
 	/**
@@ -374,6 +468,37 @@ public class Rio {
 	}
 
 	/**
+	 * Writes the given statements to the given {@link OutputStream} in the given format.
+	 * <p>
+	 * If the collection is a {@link Model}, its namespaces will also be written.
+	 * 
+	 * @param model
+	 *        A collection of statements, such as a {@link Model}, to be written.
+	 * @param output
+	 *        The {@link OutputStream} to write the statements to.
+	 * @param baseURI
+	 *        The base URI to relativize IRIs against.
+	 * @param dataFormat
+	 *        The {@link RDFFormat} to use when writing the statements.
+	 * @param settings
+	 *        The {@link WriterConfig} containing settings for configuring the writer.
+	 * @throws RDFHandlerException
+	 *         Thrown if there is an error writing the statements.
+	 * @throws URISyntaxException
+	 *         If the baseURI is invalid
+	 * @throws UnsupportedRDFormatException
+	 *         If no {@link RDFWriter} is available for the specified RDF format.
+	 */
+	public static void write(Iterable<Statement> model, OutputStream output, String baseURI,
+			RDFFormat dataFormat, WriterConfig settings)
+		throws RDFHandlerException, UnsupportedRDFormatException, URISyntaxException
+	{
+		final RDFWriter writer = Rio.createWriter(dataFormat, output, baseURI);
+		writer.setWriterConfig(settings);
+		write(model, writer);
+	}
+
+	/**
 	 * Writes the given statements to the given {@link Writer} in the given format.
 	 * <p>
 	 * If the collection is a {@link Model}, its namespaces will also be written.
@@ -396,6 +521,37 @@ public class Rio {
 		throws RDFHandlerException
 	{
 		final RDFWriter writer = Rio.createWriter(dataFormat, output);
+		writer.setWriterConfig(settings);
+		write(model, writer);
+	}
+
+	/**
+	 * Writes the given statements to the given {@link Writer} in the given format.
+	 * <p>
+	 * If the collection is a {@link Model}, its namespaces will also be written.
+	 * 
+	 * @param model
+	 *        A collection of statements, such as a {@link Model}, to be written.
+	 * @param output
+	 *        The {@link Writer} to write the statements to.
+	 * @param baseURI
+	 *        The base URI to relativize IRIs against.
+	 * @param dataFormat
+	 *        The {@link RDFFormat} to use when writing the statements.
+	 * @param settings
+	 *        The {@link WriterConfig} containing settings for configuring the writer.
+	 * @throws RDFHandlerException
+	 *         Thrown if there is an error writing the statements.
+	 * @throws URISyntaxException
+	 *         If the baseURI is invalid
+	 * @throws UnsupportedRDFormatException
+	 *         If no {@link RDFWriter} is available for the specified RDF format.
+	 */
+	public static void write(Iterable<Statement> model, Writer output, String baseURI, RDFFormat dataFormat,
+			WriterConfig settings)
+		throws RDFHandlerException, UnsupportedRDFormatException, URISyntaxException
+	{
+		final RDFWriter writer = Rio.createWriter(dataFormat, output, baseURI);
 		writer.setWriterConfig(settings);
 		write(model, writer);
 	}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
@@ -57,6 +57,14 @@ public class BasicWriterSettings {
 			Boolean.TRUE);
 
 	/**
+	 * Boolean setting for writer to determine whether it should include a base directive.
+	 * <p>
+	 * Defaults to true
+	 */
+	public static final RioSetting<Boolean> BASE_DIRECTIVE = new RioSettingImpl<Boolean>(
+			"org.eclipse.rdf4j.rio.basedirective", "Serialize base directive", Boolean.TRUE);
+
+	/**
 	 * Private default constructor.
 	 */
 	private BasicWriterSettings() {

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterFactory.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterFactory.java
@@ -35,10 +35,21 @@ public class BinaryRDFWriterFactory implements RDFWriterFactory {
 		return new BinaryRDFWriter(out);
 	}
 
+	public RDFWriter getWriter(OutputStream out, String baseURI) {
+		return new BinaryRDFWriter(out);
+	}
+
 	/**
-	 * Returns a new instance of {@link BinaryRDFWriter}.
+	 * throws UnsupportedOperationException
 	 */
 	public RDFWriter getWriter(Writer writer) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * throws UnsupportedOperationException
+	 */
+	public RDFWriter getWriter(Writer writer, String baseURI) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -49,6 +49,8 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
 
 	private final StatementCollector statementCollector = new StatementCollector(model);
 
+	private final String baseURI;
+
 	private final Writer writer;
 
 	/**
@@ -58,7 +60,17 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
 	 *        The OutputStream to write to.
 	 */
 	public JSONLDWriter(OutputStream outputStream) {
-		this(new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("UTF-8"))));
+		this(outputStream, null);
+	}
+
+	/**
+	 * Create a SesameJSONLDWriter using a {@link java.io.OutputStream}
+	 *
+	 * @param outputStream
+	 *        The OutputStream to write to.
+	 */
+	public JSONLDWriter(OutputStream outputStream, String baseURI) {
+		this(new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("UTF-8"))), baseURI);
 	}
 
 	/**
@@ -68,6 +80,17 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
 	 *        The Writer to write to.
 	 */
 	public JSONLDWriter(Writer writer) {
+		this(writer, null);
+	}
+
+	/**
+	 * Create a SesameJSONLDWriter using a {@link java.io.Writer}
+	 *
+	 * @param writer
+	 *        The Writer to write to.
+	 */
+	public JSONLDWriter(Writer writer, String baseURI) {
+		this.baseURI = baseURI;
 		this.writer = writer;
 	}
 
@@ -103,6 +126,9 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
 			opts.setUseNativeTypes(getWriterConfig().get(JSONLDSettings.USE_NATIVE_TYPES));
 			// opts.optimize = getWriterConfig().get(JSONLDSettings.OPTIMIZE);
 
+			if (baseURI != null && getWriterConfig().get(BasicWriterSettings.BASE_DIRECTIVE)) {
+				opts.setBase(baseURI);
+			}
 			if (mode == JSONLDMode.EXPAND) {
 				output = JsonLdProcessor.expand(output, opts);
 			}

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterFactory.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterFactory.java
@@ -32,8 +32,18 @@ public class JSONLDWriterFactory implements RDFWriterFactory {
 	}
 
 	@Override
+	public RDFWriter getWriter(OutputStream out, String baseURI) {
+		return new JSONLDWriter(out, baseURI);
+	}
+
+	@Override
 	public RDFWriter getWriter(Writer writer) {
 		return new JSONLDWriter(writer);
+	}
+
+	@Override
+	public RDFWriter getWriter(Writer writer, String baseURI) {
+		return new JSONLDWriter(writer, baseURI);
 	}
 
 }

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.rio.n3;
 import java.io.OutputStream;
 import java.io.Writer;
 
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
@@ -41,7 +42,19 @@ public class N3Writer extends AbstractRDFWriter implements RDFWriter {
 	 *        The OutputStream to write the N3 document to.
 	 */
 	public N3Writer(OutputStream out) {
-		ttlWriter = new TurtleWriter(out);
+		this(out, null);
+	}
+
+	/**
+	 * Creates a new N3Writer that will write to the supplied OutputStream.
+	 *
+	 * @param out
+	 *        The OutputStream to write the N3 document to.
+	 * @param baseIRI
+	 *        used to relativize IRIs to relative IRIs.
+	 */
+	public N3Writer(OutputStream out, ParsedIRI baseIRI) {
+		ttlWriter = new TurtleWriter(out, baseIRI);
 	}
 
 	/**
@@ -51,7 +64,19 @@ public class N3Writer extends AbstractRDFWriter implements RDFWriter {
 	 *        The Writer to write the N3 document to.
 	 */
 	public N3Writer(Writer writer) {
-		ttlWriter = new TurtleWriter(writer);
+		this(writer, null);
+	}
+
+	/**
+	 * Creates a new N3Writer that will write to the supplied Writer.
+	 *
+	 * @param writer
+	 *        The Writer to write the N3 document to.
+	 * @param baseIRI
+	 *        used to relativize IRIs to relative IRIs.
+	 */
+	public N3Writer(Writer writer, ParsedIRI baseIRI) {
+		ttlWriter = new TurtleWriter(writer, baseIRI);
 	}
 
 	/*---------*

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3WriterFactory.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3WriterFactory.java
@@ -9,7 +9,9 @@ package org.eclipse.rdf4j.rio.n3;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.net.URISyntaxException;
 
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
@@ -35,10 +37,22 @@ public class N3WriterFactory implements RDFWriterFactory {
 		return new N3Writer(out);
 	}
 
+	public RDFWriter getWriter(OutputStream out, String baseURI)
+		throws URISyntaxException
+	{
+		return new N3Writer(out, new ParsedIRI(baseURI));
+	}
+
 	/**
 	 * Returns a new instance of {@link N3Writer}.
 	 */
 	public RDFWriter getWriter(Writer writer) {
 		return new N3Writer(writer);
+	}
+
+	public RDFWriter getWriter(Writer writer, String baseURI)
+		throws URISyntaxException
+	{
+		return new N3Writer(writer, new ParsedIRI(baseURI));
 	}
 }

--- a/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsWriterFactory.java
+++ b/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsWriterFactory.java
@@ -35,10 +35,18 @@ public class NQuadsWriterFactory implements RDFWriterFactory {
 		return new NQuadsWriter(out);
 	}
 
+	public RDFWriter getWriter(OutputStream out, String baseURI) {
+		return getWriter(out);
+	}
+
 	/**
 	 * Returns a new instance of {@link NQuadsWriter}.
 	 */
 	public RDFWriter getWriter(Writer writer) {
 		return new NQuadsWriter(writer);
+	}
+
+	public RDFWriter getWriter(Writer writer, String baseURI) {
+		return getWriter(writer);
 	}
 }

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterFactory.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterFactory.java
@@ -35,10 +35,18 @@ public class NTriplesWriterFactory implements RDFWriterFactory {
 		return new NTriplesWriter(out);
 	}
 
+	public RDFWriter getWriter(OutputStream out, String baseURI) {
+		return getWriter(out);
+	}
+
 	/**
 	 * Returns a new instance of {@link NTriplesWriter}.
 	 */
 	public RDFWriter getWriter(Writer writer) {
 		return new NTriplesWriter(writer);
+	}
+
+	public RDFWriter getWriter(Writer writer, String baseURI) {
+		return getWriter(writer);
 	}
 }

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriterFactory.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriterFactory.java
@@ -32,8 +32,18 @@ public class RDFJSONWriterFactory implements RDFWriterFactory {
 	}
 
 	@Override
+	public RDFWriter getWriter(final OutputStream out, String baseURI) {
+		return getWriter(out);
+	}
+
+	@Override
 	public RDFWriter getWriter(final Writer writer) {
 		return new RDFJSONWriter(writer, this.getRDFFormat());
+	}
+
+	@Override
+	public RDFWriter getWriter(final Writer writer, String baseURI) {
+		return getWriter(writer);
 	}
 
 }

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterFactory.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterFactory.java
@@ -9,7 +9,9 @@ package org.eclipse.rdf4j.rio.rdfxml;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.net.URISyntaxException;
 
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
@@ -37,8 +39,30 @@ public class RDFXMLWriterFactory implements RDFWriterFactory {
 
 	/**
 	 * Returns a new instance of {@link RDFXMLWriter}.
+	 *
+	 * @throws URISyntaxException
+	 */
+	public RDFWriter getWriter(OutputStream out, String baseURI)
+		throws URISyntaxException
+	{
+		return new RDFXMLWriter(out, new ParsedIRI(baseURI));
+	}
+
+	/**
+	 * Returns a new instance of {@link RDFXMLWriter}.
 	 */
 	public RDFWriter getWriter(Writer writer) {
 		return new RDFXMLWriter(writer);
+	}
+
+	/**
+	 * Returns a new instance of {@link RDFXMLWriter}.
+	 *
+	 * @throws URISyntaxException
+	 */
+	public RDFWriter getWriter(Writer writer, String baseURI)
+		throws URISyntaxException
+	{
+		return new RDFXMLWriter(writer, new ParsedIRI(baseURI));
 	}
 }

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriter.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.io.Writer;
 import java.util.Stack;
 
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -134,6 +135,16 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 	}
 
 	/**
+	 * Creates a new RDFXMLPrintWriter that will write to the supplied OutputStream.
+	 *
+	 * @param out
+	 *        The OutputStream to write the RDF/XML document to.
+	 */
+	public RDFXMLPrettyWriter(OutputStream out, ParsedIRI baseIRI) {
+		super(out, baseIRI);
+	}
+
+	/**
 	 * Creates a new RDFXMLPrintWriter that will write to the supplied Writer.
 	 * 
 	 * @param out
@@ -141,6 +152,16 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 	 */
 	public RDFXMLPrettyWriter(Writer out) {
 		super(out);
+	}
+
+	/**
+	 * Creates a new RDFXMLPrintWriter that will write to the supplied Writer.
+	 *
+	 * @param out
+	 *        The Writer to write the RDF/XML document to.
+	 */
+	public RDFXMLPrettyWriter(Writer writer, ParsedIRI baseIRI) {
+		super(writer, baseIRI);
 	}
 
 	/*---------*

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriterFactory.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriterFactory.java
@@ -9,7 +9,9 @@ package org.eclipse.rdf4j.rio.rdfxml.util;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.net.URISyntaxException;
 
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
@@ -37,8 +39,30 @@ public class RDFXMLPrettyWriterFactory implements RDFWriterFactory {
 
 	/**
 	 * Returns a new instance of {@link RDFXMLPrettyWriter}.
+	 *
+	 * @throws URISyntaxException
+	 */
+	public RDFWriter getWriter(OutputStream out, String baseURI)
+		throws URISyntaxException
+	{
+		return new RDFXMLPrettyWriter(out, new ParsedIRI(baseURI));
+	}
+
+	/**
+	 * Returns a new instance of {@link RDFXMLPrettyWriter}.
 	 */
 	public RDFWriter getWriter(Writer writer) {
 		return new RDFXMLPrettyWriter(writer);
+	}
+
+	/**
+	 * Returns a new instance of {@link RDFXMLPrettyWriter}.
+	 *
+	 * @throws URISyntaxException
+	 */
+	public RDFWriter getWriter(Writer writer, String baseURI)
+		throws URISyntaxException
+	{
+		return new RDFXMLPrettyWriter(writer, new ParsedIRI(baseURI));
 	}
 }

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGWriter.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGWriter.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -50,6 +51,16 @@ public class TriGWriter extends TurtleWriter {
 	}
 
 	/**
+	 * Creates a new TriGWriter that will write to the supplied OutputStream.
+	 *
+	 * @param out
+	 *        The OutputStream to write the TriG document to.
+	 */
+	public TriGWriter(OutputStream out, ParsedIRI baseIRI) {
+		super(out, baseIRI);
+	}
+
+	/**
 	 * Creates a new TriGWriter that will write to the supplied Writer.
 	 * 
 	 * @param writer
@@ -57,6 +68,16 @@ public class TriGWriter extends TurtleWriter {
 	 */
 	public TriGWriter(Writer writer) {
 		super(writer);
+	}
+
+	/**
+	 * Creates a new TriGWriter that will write to the supplied Writer.
+	 *
+	 * @param writer
+	 *        The Writer to write the TriG document to.
+	 */
+	public TriGWriter(Writer writer, ParsedIRI baseIRI) {
+		super(writer,baseIRI);
 	}
 
 	/*---------*

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGWriterFactory.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGWriterFactory.java
@@ -9,7 +9,9 @@ package org.eclipse.rdf4j.rio.trig;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.net.URISyntaxException;
 
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
@@ -37,8 +39,30 @@ public class TriGWriterFactory implements RDFWriterFactory {
 
 	/**
 	 * Returns a new instance of {@link TriGWriter}.
+	 *
+	 * @throws URISyntaxException
+	 */
+	public RDFWriter getWriter(OutputStream out, String baseURI)
+		throws URISyntaxException
+	{
+		return new TriGWriter(out, new ParsedIRI(baseURI));
+	}
+
+	/**
+	 * Returns a new instance of {@link TriGWriter}.
 	 */
 	public RDFWriter getWriter(Writer writer) {
 		return new TriGWriter(writer);
+	}
+
+	/**
+	 * Returns a new instance of {@link TriGWriter}.
+	 *
+	 * @throws URISyntaxException
+	 */
+	public RDFWriter getWriter(Writer writer, String baseURI)
+		throws URISyntaxException
+	{
+		return new TriGWriter(writer, new ParsedIRI(baseURI));
 	}
 }

--- a/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriterFactory.java
+++ b/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriterFactory.java
@@ -38,7 +38,21 @@ public class TriXWriterFactory implements RDFWriterFactory {
 	/**
 	 * Returns a new instance of {@link TriXWriter}.
 	 */
+	public RDFWriter getWriter(OutputStream out, String baseURI) {
+		return new TriXWriter(out);
+	}
+
+	/**
+	 * Returns a new instance of {@link TriXWriter}.
+	 */
 	public RDFWriter getWriter(Writer writer) {
+		return new TriXWriter(writer);
+	}
+
+	/**
+	 * Returns a new instance of {@link TriXWriter}.
+	 */
+	public RDFWriter getWriter(Writer writer, String baseURI) {
 		return new TriXWriter(writer);
 	}
 }

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterFactory.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterFactory.java
@@ -9,7 +9,9 @@ package org.eclipse.rdf4j.rio.turtle;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.net.URISyntaxException;
 
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
@@ -35,10 +37,22 @@ public class TurtleWriterFactory implements RDFWriterFactory {
 		return new TurtleWriter(out);
 	}
 
+	public RDFWriter getWriter(OutputStream out, String baseURI)
+		throws URISyntaxException
+	{
+		return new TurtleWriter(out, new ParsedIRI(baseURI));
+	}
+
 	/**
 	 * Returns a new instance of {@link TurtleWriter}.
 	 */
 	public RDFWriter getWriter(Writer writer) {
 		return new TurtleWriter(writer);
+	}
+
+	public RDFWriter getWriter(Writer writer, String baseURI)
+		throws URISyntaxException
+	{
+		return new TurtleWriter(writer, new ParsedIRI(baseURI));
 	}
 }


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #876 .

* Add baseURI parameter to WriterFactory methods
* Add BasicWriterSettings.java.BASE_DIRECTIVE setting to omit directive
* Use ParsedIRI#relativize() in output when baseURI is provided
