### PR TITLE
Fix #438: Add SKOLEMIZE_ORIGIN parser setting

### DIFF
--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -199,6 +199,17 @@ public class BasicParserSettings {
 			"org.eclipse.rdf4j.rio.preservebnodeids", "Preserve blank node identifiers", Boolean.FALSE);
 
 	/**
+	 * Scheme and authority of new mint Skolem IRIs that should replace Blank Nodes. For example a value of
+	 * "http://example.com" might cause a blank node to be replaced with an IRI of
+	 * "http://example.com/.well-known/genid/d26a2d0e98334696f4ad70a677abc1f6"
+	 * <p>
+	 * Defaults to null (disabled).
+	 */
+	public static final RioSetting<String> SKOLEMIZE_ORIGIN = new RioSettingImpl<String>(
+			"org.eclipse.rdf4j.rio.skolemorigin",
+			"Replace blank nodes with well known genid IRIs using this scheme and authority", null);
+
+	/**
 	 * Boolean setting for parser to determine whether parser should preserve, truncate, drop, or otherwise
 	 * manipulate statements that contain long literals. The maximum length of literals if this setting is set
 	 * to truncate or drop is configured using {@link #LARGE_LITERALS_LIMIT}.

--- a/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFParser.java
+++ b/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFParser.java
@@ -30,7 +30,6 @@ import java.io.Reader;
 import java.util.Arrays;
 
 import org.eclipse.rdf4j.common.io.IOUtil;
-import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -238,11 +237,11 @@ public class BinaryRDFParser extends AbstractRDFParser {
 		return createURI(uri);
 	}
 
-	private BNode readBNode()
+	private Resource readBNode()
 		throws IOException, RDFParseException
 	{
 		String bnodeID = readString();
-		return createBNode(bnodeID);
+		return createNode(bnodeID);
 	}
 
 	private Literal readPlainLiteral()

--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDInternalTripleCallback.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDInternalTripleCallback.java
@@ -12,7 +12,6 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -47,9 +46,9 @@ class JSONLDInternalTripleCallback implements JsonLdTripleCallback {
 
 	private final ParseErrorListener parseErrorListener;
 
-	private final Function<String, BNode> namedBNodeCreator;
+	private final Function<String, Resource> namedBNodeCreator;
 
-	private final Supplier<BNode> anonymousBNodeCreator;
+	private final Supplier<Resource> anonymousBNodeCreator;
 
 	public JSONLDInternalTripleCallback() {
 		this(new StatementCollector(new LinkedHashModel()));
@@ -65,8 +64,8 @@ class JSONLDInternalTripleCallback implements JsonLdTripleCallback {
 	}
 
 	public JSONLDInternalTripleCallback(RDFHandler nextHandler, ValueFactory vf, ParserConfig parserConfig,
-			ParseErrorListener parseErrorListener, Function<String, BNode> namedBNodeCreator,
-			Supplier<BNode> anonymousBNodeCreator)
+			ParseErrorListener parseErrorListener, Function<String, Resource> namedBNodeCreator,
+			Supplier<Resource> anonymousBNodeCreator)
 	{
 		this.handler = nextHandler;
 		this.vf = vf;

--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -62,8 +62,8 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 
 		try {
 			final JSONLDInternalTripleCallback callback = new JSONLDInternalTripleCallback(getRDFHandler(),
-					valueFactory, getParserConfig(), getParseErrorListener(), nodeID -> createBNode(nodeID),
-					() -> createBNode());
+					valueFactory, getParserConfig(), getParseErrorListener(), nodeID -> createNode(nodeID),
+					() -> createNode());
 
 			final JsonLdOptions options = new JsonLdOptions(baseURI);
 			options.useNamespaces = true;
@@ -95,8 +95,8 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 
 		try {
 			final JSONLDInternalTripleCallback callback = new JSONLDInternalTripleCallback(getRDFHandler(),
-					valueFactory, getParserConfig(), getParseErrorListener(), nodeID -> createBNode(nodeID),
-					() -> createBNode());
+					valueFactory, getParserConfig(), getParseErrorListener(), nodeID -> createNode(nodeID),
+					() -> createNode());
 
 			final JsonLdOptions options = new JsonLdOptions(baseURI);
 			options.useNamespaces = true;

--- a/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
+++ b/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
@@ -182,7 +182,7 @@ public class NQuadsParser extends NTriplesParser {
 		else if (c == '_') {
 			// subject is a bNode
 			c = parseNodeID(c, sb);
-			context = createBNode(sb.toString());
+			context = createNode(sb.toString());
 		}
 		else if (c == -1) {
 			throwEOFException();

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -340,7 +340,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		else if (c == '_') {
 			// subject is a bNode
 			c = parseNodeID(c, sb);
-			subject = createBNode(sb.toString());
+			subject = createNode(sb.toString());
 		}
 		else if (c == -1) {
 			throwEOFException();
@@ -388,7 +388,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		else if (c == '_') {
 			// object is a bNode
 			c = parseNodeID(c, sb);
-			object = createBNode(sb.toString());
+			object = createNode(sb.toString());
 		}
 		else if (c == '"') {
 			// object is a literal

--- a/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
+++ b/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
@@ -204,7 +204,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 			final String subjStr = jp.getCurrentName();
 			Resource subject = null;
 
-			subject = subjStr.startsWith("_:") ? createBNode(subjStr.substring(2)) : vf.createIRI(subjStr);
+			subject = subjStr.startsWith("_:") ? createNode(subjStr.substring(2)) : vf.createIRI(subjStr);
 			if (jp.nextToken() != JsonToken.START_OBJECT) {
 				reportFatalError("Expected subject value to start with an Object", jp.getCurrentLocation());
 			}
@@ -342,7 +342,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 							reportFatalError("Datatype was attached to a blank node object: subject="
 									+ subjStr + " predicate=" + predStr, jp.getCurrentLocation());
 						}
-						object = createBNode(nextValue.substring(2));
+						object = createNode(nextValue.substring(2));
 					}
 					else if (RDFJSONUtility.URI.equals(nextType)) {
 						if (nextLanguage != null) {
@@ -365,7 +365,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 								context = null;
 							}
 							else if (nextContext.startsWith("_:")) {
-								context = createBNode(nextContext.substring(2));
+								context = createNode(nextContext.substring(2));
 							}
 							else {
 								context = vf.createIRI(nextContext);

--- a/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
+++ b/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
@@ -23,7 +23,6 @@ import org.apache.commons.io.input.BOMInputStream;
 import org.eclipse.rdf4j.common.net.ParsedURI;
 import org.eclipse.rdf4j.common.xml.XMLReaderFactory;
 import org.eclipse.rdf4j.common.xml.XMLUtil;
-import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -602,7 +601,7 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 
 			if (predicate.parseCollection()) {
 				Resource lastListRes = predicate.getLastListResource();
-				BNode newListRes = createBNode();
+				Resource newListRes = createNode();
 
 				if (lastListRes == null) {
 					// first element in the list
@@ -699,11 +698,11 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 			result = resolveURI(about.getValue());
 		}
 		else if (nodeID != null) {
-			result = createBNode(nodeID.getValue());
+			result = createNode(nodeID.getValue());
 		}
 		else {
 			// No resource specified, generate a bNode
-			result = createBNode();
+			result = createNode();
 		}
 
 		return result;
@@ -777,7 +776,7 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 			String parseTypeValue = parseType.getValue();
 
 			if (parseTypeValue.equals("Resource")) {
-				BNode objectResource = createBNode();
+				Resource objectResource = createNode();
 				NodeElement subject = (NodeElement)peekStack(1);
 
 				reportStatement(subject.getResource(), propURI, objectResource);
@@ -932,11 +931,11 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 			result = resolveURI(resource.getValue());
 		}
 		else if (nodeID != null) {
-			result = createBNode(nodeID.getValue());
+			result = createNode(nodeID.getValue());
 		}
 		else {
 			// No resource specified, generate a bNode
-			result = createBNode();
+			result = createNode();
 		}
 
 		return result;
@@ -1006,7 +1005,7 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 	}
 
 	@Override
-	protected BNode createBNode(String nodeID)
+	protected Resource createNode(String nodeID)
 		throws RDFParseException
 	{
 		if (getParserConfig().get(XMLParserSettings.FAIL_ON_INVALID_NCNAME)) {
@@ -1016,7 +1015,7 @@ public class RDFXMLParser extends AbstractRDFParser implements ErrorHandler {
 			}
 		}
 
-		return super.createBNode(nodeID);
+		return super.createNode(nodeID);
 	}
 
 	private Object peekStack(int distFromTop) {

--- a/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParser.java
+++ b/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParser.java
@@ -134,7 +134,7 @@ public class TriGParser extends TurtleParser {
 			skipWSC();
 			c2 = readCodePoint();
 			if (c2 == ']') {
-				contextOrSubject = createBNode();
+				contextOrSubject = createNode();
 				foundContextOrSubject = true;
 				skipWSC();
 			}
@@ -231,7 +231,7 @@ public class TriGParser extends TurtleParser {
 			c = peekCodePoint();
 			if (c == ']') {
 				c = readCodePoint();
-				subject = createBNode();
+				subject = createNode();
 				skipWSC();
 				parsePredicateObjectList();
 			}

--- a/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXParser.java
+++ b/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXParser.java
@@ -327,7 +327,7 @@ public class TriXParser extends AbstractRDFParser implements ErrorHandler {
 					valueList.add(createURI(text));
 				}
 				else if (tagName.equals(BNODE_TAG)) {
-					valueList.add(createBNode(text));
+					valueList.add(createNode(text));
 				}
 				else if (tagName.equals(PLAIN_LITERAL_TAG)) {
 					String lang = atts.get(LANGUAGE_ATT);

--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 import org.apache.commons.io.input.BOMInputStream;
 import org.eclipse.rdf4j.common.text.ASCIIUtil;
-import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -350,7 +349,7 @@ public class TurtleParser extends AbstractRDFParser {
 			c = peekCodePoint();
 			if (c == ']') {
 				c = readCodePoint();
-				subject = createBNode();
+				subject = createNode();
 				skipWSC();
 				parsePredicateObjectList();
 			} else {
@@ -493,7 +492,7 @@ public class TurtleParser extends AbstractRDFParser {
 			}
 			return RDF.NIL;
 		} else {
-			BNode listRoot = createBNode();
+			Resource listRoot = createNode();
 			if (subject != null) {
 				reportStatement(subject, predicate, listRoot);
 			}
@@ -508,11 +507,11 @@ public class TurtleParser extends AbstractRDFParser {
 
 			parseObject();
 
-			BNode bNode = listRoot;
+			Resource bNode = listRoot;
 
 			while (skipWSC() != ')') {
 				// Create another list node and link it to the previous
-				BNode newNode = createBNode();
+				Resource newNode = createNode();
 				reportStatement(bNode, RDF.REST, newNode);
 
 				// New node becomes the current
@@ -542,7 +541,7 @@ public class TurtleParser extends AbstractRDFParser {
 	protected Resource parseImplicitBlank() throws IOException, RDFParseException, RDFHandlerException {
 		verifyCharacterOrFail(readCodePoint(), "[");
 
-		BNode bNode = createBNode();
+		Resource bNode = createNode();
 		if (subject != null) {
 			reportStatement(subject, predicate, bNode);
 		}
@@ -1068,7 +1067,7 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses a blank node ID, e.g. <tt>_:node1</tt>.
 	 */
-	protected BNode parseNodeID() throws IOException, RDFParseException {
+	protected Resource parseNodeID() throws IOException, RDFParseException {
 		// Node ID should start with "_:"
 		verifyCharacterOrFail(readCodePoint(), "_");
 		verifyCharacterOrFail(readCodePoint(), ":");
@@ -1107,7 +1106,7 @@ public class TurtleParser extends AbstractRDFParser {
 			}
 		}
 
-		return createBNode(name.toString());
+		return createNode(name.toString());
 	}
 
 	protected void reportStatement(Resource subj, IRI pred, Value obj) throws RDFParseException, RDFHandlerException {


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #438 .

* Add BasicParserSettings.SKOLEMIZE_ORIGIN to store scheme and authority
* Add AbstractRDFParser#createNode() method to user SKOLEMIZE_ORIGIN setting