### PR TITLE
Remove obsolete spatial4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,11 +343,6 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
-			<dependency>
-				<groupId>org.locationtech.spatial4j</groupId>
-				<artifactId>spatial4j</artifactId>
-				<version>0.6</version>
-			</dependency>
 
 			<!-- Java Enterprise Edition -->
 			<dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: #1175  .

Briefly describe the changes proposed in this PR:

* Remove unused spatial4j 0.6 dependency
