### PR TITLE
Fix #978: Fix package name of RioFileTypeDetector

### DIFF
--- a/rio/api/src/main/resources/META-INF/services/java.nio.file.spi.FileTypeDetector
+++ b/rio/api/src/main/resources/META-INF/services/java.nio.file.spi.FileTypeDetector
@@ -1,1 +1,1 @@
-org.openrdf.rio.helpers.RioFileTypeDetector
+org.eclipse.rdf4j.rio.helpers.RioFileTypeDetector


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #978 .

* Change package name in services
