### PR TITLE
Verify that zip file entries don't try to escape the parent dir + test

### DIFF
--- a/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
@@ -26,9 +26,14 @@ public class ZipUtil {
 	 */
 	private final static byte MAGIC_NUMBER[] = { (byte)0x50, (byte)0x4B, (byte)0x03, (byte)0x04 };
 
-	public static boolean isZipStream(InputStream in)
-		throws IOException
-	{
+	/**
+	 * Test if an input stream is a zip input stream by checking the "magic number"
+	 * 
+	 * @param in input stream
+	 * @return true if start of input stream matches magic number
+	 * @throws IOException 
+	 */
+	public static boolean isZipStream(InputStream in) throws IOException {
 		in.mark(MAGIC_NUMBER.length);
 		byte[] fileHeader = IOUtil.readBytes(in, MAGIC_NUMBER.length);
 		in.reset();
@@ -45,9 +50,7 @@ public class ZipUtil {
 	 * @throws IOException
 	 *         when something untoward happens during the extraction process
 	 */
-	public static void extract(File zipFile, File destDir)
-		throws IOException
-	{
+	public static void extract(File zipFile, File destDir) throws IOException {
 		try (ZipFile zf = new ZipFile(zipFile)) {
 			extract(zf, destDir);
 		}
@@ -61,11 +64,9 @@ public class ZipUtil {
 	 * @param destDir
 	 *        the destination directory
 	 * @throws IOException
-	 *         when something untowards happens during the extraction process
+	 *         when something untoward happens during the extraction process
 	 */
-	public static void extract(ZipFile zipFile, File destDir)
-		throws IOException
-	{
+	public static void extract(ZipFile zipFile, File destDir) throws IOException {
 		assert destDir.isDirectory();
 
 		Enumeration<? extends ZipEntry> entries = zipFile.entries();
@@ -87,15 +88,16 @@ public class ZipUtil {
 	 * @throws IOException
 	 *         if the entry could not be processed
 	 */
-	public static void writeEntry(ZipFile zipFile, ZipEntry entry, File destDir)
-		throws IOException
-	{
+	public static void writeEntry(ZipFile zipFile, ZipEntry entry, File destDir) throws IOException {
 		File outFile = new File(destDir, entry.getName());
 
+		if (! outFile.getCanonicalFile().toPath().startsWith(destDir.toPath())) {
+			throw new IOException("Zip entry outside destination directory: " + entry.getName());
+		}
+				
 		if (entry.isDirectory()) {
 			outFile.mkdirs();
-		}
-		else {
+		} else {
 			outFile.getParentFile().mkdirs();
 
 			try (InputStream in = zipFile.getInputStream(entry)) {

--- a/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
@@ -33,7 +33,7 @@ public class ZipUtil {
 	 * @return true if start of input stream matches magic number
 	 * @throws IOException 
 	 */
-	public static boolean isZipStream(InputStream in) 
+	public static boolean isZipStream(InputStream in)
 		throws IOException
 	{
 		in.mark(MAGIC_NUMBER.length);
@@ -52,7 +52,7 @@ public class ZipUtil {
 	 * @throws IOException
 	 *         when something untoward happens during the extraction process
 	 */
-	public static void extract(File zipFile, File destDir) 
+	public static void extract(File zipFile, File destDir)
 		throws IOException
 	{
 		try (ZipFile zf = new ZipFile(zipFile)) {
@@ -70,7 +70,7 @@ public class ZipUtil {
 	 * @throws IOException
 	 *         when something untoward happens during the extraction process
 	 */
-	public static void extract(ZipFile zipFile, File destDir) 
+	public static void extract(ZipFile zipFile, File destDir)
 		throws IOException
 	{
 		assert destDir.isDirectory();
@@ -94,7 +94,7 @@ public class ZipUtil {
 	 * @throws IOException
 	 *         if the entry could not be processed
 	 */
-	public static void writeEntry(ZipFile zipFile, ZipEntry entry, File destDir) 
+	public static void writeEntry(ZipFile zipFile, ZipEntry entry, File destDir)
 		throws IOException
 	{
 		File outFile = new File(destDir, entry.getName());

--- a/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
@@ -34,7 +34,8 @@ public class ZipUtil {
 	 * @throws IOException 
 	 */
 	public static boolean isZipStream(InputStream in) 
-			throws IOException {
+			throws IOException
+	{
 		in.mark(MAGIC_NUMBER.length);
 		byte[] fileHeader = IOUtil.readBytes(in, MAGIC_NUMBER.length);
 		in.reset();
@@ -52,7 +53,8 @@ public class ZipUtil {
 	 *         when something untoward happens during the extraction process
 	 */
 	public static void extract(File zipFile, File destDir) 
-			throws IOException {
+			throws IOException
+	{
 		try (ZipFile zf = new ZipFile(zipFile)) {
 			extract(zf, destDir);
 		}
@@ -69,7 +71,8 @@ public class ZipUtil {
 	 *         when something untoward happens during the extraction process
 	 */
 	public static void extract(ZipFile zipFile, File destDir) 
-			throws IOException {
+			throws IOException
+	{
 		assert destDir.isDirectory();
 
 		Enumeration<? extends ZipEntry> entries = zipFile.entries();
@@ -91,7 +94,9 @@ public class ZipUtil {
 	 * @throws IOException
 	 *         if the entry could not be processed
 	 */
-	public static void writeEntry(ZipFile zipFile, ZipEntry entry, File destDir) throws IOException {
+	public static void writeEntry(ZipFile zipFile, ZipEntry entry, File destDir) 
+			throws IOException
+	{
 		File outFile = new File(destDir, entry.getName());
 
 		if (! outFile.getCanonicalFile().toPath().startsWith(destDir.getCanonicalFile().toPath())) {

--- a/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
@@ -33,7 +33,8 @@ public class ZipUtil {
 	 * @return true if start of input stream matches magic number
 	 * @throws IOException 
 	 */
-	public static boolean isZipStream(InputStream in) throws IOException {
+	public static boolean isZipStream(InputStream in) 
+			throws IOException {
 		in.mark(MAGIC_NUMBER.length);
 		byte[] fileHeader = IOUtil.readBytes(in, MAGIC_NUMBER.length);
 		in.reset();
@@ -50,7 +51,8 @@ public class ZipUtil {
 	 * @throws IOException
 	 *         when something untoward happens during the extraction process
 	 */
-	public static void extract(File zipFile, File destDir) throws IOException {
+	public static void extract(File zipFile, File destDir) 
+			throws IOException {
 		try (ZipFile zf = new ZipFile(zipFile)) {
 			extract(zf, destDir);
 		}
@@ -66,7 +68,8 @@ public class ZipUtil {
 	 * @throws IOException
 	 *         when something untoward happens during the extraction process
 	 */
-	public static void extract(ZipFile zipFile, File destDir) throws IOException {
+	public static void extract(ZipFile zipFile, File destDir) 
+			throws IOException {
 		assert destDir.isDirectory();
 
 		Enumeration<? extends ZipEntry> entries = zipFile.entries();
@@ -91,13 +94,14 @@ public class ZipUtil {
 	public static void writeEntry(ZipFile zipFile, ZipEntry entry, File destDir) throws IOException {
 		File outFile = new File(destDir, entry.getName());
 
-		if (! outFile.getCanonicalFile().toPath().startsWith(destDir.toPath())) {
+		if (! outFile.getCanonicalFile().toPath().startsWith(destDir.getCanonicalFile().toPath())) {
 			throw new IOException("Zip entry outside destination directory: " + entry.getName());
 		}
 				
 		if (entry.isDirectory()) {
 			outFile.mkdirs();
-		} else {
+		}
+		else {
 			outFile.getParentFile().mkdirs();
 
 			try (InputStream in = zipFile.getInputStream(entry)) {

--- a/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/io/ZipUtil.java
@@ -34,7 +34,7 @@ public class ZipUtil {
 	 * @throws IOException 
 	 */
 	public static boolean isZipStream(InputStream in) 
-			throws IOException
+		throws IOException
 	{
 		in.mark(MAGIC_NUMBER.length);
 		byte[] fileHeader = IOUtil.readBytes(in, MAGIC_NUMBER.length);
@@ -53,7 +53,7 @@ public class ZipUtil {
 	 *         when something untoward happens during the extraction process
 	 */
 	public static void extract(File zipFile, File destDir) 
-			throws IOException
+		throws IOException
 	{
 		try (ZipFile zf = new ZipFile(zipFile)) {
 			extract(zf, destDir);
@@ -71,7 +71,7 @@ public class ZipUtil {
 	 *         when something untoward happens during the extraction process
 	 */
 	public static void extract(ZipFile zipFile, File destDir) 
-			throws IOException
+		throws IOException
 	{
 		assert destDir.isDirectory();
 
@@ -95,7 +95,7 @@ public class ZipUtil {
 	 *         if the entry could not be processed
 	 */
 	public static void writeEntry(ZipFile zipFile, ZipEntry entry, File destDir) 
-			throws IOException
+		throws IOException
 	{
 		File outFile = new File(destDir, entry.getName());
 

--- a/util/src/test/java/org/eclipse/rdf4j/common/io/ZipUtilTest.java
+++ b/util/src/test/java/org/eclipse/rdf4j/common/io/ZipUtilTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.common.io;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ZipUtilTest {
+	@Rule
+	public TemporaryFolder dir = new TemporaryFolder();
+
+	@Test
+	public void testWriteEntryNormal() throws IOException {
+		File f = dir.newFile("testok.zip");
+		
+		try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f))) {
+			ZipEntry e = new ZipEntry("helloworld.txt");
+			out.putNextEntry(e);
+			out.write("hello world".getBytes());
+			out.closeEntry();
+		}
+		
+		ZipFile zf = new ZipFile(f);
+		File subdir = dir.newFolder("extract");
+		ZipUtil.extract(zf, subdir);
+		
+		assertTrue("File not extracted", new File(subdir, "helloworld.txt").exists());
+	}
+
+
+	@Test
+	public void testWriteEntryPathTraversing() throws IOException {
+		File f = dir.newFile("testnotok.zip");
+		
+		try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f))) {
+			ZipEntry e = new ZipEntry("hello/../../world.txt");
+			out.putNextEntry(e);
+			out.write("hello world".getBytes());
+			out.closeEntry();
+		}
+		
+		ZipFile zf = new ZipFile(f);
+		File subdir = dir.newFolder("extract");
+		try {
+			ZipUtil.extract(zf, subdir);
+			fail("No exception thrown");
+		} catch (IOException ioe) {
+			assertTrue(ioe.getMessage().startsWith("Zip entry outside destination directory"));
+		}
+	}
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #1210 .

Briefly describe the changes proposed in this PR:

* Check if zip file entries try to 'escape' / 'break out' of the directory  (i.e. tricks like `../../../etc/`)
* Added test to check if a file 
* Minor code formatting
