### PR TITLE
Remove javadoc reference to sesame versions

### DIFF
--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -118,7 +118,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Verification is performed using registered DatatypeHandlers.
 	 * <p>
-	 * Defaults to false since Sesame 2.8.0, defaulted to true in 2.7.
+	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> VERIFY_DATATYPE_VALUES = new RioSettingImpl<Boolean>(
 			"org.eclipse.rdf4j.rio.verifydatatypevalues", "Verify recognised datatype values", Boolean.FALSE);


### PR DESCRIPTION
Removes a javadoc reference to sesame versions that isn't relevant now.

Signed-off-by: Peter Ansell <p_ansell@yahoo.com>