### PR TITLE
Fix #940: synchronize RangeIterator#close

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTree.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTree.java
@@ -2157,7 +2157,7 @@ public class BTree implements Closeable {
 		}
 
 		@Override
-		public void close()
+		public synchronized void close()
 			throws IOException
 		{
 			btreeLock.readLock().lock();


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #940 .

* Add synchronized flag to close() method in the event that it is called from an interrupt handler