### PR TITLE
Fix #984: Skip whitespaces when parsing object blank node

### DIFF
--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -547,6 +547,7 @@ public class TurtleParser extends AbstractRDFParser {
 			reportStatement(subject, predicate, bNode);
 		}
 
+		skipWSC();
 		int c = readCodePoint();
 		if (c != ']') {
 			unread(c);


### PR DESCRIPTION
Signed-off-by: Yasen Marinov <yasen.marinov@ontotext.com>


This PR addresses GitHub issue: #984 .

Briefly describe the changes proposed in this PR:

Skip whitespaces when parsing a blank node as an object.
