### PR TITLE
Fix #920: Closing http repoCon forces open results to close

### DIFF
--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/BackgroundResultExecutor.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/BackgroundResultExecutor.java
@@ -1,0 +1,68 @@
+package org.eclipse.rdf4j.http.client;
+
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.QueryResult;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.impl.BackgroundGraphResult;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
+import org.eclipse.rdf4j.query.resultio.helpers.BackgroundTupleResult;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BackgroundResultExecutor implements AutoCloseable {
+
+	private final Logger logger = LoggerFactory.getLogger(BackgroundResultExecutor.class);
+
+	private final ExecutorService executor;
+
+	private final HashSet<QueryResult<?>> executing = new HashSet<>();
+
+	public BackgroundResultExecutor(ExecutorService executor) {
+		this.executor = Objects.requireNonNull(executor, "Executor service was null");
+	}
+
+	public TupleQueryResult parse(TupleQueryResultParser parser, InputStream in) {
+		BackgroundTupleResult result = new BackgroundTupleResult(parser, in);
+		autoCloseRunnable(result, result);
+		return result;
+	}
+
+	public GraphQueryResult parse(RDFParser parser, InputStream in, Charset charset, String baseURI) {
+		BackgroundGraphResult result = new BackgroundGraphResult(parser, in, charset, baseURI);
+		autoCloseRunnable(result, result);
+		return result;
+	}
+
+	/**
+	 * Force close any executing background result parsers
+	 */
+	public void close() {
+		for (AutoCloseable onclose : executing) {
+			try {
+				onclose.close();
+			}
+			catch (Exception e) {
+				logger.error(e.toString(), e);
+			}
+		}
+	}
+
+	private void autoCloseRunnable(QueryResult<?> result, Runnable runner) {
+		executing.add(result);
+		executor.execute(() -> {
+			try {
+				runner.run();
+			}
+			finally {
+				executing.remove(result);
+			}
+		});
+	}
+}

--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -350,6 +350,7 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 		return updateURL;
 	}
 
+	@Override
 	public void close() {
 		background.close();
 	}

--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -127,12 +127,10 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	}
 
 	@Override
-	public SPARQLProtocolSession createSPARQLProtocolSession(String queryEndpointUrl, String updateEndpointUrl) {
+	public SPARQLProtocolSession createSPARQLProtocolSession(String queryEndpointUrl,
+			String updateEndpointUrl)
+	{
 		SPARQLProtocolSession session = new SPARQLProtocolSession(getHttpClient(), executor) {
-
-			{
-				openSessions.put(this, true);
-			}
 
 			@Override
 			public void close() {
@@ -146,16 +144,13 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 		};
 		session.setQueryURL(queryEndpointUrl);
 		session.setUpdateURL(updateEndpointUrl);
+		openSessions.put(session, true);
 		return session;
 	}
 
 	@Override
 	public RDF4JProtocolSession createRDF4JProtocolSession(String serverURL) {
 		RDF4JProtocolSession session = new RDF4JProtocolSession(getHttpClient(), executor) {
-
-			{
-				openSessions.put(this, true);
-			}
 
 			@Override
 			public void close() {
@@ -168,6 +163,7 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 			}
 		};
 		session.setServerURL(serverURL);
+		openSessions.put(session, true);
 		return session;
 	}
 

--- a/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepository.java
+++ b/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepository.java
@@ -190,10 +190,10 @@ public class HTTPRepository extends AbstractRepository implements HttpClientDepe
 		}
 
 		boolean isWritable = false;
-		final String repositoryURL = createHTTPClient().getRepositoryURL();
 
-		try {
-			final TupleQueryResult repositoryList = createHTTPClient().getRepositoryList();
+		try (RDF4JProtocolSession client = createHTTPClient()) {
+			final String repositoryURL = client.getRepositoryURL();
+			final TupleQueryResult repositoryList = client.getRepositoryList();
 			try {
 				while (repositoryList.hasNext()) {
 					final BindingSet bindingSet = repositoryList.next();
@@ -354,8 +354,8 @@ public class HTTPRepository extends AbstractRepository implements HttpClientDepe
 			synchronized (this) {
 				result = compatibleMode;
 				if (result == null) {
-					try {
-						final String serverProtocolVersion = createHTTPClient().getServerProtocol();
+					try (RDF4JProtocolSession client = createHTTPClient()) {
+						final String serverProtocolVersion = client.getServerProtocol();
 
 						// protocol version 7 supports the new transaction
 						// handling. If the server is older, we need to run in

--- a/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
+++ b/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
@@ -373,9 +373,9 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 				logger.warn("Rolling back transaction due to connection close", new Throwable());
 				rollback();
 			}
-			super.close();
 		}
 		finally {
+			super.close();
 			client.close();
 		}
 	}

--- a/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
+++ b/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
@@ -368,12 +368,16 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 	public void close()
 		throws RepositoryException
 	{
-		if (isActive()) {
-			logger.warn("Rolling back transaction due to connection close", new Throwable());
-			rollback();
+		try {
+			if (isActive()) {
+				logger.warn("Rolling back transaction due to connection close", new Throwable());
+				rollback();
+			}
+			super.close();
 		}
-
-		super.close();
+		finally {
+			client.close();
+		}
 	}
 
 	public void add(File file, String baseURI, RDFFormat dataFormat, Resource... contexts)

--- a/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
+++ b/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
@@ -239,8 +239,7 @@ public class RemoteRepositoryManager extends RepositoryManager {
 		throws RepositoryException
 	{
 		Model model = new LinkedHashModel();
-		try {
-			RDF4JProtocolSession httpClient = getSesameClient().createRDF4JProtocolSession(serverURL);
+		try (RDF4JProtocolSession httpClient = getSesameClient().createRDF4JProtocolSession(serverURL)) {
 			httpClient.setUsernameAndPassword(username, password);
 			httpClient.setRepository(Protocol.getRepositoryLocation(serverURL, SystemRepository.ID));
 			httpClient.getStatements(null, null, null, true, new StatementCollector(model));
@@ -257,8 +256,7 @@ public class RemoteRepositoryManager extends RepositoryManager {
 	{
 		List<RepositoryInfo> result = new ArrayList<RepositoryInfo>();
 
-		try {
-			RDF4JProtocolSession httpClient = getSesameClient().createRDF4JProtocolSession(serverURL);
+		try (RDF4JProtocolSession httpClient = getSesameClient().createRDF4JProtocolSession(serverURL)) {
 			httpClient.setUsernameAndPassword(username, password);
 			TupleQueryResult responseFromServer = httpClient.getRepositoryList();
 			while (responseFromServer.hasNext()) {
@@ -318,17 +316,16 @@ public class RemoteRepositoryManager extends RepositoryManager {
 		throws RepositoryException,
 		RepositoryConfigException
 	{
-		String baseURI = Protocol.getRepositoryLocation(serverURL, config.getID());
-		Resource ctx = SimpleValueFactory.getInstance().createIRI(baseURI + "#" + config.getID());
-		RDF4JProtocolSession httpClient = getSesameClient().createRDF4JProtocolSession(serverURL);
-		httpClient.setUsernameAndPassword(username, password);
-		httpClient.setRepository(Protocol.getRepositoryLocation(serverURL, SystemRepository.ID));
-		Model model = new LinkedHashModel();
-		config.export(model, ctx);
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		Rio.write(model, baos, httpClient.getPreferredRDFFormat());
-		removeRepository(config.getID());
-		try {
+		try (RDF4JProtocolSession httpClient = getSesameClient().createRDF4JProtocolSession(serverURL)) {
+			String baseURI = Protocol.getRepositoryLocation(serverURL, config.getID());
+			Resource ctx = SimpleValueFactory.getInstance().createIRI(baseURI + "#" + config.getID());
+			httpClient.setUsernameAndPassword(username, password);
+			httpClient.setRepository(Protocol.getRepositoryLocation(serverURL, SystemRepository.ID));
+			Model model = new LinkedHashModel();
+			config.export(model, ctx);
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			Rio.write(model, baos, httpClient.getPreferredRDFFormat());
+			removeRepository(config.getID());
 			try (InputStream contents = new ByteArrayInputStream(baos.toByteArray())) {
 				httpClient.upload(contents, baseURI, httpClient.getPreferredRDFFormat(), false, true, ctx);
 			}
@@ -346,10 +343,8 @@ public class RemoteRepositoryManager extends RepositoryManager {
 		boolean existingRepo = hasRepositoryConfig(repositoryID);
 
 		if (existingRepo) {
-			RDF4JProtocolSession httpClient = getSesameClient().createRDF4JProtocolSession(serverURL);
-			httpClient.setUsernameAndPassword(username, password);
-
-			try {
+			try (RDF4JProtocolSession httpClient = getSesameClient().createRDF4JProtocolSession(serverURL)) {
+				httpClient.setUsernameAndPassword(username, password);
 				httpClient.deleteRepository(repositoryID);
 			}
 			catch (IOException e) {

--- a/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -117,6 +117,18 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 		client.setHttpClient(httpClient);
 	}
 
+	@Override
+	public void close()
+		throws RepositoryException
+	{
+		try {
+			super.close();
+		}
+		finally {
+			client.close();
+		}
+	}
+
 	public void exportStatements(Resource subj, IRI pred, Value obj, boolean includeInferred,
 			RDFHandler handler, Resource... contexts)
 		throws RepositoryException, RDFHandlerException


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #920 .
* Add AutoClose to SPARQLProtocolSession
* Force close open results when session is closed
* Close session when HTTPRepositoryConnection is closed
* Force close open sessions when session manager is closed
