### PR TITLE
Fix #77: Normalize typed literals in SPARQL parser

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.vocabulary.FN;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -2763,7 +2764,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 				// invalid URI
 				throw new VisitorException(e.getMessage());
 			}
-			literal = valueFactory.createLiteral(label, datatype);
+			String normalized = XMLDatatypeUtil.normalize(label, datatype);
+			literal = valueFactory.createLiteral(normalized, datatype);
 		}
 		else if (lang != null) {
 			literal = valueFactory.createLiteral(label, lang);
@@ -2779,7 +2781,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 	public ValueConstant visit(ASTNumericLiteral node, Object data)
 		throws VisitorException
 	{
-		Literal literal = valueFactory.createLiteral(node.getValue(), node.getDatatype());
+		IRI datatype = node.getDatatype();
+		String label = XMLDatatypeUtil.normalize(node.getValue(), datatype);
+		Literal literal = valueFactory.createLiteral(label, datatype);
 		return new ValueConstant(literal);
 	}
 

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -29,6 +29,8 @@ import org.eclipse.rdf4j.query.algebra.Slice;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.UpdateExpr;
+import org.eclipse.rdf4j.query.algebra.ValueConstant;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.parser.ParsedBooleanQuery;
 import org.eclipse.rdf4j.query.parser.ParsedGraphQuery;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
@@ -299,6 +301,25 @@ public class SPARQLParserTest {
 
 		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
 		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
+	}
+
+	@Test
+	public void testAdditiveExpression()
+		throws Exception
+	{
+		String ask = "ASK { ?this <urn:test:score> ?score FILTER (!(?score+5 != 0)) }";
+
+		ParsedQuery q = parser.parseQuery(ask, null);
+		q.getTupleExpr().visit(new AbstractQueryModelVisitor<Exception>() {
+
+			public void meet(ValueConstant node)
+				throws Exception
+			{
+				String label = node.getValue().stringValue();
+				assertFalse(label, label.startsWith("+"));
+			}
+		});
+
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #77 .

* Normalize literal labels when datatype present in SPARQL parser
