### PR TITLE
Fix #880: Periodically ping server to keep transaction alive

### DIFF
--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/SesameClientImpl.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/SesameClientImpl.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 
@@ -30,7 +30,7 @@ public class SesameClientImpl extends SharedHttpClientSessionManager {
 	 * @deprecated use {@link SharedHttpClientSessionManager} instead.
 	 */
 	@Deprecated
-	public SesameClientImpl(CloseableHttpClient dependentClient, ExecutorService dependentExecutorService) {
+	public SesameClientImpl(CloseableHttpClient dependentClient, ScheduledExecutorService dependentExecutorService) {
 		super(dependentClient, dependentExecutorService);
 	}
 

--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/SesameSession.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/SesameSession.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.http.client.HttpClient;
 
@@ -22,7 +22,7 @@ public class SesameSession extends RDF4JProtocolSession {
 	 * @deprecated use {@link RDF4JProtocolSession} instead.
 	 */
 	@Deprecated
-	public SesameSession(HttpClient client, ExecutorService executor) {
+	public SesameSession(HttpClient client, ScheduledExecutorService executor) {
 		super(client, executor);
 	}
 

--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -10,8 +10,8 @@ package org.eclipse.rdf4j.http.client;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -41,7 +41,7 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	/** dependent life cycle */
 	private volatile CloseableHttpClient dependentClient;
 
-	private final ExecutorService executor;
+	private final ScheduledExecutorService executor;
 
 	/**
 	 * Optional {@link HttpClientBuilder} to create the inner {@link #httpClient} (if not provided externally)
@@ -56,7 +56,7 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 
 	public SharedHttpClientSessionManager() {
 		final ThreadFactory backingThreadFactory = Executors.defaultThreadFactory();
-		this.executor = Executors.newCachedThreadPool(new ThreadFactory() {
+		this.executor = Executors.newScheduledThreadPool(0, new ThreadFactory() {
 
 			public Thread newThread(Runnable runnable) {
 				Thread thread = backingThreadFactory.newThread(runnable);
@@ -68,7 +68,7 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	}
 
 	public SharedHttpClientSessionManager(CloseableHttpClient dependentClient,
-			ExecutorService dependentExecutorService)
+			ScheduledExecutorService dependentExecutorService)
 	{
 		this.httpClient = this.dependentClient = Objects.requireNonNull(dependentClient,
 				"HTTP client was null");

--- a/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
+++ b/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
@@ -35,11 +35,44 @@ public abstract class Protocol {
 		QUERY,
 		/** SPARQL Update */
 		UPDATE,
+		/** Keep alive ping @since 2.3 */
+		PING,
 		/** commit */
 		COMMIT,
 		/** rollback */
 		ROLLBACK;
 	}
+
+	/**
+	 * Use an enum to allow ActiveTransactionRegistry enum to access the static values. This is necessary
+	 * because enum are initialize before static fields.
+	 */
+	@Deprecated
+	public static enum TIMEOUT {
+		CACHE;
+
+		/**
+		 * Configurable system property {@code rdf4j.server.txn.registry.timeout} for specifying the
+		 * transaction cache timeout (in seconds).
+		 */
+		public static final String CACHE_PROPERTY = "rdf4j.server.txn.registry.timeout";
+
+		/**
+		 * Default timeout setting for transaction cache entries (in seconds).
+		 */
+		public final static int DEFAULT = 60;
+	}
+
+	/**
+	 * Configurable system property {@code rdf4j.server.txn.registry.timeout} for specifying the transaction
+	 * cache timeout (in seconds).
+	 */
+	public static final String CACHE_TIMEOUT_PROPERTY = Protocol.TIMEOUT.CACHE_PROPERTY;
+
+	/**
+	 * Default timeout setting for transaction cache entries (in seconds).
+	 */
+	public final static int DEFAULT_TIMEOUT = Protocol.TIMEOUT.DEFAULT;
 
 	/**
 	 * Protocol version.


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #880 #852 #851 .

* The client sends a PING request to the server every 30s to keep the transaction from timing out
* Even if the server doesn't understand the request, it should at least reset the timeout
