### PR TITLE
Fix #473: Fail on parser errors when VERIFY_DATATYPE_VALUES is true

### DIFF
--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserTest.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.rio.trig;
 
 import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.nquads.NQuadsParser;
 import org.eclipse.rdf4j.rio.trig.TriGParser;
 import org.eclipse.rdf4j.rio.trig.TriGParserTestCase;
@@ -25,7 +26,9 @@ public class TriGParserTest extends TriGParserTestCase {
 
 	@Override
 	protected RDFParser createTriGParser() {
-		return new TriGParser();
+		TriGParser parser = new TriGParser();
+		parser.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
+		return parser;
 	}
 
 	@Override

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.rio.turtle;
 
 import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.ntriples.NTriplesParser;
 
 import junit.framework.Test;
@@ -27,6 +28,7 @@ public class TurtleParserTest extends TurtleParserTestCase {
 	@Override
 	protected RDFParser createTurtleParser() {
 		RDFParser result = new TurtleParser();
+		result.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 		return result;
 	}
 

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParser.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParser.java
@@ -113,6 +113,9 @@ public class TriGParser extends TurtleParser {
 			skipWSC();
 
 			parseGraph();
+			if (getContext() == null) {
+				reportFatalError("Missing GRAPH label or subject");
+			}
 		}
 		else {
 			unread(directive);

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParserTestCase.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParserTestCase.java
@@ -152,7 +152,7 @@ public abstract class TriGParserTestCase {
 			String nextBaseUrl = testBaseUrl + nextTestFile;
 
 			suite.addTest(new NegativeParserTest(nextTestUri, nextTestName, nextInputURL, nextBaseUrl,
-					createTriGParser(), FailureMode.IGNORE_FAILURE));
+					createTriGParser(), FailureMode.DO_NOT_IGNORE_FAILURE));
 		}
 
 		queryResult.close();
@@ -244,7 +244,7 @@ public abstract class TriGParserTestCase {
 			String nextBaseUrl = testBaseUrl + nextTestFile;
 
 			suite.addTest(new NegativeParserTest(nextTestUri, nextTestName, nextInputURL, nextBaseUrl,
-					createTriGParser(), FailureMode.IGNORE_FAILURE));
+					createTriGParser(), FailureMode.DO_NOT_IGNORE_FAILURE));
 		}
 
 		queryResult.close();

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTestCase.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTestCase.java
@@ -170,7 +170,7 @@ public abstract class TurtleParserTestCase {
 			String nextBaseUrl = testBaseUrl + nextTestFile;
 
 			suite.addTest(new NegativeParserTest(nextTestUri, nextTestName, nextInputURL, nextBaseUrl,
-					createTurtleParser(), FailureMode.IGNORE_FAILURE));
+					createTurtleParser(), FailureMode.DO_NOT_IGNORE_FAILURE));
 		}
 
 		queryResult.close();
@@ -255,7 +255,7 @@ public abstract class TurtleParserTestCase {
 			String nextBaseUrl = testBaseUrl + nextTestFile;
 
 			suite.addTest(new NegativeParserTest(nextTestUri, nextTestName, nextInputURL, nextBaseUrl,
-					createTurtleParser(), FailureMode.IGNORE_FAILURE));
+					createTurtleParser(), FailureMode.DO_NOT_IGNORE_FAILURE));
 		}
 
 		queryResult.close();
@@ -328,7 +328,7 @@ public abstract class TurtleParserTestCase {
 			String nextBaseUrl = testBaseUrl + nextTestFile;
 
 			suite.addTest(new NegativeParserTest(nextTestUri, nextTestName, nextInputURL, nextBaseUrl,
-					createNTriplesParser(), FailureMode.IGNORE_FAILURE));
+					createNTriplesParser(), FailureMode.DO_NOT_IGNORE_FAILURE));
 		}
 
 		queryResult.close();


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #473  .

* Enable VERIFY_DATATYPE_VALUES in tests
* Change tests to fail on parse errors
* Require a graph name when using the GRAPH clause in TriG
