### PR TITLE
Fix #728: Buffer size configurable using instance of RioSettings

### DIFF
--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
@@ -66,6 +66,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.repository.UnknownTransactionStateException;
 import org.eclipse.rdf4j.repository.base.AbstractRepositoryConnection;
+import org.eclipse.rdf4j.repository.http.helpers.HTTPRepositoryParserSettings;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandler;
@@ -103,12 +104,6 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 
 	private Model toRemove;
 
-	/**
-	 * Maximum size (in number of statements) allowed for statement buffers before they are forcibly flushed.
-	 * TODO: make this setting configurable.
-	 */
-	private static final long MAX_STATEMENT_BUFFER_SIZE = 200000;
-
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
@@ -123,6 +118,8 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 		setParserConfig(new ParserConfig());
 		getParserConfig().set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 		getParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
+                getParserConfig().set(HTTPRepositoryParserSettings.MAX_STATEMENT_BUFFER_SIZE, 
+                        HTTPRepositoryParserSettings.MAX_STATEMENT_BUFFER_SIZE.getDefaultValue());
 	}
 
 	/*---------*
@@ -632,13 +629,14 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 		}
 
 		if (isActive()) {
+                    int maxBufferSize = getParserConfig().get(HTTPRepositoryParserSettings.MAX_STATEMENT_BUFFER_SIZE);
 			switch (action) {
 				case ADD:
 					if (toRemove != null) {
 						removeModel(toRemove);
 						toRemove = null;
 					}
-					if (toAdd != null && MAX_STATEMENT_BUFFER_SIZE <= toAdd.size()) {
+					if (toAdd != null && maxBufferSize <= toAdd.size()) {
 						addModel(toAdd);
 						toAdd = null;
 					}
@@ -648,7 +646,7 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 						addModel(toAdd);
 						toAdd = null;
 					}
-					if (toRemove != null && MAX_STATEMENT_BUFFER_SIZE <= toRemove.size()) {
+					if (toRemove != null && maxBufferSize <= toRemove.size()) {
 						removeModel(toRemove);
 						toRemove = null;
 					}

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/helpers/HTTPRepositoryParserSettings.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/helpers/HTTPRepositoryParserSettings.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http.helpers;
+
+import org.eclipse.rdf4j.repository.http.HTTPRepository;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.RioSettingImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class encapsulates configuration settings specific for {@link HTTPRepository} parser.
+ * 
+ * @author Jacek Grzebyta
+ */
+public class HTTPRepositoryParserSettings {
+    
+    private static final Logger log = LoggerFactory.getLogger(HTTPRepositoryParserSettings.class);
+    
+    /**
+     * Maximum size (in number of statements) allowed for statement buffers 
+     * before they are forcibly flushed.
+     * <p>
+     * By default inner buffers within {@link HTTPRepositoryConnection} keep in memory up to 200000 statement before they are 
+     * flushed to the remote repository.
+     */
+    public static final RioSetting<Integer> MAX_STATEMENT_BUFFER_SIZE = 
+            new RioSettingImpl<Integer>("org.eclipse.rdf4j.http.maxstatementbuffersize", "Maximum number of statement buffered in memory", 200000);
+    
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #728  .

Changes proposed in this PR:

* Express default buffer size using `RioSetting` instance
* Apply new usage in `HTTPRepositoryConnection`
