### PR TITLE
Upgrade to latest Mockito 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,10 +466,9 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<!-- needs extra dependencies: objenesis & hamcrest -->
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.10.19</version>
+				<version>2.23.4</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -478,7 +477,6 @@
 				<version>3.9.1</version>
 				<scope>test</scope>
 			</dependency>
-
 			<dependency>
 				<groupId>com.github.jsonld-java</groupId>
 				<artifactId>jsonld-java</artifactId>
@@ -776,6 +774,9 @@
 							<rules>
 								<enforceBytecodeVersion>
 									<maxJdkVersion>1.8</maxJdkVersion>
+                                                                        <ignoreClasses>
+ 										<ignoreClass>META-INF/**/module-info</ignoreClass>
+ 									</ignoreClasses>
 									<excludes>
 										<exclude>org.apache.logging.log4j:log4j-api</exclude>
 										<exclude>org.elasticsearch:elasticsearch</exclude>
@@ -790,7 +791,7 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.0-beta-6</version>
+						<version>1.0</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
This PR addresses GitHub issue: #1214 .

Briefly describe the changes proposed in this PR:

* Upgraded to Mockito 2
* Ignore JDK 9 module-info in pom.xml
