### PR TITLE
Fix #888: Inline variable bindings for non-tuple SPARQL operations

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtil.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtil.java
@@ -35,8 +35,22 @@ public class QueryStringUtil {
 	 * @param queryString
 	 * @param bindings
 	 * @return the modified queryString
+	 * @deprecated since 2.3 use {@link #getTupleQueryString(String, BindingSet)}
 	 */
+	@Deprecated
 	public static String getQueryString(String queryString, BindingSet bindings) {
+		return getTupleQueryString(queryString, bindings);
+	}
+
+	/**
+	 * Retrieve a modified queryString into which all bindings of the given argument are replaced, with the
+	 * binding names included in the SELECT clause.
+	 *
+	 * @param queryString
+	 * @param bindings
+	 * @return the modified queryString
+	 */
+	public static String getTupleQueryString(String queryString, BindingSet bindings) {
 		if (bindings.size() == 0) {
 			return queryString;
 		}
@@ -59,6 +73,56 @@ public class QueryStringUtil {
 			}
 		}
 		return select + where;
+	}
+
+	/**
+	 * Retrieve a modified queryString into which all bindings of the given argument are replaced with their
+	 * value.
+	 *
+	 * @param queryString
+	 * @param bindings
+	 * @return the modified queryString
+	 */
+	public static String getUpdateString(String queryString, BindingSet bindings) {
+		return getGraphQueryString(queryString, bindings);
+	}
+
+	/**
+	 * Retrieve a modified queryString into which all bindings of the given argument are replaced with their
+	 * value.
+	 *
+	 * @param queryString
+	 * @param bindings
+	 * @return the modified queryString
+	 */
+	public static String getBooleanQueryString(String queryString, BindingSet bindings) {
+		return getGraphQueryString(queryString, bindings);
+	}
+
+	/**
+	 * Retrieve a modified queryString into which all bindings of the given argument are replaced with their
+	 * value.
+	 *
+	 * @param queryString
+	 * @param bindings
+	 * @return the modified queryString
+	 */
+	public static String getGraphQueryString(String queryString, BindingSet bindings) {
+		if (bindings.size() == 0) {
+			return queryString;
+		}
+
+		String qry = queryString;
+		for (String name : bindings.getBindingNames()) {
+			String replacement = getReplacement(bindings.getValue(name));
+			if (replacement != null) {
+				String pattern = "[\\?\\$]" + name + "(?=\\W)";
+				// we use Matcher.quoteReplacement to make sure things like newlines
+				// in literal values  are preserved
+				qry = qry.replaceAll(pattern, Matcher.quoteReplacement(replacement));
+			}
+		}
+		return qry;
 	}
 
 	private static String getReplacement(Value value) {

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLBooleanQuery.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLBooleanQuery.java
@@ -50,6 +50,6 @@ public class SPARQLBooleanQuery extends AbstractHTTPQuery implements BooleanQuer
 	}
 
 	private String getQueryString() {
-		return QueryStringUtil.getQueryString(queryString, getBindings());
+		return QueryStringUtil.getBooleanQueryString(queryString, getBindings());
 	}
 }

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLGraphQuery.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLGraphQuery.java
@@ -74,6 +74,6 @@ public class SPARQLGraphQuery extends AbstractHTTPQuery implements GraphQuery {
 	}
 
 	private String getQueryString() {
-		return QueryStringUtil.getQueryString(queryString, getBindings());
+		return QueryStringUtil.getGraphQueryString(queryString, getBindings());
 	}
 }

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLTupleQuery.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLTupleQuery.java
@@ -75,6 +75,6 @@ public class SPARQLTupleQuery extends AbstractHTTPQuery implements TupleQuery {
 	}
 
 	private String getQueryString() {
-		return QueryStringUtil.getQueryString(queryString, getBindings());
+		return QueryStringUtil.getTupleQueryString(queryString, getBindings());
 	}
 }

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLUpdate.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLUpdate.java
@@ -64,6 +64,6 @@ public class SPARQLUpdate extends AbstractHTTPUpdate {
 
 	@Override
 	public String getQueryString() {
-		return QueryStringUtil.getQueryString(queryString, getBindings());
+		return QueryStringUtil.getUpdateString(queryString, getBindings());
 	}
 }


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #888 .

* Skip SELECT clause replacement for non-tuple queries
