### PR TITLE
Fix #951: Handle multiline comments in QueryPrologLexer

### DIFF
--- a/queryparser/api/src/main/java/org/eclipse/rdf4j/query/parser/QueryPrologLexer.java
+++ b/queryparser/api/src/main/java/org/eclipse/rdf4j/query/parser/QueryPrologLexer.java
@@ -203,7 +203,7 @@ public class QueryPrologLexer {
 		String comment = null;
 		Matcher matcher = COMMENT_PATTERN.matcher(input.substring(index));
 		if (matcher.find()) {
-			comment = matcher.group(1);
+			comment = matcher.group(0);
 			// the regex group includes the # => just remove it
 			comment = comment.substring(1);
 		}

--- a/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryPrologLexerTest.java
+++ b/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryPrologLexerTest.java
@@ -60,7 +60,7 @@ public class QueryPrologLexerTest {
 
 	@Test
 	public void testLexWithComment() {
-		List<Token> tokens = QueryPrologLexer.lex("# COMMENT \n SELECT * WHERE {?s ?p ?o} ");
+		List<Token> tokens = QueryPrologLexer.lex("# COMMENT \nSELECT * WHERE {?s ?p ?o} ");
 		assertNotNull(tokens);
 		assertEquals(3, tokens.size());
 		assertEquals(" COMMENT \n", tokens.get(1).s);
@@ -72,7 +72,7 @@ public class QueryPrologLexerTest {
 
 	@Test
 	public void testLexWithComment_WindowsLinebreak() {
-		List<Token> tokens = QueryPrologLexer.lex("# COMMENT \r\n SELECT * WHERE {?s ?p ?o} ");
+		List<Token> tokens = QueryPrologLexer.lex("# COMMENT \r\nSELECT * WHERE {?s ?p ?o} ");
 		assertNotNull(tokens);
 
 		Token t = tokens.get(tokens.size() - 1);
@@ -92,7 +92,7 @@ public class QueryPrologLexerTest {
 
 	@Test
 	public void testFinalTokenWithComment() {
-		Token t = QueryPrologLexer.getRestOfQueryToken("# COMMENT \n  SELECT * WHERE {?s ?p ?o} ");
+		Token t = QueryPrologLexer.getRestOfQueryToken("# COMMENT \n SELECT * WHERE {?s ?p ?o} ");
 		assertNotNull(t);
 		assertTrue(t.getType().equals(TokenType.REST_OF_QUERY));
 		assertEquals("SELECT * WHERE {?s ?p ?o} ", t.s);
@@ -101,7 +101,7 @@ public class QueryPrologLexerTest {
 	@Test
 	public void testFinalTokenWithMultilineComment() {
 		Token t = QueryPrologLexer.getRestOfQueryToken(
-				"# COMMENT \n # COMMENT (continued) \n SELECT * WHERE {?s ?p ?o} ");
+				"# COMMENT \n# COMMENT (continued) \nSELECT * WHERE {?s ?p ?o} ");
 		assertNotNull(t);
 		assertTrue(t.getType().equals(TokenType.REST_OF_QUERY));
 		assertEquals("SELECT * WHERE {?s ?p ?o} ", t.s);
@@ -109,7 +109,7 @@ public class QueryPrologLexerTest {
 
 	@Test
 	public void testLexWithBaseAndComment() {
-		List<Token> tokens = QueryPrologLexer.lex("BASE <foobar> # COMMENT \n SELECT * WHERE {?s ?p ?o} ");
+		List<Token> tokens = QueryPrologLexer.lex("BASE <foobar> # COMMENT \nSELECT * WHERE {?s ?p ?o} ");
 		assertNotNull(tokens);
 
 		Token t = tokens.get(tokens.size() - 1);
@@ -120,7 +120,7 @@ public class QueryPrologLexerTest {
 	@Test
 	public void testFinalTokenWithBaseAndComment() {
 		Token t = QueryPrologLexer.getRestOfQueryToken(
-				"BASE <foobar> # COMMENT \n SELECT * WHERE {?s ?p ?o} ");
+				"BASE <foobar> # COMMENT \nSELECT * WHERE {?s ?p ?o} ");
 		assertNotNull(t);
 		assertTrue(t.getType().equals(TokenType.REST_OF_QUERY));
 	}
@@ -134,7 +134,7 @@ public class QueryPrologLexerTest {
 
 		try {
 			List<Token> tokens = QueryPrologLexer.lex(
-					"BASE <foobar # missing closing bracket \n SELECT * WHERE {?s ?p ?o} ");
+					"BASE <foobar # missing closing bracket \nSELECT * WHERE {?s ?p ?o} ");
 		}
 		catch (Exception e) {
 			fail("malformed query should not make lexer fail");
@@ -151,7 +151,7 @@ public class QueryPrologLexerTest {
 
 		try {
 			Token t = QueryPrologLexer.getRestOfQueryToken(
-					"BASE <foobar # missing closing bracket \n SELECT * WHERE {?s ?p ?o} ");
+					"BASE <foobar # missing closing bracket \nSELECT * WHERE {?s ?p ?o} ");
 		}
 		catch (Exception e) {
 			fail("malformed query should not make lexer fail");


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: #951 .

* Regex was update to handle multiline comments, but matcher group wasn't
