### PR TITLE
Fix #921: Check for special double values in turtle writer

### DIFF
--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -590,8 +590,14 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 					|| XMLSchema.DOUBLE.equals(datatype) || XMLSchema.BOOLEAN.equals(datatype))
 			{
 				try {
-					writer.write(XMLDatatypeUtil.normalize(label, datatype));
-					return; // done
+					String normalized = XMLDatatypeUtil.normalize(label, datatype);
+					if (!normalized.equals(XMLDatatypeUtil.POSITIVE_INFINITY)
+							&& !normalized.equals(XMLDatatypeUtil.NEGATIVE_INFINITY)
+							&& !normalized.equals(XMLDatatypeUtil.NaN))
+					{
+						writer.write(normalized);
+						return; // done
+					}
 				}
 				catch (IllegalArgumentException e) {
 					// not a valid numeric typed literal. ignore error and write

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -531,6 +531,40 @@ public abstract class RDFWriterTest {
 	}
 
 	@Test
+	public void testRoundTripNaN921()
+		throws RDFHandlerException, IOException, RDFParseException
+	{
+		Statement st1 = vf.createStatement(uri1, uri2, vf.createLiteral(Double.NaN));
+		Statement st2 = vf.createStatement(uri1, uri2, vf.createLiteral(Double.NEGATIVE_INFINITY));
+		Statement st3 = vf.createStatement(uri1, uri2, vf.createLiteral(Double.POSITIVE_INFINITY));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		RDFWriter rdfWriter = rdfWriterFactory.getWriter(out);
+		setupWriterConfig(rdfWriter.getWriterConfig());
+		rdfWriter.handleNamespace("ex", exNs);
+		rdfWriter.startRDF();
+		rdfWriter.handleStatement(st1);
+		rdfWriter.handleStatement(st2);
+		rdfWriter.handleStatement(st3);
+		rdfWriter.endRDF();
+
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		RDFParser rdfParser = rdfParserFactory.getParser();
+		setupParserConfig(rdfParser.getParserConfig());
+		rdfParser.setValueFactory(vf);
+		Model model = new LinkedHashModel();
+		rdfParser.setRDFHandler(new StatementCollector(model));
+
+		rdfParser.parse(in, "foo:bar");
+
+		assertEquals("Unexpected number of statements, found " + model.size(), 3, model.size());
+
+		assertTrue("missing statement with double " + st1.getObject(), model.contains(st1));
+		assertTrue("missing statement with double " + st2.getObject(), model.contains(st2));
+		assertTrue("missing statement with double " + st3.getObject(), model.contains(st3));
+	}
+
+	@Test
 	public void testPrefixRedefinition()
 		throws RDFHandlerException, RDFParseException, IOException
 	{


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #921 .

* Check for +INF, -INF, and NaN before using short numeric turtle syntax