### PR TITLE
Fix #1051: non-standard keys with arrays in JSON SPARQL results

### DIFF
--- a/compliance/queryresultio/src/test/resources/sparqljson/other-keys.srj
+++ b/compliance/queryresultio/src/test/resources/sparqljson/other-keys.srj
@@ -2,6 +2,10 @@
     "head": { "vars": [ "book" , "title" ]
     } ,
     "other": "Other keys, with different names, may be present in the JSON Results Object",
+    "otherArray": [ "Other keys, with different names, ", "may be present in the JSON Results Object" ],
+    "otherObject": { "start": { "text" : "Other keys, " }, "middle": "with different names, ", "end": [ "may be present in", " the JSON Results Object" ] },
+    "otherEmptyArray": [],
+    "otherEmptyObject": {},
     "results": {
         "bindings": [
             {

--- a/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
+++ b/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
@@ -334,6 +334,30 @@ public abstract class AbstractSPARQLJSONParser extends AbstractQueryResultParser
 			else {
 				logger.debug("Found unexpected object in top level {} field #{}.{}", baseStr,
 						jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
+				// Consume the discovered unexpected object 
+				// (in particular, if it is either an array or a composite object).
+				jp.nextToken();
+
+				if (jp.currentToken() == JsonToken.START_ARRAY) {
+					while (!(jp.getParsingContext().getParent().inRoot()
+							&& (jp.currentToken() == JsonToken.END_ARRAY)))
+					{
+						if (jp.nextToken() == null) {
+							throw new QueryResultParseException(
+									"An array value of the unexpected " + baseStr + " field is not closed.");
+						}
+					}
+				}
+				else if (jp.currentToken() == JsonToken.START_OBJECT) {
+					while (!(jp.getParsingContext().getParent().inRoot()
+							&& (jp.currentToken() == JsonToken.END_OBJECT)))
+					{
+						if (jp.nextToken() == null) {
+							throw new QueryResultParseException(
+									"An object value of the unexpected " + baseStr + " field is not closed.");
+						}
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Andriy Nikolov <an@metaphacts.com>


This PR addresses GitHub issue: #1051 .

Briefly describe the changes proposed in this PR:

* Objects with non-standard keys in SPARQL JSON results get consumed.
* Extended the test file `other-keys.srj`
