### PR TITLE
Fixes #978 by updating META-INF/services and including test.

### DIFF
--- a/rio/api/pom.xml
+++ b/rio/api/pom.xml
@@ -28,6 +28,11 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
         <build>
                 <plugins>

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioFileTypeDetectorTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioFileTypeDetectorTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertThat;
+
+import java.nio.file.spi.FileTypeDetector;
+import java.util.ServiceLoader;
+
+import org.junit.Test;
+
+public class RioFileTypeDetectorTest {
+    @Test
+    public void correctClassIsRegisteredInServices()
+    {
+        assertThat(ServiceLoader.load(FileTypeDetector.class),
+                hasItem(isA(RioFileTypeDetector.class)));
+    }
+}


### PR DESCRIPTION
- Test that the ServiceLoader knows about RioFileTypeDetector
- Update to point at the current package

Signed-off-by: Joseph Walton <joe@kafsemo.org>