### PR TITLE
Issue #919: Add jdk9 profiles to add-modules java.xml.bind for tests

### DIFF
--- a/compliance/rio/pom.xml
+++ b/compliance/rio/pom.xml
@@ -123,6 +123,26 @@
 		</dependency>
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>jdk9</id>
+			<activation>
+				<jdk>[1.9,9,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<configuration>
+							<argLine>--add-modules=java.xml.bind</argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/http/protocol/pom.xml
+++ b/http/protocol/pom.xml
@@ -40,4 +40,23 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<id>jdk9</id>
+			<activation>
+				<jdk>[1.9,9,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<argLine>--add-modules=java.xml.bind</argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #919 .

* Add JVM arg --add-modules=java.xml.bind if jdk9
