### PR TITLE
Fix #889: Add INLINE_BLANK_NODE setting for TurtleWriter

### DIFF
--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtlePrettyWriterTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtlePrettyWriterTest.java
@@ -7,24 +7,124 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
+import java.io.IOException;
+
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
-import org.eclipse.rdf4j.rio.turtle.TurtleParserFactory;
-import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory;
 
 /**
  * @author Arjohn Kampman
  */
 public class TurtlePrettyWriterTest extends RDFWriterTest {
 
+	private boolean inlineBlankNodes = true;
+
 	public TurtlePrettyWriterTest() {
 		super(new TurtleWriterFactory(), new TurtleParserFactory());
 	}
-	
+
 	@Override
 	protected void setupWriterConfig(WriterConfig config) {
-		config.set(BasicWriterSettings.PRETTY_PRINT, true);
+		config.set(BasicWriterSettings.PRETTY_PRINT, true).set(BasicWriterSettings.INLINE_BLANK_NODES,
+				inlineBlankNodes);
+	}
+
+	@Override
+	public void testPerformance()
+		throws Exception
+	{
+		try {
+			inlineBlankNodes = false;
+			super.testPerformance();
+		}
+		finally {
+			inlineBlankNodes = true;
+		}
+	}
+
+	@Override
+	public void testPerformanceNoHandling()
+		throws Exception
+	{
+		try {
+			inlineBlankNodes = false;
+			super.testPerformanceNoHandling();
+		}
+		finally {
+			inlineBlankNodes = true;
+		}
+	}
+
+	@Override
+	public void testWriteTwoStatementsObjectBNodeSinglePredicateSingleContextBNodeWithNamespace()
+		throws Exception
+	{
+		try {
+			inlineBlankNodes = false;
+			super.testWriteTwoStatementsObjectBNodeSinglePredicateSingleContextBNodeWithNamespace();
+		}
+		finally {
+			inlineBlankNodes = true;
+		}
+	}
+
+	@Override
+	public void testWriteTwoStatementsObjectBNodeSinglePredicateSingleContextBNodeReusedWithNamespace()
+		throws Exception
+	{
+		try {
+			inlineBlankNodes = false;
+			super.testWriteTwoStatementsObjectBNodeSinglePredicateSingleContextBNodeReusedWithNamespace();
+		}
+		finally {
+			inlineBlankNodes = true;
+		}
+	}
+
+	@Override
+	public void testRoundTripWithXSDString()
+		throws RDFHandlerException,
+		IOException,
+		RDFParseException
+	{
+		try {
+			inlineBlankNodes = false;
+			super.testRoundTripWithXSDString();
+		}
+		finally {
+			inlineBlankNodes = true;
+		}
+	}
+
+	@Override
+	public void testRoundTripWithoutXSDString()
+		throws RDFHandlerException,
+		IOException,
+		RDFParseException
+	{
+		try {
+			inlineBlankNodes = false;
+			super.testRoundTripWithoutXSDString();
+		}
+		finally {
+			inlineBlankNodes = true;
+		}
+	}
+
+	@Override
+	public void testRoundTripPreserveBNodeIds()
+		throws Exception
+	{
+		try {
+			inlineBlankNodes = false;
+			super.testRoundTripPreserveBNodeIds();
+		}
+		finally {
+			inlineBlankNodes = true;
+		}
 	}
 
 }

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,7 +60,11 @@ import org.eclipse.rdf4j.repository.config.RepositoryRegistry;
 import org.eclipse.rdf4j.repository.event.base.RepositoryConnectionListenerAdapter;
 import org.eclipse.rdf4j.repository.sparql.federation.SPARQLServiceResolver;
 import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 /**
  * An implementation of the {@link RepositoryManager} interface that operates directly on the repository data
@@ -78,6 +83,10 @@ public class LocalRepositoryManager extends RepositoryManager {
 	private static final RDFFormat CONFIG_FORMAT = RDFFormat.TURTLE;
 
 	private static final String CFG_FILE = "config." + CONFIG_FORMAT.getDefaultFileExtension();
+
+	private static final WriterConfig CFG_CONFIG = new WriterConfig().set(BasicWriterSettings.BASE_DIRECTIVE,
+			false).set(BasicWriterSettings.PRETTY_PRINT, true).set(BasicWriterSettings.INLINE_BLANK_NODES,
+					true);
 
 	/*-----------*
 	 * Variables *
@@ -424,9 +433,9 @@ public class LocalRepositoryManager extends RepositoryManager {
 		config.export(model, SimpleValueFactory.getInstance().createIRI(ns, config.getID()));
 		File part = new File(configFile.getParentFile(), configFile.getName() + ".part");
 		try (OutputStream output = new FileOutputStream(part)) {
-			Rio.write(model, output, CONFIG_FORMAT);
+			Rio.write(model, output, configFile.toURI().toString(), CONFIG_FORMAT, CFG_CONFIG);
 		}
-		catch (IOException e) {
+		catch (IOException | RDFHandlerException | UnsupportedRDFormatException | URISyntaxException e) {
 			throw new RepositoryConfigException(e);
 		}
 		if (updateSystem) {

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
@@ -19,10 +19,27 @@ public class BasicWriterSettings {
 	/**
 	 * Boolean setting for writer to determine whether pretty printing is preferred.
 	 * <p>
-	 * Defaults to false because it isn't always scalable.
+	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> PRETTY_PRINT = new RioSettingImpl<Boolean>(
-			"org.eclipse.rdf4j.rio.prettyprint", "Pretty print", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.prettyprint", "Pretty print", Boolean.TRUE);
+
+	/**
+	 * Inline blanks nodes by their value and don't write any blank node labels when this setting is true.
+	 * This setting should only be used when blank nodes never appear in the context and there are no blank
+	 * node cycles.
+	 * <p>
+	 * WARNING: This setting requires all triples to be processed before being written and could use a lot of
+	 * memory in the process and should be set to false for large RDF files.
+	 * <p>
+	 * Defaults to false.
+	 *
+	 * @since 2.3
+	 */
+	public static final RioSetting<Boolean> INLINE_BLANK_NODES = new RioSettingImpl<Boolean>(
+			"org.eclipse.rdf4j.rio.inlineblanknodes",
+			"Use blank node property lists, collections, and anonymous nodes instead of blank node labels",
+			Boolean.FALSE);
 
 	/**
 	 * Boolean setting for writer to determine whether it should remove the xsd:string datatype from literals

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -1,0 +1,419 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtle;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+
+/**
+ * Internal wrapper that sorts statements for pretty printing and repeats blank nodes if inlining them.
+ *
+ * @author James Leigh
+ * @since 2.3
+ */
+class ArrangedWriter implements RDFWriter {
+
+	private final static int DEFAULT_QUEUE_SIZE = 100;
+
+	private final RDFWriter delegate;
+
+	private boolean repeatBlankNodes;
+
+	private int targetQueueSize;
+
+	private int queueSize = 0;
+
+	private final Deque<SubjectInContext> stack = new LinkedList<>();
+
+	private final Map<String, String> prefixes = new TreeMap<String, String>();
+
+	private final Map<SubjectInContext, Set<Statement>> stmtBySubject = new LinkedHashMap<>();
+
+	private final Model blanks = new LinkedHashModel();
+
+	private final Model blankReferences = new LinkedHashModel();
+
+	private final Comparator<Statement> comparator = new Comparator<Statement>() {
+
+		public int compare(Statement s1, Statement s2) {
+			IRI p1 = s1.getPredicate();
+			IRI p2 = s2.getPredicate();
+			if (p1.equals(RDF.TYPE) && !p2.equals(RDF.TYPE)) {
+				return -1;
+			}
+			else if (!p1.equals(RDF.TYPE) && p2.equals(RDF.TYPE)) {
+				return 1;
+			}
+			int cmp = p1.stringValue().compareTo(p2.stringValue());
+			if (cmp != 0)
+				return cmp;
+			Value o1 = s1.getObject();
+			Value o2 = s2.getObject();
+			if (!(o1 instanceof BNode) && o2 instanceof BNode) {
+				return -1;
+			}
+			else if (o1 instanceof BNode && !(o2 instanceof BNode)) {
+				return 1;
+			}
+			if (!(o1 instanceof IRI) && o2 instanceof IRI) {
+				return -1;
+			}
+			else if (o1 instanceof IRI && !(o2 instanceof IRI)) {
+				return 1;
+			}
+			return o1.stringValue().compareTo(o2.stringValue());
+		}
+	};
+
+	public ArrangedWriter(RDFWriter delegate) {
+		this(delegate, 0);
+	}
+
+	public ArrangedWriter(RDFWriter delegate, int size) {
+		this(delegate, size, size == -1);
+	}
+
+	public ArrangedWriter(RDFWriter delegate, int size, boolean repeatBlankNodes) {
+		this.delegate = delegate;
+		this.targetQueueSize = size;
+		this.repeatBlankNodes = repeatBlankNodes;
+	}
+
+	public RDFFormat getRDFFormat() {
+		return delegate.getRDFFormat();
+	}
+
+	public RDFWriter setWriterConfig(WriterConfig config) {
+		return delegate.setWriterConfig(config);
+	}
+
+	public WriterConfig getWriterConfig() {
+		return delegate.getWriterConfig();
+	}
+
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		return delegate.getSupportedSettings();
+	}
+
+	public <T> RDFWriter set(RioSetting<T> setting, T value) {
+		return delegate.set(setting, value);
+	}
+
+	public void startRDF()
+		throws RDFHandlerException
+	{
+		if (getWriterConfig().get(BasicWriterSettings.INLINE_BLANK_NODES)) {
+			targetQueueSize = -1;
+			repeatBlankNodes = true;
+		}
+		else if (getWriterConfig().get(BasicWriterSettings.PRETTY_PRINT)) {
+			targetQueueSize = DEFAULT_QUEUE_SIZE;
+		}
+		delegate.startRDF();
+	}
+
+	public void endRDF()
+		throws RDFHandlerException
+	{
+		trimNamespaces();
+		flushStatements();
+		delegate.endRDF();
+	}
+
+	public void handleNamespace(String prefix, String uri)
+		throws RDFHandlerException
+	{
+		flushStatements();
+		if (targetQueueSize == 0) {
+			delegate.handleNamespace(prefix, uri);
+		}
+		else if (!prefixes.containsKey(uri)) {
+			prefixes.put(uri, prefix);
+		}
+	}
+
+	public void handleComment(String comment)
+		throws RDFHandlerException
+	{
+		flushStatements();
+		delegate.handleComment(comment);
+	}
+
+	public synchronized void handleStatement(Statement st)
+		throws RDFHandlerException
+	{
+		if (targetQueueSize == 0) {
+			delegate.handleStatement(st);
+		}
+		else {
+			queueStatement(st);
+		}
+		while (targetQueueSize >= 0 && queueSize > targetQueueSize) {
+			flushNamespaces();
+			delegate.handleStatement(nextStatement());
+		}
+	}
+
+	private synchronized Statement nextStatement() {
+		if (stmtBySubject.isEmpty() && blanks.isEmpty()) {
+			assert queueSize == 0;
+			return null;
+		}
+		Set<Statement> stmts = null;
+		while (stmts == null) {
+			SubjectInContext last = stack.peekLast();
+			stmts = stmtBySubject.get(last);
+			if (stmts == null && last != null
+					&& blanks.contains(last.getSubject(), null, null, last.getContext()))
+			{
+				stmts = queueBlankStatements(last);
+			}
+			else if (stmts == null) {
+				stack.pollLast();
+			}
+			if (stack.isEmpty() && stmtBySubject.isEmpty()) {
+				Statement st = blanks.iterator().next();
+				stmts = queueBlankStatements(new SubjectInContext(st));
+			}
+			else if (stack.isEmpty()) {
+				stmts = stmtBySubject.values().iterator().next();
+			}
+		}
+		Iterator<Statement> iter = stmts.iterator();
+		Statement next = iter.next();
+		queueSize--;
+		iter.remove();
+		SubjectInContext key = new SubjectInContext(next);
+		if (!key.equals(stack.peekLast())) {
+			stack.addLast(key);
+		}
+		if (!iter.hasNext()) {
+			stmtBySubject.remove(key);
+		}
+		Value obj = next.getObject();
+		if (obj instanceof BNode) {
+			// follow blank nodes before continuing with this subject
+			SubjectInContext bkey = new SubjectInContext((BNode)obj, next.getContext());
+			if (stack.contains(bkey)) {
+				// cycle detected
+				if (repeatBlankNodes) {
+					throw new RDFHandlerException("Blank node cycle detected. Try disabling "
+							+ BasicWriterSettings.INLINE_BLANK_NODES.getKey());
+				}
+			}
+			else {
+				stack.addLast(bkey);
+			}
+		}
+		return next;
+	}
+
+	private synchronized Set<Statement> queueBlankStatements(SubjectInContext key) {
+		Model firstMatch = blanks.filter(key.getSubject(), null, null, key.getContext());
+		Model matches = firstMatch.isEmpty()
+				? blankReferences.filter(key.getSubject(), null, null, key.getContext())
+				: firstMatch;
+		if (matches.isEmpty()) {
+			return null;
+		}
+		Set<Statement> set = stmtBySubject.get(key);
+		if (set == null) {
+			stmtBySubject.put(key, set = new TreeSet<Statement>(comparator));
+		}
+		set.addAll(matches);
+		if (firstMatch.isEmpty()) {
+			// repeat blank node values
+			queueSize += matches.size();
+		}
+		else {
+			if (repeatBlankNodes && key.getSubject() instanceof BNode && isStillReferenced(key)) {
+				blankReferences.addAll(matches);
+			}
+			blanks.remove(key.getSubject(), null, null, key.getContext());
+		}
+		return set;
+	}
+
+	private boolean isStillReferenced(SubjectInContext key) {
+		if (blanks.contains(null, null, key.getSubject(), key.getContext())) {
+			return true;
+		}
+		for (SubjectInContext subj : stack) {
+			Set<Statement> stmts = stmtBySubject.get(subj);
+			if (stmts != null) {
+				for (Statement st : stmts) {
+					if (st.getObject().equals(key.getSubject())
+							|| Objects.equals(st.getContext(), key.getContext()))
+					{
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	private synchronized void queueStatement(Statement st) {
+		SubjectInContext key = new SubjectInContext(st);
+		Set<Statement> stmts = stmtBySubject.get(key);
+		if (stmts == null && st.getSubject() instanceof BNode && !stack.contains(key)) {
+			blanks.add(st);
+		}
+		else {
+			if (stmts == null) {
+				stmtBySubject.put(key, stmts = new TreeSet<Statement>(comparator));
+			}
+			stmts.add(st);
+		}
+		queueSize++;
+	}
+
+	private synchronized void flushStatements()
+		throws RDFHandlerException
+	{
+		if (!stmtBySubject.isEmpty() || !blanks.isEmpty()) {
+			flushNamespaces();
+			Statement st;
+			while ((st = nextStatement()) != null) {
+				delegate.handleStatement(st);
+			}
+			assert queueSize == 0;
+		}
+	}
+
+	private synchronized void flushNamespaces()
+		throws RDFHandlerException
+	{
+		Map<String, String> namespaces = new TreeMap<String, String>();
+		for (Map.Entry<String, String> e : prefixes.entrySet()) {
+			namespaces.put(e.getValue(), e.getKey());
+		}
+		for (Map.Entry<String, String> e : namespaces.entrySet()) {
+			delegate.handleNamespace(e.getKey(), e.getValue());
+		}
+		prefixes.clear();
+	}
+
+	private synchronized void trimNamespaces() {
+		if (!prefixes.isEmpty()) {
+			Set<String> used = new HashSet<String>(prefixes.size());
+			for (Set<Statement> stmts : stmtBySubject.values()) {
+				getUsedNamespaces(stmts, used);
+			}
+			getUsedNamespaces(blanks, used);
+			prefixes.keySet().retainAll(used);
+		}
+	}
+
+	private void getUsedNamespaces(Set<Statement> stmts, Set<String> used) {
+		for (Statement st : stmts) {
+			used.add(st.getPredicate().getNamespace());
+			if (st.getObject() instanceof IRI) {
+				IRI uri = (IRI)st.getObject();
+				used.add(uri.getNamespace());
+			}
+			else if (st.getObject() instanceof Literal) {
+				Literal lit = (Literal)st.getObject();
+				if (lit.getDatatype() != null) {
+					used.add(lit.getDatatype().getNamespace());
+				}
+			}
+		}
+	}
+
+	private class SubjectInContext {
+
+		private Resource subject;
+
+		private Resource context;
+
+		private SubjectInContext(Statement st) {
+			this(st.getSubject(), st.getContext());
+		}
+
+		private SubjectInContext(Resource subject, Resource context) {
+			assert subject != null;
+			this.subject = subject;
+			this.context = context;
+		}
+
+		public Resource getSubject() {
+			return subject;
+		}
+
+		public Resource getContext() {
+			return context;
+		}
+
+		@Override
+		public String toString() {
+			if (context == null) {
+				return subject.toString();
+			}
+			else {
+				return subject.toString() + " [" + context.toString() + "]";
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + subject.hashCode();
+			result = prime * result + ((context == null) ? 0 : context.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			SubjectInContext other = (SubjectInContext)obj;
+			if (!subject.equals(other.subject))
+				return false;
+			if (context == null) {
+				if (other.context != null)
+					return false;
+			}
+			else if (!context.equals(other.context))
+				return false;
+			return true;
+		}
+	}
+
+}

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterFactory.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterFactory.java
@@ -34,25 +34,25 @@ public class TurtleWriterFactory implements RDFWriterFactory {
 	 * Returns a new instance of {@link TurtleWriter}.
 	 */
 	public RDFWriter getWriter(OutputStream out) {
-		return new TurtleWriter(out);
+		return new ArrangedWriter(new TurtleWriter(out));
 	}
 
 	public RDFWriter getWriter(OutputStream out, String baseURI)
 		throws URISyntaxException
 	{
-		return new TurtleWriter(out, new ParsedIRI(baseURI));
+		return new ArrangedWriter(new TurtleWriter(out, new ParsedIRI(baseURI)));
 	}
 
 	/**
 	 * Returns a new instance of {@link TurtleWriter}.
 	 */
 	public RDFWriter getWriter(Writer writer) {
-		return new TurtleWriter(writer);
+		return new ArrangedWriter(new TurtleWriter(writer));
 	}
 
 	public RDFWriter getWriter(Writer writer, String baseURI)
 		throws URISyntaxException
 	{
-		return new TurtleWriter(writer, new ParsedIRI(baseURI));
+		return new ArrangedWriter(new TurtleWriter(writer, new ParsedIRI(baseURI)));
 	}
 }

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/io/IndentingWriter.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/io/IndentingWriter.java
@@ -50,6 +50,11 @@ public class IndentingWriter extends Writer {
 	 */
 	private boolean indentationWritten = false;
 
+	/**
+	 * Number of characters written since the last call to {@link #writeEOL()}
+	 */
+	private int charactersSinceEOL;
+
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
@@ -89,6 +94,10 @@ public class IndentingWriter extends Writer {
 		this.indentationLevel = indentationLevel;
 	}
 
+	public int getCharactersSinceEOL() {
+		return charactersSinceEOL;
+	}
+
 	public void increaseIndentation() {
 		indentationLevel++;
 	}
@@ -106,6 +115,7 @@ public class IndentingWriter extends Writer {
 	{
 		write(LINE_SEPARATOR);
 		indentationWritten = false;
+		charactersSinceEOL = 0;
 	}
 
 	@Override
@@ -133,7 +143,7 @@ public class IndentingWriter extends Writer {
 
 			indentationWritten = true;
 		}
-
+		charactersSinceEOL += len;
 		out.write(cbuf, off, len);
 	}
 }

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -1715,6 +1715,9 @@ public abstract class RDFWriterTest {
 		Model parsedOutput = new LinkedHashModel();
 		rdfParser.setRDFHandler(new StatementCollector(parsedOutput));
 		rdfParser.parse(inputReader, "");
+		// ignore rdf:List
+		input.remove(null, RDF.TYPE, RDF.LIST);
+		parsedOutput.remove(null, RDF.TYPE, RDF.LIST);
 		assertSameModel(input, parsedOutput);
 	}
 


### PR DESCRIPTION
Omits all blank node labels and inlines their values as a nested objects or lists

Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issues: #889 #316 and #317

* PRETTY_PRINT enabled by default
* INLINE_BLANK_NODES disabled by default, but
* When enabled blank nodes are written as [] or () and repeated every time they are used, and
* Throws an exception when a blank node cycle is detected
