### PR TITLE
GH-461 servlet jsp version bump and project pom cleanup

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -212,7 +212,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>create-manifest</id>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-client</artifactId>

--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.eclipse.rdf4j</groupId>
-	<artifactId>rdf4j-client-parent</artifactId>
+	<artifactId>rdf4j-parent</artifactId>
 	<version>2.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 			<id>jeenbroekstra</id>
 			<name>Jeen Broekstra</name>
 			<email>jeen.broekstra@gmail.com</email>
-			<timezone>GMT+12</timezone>
+			<timezone>GMT+10</timezone>
 		</developer>
 		<developer>
 			<id>james_leigh</id>
@@ -210,7 +210,6 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<slf4j.version>1.7.10</slf4j.version>
 		<logback.version>1.1.2</logback.version>
-		<spring.version>4.2.1.RELEASE</spring.version>
 		<httpclient.version>4.5.5</httpclient.version>
 		<httpcore.version>4.4.9</httpcore.version>
 		<jackson.version>2.9.6</jackson.version>
@@ -350,9 +349,9 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>com.spatial4j</groupId>
+				<groupId>org.locationtech.spatial4j</groupId>
 				<artifactId>spatial4j</artifactId>
-				<version>0.4.1</version>
+				<version>0.6</version>
 			</dependency>
 
 			<!-- Java Enterprise Edition -->
@@ -417,41 +416,16 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
-
-			<!-- Spring framework -->
+			
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-aop</artifactId>
-				<version>${spring.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-				</exclusions>
+				<groupId>cglib</groupId>
+				<artifactId>cglib</artifactId>
+				<version>3.1</version>
 			</dependency>
 			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-webmvc</artifactId>
-				<version>${spring.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-test</artifactId>
-				<version>${spring.version}</version>
-				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-				</exclusions>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>18.0</version>
 			</dependency>
 
 			<!-- Logging: SLF4J and logback -->
@@ -669,7 +643,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.5</version>
+					<version>3.0.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -679,7 +653,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.19.1</version>
+					<version>2.21.0</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 						<argLine>-Xmx1024M</argLine>
@@ -812,6 +786,10 @@
 							<rules>
 								<enforceBytecodeVersion>
 									<maxJdkVersion>1.8</maxJdkVersion>
+									<excludes>
+										<exclude>org.apache.logging.log4j:log4j-api</exclude>
+										<exclude>org.elasticsearch:elasticsearch</exclude>
+									</excludes>
 								</enforceBytecodeVersion>
 							</rules>
 							<fail>true</fail>

--- a/pom.xml
+++ b/pom.xml
@@ -365,13 +365,13 @@
 			<dependency>
 				<groupId>javax.servlet.jsp</groupId>
 				<artifactId>jsp-api</artifactId>
-				<version>2.0</version>
+				<version>2.2</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>jstl</artifactId>
-				<version>1.1.2</version>
+				<version>1.2</version>
 			</dependency>
 			<dependency>
 				<groupId>taglibs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -826,11 +826,6 @@
 			<id>oss-sonatype-snapshots</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</repository>
-		<repository>
-			<id>maven-restlet</id>
-			<name>Public online Restlet repository</name>
-			<url>https://maven.restlet.com</url>
-		</repository>
 	</repositories>
 
 	<scm>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/queryalgebra-model/pom.xml
+++ b/queryalgebra-model/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/queryparser/pom.xml
+++ b/queryparser/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/queryrender/pom.xml
+++ b/queryrender/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/queryresultio/pom.xml
+++ b/queryresultio/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/rio/pom.xml
+++ b/rio/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/sparqlbuilder/pom.xml
+++ b/sparqlbuilder/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-client-parent</artifactId>
+		<artifactId>rdf4j-parent</artifactId>
 		<version>2.4-SNAPSHOT</version>
 	</parent>
 


### PR DESCRIPTION
This PR addresses GitHub issue: #461 .

Briefly describe the changes proposed in this PR:

* bump jsp and jstl jar versions
* `rdf4j-client-parent` renamed to `rdf4j-parent` 
* fixes to streamline reuse of `rdf4j-parent` as cross-repo project root pom. Saves us having to duplicate dependency versions, plugin configurations etc across repos.
