### PR TITLE
Fix #896: Finish parsing background results on close

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/BackgroundGraphResult.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/BackgroundGraphResult.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.impl;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -131,28 +130,10 @@ public class BackgroundGraphResult extends IterationWrapper<Statement, QueryEval
 		throws QueryEvaluationException
 	{
 		try {
-			try {
-				super.handleClose();
-			}
-			finally {
-				try {
-					// After checking that we ourselves cannot possibly be generating an NPE ourselves, 
-					// attempt to close the input stream we were given
-					InputStream toClose = in;
-					if (toClose != null) {
-						toClose.close();
-					}
-				}
-				catch (NullPointerException e) {
-					// Swallow NullPointerException that Apache HTTPClient is hiding behind a NotThreadSafe annotation
-				}
-			}
-		}
-		catch (IOException e) {
-			throw new QueryEvaluationException(e);
+			super.handleClose();
 		}
 		finally {
-			queue.close();
+			queue.done();
 		}
 	}
 

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/helpers/BackgroundTupleResult.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/helpers/BackgroundTupleResult.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.helpers;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.ArrayList;
@@ -61,28 +60,10 @@ public class BackgroundTupleResult extends IteratingTupleQueryResult
 		throws QueryEvaluationException
 	{
 		try {
-			try {
-				super.handleClose();
-			}
-			finally {
-				try {
-					// After checking that we ourselves cannot possibly be generating an NPE ourselves, 
-					// attempt to close the input stream we were given
-					InputStream toClose = in;
-					if (toClose != null) {
-						toClose.close();
-					}
-				}
-				catch (NullPointerException e) {
-					// Swallow NullPointerException that Apache HTTPClient is hiding behind a NotThreadSafe annotation
-				}
-			}
-		}
-		catch (IOException e) {
-			throw new QueryEvaluationException(e);
+			super.handleClose();
 		}
 		finally {
-			queue.close();
+			queue.done();
 		}
 	}
 

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/IterationWrapper.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/IterationWrapper.java
@@ -60,6 +60,10 @@ public class IterationWrapper<E, X extends Exception> extends AbstractCloseableI
 		if (isClosed()) {
 			return false;
 		}
+		else if (Thread.currentThread().isInterrupted()) {
+			close();
+			return false;
+		}
 		boolean result = wrappedIter.hasNext();
 		if (!result) {
 			close();
@@ -78,6 +82,10 @@ public class IterationWrapper<E, X extends Exception> extends AbstractCloseableI
 	{
 		if (isClosed()) {
 			throw new NoSuchElementException("The iteration has been closed.");
+		}
+		else if (Thread.currentThread().isInterrupted()) {
+			close();
+			throw new NoSuchElementException("The iteration has been interrupted.");
 		}
 		try {
 			return wrappedIter.next();
@@ -102,6 +110,10 @@ public class IterationWrapper<E, X extends Exception> extends AbstractCloseableI
 	{
 		if (isClosed()) {
 			throw new IllegalStateException("The iteration has been closed.");
+		}
+		else if (Thread.currentThread().isInterrupted()) {
+			close();
+			throw new IllegalStateException("The iteration has been interrupted.");
 		}
 		try {
 			wrappedIter.remove();

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/QueueIteration.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/QueueIteration.java
@@ -142,8 +142,8 @@ public abstract class QueueIteration<E, T extends Exception> extends LookAheadIt
 				}
 			}
 			if (isAfterLast(take)) {
-				checkException();
 				done(); // put afterLast back for others
+				checkException();
 				return null;
 			}
 			checkException();


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #896 and #853   .

* When result is closed, resume parsing until complete, and then close underlying
