### PR TITLE
Fix GH-1066 host ip address with no following port or path is still valid

### DIFF
--- a/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
@@ -871,7 +871,7 @@ public class ParsedIRI implements Cloneable, Serializable {
 				path = parsePath();
 			}
 			else {
-				error("absolute or empty path expected");
+				throw error("absolute or empty path expected");
 			}
 		}
 		else if ('/' == peek || '?' == peek || '#' == peek || EOF == peek) {

--- a/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
@@ -450,7 +450,7 @@ public class ParsedIRI implements Cloneable, Serializable {
 	 * @return {@code true} if, and only if, this IRI is absolute and its path does not start with a slash
 	 */
 	public boolean isOpaque() {
-		return scheme != null && !path.startsWith("/");
+		return scheme != null && !path.isEmpty() && !path.startsWith("/");
 	}
 
 	/**
@@ -991,8 +991,8 @@ public class ParsedIRI implements Cloneable, Serializable {
 					advance(1);
 				}
 				else {
-					if (i == 3 && (':' == peek() || '/' == peek())) {
-						// next is a port
+					if (i == 3 && (EOF == peek() || ':' == peek() || '/' == peek())) {
+						// next is end of IRI, a port, or a path
 					} else {
 						parsingException = error("Invalid IPv4 address");
 						break;
@@ -1136,8 +1136,11 @@ public class ParsedIRI implements Cloneable, Serializable {
 	}
 
 	private URISyntaxException error(String reason) {
-		int cp = iri.codePointAt(pos);
-		return new URISyntaxException(iri, reason + " U+" + Integer.toHexString(cp).toUpperCase(), pos);
+		if (pos > -1 && pos < iri.length()) {
+			int cp = iri.codePointAt(pos);
+			reason = reason + " U+" + Integer.toHexString(cp).toUpperCase();
+		}
+		return new URISyntaxException(iri, reason, pos);
 	}
 
 	private void appendAscii(StringBuilder sb, String input) {

--- a/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java.orig
+++ b/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java.orig
@@ -79,6 +79,9 @@ public class ParsedIRITest {
 	}
 	
 	@Test
+<<<<<<< Updated upstream
+	public void absoluteIpAddrWithPortDescribedCorrectly() throws URISyntaxException {
+=======
 	public void absoluteIpAddrNoPath()
 		throws URISyntaxException
 	{
@@ -90,9 +93,10 @@ public class ParsedIRITest {
 	}
 
 	@Test
-    public void absoluteIpAddrWithPortDescribedCorrectly() 
-        throws URISyntaxException 
-    {
+	public void absoluteIpAddrWithPortDescribedCorrectly()
+		throws URISyntaxException
+	{
+>>>>>>> Stashed changes
 		ParsedIRI uri = new ParsedIRI("http://127.0.0.1:3333/path");
 		assertTrue(uri.isAbsolute());
 		assertEquals(uri.getHost(), "127.0.0.1");


### PR DESCRIPTION
This PR addresses GitHub issue: #1066  .

Briefly describe the changes proposed in this PR:

* IRI with ip address followed by no path or port are still valid 
* fix in error reporting to avoid index out of bounds exception

