### PR TITLE
Fix #934: Allow years >9999 in xsd validation

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -486,7 +486,7 @@ public class XMLDatatypeUtil {
 	 */
 	public static boolean isValidDate(String value) {
 
-		String regex = "-?\\d\\d\\d\\d-\\d\\d-\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?";
+		String regex = "-?\\d{4,}-\\d\\d-\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?";
 
 		if (value.matches(regex)) {
 			return isValidCalendarValue(value);
@@ -576,7 +576,7 @@ public class XMLDatatypeUtil {
 	 */
 	public static boolean isValidGYear(String value) {
 
-		String regex = "-?\\d\\d\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?";
+		String regex = "-?\\d{4,}(Z|(\\+|-)\\d\\d:\\d\\d)?";
 
 		if (value.matches(regex)) {
 			return isValidCalendarValue(value);
@@ -594,7 +594,7 @@ public class XMLDatatypeUtil {
 	 */
 	public static boolean isValidGYearMonth(String value) {
 
-		String regex = "-?\\d\\d\\d\\d-\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?";
+		String regex = "-?\\d{4,}-\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?";
 
 		if (value.matches(regex)) {
 			return isValidCalendarValue(value);

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
@@ -90,7 +90,7 @@ public class XMLDatatypeUtilTest {
 			"25:25:25" };
 
 	/** valid xsd:gYear values */
-	private static final String[] VALID_GYEAR = { "2001", "2001+02:00", "2001Z", "-2001" };
+	private static final String[] VALID_GYEAR = { "2001", "2001+02:00", "2001Z", "-2001", "-20000", "20000" };
 
 	/** invalid xsd:gYear values */
 	private static final String[] INVALID_GYEAR = { "foo", "01", "2001-01", "2001-01-01" };


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #934 .

* XMLGregorianCalendar supports years >9999
* Change regex to pass these through
