### PR TITLE
Fix #994: Ignore other json keys in sparql-json

### DIFF
--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
@@ -268,4 +268,39 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		// -1 results
 		assertEquals(100, handler.getBindingSets().size());
 	}
+
+	@Test
+	public void testOtherKeys()
+		throws Exception
+	{
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/other-keys.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		// there must be two variables
+		assertEquals(2, handler.getBindingNames().size());
+
+		// first must be called "book", the second "title"
+		assertEquals("book", handler.getBindingNames().get(0));
+		assertEquals("title", handler.getBindingNames().get(1));
+
+		// should be 7 solutions alltogether
+		assertEquals(7, handler.getBindingSets().size());
+
+		// Results are ordered, so first should be book6
+		assertEquals("http://example.org/book/book6",
+				handler.getBindingSets().get(0).getValue("book").stringValue());
+
+		for (BindingSet b : handler.getBindingSets()) {
+			assertNotNull(b.getValue("book"));
+			assertNotNull(b.getValue("title"));
+			assertTrue(b.getValue("book") instanceof IRI);
+			assertTrue(b.getValue("title") instanceof Literal);
+		}
+
+	}
 }

--- a/compliance/queryresultio/src/test/resources/sparqljson/other-keys.srj
+++ b/compliance/queryresultio/src/test/resources/sparqljson/other-keys.srj
@@ -1,0 +1,37 @@
+{
+    "head": { "vars": [ "book" , "title" ]
+    } ,
+    "other": "Other keys, with different names, may be present in the JSON Results Object",
+    "results": {
+        "bindings": [
+            {
+                "book": { "type": "uri" , "value": "http://example.org/book/book6" } ,
+                "title": { "type": "literal" , "value": "Harry Potter and the Half-Blood Prince" }
+            } ,
+            {
+                "book": { "type": "uri" , "value": "http://example.org/book/book7" } ,
+                "title": { "type": "literal" , "value": "Harry Potter and the Deathly Hallows" }
+            } ,
+            {
+                "book": { "type": "uri" , "value": "http://example.org/book/book5" } ,
+                "title": { "type": "literal" , "value": "Harry Potter and the Order of the Phoenix" }
+            } ,
+            {
+                "book": { "type": "uri" , "value": "http://example.org/book/book4" } ,
+                "title": { "type": "literal" , "value": "Harry Potter and the Goblet of Fire" }
+            } ,
+            {
+                "book": { "type": "uri" , "value": "http://example.org/book/book2" } ,
+                "title": { "type": "literal" , "value": "Harry Potter and the Chamber of Secrets" }
+            } ,
+            {
+                "book": { "type": "uri" , "value": "http://example.org/book/book3" } ,
+                "title": { "type": "literal" , "value": "Harry Potter and the Prisoner Of Azkaban" }
+            } ,
+            {
+                "book": { "type": "uri" , "value": "http://example.org/book/book1" } ,
+                "title": { "type": "literal" , "value": "Harry Potter and the Philosopher's Stone" }
+            }
+        ]
+    }
+}

--- a/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
+++ b/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
@@ -332,8 +332,7 @@ public abstract class AbstractSPARQLJSONParser extends AbstractQueryResultParser
 				}
 			}
 			else {
-				throw new QueryResultParseException(
-						"Found unexpected object in top level " + baseStr + " field",
+				logger.debug("Found unexpected object in top level {} field #{}.{}", baseStr,
 						jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
 			}
 		}


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #994 .

* Spec allows other json keys in result
* Ignore unknown json keys when parsing
