### PR TITLE
GH-1069 fix in handling of (fatal) errors when FAIL option is not set

### DIFF
--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -195,7 +195,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * Reads characters from reader until it finds a character that is not a space or tab, and returns this
 	 * last character code point. In case the end of the character stream has been reached, -1 is returned.
 	 */
-	protected int skipWhitespace(int c) throws IOException {
+	protected int skipWhitespace(int c)
+		throws IOException
+	{
 		while (c == ' ' || c == '\t') {
 			c = readCodePoint();
 		}
@@ -206,7 +208,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	/**
 	 * Verifies that there is only whitespace or comments until the end of the line.
 	 */
-	protected int assertLineTerminates(int c) throws IOException, RDFParseException {
+	protected int assertLineTerminates(int c)
+		throws IOException, RDFParseException
+	{
 		c = readCodePoint();
 
 		c = skipWhitespace(c);
@@ -226,7 +230,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	/**
 	 * Reads characters from reader until the first EOL has been read. The EOL character or -1 is returned.
 	 */
-	protected int skipToEndOfLine(int c) throws IOException {
+	protected int skipToEndOfLine(int c)
+		throws IOException
+	{
 		while (c != -1 && c != '\r' && c != '\n') {
 			c = readCodePoint();
 		}
@@ -238,7 +244,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * Reads characters from reader until the first EOL has been read. The first character after the EOL is
 	 * returned. In case the end of the character stream has been reached, -1 is returned.
 	 */
-	protected int skipLine(int c) throws IOException {
+	protected int skipLine(int c)
+		throws IOException
+	{
 		while (c != -1 && c != '\r' && c != '\n') {
 			c = readCodePoint();
 		}
@@ -268,7 +276,9 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	private int parseTriple(int c) throws IOException, RDFParseException, RDFHandlerException {
+	private int parseTriple(int c)
+		throws IOException, RDFParseException, RDFHandlerException
+	{
 		boolean ignoredAnError = false;
 		try {
 			c = parseSubject(c);
@@ -322,7 +332,9 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parseSubject(int c) throws IOException, RDFParseException {
+	protected int parseSubject(int c)
+		throws IOException, RDFParseException
+	{
 		StringBuilder sb = new StringBuilder(100);
 
 		// subject is either an uriref (<foo://bar>) or a nodeID (_:node1)
@@ -347,7 +359,9 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parsePredicate(int c) throws IOException, RDFParseException {
+	protected int parsePredicate(int c)
+		throws IOException, RDFParseException
+	{
 		StringBuilder sb = new StringBuilder(100);
 
 		// predicate must be an uriref (<foo://bar>)
@@ -367,7 +381,9 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parseObject(int c) throws IOException, RDFParseException {
+	protected int parseObject(int c)
+		throws IOException, RDFParseException
+	{
 		StringBuilder sb = getBuffer();
 
 		// object is either an uriref (<foo://bar>), a nodeID (_:node1) or a
@@ -400,7 +416,9 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parseUriRef(int c, StringBuilder uriRef) throws IOException, RDFParseException {
+	protected int parseUriRef(int c, StringBuilder uriRef)
+		throws IOException, RDFParseException
+	{
 		if (c != '<') {
 			reportError("Supplied char should be a '<', is: " + new String(Character.toChars(c)),
 					NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
@@ -439,7 +457,9 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parseNodeID(int c, StringBuilder name) throws IOException, RDFParseException {
+	protected int parseNodeID(int c, StringBuilder name)
+		throws IOException, RDFParseException
+	{
 		if (c != '_') {
 			reportError("Supplied char should be a '_', is: " + new String(Character.toChars(c)),
 					NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
@@ -484,7 +504,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
 	 * @throws IOException
 	 */
-	protected int peekCodePoint() throws IOException {
+	protected int peekCodePoint()
+		throws IOException
+	{
 		int result = readCodePoint();
 		unread(result);
 		return result;
@@ -498,7 +520,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	 *        a single Unicode code point.
 	 * @throws IOException
 	 */
-	protected void unread(int codePoint) throws IOException {
+	protected void unread(int codePoint)
+		throws IOException
+	{
 		if (codePoint != -1) {
 			if (Character.isSupplementaryCodePoint(codePoint)) {
 				final char[] surrogatePair = Character.toChars(codePoint);
@@ -586,7 +610,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	}
 
 	@Override
-	protected IRI createURI(String uri) throws RDFParseException {
+	protected IRI createURI(String uri)
+		throws RDFParseException
+	{
 		try {
 			uri = NTriplesUtil.unescapeString(uri);
 		}
@@ -603,7 +629,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
 	 * @throws IOException
 	 */
-	protected int readCodePoint() throws IOException {
+	protected int readCodePoint()
+		throws IOException
+	{
 		int next = reader.read();
 		if (Character.isHighSurrogate((char)next)) {
 			next = Character.toCodePoint((char)next, (char)reader.read());
@@ -611,7 +639,9 @@ public class NTriplesParser extends AbstractRDFParser {
 		return next;
 	}
 
-	protected Literal createLiteral(String label, String lang, String datatype) throws RDFParseException {
+	protected Literal createLiteral(String label, String lang, String datatype)
+		throws RDFParseException
+	{
 		try {
 			label = NTriplesUtil.unescapeString(label);
 		}
@@ -648,11 +678,15 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * the error.
 	 */
 	@Override
-	protected void reportError(String msg, RioSetting<Boolean> setting) throws RDFParseException {
+	protected void reportError(String msg, RioSetting<Boolean> setting)
+		throws RDFParseException
+	{
 		reportError(msg, lineNo, -1, setting);
 	}
 
-	protected void reportError(Exception e, RioSetting<Boolean> setting) throws RDFParseException {
+	protected void reportError(Exception e, RioSetting<Boolean> setting)
+		throws RDFParseException
+	{
 		reportError(e, lineNo, -1, setting);
 	}
 
@@ -661,7 +695,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * error.
 	 */
 	@Override
-	protected void reportFatalError(String msg) throws RDFParseException {
+	protected void reportFatalError(String msg)
+		throws RDFParseException
+	{
 		reportFatalError(msg, lineNo, -1);
 	}
 
@@ -670,11 +706,15 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * error.
 	 */
 	@Override
-	protected void reportFatalError(Exception e) throws RDFParseException {
+	protected void reportFatalError(Exception e)
+		throws RDFParseException
+	{
 		reportFatalError(e, lineNo, -1);
 	}
 
-	protected void throwEOFException() throws RDFParseException {
+	protected void throwEOFException()
+		throws RDFParseException
+	{
 		throw new RDFParseException("Unexpected end of file");
 	}
 

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -107,9 +107,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 */
 	@Override
 	public synchronized void parse(InputStream in, String baseURI)
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
+		throws IOException, RDFParseException, RDFHandlerException
 	{
 		if (in == null) {
 			throw new IllegalArgumentException("Input stream can not be 'null'");
@@ -143,9 +141,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 */
 	@Override
 	public synchronized void parse(Reader reader, String baseURI)
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
+		throws IOException, RDFParseException, RDFHandlerException
 	{
 		clear();
 
@@ -199,9 +195,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * Reads characters from reader until it finds a character that is not a space or tab, and returns this
 	 * last character code point. In case the end of the character stream has been reached, -1 is returned.
 	 */
-	protected int skipWhitespace(int c)
-		throws IOException
-	{
+	protected int skipWhitespace(int c) throws IOException {
 		while (c == ' ' || c == '\t') {
 			c = readCodePoint();
 		}
@@ -212,10 +206,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	/**
 	 * Verifies that there is only whitespace or comments until the end of the line.
 	 */
-	protected int assertLineTerminates(int c)
-		throws IOException,
-		RDFParseException
-	{
+	protected int assertLineTerminates(int c) throws IOException, RDFParseException {
 		c = readCodePoint();
 
 		c = skipWhitespace(c);
@@ -235,9 +226,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	/**
 	 * Reads characters from reader until the first EOL has been read. The EOL character or -1 is returned.
 	 */
-	protected int skipToEndOfLine(int c)
-		throws IOException
-	{
+	protected int skipToEndOfLine(int c) throws IOException {
 		while (c != -1 && c != '\r' && c != '\n') {
 			c = readCodePoint();
 		}
@@ -249,9 +238,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * Reads characters from reader until the first EOL has been read. The first character after the EOL is
 	 * returned. In case the end of the character stream has been reached, -1 is returned.
 	 */
-	protected int skipLine(int c)
-		throws IOException
-	{
+	protected int skipLine(int c) throws IOException {
 		while (c != -1 && c != '\r' && c != '\n') {
 			c = readCodePoint();
 		}
@@ -281,11 +268,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	private int parseTriple(int c)
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	private int parseTriple(int c) throws IOException, RDFParseException, RDFHandlerException {
 		boolean ignoredAnError = false;
 		try {
 			c = parseSubject(c);
@@ -311,8 +294,10 @@ public class NTriplesParser extends AbstractRDFParser {
 			c = assertLineTerminates(c);
 		}
 		catch (RDFParseException rdfpe) {
-			if (!getParserConfig().get(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES) ||
-					getParserConfig().isNonFatalError(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES)) {
+			if (!getParserConfig().get(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES)
+					|| getParserConfig().isNonFatalError(
+							NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES))
+			{
 				reportError(rdfpe, NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
 				ignoredAnError = true;
 			}
@@ -337,10 +322,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parseSubject(int c)
-		throws IOException,
-		RDFParseException
-	{
+	protected int parseSubject(int c) throws IOException, RDFParseException {
 		StringBuilder sb = new StringBuilder(100);
 
 		// subject is either an uriref (<foo://bar>) or a nodeID (_:node1)
@@ -365,10 +347,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parsePredicate(int c)
-		throws IOException,
-		RDFParseException
-	{
+	protected int parsePredicate(int c) throws IOException, RDFParseException {
 		StringBuilder sb = new StringBuilder(100);
 
 		// predicate must be an uriref (<foo://bar>)
@@ -388,10 +367,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parseObject(int c)
-		throws IOException,
-		RDFParseException
-	{
+	protected int parseObject(int c) throws IOException, RDFParseException {
 		StringBuilder sb = getBuffer();
 
 		// object is either an uriref (<foo://bar>), a nodeID (_:node1) or a
@@ -424,10 +400,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parseUriRef(int c, StringBuilder uriRef)
-		throws IOException,
-		RDFParseException
-	{
+	protected int parseUriRef(int c, StringBuilder uriRef) throws IOException, RDFParseException {
 		if (c != '<') {
 			reportError("Supplied char should be a '<', is: " + new String(Character.toChars(c)),
 					NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
@@ -466,10 +439,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		return c;
 	}
 
-	protected int parseNodeID(int c, StringBuilder name)
-		throws IOException,
-		RDFParseException
-	{
+	protected int parseNodeID(int c, StringBuilder name) throws IOException, RDFParseException {
 		if (c != '_') {
 			reportError("Supplied char should be a '_', is: " + new String(Character.toChars(c)),
 					NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
@@ -514,9 +484,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
 	 * @throws IOException
 	 */
-	protected int peekCodePoint()
-		throws IOException
-	{
+	protected int peekCodePoint() throws IOException {
 		int result = readCodePoint();
 		unread(result);
 		return result;
@@ -530,9 +498,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 *        a single Unicode code point.
 	 * @throws IOException
 	 */
-	protected void unread(int codePoint)
-		throws IOException
-	{
+	protected void unread(int codePoint) throws IOException {
 		if (codePoint != -1) {
 			if (Character.isSupplementaryCodePoint(codePoint)) {
 				final char[] surrogatePair = Character.toChars(codePoint);
@@ -545,8 +511,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	}
 
 	private int parseLiteral(int c, StringBuilder value, StringBuilder lang, StringBuilder datatype)
-		throws IOException,
-		RDFParseException
+		throws IOException, RDFParseException
 	{
 		if (c != '"') {
 			reportError("Supplied char should be a '\"', is: " + c,
@@ -621,9 +586,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	}
 
 	@Override
-	protected IRI createURI(String uri)
-		throws RDFParseException
-	{
+	protected IRI createURI(String uri) throws RDFParseException {
 		try {
 			uri = NTriplesUtil.unescapeString(uri);
 		}
@@ -640,9 +603,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
 	 * @throws IOException
 	 */
-	protected int readCodePoint()
-		throws IOException
-	{
+	protected int readCodePoint() throws IOException {
 		int next = reader.read();
 		if (Character.isHighSurrogate((char)next)) {
 			next = Character.toCodePoint((char)next, (char)reader.read());
@@ -650,9 +611,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		return next;
 	}
 
-	protected Literal createLiteral(String label, String lang, String datatype)
-		throws RDFParseException
-	{
+	protected Literal createLiteral(String label, String lang, String datatype) throws RDFParseException {
 		try {
 			label = NTriplesUtil.unescapeString(label);
 		}
@@ -689,15 +648,11 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * the error.
 	 */
 	@Override
-	protected void reportError(String msg, RioSetting<Boolean> setting)
-		throws RDFParseException
-	{
+	protected void reportError(String msg, RioSetting<Boolean> setting) throws RDFParseException {
 		reportError(msg, lineNo, -1, setting);
 	}
 
-	protected void reportError(Exception e, RioSetting<Boolean> setting)
-		throws RDFParseException
-	{
+	protected void reportError(Exception e, RioSetting<Boolean> setting) throws RDFParseException {
 		reportError(e, lineNo, -1, setting);
 	}
 
@@ -706,9 +661,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * error.
 	 */
 	@Override
-	protected void reportFatalError(String msg)
-		throws RDFParseException
-	{
+	protected void reportFatalError(String msg) throws RDFParseException {
 		reportFatalError(msg, lineNo, -1);
 	}
 
@@ -717,15 +670,11 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * error.
 	 */
 	@Override
-	protected void reportFatalError(Exception e)
-		throws RDFParseException
-	{
+	protected void reportFatalError(Exception e) throws RDFParseException {
 		reportFatalError(e, lineNo, -1);
 	}
 
-	protected void throwEOFException()
-		throws RDFParseException
-	{
+	protected void throwEOFException() throws RDFParseException {
 		throw new RDFParseException("Unexpected end of file");
 	}
 


### PR DESCRIPTION
Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>


This PR addresses GitHub issue: #1069  .

Briefly describe the changes proposed in this PR:

* parsing of subcomponents of triple simply throws an exception when it encounters a problem
* `parseTriple` catches exception and handles it based on parser configuration

