### PR TITLE
GH-1029 marked org.eclipse.rdf4j.queryrender.builder classes deprecated

### DIFF
--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/BaseTupleExprRenderer.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/BaseTupleExprRenderer.java
@@ -30,7 +30,7 @@ import org.eclipse.rdf4j.query.parser.ParsedQuery;
 
 /**
  * <p>
- * Base class for rendering Sesame query API objects into strings.
+ * Base class for rendering RDF4J query API objects into strings.
  * </p>
  * 
  * @author Michael Grove

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/QueryRenderer.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/QueryRenderer.java
@@ -12,7 +12,7 @@ import org.eclipse.rdf4j.query.parser.ParsedQuery;
 
 /**
  * <p>
- * Interface for Sesame-based query renderers
+ * Interface for RDF4J-based query renderers
  * </p>
  * 
  * @author Michael Grove

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/RenderUtils.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/RenderUtils.java
@@ -35,7 +35,7 @@ public final class RenderUtils {
 	 * @param theValue
 	 *        the value to render
 	 * @return the value rendered in its query string representation
-	 * @deprecated since 2.8.0. Use {@link #toSPARQL(Value)} instead.
+	 * @deprecated Use {@link #toSPARQL(Value)} instead.
 	 */
 	@Deprecated
 	public static String getSPARQLQueryString(Value theValue) {
@@ -94,7 +94,7 @@ public final class RenderUtils {
 	 * @param theValue
 	 *        the value to render
 	 * @return the value rendered in its query string representation
-	 * @deprecated since 2.8.0. Use {{@link #toSeRQL(Value)} instead.
+	 * @deprecated Use {{@link #toSeRQL(Value)} instead.
 	 */
 	@Deprecated
 	public static String getSerqlQueryString(Value theValue) {

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/AbstractQueryBuilder.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/AbstractQueryBuilder.java
@@ -50,7 +50,9 @@ import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link SparqlBuilder} instead.
  */
+@Deprecated
 public class AbstractQueryBuilder<T extends ParsedQuery> implements QueryBuilder<T> {
 
 	// this is a bit of a hack making these protected so the select/construct

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/BasicGroup.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/BasicGroup.java
@@ -30,7 +30,9 @@ import org.eclipse.rdf4j.query.algebra.ValueExpr;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public class BasicGroup implements Group {
 
 	private boolean mIsOptional = false;

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/FilterBuilder.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/FilterBuilder.java
@@ -27,7 +27,9 @@ import org.eclipse.rdf4j.query.parser.ParsedQuery;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public class FilterBuilder<T extends ParsedQuery, E extends SupportsGroups> {
 
 	// TODO: merge this somehow with ValueExprFactory

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/GroupBuilder.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/GroupBuilder.java
@@ -25,7 +25,9 @@ import org.eclipse.rdf4j.query.parser.ParsedQuery;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public class GroupBuilder<T extends ParsedQuery, E extends SupportsGroups> {
 
 	private E mBuilder;
@@ -58,8 +60,7 @@ public class GroupBuilder<T extends ParsedQuery, E extends SupportsGroups> {
 			if (mBuilder != null) {
 				mBuilder.addGroup(mGroup);
 			}
-		}
-		else {
+		} else {
 			mParent = theParent;
 			theParent.addChild(mGroup);
 		}
@@ -81,8 +82,7 @@ public class GroupBuilder<T extends ParsedQuery, E extends SupportsGroups> {
 		if (mGroup.isEmpty()) {
 			if (mParent != null) {
 				mParent.removeChild(mGroup);
-			}
-			else {
+			} else {
 				mBuilder.removeGroup(mGroup);
 			}
 		}

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/QueryBuilder.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/QueryBuilder.java
@@ -18,7 +18,9 @@ import org.eclipse.rdf4j.query.parser.ParsedQuery;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public interface QueryBuilder<T extends ParsedQuery> extends SupportsGroups {
 
 	/**

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/QueryBuilderFactory.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/QueryBuilderFactory.java
@@ -22,7 +22,9 @@ import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public class QueryBuilderFactory {
 
 	/**

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/SupportsExpr.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/SupportsExpr.java
@@ -15,7 +15,9 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public interface SupportsExpr {
 
 	TupleExpr expr();

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/SupportsGroups.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/SupportsGroups.java
@@ -13,7 +13,9 @@ package org.eclipse.rdf4j.queryrender.builder;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public interface SupportsGroups<T> {
 
 	/**

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/UnionBuilder.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/UnionBuilder.java
@@ -17,7 +17,9 @@ import org.eclipse.rdf4j.query.parser.ParsedQuery;
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public class UnionBuilder<T extends ParsedQuery, E extends SupportsGroups>
 		implements SupportsGroups<UnionBuilder<T, E>>, Group
 {

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/ValueExprFactory.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/ValueExprFactory.java
@@ -22,11 +22,13 @@ import org.eclipse.rdf4j.query.algebra.Var;
 
 /**
  * <p>
- * Collection of utility methods for building the various ValueExpr objects in the Sesame query API.
+ * Collection of utility methods for building the various ValueExpr objects in the RDF4J query API.
  * </p>
  * 
  * @author Michael Grove
+ * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
  */
+@Deprecated
 public class ValueExprFactory {
 
 	public static LangMatches langMatches(String theVar, String theLang) {

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/package-info.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/builder/package-info.java
@@ -5,22 +5,10 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.queryrender.builder;
-
 /**
- * <p>
- * Abstract representation of a group of atoms in a query
- * </p>
+ * <b>This package is deprecated. Use the new rdf4j-sparqlbuilder module for query building instead.</b>
  * 
- * @author Michael Grove
- * @deprecated use {@link org.eclipse.rdf4j.sparqlbuilder} instead.
+ * @see org.eclipse.rdf4j.sparqlbuilder
  */
 @Deprecated
-public interface Group extends SupportsExpr {
-
-	public boolean isOptional();
-
-	public void addChild(Group theGroup);
-
-	public int size();
-}
+package org.eclipse.rdf4j.queryrender.builder;

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/package-info.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/package-info.java
@@ -6,8 +6,8 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
 /**
- * This package contains classes for working with OpenRDF query objects. It includes utilities for rendering,
- * building, modifying, and executing SPARQL & SeRQL queries. This functionality was contributed to OpenRDF
- * Sesame by Michael Grove of <a href="http://www.clarkparsia.com/">Clark & Parsia, LLC</a>.
+ * This package contains classes for working with RDF4J query objects. It includes utilities for rendering,
+ * building, modifying, and executing SPARQL & SeRQL queries. This functionality was contributed to RDF4J by 
+ * Michael Grove of <a href="http://www.clarkparsia.com/">Clark & Parsia, LLC</a>.
  */
 package org.eclipse.rdf4j.queryrender;

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/serql/SerqlTupleExprRenderer.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/serql/SerqlTupleExprRenderer.java
@@ -27,7 +27,7 @@ import org.eclipse.rdf4j.queryrender.BaseTupleExprRenderer;
 
 /**
  * <p>
- * Renders a Sesame {@link TupleExpr} into SeRQL Syntax
+ * Renders a {@link TupleExpr} into SeRQL Syntax
  * </p>
  * 
  * @author Michael Grove

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/serql/SerqlValueExprRenderer.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/serql/SerqlValueExprRenderer.java
@@ -47,7 +47,7 @@ import org.eclipse.rdf4j.queryrender.RenderUtils;
 
 /**
  * <p>
- * Renders a Sesame {@link ValueExpr} into SeRQL syntax.
+ * Renders a {@link ValueExpr} into SeRQL syntax.
  * </p>
  * 
  * @author Michael Grove

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/ContextCollector.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/ContextCollector.java
@@ -23,7 +23,7 @@ import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 
 /**
  * <p>
- * Visitor implementation for the sesame query algebra which walks the tree and figures out the context for
+ * Visitor implementation for the query algebra which walks the tree and figures out the context for
  * nodes in the algebra. The context for a node is set on the highest node in the tree. That is, everything
  * below it shares the same context.
  * </p>

--- a/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SparqlValueExprRenderer.java
+++ b/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SparqlValueExprRenderer.java
@@ -48,7 +48,7 @@ import org.eclipse.rdf4j.queryrender.RenderUtils;
 
 /**
  * <p>
- * Renders a Sesame {@link ValueExpr} into SPARQL syntax.
+ * Renders a {@link ValueExpr} into SPARQL syntax.
  * </p>
  * 
  * @author Michael Grove


### PR DESCRIPTION
This PR addresses GitHub issue: #1029 .

Briefly describe the changes proposed in this PR:

* all classes in `org.eclipse.rdf4j.queryrender.builder` package marked deprecated in favor of new `sparqlbuilder` module. 
