### PR TITLE
Suggest a few more valid xsd:gYear values

### DIFF
--- a/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
@@ -90,10 +90,10 @@ public class XMLDatatypeUtilTest {
 			"25:25:25" };
 
 	/** valid xsd:gYear values */
-	private static final String[] VALID_GYEAR = { "2001", "2001+02:00", "2001Z", "-2001" };
+	private static final String[] VALID_GYEAR = { "2001", "2001+02:00", "2001Z", "-2001", "-20000", "20000", "0000"  };
 
 	/** invalid xsd:gYear values */
-	private static final String[] INVALID_GYEAR = { "foo", "01", "2001-01", "2001-01-01" };
+	private static final String[] INVALID_GYEAR = { "foo", "01", "2001-01", "2001-01-01"};
 
 	/** valid xsd:gDay values */
 	private static final String[] VALID_GDAY = { "---01", "---26Z", "---12-06:00", "---13+10:00" };

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
@@ -90,10 +90,10 @@ public class XMLDatatypeUtilTest {
 			"25:25:25" };
 
 	/** valid xsd:gYear values */
-	private static final String[] VALID_GYEAR = { "2001", "2001+02:00", "2001Z", "-2001", "-20000", "20000", "0000"  };
+	private static final String[] VALID_GYEAR = { "2001", "2001+02:00", "2001Z", "-2001", "-20000", "20000", "0000" };
 
 	/** invalid xsd:gYear values */
-	private static final String[] INVALID_GYEAR = { "foo", "01", "2001-01", "2001-01-01"};
+	private static final String[] INVALID_GYEAR = { "foo", "01", "2001-01", "2001-01-01" };
 
 	/** valid xsd:gDay values */
 	private static final String[] VALID_GDAY = { "---01", "---26Z", "---12-06:00", "---13+10:00" };


### PR DESCRIPTION
A library that was using a previous version of this library (openRDF)  was failing to parse xsd:gYear values greater than 9999. Even though I did not test the current version behavior, I thought it was a good idea to add these unit tests in the code base.

This PR adds the following tests in the rdf4j unit tests.

* checks that `20000` is a valid `xsd:gYear` value
* checks that `-20000` is a valid `xsd:gYear` value
* checks that `0000` is a valid `xsd:gYear` value

