### PR TITLE
Fix #986: Encode illegal IRI characters as codepoints in Turtle

### DIFF
--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -29,6 +29,7 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFParser;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
 
 /**
@@ -422,7 +423,7 @@ public class NTriplesParser extends AbstractRDFParser {
 			}
 			if (c == ' ') {
 				reportError("IRI included an unencoded space: " + new String(Character.toChars(c)),
-						NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+						BasicParserSettings.VERIFY_URI_SYNTAX);
 			}
 			uriRef.append(Character.toChars(c));
 
@@ -434,7 +435,7 @@ public class NTriplesParser extends AbstractRDFParser {
 				}
 				if (c != 'u' && c != 'U') {
 					reportError("IRI includes string escapes: '\\" + c + "'",
-							NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+							BasicParserSettings.VERIFY_URI_SYNTAX);
 				}
 				uriRef.append(Character.toChars(c));
 			}

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtil.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtil.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.rio.ntriples;
 
 import java.io.IOException;
 
+import org.eclipse.rdf4j.common.text.StringUtil;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -319,9 +320,12 @@ public class NTriplesUtil {
 	public static void append(IRI uri, Appendable appendable)
 		throws IOException
 	{
-		appendable.append("<");
-		escapeString(uri.toString(), appendable);
-		appendable.append(">");
+		StringBuilder sb = new StringBuilder();
+		escapeString(uri.toString(), sb);
+		String s = sb.toString();
+		s = StringUtil.gsub("<", "\\u003C", s);
+		s = StringUtil.gsub(">", "\\u003E", s);
+		appendable.append("<").append(s).append(">");
 	}
 
 	/**

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
@@ -194,9 +194,7 @@ public class NTriplesWriter extends AbstractRDFWriter implements RDFWriter {
 	private void writeIRI(IRI iri)
 		throws IOException
 	{
-		writer.append("<");
-		writeString(iri.stringValue());
-		writer.append(">");
+		NTriplesUtil.append(iri, writer);
 	}
 
 	private void writeBNode(BNode bNode)

--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleUtil.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleUtil.java
@@ -470,8 +470,17 @@ public class TurtleUtil {
 	 * Encodes the supplied string for inclusion as a (relative) URI in a Turtle document.
 	 **/
 	public static String encodeURIString(String s) {
-		s = StringUtil.gsub("\\", "\\\\", s);
-		s = StringUtil.gsub(">", "\\>", s);
+		s = StringUtil.gsub("\\", "\\u005C", s);
+		s = StringUtil.gsub("\t", "\\u0009", s);
+		s = StringUtil.gsub("\n", "\\u000A", s);
+		s = StringUtil.gsub("\r", "\\u000D", s);
+		s = StringUtil.gsub("\"", "\\u0022", s);
+		s = StringUtil.gsub("`", "\\u0060", s);
+		s = StringUtil.gsub("^", "\\u005E", s);
+		s = StringUtil.gsub("|", "\\u007C", s);
+		s = StringUtil.gsub("<", "\\u003C", s);
+		s = StringUtil.gsub(">", "\\u003E", s);
+		s = StringUtil.gsub(" ", "\\u0020", s);
 		return s;
 	}
 


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #986 .

* Encode illegal IRI characters that could trip up parsing, such as <>
