### PR TITLE
Fix #1006: Unread trailing dot from prefix/boolean term

### DIFF
--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
@@ -7,7 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trig;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.StringReader;
 import java.util.concurrent.TimeUnit;
@@ -17,6 +20,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
@@ -227,6 +231,50 @@ public class TriGParserCustomTest {
 		throws Exception
 	{
 		assertEquals(13, Rio.createParser(RDFFormat.TRIG).getSupportedSettings().size());
+	}
+
+	@Test
+	public void testParseTruePrefix()
+		throws Exception
+	{
+		Rio.parse(new StringReader("@prefix true: <http://example/c/> . {true:s true:p true:o .}"), "",
+				RDFFormat.TRIG);
+	}
+
+	@Test
+	public void testParseTrig_booleanLiteral()
+		throws Exception
+	{
+		String trig = "{\n" + "  <http://www.ex.com/s> <http://www.ex.com/b> true.\n" + "}";
+		Model m = Rio.parse(new StringReader(trig), "http://ex/", RDFFormat.TRIG);
+		assertEquals(1, m.size());
+	}
+
+	@Test
+	public void testParseTrig_booleanLiteral_space()
+		throws Exception
+	{
+		String trig = "{\n" + "  <http://www.ex.com/s> <http://www.ex.com/b> true .\n" + "}";
+		Model m = Rio.parse(new StringReader(trig), "http://ex/", RDFFormat.TRIG);
+		assertEquals(1, m.size());
+	}
+
+	@Test
+	public void testParseTrig_intLiteral()
+		throws Exception
+	{
+		String trig = "{\n" + "  <http://www.ex.com/s> <http://www.ex.com/b> 1.\n" + "}";
+		Model m = Rio.parse(new StringReader(trig), "http://ex/", RDFFormat.TRIG);
+		assertEquals(1, Models.objectLiteral(m).get().intValue());
+	}
+
+	@Test
+	public void testParseTrig_doubleLiteral()
+		throws Exception
+	{
+		String trig = "{\n" + "  <http://www.ex.com/s> <http://www.ex.com/b> 1.2.\n" + "}";
+		Model m = Rio.parse(new StringReader(trig), "http://ex/", RDFFormat.TRIG);
+		assertEquals(1.2d, Models.objectLiteral(m).get().doubleValue(), 0.01);
 	}
 
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
@@ -15,13 +15,11 @@ import static org.junit.Assert.fail;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Collections;
-import java.util.function.Consumer;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.NamespaceImpl;
@@ -532,5 +530,49 @@ public class CustomTurtleParserTest {
 		assertEquals(1, model.size());
 		model.filter(null, RDF.TYPE, null).objects().forEach(obj -> assertEquals(
 				"http://purl.bioontology.org/ontology/UATC/%20SERINE%20%20", obj.stringValue()));
+	}
+
+	@Test
+	public void testParseTruePrefix()
+		throws Exception
+	{
+		Rio.parse(new StringReader("@prefix true: <http://example/c/> . true:s true:p true:o ."), "",
+				RDFFormat.TURTLE);
+	}
+
+	@Test
+	public void testParseBooleanLiteral()
+		throws Exception
+	{
+		String ttl = "<http://www.ex.com/s> <http://www.ex.com/b> true.\n";
+		Model m = Rio.parse(new StringReader(ttl), "http://ex/", RDFFormat.TURTLE);
+		assertEquals(1, m.size());
+	}
+
+	@Test
+	public void testParseBooleanLiteral_space()
+		throws Exception
+	{
+		String ttl = "<http://www.ex.com/s> <http://www.ex.com/b> true .\n";
+		Model m = Rio.parse(new StringReader(ttl), "http://ex/", RDFFormat.TURTLE);
+		assertEquals(1, m.size());
+	}
+
+	@Test
+	public void testParseIntLiteral()
+		throws Exception
+	{
+		String ttl = "<http://www.ex.com/s> <http://www.ex.com/b> 1.\n";
+		Model m = Rio.parse(new StringReader(ttl), "http://ex/", RDFFormat.TURTLE);
+		assertEquals(1, Models.objectLiteral(m).get().intValue());
+	}
+
+	@Test
+	public void testParseDoubleLiteral()
+		throws Exception
+	{
+		String ttl = "<http://www.ex.com/s> <http://www.ex.com/b> 1.2.\n";
+		Model m = Rio.parse(new StringReader(ttl), "http://ex/", RDFFormat.TURTLE);
+		assertEquals(1.2d, Models.objectLiteral(m).get().doubleValue(), 0.01);
 	}
 }

--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -976,20 +976,24 @@ public class TurtleParser extends AbstractRDFParser {
 				previousChar = c;
 				c = readCodePoint();
 			}
+			while (previousChar == '.' && prefix.length() > 0) {
+				// '.' is a legal prefix name char, but can not appear at the end
+				unread(c);
+				c = previousChar;
+				prefix.setLength(prefix.length() -1);
+				previousChar = prefix.codePointAt(prefix.codePointCount(0, prefix.length()) -1);
+			}
 
 			if (c != ':') {
 				// prefix may actually be a boolean value
 				String value = prefix.toString();
 
-				if (value.equals("true") || value.equals("false")) {
+				if (value.equals("true")) {
 					unread(c);
-					return createLiteral(value, null, XMLSchema.BOOLEAN, getLineNumber(), -1);
-				}
-			} else {
-				if (previousChar == '.') {
-					// '.' is a legal prefix name char, but can not appear at
-					// the end
-					reportFatalError("prefix can not end with with '.'");
+					return createLiteral("true", null, XMLSchema.BOOLEAN, getLineNumber(), -1);
+				} else if (value.equals("false")) {
+					unread(c);
+					return createLiteral("false", null, XMLSchema.BOOLEAN, getLineNumber(), -1);
 				}
 			}
 

--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -654,7 +654,7 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 		closeNestedResources(null);
 		if (!statementClosed) {
 			// The previous statement still needs to be closed:
-			writer.write(".");
+			writer.write(" .");
 			writer.writeEOL();
 			writer.decreaseIndentation();
 			writer.decreaseIndentation();


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #1006 .
* Remove trailing dots in prefix as they are not part of the prefix or boolean value

PR #889 stopped printing a space before period, which exposed this parsing issue