### PR TITLE
Fix #1009: Use Files#createDirectory, which gives more details about failures

### DIFF
--- a/util/src/main/java/org/eclipse/rdf4j/common/io/FileUtil.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/io/FileUtil.java
@@ -11,6 +11,7 @@ package org.eclipse.rdf4j.common.io;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.StringTokenizer;
 
@@ -348,12 +349,7 @@ public class FileUtil {
 			throw new IOException(
 					failureCount + " attempts to generate a non-existent directory name failed, giving up");
 		}
-		boolean created = resultDir.mkdir();
-		if (!created) {
-			throw new IOException("Failed to create tmp directory");
-		}
-
-		return resultDir;
+		return Files.createDirectory(resultDir.toPath()).toFile();
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #1009 .

* File#mkdir() is return false on ci.eclipse.org build server
* Use Files#createDirectory, which gives more detailed error messages
