### PR TITLE
issue #1162 : JSON parser configuration settings through to Jackson

### DIFF
--- a/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONParserCustomTest.java
+++ b/compliance/queryresultio/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONParserCustomTest.java
@@ -1,0 +1,417 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqljson;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
+import org.eclipse.rdf4j.query.resultio.QueryResultParser;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
+import org.eclipse.rdf4j.rio.helpers.JSONSettings;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/**
+ * Custom (non-manifest) tests for SPARQL/JSON parser.
+ * 
+ * @author Peter Ansell
+ */
+public class SPARQLJSONParserCustomTest {
+
+	/**
+	 * Backslash escaped "h" in "http"
+	 */
+	private static final String BACKSLASH_ESCAPED_TEST_STRING = "{\"head\": { \"vars\": [ \"test-binding\" ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\"value\": \"\\http://example.com/Obj1\", \"type\": \"uri\"}}]}}";
+
+	/**
+	 * Java/C++ style comments
+	 */
+	private static final String COMMENTS_TEST_STRING = "{/*This is a non-standard java/c++ style comment\\n*/\"head\": { \"vars\": [ \"test-binding\" ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\"value\": \"http://example.com/Obj1\", \"type\": \"uri\"}}]}}";
+
+	/**
+	 * Tests for NaN
+	 */
+	private static final String NON_NUMERIC_NUMBERS_TEST_STRING = "{\"head\": { \"vars\": [ \"test-binding\" ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\"value\": NaN, \"type\": \"literal\", \"datatype\": \"http://www.w3.org/2001/XMLSchema#double\"}}]}}";
+
+	/**
+	 * Tests for numeric leading zeroes
+	 */
+	private static final String NUMERIC_LEADING_ZEROES_TEST_STRING = "{\"head\": { \"vars\": [ \"test-binding\" ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\"value\": 000042, \"type\": \"literal\", \"datatype\": \"http://www.w3.org/2001/XMLSchema#integer\"}}]}}";
+
+	/**
+	 * Tests for single-quotes
+	 */
+	private static final String SINGLE_QUOTES_TEST_STRING = "{\"head\": { \"vars\": [ \"test-binding\" ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\'value\': \"42\", \"type\": \"literal\", \'datatype\': \"http://www.w3.org/2001/XMLSchema#integer\"}}]}}";
+
+	/**
+	 * Tests for unquoted control char
+	 */
+	private static final String UNQUOTED_CONTROL_CHARS_TEST_STRING = "{\"head\": { \"vars\": [ \"test-binding\" ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\"value\": \"42\u0009\", \"type\": \"literal\"}}]}}";
+
+	/**
+	 * Tests for unquoted field names
+	 */
+	private static final String UNQUOTED_FIELD_NAMES_TEST_STRING = "{\"head\": { \"vars\": [ \"test-binding\" ]  } , results: { \"bindings\": [{ \"test-binding\": {value: \"42\", \"type\": \"literal\", datatype: \"http://www.w3.org/2001/XMLSchema#integer\"}}]}}";
+
+	/**
+	 * YAML style comments
+	 */
+	private static final String YAML_COMMENTS_TEST_STRING = "{\n#This is a non-standard yaml style comment/*\n\"head\": { \"vars\": [ \"test-binding\" ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\"value\": \"http://example.com/Obj1\", \"type\": \"uri\"}}]}}";
+
+	/**
+	 * Trailing comma
+	 */
+	private static final String TRAILING_COMMA_TEST_STRING = "{\"head\": { \"vars\": [ \"test-binding\", ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\"value\": \"http://example.com/Obj1\", \"type\": \"uri\",}}]}}";
+
+	/**
+	 * Strict duplicate detection
+	 */
+	private static final String STRICT_DUPLICATE_DETECTION_TEST_STRING = "{\"head\": { \"vars\": [ \"test-binding\", ]  } , \"results\": { \"bindings\": [{ \"test-binding\": {\"value\": \"http://example.com/Obj1\", \"type\": \"uri\", \"type\": \"uri\"}}]}}";
+
+	private QueryResultParser parser;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private QueryResultCollector results;
+
+	private ParseErrorCollector errors;
+
+	private final String testBindingName = "test-binding";
+
+	private final IRI testBindingValueIRI = SimpleValueFactory.getInstance().createIRI("http://example.com/Obj1");
+
+	private final Literal testBindingValueNotANumber = SimpleValueFactory.getInstance().createLiteral("NaN",
+			XMLSchema.DOUBLE);
+
+	private final Literal testBindingValueLiteralNumber = SimpleValueFactory.getInstance().createLiteral("42",
+			XMLSchema.INTEGER);
+
+	private final Literal testBindingValueLiteralUnquotedControlChar = SimpleValueFactory.getInstance()
+			.createLiteral("42\u0009", XMLSchema.STRING);
+
+	@Before
+	public void setUp() throws Exception {
+		parser = QueryResultIO.createTupleParser(TupleQueryResultFormat.JSON);
+		errors = new ParseErrorCollector();
+		results = new QueryResultCollector();
+		parser.setParseErrorListener(errors);
+		parser.setQueryResultHandler(results);
+	}
+
+	private void verifyParseResults(String bindingName, Value nextObject) throws Exception {
+		assertEquals(0, errors.getWarnings().size());
+		assertEquals(0, errors.getErrors().size());
+		assertEquals(0, errors.getFatalErrors().size());
+
+		assertEquals(1, results.getBindingSets().size());
+		BindingSet bindingSet = results.getBindingSets().get(0);
+		assertTrue(bindingSet.hasBinding(bindingName));
+		assertEquals(nextObject, bindingSet.getValue(bindingName));
+	}
+
+	private InputStream stringToInputStream(String input) {
+		return new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	public void testSupportedSettings() throws Exception {
+		// 11 supported in AbstractSPARQLJSONParser + 0 from AbstractQueryResultParser
+		assertEquals(11, parser.getSupportedSettings().size());
+	}
+
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(BACKSLASH_ESCAPED_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
+		parser.parseQueryResult(stringToInputStream(BACKSLASH_ESCAPED_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueIRI);
+	}
+
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, false);
+		parser.parseQueryResult(stringToInputStream(BACKSLASH_ESCAPED_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowCommentsDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(COMMENTS_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowCommentsEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_COMMENTS, true);
+		parser.parseQueryResult(stringToInputStream(COMMENTS_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueIRI);
+	}
+
+	@Test
+	public void testAllowCommentsDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_COMMENTS, false);
+		parser.parseQueryResult(stringToInputStream(COMMENTS_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowNonNumericNumbersDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(NON_NUMERIC_NUMBERS_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowNonNumericNumbersEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, true);
+		parser.parseQueryResult(stringToInputStream(NON_NUMERIC_NUMBERS_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueNotANumber);
+	}
+
+	@Test
+	public void testAllowNonNumericNumbersDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, false);
+		parser.parseQueryResult(stringToInputStream(NON_NUMERIC_NUMBERS_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowNumericLeadingZeroesDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(NUMERIC_LEADING_ZEROES_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowNumericLeadingZeroesEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, true);
+		parser.parseQueryResult(stringToInputStream(NUMERIC_LEADING_ZEROES_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueLiteralNumber);
+	}
+
+	@Test
+	public void testAllowNumericLeadingZeroesDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, false);
+		parser.parseQueryResult(stringToInputStream(NUMERIC_LEADING_ZEROES_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowSingleQuotesDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(SINGLE_QUOTES_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowSingleQuotesEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, true);
+		parser.parseQueryResult(stringToInputStream(SINGLE_QUOTES_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueLiteralNumber);
+	}
+
+	@Test
+	public void testAllowSingleQuotesDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, false);
+		parser.parseQueryResult(stringToInputStream(SINGLE_QUOTES_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(UNQUOTED_CONTROL_CHARS_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, true);
+		parser.parseQueryResult(stringToInputStream(UNQUOTED_CONTROL_CHARS_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueLiteralUnquotedControlChar);
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, false);
+		parser.parseQueryResult(stringToInputStream(UNQUOTED_CONTROL_CHARS_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(UNQUOTED_FIELD_NAMES_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, true);
+		parser.parseQueryResult(stringToInputStream(UNQUOTED_FIELD_NAMES_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueLiteralNumber);
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, false);
+		parser.parseQueryResult(stringToInputStream(UNQUOTED_FIELD_NAMES_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowYamlCommentsDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(YAML_COMMENTS_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowYamlCommentsEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, true);
+		parser.parseQueryResult(stringToInputStream(YAML_COMMENTS_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueIRI);
+	}
+
+	@Test
+	public void testAllowYamlCommentsDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, false);
+		parser.parseQueryResult(stringToInputStream(YAML_COMMENTS_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowTrailingCommaDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.parseQueryResult(stringToInputStream(TRAILING_COMMA_TEST_STRING));
+	}
+
+	@Test
+	public void testAllowTrailingCommaEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, true);
+		parser.parseQueryResult(stringToInputStream(TRAILING_COMMA_TEST_STRING));
+		verifyParseResults(testBindingName, testBindingValueIRI);
+	}
+
+	@Test
+	public void testAllowTrailingCommaDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, false);
+		parser.parseQueryResult(stringToInputStream(TRAILING_COMMA_TEST_STRING));
+	}
+
+	@Test
+	public void testIncludeSourceLocationDefault() throws Exception {
+		final InputStream source = stringToInputStream(YAML_COMMENTS_TEST_STRING);
+		try {
+			parser.parseQueryResult(source);
+			fail("Expected to find an exception");
+		} catch (QueryResultParseException e) {
+			assertNotNull(e.getCause());
+			assertTrue(e.getCause() instanceof JsonProcessingException);
+			JsonProcessingException cause = (JsonProcessingException) e.getCause();
+			assertEquals(2, cause.getLocation().getLineNr());
+			assertEquals(2, cause.getLocation().getColumnNr());
+			assertNotNull(cause.getLocation().getSourceRef());
+			assertEquals(source, cause.getLocation().getSourceRef());
+		}
+	}
+
+	@Test
+	public void testIncludeSourceLocationEnabled() throws Exception {
+		final InputStream source = stringToInputStream(YAML_COMMENTS_TEST_STRING);
+		try {
+			parser.set(JSONSettings.INCLUDE_SOURCE_IN_LOCATION, true);
+			parser.parseQueryResult(source);
+			fail("Expected to find an exception");
+		} catch (QueryResultParseException e) {
+			assertNotNull(e.getCause());
+			assertTrue(e.getCause() instanceof JsonProcessingException);
+			JsonProcessingException cause = (JsonProcessingException) e.getCause();
+			assertEquals(2, cause.getLocation().getLineNr());
+			assertEquals(2, cause.getLocation().getColumnNr());
+			assertNotNull(cause.getLocation().getSourceRef());
+			assertEquals(source, cause.getLocation().getSourceRef());
+		}
+	}
+
+	@Test
+	public void testIncludeSourceLocationDisabled() throws Exception {
+		try {
+			parser.set(JSONSettings.INCLUDE_SOURCE_IN_LOCATION, false);
+			parser.parseQueryResult(stringToInputStream(YAML_COMMENTS_TEST_STRING));
+			fail("Expected to find an exception");
+		} catch (QueryResultParseException e) {
+			assertNotNull(e.getCause());
+			assertTrue(e.getCause() instanceof JsonProcessingException);
+			JsonProcessingException cause = (JsonProcessingException) e.getCause();
+			assertEquals(2, cause.getLocation().getLineNr());
+			assertEquals(2, cause.getLocation().getColumnNr());
+			assertNull(cause.getLocation().getSourceRef());
+		}
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionDefault() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
+		parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING));
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionEnabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, true);
+		parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING));
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionDisabled() throws Exception {
+		thrown.expect(QueryResultParseException.class);
+		thrown.expectMessage("Could not parse SPARQL/JSON");
+		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
+		parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING));
+	}
+}

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.jsonld;
+
+import static org.junit.Assert.*;
+
+import java.io.StringReader;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.JSONSettings;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Custom (non-manifest) tests for JSON-LD parser.
+ * 
+ * @author Peter Ansell
+ */
+public class JSONLDParserCustomTest {
+
+	/**
+	 * Backslash escaped "h" in "http"
+	 */
+	private static final String BACKSLASH_ESCAPED_TEST_STRING = "[{\"@id\": \"\\http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"}]}]";
+
+	private RDFParser parser;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Before
+	public void setUp() throws Exception {
+		parser = Rio.createParser(RDFFormat.JSONLD);
+	}
+
+	@Test
+	public void testSupportedSettings() throws Exception {
+		// 10 supported in JSONLDParser + 12 from AbstractRDFParser
+		assertEquals(22, parser.getSupportedSettings().size());
+	}
+
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterDefault() throws Exception {
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
+		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterDisabled() throws Exception {
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, false);
+		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+	}
+}

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -61,6 +61,11 @@ public class JSONLDParserCustomTest {
 	 */
 	private static final String NUMERIC_LEADING_ZEROES_TEST_STRING = "[{\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": 000042}]";
 
+	/**
+	 * Tests for single-quotes
+	 */
+	private static final String SINGLE_QUOTES_TEST_STRING = "[{\'@id\': \"http://example.com/Subj1\",\'http://example.com/prop1\': 42}]";
+
 	private RDFParser parser;
 
 	@Rule
@@ -81,7 +86,7 @@ public class JSONLDParserCustomTest {
 
 	private final Literal testObjectLiteralNumber = SimpleValueFactory.getInstance().createLiteral("42",
 			XMLSchema.INTEGER);
-	
+
 	@Before
 	public void setUp()
 		throws Exception
@@ -101,7 +106,8 @@ public class JSONLDParserCustomTest {
 		assertEquals(0, errors.getFatalErrors().size());
 
 		assertEquals(1, model.size());
-		assertTrue("model was not as expected: " + model.toString(), model.contains(nextSubject, nextPredicate, nextObject));
+		assertTrue("model was not as expected: " + model.toString(),
+				model.contains(nextSubject, nextPredicate, nextObject));
 	}
 
 	@Test
@@ -198,7 +204,6 @@ public class JSONLDParserCustomTest {
 		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
 	}
 
-
 	@Test
 	public void testAllowNumericLeadingZeroesDefault()
 		throws Exception
@@ -225,5 +230,33 @@ public class JSONLDParserCustomTest {
 		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, false);
 		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowSingleQuotesDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowSingleQuotesEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, true);
+		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralNumber);
+	}
+
+	@Test
+	public void testAllowSingleQuotesDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, false);
+		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
 	}
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -87,6 +87,11 @@ public class JSONLDParserCustomTest {
 	private static final String YAML_COMMENTS_TEST_STRING = "[\n{#This is a non-standard yaml style comment/*\n\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"}]}]";
 
 	/**
+	 * Trailing comma
+	 */
+	private static final String TRAILING_COMMA_TEST_STRING = "[{\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"},]}]";
+
+	/**
 	 * Strict duplicate detection
 	 */
 	private static final String STRICT_DUPLICATE_DETECTION_TEST_STRING = "[{\"@context\": {}, \"@context\": {}, \"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"}]}]";
@@ -142,8 +147,8 @@ public class JSONLDParserCustomTest {
 	public void testSupportedSettings()
 		throws Exception
 	{
-		// 10 supported in JSONLDParser + 12 from AbstractRDFParser
-		assertEquals(22, parser.getSupportedSettings().size());
+		// 11 supported in JSONLDParser + 12 from AbstractRDFParser
+		assertEquals(23, parser.getSupportedSettings().size());
 	}
 
 	@Test
@@ -370,6 +375,34 @@ public class JSONLDParserCustomTest {
 		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, false);
 		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowTrailingCommaDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowTrailingCommaEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, true);
+		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectIRI);
+	}
+
+	@Test
+	public void testAllowTrailingCommaDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, false);
+		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
 	}
 
 	@Test

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -8,22 +8,18 @@
 package org.eclipse.rdf4j.rio.jsonld;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.Collection;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
-import org.eclipse.rdf4j.rio.ParseErrorListener;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
@@ -36,7 +32,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -10,12 +10,23 @@ package org.eclipse.rdf4j.rio.jsonld;
 import static org.junit.Assert.*;
 
 import java.io.StringReader;
+import java.util.Collection;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.ParseErrorListener;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector;
 import org.eclipse.rdf4j.rio.helpers.JSONSettings;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,14 +44,42 @@ public class JSONLDParserCustomTest {
 	 */
 	private static final String BACKSLASH_ESCAPED_TEST_STRING = "[{\"@id\": \"\\http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"}]}]";
 
+	/**
+	 * Java/C++ style comments
+	 */
+	private static final String COMMENTS_TEST_STRING = "[{/*This is a non-standard java/c++ style comment\n*/\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"}]}]";
+	
 	private RDFParser parser;
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
+	private ParseErrorCollector errors;
+
+	private Model model;
+
+	private final Resource testSubject = SimpleValueFactory.getInstance().createIRI("http://example.com/Subj1");
+
+	private final IRI testPredicate = SimpleValueFactory.getInstance().createIRI("http://example.com/prop1");
+
+	private final Value testObject = SimpleValueFactory.getInstance().createIRI("http://example.com/Obj1");
+
 	@Before
 	public void setUp() throws Exception {
 		parser = Rio.createParser(RDFFormat.JSONLD);
+		errors = new ParseErrorCollector();
+		model = new LinkedHashModel();
+		parser.setParseErrorListener(errors);
+		parser.setRDFHandler(new ContextStatementCollector(model, SimpleValueFactory.getInstance()));
+	}
+	
+	private void verifyParseResults() throws Exception {
+		assertEquals(0, errors.getWarnings().size());
+		assertEquals(0, errors.getErrors().size());
+		assertEquals(0, errors.getFatalErrors().size());
+		
+		assertEquals(1, model.size());
+		assertTrue(model.contains(testSubject, testPredicate, testObject));
 	}
 
 	@Test
@@ -60,6 +99,7 @@ public class JSONLDParserCustomTest {
 	public void testAllowBackslashEscapingAnyCharacterEnabled() throws Exception {
 		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
 		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+		verifyParseResults();
 	}
 
 	@Test
@@ -68,5 +108,27 @@ public class JSONLDParserCustomTest {
 		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, false);
 		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowCommentsDefault() throws Exception {
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowCommentsEnabled() throws Exception {
+		parser.set(JSONSettings.ALLOW_COMMENTS, true);
+		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+		verifyParseResults();
+	}
+
+	@Test
+	public void testAllowCommentsDisabled() throws Exception {
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.ALLOW_COMMENTS, false);
+		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
 	}
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -66,6 +66,11 @@ public class JSONLDParserCustomTest {
 	 */
 	private static final String SINGLE_QUOTES_TEST_STRING = "[{\'@id\': \"http://example.com/Subj1\",\'http://example.com/prop1\': 42}]";
 
+	/**
+	 * Tests for unquoted control char
+	 */
+	private static final String UNQUOTED_CONTROL_CHARS_TEST_STRING = "[{\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": \"42\u0009\"}]";
+
 	private RDFParser parser;
 
 	@Rule
@@ -86,6 +91,9 @@ public class JSONLDParserCustomTest {
 
 	private final Literal testObjectLiteralNumber = SimpleValueFactory.getInstance().createLiteral("42",
 			XMLSchema.INTEGER);
+
+	private final Literal testObjectLiteralUnquotedControlChar = SimpleValueFactory.getInstance().createLiteral(
+			"42\u0009", XMLSchema.STRING);
 
 	@Before
 	public void setUp()
@@ -258,5 +266,33 @@ public class JSONLDParserCustomTest {
 		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, false);
 		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, true);
+		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralUnquotedControlChar);
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, false);
+		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
 	}
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -71,6 +71,11 @@ public class JSONLDParserCustomTest {
 	 */
 	private static final String UNQUOTED_CONTROL_CHARS_TEST_STRING = "[{\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": \"42\u0009\"}]";
 
+	/**
+	 * Tests for unquoted field names
+	 */
+	private static final String UNQUOTED_FIELD_NAMES_TEST_STRING = "[{@id: \"http://example.com/Subj1\",\"http://example.com/prop1\": 42}]";
+
 	private RDFParser parser;
 
 	@Rule
@@ -294,5 +299,33 @@ public class JSONLDParserCustomTest {
 		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, false);
 		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, true);
+		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralNumber);
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, false);
+		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
 	}
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -81,6 +81,11 @@ public class JSONLDParserCustomTest {
 	 */
 	private static final String YAML_COMMENTS_TEST_STRING = "[{#This is a non-standard yaml style comment/*\n\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"}]}]";
 
+	/**
+	 * Strict duplicate detection
+	 */
+	private static final String STRICT_DUPLICATE_DETECTION_TEST_STRING = "[{\"@context\": {}, \"@context\": {}, \"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"}]}]";
+
 	private RDFParser parser;
 
 	@Rule
@@ -360,6 +365,34 @@ public class JSONLDParserCustomTest {
 		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, false);
 		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionEnabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, true);
+		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionDisabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
+		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectIRI);
 	}
 
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -56,6 +56,11 @@ public class JSONLDParserCustomTest {
 	 */
 	private static final String NON_NUMERIC_NUMBERS_TEST_STRING = "[{\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": NaN}]";
 
+	/**
+	 * Tests for numeric leading zeroes
+	 */
+	private static final String NUMERIC_LEADING_ZEROES_TEST_STRING = "[{\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": 000042}]";
+
 	private RDFParser parser;
 
 	@Rule
@@ -74,6 +79,9 @@ public class JSONLDParserCustomTest {
 	private final Literal testObjectLiteralNotANumber = SimpleValueFactory.getInstance().createLiteral("NaN",
 			XMLSchema.DOUBLE);
 
+	private final Literal testObjectLiteralNumber = SimpleValueFactory.getInstance().createLiteral("42",
+			XMLSchema.INTEGER);
+	
 	@Before
 	public void setUp()
 		throws Exception
@@ -93,7 +101,7 @@ public class JSONLDParserCustomTest {
 		assertEquals(0, errors.getFatalErrors().size());
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(nextSubject, nextPredicate, nextObject));
+		assertTrue("model was not as expected: " + model.toString(), model.contains(nextSubject, nextPredicate, nextObject));
 	}
 
 	@Test
@@ -188,5 +196,34 @@ public class JSONLDParserCustomTest {
 		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, false);
 		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
+	}
+
+
+	@Test
+	public void testAllowNumericLeadingZeroesDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowNumericLeadingZeroesEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, true);
+		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralNumber);
+	}
+
+	@Test
+	public void testAllowNumericLeadingZeroesDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, false);
+		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
 	}
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -76,6 +76,11 @@ public class JSONLDParserCustomTest {
 	 */
 	private static final String UNQUOTED_FIELD_NAMES_TEST_STRING = "[{@id: \"http://example.com/Subj1\",\"http://example.com/prop1\": 42}]";
 
+	/**
+	 * YAML style comments
+	 */
+	private static final String YAML_COMMENTS_TEST_STRING = "[{#This is a non-standard yaml style comment/*\n\"@id\": \"http://example.com/Subj1\",\"http://example.com/prop1\": [{\"@id\": \"http://example.com/Obj1\"}]}]";
+
 	private RDFParser parser;
 
 	@Rule
@@ -328,4 +333,33 @@ public class JSONLDParserCustomTest {
 		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, false);
 		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
 	}
+
+	@Test
+	public void testAllowYamlCommentsDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowYamlCommentsEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, true);
+		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectIRI);
+	}
+
+	@Test
+	public void testAllowYamlCommentsDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Could not parse JSONLD");
+		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, false);
+		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+	}
+
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserCustomTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserCustomTest.java
@@ -9,9 +9,30 @@ package org.eclipse.rdf4j.rio.rdfjson;
 
 import static org.junit.Assert.*;
 
+import java.io.Reader;
+import java.io.StringReader;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector;
+import org.eclipse.rdf4j.rio.helpers.JSONSettings;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * Custom (non-manifest) tests for RDF/JSON parser.
@@ -20,11 +41,453 @@ import org.junit.Test;
  */
 public class RDFJSONParserCustomTest {
 
+	/**
+	 * Backslash escaped "h" in "http"
+	 */
+	private static final String BACKSLASH_ESCAPED_TEST_STRING = "{\"\\http://example.com/Subj1\": { \"http://example.com/prop1\": [{\"value\": \"http://example.com/Obj1\", \"type\": \"uri\"}]}}";
+
+	/**
+	 * Java/C++ style comments
+	 */
+	private static final String COMMENTS_TEST_STRING = "{/*This is a non-standard java/c++ style comment\n*/\"http://example.com/Subj1\": { \"http://example.com/prop1\": [{\"value\": \"http://example.com/Obj1\", \"type\": \"uri\"}]}}";
+
+	/**
+	 * Tests for NaN
+	 */
+	private static final String NON_NUMERIC_NUMBERS_TEST_STRING = "{\"http://example.com/Subj1\": { \"http://example.com/prop1\": [{\"value\": NaN, \"type\": \"literal\", \"datatype\": \"http://www.w3.org/2001/XMLSchema#double\"}]}}";
+
+	/**
+	 * Tests for numeric leading zeroes
+	 */
+	private static final String NUMERIC_LEADING_ZEROES_TEST_STRING = "{\"http://example.com/Subj1\": { \"http://example.com/prop1\": [{\"value\": 000042, \"type\": \"literal\", \"datatype\": \"http://www.w3.org/2001/XMLSchema#integer\"}]}}";
+
+	/**
+	 * Tests for single-quotes
+	 */
+	private static final String SINGLE_QUOTES_TEST_STRING = "{\'http://example.com/Subj1\': { \"http://example.com/prop1\": [{\"value\": \"42\", \'type\': \"literal\", \"datatype\": \"http://www.w3.org/2001/XMLSchema#integer\"}]}}";
+
+	/**
+	 * Tests for unquoted control char
+	 */
+	private static final String UNQUOTED_CONTROL_CHARS_TEST_STRING = "{\"http://example.com/Subj1\": { \"http://example.com/prop1\": [{\"value\": \"42\u0009\", \"type\": \"literal\", \"datatype\": \"http://www.w3.org/2001/XMLSchema#string\"}]}}";
+
+	/**
+	 * Tests for unquoted field names
+	 */
+	private static final String UNQUOTED_FIELD_NAMES_TEST_STRING = "{\"http://example.com/Subj1\": { \"http://example.com/prop1\": [{value: \"42\", type: \"literal\", datatype: \"http://www.w3.org/2001/XMLSchema#integer\"}]}}";
+
+	/**
+	 * YAML style comments
+	 */
+	private static final String YAML_COMMENTS_TEST_STRING = "{\n#This is a non-standard yaml style comment/*\n\"http://example.com/Subj1\": { \"http://example.com/prop1\": [{\"value\": \"http://example.com/Obj1\", \"type\": \"uri\"}]}}";
+
+	/**
+	 * Trailing comma
+	 */
+	private static final String TRAILING_COMMA_TEST_STRING = "{\"http://example.com/Subj1\": { \"http://example.com/prop1\": [{\"value\": \"http://example.com/Obj1\", \"type\": \"uri\",}]}}";
+
+	/**
+	 * Strict duplicate detection
+	 */
+	private static final String STRICT_DUPLICATE_DETECTION_TEST_STRING = "{\"http://example.com/Subj1\": { \"http://example.com/prop1\": [{\"value\": \"http://example.com/Obj1\", \"type\": \"uri\", \"type\": \"uri\"}]}}";
+
+	private RDFParser parser;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private ParseErrorCollector errors;
+
+	private Model model;
+
+	private final IRI testSubjectIRI = SimpleValueFactory.getInstance().createIRI("http://example.com/Subj1");
+
+	private final IRI testPredicate = SimpleValueFactory.getInstance().createIRI("http://example.com/prop1");
+
+	private final IRI testObjectIRI = SimpleValueFactory.getInstance().createIRI("http://example.com/Obj1");
+
+	private final Literal testObjectLiteralNotANumber = SimpleValueFactory.getInstance().createLiteral("NaN",
+			XMLSchema.DOUBLE);
+
+	private final Literal testObjectLiteralNumber = SimpleValueFactory.getInstance().createLiteral("42",
+			XMLSchema.INTEGER);
+
+	private final Literal testObjectLiteralUnquotedControlChar = SimpleValueFactory.getInstance().createLiteral(
+			"42\u0009", XMLSchema.STRING);
+
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		parser = Rio.createParser(RDFFormat.RDFJSON);
+		errors = new ParseErrorCollector();
+		model = new LinkedHashModel();
+		parser.setParseErrorListener(errors);
+		parser.setRDFHandler(new ContextStatementCollector(model, SimpleValueFactory.getInstance()));
+	}
+
+	private void verifyParseResults(Resource nextSubject, IRI nextPredicate, Value nextObject)
+		throws Exception
+	{
+		assertEquals(0, errors.getWarnings().size());
+		assertEquals(0, errors.getErrors().size());
+		assertEquals(0, errors.getFatalErrors().size());
+
+		assertEquals(1, model.size());
+		assertTrue("model was not as expected: " + model.toString(),
+				model.contains(nextSubject, nextPredicate, nextObject));
+	}
+
 	@Test
 	public void testSupportedSettings()
 		throws Exception
 	{
-		assertEquals(18, Rio.createParser(RDFFormat.RDFJSON).getSupportedSettings().size());
+		// 17 supported in RDFJSONParser + 12 from AbstractRDFParser
+		assertEquals(29, parser.getSupportedSettings().size());
 	}
 
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 5]");
+		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
+		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectIRI);
+	}
+
+	@Test
+	public void testAllowBackslashEscapingAnyCharacterDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 5]");
+		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, false);
+		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowCommentsDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 3]");
+		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowCommentsEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_COMMENTS, true);
+		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectIRI);
+	}
+
+	@Test
+	public void testAllowCommentsDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 3]");
+		parser.set(JSONSettings.ALLOW_COMMENTS, false);
+		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowNonNumericNumbersDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 74]");
+		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowNonNumericNumbersEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, true);
+		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralNotANumber);
+	}
+
+	@Test
+	public void testAllowNonNumericNumbersDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 74]");
+		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, false);
+		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowNumericLeadingZeroesDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 72]");
+		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowNumericLeadingZeroesEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, true);
+		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralNumber);
+	}
+
+	@Test
+	public void testAllowNumericLeadingZeroesDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 72]");
+		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, false);
+		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowSingleQuotesDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 3]");
+		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowSingleQuotesEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, true);
+		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralNumber);
+	}
+
+	@Test
+	public void testAllowSingleQuotesDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 3]");
+		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, false);
+		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 75]");
+		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, true);
+		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralUnquotedControlChar);
+	}
+
+	@Test
+	public void testAllowUnquotedControlCharactersDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 75]");
+		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, false);
+		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 63]");
+		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, true);
+		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectLiteralNumber);
+	}
+
+	@Test
+	public void testAllowUnquotedFieldNamesDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 63]");
+		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, false);
+		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowYamlCommentsDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 2, column 2]");
+		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowYamlCommentsEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, true);
+		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectIRI);
+	}
+
+	@Test
+	public void testAllowYamlCommentsDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 2, column 2]");
+		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, false);
+		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowTrailingCommaDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 113]");
+		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+	}
+
+	@Test
+	public void testAllowTrailingCommaEnabled()
+		throws Exception
+	{
+		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, true);
+		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+		verifyParseResults(testSubjectIRI, testPredicate, testObjectIRI);
+	}
+
+	@Test
+	public void testAllowTrailingCommaDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 113]");
+		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, false);
+		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+	}
+
+	@Test
+	public void testIncludeSourceLocationDefault()
+		throws Exception
+	{
+		final Reader source = new StringReader(YAML_COMMENTS_TEST_STRING);
+		try {
+			parser.parse(source, "");
+			fail("Expected to find an exception");
+		}
+		catch (RDFParseException e) {
+			assertNotNull(e.getCause());
+			assertTrue(e.getCause() instanceof JsonProcessingException);
+			JsonProcessingException cause = (JsonProcessingException)e.getCause();
+			assertEquals(2, cause.getLocation().getLineNr());
+			assertEquals(2, cause.getLocation().getColumnNr());
+			assertNotNull(cause.getLocation().getSourceRef());
+			assertEquals(source, cause.getLocation().getSourceRef());
+		}
+	}
+
+	@Test
+	public void testIncludeSourceLocationEnabled()
+		throws Exception
+	{
+		final Reader source = new StringReader(YAML_COMMENTS_TEST_STRING);
+		try {
+			parser.set(JSONSettings.INCLUDE_SOURCE_IN_LOCATION, true);
+			parser.parse(source, "");
+			fail("Expected to find an exception");
+		}
+		catch (RDFParseException e) {
+			assertNotNull(e.getCause());
+			assertTrue(e.getCause() instanceof JsonProcessingException);
+			JsonProcessingException cause = (JsonProcessingException)e.getCause();
+			assertEquals(2, cause.getLocation().getLineNr());
+			assertEquals(2, cause.getLocation().getColumnNr());
+			assertNotNull(cause.getLocation().getSourceRef());
+			assertEquals(source, cause.getLocation().getSourceRef());
+		}
+	}
+
+	@Test
+	public void testIncludeSourceLocationDisabled()
+		throws Exception
+	{
+		try {
+			parser.set(JSONSettings.INCLUDE_SOURCE_IN_LOCATION, false);
+			parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+			fail("Expected to find an exception");
+		}
+		catch (RDFParseException e) {
+			assertNotNull(e.getCause());
+			assertTrue(e.getCause() instanceof JsonProcessingException);
+			JsonProcessingException cause = (JsonProcessingException)e.getCause();
+			assertEquals(2, cause.getLocation().getLineNr());
+			assertEquals(2, cause.getLocation().getColumnNr());
+			assertNull(cause.getLocation().getSourceRef());
+		}
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionDefault()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		// Extra checking inbuilt in this case. This verifies it moves past Jackson into RDFJSONParser
+		thrown.expectMessage(
+				"Multiple types found for a single object: subject=http://example.com/Subj1 predicate=http://example.com/prop1 [line 1, column 122]");
+		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
+		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionEnabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		thrown.expectMessage("Found IOException during parsing [line 1, column 119]");
+		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, true);
+		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+	}
+
+	@Test
+	public void testStrictDuplicateDetectionDisabled()
+		throws Exception
+	{
+		thrown.expect(RDFParseException.class);
+		// Extra checking inbuilt in this case. This verifies it moves past Jackson into RDFJSONParser
+		thrown.expectMessage("Multiple types found for a single object: subject=http://example.com/Subj1 predicate=http://example.com/prop1 [line 1, column 122]");
+		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
+		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
 		<httpclient.version>4.5.5</httpclient.version>
 		<httpcore.version>4.4.9</httpcore.version>
 		<jackson.version>2.9.6</jackson.version>
-		<jsonldjava.version>0.12.0</jsonldjava.version>
+		<jsonldjava.version>0.12.3</jsonldjava.version>
 		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
 	</properties>
 

--- a/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultParseException.java
+++ b/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultParseException.java
@@ -101,6 +101,24 @@ public class QueryResultParseException extends RDF4JException {
 		this.columnNo = columnNo;
 	}
 
+	/**
+	 * Creates a new QueryResultParseException wrapping another exception.
+	 * 
+	 * @param msg
+	 *        An error message.
+	 * @param t
+	 *        The source exception.
+	 * @param lineNo
+	 *        A line number associated with the message.
+	 * @param columnNo
+	 *        A column number associated with the message.
+	 */
+	public QueryResultParseException(String msg, Throwable t, long lineNo, long columnNo) {
+		super(msg, t);
+		this.lineNo = lineNo;
+		this.columnNo = columnNo;
+	}
+
 	/*-----------*
 	 * Variables *
 	 *-----------*/

--- a/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
+++ b/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -21,12 +22,16 @@ import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultParser;
 import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.JSONSettings;
+import org.eclipse.rdf4j.rio.helpers.RDFJSONParserSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 
 /**
@@ -39,14 +44,6 @@ import com.fasterxml.jackson.core.JsonToken;
 public abstract class AbstractSPARQLJSONParser extends AbstractQueryResultParser {
 
 	private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-	private static final JsonFactory JSON_FACTORY = new JsonFactory();
-
-	static {
-		JSON_FACTORY.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
-		JSON_FACTORY.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
-		JSON_FACTORY.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
-	}
 
 	public static final String HEAD = "head";
 
@@ -102,263 +99,291 @@ public abstract class AbstractSPARQLJSONParser extends AbstractQueryResultParser
 
 	@Override
 	public void parseQueryResult(InputStream in)
-		throws IOException, QueryResultParseException, QueryResultHandlerException
+		throws IOException,
+		QueryResultParseException,
+		QueryResultHandlerException
 	{
 		parseQueryResultInternal(in, true, true);
 	}
 
 	protected boolean parseQueryResultInternal(InputStream in, boolean attemptParseBoolean,
 			boolean attemptParseTuple)
-		throws IOException, QueryResultParseException, QueryResultHandlerException
+		throws IOException,
+		QueryResultParseException,
+		QueryResultHandlerException
 	{
 		if (!attemptParseBoolean && !attemptParseTuple) {
 			throw new IllegalArgumentException(
 					"Internal error: Did not specify whether to parse as either boolean and/or tuple");
 		}
 
-		JsonParser jp = JSON_FACTORY.createParser(in);
+		JsonParser jp = null;
+
 		boolean result = false;
+		try {
+			jp = configureNewJsonFactory().createParser(in);
 
-		if (jp.nextToken() != JsonToken.START_OBJECT) {
-			throw new QueryResultParseException(
-					"Expected SPARQL Results JSON document to start with an Object",
-					jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
-		}
+			if (jp.nextToken() != JsonToken.START_OBJECT) {
+				throw new QueryResultParseException(
+						"Expected SPARQL Results JSON document to start with an Object",
+						jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
+			}
 
-		List<String> varsList = new ArrayList<String>();
-		boolean varsFound = false;
-		Set<BindingSet> bindings = new HashSet<BindingSet>();
+			List<String> varsList = new ArrayList<String>();
+			boolean varsFound = false;
+			Set<BindingSet> bindings = new HashSet<BindingSet>();
 
-		while (jp.nextToken() != JsonToken.END_OBJECT) {
+			while (jp.nextToken() != JsonToken.END_OBJECT) {
 
-			final String baseStr = jp.getCurrentName();
+				final String baseStr = jp.getCurrentName();
 
-			if (baseStr.equals(HEAD)) {
-				if (jp.nextToken() != JsonToken.START_OBJECT) {
-					throw new QueryResultParseException("Did not find object under " + baseStr + " field",
-							jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
-				}
-
-				while (jp.nextToken() != JsonToken.END_OBJECT) {
-					final String headStr = jp.getCurrentName();
-
-					if (headStr.equals(VARS)) {
-						if (!attemptParseTuple) {
-							throw new QueryResultParseException(
-									"Found tuple results variables when attempting to parse SPARQL Results JSON to boolean result");
-						}
-
-						if (jp.nextToken() != JsonToken.START_ARRAY) {
-							throw new QueryResultParseException("Expected variable labels to be an array",
-									jp.getCurrentLocation().getLineNr(),
-									jp.getCurrentLocation().getColumnNr());
-						}
-
-						while (jp.nextToken() != JsonToken.END_ARRAY) {
-							varsList.add(jp.getText());
-						}
-
-						if (this.handler != null) {
-							handler.startQueryResult(varsList);
-						}
-
-						varsFound = true;
-
-						// If the bindings were populated before this point push them
-						// out now.
-						if (!bindings.isEmpty() && this.handler != null) {
-							for (BindingSet nextBinding : bindings) {
-								handler.handleSolution(nextBinding);
-								handler.endQueryResult();
-							}
-							bindings.clear();
-						}
-
-					}
-					else if (headStr.equals(LINK)) {
-						List<String> linksList = new ArrayList<String>();
-						if (jp.nextToken() != JsonToken.START_ARRAY) {
-							throw new QueryResultParseException("Expected links to be an array",
-									jp.getCurrentLocation().getLineNr(),
-									jp.getCurrentLocation().getColumnNr());
-						}
-
-						while (jp.nextToken() != JsonToken.END_ARRAY) {
-							linksList.add(jp.getText());
-						}
-
-						if (this.handler != null) {
-							handler.handleLinks(linksList);
-						}
-
-					}
-					else {
-						throw new QueryResultParseException(
-								"Found unexpected object in head field: " + headStr,
+				if (baseStr.equals(HEAD)) {
+					if (jp.nextToken() != JsonToken.START_OBJECT) {
+						throw new QueryResultParseException("Did not find object under " + baseStr + " field",
 								jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
 					}
-				}
-			}
-			else if (baseStr.equals(RESULTS)) {
-				if (!attemptParseTuple) {
-					throw new QueryResultParseException(
-							"Found tuple results bindings when attempting to parse SPARQL Results JSON to boolean result");
-				}
-				if (jp.nextToken() != JsonToken.START_OBJECT) {
-					throw new QueryResultParseException(
-							"Found unexpected token in results object: " + jp.getCurrentName(),
-							jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
-				}
 
-				while (jp.nextToken() != JsonToken.END_OBJECT) {
+					while (jp.nextToken() != JsonToken.END_OBJECT) {
+						final String headStr = jp.getCurrentName();
 
-					if (jp.getCurrentName().equals(BINDINGS)) {
-						if (jp.nextToken() != JsonToken.START_ARRAY) {
-							throw new QueryResultParseException("Found unexpected token in bindings object",
-									jp.getCurrentLocation().getLineNr(),
-									jp.getCurrentLocation().getColumnNr());
-						}
-
-						while (jp.nextToken() != JsonToken.END_ARRAY) {
-
-							MapBindingSet nextBindingSet = new MapBindingSet();
-
-							if (jp.getCurrentToken() != JsonToken.START_OBJECT) {
+						if (headStr.equals(VARS)) {
+							if (!attemptParseTuple) {
 								throw new QueryResultParseException(
-										"Did not find object in bindings array: " + jp.getCurrentName(),
+										"Found tuple results variables when attempting to parse SPARQL Results JSON to boolean result",
+										jp.getCurrentLocation().getLineNr(),
+										jp.getCurrentLocation().getLineNr());
+							}
+
+							if (jp.nextToken() != JsonToken.START_ARRAY) {
+								throw new QueryResultParseException("Expected variable labels to be an array",
 										jp.getCurrentLocation().getLineNr(),
 										jp.getCurrentLocation().getColumnNr());
 							}
 
-							while (jp.nextToken() != JsonToken.END_OBJECT) {
+							while (jp.nextToken() != JsonToken.END_ARRAY) {
+								varsList.add(jp.getText());
+							}
 
-								if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
-									throw new QueryResultParseException("Did not find binding name",
-											jp.getCurrentLocation().getLineNr(),
-											jp.getCurrentLocation().getColumnNr());
+							if (this.handler != null) {
+								handler.startQueryResult(varsList);
+							}
+
+							varsFound = true;
+
+							// If the bindings were populated before this point push them
+							// out now.
+							if (!bindings.isEmpty() && this.handler != null) {
+								for (BindingSet nextBinding : bindings) {
+									handler.handleSolution(nextBinding);
+									handler.endQueryResult();
 								}
+								bindings.clear();
+							}
 
-								final String bindingStr = jp.getCurrentName();
+						}
+						else if (headStr.equals(LINK)) {
+							List<String> linksList = new ArrayList<String>();
+							if (jp.nextToken() != JsonToken.START_ARRAY) {
+								throw new QueryResultParseException("Expected links to be an array",
+										jp.getCurrentLocation().getLineNr(),
+										jp.getCurrentLocation().getColumnNr());
+							}
 
-								if (jp.nextToken() != JsonToken.START_OBJECT) {
+							while (jp.nextToken() != JsonToken.END_ARRAY) {
+								linksList.add(jp.getText());
+							}
+
+							if (this.handler != null) {
+								handler.handleLinks(linksList);
+							}
+
+						}
+						else {
+							throw new QueryResultParseException(
+									"Found unexpected object in head field: " + headStr,
+									jp.getCurrentLocation().getLineNr(),
+									jp.getCurrentLocation().getColumnNr());
+						}
+					}
+				}
+				else if (baseStr.equals(RESULTS)) {
+					if (!attemptParseTuple) {
+						throw new QueryResultParseException(
+								"Found tuple results bindings when attempting to parse SPARQL Results JSON to boolean result",
+								jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getLineNr());
+					}
+					if (jp.nextToken() != JsonToken.START_OBJECT) {
+						throw new QueryResultParseException(
+								"Found unexpected token in results object: " + jp.getCurrentName(),
+								jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
+					}
+
+					while (jp.nextToken() != JsonToken.END_OBJECT) {
+
+						if (jp.getCurrentName().equals(BINDINGS)) {
+							if (jp.nextToken() != JsonToken.START_ARRAY) {
+								throw new QueryResultParseException(
+										"Found unexpected token in bindings object",
+										jp.getCurrentLocation().getLineNr(),
+										jp.getCurrentLocation().getColumnNr());
+							}
+
+							while (jp.nextToken() != JsonToken.END_ARRAY) {
+
+								MapBindingSet nextBindingSet = new MapBindingSet();
+
+								if (jp.getCurrentToken() != JsonToken.START_OBJECT) {
 									throw new QueryResultParseException(
-											"Did not find object for binding value",
+											"Did not find object in bindings array: " + jp.getCurrentName(),
 											jp.getCurrentLocation().getLineNr(),
 											jp.getCurrentLocation().getColumnNr());
 								}
-
-								String lang = null;
-								String type = null;
-								String datatype = null;
-								String value = null;
 
 								while (jp.nextToken() != JsonToken.END_OBJECT) {
 
 									if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
-										throw new QueryResultParseException(
-												"Did not find value attribute under " + bindingStr + " field",
+										throw new QueryResultParseException("Did not find binding name",
 												jp.getCurrentLocation().getLineNr(),
 												jp.getCurrentLocation().getColumnNr());
 									}
-									String fieldName = jp.getCurrentName();
 
-									// move to the value token
-									jp.nextToken();
+									final String bindingStr = jp.getCurrentName();
 
-									// set the appropriate state variable
-									if (TYPE.equals(fieldName)) {
-										type = jp.getText();
-									}
-									else if (XMLLANG.equals(fieldName)) {
-										lang = jp.getText();
-									}
-									else if (DATATYPE.equals(fieldName)) {
-										datatype = jp.getText();
-									}
-									else if (VALUE.equals(fieldName)) {
-										value = jp.getText();
-									}
-									else {
+									if (jp.nextToken() != JsonToken.START_OBJECT) {
 										throw new QueryResultParseException(
-												"Unexpected field name: " + fieldName,
+												"Did not find object for binding value",
 												jp.getCurrentLocation().getLineNr(),
 												jp.getCurrentLocation().getColumnNr());
-
 									}
+
+									String lang = null;
+									String type = null;
+									String datatype = null;
+									String value = null;
+
+									while (jp.nextToken() != JsonToken.END_OBJECT) {
+
+										if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
+											throw new QueryResultParseException(
+													"Did not find value attribute under " + bindingStr
+															+ " field",
+													jp.getCurrentLocation().getLineNr(),
+													jp.getCurrentLocation().getColumnNr());
+										}
+										String fieldName = jp.getCurrentName();
+
+										// move to the value token
+										jp.nextToken();
+
+										// set the appropriate state variable
+										if (TYPE.equals(fieldName)) {
+											type = jp.getText();
+										}
+										else if (XMLLANG.equals(fieldName)) {
+											lang = jp.getText();
+										}
+										else if (DATATYPE.equals(fieldName)) {
+											datatype = jp.getText();
+										}
+										else if (VALUE.equals(fieldName)) {
+											value = jp.getText();
+										}
+										else {
+											throw new QueryResultParseException(
+													"Unexpected field name: " + fieldName,
+													jp.getCurrentLocation().getLineNr(),
+													jp.getCurrentLocation().getColumnNr());
+
+										}
+									}
+
+									nextBindingSet.addBinding(bindingStr,
+											parseValue(type, value, lang, datatype));
 								}
-
-								nextBindingSet.addBinding(bindingStr,
-										parseValue(type, value, lang, datatype));
+								// parsing of solution finished, report result return to
+								// bindings state
+								if (!varsFound) {
+									// Buffer the bindings to fit with the
+									// QueryResultHandler contract so that startQueryResults
+									// is
+									// always called before handleSolution
+									bindings.add(nextBindingSet);
+								}
+								else if (handler != null) {
+									handler.handleSolution(nextBindingSet);
+								}
 							}
-							// parsing of solution finished, report result return to
-							// bindings state
-							if (!varsFound) {
-								// Buffer the bindings to fit with the
-								// QueryResultHandler contract so that startQueryResults
-								// is
-								// always called before handleSolution
-								bindings.add(nextBindingSet);
-							}
-							else if (handler != null) {
-								handler.handleSolution(nextBindingSet);
+							if (handler != null) {
+								handler.endQueryResult();
 							}
 						}
-						if (handler != null) {
-							handler.endQueryResult();
+						// Backwards compatibility with very old draft of the original
+						// SPARQL spec
+						else if (jp.getCurrentName().equals(DISTINCT)
+								|| jp.getCurrentName().equals(ORDERED))
+						{
+							jp.nextToken();
+						}
+						else {
+							throw new QueryResultParseException(
+									"Found unexpected field in results: " + jp.getCurrentName(),
+									jp.getCurrentLocation().getLineNr(),
+									jp.getCurrentLocation().getColumnNr());
 						}
 					}
-					// Backwards compatibility with very old draft of the original
-					// SPARQL spec
-					else if (jp.getCurrentName().equals(DISTINCT) || jp.getCurrentName().equals(ORDERED)) {
-						jp.nextToken();
-					}
-					else {
+				}
+				else if (baseStr.equals(BOOLEAN)) {
+					if (!attemptParseBoolean) {
 						throw new QueryResultParseException(
-								"Found unexpected field in results: " + jp.getCurrentName(),
-								jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
+								"Found boolean results when attempting to parse SPARQL Results JSON to tuple results",
+								jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getLineNr());
+					}
+					jp.nextToken();
+
+					result = Boolean.parseBoolean(jp.getText());
+					if (handler != null) {
+						handler.handleBoolean(result);
 					}
 				}
-			}
-			else if (baseStr.equals(BOOLEAN)) {
-				if (!attemptParseBoolean) {
-					throw new QueryResultParseException(
-							"Found boolean results when attempting to parse SPARQL Results JSON to tuple results");
-				}
-				jp.nextToken();
+				else {
+					logger.debug("Found unexpected object in top level {} field #{}.{}", baseStr,
+							jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
+					// Consume the discovered unexpected object
+					// (in particular, if it is either an array or a composite object).
+					jp.nextToken();
 
-				result = Boolean.parseBoolean(jp.getText());
-				if (handler != null) {
-					handler.handleBoolean(result);
-				}
-			}
-			else {
-				logger.debug("Found unexpected object in top level {} field #{}.{}", baseStr,
-						jp.getCurrentLocation().getLineNr(), jp.getCurrentLocation().getColumnNr());
-				// Consume the discovered unexpected object 
-				// (in particular, if it is either an array or a composite object).
-				jp.nextToken();
-
-				if (jp.currentToken() == JsonToken.START_ARRAY) {
-					while (!(jp.getParsingContext().getParent().inRoot()
-							&& (jp.currentToken() == JsonToken.END_ARRAY)))
-					{
-						if (jp.nextToken() == null) {
-							throw new QueryResultParseException(
-									"An array value of the unexpected " + baseStr + " field is not closed.");
+					if (jp.currentToken() == JsonToken.START_ARRAY) {
+						while (!(jp.getParsingContext().getParent().inRoot()
+								&& (jp.currentToken() == JsonToken.END_ARRAY)))
+						{
+							if (jp.nextToken() == null) {
+								throw new QueryResultParseException(
+										"An array value of the unexpected " + baseStr
+												+ " field is not closed.",
+										jp.getCurrentLocation().getLineNr(),
+										jp.getCurrentLocation().getLineNr());
+							}
+						}
+					}
+					else if (jp.currentToken() == JsonToken.START_OBJECT) {
+						while (!(jp.getParsingContext().getParent().inRoot()
+								&& (jp.currentToken() == JsonToken.END_OBJECT)))
+						{
+							if (jp.nextToken() == null) {
+								throw new QueryResultParseException(
+										"An object value of the unexpected " + baseStr
+												+ " field is not closed.",
+										jp.getCurrentLocation().getLineNr(),
+										jp.getCurrentLocation().getLineNr());
+							}
 						}
 					}
 				}
-				else if (jp.currentToken() == JsonToken.START_OBJECT) {
-					while (!(jp.getParsingContext().getParent().inRoot()
-							&& (jp.currentToken() == JsonToken.END_OBJECT)))
-					{
-						if (jp.nextToken() == null) {
-							throw new QueryResultParseException(
-									"An object value of the unexpected " + baseStr + " field is not closed.");
-						}
-					}
-				}
 			}
+		}
+		catch (JsonProcessingException e) {
+			throw new QueryResultParseException("Could not parse SPARQL/JSON", e, e.getLocation().getLineNr(),
+					e.getLocation().getLineNr());
 		}
 
 		return result;
@@ -406,5 +431,86 @@ public abstract class AbstractSPARQLJSONParser extends AbstractQueryResultParser
 		logger.debug("result value: {}", result);
 
 		return result;
+	}
+
+	@Override
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		Collection<RioSetting<?>> result = new HashSet<RioSetting<?>>(super.getSupportedSettings());
+
+		result.add(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER);
+		result.add(JSONSettings.ALLOW_COMMENTS);
+		result.add(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS);
+		result.add(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS);
+		result.add(JSONSettings.ALLOW_SINGLE_QUOTES);
+		result.add(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS);
+		result.add(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES);
+		result.add(JSONSettings.ALLOW_YAML_COMMENTS);
+		result.add(JSONSettings.ALLOW_TRAILING_COMMA);
+		result.add(JSONSettings.INCLUDE_SOURCE_IN_LOCATION);
+		result.add(JSONSettings.STRICT_DUPLICATE_DETECTION);
+
+		return result;
+	}
+
+	/**
+	 * Get an instance of JsonFactory configured using the settings from {@link #getParserConfig()}.
+	 * 
+	 * @return A newly configured JsonFactory based on the currently enabled settings
+	 */
+	private JsonFactory configureNewJsonFactory() {
+		final JsonFactory nextJsonFactory = new JsonFactory();
+		// Disable features that may work for most JSON where the field names are
+		// in limited supply,
+		// but does not work for SPARQL/JSON where a wide range of URIs are used for
+		// subjects and predicates
+		nextJsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+		nextJsonFactory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
+		nextJsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+		if (getParserConfig().isSet(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
+					getParserConfig().get(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_COMMENTS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS,
+					getParserConfig().get(JSONSettings.ALLOW_COMMENTS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS,
+					getParserConfig().get(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS,
+					getParserConfig().get(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_SINGLE_QUOTES)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES,
+					getParserConfig().get(JSONSettings.ALLOW_SINGLE_QUOTES));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
+					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES,
+					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_YAML_COMMENTS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS,
+					getParserConfig().get(JSONSettings.ALLOW_YAML_COMMENTS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_TRAILING_COMMA)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA,
+					getParserConfig().get(JSONSettings.ALLOW_TRAILING_COMMA));
+		}
+		if (getParserConfig().isSet(JSONSettings.INCLUDE_SOURCE_IN_LOCATION)) {
+			nextJsonFactory.configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION,
+					getParserConfig().get(JSONSettings.INCLUDE_SOURCE_IN_LOCATION));
+		}
+		if (getParserConfig().isSet(JSONSettings.STRICT_DUPLICATE_DETECTION)) {
+			nextJsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION,
+					getParserConfig().get(JSONSettings.STRICT_DUPLICATE_DETECTION));
+		}
+		return nextJsonFactory;
 	}
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -40,8 +40,7 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
- * Base class for {@link RDFParser}s offering common functionality for RDF
- * parsers.
+ * Base class for {@link RDFParser}s offering common functionality for RDF parsers.
  * 
  * @author Arjohn Kampman
  */
@@ -64,8 +63,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 	private ParseErrorListener errListener;
 
 	/**
-	 * An optional ParseLocationListener to report parse progress in the form of
-	 * line- and column numbers to.
+	 * An optional ParseLocationListener to report parse progress in the form of line- and column numbers to.
 	 */
 	private ParseLocationListener locationListener;
 
@@ -80,9 +78,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 	private ParsedIRI baseURI;
 
 	/**
-	 * Enables a consistent global mapping of blank node identifiers without using a
-	 * map, but concatenating this as a prefix for the blank node identifiers
-	 * supplied by the parser.
+	 * Enables a consistent global mapping of blank node identifiers without using a map, but concatenating
+	 * this as a prefix for the blank node identifiers supplied by the parser.
 	 */
 	private String nextBNodePrefix;
 
@@ -101,24 +98,23 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 *--------------*/
 
 	/**
-	 * Creates a new RDFParserBase that will use a {@link SimpleValueFactory} to
-	 * create RDF model objects.
+	 * Creates a new RDFParserBase that will use a {@link SimpleValueFactory} to create RDF model objects.
 	 */
 	public AbstractRDFParser() {
 		this(SimpleValueFactory.getInstance());
 	}
 
 	/**
-	 * Creates a new RDFParserBase that will use the supplied ValueFactory to create
-	 * RDF model objects.
+	 * Creates a new RDFParserBase that will use the supplied ValueFactory to create RDF model objects.
 	 * 
 	 * @param valueFactory
-	 *            A ValueFactory.
+	 *        A ValueFactory.
 	 */
 	public AbstractRDFParser(ValueFactory valueFactory) {
 		try {
 			md5 = MessageDigest.getInstance("MD5");
-		} catch (NoSuchAlgorithmException e) {
+		}
+		catch (NoSuchAlgorithmException e) {
 			throw new RuntimeException(e);
 		}
 
@@ -181,8 +177,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/*
-	 * Default implementation, specific parsers are encouraged to override this
-	 * method as necessary.
+	 * Default implementation, specific parsers are encouraged to override this method as necessary.
 	 */
 	@Override
 	public Collection<RioSetting<?>> getSupportedSettings() {
@@ -248,7 +243,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 		getParserConfig().set(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES, stopAtFirstError);
 		if (!stopAtFirstError) {
 			getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
-		} else {
+		}
+		else {
 			// TODO: Add a ParserConfig.removeNonFatalError function to avoid
 			// this
 			Set<RioSetting<?>> set = new HashSet<RioSetting<?>>(getParserConfig().getNonFatalErrors());
@@ -271,16 +267,19 @@ public abstract class AbstractRDFParser implements RDFParser {
 		if (datatypeHandling == DatatypeHandling.VERIFY) {
 			this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 			this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
-		} else if (datatypeHandling == DatatypeHandling.NORMALIZE) {
+		}
+		else if (datatypeHandling == DatatypeHandling.NORMALIZE) {
 			this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 			this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
 			this.parserConfig.set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, true);
-		} else {
+		}
+		else {
 			// Only ignore if they have not explicitly set any of the relevant
 			// settings before this point
 			if (!this.parserConfig.isSet(BasicParserSettings.NORMALIZE_DATATYPE_VALUES)
 					&& !this.parserConfig.isSet(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES)
-					&& !this.parserConfig.isSet(BasicParserSettings.NORMALIZE_DATATYPE_VALUES)) {
+					&& !this.parserConfig.isSet(BasicParserSettings.NORMALIZE_DATATYPE_VALUES))
+			{
 				this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, false);
 				this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, false);
 				this.parserConfig.set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, false);
@@ -299,8 +298,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Parses the supplied URI-string and sets it as the base URI for resolving
-	 * relative URIs.
+	 * Parses the supplied URI-string and sets it as the base URI for resolving relative URIs.
 	 */
 	protected void setBaseURI(String uriSpec) {
 		// Store base URI
@@ -324,13 +322,14 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Gets the namespace that is associated with the specified prefix or throws an
-	 * {@link RDFParseException}.
+	 * Gets the namespace that is associated with the specified prefix or throws an {@link RDFParseException}.
 	 * 
 	 * @throws RDFParseException
-	 *             if no namespace is associated with this prefix
+	 *         if no namespace is associated with this prefix
 	 */
-	protected String getNamespace(String prefix) throws RDFParseException {
+	protected String getNamespace(String prefix)
+		throws RDFParseException
+	{
 		if (namespaceTable.containsKey(prefix))
 			return namespaceTable.get(prefix);
 		String msg = "Namespace prefix '" + prefix + "' used but not defined";
@@ -344,8 +343,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Clears any information that has been collected while parsing. This method
-	 * must be called by subclasses when finishing the parse process.
+	 * Clears any information that has been collected while parsing. This method must be called by subclasses
+	 * when finishing the parse process.
 	 */
 	protected void clear() {
 		baseURI = null;
@@ -362,10 +361,9 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Clears the map that keeps track of blank nodes that have been parsed.
-	 * Normally, this map is clear when the document has been parsed completely, but
-	 * subclasses can clear the map at other moments too, for example when a bnode
-	 * scope ends.
+	 * Clears the map that keeps track of blank nodes that have been parsed. Normally, this map is clear when
+	 * the document has been parsed completely, but subclasses can clear the map at other moments too, for
+	 * example when a bnode scope ends.
 	 * 
 	 * @deprecated Map is no longer used, call {@link #clear()} instead.
 	 */
@@ -375,21 +373,24 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Resolves a URI-string against the base URI and creates a {@link IRI} object
-	 * for it.
+	 * Resolves a URI-string against the base URI and creates a {@link IRI} object for it.
 	 */
-	protected IRI resolveURI(String uriSpec) throws RDFParseException {
+	protected IRI resolveURI(String uriSpec)
+		throws RDFParseException
+	{
 		// Resolve relative URIs against base URI
 		ParsedIRI uri;
 		try {
 			uri = new ParsedIRI(uriSpec);
-		} catch (URISyntaxException e) {
+		}
+		catch (URISyntaxException e) {
 			reportError("Invalid IRI '" + uriSpec, BasicParserSettings.VERIFY_URI_SYNTAX);
 			try {
 				uri = ParsedIRI.create(uriSpec);
-			} catch (IllegalArgumentException ex) {
+			}
+			catch (IllegalArgumentException ex) {
 				if (getParserConfig().isNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX)) {
-					return null; 
+					return null;
 				}
 				return valueFactory.createIRI(uriSpec);
 			}
@@ -401,9 +402,12 @@ public abstract class AbstractRDFParser implements RDFParser {
 			}
 
 			if (getParserConfig().get(BasicParserSettings.VERIFY_RELATIVE_URIS)) {
-				if (!uri.isAbsolute() && uriSpec.length() > 0 && !uriSpec.startsWith("#") && baseURI.isOpaque()) {
-					reportError("Relative URI '" + uriSpec + "' cannot be resolved using the opaque base URI '"
-							+ baseURI + "'", BasicParserSettings.VERIFY_RELATIVE_URIS);
+				if (!uri.isAbsolute() && uriSpec.length() > 0 && !uriSpec.startsWith("#")
+						&& baseURI.isOpaque())
+				{
+					reportError("Relative URI '" + uriSpec
+							+ "' cannot be resolved using the opaque base URI '" + baseURI + "'",
+							BasicParserSettings.VERIFY_RELATIVE_URIS);
 				}
 			}
 
@@ -416,17 +420,21 @@ public abstract class AbstractRDFParser implements RDFParser {
 	/**
 	 * Creates a {@link IRI} object for the specified URI-string.
 	 */
-	protected IRI createURI(String uri) throws RDFParseException {
+	protected IRI createURI(String uri)
+		throws RDFParseException
+	{
 		if (getParserConfig().get(BasicParserSettings.VERIFY_URI_SYNTAX)) {
 			try {
 				new ParsedIRI(uri);
-			} catch (URISyntaxException e) {
+			}
+			catch (URISyntaxException e) {
 				reportError(e.getMessage(), BasicParserSettings.VERIFY_URI_SYNTAX);
 			}
 		}
 		try {
 			return valueFactory.createIRI(uri);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
@@ -435,33 +443,39 @@ public abstract class AbstractRDFParser implements RDFParser {
 	/**
 	 * Creates a new {@link BNode} or Skolem {@link IRI} object.
 	 */
-	protected Resource createNode() throws RDFParseException {
+	protected Resource createNode()
+		throws RDFParseException
+	{
 		try {
 			String origin = parserConfig.get(BasicParserSettings.SKOLEMIZE_ORIGIN);
 			if (preserveBNodeIDs() || origin == null || origin.length() == 0) {
 				return valueFactory.createBNode();
-			} else {
+			}
+			else {
 				String nodeId = valueFactory.createBNode().getID();
 				String path = "/.well-known/genid/" + nextBNodePrefix + nodeId;
 				String iri = ParsedIRI.create(origin).resolve(path);
 				return valueFactory.createIRI(iri);
 			}
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
 	}
 
 	/**
-	 * Creates a {@link BNode} or Skolem {@link IRI} object for the specified
-	 * identifier.
+	 * Creates a {@link BNode} or Skolem {@link IRI} object for the specified identifier.
 	 */
-	protected Resource createNode(String nodeID) throws RDFParseException {
+	protected Resource createNode(String nodeID)
+		throws RDFParseException
+	{
 		// If we are preserving blank node ids then we do not prefix them to
 		// make them globally unique
 		if (preserveBNodeIDs()) {
 			return valueFactory.createBNode(nodeID);
-		} else {
+		}
+		else {
 			// Prefix the node ID with a unique UUID prefix to reduce
 			// cross-document clashes
 			// This is consistent as long as nextBNodePrefix is not modified
@@ -482,7 +496,8 @@ public abstract class AbstractRDFParser implements RDFParser {
 			String origin = parserConfig.get(BasicParserSettings.SKOLEMIZE_ORIGIN);
 			if (origin == null || origin.length() == 0) {
 				return valueFactory.createBNode("genid-" + nextBNodePrefix + toAppend);
-			} else {
+			}
+			else {
 				String path = "/.well-known/genid/" + nextBNodePrefix + toAppend;
 				String iri = ParsedIRI.create(origin).resolve(path);
 				return valueFactory.createIRI(iri);
@@ -494,10 +509,13 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 * Creates a new {@link BNode} object.
 	 */
 	@Deprecated
-	protected BNode createBNode() throws RDFParseException {
+	protected BNode createBNode()
+		throws RDFParseException
+	{
 		try {
 			return valueFactory.createBNode();
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
@@ -507,12 +525,15 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 * Creates a {@link BNode} object for the specified identifier.
 	 */
 	@Deprecated
-	protected BNode createBNode(String nodeID) throws RDFParseException {
+	protected BNode createBNode(String nodeID)
+		throws RDFParseException
+	{
 		// If we are preserving blank node ids then we do not prefix them to
 		// make them globally unique
 		if (preserveBNodeIDs()) {
 			return valueFactory.createBNode(nodeID);
-		} else {
+		}
+		else {
 			// Prefix the node ID with a unique UUID prefix to reduce
 			// cross-document clashes
 			// This is consistent as long as nextBNodePrefix is not modified
@@ -538,32 +559,37 @@ public abstract class AbstractRDFParser implements RDFParser {
 	/**
 	 * Creates a {@link Literal} object with the supplied parameters.
 	 */
-	protected Literal createLiteral(String label, String lang, IRI datatype) throws RDFParseException {
-		return RDFParserHelper.createLiteral(label, lang, datatype, getParserConfig(), getParseErrorListener(),
-				valueFactory);
+	protected Literal createLiteral(String label, String lang, IRI datatype)
+		throws RDFParseException
+	{
+		return RDFParserHelper.createLiteral(label, lang, datatype, getParserConfig(),
+				getParseErrorListener(), valueFactory);
 	}
 
 	/**
-	 * Creates a {@link Literal} object with the supplied parameters, using the
-	 * lineNo and columnNo to enhance error messages or exceptions that may be
-	 * generated during the creation of the literal.
+	 * Creates a {@link Literal} object with the supplied parameters, using the lineNo and columnNo to enhance
+	 * error messages or exceptions that may be generated during the creation of the literal.
 	 * 
-	 * @see org.eclipse.rdf4j.rio.helpers.RDFParserHelper#createLiteral(String,
-	 *      String, IRI, ParserConfig, ParseErrorListener, ValueFactory, long, long)
+	 * @see org.eclipse.rdf4j.rio.helpers.RDFParserHelper#createLiteral(String, String, IRI, ParserConfig,
+	 *      ParseErrorListener, ValueFactory, long, long)
 	 */
 	protected Literal createLiteral(String label, String lang, IRI datatype, long lineNo, long columnNo)
-			throws RDFParseException {
-		return RDFParserHelper.createLiteral(label, lang, datatype, getParserConfig(), getParseErrorListener(),
-				valueFactory, lineNo, columnNo);
+		throws RDFParseException
+	{
+		return RDFParserHelper.createLiteral(label, lang, datatype, getParserConfig(),
+				getParseErrorListener(), valueFactory, lineNo, columnNo);
 	}
 
 	/**
 	 * Creates a new {@link Statement} object with the supplied components.
 	 */
-	protected Statement createStatement(Resource subj, IRI pred, Value obj) throws RDFParseException {
+	protected Statement createStatement(Resource subj, IRI pred, Value obj)
+		throws RDFParseException
+	{
 		try {
 			return valueFactory.createStatement(subj, pred, obj);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
@@ -572,18 +598,20 @@ public abstract class AbstractRDFParser implements RDFParser {
 	/**
 	 * Creates a new {@link Statement} object with the supplied components.
 	 */
-	protected Statement createStatement(Resource subj, IRI pred, Value obj, Resource context) throws RDFParseException {
+	protected Statement createStatement(Resource subj, IRI pred, Value obj, Resource context)
+		throws RDFParseException
+	{
 		try {
 			return valueFactory.createStatement(subj, pred, obj, context);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			reportFatalError(e);
 			return null; // required by compiler
 		}
 	}
 
 	/**
-	 * Reports the specified line- and column number to the registered
-	 * {@link ParseLocationListener}, if any.
+	 * Reports the specified line- and column number to the registered {@link ParseLocationListener}, if any.
 	 */
 	protected void reportLocation(long lineNo, long columnNo) {
 		if (locationListener != null) {
@@ -592,17 +620,15 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Reports a warning to the registered ParseErrorListener, if any. This method
-	 * simply calls {@link #reportWarning(String,long,long)} supplying <tt>-1</tt>
-	 * for the line- and column number.
+	 * Reports a warning to the registered ParseErrorListener, if any. This method simply calls
+	 * {@link #reportWarning(String,long,long)} supplying <tt>-1</tt> for the line- and column number.
 	 */
 	protected void reportWarning(String msg) {
 		reportWarning(msg, -1, -1);
 	}
 
 	/**
-	 * Reports a warning with associated line- and column number to the registered
-	 * ParseErrorListener, if any.
+	 * Reports a warning with associated line- and column number to the registered ParseErrorListener, if any.
 	 */
 	protected void reportWarning(String msg, long lineNo, long columnNo) {
 		if (errListener != null) {
@@ -611,229 +637,221 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered
-	 * ParseErrorListener, if the given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
+	 * given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting
-	 * has been set to <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting has been set to
+	 * <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param msg
-	 *            The message to use for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        The message to use for {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *            The boolean setting that will be checked to determine if this is
-	 *            an issue that we need to look at at all. If this setting is true,
-	 *            then the error listener will receive the error, and if
-	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
-	 *            exception will be thrown.
+	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
+	 *        at at all. If this setting is true, then the error listener will receive the error, and if
+	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
 	 * @throws RDFParseException
-	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
-	 *             the given setting.
+	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
 	 */
-	protected void reportError(String msg, RioSetting<Boolean> relevantSetting) throws RDFParseException {
+	protected void reportError(String msg, RioSetting<Boolean> relevantSetting)
+		throws RDFParseException
+	{
 		RDFParserHelper.reportError(msg, relevantSetting, getParserConfig(), getParseErrorListener());
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered
-	 * ParseErrorListener, if the given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
+	 * given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting
-	 * has been set to <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting has been set to
+	 * <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param msg
-	 *            The message to use for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        The message to use for {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param lineNo
-	 *            Optional line number, should default to setting this as -1 if not
-	 *            known. Used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        Optional line number, should default to setting this as -1 if not known. Used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param columnNo
-	 *            Optional column number, should default to setting this as -1 if
-	 *            not known. Used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        Optional column number, should default to setting this as -1 if not known. Used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *            The boolean setting that will be checked to determine if this is
-	 *            an issue that we need to look at at all. If this setting is true,
-	 *            then the error listener will receive the error, and if
-	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
-	 *            exception will be thrown.
+	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
+	 *        at at all. If this setting is true, then the error listener will receive the error, and if
+	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
 	 * @throws RDFParseException
-	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
-	 *             the given setting.
+	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
 	 */
 	protected void reportError(String msg, long lineNo, long columnNo, RioSetting<Boolean> relevantSetting)
-			throws RDFParseException {
-		RDFParserHelper.reportError(msg, lineNo, columnNo, relevantSetting, getParserConfig(), getParseErrorListener());
+		throws RDFParseException
+	{
+		RDFParserHelper.reportError(msg, lineNo, columnNo, relevantSetting, getParserConfig(),
+				getParseErrorListener());
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered
-	 * ParseErrorListener, if the given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
+	 * given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting
-	 * has been set to <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting has been set to
+	 * <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param e
-	 *            The exception whose message will be used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        The exception whose message will be used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *            The boolean setting that will be checked to determine if this is
-	 *            an issue that we need to look at at all. If this setting is true,
-	 *            then the error listener will receive the error, and if
-	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
-	 *            exception will be thrown.
+	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
+	 *        at at all. If this setting is true, then the error listener will receive the error, and if
+	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
 	 * @throws RDFParseException
-	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
-	 *             the given setting.
+	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
 	 */
-	protected void reportError(Exception e, RioSetting<Boolean> relevantSetting) throws RDFParseException {
+	protected void reportError(Exception e, RioSetting<Boolean> relevantSetting)
+		throws RDFParseException
+	{
 		RDFParserHelper.reportError(e, -1, -1, relevantSetting, getParserConfig(), getParseErrorListener());
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered
-	 * ParseErrorListener, if the given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
+	 * given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting
-	 * has been set to <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting has been set to
+	 * <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param e
-	 *            The exception whose message will be used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        The exception whose message will be used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param lineNo
-	 *            Optional line number, should default to setting this as -1 if not
-	 *            known. Used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        Optional line number, should default to setting this as -1 if not known. Used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param columnNo
-	 *            Optional column number, should default to setting this as -1 if
-	 *            not known. Used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        Optional column number, should default to setting this as -1 if not known. Used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *            The boolean setting that will be checked to determine if this is
-	 *            an issue that we need to look at at all. If this setting is true,
-	 *            then the error listener will receive the error, and if
-	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
-	 *            exception will be thrown.
+	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
+	 *        at at all. If this setting is true, then the error listener will receive the error, and if
+	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
 	 * @throws RDFParseException
-	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
-	 *             the given setting.
+	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
 	 */
 	protected void reportError(Exception e, long lineNo, long columnNo, RioSetting<Boolean> relevantSetting)
-			throws RDFParseException {
-		RDFParserHelper.reportError(e, lineNo, columnNo, relevantSetting, getParserConfig(), getParseErrorListener());
+		throws RDFParseException
+	{
+		RDFParserHelper.reportError(e, lineNo, columnNo, relevantSetting, getParserConfig(),
+				getParseErrorListener());
 	}
 
 	/**
-	 * Reports an error with associated line- and column number to the registered
-	 * ParseErrorListener, if the given setting has been set to true.
+	 * Reports an error with associated line- and column number to the registered ParseErrorListener, if the
+	 * given setting has been set to true.
 	 * <p>
-	 * This method also throws an {@link RDFParseException} when the given setting
-	 * has been set to <tt>true</tt> and it is not a nonFatalError.
+	 * This method also throws an {@link RDFParseException} when the given setting has been set to
+	 * <tt>true</tt> and it is not a nonFatalError.
 	 * 
 	 * @param msg
-	 *            The message to use for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        The message to use for {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param e
-	 *            The exception whose message will be used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        The exception whose message will be used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param lineNo
-	 *            Optional line number, should default to setting this as -1 if not
-	 *            known. Used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        Optional line number, should default to setting this as -1 if not known. Used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param columnNo
-	 *            Optional column number, should default to setting this as -1 if
-	 *            not known. Used for
-	 *            {@link ParseErrorListener#error(String, long, long)} and for
-	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 *        Optional column number, should default to setting this as -1 if not known. Used for
+	 *        {@link ParseErrorListener#error(String, long, long)} and for
+	 *        {@link RDFParseException#RDFParseException(String, long, long)} .
 	 * @param relevantSetting
-	 *            The boolean setting that will be checked to determine if this is
-	 *            an issue that we need to look at at all. If this setting is true,
-	 *            then the error listener will receive the error, and if
-	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
-	 *            exception will be thrown.
+	 *        The boolean setting that will be checked to determine if this is an issue that we need to look
+	 *        at at all. If this setting is true, then the error listener will receive the error, and if
+	 *        {@link ParserConfig#isNonFatalError(RioSetting)} returns true an exception will be thrown.
 	 * @throws RDFParseException
-	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
-	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
-	 *             the given setting.
+	 *         If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *         {@link ParserConfig#isNonFatalError(RioSetting)} returns true for the given setting.
 	 */
-	protected void reportError(String msg, Exception e, long lineNo, long columnNo, RioSetting<Boolean> relevantSetting)
-			throws RDFParseException {
-		RDFParserHelper.reportError(e, lineNo, columnNo, relevantSetting, getParserConfig(), getParseErrorListener());
+	protected void reportError(String msg, Exception e, long lineNo, long columnNo,
+			RioSetting<Boolean> relevantSetting)
+		throws RDFParseException
+	{
+		RDFParserHelper.reportError(e, lineNo, columnNo, relevantSetting, getParserConfig(),
+				getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error to the registered ParseErrorListener, if any, and
-	 * throws a <tt>ParseException</tt> afterwards. This method simply calls
-	 * {@link #reportFatalError(String,long,long)} supplying <tt>-1</tt> for the
-	 * line- and column number.
+	 * Reports a fatal error to the registered ParseErrorListener, if any, and throws a
+	 * <tt>ParseException</tt> afterwards. This method simply calls
+	 * {@link #reportFatalError(String,long,long)} supplying <tt>-1</tt> for the line- and column number.
 	 */
-	protected void reportFatalError(String msg) throws RDFParseException {
+	protected void reportFatalError(String msg)
+		throws RDFParseException
+	{
 		RDFParserHelper.reportFatalError(msg, getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error with associated line- and column number to the
-	 * registered ParseErrorListener, if any, and throws a <tt>ParseException</tt>
-	 * afterwards.
+	 * Reports a fatal error with associated line- and column number to the registered ParseErrorListener, if
+	 * any, and throws a <tt>ParseException</tt> afterwards.
 	 */
-	protected void reportFatalError(String msg, long lineNo, long columnNo) throws RDFParseException {
+	protected void reportFatalError(String msg, long lineNo, long columnNo)
+		throws RDFParseException
+	{
 		RDFParserHelper.reportFatalError(msg, lineNo, columnNo, getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error to the registered ParseErrorListener, if any, and
-	 * throws a <tt>ParseException</tt> afterwards. An exception is made for the
-	 * case where the supplied exception is a {@link RDFParseException}; in that
-	 * case the supplied exception is not wrapped in another ParseException and the
-	 * error message is not reported to the ParseErrorListener, assuming that it has
-	 * already been reported when the original ParseException was thrown.
+	 * Reports a fatal error to the registered ParseErrorListener, if any, and throws a
+	 * <tt>ParseException</tt> afterwards. An exception is made for the case where the supplied exception is a
+	 * {@link RDFParseException}; in that case the supplied exception is not wrapped in another ParseException
+	 * and the error message is not reported to the ParseErrorListener, assuming that it has already been
+	 * reported when the original ParseException was thrown.
 	 * <p>
-	 * This method simply calls {@link #reportFatalError(Exception,long,long)}
-	 * supplying <tt>-1</tt> for the line- and column number.
+	 * This method simply calls {@link #reportFatalError(Exception,long,long)} supplying <tt>-1</tt> for the
+	 * line- and column number.
 	 */
-	protected void reportFatalError(Exception e) throws RDFParseException {
+	protected void reportFatalError(Exception e)
+		throws RDFParseException
+	{
 		RDFParserHelper.reportFatalError(e, getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error with associated line- and column number to the
-	 * registered ParseErrorListener, if any, and throws a <tt>ParseException</tt>
-	 * wrapped the supplied exception afterwards. An exception is made for the case
-	 * where the supplied exception is a {@link RDFParseException}; in that case the
-	 * supplied exception is not wrapped in another ParseException and the error
-	 * message is not reported to the ParseErrorListener, assuming that it has
-	 * already been reported when the original ParseException was thrown.
+	 * Reports a fatal error with associated line- and column number to the registered ParseErrorListener, if
+	 * any, and throws a <tt>ParseException</tt> wrapped the supplied exception afterwards. An exception is
+	 * made for the case where the supplied exception is a {@link RDFParseException}; in that case the
+	 * supplied exception is not wrapped in another ParseException and the error message is not reported to
+	 * the ParseErrorListener, assuming that it has already been reported when the original ParseException was
+	 * thrown.
 	 */
-	protected void reportFatalError(Exception e, long lineNo, long columnNo) throws RDFParseException {
+	protected void reportFatalError(Exception e, long lineNo, long columnNo)
+		throws RDFParseException
+	{
 		RDFParserHelper.reportFatalError(e, lineNo, columnNo, getParseErrorListener());
 	}
 
 	/**
-	 * Reports a fatal error with associated line- and column number to the
-	 * registered ParseErrorListener, if any, and throws a <tt>ParseException</tt>
-	 * wrapped the supplied exception afterwards. An exception is made for the case
-	 * where the supplied exception is a {@link RDFParseException}; in that case the
-	 * supplied exception is not wrapped in another ParseException and the error
-	 * message is not reported to the ParseErrorListener, assuming that it has
-	 * already been reported when the original ParseException was thrown.
+	 * Reports a fatal error with associated line- and column number to the registered ParseErrorListener, if
+	 * any, and throws a <tt>ParseException</tt> wrapped the supplied exception afterwards. An exception is
+	 * made for the case where the supplied exception is a {@link RDFParseException}; in that case the
+	 * supplied exception is not wrapped in another ParseException and the error message is not reported to
+	 * the ParseErrorListener, assuming that it has already been reported when the original ParseException was
+	 * thrown.
 	 */
-	protected void reportFatalError(String message, Exception e, long lineNo, long columnNo) throws RDFParseException {
+	protected void reportFatalError(String message, Exception e, long lineNo, long columnNo)
+		throws RDFParseException
+	{
 		RDFParserHelper.reportFatalError(message, e, lineNo, columnNo, getParseErrorListener());
 	}
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -737,6 +737,47 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	/**
+	 * Reports an error with associated line- and column number to the registered
+	 * ParseErrorListener, if the given setting has been set to true.
+	 * <p>
+	 * This method also throws an {@link RDFParseException} when the given setting
+	 * has been set to <tt>true</tt> and it is not a nonFatalError.
+	 * 
+	 * @param msg
+	 *            The message to use for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 * @param e
+	 *            The exception whose message will be used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 * @param lineNo
+	 *            Optional line number, should default to setting this as -1 if not
+	 *            known. Used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 * @param columnNo
+	 *            Optional column number, should default to setting this as -1 if
+	 *            not known. Used for
+	 *            {@link ParseErrorListener#error(String, long, long)} and for
+	 *            {@link RDFParseException#RDFParseException(String, long, long)} .
+	 * @param relevantSetting
+	 *            The boolean setting that will be checked to determine if this is
+	 *            an issue that we need to look at at all. If this setting is true,
+	 *            then the error listener will receive the error, and if
+	 *            {@link ParserConfig#isNonFatalError(RioSetting)} returns true an
+	 *            exception will be thrown.
+	 * @throws RDFParseException
+	 *             If {@link ParserConfig#get(RioSetting)} returns true, and
+	 *             {@link ParserConfig#isNonFatalError(RioSetting)} returns true for
+	 *             the given setting.
+	 */
+	protected void reportError(String msg, Exception e, long lineNo, long columnNo, RioSetting<Boolean> relevantSetting)
+			throws RDFParseException {
+		RDFParserHelper.reportError(e, lineNo, columnNo, relevantSetting, getParserConfig(), getParseErrorListener());
+	}
+
+	/**
 	 * Reports a fatal error to the registered ParseErrorListener, if any, and
 	 * throws a <tt>ParseException</tt> afterwards. This method simply calls
 	 * {@link #reportFatalError(String,long,long)} supplying <tt>-1</tt> for the
@@ -781,6 +822,19 @@ public abstract class AbstractRDFParser implements RDFParser {
 	 */
 	protected void reportFatalError(Exception e, long lineNo, long columnNo) throws RDFParseException {
 		RDFParserHelper.reportFatalError(e, lineNo, columnNo, getParseErrorListener());
+	}
+
+	/**
+	 * Reports a fatal error with associated line- and column number to the
+	 * registered ParseErrorListener, if any, and throws a <tt>ParseException</tt>
+	 * wrapped the supplied exception afterwards. An exception is made for the case
+	 * where the supplied exception is a {@link RDFParseException}; in that case the
+	 * supplied exception is not wrapped in another ParseException and the error
+	 * message is not reported to the ParseErrorListener, assuming that it has
+	 * already been reported when the original ParseException was thrown.
+	 */
+	protected void reportFatalError(String message, Exception e, long lineNo, long columnNo) throws RDFParseException {
+		RDFParserHelper.reportFatalError(message, e, lineNo, columnNo, getParseErrorListener());
 	}
 
 	private final String createUniqueBNodePrefix() {

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONSettings.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+
+/**
+ * Generic JSON settings, mostly related to Jackson Features.
+ *
+ * @author Peter Ansell
+ */
+public class JSONSettings {
+
+	/**
+	 * Boolean setting for JSON parsers to determine if any character is allowed to be backslash escaped.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_backslash_escaping_any_character",
+			"Allow backslash escaping any character", Boolean.FALSE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if Java/C++ style comments are allowed.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_COMMENTS = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_comments", "Allow comments", Boolean.FALSE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if non-numeric numbers (INF/-INF/NaN) are allowed.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_NON_NUMERIC_NUMBERS = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_non_numeric_numbers", "Allow non-numeric numbers",
+			Boolean.FALSE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if numeric leading zeroes are allowed.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_NUMERIC_LEADING_ZEROS = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_numeric_leading_zeros", "Allow numeric leading zeros",
+			Boolean.FALSE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if single quotes are allowed.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_SINGLE_QUOTES = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_single_quotes", "Allow single quotes", Boolean.FALSE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if unquoted control characters are allowed.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_UNQUOTED_CONTROL_CHARS = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_unquoted_control_chars", "Allow unquoted control chars",
+			Boolean.FALSE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if unquoted field names are allowed.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_UNQUOTED_FIELD_NAMES = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_unquoted_field_names", "Allow unquoted field names",
+			Boolean.FALSE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if YAML comments (starting with '#') are allowed.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_YAML_COMMENTS = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_yaml_comments", "Allow YAML comments", Boolean.FALSE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if errors should include a reference to the source or
+	 * not.
+	 * <p>
+	 * Defaults to true.
+	 */
+	public static final RioSetting<Boolean> INCLUDE_SOURCE_IN_LOCATION = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.include_source_in_location", "Include Source in Location",
+			Boolean.TRUE);
+
+	/**
+	 * Boolean setting for JSON parsers to determine if strict duplicate detection is allowed for JSON Object
+	 * field names.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> STRICT_DUPLICATE_DETECTION = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.strict_duplicate_detection", "Strict duplicate detection",
+			Boolean.FALSE);
+
+	/**
+	 * Private default constructor.
+	 */
+	private JSONSettings() {
+	}
+
+}

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONSettings.java
@@ -86,6 +86,14 @@ public class JSONSettings {
 			"org.eclipse.rdf4j.rio.json.allow_yaml_comments", "Allow YAML comments", Boolean.FALSE);
 
 	/**
+	 * Boolean setting for JSON parsers to determine if trailing commas are allows.
+	 * <p>
+	 * Defaults to false.
+	 */
+	public static final RioSetting<Boolean> ALLOW_TRAILING_COMMA = new RioSettingImpl<>(
+			"org.eclipse.rdf4j.rio.json.allow_yaml_comments", "Allow trailing comma", Boolean.FALSE);
+
+	/**
 	 * Boolean setting for JSON parsers to determine if errors should include a reference to the source or
 	 * not.
 	 * <p>

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFParserHelper.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFParserHelper.java
@@ -444,6 +444,30 @@ public class RDFParserHelper {
 	}
 
 	/**
+	 * Reports a fatal error with associated line- and column number to the registered ParseErrorListener, if
+	 * any, and throws a <tt>ParseException</tt> wrapped the supplied exception afterwards. An exception is
+	 * made for the case where the supplied exception is a {@link RDFParseException}; in that case the
+	 * supplied exception is not wrapped in another ParseException and the error message is not reported to
+	 * the ParseErrorListener, assuming that it has already been reported when the original ParseException was
+	 * thrown.
+	 */
+	public static void reportFatalError(String message, Exception e, long lineNo, long columnNo,
+			ParseErrorListener errListener)
+		throws RDFParseException
+	{
+		if (e instanceof RDFParseException) {
+			throw (RDFParseException)e;
+		}
+		else {
+			if (errListener != null) {
+				errListener.fatalError(message, lineNo, columnNo);
+			}
+
+			throw new RDFParseException(message, e, lineNo, columnNo);
+		}
+	}
+
+	/**
 	 * Protected constructor to prevent direct instantiation.
 	 */
 	protected RDFParserHelper() {

--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -48,11 +48,10 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Creates a Sesame JSONLD Parser using the given {@link ValueFactory} to create
-	 * new {@link Value}s.
+	 * Creates a Sesame JSONLD Parser using the given {@link ValueFactory} to create new {@link Value}s.
 	 * 
 	 * @param valueFactory
-	 *            The ValueFactory to use
+	 *        The ValueFactory to use
 	 */
 	public JSONLDParser(final ValueFactory valueFactory) {
 		super(valueFactory);
@@ -75,6 +74,7 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 		result.add(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS);
 		result.add(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES);
 		result.add(JSONSettings.ALLOW_YAML_COMMENTS);
+		result.add(JSONSettings.ALLOW_TRAILING_COMMA);
 		result.add(JSONSettings.INCLUDE_SOURCE_IN_LOCATION);
 		result.add(JSONSettings.STRICT_DUPLICATE_DETECTION);
 
@@ -83,7 +83,10 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 
 	@Override
 	public void parse(final InputStream in, final String baseURI)
-			throws IOException, RDFParseException, RDFHandlerException {
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		clear();
 
 		try {
@@ -101,23 +104,30 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 			final Object parsedJson = JsonUtils.fromJsonParser(nextParser);
 
 			JsonLdProcessor.toRDF(parsedJson, callback, options);
-		} catch (final JsonLdError e) {
+		}
+		catch (final JsonLdError e) {
 			throw new RDFParseException("Could not parse JSONLD", e);
-		} catch (final JsonProcessingException e) {
+		}
+		catch (final JsonProcessingException e) {
 			throw new RDFParseException("Could not parse JSONLD", e);
-		} catch (final RuntimeException e) {
+		}
+		catch (final RuntimeException e) {
 			if (e.getCause() != null && e.getCause() instanceof RDFParseException) {
-				throw (RDFParseException) e.getCause();
+				throw (RDFParseException)e.getCause();
 			}
 			throw e;
-		} finally {
+		}
+		finally {
 			clear();
 		}
 	}
 
 	@Override
 	public void parse(final Reader reader, final String baseURI)
-			throws IOException, RDFParseException, RDFHandlerException {
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		clear();
 
 		try {
@@ -135,26 +145,29 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 			final Object parsedJson = JsonUtils.fromJsonParser(nextParser);
 
 			JsonLdProcessor.toRDF(parsedJson, callback, options);
-		} catch (final JsonLdError e) {
+		}
+		catch (final JsonLdError e) {
 			throw new RDFParseException("Could not parse JSONLD", e);
-		} catch (final JsonProcessingException e) {
-			throw new RDFParseException("Could not parse JSONLD", e, e.getLocation().getLineNr(), e.getLocation().getColumnNr());
-		} catch (final RuntimeException e) {
+		}
+		catch (final JsonProcessingException e) {
+			throw new RDFParseException("Could not parse JSONLD", e, e.getLocation().getLineNr(),
+					e.getLocation().getColumnNr());
+		}
+		catch (final RuntimeException e) {
 			if (e.getCause() != null && e.getCause() instanceof RDFParseException) {
-				throw (RDFParseException) e.getCause();
+				throw (RDFParseException)e.getCause();
 			}
 			throw e;
-		} finally {
+		}
+		finally {
 			clear();
 		}
 	}
 
 	/**
-	 * Get an instance of JsonFactory configured using the settings from
-	 * {@link #getParserConfig()}.
+	 * Get an instance of JsonFactory configured using the settings from {@link #getParserConfig()}.
 	 * 
-	 * @return A newly configured JsonFactory based on the currently enabled
-	 *         settings
+	 * @return A newly configured JsonFactory based on the currently enabled settings
 	 */
 	private JsonFactory configureNewJsonFactory() {
 		final JsonFactory nextJsonFactory = new JsonFactory(JSON_MAPPER);

--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -138,7 +138,7 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 		} catch (final JsonLdError e) {
 			throw new RDFParseException("Could not parse JSONLD", e);
 		} catch (final JsonProcessingException e) {
-			throw new RDFParseException("Could not parse JSONLD", e);
+			throw new RDFParseException("Could not parse JSONLD", e, e.getLocation().getLineNr(), e.getLocation().getColumnNr());
 		} catch (final RuntimeException e) {
 			if (e.getCause() != null && e.getCause() instanceof RDFParseException) {
 				throw (RDFParseException) e.getCause();

--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.rio.jsonld;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.util.Collection;
 
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -17,9 +18,14 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFParser;
+import org.eclipse.rdf4j.rio.helpers.JSONSettings;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.core.JsonLdProcessor;
@@ -32,6 +38,8 @@ import com.github.jsonldjava.utils.JsonUtils;
  */
 public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 
+	private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
 	/**
 	 * Default constructor
 	 */
@@ -40,10 +48,11 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 	}
 
 	/**
-	 * Creates a Sesame JSONLD Parser using the given {@link ValueFactory} to create new {@link Value}s.
+	 * Creates a Sesame JSONLD Parser using the given {@link ValueFactory} to create
+	 * new {@link Value}s.
 	 * 
 	 * @param valueFactory
-	 *        The ValueFactory to use
+	 *            The ValueFactory to use
 	 */
 	public JSONLDParser(final ValueFactory valueFactory) {
 		super(valueFactory);
@@ -55,9 +64,26 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 	}
 
 	@Override
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		Collection<RioSetting<?>> result = super.getSupportedSettings();
+
+		result.add(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER);
+		result.add(JSONSettings.ALLOW_COMMENTS);
+		result.add(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS);
+		result.add(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS);
+		result.add(JSONSettings.ALLOW_SINGLE_QUOTES);
+		result.add(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS);
+		result.add(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES);
+		result.add(JSONSettings.ALLOW_YAML_COMMENTS);
+		result.add(JSONSettings.INCLUDE_SOURCE_IN_LOCATION);
+		result.add(JSONSettings.STRICT_DUPLICATE_DETECTION);
+
+		return result;
+	}
+
+	@Override
 	public void parse(final InputStream in, final String baseURI)
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+			throws IOException, RDFParseException, RDFHandlerException {
 		clear();
 
 		try {
@@ -68,29 +94,30 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 			final JsonLdOptions options = new JsonLdOptions(baseURI);
 			options.useNamespaces = true;
 
-			JsonLdProcessor.toRDF(JsonUtils.fromInputStream(in), callback, options);
-		}
-		catch (final JsonLdError e) {
+			final JsonFactory nextJsonFactory = configureNewJsonFactory();
+
+			final JsonParser nextParser = nextJsonFactory.createParser(in);
+
+			final Object parsedJson = JsonUtils.fromJsonParser(nextParser);
+
+			JsonLdProcessor.toRDF(parsedJson, callback, options);
+		} catch (final JsonLdError e) {
 			throw new RDFParseException("Could not parse JSONLD", e);
-		}
-		catch (final JsonParseException e) {
+		} catch (final JsonProcessingException e) {
 			throw new RDFParseException("Could not parse JSONLD", e);
-		}
-		catch (final RuntimeException e) {
+		} catch (final RuntimeException e) {
 			if (e.getCause() != null && e.getCause() instanceof RDFParseException) {
-				throw (RDFParseException)e.getCause();
+				throw (RDFParseException) e.getCause();
 			}
 			throw e;
-		}
-		finally {
+		} finally {
 			clear();
 		}
 	}
 
 	@Override
 	public void parse(final Reader reader, final String baseURI)
-		throws IOException, RDFParseException, RDFHandlerException
-	{
+			throws IOException, RDFParseException, RDFHandlerException {
 		clear();
 
 		try {
@@ -101,23 +128,78 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 			final JsonLdOptions options = new JsonLdOptions(baseURI);
 			options.useNamespaces = true;
 
-			JsonLdProcessor.toRDF(JsonUtils.fromReader(reader), callback, options);
-		}
-		catch (final JsonLdError e) {
+			final JsonFactory nextJsonFactory = configureNewJsonFactory();
+
+			final JsonParser nextParser = nextJsonFactory.createParser(reader);
+
+			final Object parsedJson = JsonUtils.fromJsonParser(nextParser);
+
+			JsonLdProcessor.toRDF(parsedJson, callback, options);
+		} catch (final JsonLdError e) {
 			throw new RDFParseException("Could not parse JSONLD", e);
-		}
-		catch (final JsonParseException e) {
+		} catch (final JsonProcessingException e) {
 			throw new RDFParseException("Could not parse JSONLD", e);
-		}
-		catch (final RuntimeException e) {
+		} catch (final RuntimeException e) {
 			if (e.getCause() != null && e.getCause() instanceof RDFParseException) {
-				throw (RDFParseException)e.getCause();
+				throw (RDFParseException) e.getCause();
 			}
 			throw e;
-		}
-		finally {
+		} finally {
 			clear();
 		}
+	}
+
+	/**
+	 * Get an instance of JsonFactory configured using the settings from
+	 * {@link #getParserConfig()}.
+	 * 
+	 * @return A newly configured JsonFactory based on the currently enabled
+	 *         settings
+	 */
+	private JsonFactory configureNewJsonFactory() {
+		final JsonFactory nextJsonFactory = new JsonFactory(JSON_MAPPER);
+
+		if (getParserConfig().isSet(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
+					getParserConfig().get(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_COMMENTS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS,
+					getParserConfig().get(JSONSettings.ALLOW_COMMENTS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS,
+					getParserConfig().get(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS,
+					getParserConfig().get(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_SINGLE_QUOTES)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES,
+					getParserConfig().get(JSONSettings.ALLOW_SINGLE_QUOTES));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
+					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES,
+					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_YAML_COMMENTS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS,
+					getParserConfig().get(JSONSettings.ALLOW_YAML_COMMENTS));
+		}
+		if (getParserConfig().isSet(JSONSettings.INCLUDE_SOURCE_IN_LOCATION)) {
+			nextJsonFactory.configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION,
+					getParserConfig().get(JSONSettings.INCLUDE_SOURCE_IN_LOCATION));
+		}
+		if (getParserConfig().isSet(JSONSettings.STRICT_DUPLICATE_DETECTION)) {
+			nextJsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION,
+					getParserConfig().get(JSONSettings.STRICT_DUPLICATE_DETECTION));
+		}
+		return nextJsonFactory;
 	}
 
 }

--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -204,6 +204,10 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 			nextJsonFactory.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS,
 					getParserConfig().get(JSONSettings.ALLOW_YAML_COMMENTS));
 		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_TRAILING_COMMA)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA,
+					getParserConfig().get(JSONSettings.ALLOW_TRAILING_COMMA));
+		}
 		if (getParserConfig().isSet(JSONSettings.INCLUDE_SOURCE_IN_LOCATION)) {
 			nextJsonFactory.configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION,
 					getParserConfig().get(JSONSettings.INCLUDE_SOURCE_IN_LOCATION));

--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -109,7 +109,8 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 			throw new RDFParseException("Could not parse JSONLD", e);
 		}
 		catch (final JsonProcessingException e) {
-			throw new RDFParseException("Could not parse JSONLD", e);
+			throw new RDFParseException("Could not parse JSONLD", e, e.getLocation().getLineNr(),
+					e.getLocation().getColumnNr());
 		}
 		catch (final RuntimeException e) {
 			if (e.getCause() != null && e.getCause() instanceof RDFParseException) {

--- a/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
+++ b/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
@@ -69,7 +69,9 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 
 	@Override
 	public void parse(final InputStream inputStream, final String baseUri)
-		throws IOException, RDFParseException, RDFHandlerException
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
 	{
 		JsonParser jp = null;
 
@@ -156,7 +158,9 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 
 	@Override
 	public void parse(final Reader reader, final String baseUri)
-		throws IOException, RDFParseException, RDFHandlerException
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
 	{
 		JsonParser jp = null;
 
@@ -196,7 +200,10 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 
 	private void rdfJsonToHandlerInternal(final RDFHandler handler, final ValueFactory vf,
 			final JsonParser jp)
-		throws IOException, JsonParseException, RDFParseException, RDFHandlerException
+		throws IOException,
+		JsonParseException,
+		RDFParseException,
+		RDFHandlerException
 	{
 		if (jp.nextToken() != JsonToken.START_OBJECT) {
 			reportFatalError("Expected RDF/JSON document to start with an Object", jp.getCurrentLocation());

--- a/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
+++ b/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.io.input.BOMInputStream;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -28,8 +27,11 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFParser;
+import org.eclipse.rdf4j.rio.helpers.JSONSettings;
 import org.eclipse.rdf4j.rio.helpers.RDFJSONParserSettings;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
@@ -78,7 +80,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 				this.rdfHandler.startRDF();
 			}
 
-			jp = RDFJSONUtility.JSON_FACTORY.createParser(new BOMInputStream(inputStream, false));
+			jp = configureNewJsonFactory().createParser(inputStream);
 			rdfJsonToHandlerInternal(this.rdfHandler, this.valueFactory, jp);
 		}
 		catch (final IOException e) {
@@ -128,10 +130,10 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 				currentLocation.getColumnNr());
 	}
 
-	protected void reportError(String msg, Throwable e, JsonLocation location, RioSetting<Boolean> setting)
+	protected void reportError(String msg, Exception e, JsonLocation location, RioSetting<Boolean> setting)
 		throws RDFParseException
 	{
-		reportError(msg, location.getLineNr(), location.getColumnNr(), setting);
+		reportError(msg, e, location.getLineNr(), location.getColumnNr(), setting);
 	}
 
 	protected void reportError(String msg, JsonLocation location, RioSetting<Boolean> setting)
@@ -140,10 +142,10 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 		reportError(msg, location.getLineNr(), location.getColumnNr(), setting);
 	}
 
-	protected void reportFatalError(String msg, Throwable e, JsonLocation location)
+	protected void reportFatalError(String msg, Exception e, JsonLocation location)
 		throws RDFParseException
 	{
-		reportFatalError(msg, location.getLineNr(), location.getColumnNr());
+		reportFatalError(msg, e, location.getLineNr(), location.getColumnNr());
 	}
 
 	protected void reportFatalError(String msg, JsonLocation location)
@@ -165,7 +167,7 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 				this.rdfHandler.startRDF();
 			}
 
-			jp = RDFJSONUtility.JSON_FACTORY.createParser(reader);
+			jp = configureNewJsonFactory().createParser(reader);
 			rdfJsonToHandlerInternal(rdfHandler, valueFactory, jp);
 		}
 		catch (final IOException e) {
@@ -407,7 +409,80 @@ public class RDFJSONParser extends AbstractRDFParser implements RDFParser {
 		result.add(RDFJSONParserSettings.FAIL_ON_UNKNOWN_PROPERTY);
 		result.add(RDFJSONParserSettings.SUPPORT_GRAPHS_EXTENSION);
 
+		result.add(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER);
+		result.add(JSONSettings.ALLOW_COMMENTS);
+		result.add(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS);
+		result.add(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS);
+		result.add(JSONSettings.ALLOW_SINGLE_QUOTES);
+		result.add(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS);
+		result.add(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES);
+		result.add(JSONSettings.ALLOW_YAML_COMMENTS);
+		result.add(JSONSettings.ALLOW_TRAILING_COMMA);
+		result.add(JSONSettings.INCLUDE_SOURCE_IN_LOCATION);
+		result.add(JSONSettings.STRICT_DUPLICATE_DETECTION);
+
 		return result;
 	}
 
+	/**
+	 * Get an instance of JsonFactory configured using the settings from {@link #getParserConfig()}.
+	 * 
+	 * @return A newly configured JsonFactory based on the currently enabled settings
+	 */
+	private JsonFactory configureNewJsonFactory() {
+		final JsonFactory nextJsonFactory = new JsonFactory();
+		// Disable features that may work for most JSON where the field names are
+		// in limited supply,
+		// but does not work for RDF/JSON where a wide range of URIs are used for
+		// subjects and predicates
+		nextJsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+		nextJsonFactory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
+		nextJsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+		if (getParserConfig().isSet(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
+					getParserConfig().get(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_COMMENTS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS,
+					getParserConfig().get(JSONSettings.ALLOW_COMMENTS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS,
+					getParserConfig().get(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS,
+					getParserConfig().get(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_SINGLE_QUOTES)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES,
+					getParserConfig().get(JSONSettings.ALLOW_SINGLE_QUOTES));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
+					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES,
+					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_YAML_COMMENTS)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS,
+					getParserConfig().get(JSONSettings.ALLOW_YAML_COMMENTS));
+		}
+		if (getParserConfig().isSet(JSONSettings.ALLOW_TRAILING_COMMA)) {
+			nextJsonFactory.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA,
+					getParserConfig().get(JSONSettings.ALLOW_TRAILING_COMMA));
+		}
+		if (getParserConfig().isSet(JSONSettings.INCLUDE_SOURCE_IN_LOCATION)) {
+			nextJsonFactory.configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION,
+					getParserConfig().get(JSONSettings.INCLUDE_SOURCE_IN_LOCATION));
+		}
+		if (getParserConfig().isSet(JSONSettings.STRICT_DUPLICATE_DETECTION)) {
+			nextJsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION,
+					getParserConfig().get(JSONSettings.STRICT_DUPLICATE_DETECTION));
+		}
+		return nextJsonFactory;
+	}
 }

--- a/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONUtility.java
+++ b/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONUtility.java
@@ -7,9 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfjson;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-
 /**
  * A utility class to help converting Sesame Models to and from RDF/JSON using Jackson.
  * 
@@ -34,17 +31,5 @@ class RDFJSONUtility {
 	public static final String TYPE = "type";
 
 	public static final String VALUE = "value";
-
-	public static final JsonFactory JSON_FACTORY = new JsonFactory();
-
-	static {
-		// Disable features that may work for most JSON where the field names are
-		// in limited supply,
-		// but does not work for RDF/JSON where a wide range of URIs are used for
-		// subjects and predicates
-		JSON_FACTORY.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
-		JSON_FACTORY.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
-		JSON_FACTORY.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
-	}
 
 }

--- a/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -31,6 +31,7 @@ import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
@@ -68,7 +69,7 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	{
 		try {
 			if (this.writer != null) {
-				try (final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createGenerator(this.writer);) {
+				try (final JsonGenerator jg = configureNewJsonFactory().createGenerator(this.writer);) {
 					RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
 				}
 				finally {
@@ -76,9 +77,7 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 				}
 			}
 			else if (this.outputStream != null) {
-				try (final JsonGenerator jg = RDFJSONUtility.JSON_FACTORY.createGenerator(
-						this.outputStream);)
-				{
+				try (final JsonGenerator jg = configureNewJsonFactory().createGenerator(this.outputStream);) {
 					RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
 				}
 				finally {
@@ -151,7 +150,8 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @throws JSONException
 	 */
 	public static void writeObject(final Value object, final Set<Resource> contexts, final JsonGenerator jg)
-		throws JsonGenerationException, IOException
+		throws JsonGenerationException,
+		IOException
 	{
 		jg.writeStartObject();
 		if (object instanceof Literal) {
@@ -214,7 +214,8 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 
 	public static void modelToRdfJsonInternal(final Model graph, final WriterConfig writerConfig,
 			final JsonGenerator jg)
-		throws IOException, JsonGenerationException
+		throws IOException,
+		JsonGenerationException
 	{
 		if (writerConfig.get(BasicWriterSettings.PRETTY_PRINT)) {
 			// SES-2011: Always use \n for consistency
@@ -246,4 +247,21 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 		jg.writeEndObject();
 	}
 
+	/**
+	 * Get an instance of JsonFactory configured using the settings from {@link #getParserConfig()}.
+	 * 
+	 * @return A newly configured JsonFactory based on the currently enabled settings
+	 */
+	private JsonFactory configureNewJsonFactory() {
+		final JsonFactory nextJsonFactory = new JsonFactory();
+		// Disable features that may work for most JSON where the field names are
+		// in limited supply,
+		// but does not work for RDF/JSON where a wide range of URIs are used for
+		// subjects and predicates
+		nextJsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+		nextJsonFactory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
+		nextJsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+		return nextJsonFactory;
+	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #1162 .

Briefly describe the changes proposed in this PR:

* Adds support and tests for pushing non-standard JSON settings through to Jackson for the JSONLD and RDF/JSON parsers to enable users to configurably switch on these Jackson feature.

Note jsonld-java requires an upgrade to the new version released today, 0.12.3, to fix raw ``NaN`` parsing. See issue #1185 for the tracking issue for that.