### PR TITLE
Fix #908: Add text in textarea tag for MS Edge browser rendering

### DIFF
--- a/core/http/workbench/src/main/webapp/transformations/update.xsl
+++ b/core/http/workbench/src/main/webapp/transformations/update.xsl
@@ -21,6 +21,8 @@
 						</th>
 						<td>
 							<textarea id="update" name="update" rows="16" cols="80">
+								<xsl:text>
+								</xsl:text>
 							</textarea>
 						</td>
 						<td></td>


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #908 #373  .

* Add text in textarea tag to force xslt to include and end tag
