### PR TITLE
issues/#1041 Changes in NTriplesParser to allow liberlaized character…

### DIFF
--- a/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
+++ b/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.rio.nquads;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
@@ -76,7 +77,7 @@ public class NQuadsParser extends NTriplesParser {
 				rdfHandler.startRDF();
 			}
 
-			this.reader = reader;
+			this.reader = new PushbackReader(reader);
 			lineNo = 1;
 
 			reportLocation(lineNo, 1);

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.rio.ntriples;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
@@ -45,7 +46,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * Variables *
 	 *-----------*/
 
-	protected Reader reader;
+	protected PushbackReader reader;
 
 	protected long lineNo;
 
@@ -156,7 +157,8 @@ public class NTriplesParser extends AbstractRDFParser {
 				rdfHandler.startRDF();
 			}
 
-			this.reader = reader;
+			// Allow 1 characters to be pushed back
+			this.reader = new PushbackReader(reader);
 			lineNo = 1;
 
 			reportLocation(lineNo, 1);
@@ -470,20 +472,57 @@ public class NTriplesParser extends AbstractRDFParser {
 		if (c == -1) {
 			throwEOFException();
 		}
-		else if (!NTriplesUtil.isLetterOrNumber(c)) {
-			reportError("Expected a letter or number, found: " + new String(Character.toChars(c)),
+		else if (!NTriplesUtil.isLetterOrNumber(c) && !NTriplesUtil.isUnderscore(c)) {
+			reportError("Expected a letter or number or underscore, found: " + new String(Character.toChars(c)),
 					NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
 		}
 		name.append(Character.toChars(c));
 
 		// Read all following letter and numbers, they are part of the name
 		c = readCodePoint();
-		while (c != -1 && NTriplesUtil.isLetterOrNumber(c)) {
+		while (c != -1 && NTriplesUtil.isValidCharacterForBNodeLabel(c)) {
+			if(NTriplesUtil.isDot(c) && !NTriplesUtil.isValidCharacterForBNodeLabel(peekCodePoint())) {
+				break;
+			}
 			name.append(Character.toChars(c));
 			c = readCodePoint();
 		}
 
 		return c;
+	}
+
+	/**
+	 * Peeks at the next Unicode code point without advancing the reader, and
+	 * returns its value.
+	 *
+	 * @return the next Unicode code point, or -1 if the end of the stream has
+	 *         been reached.
+	 * @throws IOException
+	 */
+	protected int peekCodePoint() throws IOException {
+		int result = readCodePoint();
+		unread(result);
+		return result;
+	}
+
+	/**
+	 * Pushes back a single code point by copying it to the front of the buffer.
+	 * After this method returns, a call to {@link #readCodePoint()} will return
+	 * the same code point c again.
+	 *
+	 * @param codePoint
+	 *            a single Unicode code point.
+	 * @throws IOException
+	 */
+	protected void unread(int codePoint) throws IOException {
+		if (codePoint != -1) {
+			if (Character.isSupplementaryCodePoint(codePoint)) {
+				final char[] surrogatePair = Character.toChars(codePoint);
+				reader.unread(surrogatePair);
+			} else {
+				reader.unread(codePoint);
+			}
+		}
 	}
 
 	private int parseLiteral(int c, StringBuilder value, StringBuilder lang, StringBuilder datatype)

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtil.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtil.java
@@ -475,6 +475,36 @@ public class NTriplesUtil {
 	}
 
 	/**
+	 * Checks whether the supplied character is valid character as per N-Triples specification.
+	 * See <a href="https://www.w3.org/TR/n-triples/#BNodes">https://www.w3.org/TR/n-triples/#BNodes</a>.
+	 *
+	 */
+	public static boolean isValidCharacterForBNodeLabel(int c) {
+		return isLetterOrNumber(c) || isLiberalCharactersButNotDot(c) || isDot(c);
+	}
+
+	/**
+	 * Checks whether the supplied character is in list of liberal characters according to the N-Triples specification except Dot.
+	 */
+	public static boolean isLiberalCharactersButNotDot(int c) {
+		return isUnderscore(c) || c == 45 || c == 183 || (c >= 768 && c <= 879) || c == 8255 || c == 8256;
+	}
+
+	/**
+	 * Checks whether the supplied character is Underscore.
+	 */
+	public static boolean isUnderscore(int c) {
+		return c == 95;
+	}
+
+	/**
+	 * Checks whether the supplied character is Dot '.'.
+	 */
+	public static boolean isDot(int c) {
+		return c == 46;
+	}
+
+	/**
 	 * Escapes a Unicode string to an all-ASCII character sequence. Any special characters are escaped using
 	 * backslashes (<tt>"</tt> becomes <tt>\"</tt>, etc.), and non-ascii/non-printable characters are escaped
 	 * using Unicode escapes (<tt>&#x5C;uxxxx</tt> and <tt>&#x5C;Uxxxxxxxx</tt>).


### PR DESCRIPTION
…s in blank node label. As NQuadsParser extends from NTriplesParser and spec for bnode label is same for both this change also applies to NQuadsParser.

Signed-off-by: RavinderSinghMaan <ravinder.singh@pearson.com>


This PR addresses GitHub issue: #1041  .

Briefly describe the changes proposed in this PR:

* As per the spec for NTriples blank node label can contain characters other than letters or numbers.
* This change contains fix for same.
* This change is also applicable to NQuadParser as blank node label spec is same for both NQuads and Ntriples. 
