### PR TITLE
GH-1047 commons-io 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.4</version>
+				<version>2.5</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>


### PR DESCRIPTION
This PR addresses GitHub issue: #1047 .

Briefly describe the changes proposed in this PR:

* solr compliance tests fail when using commons-io 2.4 
* possibly a last-minute regression due to change in maven dependency resolution (change of root pom setup)
* fix to bump to commons-io 2.5
