### PR TITLE
Fix #911: Federation not compatible with RDF 1.0 endpoints

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/RepositoryFederatedService.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/RepositoryFederatedService.java
@@ -17,10 +17,6 @@ import java.util.Set;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.URI;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.BooleanQuery;
@@ -38,6 +34,7 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sparql.query.InsertBindingSetCursor;
+import org.eclipse.rdf4j.repository.sparql.query.QueryStringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -447,65 +444,12 @@ public class RepositoryFederatedService implements FederatedService {
 															// the row for post
 															// processing
 			for (String bName : relevantBindingNames) {
-				appendValueAsString(sb, b.getValue(bName)).append(" ");
+				QueryStringUtil.appendValueAsString(sb, b.getValue(bName)).append(" ");
 			}
 			sb.append(")");
 		}
 
 		sb.append(" }");
 		return sb.toString();
-	}
-
-	protected StringBuilder appendValueAsString(StringBuilder sb, Value value) {
-
-		// TODO check if there is some convenient method in Sesame!
-
-		if (value == null)
-			return sb.append("UNDEF"); // see grammar for BINDINGs def
-
-		else if (value instanceof URI)
-			return appendURI(sb, (URI)value);
-
-		else if (value instanceof Literal)
-			return appendLiteral(sb, (Literal)value);
-
-		// XXX check for other types ? BNode ?
-		throw new RuntimeException("Type not supported: " + value.getClass().getCanonicalName());
-	}
-
-	/**
-	 * Append the uri to the stringbuilder, i.e. <uri.stringValue>.
-	 * 
-	 * @param sb
-	 * @param uri
-	 * @return the StringBuilder, for convenience
-	 */
-	protected static StringBuilder appendURI(StringBuilder sb, URI uri) {
-		sb.append("<").append(uri.stringValue()).append(">");
-		return sb;
-	}
-
-	/**
-	 * Append the literal to the stringbuilder: "myLiteral"^^<dataType>
-	 * 
-	 * @param sb
-	 * @param lit
-	 * @return the StringBuilder, for convenience
-	 */
-	protected static StringBuilder appendLiteral(StringBuilder sb, Literal lit) {
-		sb.append('"');
-		sb.append(lit.getLabel().replace("\"", "\\\""));
-		sb.append('"');
-
-		if (Literals.isLanguageLiteral(lit)) {
-			sb.append('@');
-			sb.append(lit.getLanguage());
-		}
-		else {
-			sb.append("^^<");
-			sb.append(lit.getDatatype().stringValue());
-			sb.append('>');
-		}
-		return sb;
 	}
 }

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtil.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtil.java
@@ -13,6 +13,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLUtil;
 
@@ -152,7 +153,8 @@ public class QueryStringUtil {
 			sb.append('@');
 			sb.append(lit.getLanguage().get());
 		}
-		else {
+		else if (!lit.getDatatype().equals(XMLSchema.STRING)) {
+			// Don't append type if it's xsd:string, this keeps it compatible with RDF 1.0
 			sb.append("^^<");
 			sb.append(lit.getDatatype().stringValue());
 			sb.append('>');

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtilTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtilTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package org.eclipse.rdf4j.repository.sparql.query;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Verifies that QueryStringUtil converts values to their SPARQL string representations.
+ */
+public class QueryStringUtilTest {
+
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+
+	@Test
+	public void testIRI() {
+		IRI iri = VF.createIRI("http://example.com/test");
+
+		assertEquals("<http://example.com/test>", QueryStringUtil.valueToString(iri));
+		assertEquals("<http://example.com/test>", valueToStringWithStringBuilder(iri));
+	}
+
+	@Test
+	public void testSimpleLiteral() {
+		Literal literal = VF.createLiteral("simple \"literal\"");
+
+		assertEquals("\"simple \\\"literal\\\"\"", QueryStringUtil.valueToString(literal));
+		assertEquals("\"simple \\\"literal\\\"\"", valueToStringWithStringBuilder(literal));
+	}
+
+	@Test
+	public void testLanguageLiteral() {
+		Literal literal = VF.createLiteral("lang \"literal\"", "en");
+
+		assertEquals("\"lang \\\"literal\\\"\"@en", QueryStringUtil.valueToString(literal));
+		assertEquals("\"lang \\\"literal\\\"\"@en", valueToStringWithStringBuilder(literal));
+	}
+
+	@Test
+	public void testTypedLiteral() {
+		Literal literal = VF.createLiteral("typed \"literal\"", VF.createIRI("http://example.com/test"));
+
+		assertEquals("\"typed \\\"literal\\\"\"^^<http://example.com/test>",
+				QueryStringUtil.valueToString(literal));
+		assertEquals("\"typed \\\"literal\\\"\"^^<http://example.com/test>",
+				valueToStringWithStringBuilder(literal));
+	}
+
+	@Test
+	public void testNullValue() {
+		assertEquals("UNDEF", QueryStringUtil.valueToString(null));
+		assertEquals("UNDEF", valueToStringWithStringBuilder(null));
+	}
+
+	@Test
+	public void testBNode() {
+		try {
+			QueryStringUtil.valueToString(VF.createBNode());
+			fail("Must throw exception");
+		}
+		catch (IllegalArgumentException e) {
+			// ok
+		}
+
+		try {
+			valueToStringWithStringBuilder(VF.createBNode());
+			fail("Must throw exception");
+		}
+		catch (IllegalArgumentException e) {
+			// ok
+		}
+	}
+
+	private String valueToStringWithStringBuilder(Value value) {
+		return QueryStringUtil.appendValueAsString(new StringBuilder(), value).toString();
+	}
+}


### PR DESCRIPTION
Signed-off-by: Pavel Mihaylov <pavel@ontotext.com>

This PR addresses GitHub issue: #911.

* Expand simple literals without xsd:string, include the datatype if it isn't xsd:string
* Compatible with both RDF 1.0 and RDF 1.1
