### PR TITLE
GH-1054 test + fix for unparsable IRI when syntax verify is off

### DIFF
--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -40,7 +40,8 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
- * Base class for {@link RDFParser}s offering common functionality for RDF parsers.
+ * Base class for {@link RDFParser}s offering common functionality for RDF
+ * parsers.
  * 
  * @author Arjohn Kampman
  */
@@ -63,7 +64,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 	private ParseErrorListener errListener;
 
 	/**
-	 * An optional ParseLocationListener to report parse progress in the form of line- and column numbers to.
+	 * An optional ParseLocationListener to report parse progress in the form of
+	 * line- and column numbers to.
 	 */
 	private ParseLocationListener locationListener;
 
@@ -78,8 +80,9 @@ public abstract class AbstractRDFParser implements RDFParser {
 	private ParsedIRI baseURI;
 
 	/**
-	 * Enables a consistent global mapping of blank node identifiers without using a map, but concatenating
-	 * this as a prefix for the blank node identifiers supplied by the parser.
+	 * Enables a consistent global mapping of blank node identifiers without using a
+	 * map, but concatenating this as a prefix for the blank node identifiers
+	 * supplied by the parser.
 	 */
 	private String nextBNodePrefix;
 
@@ -98,23 +101,24 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 *--------------*/
 
 	/**
-	 * Creates a new RDFParserBase that will use a {@link SimpleValueFactory} to create RDF model objects.
+	 * Creates a new RDFParserBase that will use a {@link SimpleValueFactory} to
+	 * create RDF model objects.
 	 */
 	public AbstractRDFParser() {
 		this(SimpleValueFactory.getInstance());
 	}
 
 	/**
-	 * Creates a new RDFParserBase that will use the supplied ValueFactory to create RDF model objects.
+	 * Creates a new RDFParserBase that will use the supplied ValueFactory to create
+	 * RDF model objects.
 	 * 
 	 * @param valueFactory
-	 *        A ValueFactory.
+	 *            A ValueFactory.
 	 */
 	public AbstractRDFParser(ValueFactory valueFactory) {
 		try {
 			md5 = MessageDigest.getInstance("MD5");
-		}
-		catch (NoSuchAlgorithmException e) {
+		} catch (NoSuchAlgorithmException e) {
 			throw new RuntimeException(e);
 		}
 
@@ -177,7 +181,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/*
-	 * Default implementation, specific parsers are encouraged to override this method as necessary.
+	 * Default implementation, specific parsers are encouraged to override this
+	 * method as necessary.
 	 */
 	@Override
 	public Collection<RioSetting<?>> getSupportedSettings() {
@@ -243,8 +248,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 		getParserConfig().set(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES, stopAtFirstError);
 		if (!stopAtFirstError) {
 			getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
-		}
-		else {
+		} else {
 			// TODO: Add a ParserConfig.removeNonFatalError function to avoid
 			// this
 			Set<RioSetting<?>> set = new HashSet<RioSetting<?>>(getParserConfig().getNonFatalErrors());
@@ -267,19 +271,16 @@ public abstract class AbstractRDFParser implements RDFParser {
 		if (datatypeHandling == DatatypeHandling.VERIFY) {
 			this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 			this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
-		}
-		else if (datatypeHandling == DatatypeHandling.NORMALIZE) {
+		} else if (datatypeHandling == DatatypeHandling.NORMALIZE) {
 			this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 			this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
 			this.parserConfig.set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, true);
-		}
-		else {
+		} else {
 			// Only ignore if they have not explicitly set any of the relevant
 			// settings before this point
 			if (!this.parserConfig.isSet(BasicParserSettings.NORMALIZE_DATATYPE_VALUES)
 					&& !this.parserConfig.isSet(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES)
-					&& !this.parserConfig.isSet(BasicParserSettings.NORMALIZE_DATATYPE_VALUES))
-			{
+					&& !this.parserConfig.isSet(BasicParserSettings.NORMALIZE_DATATYPE_VALUES)) {
 				this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, false);
 				this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, false);
 				this.parserConfig.set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, false);
@@ -298,7 +299,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Parses the supplied URI-string and sets it as the base URI for resolving relative URIs.
+	 * Parses the supplied URI-string and sets it as the base URI for resolving
+	 * relative URIs.
 	 */
 	protected void setBaseURI(String uriSpec) {
 		// Store base URI
@@ -322,14 +324,13 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Gets the namespace that is associated with the specified prefix or throws an {@link RDFParseException}.
+	 * Gets the namespace that is associated with the specified prefix or throws an
+	 * {@link RDFParseException}.
 	 * 
 	 * @throws RDFParseException
-	 *         if no namespace is associated with this prefix
+	 *             if no namespace is associated with this prefix
 	 */
-	protected String getNamespace(String prefix)
-		throws RDFParseException
-	{
+	protected String getNamespace(String prefix) throws RDFParseException {
 		if (namespaceTable.containsKey(prefix))
 			return namespaceTable.get(prefix);
 		String msg = "Namespace prefix '" + prefix + "' used but not defined";
@@ -343,8 +344,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Clears any information that has been collected while parsing. This method must be called by subclasses
-	 * when finishing the parse process.
+	 * Clears any information that has been collected while parsing. This method
+	 * must be called by subclasses when finishing the parse process.
 	 */
 	protected void clear() {
 		baseURI = null;
@@ -361,9 +362,10 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Clears the map that keeps track of blank nodes that have been parsed. Normally, this map is clear when
-	 * the document has been parsed completely, but subclasses can clear the map at other moments too, for
-	 * example when a bnode scope ends.
+	 * Clears the map that keeps track of blank nodes that have been parsed.
+	 * Normally, this map is clear when the document has been parsed completely, but
+	 * subclasses can clear the map at other moments too, for example when a bnode
+	 * scope ends.
 	 * 
 	 * @deprecated Map is no longer used, call {@link #clear()} instead.
 	 */
@@ -373,20 +375,24 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Resolves a URI-string against the base URI and creates a {@link IRI} object for it.
+	 * Resolves a URI-string against the base URI and creates a {@link IRI} object
+	 * for it.
 	 */
-	protected IRI resolveURI(String uriSpec)
-		throws RDFParseException
-	{
+	protected IRI resolveURI(String uriSpec) throws RDFParseException {
 		// Resolve relative URIs against base URI
 		ParsedIRI uri;
 		try {
 			uri = new ParsedIRI(uriSpec);
-		}
-		catch (URISyntaxException e) {
-			reportError("Invalid IRI '" + uriSpec,
-					BasicParserSettings.VERIFY_URI_SYNTAX);
-			uri = ParsedIRI.create(uriSpec);
+		} catch (URISyntaxException e) {
+			reportError("Invalid IRI '" + uriSpec, BasicParserSettings.VERIFY_URI_SYNTAX);
+			try {
+				uri = ParsedIRI.create(uriSpec);
+			} catch (IllegalArgumentException ex) {
+				if (getParserConfig().isNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX)) {
+					return null; 
+				}
+				return valueFactory.createIRI(uriSpec);
+			}
 		}
 
 		if (!uri.isAbsolute()) {
@@ -396,9 +402,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 
 			if (getParserConfig().get(BasicParserSettings.VERIFY_RELATIVE_URIS)) {
 				if (!uri.isAbsolute() && uriSpec.length() > 0 && !uriSpec.startsWith("#") && baseURI.isOpaque()) {
-					reportError("Relative URI '" + uriSpec
-							+ "' cannot be resolved using the opaque base URI '" + baseURI + "'",
-							BasicParserSettings.VERIFY_RELATIVE_URIS);
+					reportError("Relative URI '" + uriSpec + "' cannot be resolved using the opaque base URI '"
+							+ baseURI + "'", BasicParserSettings.VERIFY_RELATIVE_URIS);
 				}
 			}
 
@@ -411,22 +416,17 @@ public abstract class AbstractRDFParser implements RDFParser {
 	/**
 	 * Creates a {@link IRI} object for the specified URI-string.
 	 */
-	protected IRI createURI(String uri)
-		throws RDFParseException
-	{
+	protected IRI createURI(String uri) throws RDFParseException {
 		if (getParserConfig().get(BasicParserSettings.VERIFY_URI_SYNTAX)) {
 			try {
 				new ParsedIRI(uri);
-			}
-			catch (URISyntaxException e) {
-				reportError(e.getMessage(),
-						BasicParserSettings.VERIFY_URI_SYNTAX);
+			} catch (URISyntaxException e) {
+				reportError(e.getMessage(), BasicParserSettings.VERIFY_URI_SYNTAX);
 			}
 		}
 		try {
 			return valueFactory.createIRI(uri);
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
@@ -435,39 +435,33 @@ public abstract class AbstractRDFParser implements RDFParser {
 	/**
 	 * Creates a new {@link BNode} or Skolem {@link IRI} object.
 	 */
-	protected Resource createNode()
-		throws RDFParseException
-	{
+	protected Resource createNode() throws RDFParseException {
 		try {
 			String origin = parserConfig.get(BasicParserSettings.SKOLEMIZE_ORIGIN);
 			if (preserveBNodeIDs() || origin == null || origin.length() == 0) {
 				return valueFactory.createBNode();
-			}
-			else {
+			} else {
 				String nodeId = valueFactory.createBNode().getID();
 				String path = "/.well-known/genid/" + nextBNodePrefix + nodeId;
 				String iri = ParsedIRI.create(origin).resolve(path);
 				return valueFactory.createIRI(iri);
 			}
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
 	}
 
 	/**
-	 * Creates a {@link BNode} or Skolem {@link IRI} object for the specified identifier.
+	 * Creates a {@link BNode} or Skolem {@link IRI} object for the specified
+	 * identifier.
 	 */
-	protected Resource createNode(String nodeID)
-		throws RDFParseException
-	{
+	protected Resource createNode(String nodeID) throws RDFParseException {
 		// If we are preserving blank node ids then we do not prefix them to
 		// make them globally unique
 		if (preserveBNodeIDs()) {
 			return valueFactory.createBNode(nodeID);
-		}
-		else {
+		} else {
 			// Prefix the node ID with a unique UUID prefix to reduce
 			// cross-document clashes
 			// This is consistent as long as nextBNodePrefix is not modified
@@ -488,8 +482,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 			String origin = parserConfig.get(BasicParserSettings.SKOLEMIZE_ORIGIN);
 			if (origin == null || origin.length() == 0) {
 				return valueFactory.createBNode("genid-" + nextBNodePrefix + toAppend);
-			}
-			else {
+			} else {
 				String path = "/.well-known/genid/" + nextBNodePrefix + toAppend;
 				String iri = ParsedIRI.create(origin).resolve(path);
 				return valueFactory.createIRI(iri);
@@ -501,13 +494,10 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 * Creates a new {@link BNode} object.
 	 */
 	@Deprecated
-	protected BNode createBNode()
-		throws RDFParseException
-	{
+	protected BNode createBNode() throws RDFParseException {
 		try {
 			return valueFactory.createBNode();
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
@@ -517,15 +507,12 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 * Creates a {@link BNode} object for the specified identifier.
 	 */
 	@Deprecated
-	protected BNode createBNode(String nodeID)
-		throws RDFParseException
-	{
+	protected BNode createBNode(String nodeID) throws RDFParseException {
 		// If we are preserving blank node ids then we do not prefix them to
 		// make them globally unique
 		if (preserveBNodeIDs()) {
 			return valueFactory.createBNode(nodeID);
-		}
-		else {
+		} else {
 			// Prefix the node ID with a unique UUID prefix to reduce
 			// cross-document clashes
 			// This is consistent as long as nextBNodePrefix is not modified
@@ -551,37 +538,32 @@ public abstract class AbstractRDFParser implements RDFParser {
 	/**
 	 * Creates a {@link Literal} object with the supplied parameters.
 	 */
-	protected Literal createLiteral(String label, String lang, IRI datatype)
-		throws RDFParseException
-	{
-		return RDFParserHelper.createLiteral(label, lang, datatype, getParserConfig(),
-				getParseErrorListener(), valueFactory);
+	protected Literal createLiteral(String label, String lang, IRI datatype) throws RDFParseException {
+		return RDFParserHelper.createLiteral(label, lang, datatype, getParserConfig(), getParseErrorListener(),
+				valueFactory);
 	}
 
 	/**
-	 * Creates a {@link Literal} object with the supplied parameters, using the lineNo and columnNo to enhance
-	 * error messages or exceptions that may be generated during the creation of the literal.
+	 * Creates a {@link Literal} object with the supplied parameters, using the
+	 * lineNo and columnNo to enhance error messages or exceptions that may be
+	 * generated during the creation of the literal.
 	 * 
-	 * @see org.eclipse.rdf4j.rio.helpers.RDFParserHelper#createLiteral(String, String, IRI, ParserConfig,
-	 *      ParseErrorListener, ValueFactory, long, long)
+	 * @see org.eclipse.rdf4j.rio.helpers.RDFParserHelper#createLiteral(String,
+	 *      String, IRI, ParserConfig, ParseErrorListener, ValueFactory, long, long)
 	 */
 	protected Literal createLiteral(String label, String lang, IRI datatype, long lineNo, long columnNo)
-		throws RDFParseException
-	{
-		return RDFParserHelper.createLiteral(label, lang, datatype, getParserConfig(),
-				getParseErrorListener(), valueFactory, lineNo, columnNo);
+			throws RDFParseException {
+		return RDFParserHelper.createLiteral(label, lang, datatype, getParserConfig(), getParseErrorListener(),
+				valueFactory, lineNo, columnNo);
 	}
 
 	/**
 	 * Creates a new {@link Statement} object with the supplied components.
 	 */
-	protected Statement createStatement(Resource subj, IRI pred, Value obj)
-		throws RDFParseException
-	{
+	protected Statement createStatement(Resource subj, IRI pred, Value obj) throws RDFParseException {
 		try {
 			return valueFactory.createStatement(subj, pred, obj);
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
@@ -590,20 +572,18 @@ public abstract class AbstractRDFParser implements RDFParser {
 	/**
 	 * Creates a new {@link Statement} object with the supplied components.
 	 */
-	protected Statement createStatement(Resource subj, IRI pred, Value obj, Resource context)
-		throws RDFParseException
-	{
+	protected Statement createStatement(Resource subj, IRI pred, Value obj, Resource context) throws RDFParseException {
 		try {
 			return valueFactory.createStatement(subj, pred, obj, context);
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
 	}
 
 	/**
-	 * Reports the specified line- and column number to the registered {@link ParseLocationListener}, if any.
+	 * Reports the specified line- and column number to the registered
+	 * {@link ParseLocationListener}, if any.
 	 */
 	protected void reportLocation(long lineNo, long columnNo) {
 		if (locationListener != null) {
@@ -612,15 +592,17 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Reports a warning to the registered ParseErrorListener, if any. This method simply calls
-	 * {@link #reportWarning(String,long,long)} supplying <tt>-1</tt> for the line- and column number.
+	 * Reports a warning to the registered ParseErrorListener, if any. This method
+	 * simply calls {@link #reportWarning(String,long,long)} supplying <tt>-1</tt>
+	 * for the line- and column number.
 	 */
 	protected void reportWarning(String msg) {
 		reportWarning(msg, -1, -1);
 	}
 
 	/**
-	 * Reports a warning with associated line- and column number to the registered ParseErrorListener, if any.
+	 * Reports a warning with associated line- and column number to the registered
+	 * ParseErrorListener, if any.
 	 */
 	protected void reportWarning(String msg, long lineNo, long columnNo) {
 		if (errListener != null) {
@@ -629,169 +611,175 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
-	 * given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered
+	 * ParseErrorListener, if the given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting has been set to
-	 * <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting
+	 * has been set to <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param msg
-	 *        The message to use for {@link ParseErrorListener#error(String, long, long)} and for
-	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *            The message to use for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
-	 *        at at all. If this setting is true, then the error listener will receive the error, and if
-	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
+	 *            The boolean setting that will be checked to determine if this is
+	 *            an issue that we need to look at at all. If this setting is true,
+	 *            then the error listener will receive the error, and if
+	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
+	 *            exception will be thrown.
 	 * @throws RDFParseException
-	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
+	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
+	 *             the given setting.
 	 */
-	protected void reportError(String msg, RioSetting<Boolean> relevantSetting)
-		throws RDFParseException
-	{
+	protected void reportError(String msg, RioSetting<Boolean> relevantSetting) throws RDFParseException {
 		RDFParserHelper.reportError(msg, relevantSetting, getParserConfig(), getParseErrorListener());
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
-	 * given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered
+	 * ParseErrorListener, if the given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting has been set to
-	 * <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting
+	 * has been set to <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param msg
-	 *        The message to use for {@link ParseErrorListener#error(String, long, long)} and for
-	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *            The message to use for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param lineNo
-	 *        Optional line number, should default to setting this as -1 if not known. Used for
-	 *        {@link ParseErrorListener#error(String, long, long)} and for
-	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *            Optional line number, should default to setting this as -1 if not
+	 *            known. Used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param columnNo
-	 *        Optional column number, should default to setting this as -1 if not known. Used for
-	 *        {@link ParseErrorListener#error(String, long, long)} and for
-	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *            Optional column number, should default to setting this as -1 if
+	 *            not known. Used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
-	 *        at at all. If this setting is true, then the error listener will receive the error, and if
-	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
+	 *            The boolean setting that will be checked to determine if this is
+	 *            an issue that we need to look at at all. If this setting is true,
+	 *            then the error listener will receive the error, and if
+	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
+	 *            exception will be thrown.
 	 * @throws RDFParseException
-	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
+	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
+	 *             the given setting.
 	 */
 	protected void reportError(String msg, long lineNo, long columnNo, RioSetting<Boolean> relevantSetting)
-		throws RDFParseException
-	{
-		RDFParserHelper.reportError(msg, lineNo, columnNo, relevantSetting, getParserConfig(),
-				getParseErrorListener());
+			throws RDFParseException {
+		RDFParserHelper.reportError(msg, lineNo, columnNo, relevantSetting, getParserConfig(), getParseErrorListener());
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
-	 * given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered
+	 * ParseErrorListener, if the given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting has been set to
-	 * <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting
+	 * has been set to <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param e
-	 *        The exception whose message will be used for
-	 *        {@link ParseErrorListener#error(String, long, long)} and for
-	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *            The exception whose message will be used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
-	 *        at at all. If this setting is true, then the error listener will receive the error, and if
-	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
+	 *            The boolean setting that will be checked to determine if this is
+	 *            an issue that we need to look at at all. If this setting is true,
+	 *            then the error listener will receive the error, and if
+	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
+	 *            exception will be thrown.
 	 * @throws RDFParseException
-	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
+	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
+	 *             the given setting.
 	 */
-	protected void reportError(Exception e, RioSetting<Boolean> relevantSetting)
-		throws RDFParseException
-	{
+	protected void reportError(Exception e, RioSetting<Boolean> relevantSetting) throws RDFParseException {
 		RDFParserHelper.reportError(e, -1, -1, relevantSetting, getParserConfig(), getParseErrorListener());
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
-	 * given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered
+	 * ParseErrorListener, if the given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting has been set to
-	 * <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting
+	 * has been set to <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param e
-	 *        The exception whose message will be used for
-	 *        {@link ParseErrorListener#error(String, long, long)} and for
-	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *            The exception whose message will be used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param lineNo
-	 *        Optional line number, should default to setting this as -1 if not known. Used for
-	 *        {@link ParseErrorListener#error(String, long, long)} and for
-	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *            Optional line number, should default to setting this as -1 if not
+	 *            known. Used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param columnNo
-	 *        Optional column number, should default to setting this as -1 if not known. Used for
-	 *        {@link ParseErrorListener#error(String, long, long)} and for
-	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *            Optional column number, should default to setting this as -1 if
+	 *            not known. Used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
-	 *        at at all. If this setting is true, then the error listener will receive the error, and if
-	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
+	 *            The boolean setting that will be checked to determine if this is
+	 *            an issue that we need to look at at all. If this setting is true,
+	 *            then the error listener will receive the error, and if
+	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
+	 *            exception will be thrown.
 	 * @throws RDFParseException
-	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
+	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
+	 *             the given setting.
 	 */
 	protected void reportError(Exception e, long lineNo, long columnNo, RioSetting<Boolean> relevantSetting)
-		throws RDFParseException
-	{
-		RDFParserHelper.reportError(e, lineNo, columnNo, relevantSetting, getParserConfig(),
-				getParseErrorListener());
+			throws RDFParseException {
+		RDFParserHelper.reportError(e, lineNo, columnNo, relevantSetting, getParserConfig(), getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error to the registered ParseErrorListener, if any, and throws a
-	 * <tt>ParseException</tt> afterwards. This method simply calls
-	 * {@link #reportFatalError(String,long,long)} supplying <tt>-1</tt> for the line- and column number.
+	 * Reports a fatal error to the registered ParseErrorListener, if any, and
+	 * throws a <tt>ParseException</tt> afterwards. This method simply calls
+	 * {@link #reportFatalError(String,long,long)} supplying <tt>-1</tt> for the
+	 * line- and column number.
 	 */
-	protected void reportFatalError(String msg)
-		throws RDFParseException
-	{
+	protected void reportFatalError(String msg) throws RDFParseException {
 		RDFParserHelper.reportFatalError(msg, getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error with associated line- and column number to the registered ParseErrorListener, if
-	 * any, and throws a <tt>ParseException</tt> afterwards.
+	 * Reports a fatal error with associated line- and column number to the
+	 * registered ParseErrorListener, if any, and throws a <tt>ParseException</tt>
+	 * afterwards.
 	 */
-	protected void reportFatalError(String msg, long lineNo, long columnNo)
-		throws RDFParseException
-	{
+	protected void reportFatalError(String msg, long lineNo, long columnNo) throws RDFParseException {
 		RDFParserHelper.reportFatalError(msg, lineNo, columnNo, getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error to the registered ParseErrorListener, if any, and throws a
-	 * <tt>ParseException</tt> afterwards. An exception is made for the case where the supplied exception is a
-	 * {@link RDFParseException}; in that case the supplied exception is not wrapped in another ParseException
-	 * and the error message is not reported to the ParseErrorListener, assuming that it has already been
-	 * reported when the original ParseException was thrown.
+	 * Reports a fatal error to the registered ParseErrorListener, if any, and
+	 * throws a <tt>ParseException</tt> afterwards. An exception is made for the
+	 * case where the supplied exception is a {@link RDFParseException}; in that
+	 * case the supplied exception is not wrapped in another ParseException and the
+	 * error message is not reported to the ParseErrorListener, assuming that it has
+	 * already been reported when the original ParseException was thrown.
 	 * <p>
-	 * This method simply calls {@link #reportFatalError(Exception,long,long)} supplying <tt>-1</tt> for the
-	 * line- and column number.
+	 * This method simply calls {@link #reportFatalError(Exception,long,long)}
+	 * supplying <tt>-1</tt> for the line- and column number.
 	 */
-	protected void reportFatalError(Exception e)
-		throws RDFParseException
-	{
+	protected void reportFatalError(Exception e) throws RDFParseException {
 		RDFParserHelper.reportFatalError(e, getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error with associated line- and column number to the registered ParseErrorListener, if
-	 * any, and throws a <tt>ParseException</tt> wrapped the supplied exception afterwards. An exception is
-	 * made for the case where the supplied exception is a {@link RDFParseException}; in that case the
-	 * supplied exception is not wrapped in another ParseException and the error message is not reported to
-	 * the ParseErrorListener, assuming that it has already been reported when the original ParseException was
-	 * thrown.
+	 * Reports a fatal error with associated line- and column number to the
+	 * registered ParseErrorListener, if any, and throws a <tt>ParseException</tt>
+	 * wrapped the supplied exception afterwards. An exception is made for the case
+	 * where the supplied exception is a {@link RDFParseException}; in that case the
+	 * supplied exception is not wrapped in another ParseException and the error
+	 * message is not reported to the ParseErrorListener, assuming that it has
+	 * already been reported when the original ParseException was thrown.
 	 */
-	protected void reportFatalError(Exception e, long lineNo, long columnNo)
-		throws RDFParseException
-	{
+	protected void reportFatalError(Exception e, long lineNo, long columnNo) throws RDFParseException {
 		RDFParserHelper.reportFatalError(e, lineNo, columnNo, getParseErrorListener());
 	}
 

--- a/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TestTurtleParser.java
+++ b/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TestTurtleParser.java
@@ -133,6 +133,53 @@ public class TestTurtleParser {
 		assertThat(statementCollector.getStatements()).hasSize(3)
 		        .overridingErrorMessage("all triples should have been reported");
 	}
+	
+	@Test
+	public void testUnparsableIRIFatal() throws Exception
+	{
+		// subject IRI is not processable by ParsedIRI
+		String data = " <http://www:example.org/> <urn:foo> <urn:bar> . ";
+
+		try {
+			parser.parse(new StringReader(data), baseURI);
+			fail("default config should result in fatal error / parse exception");
+		}
+		catch (RDFParseException e) {
+			// expected
+		}
+
+	}
+	
+	@Test
+	public void testUnparsableIRINonFatal() throws Exception
+	{
+		// subject IRI is not processable by ParsedIRI
+		String data = " <http://www:example.org/> <urn:foo> <urn:bar> . <urn:foo2> <urn:foo> <urn:bar> .";
+		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
+		parser.parse(new StringReader(data), baseURI);
+		assertThat(errorCollector.getErrors()).hasSize(1);
+		assertThat(errorCollector.getFatalErrors()).isEmpty();
+		assertThat(statementCollector.getStatements()).isNotEmpty();
+		assertThat(statementCollector.getStatements()).hasSize(1)
+		        .overridingErrorMessage("only syntactically legal triples should have been reported");
+
+	}
+
+	@Test
+	public void testUnparsableIRINoVerify() throws Exception
+	{
+		// subject IRI is not processable by ParsedIRI
+		String data = " <http://www:example.org/> <urn:foo> <urn:bar> . <urn:foo2> <urn:foo> <urn:bar> .";
+		parser.getParserConfig().set(BasicParserSettings.VERIFY_URI_SYNTAX, false);
+
+		parser.parse(new StringReader(data), baseURI);
+		assertThat(errorCollector.getErrors()).isEmpty();
+		assertThat(errorCollector.getFatalErrors()).isEmpty();
+		assertThat(statementCollector.getStatements()).isNotEmpty();
+		assertThat(statementCollector.getStatements()).hasSize(2)
+		        .overridingErrorMessage("all triples should have been reported");
+
+	}
 
 	@Test
 	public void testParseBNodes()


### PR DESCRIPTION
This PR addresses GitHub issue: #1054 .

Briefly describe the changes proposed in this PR:

* Rio parsers handle unparsable IRIs by passing them to the valuefactory as-is, unless VERIFY_URI_SYNTAX is enabled.
