### PR TITLE
added jdk.tools for resolving issue #881

### DIFF
--- a/core/sail/fts/solr/pom.xml
+++ b/core/sail/fts/solr/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -40,6 +41,15 @@
 					<artifactId>log4j</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+
+		<!-- jdk.tools -->
+		<dependency>
+			<groupId>jdk.tools</groupId>
+			<artifactId>jdk.tools</artifactId>
+			<version>1.8</version>
+			<scope>system</scope>
+			<systemPath>${JAVA_HOME}/lib/tools.jar</systemPath>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Signed-off-by: Alfredo Serafini <seralf@gmail.com>


This PR addresses GitHub issue: #881  .

I've re-added the dependency only for `rdf4j-sail-solr` only, in order to avoid breaking other component.

The dependency is added as follows:

```
<dependency>
	<groupId>jdk.tools</groupId>
	<artifactId>jdk.tools</artifactId>
	<version>1.8</version>
	<scope>system</scope>
	<systemPath>${JAVA_HOME}/lib/tools.jar</systemPath>
</dependency>
```
to be honest I'n not a big fan of those systemPath dependencies, but in this case it seems something very conventional, so I think it could be a good compromise to re-add it here only.


