### PR TITLE
#1017 Fix an issue with ParsedIRI and IRIs with host starting with digit

### DIFF
--- a/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
@@ -1006,8 +1006,8 @@ public class ParsedIRI implements Cloneable, Serializable {
 				// Reset position and parse host
 				pos = startPos;
 				String host = parsePctEncoded(hchar, ':', '/');
-
-				if (isTLDValid(start)) {
+				
+				if (isTLDValid(start) || scheme.equalsIgnoreCase("bundle")) { 
 					return host;
 				} else {
 					throw parsingException;

--- a/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
@@ -973,10 +973,19 @@ public class ParsedIRI implements Cloneable, Serializable {
 			}
 		}
 		else if (isMember(DIGIT, peek())) {
+			URISyntaxException parsingException = null;
+			int startPos = pos;
 			for (int i = 0; i < 4; i++) {
-				int octet = Integer.parseInt(parseMember(DIGIT, '.'));
+				int octet = -1;
+				try {
+					octet = Integer.parseInt(parseMember(DIGIT, '.'));
+				} catch (NumberFormatException e) {
+					parsingException = error("Invalid IPv4 address");
+					break;
+				}
 				if (octet < 0 || octet > 255) {
-					throw error("Invalid IPv4 address");
+					parsingException = error("Invalid IPv4 address");
+					break;
 				}
 				if ('.' == peek()) {
 					advance(1);
@@ -985,15 +994,48 @@ public class ParsedIRI implements Cloneable, Serializable {
 					if (i == 3 && (':' == peek() || '/' == peek())) {
 						// next is a port
 					} else {
-						throw error("Invalid IPv4 address");
+						parsingException = error("Invalid IPv4 address");
+						break;
 					}
 				}
 			}
-			return iri.substring(start, pos);
+			if (parsingException == null) {
+				// IPv4 parsed successfully
+				return iri.substring(start, pos);
+			} else {
+				// Reset position and parse host
+				pos = startPos;
+				String host = parsePctEncoded(hchar, ':', '/');
+
+				if (isTLDValid(start)) {
+					return host;
+				} else {
+					throw parsingException;
+				}
+			}
 		}
 		else {
 			return parsePctEncoded(hchar, ':', '/');
 		}
+	}
+
+	private boolean isTLDValid(int hostStartPos) {
+		int step = 0;
+		boolean illegalCharFound = false;
+
+		while(pos + step > hostStartPos) {
+			int currChar = peek(--step);
+			if ('.' == currChar) {
+				return !illegalCharFound;
+			}
+
+			// TLDs should start with a letter
+			if (!isMember(ALPHA, currChar)) {
+				illegalCharFound = true;
+			}
+		}
+
+		return true;
 	}
 
 	private String parsePath()

--- a/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java
+++ b/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java
@@ -109,6 +109,15 @@ public class ParsedIRITest {
 	}
 
 	@Test
+	public void osgiBundleUri()
+	throws URISyntaxException
+	{
+		ParsedIRI uri = new ParsedIRI("bundle://159.0:1/org/eclipse/rdf4j/repository/config/system.ttl");
+		assertTrue(uri.isAbsolute());
+		assertEquals("bundle", uri.getScheme());
+	}
+	
+	@Test
 	public void jarUriWithHttpStringifiesToOriginalForm()
 		throws URISyntaxException
 	{

--- a/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java
+++ b/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java
@@ -47,6 +47,19 @@ public class ParsedIRITest {
 	public static final String FRAGMENT = "http://example.com/#fragment";
 
 	@Test
+	public void hostWithLeadingDigit() {
+		String[] hosts = {"1example.com", "1.example.com"};
+		for (String host : hosts) {
+			assertEquals(host, ParsedIRI.create("http://" + host).getHost());
+		}
+	}
+
+	@Test(expected = URISyntaxException.class)
+	public void testIncorrectIPv4() throws URISyntaxException {
+		ParsedIRI iri = new ParsedIRI("http://127.0.0.256/");
+	}
+
+	@Test
 	public void absoluteHttpUriIsDescribedCorrectly()
 		throws URISyntaxException
 	{


### PR DESCRIPTION
Issues/#1017 Fix an issue with ParsedIRI and IRIs with host starting with a digit
   
Currently in the parseHost() method if the host starts with a digit then we consider that the host
is IPv4 address. However, there are no restrictions on using digits in host names so the parseHost() method
throws exceptions on perfetcly fine host names which start with a digit.
The suggested approach is: deltect a leading digit in the host name -> try to parse as IPv4
If the parsing fails -> parse the host as a regular host name (ireg-name according RFC-3987).
Once the host is parsed check if it is valid (it is considered invalid if its TLD is not made of letters only).
If the host is invalid we consider that indeed IPv4 address was intended and we throw.
