### PR TITLE
Issues/#1065 literal emptylang

### DIFF
--- a/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
@@ -113,12 +113,16 @@ public class SimpleLiteral implements Literal {
 		this.label = label;
 	}
 
+	@Override
 	public String getLabel() {
 		return label;
 	}
 
 	protected void setLanguage(String language) {
 		Objects.requireNonNull(language);
+		if (language.isEmpty()) {
+			throw new IllegalArgumentException("Language tag cannot be empty");
+		}
 		this.language = language;
 		setDatatype(RDF.LANGSTRING);
 	}

--- a/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
@@ -78,7 +78,7 @@ public class SimpleLiteral implements Literal {
 	 * @param label
 	 *        The label for the literal, must not be <tt>null</tt>.
 	 * @param language
-	 *        The language tag for the literal, must not be <tt>null</tt>.
+	 *        The language tag for the literal, must not be <tt>null</tt> and not be empty.
 	 */
 	protected SimpleLiteral(String label, String language) {
 		setLabel(label);

--- a/model/src/test/java/org/eclipse/rdf4j/model/impl/SimpleLiteralTest.java
+++ b/model/src/test/java/org/eclipse/rdf4j/model/impl/SimpleLiteralTest.java
@@ -202,6 +202,21 @@ public class SimpleLiteralTest {
 
 	/**
 	 * Test method for
+	 * {@link org.eclipse.rdf4j.model.impl.SimpleLiteral#SimpleLiteral(java.lang.String, java.lang.String)} .
+	 */
+	@Test
+	public final void testStringStringEmptyEmpty()
+		throws Exception
+	{
+		String label = "";
+		String language = "";
+
+		thrown.expect(IllegalArgumentException.class);
+		new SimpleLiteral(label, language);
+	}
+
+	/**
+	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.impl.SimpleLiteral#SimpleLiteral(java.lang.String, org.eclipse.rdf4j.model.IRI)}
 	 * .
 	 */


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>

This PR addresses GitHub issue: #1065 .

Briefly describe the changes proposed in this PR:

* Throw an InvalidArgumentException when SimpleLiteral is created with an empty language tag 
* Added unit test

Another option would be to change the type to xsd:string when an empty language tag is provided, but that would probably be confusing