### PR TITLE
Use AssertJ

### DIFF
--- a/compliance/manager/pom.xml
+++ b/compliance/manager/pom.xml
@@ -43,5 +43,10 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/compliance/manager/src/test/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManagerTest.java
+++ b/compliance/manager/src/test/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManagerTest.java
@@ -7,12 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.manager;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -88,7 +86,7 @@ public class LocalRepositoryManagerTest {
 	/**
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.repository.manager.LocalRepositoryManager#getRepository(java.lang.String)} .
-	 * 
+	 *
 	 * @throws RepositoryException
 	 *         if a problem occurs accessing the repository
 	 * @throws RepositoryConfigException
@@ -181,7 +179,7 @@ public class LocalRepositoryManagerTest {
 
 	/**
 	 * Test method for {@link RepositoryManager.isSafeToRemove(String)}.
-	 * 
+	 *
 	 * @throws RepositoryException
 	 *         if a problem occurs during execution
 	 * @throws RepositoryConfigException
@@ -191,11 +189,11 @@ public class LocalRepositoryManagerTest {
 	public void testIsSafeToRemove()
 		throws RepositoryException, RepositoryConfigException
 	{
-		assertThat(manager.isSafeToRemove(PROXY_ID), is(equalTo(true)));
-		assertThat(manager.isSafeToRemove(TEST_REPO), is(equalTo(false)));
+		assertThat(manager.isSafeToRemove(PROXY_ID)).isTrue();
+		assertThat(manager.isSafeToRemove(TEST_REPO)).isFalse();
 		manager.removeRepository(PROXY_ID);
-		assertThat(manager.hasRepositoryConfig(PROXY_ID), is(equalTo(false)));
-		assertThat(manager.isSafeToRemove(TEST_REPO), is(equalTo(true)));
+		assertThat(manager.hasRepositoryConfig(PROXY_ID)).isFalse();;
+		assertThat(manager.isSafeToRemove(TEST_REPO)).isTrue();;
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -508,9 +508,9 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.hamcrest</groupId>
-				<artifactId>hamcrest-library</artifactId>
-				<version>1.3</version>
+				<groupId>org.assertj</groupId>
+				<artifactId>assertj-core</artifactId>
+				<version>3.9.1</version>
 				<scope>test</scope>
 			</dependency>
 

--- a/rio/api/pom.xml
+++ b/rio/api/pom.xml
@@ -29,8 +29,8 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioFileTypeDetectorTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioFileTypeDetectorTest.java
@@ -7,20 +7,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.isA;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.spi.FileTypeDetector;
 import java.util.ServiceLoader;
 
 import org.junit.Test;
 
-public class RioFileTypeDetectorTest {
+public class RioFileTypeDetectorTest
+{
     @Test
     public void correctClassIsRegisteredInServices()
     {
-        assertThat(ServiceLoader.load(FileTypeDetector.class),
-                hasItem(isA(RioFileTypeDetector.class)));
+        assertThat(ServiceLoader.load(FileTypeDetector.class)).anyMatch(ftd -> ftd instanceof RioFileTypeDetector);
     }
 }

--- a/rio/rdfxml/pom.xml
+++ b/rio/rdfxml/pom.xml
@@ -52,8 +52,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
+++ b/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
@@ -7,9 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfxml;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -30,8 +30,6 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +51,7 @@ public class RDFXMLParserTest {
 		throws Exception
 	{
 		platformLocale = Locale.getDefault();
-		
+
 		Locale.setDefault(Locale.ENGLISH);
 		vf = SimpleValueFactory.getInstance();
 		parser = new RDFXMLParser();
@@ -87,7 +85,7 @@ public class RDFXMLParserTest {
 
 		Collection<Statement> stmts = sc.getStatements();
 
-		assertThat(stmts, Matchers.<Statement> iterableWithSize(3));
+		assertThat(stmts).hasSize(3);
 
 		Iterator<Statement> iter = stmts.iterator();
 
@@ -102,7 +100,7 @@ public class RDFXMLParserTest {
 
 		String resourceUrl = res.stringValue();
 
-		assertThat(resourceUrl, CoreMatchers.startsWith("jar:" + zipfileUrl + "!"));
+		assertThat(resourceUrl).startsWith("jar:" + zipfileUrl + "!");
 
 		URL javaUrl = new URL(resourceUrl);
 		assertEquals("jar", javaUrl.getProtocol());

--- a/rio/trix/pom.xml
+++ b/rio/trix/pom.xml
@@ -50,10 +50,5 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/rio/trix/pom.xml
+++ b/rio/trix/pom.xml
@@ -51,8 +51,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/rio/turtle/pom.xml
+++ b/rio/turtle/pom.xml
@@ -52,8 +52,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TestTurtleParser.java
+++ b/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TestTurtleParser.java
@@ -7,13 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -35,8 +32,6 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -116,11 +111,11 @@ public class TestTurtleParser {
 
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
 		parser.parse(new StringReader(data), baseURI);
-		assertThat(errorCollector.getErrors(), hasSize(1));
-		assertThat(errorCollector.getFatalErrors(), empty());
-		assertThat(statementCollector.getStatements(), not(empty()));
-		assertThat("only syntactically legal triples should have been reported",
-				statementCollector.getStatements(), hasSize(1));
+		assertThat(errorCollector.getErrors()).hasSize(1);
+		assertThat(errorCollector.getFatalErrors()).isEmpty();
+		assertThat(statementCollector.getStatements()).isNotEmpty();
+		assertThat(statementCollector.getStatements()).hasSize(1)
+		        .overridingErrorMessage("only syntactically legal triples should have been reported");
 	}
 
 	@Test
@@ -132,10 +127,11 @@ public class TestTurtleParser {
 		parser.getParserConfig().set(BasicParserSettings.VERIFY_URI_SYNTAX, false);
 
 		parser.parse(new StringReader(data), baseURI);
-		assertThat(errorCollector.getErrors(), empty());
-		assertThat(errorCollector.getFatalErrors(), empty());
-		assertThat(statementCollector.getStatements(), not(empty()));
-		assertThat("all triples should have been reported", statementCollector.getStatements(), hasSize(3));
+		assertThat(errorCollector.getErrors()).isEmpty();
+		assertThat(errorCollector.getFatalErrors()).isEmpty();
+		assertThat(statementCollector.getStatements()).isNotEmpty();
+		assertThat(statementCollector.getStatements()).hasSize(3)
+		        .overridingErrorMessage("all triples should have been reported");
 	}
 
 	@Test
@@ -360,7 +356,7 @@ public class TestTurtleParser {
 
 		Collection<Statement> stmts = sc.getStatements();
 
-		assertThat(stmts, Matchers.<Statement> iterableWithSize(2));
+		assertThat(stmts).hasSize(2);
 
 		Iterator<Statement> iter = stmts.iterator();
 
@@ -373,7 +369,7 @@ public class TestTurtleParser {
 
 		String resourceUrl = res.stringValue();
 
-		assertThat(resourceUrl, CoreMatchers.startsWith("jar:" + zipfileUrl + "!"));
+		assertThat(resourceUrl).startsWith("jar:" + zipfileUrl + "!");
 
 		URL javaUrl = new URL(resourceUrl);
 		assertEquals("jar", javaUrl.getProtocol());


### PR DESCRIPTION
Java Hamcrest development has [largely stalled](https://github.com/hamcrest/JavaHamcrest/issues/131). Although it's only lightly used in rdf4j's tests, I believe it's worth tracking a currently maintained framework.

This PR switches all use of `org.hamcrest` over to [AssertJ](http://joel-costigliola.github.io/assertj/). As a side benefit, some assertions are substantially more concise.

(Partly addresses #1030.)