### PR TITLE
Fix #1000: Check for literal datatype/language when comparing literals

### DIFF
--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -80,6 +80,9 @@ class ArrangedWriter implements RDFWriter {
 				return cmp;
 			Value o1 = s1.getObject();
 			Value o2 = s2.getObject();
+			if (o1.equals(o2)) {
+				return 0;
+			}
 			if (!(o1 instanceof BNode) && o2 instanceof BNode) {
 				return -1;
 			}
@@ -92,7 +95,17 @@ class ArrangedWriter implements RDFWriter {
 			else if (o1 instanceof IRI && !(o2 instanceof IRI)) {
 				return 1;
 			}
-			return o1.stringValue().compareTo(o2.stringValue());
+			int str_cmp = o1.stringValue().compareTo(o2.stringValue());
+			if (str_cmp != 0) {
+				return str_cmp;
+			}
+			Literal lit1 = (Literal) o1;
+			Literal lit2 = (Literal) o2;
+			int dt_cmp = lit1.getDatatype().stringValue().compareTo(lit2.getDatatype().stringValue());
+			if (dt_cmp != 0) {
+				return dt_cmp;
+			}
+			return lit1.getLanguage().orElse("").compareTo(lit2.getLanguage().orElse(""));
 		}
 	};
 


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #1000!

* Use a stable comparison with literals that have the same label
