### PR TITLE
Fix tests on windows

### DIFF
--- a/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
+++ b/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
@@ -20,6 +20,9 @@ import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -441,7 +444,11 @@ public class LocalRepositoryManager extends RepositoryManager {
 		if (updateSystem) {
 			super.addRepositoryConfig(config);
 		}
-		part.renameTo(configFile);
+		try {
+			Files.move(part.toPath(), configFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		} catch (IOException e) {
+			throw new RepositoryConfigException(e);
+		}
 	}
 
 	@Override

--- a/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
+++ b/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
@@ -287,7 +287,7 @@ public class JSONLDHierarchicalWriterTest {
 	}
 
 	private class ComparingOutputStream extends OutputStream {
-		int[] toIgnore = new int[]{' ', '\n', '\t'};
+		int[] toIgnore = new int[]{' ', '\n', '\t', '\r'};
 		int charInFile;
 		InputStream is;
 


### PR DESCRIPTION
This PR addresses GitHub issue: #1057 .

Briefly describe the changes proposed in this PR:
* Add `\r` to ignored characters in jsonld test, thus fixing those tests on Windows.
* Use `Files.move` with `REPLACE_EXISTING` to replace the local repository configuration. Failure of this operation cause exception to be thrown. This change might require a consideration as until now failure of this operation was silently ignored.