### PR TITLE
Fix #87: Handle multiple aggregates in ORDER BY clause

### DIFF
--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BinaryTupleOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BinaryTupleOperator.java
@@ -67,6 +67,7 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 	 */
 	public void setLeftArg(TupleExpr leftArg) {
 		assert leftArg != null : "leftArg must not be null";
+		assert leftArg != this : "leftArg must not be itself";
 		leftArg.setParentNode(this);
 		this.leftArg = leftArg;
 	}
@@ -88,6 +89,7 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 	 */
 	public void setRightArg(TupleExpr rightArg) {
 		assert rightArg != null : "rightArg must not be null";
+		assert rightArg != this : "rightArg must not be itself";
 		rightArg.setParentNode(this);
 		this.rightArg = rightArg;
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
@@ -61,6 +61,7 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 	 */
 	public void setArg(TupleExpr arg) {
 		assert arg != null : "arg must not be null";
+		assert arg != this : "arg must not be itself";
 		arg.setParentNode(this);
 		this.arg = arg;
 	}

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -375,7 +375,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 					// add the aggregate operator to the group.
 					GroupElem ge = new GroupElem(alias, operator);
 					group.addGroupElement(ge);
+				}
 
+				if (!extension.getElements().isEmpty()) {
 					extension.setArg(tupleExpr);
 					tupleExpr = extension;
 				}

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/algebra/AbstractNaryOperator.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/algebra/AbstractNaryOperator.java
@@ -115,6 +115,7 @@ public abstract class AbstractNaryOperator<Expr extends QueryModelNode> extends 
 	 * Sets the <tt>idx</tt>-th argument of this n-ary tuple operator.
 	 */
 	protected final void setArg(final int idx, final Expr arg) {
+		assert arg != this : "arg must not be itself";
 		if (arg != null) {
 			// arg can be null (i.e. Regex)
 			arg.setParentNode(this);


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #87  .

* Include multiple aggregate operations into the same Extension
