### PR TITLE
GH-1200 RioSetting with string, boolean or long values can now be set with system properties

### DIFF
--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioConfig.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioConfig.java
@@ -18,8 +18,19 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Superclass for {@link ParserConfig} and {@link WriterConfig}.
+ * <p>
+ * A RioConfig is a container for several {@link RioSetting} objects, each of which has a default value. You
+ * can override the default value for a {@link RioSetting} in one of two ways:
+ * <ol>
+ * <li>You can programmatically override its value using {@link RioConfig#set(RioSetting, Object)}</li>
+ * <li>You can set a Java system property (e.g. by means of a <code>-D</code> jvm command line switch). The property name
+ * should corresponds to the {@link RioSetting#getKey() key} of the setting. Note that this method is not
+ * supported by every type of {@link RioSetting}: boolean values, strings, and numeric (long) values are
+ * supported, but more complex types are not</li>
+ * </ol>
  * 
  * @author Peter Ansell
+ * @see RioSetting
  */
 public class RioConfig implements Serializable {
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioConfig.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioConfig.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.eclipse.rdf4j.rio.helpers.RioConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +31,12 @@ public class RioConfig implements Serializable {
 	 * A map containing mappings from settings to their values.
 	 */
 	protected final ConcurrentMap<RioSetting<Object>, Object> settings = new ConcurrentHashMap<RioSetting<Object>, Object>();
+
+	/**
+	 * A map containing mappings from settings to system properties that have been discovered since the last
+	 * call to {@link #useDefaults()}.
+	 */
+	protected final ConcurrentMap<RioSetting<Object>, Object> systemPropertyCache = new ConcurrentHashMap<RioSetting<Object>, Object>();
 
 	protected final Logger log = LoggerFactory.getLogger(this.getClass());
 
@@ -50,6 +57,24 @@ public class RioConfig implements Serializable {
 	@SuppressWarnings("unchecked")
 	public <T extends Object> T get(RioSetting<T> setting) {
 		Object result = settings.get(setting);
+
+		if (result == null) {
+			result = systemPropertyCache.get(setting);
+		}
+
+		if (result == null) {
+			String stringRepresentation = System.getProperty(setting.getKey());
+			if (stringRepresentation != null) {
+				try {
+					T typesafeSystemProperty = setting.convert(stringRepresentation);
+					systemPropertyCache.put((RioSetting<Object>)setting, typesafeSystemProperty);
+					return typesafeSystemProperty;
+				}
+				catch (RioConfigurationException e) {
+					log.trace(e.getMessage(), e);
+				}
+			}
+		}
 
 		if (result == null) {
 			return setting.getDefaultValue();
@@ -93,16 +118,13 @@ public class RioConfig implements Serializable {
 
 	/**
 	 * Checks for whether a {@link RioSetting} has been explicitly set by a user.
-	 * <p>
-	 * a RioSetting may be set using {@link RioConfig#set} or by overriding the default value through a system
-	 * property.
 	 * 
 	 * @param setting
 	 *        The setting to check for.
 	 * @return True if the parser setting has been explicitly set, or false otherwise.
 	 */
 	public <T extends Object> boolean isSet(RioSetting<T> setting) {
-		return settings.containsKey(setting) || hasSystemPropertyOverride(setting);
+		return settings.containsKey(setting);
 	}
 
 	/**
@@ -113,18 +135,7 @@ public class RioConfig implements Serializable {
 	 */
 	public RioConfig useDefaults() {
 		settings.clear();
-
+		systemPropertyCache.clear();
 		return this;
-	}
-
-	/**
-	 * Checks if the supplied {@link RioSetting}'s default value has been override by setting a system property.
-	 * 
-	 * @param setting
-	 *        the setting to check the existence of an override for
-	 * @return true if the default value is overridden by system property, false otherwise.
-	 */
-	private boolean hasSystemPropertyOverride(RioSetting<?> setting) {
-		return !Objects.isNull(System.getProperty(setting.getKey()));
 	}
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioConfig.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioConfig.java
@@ -22,11 +22,11 @@ import org.slf4j.LoggerFactory;
  * A RioConfig is a container for several {@link RioSetting} objects, each of which has a default value. You
  * can override the default value for a {@link RioSetting} in one of two ways:
  * <ol>
- * <li>You can programmatically override its value using {@link RioConfig#set(RioSetting, Object)}</li>
- * <li>You can set a Java system property (e.g. by means of a <code>-D</code> jvm command line switch). The property name
- * should corresponds to the {@link RioSetting#getKey() key} of the setting. Note that this method is not
- * supported by every type of {@link RioSetting}: boolean values, strings, and numeric (long) values are
- * supported, but more complex types are not</li>
+ * <li>You can programmatically set its value using {@link RioConfig#set(RioSetting, Object)}</li>
+ * <li>You can set a Java system property (e.g. by means of a <code>-D</code> jvm command line switch). The
+ * property name should corresponds to the {@link RioSetting#getKey() key} of the setting. Note that this
+ * method is not supported by every type of {@link RioSetting}: boolean values, strings, and numeric (long)
+ * values are supported, but more complex types are not</li>
  * </ol>
  * 
  * @author Peter Ansell
@@ -129,13 +129,20 @@ public class RioConfig implements Serializable {
 
 	/**
 	 * Checks for whether a {@link RioSetting} has been explicitly set by a user.
+	 * <p>
+	 * A setting can be set via {@link RioConfig#set(RioSetting, Object)}, or via use of a system property.
 	 * 
 	 * @param setting
 	 *        The setting to check for.
-	 * @return True if the parser setting has been explicitly set, or false otherwise.
+	 * @return True if the setting has been explicitly set, or false otherwise.
 	 */
 	public <T extends Object> boolean isSet(RioSetting<T> setting) {
-		return settings.containsKey(setting);
+		return settings.containsKey(setting) || systemPropertyCache.containsKey(setting)
+				|| hasSystemPropertyOverride(setting);
+	}
+
+	private boolean hasSystemPropertyOverride(RioSetting<?> setting) {
+		return Objects.nonNull(System.getProperty(setting.getKey()));
 	}
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioConfig.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioConfig.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.rio;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -92,13 +93,16 @@ public class RioConfig implements Serializable {
 
 	/**
 	 * Checks for whether a {@link RioSetting} has been explicitly set by a user.
+	 * <p>
+	 * a RioSetting may be set using {@link RioConfig#set} or by overriding the default value through a system
+	 * property.
 	 * 
 	 * @param setting
 	 *        The setting to check for.
 	 * @return True if the parser setting has been explicitly set, or false otherwise.
 	 */
 	public <T extends Object> boolean isSet(RioSetting<T> setting) {
-		return settings.containsKey(setting);
+		return settings.containsKey(setting) || hasSystemPropertyOverride(setting);
 	}
 
 	/**
@@ -111,5 +115,16 @@ public class RioConfig implements Serializable {
 		settings.clear();
 
 		return this;
+	}
+
+	/**
+	 * Checks if the supplied {@link RioSetting}'s default value has been override by setting a system property.
+	 * 
+	 * @param setting
+	 *        the setting to check the existence of an override for
+	 * @return true if the default value is overridden by system property, false otherwise.
+	 */
+	private boolean hasSystemPropertyOverride(RioSetting<?> setting) {
+		return !Objects.isNull(System.getProperty(setting.getKey()));
 	}
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/RioSetting.java
@@ -9,6 +9,8 @@ package org.eclipse.rdf4j.rio;
 
 import java.io.Serializable;
 
+import org.eclipse.rdf4j.rio.helpers.RioConfigurationException;
+
 /**
  * Identifies a parser setting along with its default value.
  * 
@@ -36,4 +38,17 @@ public interface RioSetting<T extends Object> extends Serializable {
 	 * @return The default value for this parser setting.
 	 */
 	T getDefaultValue();
+
+	/**
+	 * Attempts to convert from a string to a type-safe representation based on the generic type of this setting.
+	 * 
+	 * @param stringValue
+	 *        a string representation of a value for this setting.
+	 * @return The corresponding object of type T for the supplied string value.
+	 * @throws RioConfigurationException
+	 *         if the setting type does not provide conversion from a string to the expected type.
+	 */
+	default T convert(String stringRepresentation) {
+		throw new RioConfigurationException("Conversion not implemented for setting: " + getKey());
+	}
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
@@ -111,7 +111,7 @@ public abstract class AbstractRioSetting<T> implements RioSetting<T> {
 	 * @param stringValue
 	 *        a string representation of the default value, typically supplied by means of a system property.
 	 * @return The corresponding object of type T for the supplied string value.
-	 * @throws UnsupportedOperationException
+	 * @throws RioConfigurationException
 	 *         if the setting type does not provide conversion from a string to the expected type.
 	 */
 	protected abstract T convert(String stringValue);

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+
+/**
+ * Base class for {@link RioSetting}. Includes base functionality for reading default values from system
+ * properties.
+ * 
+ * @author Jeen Broekstra
+ * @param <T>
+ *        the setting type
+ */
+public abstract class AbstractRioSetting<T> implements RioSetting<T> {
+
+	private static final long serialVersionUID = -7645860224121962271L;
+
+	/**
+	 * A unique key for this setting.
+	 */
+	private final String key;
+
+	/**
+	 * A human-readable description for this setting
+	 */
+	private final String description;
+
+	/**
+	 * The default value for this setting. <br>
+	 * NOTE: This value must be immutable.
+	 */
+	private final T defaultValue;
+
+	/**
+	 * Create a new setting object that will be used to reference the given setting.
+	 * 
+	 * @param key
+	 *        A unique key to use for this setting.
+	 * @param description
+	 *        A short human-readable description for this setting.
+	 * @param defaultValue
+	 *        An immutable value specifying the default for this setting. This can be optionally be overriden by means of an
+	 *        environment variable with a name equal to the setting key.
+	 */
+	public AbstractRioSetting(String key, String description, T defaultValue) {
+
+		if (key == null) {
+			throw new NullPointerException("Setting key cannot be null");
+		}
+
+		if (description == null) {
+			throw new NullPointerException("Setting description cannot be null");
+		}
+
+		this.key = key;
+		this.description = description;
+		this.defaultValue = determineDefaultValue(defaultValue);
+	}
+
+	@Override
+	public String getKey() {
+		return key;
+	}
+
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	@Override
+	public T getDefaultValue() {
+		return defaultValue;
+	}
+
+	/**
+	 * Determines the default value for this {@link RioSetting}. If an environment variable with the setting {@link #getKey() key} is
+	 * specified, that property value is taken as the default and converted to the correct type. Otherwise, the
+	 * argument-supplied value is used.
+	 * 
+	 * @param suppliedDefaultValue
+	 *        the argument-supplied default value.
+	 * @return the default value for this Setting.
+	 */
+	protected final T determineDefaultValue(T suppliedDefaultValue) {
+		String envVarDefault = System.getProperty(getKey());
+		if (envVarDefault != null) {
+			return convert(envVarDefault);
+		}
+		return suppliedDefaultValue;
+	}
+
+	/**
+	 * Converts a string-representation of the default value to its actual type T
+	 * 
+	 * @param stringValue
+	 *        a string representation of the default value, typically supplied by means of a system property.
+	 * @return The corresponding object of type T for the supplied string value.
+	 * @throws UnsupportedOperationException
+	 *         if the setting type does not provide conversion from a string to the expected type.
+	 */
+	protected abstract T convert(String stringValue);
+}

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
@@ -56,7 +56,7 @@ public abstract class AbstractRioSetting<T> implements RioSetting<T> {
 
 		this.key = key;
 		this.description = description;
-		this.defaultValue = determineDefaultValue(defaultValue);
+		this.defaultValue = defaultValue;
 	}
 
 	@Override
@@ -88,31 +88,4 @@ public abstract class AbstractRioSetting<T> implements RioSetting<T> {
 		return getKey().hashCode();
 	}
 
-	/**
-	 * Determines the default value for this {@link RioSetting}. If a system property with the setting
-	 * {@link #getKey() key} is specified, that property value is taken as the default and converted to the
-	 * correct type. Otherwise, the argument-supplied value is used.
-	 * 
-	 * @param suppliedDefaultValue
-	 *        the argument-supplied default value.
-	 * @return the default value for this Setting.
-	 */
-	protected final T determineDefaultValue(T suppliedDefaultValue) {
-		String envVarDefault = System.getProperty(getKey());
-		if (envVarDefault != null) {
-			return convert(envVarDefault);
-		}
-		return suppliedDefaultValue;
-	}
-
-	/**
-	 * Converts a string-representation of the default value to its actual type T
-	 * 
-	 * @param stringValue
-	 *        a string representation of the default value, typically supplied by means of a system property.
-	 * @return The corresponding object of type T for the supplied string value.
-	 * @throws RioConfigurationException
-	 *         if the setting type does not provide conversion from a string to the expected type.
-	 */
-	protected abstract T convert(String stringValue);
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
@@ -45,18 +47,12 @@ public abstract class AbstractRioSetting<T> implements RioSetting<T> {
 	 * @param description
 	 *        A short human-readable description for this setting.
 	 * @param defaultValue
-	 *        An immutable value specifying the default for this setting. This can be optionally be overriden by means of an
-	 *        environment variable with a name equal to the setting key.
+	 *        An immutable value specifying the default for this setting. This can be optionally be overriden by
+	 *        means of a system property with a name equal to the setting key.
 	 */
 	public AbstractRioSetting(String key, String description, T defaultValue) {
-
-		if (key == null) {
-			throw new NullPointerException("Setting key cannot be null");
-		}
-
-		if (description == null) {
-			throw new NullPointerException("Setting description cannot be null");
-		}
+		Objects.requireNonNull(key, "Setting key cannot be null");
+		Objects.requireNonNull(description, "Setting description cannot be null");
 
 		this.key = key;
 		this.description = description;
@@ -79,9 +75,9 @@ public abstract class AbstractRioSetting<T> implements RioSetting<T> {
 	}
 
 	/**
-	 * Determines the default value for this {@link RioSetting}. If an environment variable with the setting {@link #getKey() key} is
-	 * specified, that property value is taken as the default and converted to the correct type. Otherwise, the
-	 * argument-supplied value is used.
+	 * Determines the default value for this {@link RioSetting}. If a system property with the setting
+	 * {@link #getKey() key} is specified, that property value is taken as the default and converted to the
+	 * correct type. Otherwise, the argument-supplied value is used.
 	 * 
 	 * @param suppliedDefaultValue
 	 *        the argument-supplied default value.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
@@ -47,8 +47,8 @@ public abstract class AbstractRioSetting<T> implements RioSetting<T> {
 	 * @param description
 	 *        A short human-readable description for this setting.
 	 * @param defaultValue
-	 *        An immutable value specifying the default for this setting. This can be optionally be overriden by
-	 *        means of a system property with a name equal to the setting key.
+	 *        An immutable value specifying the default for this setting. This can be optionally be overridden
+	 *        by a system property with a name equal to the setting's unique key.
 	 */
 	public AbstractRioSetting(String key, String description, T defaultValue) {
 		Objects.requireNonNull(key, "Setting key cannot be null");
@@ -72,6 +72,20 @@ public abstract class AbstractRioSetting<T> implements RioSetting<T> {
 	@Override
 	public T getDefaultValue() {
 		return defaultValue;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof RioSetting<?>) {
+			RioSetting<?> that = (RioSetting<?>)other;
+			return that.getKey().equals(this.getKey());
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return getKey().hashCode();
 	}
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -29,8 +29,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A class encapsulating the basic parser settings that most parsers may support. 
- * <p>
- * Several of these settings can be overridden by means of a system property, but only if specified at JVM startup time. 
  * 
  * @author Peter Ansell
  */

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -121,7 +121,7 @@ public class BasicParserSettings {
 	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> VERIFY_DATATYPE_VALUES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.verifydatatypevalues", "Verify recognised datatype values", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.verify_datatype_values", "Verify recognised datatype values", Boolean.FALSE);
 
 	/**
 	 * Boolean setting for parser to determine whether to fail parsing if datatypes are not recognised.
@@ -131,7 +131,7 @@ public class BasicParserSettings {
 	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_DATATYPES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonunknowndatatypes", "Fail on unknown datatypes", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.fail_on_unknown_datatypes", "Fail on unknown datatypes", Boolean.FALSE);
 
 	/**
 	 * Boolean setting for parser to determine whether recognised datatypes need to have their values be
@@ -142,7 +142,7 @@ public class BasicParserSettings {
 	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> NORMALIZE_DATATYPE_VALUES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.normalizedatatypevalues", "Normalize recognised datatype values",
+			"org.eclipse.rdf4j.rio.normalize_datatype_values", "Normalize recognised datatype values",
 			Boolean.FALSE);
 
 	/**
@@ -162,7 +162,7 @@ public class BasicParserSettings {
 	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_LANGUAGES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonunknownlanguages", "Fail on unknown languages", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.fail_on_unknown_languages", "Fail on unknown languages", Boolean.FALSE);
 
 	/**
 	 * Boolean setting for parser to determine whether languages are to be verified based on a given set of
@@ -173,7 +173,7 @@ public class BasicParserSettings {
 	 * Defaults to true.
 	 */
 	public static final RioSetting<Boolean> VERIFY_LANGUAGE_TAGS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.verifylanguagevalues", "Verify language tags", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.verify_language_values", "Verify language tags", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine whether languages need to be normalized, and to which format
@@ -184,7 +184,7 @@ public class BasicParserSettings {
 	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> NORMALIZE_LANGUAGE_TAGS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.normalizelanguagevalues", "Normalize recognised language tags",
+			"org.eclipse.rdf4j.rio.normalize_language_values", "Normalize recognised language tags",
 			Boolean.FALSE);
 
 	/**
@@ -201,7 +201,7 @@ public class BasicParserSettings {
 	 * Defaults to true.
 	 */
 	public static final RioSetting<Boolean> VERIFY_RELATIVE_URIS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.verifyrelativeuris", "Verify relative URIs", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.verify_relative_uris", "Verify relative URIs", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine if URIs should be verified to contain only legal characters.
@@ -210,7 +210,7 @@ public class BasicParserSettings {
 	 * the {@link RDFHandler}.
 	 */
 	public static final RioSetting<Boolean> VERIFY_URI_SYNTAX = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.verifyurisyntax", "Verify URI syntax", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.verify_uri_syntax", "Verify URI syntax", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine whether parser should attempt to preserve identifiers for blank
@@ -220,7 +220,7 @@ public class BasicParserSettings {
 	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> PRESERVE_BNODE_IDS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.preservebnodeids", "Preserve blank node identifiers", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.preserve_bnode_ids", "Preserve blank node identifiers", Boolean.FALSE);
 
 	/**
 	 * Scheme and authority of new mint Skolem IRIs that should replace Blank Nodes. For example a value of
@@ -230,7 +230,7 @@ public class BasicParserSettings {
 	 * Defaults to null (disabled).
 	 */
 	public static final RioSetting<String> SKOLEMIZE_ORIGIN = new StringRioSetting(
-			"org.eclipse.rdf4j.rio.skolemorigin",
+			"org.eclipse.rdf4j.rio.skolem_origin",
 			"Replace blank nodes with well known genid IRIs using this scheme and authority", null);
 
 	/**
@@ -241,7 +241,7 @@ public class BasicParserSettings {
 	 * Defaults to {@link LargeLiteralHandling#PRESERVE}.
 	 */
 	public static final RioSetting<LargeLiteralHandling> LARGE_LITERALS_HANDLING = new RioSettingImpl<LargeLiteralHandling>(
-			"org.eclipse.rdf4j.rio.largeliterals", "Large literals handling", LargeLiteralHandling.PRESERVE);
+			"org.eclipse.rdf4j.rio.large_literals", "Large literals handling", LargeLiteralHandling.PRESERVE);
 
 	/**
 	 * If {@link #LARGE_LITERALS_HANDLING} is set to {@link LargeLiteralHandling#PRESERVE}, which it is by
@@ -257,7 +257,7 @@ public class BasicParserSettings {
 	 * Defaults to 1048576 bytes, which is equivalent to 1 megabyte.
 	 */
 	public static final RioSetting<Long> LARGE_LITERALS_LIMIT = new LongRioSetting(
-			"org.eclipse.rdf4j.rio.largeliteralslimit", "Size limit for large literals", 1048576L);
+			"org.eclipse.rdf4j.rio.large_literals_limit", "Size limit for large literals", 1048576L);
 
 	/**
 	 * <p>
@@ -297,7 +297,7 @@ public class BasicParserSettings {
 			log.warn("Found an error loading DatatypeHandler services", e);
 		}
 
-		DATATYPE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.datatypehandlers",
+		DATATYPE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.datatype_handlers",
 				"Datatype Handlers", Collections.unmodifiableList(defaultDatatypeHandlers));
 
 		List<LanguageHandler> defaultLanguageHandlers = new ArrayList<>(1);
@@ -320,7 +320,7 @@ public class BasicParserSettings {
 			log.warn("Found an error loading LanguageHandler services", e);
 		}
 
-		LANGUAGE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.languagehandlers",
+		LANGUAGE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.language_handlers",
 				"Language Handlers", Collections.unmodifiableList(defaultLanguageHandlers));
 	}
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -28,7 +28,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A class encapsulating the basic parser settings that most parsers may support.
+ * A class encapsulating the basic parser settings that most parsers may support. 
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM startup time. 
  * 
  * @author Peter Ansell
  */
@@ -68,7 +70,7 @@ public class BasicParserSettings {
 		aNamespaces.add(new SimpleNamespace("skosxl", "http://www.w3.org/2008/05/skos-xl#"));
 		aNamespaces.add(new SimpleNamespace("ssn", "http://www.w3.org/ns/ssn/"));
 		aNamespaces.add(new SimpleNamespace("sosa", "http://www.w3.org/ns/sosa/"));
-		aNamespaces.add(new SimpleNamespace("time", "http://www.w3.org/2006/time#"));		
+		aNamespaces.add(new SimpleNamespace("time", "http://www.w3.org/2006/time#"));
 		aNamespaces.add(new SimpleNamespace("void", "http://rdfs.org/ns/void#"));
 		aNamespaces.add(new SimpleNamespace("wdr", "http://www.w3.org/2007/05/powder#"));
 		aNamespaces.add(new SimpleNamespace("wdrs", "http://www.w3.org/2007/05/powder-s#"));
@@ -79,7 +81,7 @@ public class BasicParserSettings {
 		// Some vocabularies are currently in development at W3C
 		aNamespaces.add(new SimpleNamespace("earl", "http://www.w3.org/ns/earl#"));
 		aNamespaces.add(new SimpleNamespace("odrl", "http://www.w3.org/ns/odrl/2/"));
-		
+
 		// Widely used Vocabulary prefixes based on the vocabulary usage on the Semantic Web
 		aNamespaces.add(new SimpleNamespace("cc", "http://creativecommons.org/ns#"));
 		aNamespaces.add(new SimpleNamespace("ctag", "http://commontag.org/ns#"));
@@ -94,12 +96,12 @@ public class BasicParserSettings {
 		aNamespaces.add(new SimpleNamespace("sioc", "http://rdfs.org/sioc/ns#"));
 		aNamespaces.add(new SimpleNamespace("v", "http://rdf.data-vocabulary.org/#"));
 		aNamespaces.add(new SimpleNamespace("vcard", "http://www.w3.org/2006/vcard/ns#"));
-		aNamespaces.add(new SimpleNamespace("schema", "http://schema.org/"));		
+		aNamespaces.add(new SimpleNamespace("schema", "http://schema.org/"));
 
 		// Terms defined by W3C Documents
 		aNamespaces.add(new SimpleNamespace("describedby", "http://www.w3.org/2007/05/powder-s#describedby"));
 		aNamespaces.add(new SimpleNamespace("license", "http://www.w3.org/1999/xhtml/vocab#license"));
-		aNamespaces.add(new SimpleNamespace("role", "http://www.w3.org/1999/xhtml/vocab#role"));	
+		aNamespaces.add(new SimpleNamespace("role", "http://www.w3.org/1999/xhtml/vocab#role"));
 
 		// JSON-LD Context
 		aNamespaces.add(new SimpleNamespace("cat", "http://www.w3.org/ns/dcat#"));
@@ -119,6 +121,8 @@ public class BasicParserSettings {
 	 * Verification is performed using registered DatatypeHandlers.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.verify_datatype_values}.
 	 */
 	public static final RioSetting<Boolean> VERIFY_DATATYPE_VALUES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.verify_datatype_values", "Verify recognised datatype values", Boolean.FALSE);
@@ -129,6 +133,8 @@ public class BasicParserSettings {
 	 * Datatypes are recognised based on matching one of the registered {@link DatatypeHandler}s.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.fail_on_unknown_datatypes}.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_DATATYPES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.fail_on_unknown_datatypes", "Fail on unknown datatypes", Boolean.FALSE);
@@ -140,6 +146,8 @@ public class BasicParserSettings {
 	 * Normalization is performed using registered DatatypeHandlers.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.normalize_datatype_values}.
 	 */
 	public static final RioSetting<Boolean> NORMALIZE_DATATYPE_VALUES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.normalize_datatype_values", "Normalize recognised datatype values",
@@ -149,17 +157,19 @@ public class BasicParserSettings {
 	 * Setting used to specify which {@link DatatypeHandler} implementations are to be used for a given parser
 	 * configuration.
 	 * <p>
-	 * Defaults to an XMLSchema DatatypeHandler implementation based on {@link DatatypeHandler#XMLSCHEMA} and
-	 * an RDF DatatypeHandler implementation based on {@link DatatypeHandler#RDFDATATYPES}.
+	 * Defaults to an XMLSchema DatatypeHandler implementation based on {@link DatatypeHandler#XMLSCHEMA} and an
+	 * RDF DatatypeHandler implementation based on {@link DatatypeHandler#RDFDATATYPES}.
 	 */
 	public static final RioSetting<List<DatatypeHandler>> DATATYPE_HANDLERS;
 
 	/**
-	 * Boolean setting for parser to determine whether to fail parsing if languages are not recognised.
+	 * Boolean setting for parser to determine whether to fail parsing if languages are not recognized.
 	 * <p>
-	 * Languages are recognised based on matching one of the registered {@link LanguageHandler}s.
+	 * Languages are recognized based on matching one of the registered {@link LanguageHandler}s.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.fail_on_unknown_languages}.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_LANGUAGES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.fail_on_unknown_languages", "Fail on unknown languages", Boolean.FALSE);
@@ -171,21 +181,24 @@ public class BasicParserSettings {
 	 * Verification is performed using registered {@link LanguageHandler}s.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.verify_language_tags}.
 	 */
 	public static final RioSetting<Boolean> VERIFY_LANGUAGE_TAGS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.verify_language_values", "Verify language tags", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.verify_language_tags", "Verify language tags", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for parser to determine whether languages need to be normalized, and to which format
-	 * they should be normalised.
+	 * Boolean setting for parser to determine whether languages need to be normalized, and to which format they
+	 * should be normalized.
 	 * <p>
 	 * Normalization is performed using registered {@link LanguageHandler}s.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.normalize_language_tags}.
 	 */
 	public static final RioSetting<Boolean> NORMALIZE_LANGUAGE_TAGS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.normalize_language_values", "Normalize recognised language tags",
-			Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.normalize_language_tags", "Normalize recognised language tags", Boolean.FALSE);
 
 	/**
 	 * Setting used to specify which {@link LanguageHandler} implementations are to be used for a given parser
@@ -198,7 +211,9 @@ public class BasicParserSettings {
 	/**
 	 * Boolean setting for parser to determine whether relative URIs are verified.
 	 * <p>
-	 * Defaults to true.
+	 * Defaults to true..
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.verify_relative_uris}.
 	 */
 	public static final RioSetting<Boolean> VERIFY_RELATIVE_URIS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.verify_relative_uris", "Verify relative URIs", Boolean.TRUE);
@@ -208,6 +223,8 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to {@code true}. If set to {@code false}, the parser will report syntactically illegal URIs to
 	 * the {@link RDFHandler}.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.verify_uri_syntax}.
 	 */
 	public static final RioSetting<Boolean> VERIFY_URI_SYNTAX = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.verify_uri_syntax", "Verify URI syntax", Boolean.TRUE);
@@ -218,6 +235,8 @@ public class BasicParserSettings {
 	 * for it.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.preserve_bnode_ids}.
 	 */
 	public static final RioSetting<Boolean> PRESERVE_BNODE_IDS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.preserve_bnode_ids", "Preserve blank node identifiers", Boolean.FALSE);
@@ -228,6 +247,8 @@ public class BasicParserSettings {
 	 * "http://example.com/.well-known/genid/d26a2d0e98334696f4ad70a677abc1f6"
 	 * <p>
 	 * Defaults to null (disabled).
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.skolem_origin}.
 	 */
 	public static final RioSetting<String> SKOLEMIZE_ORIGIN = new StringRioSetting(
 			"org.eclipse.rdf4j.rio.skolem_origin",
@@ -247,14 +268,16 @@ public class BasicParserSettings {
 	 * If {@link #LARGE_LITERALS_HANDLING} is set to {@link LargeLiteralHandling#PRESERVE}, which it is by
 	 * default, then the value of this setting is not used.
 	 * <p>
-	 * If {@link #LARGE_LITERALS_HANDLING} is set to {@link LargeLiteralHandling#DROP} , then the value of
-	 * this setting corresponds to the maximum number of bytes for a literal before the statement it is a part
-	 * of is dropped silently by the parser.
+	 * If {@link #LARGE_LITERALS_HANDLING} is set to {@link LargeLiteralHandling#DROP} , then the value of this
+	 * setting corresponds to the maximum number of bytes for a literal before the statement it is a part of is
+	 * dropped silently by the parser.
 	 * <p>
 	 * If {@link #LARGE_LITERALS_HANDLING} is set to {@link LargeLiteralHandling#TRUNCATE} , then the value of
 	 * this setting corresponds to the maximum number of bytes for a literal before the value is truncated.
 	 * <p>
 	 * Defaults to 1048576 bytes, which is equivalent to 1 megabyte.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.large_literals_limit}.
 	 */
 	public static final RioSetting<Long> LARGE_LITERALS_LIMIT = new LongRioSetting(
 			"org.eclipse.rdf4j.rio.large_literals_limit", "Size limit for large literals", 1048576L);
@@ -297,8 +320,8 @@ public class BasicParserSettings {
 			log.warn("Found an error loading DatatypeHandler services", e);
 		}
 
-		DATATYPE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.datatype_handlers",
-				"Datatype Handlers", Collections.unmodifiableList(defaultDatatypeHandlers));
+		DATATYPE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.datatype_handlers", "Datatype Handlers",
+				Collections.unmodifiableList(defaultDatatypeHandlers));
 
 		List<LanguageHandler> defaultLanguageHandlers = new ArrayList<>(1);
 		try {
@@ -320,8 +343,8 @@ public class BasicParserSettings {
 			log.warn("Found an error loading LanguageHandler services", e);
 		}
 
-		LANGUAGE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.language_handlers",
-				"Language Handlers", Collections.unmodifiableList(defaultLanguageHandlers));
+		LANGUAGE_HANDLERS = new RioSettingImpl<>("org.eclipse.rdf4j.rio.language_handlers", "Language Handlers",
+				Collections.unmodifiableList(defaultLanguageHandlers));
 	}
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -120,7 +120,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> VERIFY_DATATYPE_VALUES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> VERIFY_DATATYPE_VALUES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.verifydatatypevalues", "Verify recognised datatype values", Boolean.FALSE);
 
 	/**
@@ -130,7 +130,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_DATATYPES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_DATATYPES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonunknowndatatypes", "Fail on unknown datatypes", Boolean.FALSE);
 
 	/**
@@ -141,7 +141,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> NORMALIZE_DATATYPE_VALUES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> NORMALIZE_DATATYPE_VALUES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.normalizedatatypevalues", "Normalize recognised datatype values",
 			Boolean.FALSE);
 
@@ -161,7 +161,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_LANGUAGES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_LANGUAGES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonunknownlanguages", "Fail on unknown languages", Boolean.FALSE);
 
 	/**
@@ -172,7 +172,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> VERIFY_LANGUAGE_TAGS = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> VERIFY_LANGUAGE_TAGS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.verifylanguagevalues", "Verify language tags", Boolean.TRUE);
 
 	/**
@@ -183,7 +183,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> NORMALIZE_LANGUAGE_TAGS = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> NORMALIZE_LANGUAGE_TAGS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.normalizelanguagevalues", "Normalize recognised language tags",
 			Boolean.FALSE);
 
@@ -200,7 +200,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> VERIFY_RELATIVE_URIS = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> VERIFY_RELATIVE_URIS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.verifyrelativeuris", "Verify relative URIs", Boolean.TRUE);
 
 	/**
@@ -209,7 +209,7 @@ public class BasicParserSettings {
 	 * Defaults to {@code true}. If set to {@code false}, the parser will report syntactically illegal URIs to
 	 * the {@link RDFHandler}.
 	 */
-	public static final RioSetting<Boolean> VERIFY_URI_SYNTAX = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> VERIFY_URI_SYNTAX = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.verifyurisyntax", "Verify URI syntax", Boolean.TRUE);
 
 	/**
@@ -219,7 +219,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> PRESERVE_BNODE_IDS = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> PRESERVE_BNODE_IDS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.preservebnodeids", "Preserve blank node identifiers", Boolean.FALSE);
 
 	/**
@@ -229,7 +229,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to null (disabled).
 	 */
-	public static final RioSetting<String> SKOLEMIZE_ORIGIN = new RioSettingImpl<String>(
+	public static final RioSetting<String> SKOLEMIZE_ORIGIN = new StringRioSetting(
 			"org.eclipse.rdf4j.rio.skolemorigin",
 			"Replace blank nodes with well known genid IRIs using this scheme and authority", null);
 
@@ -256,7 +256,7 @@ public class BasicParserSettings {
 	 * <p>
 	 * Defaults to 1048576 bytes, which is equivalent to 1 megabyte.
 	 */
-	public static final RioSetting<Long> LARGE_LITERALS_LIMIT = new RioSettingImpl<Long>(
+	public static final RioSetting<Long> LARGE_LITERALS_LIMIT = new LongRioSetting(
 			"org.eclipse.rdf4j.rio.largeliteralslimit", "Size limit for large literals", 1048576L);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
@@ -11,6 +11,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * A class encapsulating the basic writer settings that most writers may support.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  */
@@ -20,23 +23,27 @@ public class BasicWriterSettings {
 	 * Boolean setting for writer to determine whether pretty printing is preferred.
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.pretty_print}.
 	 */
 	public static final RioSetting<Boolean> PRETTY_PRINT = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.pretty_print", "Pretty print", Boolean.TRUE);
 
 	/**
-	 * Inline blanks nodes by their value and don't write any blank node labels when this setting is true.
-	 * This setting should only be used when blank nodes never appear in the context and there are no blank
-	 * node cycles.
+	 * Inline blanks nodes by their value and don't write any blank node labels when this setting is true. This
+	 * setting should only be used when blank nodes never appear in the context and there are no blank node
+	 * cycles.
 	 * <p>
 	 * WARNING: This setting requires all triples to be processed before being written and could use a lot of
 	 * memory in the process and should be set to false for large RDF files.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.inline_blank_nodes}.
 	 *
 	 * @since 2.3
 	 */
-	public static final RioSetting<Boolean> INLINE_BLANK_NODES =  new BooleanRioSetting(
+	public static final RioSetting<Boolean> INLINE_BLANK_NODES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.inline_blank_nodes",
 			"Use blank node property lists, collections, and anonymous nodes instead of blank node labels",
 			Boolean.FALSE);
@@ -49,34 +56,39 @@ public class BasicWriterSettings {
 	 * internally.
 	 * <p>
 	 * Defaults to true to allow for backwards compatibility without enforcing it.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.rdf10_plain_literals}.
 	 */
-	public static final RioSetting<Boolean> XSD_STRING_TO_PLAIN_LITERAL =  new BooleanRioSetting(
+	public static final RioSetting<Boolean> XSD_STRING_TO_PLAIN_LITERAL = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.rdf10_plain_literals", "RDF-1.0 compatible Plain Literals", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for writer to determine whether it should omit the rdf:langString datatype from
-	 * language literals when serialising them.
+	 * Boolean setting for writer to determine whether it should omit the rdf:langString datatype from language
+	 * literals when serialising them.
 	 * <p>
-	 * In RDF-1.1, all RDF-1.0 Language Literals are typed using rdf:langString in the abstract model, but
-	 * this datatype is not necessary for concrete syntaxes.
+	 * In RDF-1.1, all RDF-1.0 Language Literals are typed using rdf:langString in the abstract model, but this
+	 * datatype is not necessary for concrete syntaxes.
 	 * <p>
-	 * In most concrete syntaxes it is either syntactically invalid or semantically ambiguous to have a
-	 * language tagged literal with an explicit datatype. In those cases this setting will not be used, and
-	 * the rdf:langString datatype will not be attached to language tagged literals.
+	 * In most concrete syntaxes it is either syntactically invalid or semantically ambiguous to have a language
+	 * tagged literal with an explicit datatype. In those cases this setting will not be used, and the
+	 * rdf:langString datatype will not be attached to language tagged literals.
 	 * <p>
-	 * In particular, in RDF/XML, if rdf:langString is serialised, the language tag may not be retained when
-	 * the document is parsed due to the precedence rule in RDF/XML for datatype over language.
+	 * In particular, in RDF/XML, if rdf:langString is serialised, the language tag may not be retained when the
+	 * document is parsed due to the precedence rule in RDF/XML for datatype over language.
 	 * <p>
 	 * Defaults to true as rdf:langString was not previously used, and should not be commonly required.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.rdf10_language_literals}.
 	 */
-	public static final RioSetting<Boolean> RDF_LANGSTRING_TO_LANG_LITERAL =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.rdf10_language_literals", "RDF-1.0 compatible Language Literals",
-			Boolean.TRUE);
+	public static final RioSetting<Boolean> RDF_LANGSTRING_TO_LANG_LITERAL = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.rdf10_language_literals", "RDF-1.0 compatible Language Literals", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for writer to determine whether it should include a base directive.
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.base_directive}.
 	 */
 	public static final RioSetting<Boolean> BASE_DIRECTIVE = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.base_directive", "Serialize base directive", Boolean.TRUE);

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
@@ -21,7 +21,7 @@ public class BasicWriterSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> PRETTY_PRINT = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> PRETTY_PRINT = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.prettyprint", "Pretty print", Boolean.TRUE);
 
 	/**
@@ -36,7 +36,7 @@ public class BasicWriterSettings {
 	 *
 	 * @since 2.3
 	 */
-	public static final RioSetting<Boolean> INLINE_BLANK_NODES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> INLINE_BLANK_NODES =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.inlineblanknodes",
 			"Use blank node property lists, collections, and anonymous nodes instead of blank node labels",
 			Boolean.FALSE);
@@ -50,7 +50,7 @@ public class BasicWriterSettings {
 	 * <p>
 	 * Defaults to true to allow for backwards compatibility without enforcing it.
 	 */
-	public static final RioSetting<Boolean> XSD_STRING_TO_PLAIN_LITERAL = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> XSD_STRING_TO_PLAIN_LITERAL =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.rdf10plainliterals", "RDF-1.0 compatible Plain Literals", Boolean.TRUE);
 
 	/**
@@ -69,7 +69,7 @@ public class BasicWriterSettings {
 	 * <p>
 	 * Defaults to true as rdf:langString was not previously used, and should not be commonly required.
 	 */
-	public static final RioSetting<Boolean> RDF_LANGSTRING_TO_LANG_LITERAL = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> RDF_LANGSTRING_TO_LANG_LITERAL =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.rdf10languageliterals", "RDF-1.0 compatible Language Literals",
 			Boolean.TRUE);
 
@@ -78,7 +78,7 @@ public class BasicWriterSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> BASE_DIRECTIVE = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> BASE_DIRECTIVE = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.basedirective", "Serialize base directive", Boolean.TRUE);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
@@ -22,7 +22,7 @@ public class BasicWriterSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> PRETTY_PRINT = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.prettyprint", "Pretty print", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.pretty_print", "Pretty print", Boolean.TRUE);
 
 	/**
 	 * Inline blanks nodes by their value and don't write any blank node labels when this setting is true.
@@ -37,7 +37,7 @@ public class BasicWriterSettings {
 	 * @since 2.3
 	 */
 	public static final RioSetting<Boolean> INLINE_BLANK_NODES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.inlineblanknodes",
+			"org.eclipse.rdf4j.rio.inline_blank_nodes",
 			"Use blank node property lists, collections, and anonymous nodes instead of blank node labels",
 			Boolean.FALSE);
 
@@ -51,7 +51,7 @@ public class BasicWriterSettings {
 	 * Defaults to true to allow for backwards compatibility without enforcing it.
 	 */
 	public static final RioSetting<Boolean> XSD_STRING_TO_PLAIN_LITERAL =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.rdf10plainliterals", "RDF-1.0 compatible Plain Literals", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.rdf10_plain_literals", "RDF-1.0 compatible Plain Literals", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for writer to determine whether it should omit the rdf:langString datatype from
@@ -70,7 +70,7 @@ public class BasicWriterSettings {
 	 * Defaults to true as rdf:langString was not previously used, and should not be commonly required.
 	 */
 	public static final RioSetting<Boolean> RDF_LANGSTRING_TO_LANG_LITERAL =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.rdf10languageliterals", "RDF-1.0 compatible Language Literals",
+			"org.eclipse.rdf4j.rio.rdf10_language_literals", "RDF-1.0 compatible Language Literals",
 			Boolean.TRUE);
 
 	/**
@@ -79,7 +79,7 @@ public class BasicWriterSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> BASE_DIRECTIVE = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.basedirective", "Serialize base directive", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.base_directive", "Serialize base directive", Boolean.TRUE);
 
 	/**
 	 * Private default constructor.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
@@ -11,9 +11,6 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * A class encapsulating the basic writer settings that most writers may support.
- * <p>
- * Several of these settings can be overridden by means of a system property, but only if specified at JVM
- * startup time.
  * 
  * @author Peter Ansell
  */

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSetting.java
@@ -41,7 +41,7 @@ public class BooleanRioSetting extends AbstractRioSetting<Boolean> {
 	 *         the returned Boolean will be {@code true}, otherwise {@code false}.
 	 */
 	@Override
-	protected Boolean convert(String stringValue) {
+	public Boolean convert(String stringValue) {
 		return Boolean.valueOf(stringValue);
 	}
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSetting.java
@@ -10,8 +10,9 @@ package org.eclipse.rdf4j.rio.helpers;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
- * A {@link RioSetting} with a {@link Boolean} value. The given default for the setting can be overriden by
- * means of an environment variable with a name equal to the setting key.
+ * A {@link RioSetting} with a {@link Boolean} value. The given default for the setting can be overridden by
+ * means of a System property with a name equal to the setting key, and a string value of "true" or
+ * "false" (ignoring case).
  * 
  * @author Jeen Broekstra
  */
@@ -27,12 +28,18 @@ public class BooleanRioSetting extends AbstractRioSetting<Boolean> {
 	 * @param description
 	 *        A short human-readable description for this setting.
 	 * @param defaultValue
-	 *        An immutable value specifying the default for this setting. 
+	 *        An immutable value specifying the default for this setting.
 	 */
 	public BooleanRioSetting(String key, String description, Boolean defaultValue) {
 		super(key, description, defaultValue);
 	}
 
+	/**
+	 * Converts a String to a Boolean
+	 * 
+	 * @return a Boolean representing the supplied string value. Iff the string value is "true" (ignoring case),
+	 *         the returned Boolean will be {@code true}, otherwise {@code false}.
+	 */
 	@Override
 	protected Boolean convert(String stringValue) {
 		return Boolean.valueOf(stringValue);

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSetting.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+
+/**
+ * A {@link RioSetting} with a {@link Boolean} value. The given default for the setting can be overriden by
+ * means of an environment variable with a name equal to the setting key.
+ * 
+ * @author Jeen Broekstra
+ */
+public class BooleanRioSetting extends AbstractRioSetting<Boolean> {
+
+	private static final long serialVersionUID = 2732349679294063815L;
+
+	/**
+	 * Creates a new boolean {@link RioSetting}.
+	 * 
+	 * @param key
+	 *        A unique key to use for this setting.
+	 * @param description
+	 *        A short human-readable description for this setting.
+	 * @param defaultValue
+	 *        An immutable value specifying the default for this setting. 
+	 */
+	public BooleanRioSetting(String key, String description, Boolean defaultValue) {
+		super(key, description, defaultValue);
+	}
+
+	@Override
+	protected Boolean convert(String stringValue) {
+		return Boolean.valueOf(stringValue);
+	}
+
+}

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONLDSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONLDSettings.java
@@ -25,7 +25,7 @@ public class JSONLDSettings {
 	 * 
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
-	public static final RioSetting<Boolean> COMPACT_ARRAYS = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> COMPACT_ARRAYS =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.compactarrays", "Compact arrays", Boolean.TRUE);
 
 	/**
@@ -37,7 +37,7 @@ public class JSONLDSettings {
 	 * 
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
-	public static final RioSetting<Boolean> OPTIMIZE = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> OPTIMIZE =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.optimize", "Optimize output", Boolean.FALSE);
 
 	/**
@@ -49,7 +49,7 @@ public class JSONLDSettings {
 	 * 
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
-	public static final RioSetting<Boolean> USE_NATIVE_TYPES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> USE_NATIVE_TYPES =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.usenativetypes", "Use Native JSON Types", Boolean.FALSE);
 
 	/**
@@ -60,7 +60,7 @@ public class JSONLDSettings {
 	 * 
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
-	public static final RioSetting<Boolean> USE_RDF_TYPE = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> USE_RDF_TYPE =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.userdftype", "Use RDF Type", Boolean.FALSE);
 
 	/**
@@ -78,7 +78,7 @@ public class JSONLDSettings {
 	 * <p>
 	 * Default to false
 	 */
-	public static final RioSetting<Boolean> HIERARCHICAL_VIEW = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> HIERARCHICAL_VIEW =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.hierarchicalview", "Hierarchical representation of the JSON", Boolean.FALSE);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONLDSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONLDSettings.java
@@ -11,6 +11,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * Settings that can be passed to JSONLD Parsers and Writers.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
@@ -22,45 +25,53 @@ public class JSONLDSettings {
 	 * compaction. If set to false, all arrays will remain arrays even if they have just one element.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.jsonld.compact_arrays}.
 	 * 
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
-	public static final RioSetting<Boolean> COMPACT_ARRAYS =  new BooleanRioSetting(
+	public static final RioSetting<Boolean> COMPACT_ARRAYS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.compact_arrays", "Compact arrays", Boolean.TRUE);
 
 	/**
 	 * If set to true, the JSON-LD processor is allowed to optimize the output of the
-	 * <a href= "http://json-ld.org/spec/latest/json-ld-api/#compaction-algorithm" >Compaction algorithm</a>
-	 * to produce even compacter representations.
+	 * <a href= "http://json-ld.org/spec/latest/json-ld-api/#compaction-algorithm" >Compaction algorithm</a> to
+	 * produce even compacter representations.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.jsonld.optimize}.
 	 * 
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
-	public static final RioSetting<Boolean> OPTIMIZE =  new BooleanRioSetting(
+	public static final RioSetting<Boolean> OPTIMIZE = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.optimize", "Optimize output", Boolean.FALSE);
 
 	/**
 	 * If set to true, the JSON-LD processor will try to convert typed values to JSON native types instead of
-	 * using the expanded object form when converting from RDF. xsd:boolean values will be converted to true
-	 * or false. xsd:integer and xsd:double values will be converted to JSON numbers.
+	 * using the expanded object form when converting from RDF. xsd:boolean values will be converted to true or
+	 * false. xsd:integer and xsd:double values will be converted to JSON numbers.
 	 * <p>
 	 * Defaults to false for RDF compatibility.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.jsonld.use_native_types}.
 	 * 
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
-	public static final RioSetting<Boolean> USE_NATIVE_TYPES =  new BooleanRioSetting(
+	public static final RioSetting<Boolean> USE_NATIVE_TYPES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.use_native_types", "Use Native JSON Types", Boolean.FALSE);
 
 	/**
-	 * If set to true, the JSON-LD processor will use the expanded rdf:type IRI as the property instead
-	 * of @type when converting from RDF.
+	 * If set to true, the JSON-LD processor will use the expanded rdf:type IRI as the property instead of @type
+	 * when converting from RDF.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.jsonld.use_rdf_type}.
 	 * 
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
-	public static final RioSetting<Boolean> USE_RDF_TYPE =  new BooleanRioSetting(
+	public static final RioSetting<Boolean> USE_RDF_TYPE = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.jsonld.use_rdf_type", "Use RDF Type", Boolean.FALSE);
 
 	/**
@@ -77,9 +88,12 @@ public class JSONLDSettings {
 	 * If set to true, the JSON-LD processor will try to represent the JSON-LD object in a hierarchical view.
 	 * <p>
 	 * Default to false
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.jsonld.hierarchical_view}.
 	 */
-	public static final RioSetting<Boolean> HIERARCHICAL_VIEW =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.jsonld.hierarchical_view", "Hierarchical representation of the JSON", Boolean.FALSE);
+	public static final RioSetting<Boolean> HIERARCHICAL_VIEW = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.jsonld.hierarchical_view", "Hierarchical representation of the JSON",
+			Boolean.FALSE);
 
 	/**
 	 * Private default constructor.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONLDSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONLDSettings.java
@@ -11,9 +11,6 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * Settings that can be passed to JSONLD Parsers and Writers.
- * <p>
- * Several of these settings can be overridden by means of a system property, but only if specified at JVM
- * startup time.
  * 
  * @author Peter Ansell
  * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONLDSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONLDSettings.java
@@ -26,7 +26,7 @@ public class JSONLDSettings {
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
 	public static final RioSetting<Boolean> COMPACT_ARRAYS =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.jsonld.compactarrays", "Compact arrays", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.jsonld.compact_arrays", "Compact arrays", Boolean.TRUE);
 
 	/**
 	 * If set to true, the JSON-LD processor is allowed to optimize the output of the
@@ -50,7 +50,7 @@ public class JSONLDSettings {
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
 	public static final RioSetting<Boolean> USE_NATIVE_TYPES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.jsonld.usenativetypes", "Use Native JSON Types", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.jsonld.use_native_types", "Use Native JSON Types", Boolean.FALSE);
 
 	/**
 	 * If set to true, the JSON-LD processor will use the expanded rdf:type IRI as the property instead
@@ -61,7 +61,7 @@ public class JSONLDSettings {
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#data-structures">JSONLD Data Structures</a>
 	 */
 	public static final RioSetting<Boolean> USE_RDF_TYPE =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.jsonld.userdftype", "Use RDF Type", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.jsonld.use_rdf_type", "Use RDF Type", Boolean.FALSE);
 
 	/**
 	 * The {@link JSONLDMode} that the writer will use to reorganise the JSONLD document after it is created.
@@ -71,7 +71,7 @@ public class JSONLDSettings {
 	 * @see <a href="http://json-ld.org/spec/latest/json-ld-api/#features">JSONLD Features</a>
 	 */
 	public static final RioSetting<JSONLDMode> JSONLD_MODE = new RioSettingImpl<JSONLDMode>(
-			"org.eclipse.rdf4j.rio.jsonld.mode", "JSONLD Mode", JSONLDMode.EXPAND);
+			"org.eclipse.rdf4j.rio.jsonld_mode", "JSONLD Mode", JSONLDMode.EXPAND);
 
 	/**
 	 * If set to true, the JSON-LD processor will try to represent the JSON-LD object in a hierarchical view.
@@ -79,7 +79,7 @@ public class JSONLDSettings {
 	 * Default to false
 	 */
 	public static final RioSetting<Boolean> HIERARCHICAL_VIEW =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.jsonld.hierarchicalview", "Hierarchical representation of the JSON", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.jsonld.hierarchical_view", "Hierarchical representation of the JSON", Boolean.FALSE);
 
 	/**
 	 * Private default constructor.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONSettings.java
@@ -21,7 +21,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_backslash_escaping_any_character",
 			"Allow backslash escaping any character", Boolean.FALSE);
 
@@ -30,7 +30,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_COMMENTS = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_COMMENTS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_comments", "Allow comments", Boolean.FALSE);
 
 	/**
@@ -38,7 +38,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_NON_NUMERIC_NUMBERS = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_NON_NUMERIC_NUMBERS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_non_numeric_numbers", "Allow non-numeric numbers",
 			Boolean.FALSE);
 
@@ -47,7 +47,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_NUMERIC_LEADING_ZEROS = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_NUMERIC_LEADING_ZEROS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_numeric_leading_zeros", "Allow numeric leading zeros",
 			Boolean.FALSE);
 
@@ -56,7 +56,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_SINGLE_QUOTES = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_SINGLE_QUOTES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_single_quotes", "Allow single quotes", Boolean.FALSE);
 
 	/**
@@ -64,7 +64,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_UNQUOTED_CONTROL_CHARS = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_UNQUOTED_CONTROL_CHARS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_unquoted_control_chars", "Allow unquoted control chars",
 			Boolean.FALSE);
 
@@ -73,7 +73,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_UNQUOTED_FIELD_NAMES = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_UNQUOTED_FIELD_NAMES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_unquoted_field_names", "Allow unquoted field names",
 			Boolean.FALSE);
 
@@ -82,7 +82,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_YAML_COMMENTS = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_YAML_COMMENTS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_yaml_comments", "Allow YAML comments", Boolean.FALSE);
 
 	/**
@@ -90,7 +90,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ALLOW_TRAILING_COMMA = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> ALLOW_TRAILING_COMMA = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_yaml_comments", "Allow trailing comma", Boolean.FALSE);
 
 	/**
@@ -99,7 +99,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> INCLUDE_SOURCE_IN_LOCATION = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> INCLUDE_SOURCE_IN_LOCATION = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.include_source_in_location", "Include Source in Location",
 			Boolean.TRUE);
 
@@ -109,7 +109,7 @@ public class JSONSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> STRICT_DUPLICATE_DETECTION = new RioSettingImpl<>(
+	public static final RioSetting<Boolean> STRICT_DUPLICATE_DETECTION = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.strict_duplicate_detection", "Strict duplicate detection",
 			Boolean.FALSE);
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/JSONSettings.java
@@ -11,6 +11,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * Generic JSON settings, mostly related to Jackson Features.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  *
  * @author Peter Ansell
  */
@@ -20,6 +23,9 @@ public class JSONSettings {
 	 * Boolean setting for JSON parsers to determine if any character is allowed to be backslash escaped.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.json.allow_backslash_escaping_any_character}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_backslash_escaping_any_character",
@@ -29,6 +35,8 @@ public class JSONSettings {
 	 * Boolean setting for JSON parsers to determine if Java/C++ style comments are allowed.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.json.allow_comments}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_COMMENTS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_comments", "Allow comments", Boolean.FALSE);
@@ -37,24 +45,30 @@ public class JSONSettings {
 	 * Boolean setting for JSON parsers to determine if non-numeric numbers (INF/-INF/NaN) are allowed.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.json.allow_non_numeric_numbers}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_NON_NUMERIC_NUMBERS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.json.allow_non_numeric_numbers", "Allow non-numeric numbers",
-			Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.json.allow_non_numeric_numbers", "Allow non-numeric numbers", Boolean.FALSE);
 
 	/**
 	 * Boolean setting for JSON parsers to determine if numeric leading zeroes are allowed.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.json.allow_numeric_leading_zeros}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_NUMERIC_LEADING_ZEROS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.json.allow_numeric_leading_zeros", "Allow numeric leading zeros",
-			Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.json.allow_numeric_leading_zeros", "Allow numeric leading zeros", Boolean.FALSE);
 
 	/**
 	 * Boolean setting for JSON parsers to determine if single quotes are allowed.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.json.allow_single_quotes}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_SINGLE_QUOTES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_single_quotes", "Allow single quotes", Boolean.FALSE);
@@ -63,6 +77,9 @@ public class JSONSettings {
 	 * Boolean setting for JSON parsers to determine if unquoted control characters are allowed.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.json.allow_unquoted_control_chars}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_UNQUOTED_CONTROL_CHARS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_unquoted_control_chars", "Allow unquoted control chars",
@@ -72,15 +89,19 @@ public class JSONSettings {
 	 * Boolean setting for JSON parsers to determine if unquoted field names are allowed.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.json.allow_unquoted_field_names}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_UNQUOTED_FIELD_NAMES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.json.allow_unquoted_field_names", "Allow unquoted field names",
-			Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.json.allow_unquoted_field_names", "Allow unquoted field names", Boolean.FALSE);
 
 	/**
 	 * Boolean setting for JSON parsers to determine if YAML comments (starting with '#') are allowed.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.json.allow_yaml_comments}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_YAML_COMMENTS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.json.allow_yaml_comments", "Allow YAML comments", Boolean.FALSE);
@@ -89,29 +110,34 @@ public class JSONSettings {
 	 * Boolean setting for JSON parsers to determine if trailing commas are allows.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.json.allow_trailing_comma}.
 	 */
 	public static final RioSetting<Boolean> ALLOW_TRAILING_COMMA = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.json.allow_yaml_comments", "Allow trailing comma", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.json.allow_trailing_comma", "Allow trailing comma", Boolean.FALSE);
 
 	/**
-	 * Boolean setting for JSON parsers to determine if errors should include a reference to the source or
-	 * not.
+	 * Boolean setting for JSON parsers to determine if errors should include a reference to the source or not.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.json.include_source_in_location}.
 	 */
 	public static final RioSetting<Boolean> INCLUDE_SOURCE_IN_LOCATION = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.json.include_source_in_location", "Include Source in Location",
-			Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.json.include_source_in_location", "Include Source in Location", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for JSON parsers to determine if strict duplicate detection is allowed for JSON Object
 	 * field names.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.json.strict_duplicate_detection}.
 	 */
 	public static final RioSetting<Boolean> STRICT_DUPLICATE_DETECTION = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.json.strict_duplicate_detection", "Strict duplicate detection",
-			Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.json.strict_duplicate_detection", "Strict duplicate detection", Boolean.FALSE);
 
 	/**
 	 * Private default constructor.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/LongRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/LongRioSetting.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+
+/**
+ * A {@link RioSetting} with a {@link Long} value. The given default for the setting can be overriden by
+ * means of an environment variable with a name equal to the setting key.
+ * 
+ * @author Jeen Broekstra
+ */
+public class LongRioSetting extends AbstractRioSetting<Long> {
+
+	private static final long serialVersionUID = 618659802892042423L;
+
+	public LongRioSetting(String key, String description, Long defaultValue) {
+		super(key, description, defaultValue);
+	}
+
+	@Override
+	protected Long convert(String stringValue) {
+		return Long.parseLong(stringValue);
+	}
+
+}

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/LongRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/LongRioSetting.java
@@ -11,7 +11,7 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * A {@link RioSetting} with a {@link Long} value. The given default for the setting can be overriden by
- * means of an environment variable with a name equal to the setting key.
+ * means of a system property with a name equal to the setting key.
  * 
  * @author Jeen Broekstra
  */

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/LongRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/LongRioSetting.java
@@ -10,8 +10,8 @@ package org.eclipse.rdf4j.rio.helpers;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
- * A {@link RioSetting} with a {@link Long} value. The given default for the setting can be overriden by
- * means of a system property with a name equal to the setting key.
+ * A {@link RioSetting} with a {@link Long} value. The given default for the setting can be overriden by means
+ * of a system property with a name equal to the setting key.
  * 
  * @author Jeen Broekstra
  */
@@ -24,8 +24,13 @@ public class LongRioSetting extends AbstractRioSetting<Long> {
 	}
 
 	@Override
-	protected Long convert(String stringValue) {
-		return Long.parseLong(stringValue);
+	public Long convert(String stringValue) {
+		try {
+			return Long.parseLong(stringValue);
+		}
+		catch (NumberFormatException e) {
+			throw new RioConfigurationException(e);
+		}
 	}
 
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/LongRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/LongRioSetting.java
@@ -29,7 +29,7 @@ public class LongRioSetting extends AbstractRioSetting<Long> {
 			return Long.parseLong(stringValue);
 		}
 		catch (NumberFormatException e) {
-			throw new RioConfigurationException(e);
+			throw new RioConfigurationException("Conversion error for setting: " + getKey(), e);
 		}
 	}
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesParserSettings.java
@@ -22,7 +22,7 @@ public class NTriplesParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_NTRIPLES_INVALID_LINES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_NTRIPLES_INVALID_LINES =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonntriplesinvalidlines", "Fail on N-Triples invalid lines",
 			Boolean.TRUE);
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesParserSettings.java
@@ -23,7 +23,7 @@ public class NTriplesParserSettings {
 	 * Defaults to true.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_NTRIPLES_INVALID_LINES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonntriplesinvalidlines", "Fail on N-Triples invalid lines",
+			"org.eclipse.rdf4j.rio.fail_on_ntriples_invalid_lines", "Fail on N-Triples invalid lines",
 			Boolean.TRUE);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesParserSettings.java
@@ -11,6 +11,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * ParserSettings for the N-Triples parser features.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  */
@@ -21,10 +24,25 @@ public class NTriplesParserSettings {
 	 * documents generate a parse error.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.ntriples.fail_on_invalid_lines}
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_NTRIPLES_INVALID_LINES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.fail_on_ntriples_invalid_lines", "Fail on N-Triples invalid lines",
+	public static final RioSetting<Boolean> FAIL_ON_INVALID_LINES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.ntriples.fail_on_invalid_lines", "Fail on N-Triples invalid lines",
 			Boolean.TRUE);
+
+	/**
+	 * Boolean setting for parser to determine whether syntactically invalid lines in N-Triples and N-Quads
+	 * documents generate a parse error.
+	 * <p>
+	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.ntriples.fail_on_invalid_lines}
+	 * 
+	 * @deprecated use {@link #FAIL_ON_INVALID_LINES} instead.
+	 */
+	@Deprecated
+	public static final RioSetting<Boolean> FAIL_ON_NTRIPLES_INVALID_LINES = FAIL_ON_INVALID_LINES;
 
 	/**
 	 * Private constructor

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesWriterSettings.java
@@ -22,7 +22,7 @@ public class NTriplesWriterSettings {
 	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> ESCAPE_UNICODE =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.escapeunicode", "Escape Unicode characters", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.escape_unicode", "Escape Unicode characters", Boolean.FALSE);
 
 	/**
 	 * Private constructor

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesWriterSettings.java
@@ -11,9 +11,6 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * WriterSettings for the N-Triples writer features.
- * <p>
- * Several of these settings can be overridden by means of a system property, but only if specified at JVM
- * startup time.
  * 
  * @author Peter Ansell
  */

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesWriterSettings.java
@@ -21,7 +21,7 @@ public class NTriplesWriterSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> ESCAPE_UNICODE = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> ESCAPE_UNICODE =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.escapeunicode", "Escape Unicode characters", Boolean.FALSE);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesWriterSettings.java
@@ -11,6 +11,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * WriterSettings for the N-Triples writer features.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  */
@@ -19,10 +22,12 @@ public class NTriplesWriterSettings {
 	/**
 	 * Boolean setting for writer to determine if unicode escapes are used.
 	 * <p>
-	 * Defaults to false.
+	 * Defaults to false. 
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.ntriples.escape_unicode}
 	 */
-	public static final RioSetting<Boolean> ESCAPE_UNICODE =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.escape_unicode", "Escape Unicode characters", Boolean.FALSE);
+	public static final RioSetting<Boolean> ESCAPE_UNICODE = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.ntriples.escape_unicode", "Escape Unicode characters", Boolean.FALSE);
 
 	/**
 	 * Private constructor

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFJSONParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFJSONParserSettings.java
@@ -11,6 +11,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * A selection of parser settings specific to RDF/JSON parsers.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  */
@@ -21,27 +24,38 @@ public class RDFJSONParserSettings {
 	 * values for a single object in a single statement.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.rdfjson.fail_on_multiple_object_values}.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_VALUES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.fail_on_multiple_object_values", "Fail on multiple object values", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.rdfjson.fail_on_multiple_object_values", "Fail on multiple object values",
+			Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine whether an RDF/JSON parser should fail if it finds multiple types
 	 * for a single object in a single statement.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.rdfjson.fail_on_multiple_object_types}.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_TYPES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.fail_on_multiple_object_types", "Fail on multiple object types", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.rdfjson.fail_on_multiple_object_types", "Fail on multiple object types",
+			Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine whether an RDF/JSON parser should fail if it finds multiple
 	 * languages for a single object in a single statement.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.rdfjson.fail_on_multiple_object_languages}.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_LANGUAGES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.fail_on_multiple_object_languages", "Fail on multiple object languages",
+			"org.eclipse.rdf4j.rio.rdfjson.fail_on_multiple_object_languages", "Fail on multiple object languages",
 			Boolean.TRUE);
 
 	/**
@@ -49,28 +63,37 @@ public class RDFJSONParserSettings {
 	 * datatypes for a single object in a single statement.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.rdfjson.fail_on_multiple_object_datatypes}.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_DATATYPES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.fail_on_multiple_object_datatypes", "Fail on multiple object datatypes",
+			"org.eclipse.rdf4j.rio.rdfjson.fail_on_multiple_object_datatypes", "Fail on multiple object datatypes",
 			Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine whether an RDF/JSON parser should fail if it finds multiple
-	 * properties that it does not recognise in the JSON document.
+	 * properties that it does not recognize in the JSON document.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.rdfjson.fail_on_unknown_property}.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_PROPERTY = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.fail_on_unknown_property", "Fail on unknown property", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.rdfjson.fail_on_unknown_property", "Fail on unknown property", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine whether an RDF/JSON parser should support the graphs extension to
 	 * make it a quads format.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.rdfjson.support_graphs_extension}.
 	 */
 	public static final RioSetting<Boolean> SUPPORT_GRAPHS_EXTENSION = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.support_graphs_extension", "SUPPORT_GRAPHS_EXTENSION", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.rdfjson.support_graphs_extension", "SUPPORT_GRAPHS_EXTENSION", Boolean.TRUE);
 
 	/**
 	 * Private default constructor.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFJSONParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFJSONParserSettings.java
@@ -22,18 +22,17 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_VALUES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonmultipleobjectvalues", "Fail on multiple object values",
-			Boolean.TRUE);
+	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_VALUES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.fail_on_multiple_object_values", "Fail on multiple object values", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for parser to determine whether an RDF/JSON parser should fail if it finds multiple
-	 * types for a single object in a single statement.
+	 * Boolean setting for parser to determine whether an RDF/JSON parser should fail if it finds multiple types
+	 * for a single object in a single statement.
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_TYPES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonmultipleobjecttypes", "Fail on multiple object types", Boolean.TRUE);
+	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_TYPES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.fail_on_multiple_object_types", "Fail on multiple object types", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine whether an RDF/JSON parser should fail if it finds multiple
@@ -41,8 +40,8 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_LANGUAGES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonmultipleobjectlanguages", "Fail on multiple object languages",
+	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_LANGUAGES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.fail_on_multiple_object_languages", "Fail on multiple object languages",
 			Boolean.TRUE);
 
 	/**
@@ -51,8 +50,8 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_DATATYPES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonmultipleobjectdatatypes", "Fail on multiple object datatypes",
+	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_DATATYPES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.fail_on_multiple_object_datatypes", "Fail on multiple object datatypes",
 			Boolean.TRUE);
 
 	/**
@@ -61,17 +60,17 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_PROPERTY =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonunknownproperty", "Fail on unknown property", Boolean.TRUE);
+	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_PROPERTY = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.fail_on_unknown_property", "Fail on unknown property", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for parser to determine whether an RDF/JSON parser should support the graphs extension
-	 * to make it a quads format.
+	 * Boolean setting for parser to determine whether an RDF/JSON parser should support the graphs extension to
+	 * make it a quads format.
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> SUPPORT_GRAPHS_EXTENSION =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.supportgraphsextension", "SUPPORT_GRAPHS_EXTENSION", Boolean.TRUE);
+	public static final RioSetting<Boolean> SUPPORT_GRAPHS_EXTENSION = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.support_graphs_extension", "SUPPORT_GRAPHS_EXTENSION", Boolean.TRUE);
 
 	/**
 	 * Private default constructor.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFJSONParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFJSONParserSettings.java
@@ -22,7 +22,7 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_VALUES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_VALUES =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonmultipleobjectvalues", "Fail on multiple object values",
 			Boolean.TRUE);
 
@@ -32,7 +32,7 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_TYPES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_TYPES =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonmultipleobjecttypes", "Fail on multiple object types", Boolean.TRUE);
 
 	/**
@@ -41,7 +41,7 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_LANGUAGES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_LANGUAGES =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonmultipleobjectlanguages", "Fail on multiple object languages",
 			Boolean.TRUE);
 
@@ -51,7 +51,7 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_DATATYPES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_MULTIPLE_OBJECT_DATATYPES =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonmultipleobjectdatatypes", "Fail on multiple object datatypes",
 			Boolean.TRUE);
 
@@ -61,7 +61,7 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_PROPERTY = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_UNKNOWN_PROPERTY =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonunknownproperty", "Fail on unknown property", Boolean.TRUE);
 
 	/**
@@ -70,7 +70,7 @@ public class RDFJSONParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> SUPPORT_GRAPHS_EXTENSION = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> SUPPORT_GRAPHS_EXTENSION =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.supportgraphsextension", "SUPPORT_GRAPHS_EXTENSION", Boolean.TRUE);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
@@ -11,6 +11,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * A selection of parser settings specific to RDFa parsers.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  */
@@ -26,30 +29,32 @@ public class RDFaParserSettings {
 
 	/**
 	 * Enables or disables
-	 * <a href= "http://www.w3.org/TR/2012/REC-rdfa-core-20120607/#s_vocab_expansion" >vocabulary
-	 * expansion</a> feature.
+	 * <a href= "http://www.w3.org/TR/2012/REC-rdfa-core-20120607/#s_vocab_expansion" >vocabulary expansion</a>
+	 * feature.
 	 * <p>
 	 * Defaults to false
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.rdfa.vocab_expansion}.
 	 * 
 	 * @see <a href="http://www.w3.org/TR/2012/REC-rdfa-core-20120607/#s_vocab_expansion">RDFa Vocabulary
 	 *      Expansion</a>
 	 */
-	public static final RioSetting<Boolean> VOCAB_EXPANSION_ENABLED =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.rdfa.vocab_expansion", "Vocabulary Expansion",
-			Boolean.FALSE);
+	public static final RioSetting<Boolean> VOCAB_EXPANSION_ENABLED = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.rdfa.vocab_expansion", "Vocabulary Expansion", Boolean.FALSE);
 
 	/**
 	 * Boolean setting for parser to determine whether the published RDFa prefixes are used to substitute for
 	 * undefined prefixes.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.rdfa.allow_undefined_prefixes}.
 	 *
 	 * @deprecated Use {@link BasicParserSettings#NAMESPACES}
 	 */
 	@Deprecated
-	public static final RioSetting<Boolean> FAIL_ON_RDFA_UNDEFINED_PREFIXES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.allow_rdfa_undefined_prefixes", "Allow RDFa Undefined Prefixes",
-			Boolean.FALSE);
+	public static final RioSetting<Boolean> FAIL_ON_RDFA_UNDEFINED_PREFIXES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.rdfa.allow_undefined_prefixes", "Allow RDFa Undefined Prefixes", Boolean.FALSE);
 
 	/**
 	 * Private default constructor.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
@@ -34,7 +34,7 @@ public class RDFaParserSettings {
 	 * @see <a href="http://www.w3.org/TR/2012/REC-rdfa-core-20120607/#s_vocab_expansion">RDFa Vocabulary
 	 *      Expansion</a>
 	 */
-	public static final RioSetting<Boolean> VOCAB_EXPANSION_ENABLED = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> VOCAB_EXPANSION_ENABLED =  new BooleanRioSetting(
 			"http://www.w3.org/TR/2012/REC-rdfa-core-20120607/#s_vocab_expansion", "Vocabulary Expansion",
 			Boolean.FALSE);
 
@@ -47,7 +47,7 @@ public class RDFaParserSettings {
 	 * @deprecated Use {@link BasicParserSettings#NAMESPACES}
 	 */
 	@Deprecated
-	public static final RioSetting<Boolean> FAIL_ON_RDFA_UNDEFINED_PREFIXES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_RDFA_UNDEFINED_PREFIXES =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.allowrdfaundefinedprefixes", "Allow RDFa Undefined Prefixes",
 			Boolean.FALSE);
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFaParserSettings.java
@@ -35,7 +35,7 @@ public class RDFaParserSettings {
 	 *      Expansion</a>
 	 */
 	public static final RioSetting<Boolean> VOCAB_EXPANSION_ENABLED =  new BooleanRioSetting(
-			"http://www.w3.org/TR/2012/REC-rdfa-core-20120607/#s_vocab_expansion", "Vocabulary Expansion",
+			"org.eclipse.rdf4j.rio.rdfa.vocab_expansion", "Vocabulary Expansion",
 			Boolean.FALSE);
 
 	/**
@@ -48,7 +48,7 @@ public class RDFaParserSettings {
 	 */
 	@Deprecated
 	public static final RioSetting<Boolean> FAIL_ON_RDFA_UNDEFINED_PREFIXES =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.allowrdfaundefinedprefixes", "Allow RDFa Undefined Prefixes",
+			"org.eclipse.rdf4j.rio.allow_rdfa_undefined_prefixes", "Allow RDFa Undefined Prefixes",
 			Boolean.FALSE);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioConfigurationException.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioConfigurationException.java
@@ -23,4 +23,12 @@ public class RioConfigurationException extends RDF4JException {
 	public RioConfigurationException(String message) {
 		super(message);
 	}
+	
+	public RioConfigurationException(Throwable t) {
+		super(t);
+	}
+	
+	public RioConfigurationException(String message, Throwable t) {
+		super(message, t);
+	}
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioConfigurationException.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioConfigurationException.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import org.eclipse.rdf4j.RDF4JException;
+
+/**
+ * A RuntimeException indicating that a specific Rio parser/writer configuration setting is not supported. A
+ * typical cause of this exception is that a system property is used to specify a default setting, for a
+ * setting that does not support this way of default specification.
+ * 
+ * @author Jeen Broekstra
+ */
+public class RioConfigurationException extends RDF4JException {
+
+	private static final long serialVersionUID = -1644521868096562781L;
+
+	public RioConfigurationException(String message) {
+		super(message);
+	}
+}

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioSettingImpl.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioSettingImpl.java
@@ -10,7 +10,8 @@ package org.eclipse.rdf4j.rio.helpers;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
- * Basic implementation of {@link RioSetting} interface, without support for default override via system properties.
+ * Basic implementation of {@link RioSetting} interface, without support for default override via system
+ * properties.
  * 
  * @author Peter Ansell
  * @see StringRioSetting
@@ -25,10 +26,14 @@ public final class RioSettingImpl<T> extends AbstractRioSetting<T> {
 		super(key, description, defaultValue);
 	}
 
+	/**
+	 * @throws RioConfigurationException
+	 *         to indicate this setting can no be specified through a system property.
+	 */
 	@Override
 	protected T convert(String stringValue) {
-		throw new UnsupportedOperationException(
-				String.format("setting '%s' can not be specified through an environment variable", getKey()));
+		throw new RioConfigurationException(
+				String.format("setting '%s' can not be specified through a system property", getKey()));
 	}
 
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioSettingImpl.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioSettingImpl.java
@@ -10,70 +10,26 @@ package org.eclipse.rdf4j.rio.helpers;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
- * Basic implementation of {@link RioSetting} interface.
+ * Basic implementation of {@link RioSetting} interface, without support for default override via environment
+ * variables.
  * 
  * @author Peter Ansell
+ * @see StringRioSetting
+ * @see BooleanRioSetting
+ * @see LongRioSetting
  */
-public final class RioSettingImpl<T> implements RioSetting<T> {
+public final class RioSettingImpl<T> extends AbstractRioSetting<T> {
 
-	/**
-	 */
-	private static final long serialVersionUID = 270L;
+	private static final long serialVersionUID = 5522964700661094393L;
 
-	/**
-	 * A unique key for this setting.
-	 */
-	private final String key;
-
-	/**
-	 * A human-readable description for this setting
-	 */
-	private final String description;
-
-	/**
-	 * The default value for this setting. <br>
-	 * NOTE: This value must be immutable.
-	 */
-	private final T defaultValue;
-
-	/**
-	 * Create a new setting object that will be used to reference the given setting.
-	 * 
-	 * @param key
-	 *        A unique key to use for this setting.
-	 * @param description
-	 *        A short human-readable description for this setting.
-	 * @param defaultValue
-	 *        An immutable value specifying the default for this setting.
-	 */
 	public RioSettingImpl(String key, String description, T defaultValue) {
-
-		if (key == null) {
-			throw new NullPointerException("Setting key cannot be null");
-		}
-
-		if (description == null) {
-			throw new NullPointerException("Setting description cannot be null");
-		}
-
-		this.key = key;
-		this.description = description;
-		this.defaultValue = defaultValue;
+		super(key, description, defaultValue);
 	}
 
 	@Override
-	public String getKey() {
-		return key;
-	}
-
-	@Override
-	public String getDescription() {
-		return description;
-	}
-
-	@Override
-	public T getDefaultValue() {
-		return defaultValue;
+	protected T convert(String stringValue) {
+		throw new UnsupportedOperationException(
+				String.format("setting '%s' can not be specified through an environment variable", getKey()));
 	}
 
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioSettingImpl.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioSettingImpl.java
@@ -25,15 +25,4 @@ public final class RioSettingImpl<T> extends AbstractRioSetting<T> {
 	public RioSettingImpl(String key, String description, T defaultValue) {
 		super(key, description, defaultValue);
 	}
-
-	/**
-	 * @throws RioConfigurationException
-	 *         to indicate this setting can no be specified through a system property.
-	 */
-	@Override
-	protected T convert(String stringValue) {
-		throw new RioConfigurationException(
-				String.format("setting '%s' can not be specified through a system property", getKey()));
-	}
-
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioSettingImpl.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RioSettingImpl.java
@@ -10,8 +10,7 @@ package org.eclipse.rdf4j.rio.helpers;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
- * Basic implementation of {@link RioSetting} interface, without support for default override via environment
- * variables.
+ * Basic implementation of {@link RioSetting} interface, without support for default override via system properties.
  * 
  * @author Peter Ansell
  * @see StringRioSetting

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/StringRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/StringRioSetting.java
@@ -10,8 +10,8 @@ package org.eclipse.rdf4j.rio.helpers;
 import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
- * A {@link RioSetting} with a {@link String} value. The given default for the setting can be overriden by
- * means of an environment variable with a name equal to the setting key.
+ * A {@link RioSetting} with a {@link String} value. The given default for the setting can be overridden by
+ * means of a system property with a name equal to the setting key.
  * 
  * @author Jeen Broekstra
  */

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/StringRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/StringRioSetting.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+
+/**
+ * A {@link RioSetting} with a {@link String} value. The given default for the setting can be overriden by
+ * means of an environment variable with a name equal to the setting key.
+ * 
+ * @author Jeen Broekstra
+ */
+public class StringRioSetting extends AbstractRioSetting<String> {
+
+	private static final long serialVersionUID = -3723273606390299263L;
+
+	public StringRioSetting(String key, String description, String defaultValue) {
+		super(key, description, defaultValue);
+	}
+
+	@Override
+	protected String convert(String stringValue) {
+		return stringValue;
+	}
+
+}

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/StringRioSetting.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/StringRioSetting.java
@@ -24,7 +24,7 @@ public class StringRioSetting extends AbstractRioSetting<String> {
 	}
 
 	@Override
-	protected String convert(String stringValue) {
+	public String convert(String stringValue) {
 		return stringValue;
 	}
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TriXParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TriXParserSettings.java
@@ -21,7 +21,7 @@ public class TriXParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_TRIX_MISSING_DATATYPE = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_TRIX_MISSING_DATATYPE =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.ignoretrixmissingdatatype", "Ignore TriX missing datatype", Boolean.TRUE);
 
 	/**
@@ -29,7 +29,7 @@ public class TriXParserSettings {
 	 * <p>
 	 * Defaults to true.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_TRIX_INVALID_STATEMENT = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_TRIX_INVALID_STATEMENT =  new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.ignoretrixmissingdatatype", "Ignore TriX missing datatype", Boolean.TRUE);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TriXParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TriXParserSettings.java
@@ -11,26 +11,48 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * ParserSettings for the TriX parser features.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  */
 public class TriXParserSettings {
 
 	/**
-	 * Boolean setting for parser to determine whether missing datatypes in TriX are ignored.
+	 * Boolean setting for parser to determine whether the TriX parser should treat missing datatypes as an
+	 * error.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.trix.fail_on_missing_datatype}.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_TRIX_MISSING_DATATYPE =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.ignore_trix_missing_datatype", "Ignore TriX missing datatype", Boolean.TRUE);
+	public static final RioSetting<Boolean> FAIL_ON_MISSING_DATATYPE = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.trix.fail_on_missing_datatype", "Fail on TriX missing datatype", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for parser to determine whether invalid statements are ignored in TriX.
+	 * @deprecated use {@link #FAIL_ON_MISSING_DATATYPE} instead.
+	 */
+	@Deprecated
+	public static final RioSetting<Boolean> FAIL_ON_TRIX_MISSING_DATATYPE = FAIL_ON_MISSING_DATATYPE;
+
+	/**
+	 * Boolean setting for parser to determine whether the TriX parser should treat invalid statements as an
+	 * error.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.trix.fail_on_invalid_statement}.
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_TRIX_INVALID_STATEMENT =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.ignore_trix_invalid_statement", "Ignore TriX invalid statement", Boolean.TRUE);
+	public static final RioSetting<Boolean> FAIL_ON_INVALID_STATEMENT = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.trix.fail_on_invalid_statement", "Fail on TriX invalid statement", Boolean.TRUE);
+
+	/**
+	 * @deprecated use {@link #FAIL_ON_INVALID_STATEMENT} instead
+	 */
+	@Deprecated
+	public static final RioSetting<Boolean> FAIL_ON_TRIX_INVALID_STATEMENT = FAIL_ON_INVALID_STATEMENT;
 
 	/**
 	 * Private constructor

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TriXParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TriXParserSettings.java
@@ -22,7 +22,7 @@ public class TriXParserSettings {
 	 * Defaults to true.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_TRIX_MISSING_DATATYPE =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.ignoretrixmissingdatatype", "Ignore TriX missing datatype", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.ignore_trix_missing_datatype", "Ignore TriX missing datatype", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for parser to determine whether invalid statements are ignored in TriX.
@@ -30,7 +30,7 @@ public class TriXParserSettings {
 	 * Defaults to true.
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_TRIX_INVALID_STATEMENT =  new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.ignoretrixmissingdatatype", "Ignore TriX missing datatype", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.ignore_trix_invalid_statement", "Ignore TriX invalid statement", Boolean.TRUE);
 
 	/**
 	 * Private constructor

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
@@ -22,7 +22,7 @@ public class TurtleParserSettings {
 	 * <p>
 	 * Defaults to false.
 	 */
-	public static final RioSetting<Boolean> CASE_INSENSITIVE_DIRECTIVES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> CASE_INSENSITIVE_DIRECTIVES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.turtle.caseinsensitivedirectives",
 			"Allows case-insensitive directives to be recognised", Boolean.FALSE);
 

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
@@ -11,9 +11,6 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * Parser Settings that are specific to {@link org.eclipse.rdf4j.rio.RDFFormat#TURTLE} parsers.
- * <p>
- * Several of these settings can be overridden by means of a system property, but only if specified at JVM
- * startup time.
  * 
  * @author Peter Ansell
  */

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
@@ -11,16 +11,22 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * Parser Settings that are specific to {@link org.eclipse.rdf4j.rio.RDFFormat#TURTLE} parsers.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  */
 public class TurtleParserSettings {
 
 	/**
-	 * Allows the Turtle parser to recognise <tt>@BASE</tt> and <tt>@PREFIX</tt> in a similar way to the
-	 * SPARQL case insensitive directives.
+	 * Allows the Turtle parser to recognize <tt>@BASE</tt> and <tt>@PREFIX</tt> in a similar way to the SPARQL
+	 * case insensitive directives.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.turtle.case_insensitive_directives}.
 	 */
 	public static final RioSetting<Boolean> CASE_INSENSITIVE_DIRECTIVES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.turtle.case_insensitive_directives",

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
@@ -23,7 +23,7 @@ public class TurtleParserSettings {
 	 * Defaults to false.
 	 */
 	public static final RioSetting<Boolean> CASE_INSENSITIVE_DIRECTIVES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.turtle.caseinsensitivedirectives",
+			"org.eclipse.rdf4j.rio.turtle.case_insensitive_directives",
 			"Allows case-insensitive directives to be recognised", Boolean.FALSE);
 
 }

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLParserSettings.java
@@ -15,6 +15,9 @@ import org.xml.sax.XMLReader;
 
 /**
  * ParserSettings for the XML parser features.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Michael Grove
  * @author Peter Ansell
@@ -27,6 +30,9 @@ public final class XMLParserSettings {
 	 * Parser setting for the secure processing feature of XML parsers to avoid DOS attacks
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code http://javax.xml.XMLConstants/feature/secure-processing}
 	 * 
 	 * @see <a href=
 	 *      "http://docs.oracle.com/javase/6/docs/api/javax/xml/XMLConstants.html#FEATURE_SECURE_PROCESSING">
@@ -39,6 +45,8 @@ public final class XMLParserSettings {
 	 * Parser setting specifying whether DOCTYPE declaration should be disallowed.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property {@code http://apache.org/xml/features/disallow-doctype-decl}
 	 * 
 	 * @see <a href="http://xerces.apache.org/xerces2-j/features.html">Apache XML Project - Features</a>
 	 * @see <a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet">XXE
@@ -52,6 +60,9 @@ public final class XMLParserSettings {
 	 * Parser setting specifying whether external DTDs should be loaded.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code http://apache.org/xml/features/nonvalidating/load-external-dtd}
 	 * 
 	 * @see <a href="http://xerces.apache.org/xerces2-j/features.html">Apache XML Project - Features</a>
 	 */
@@ -62,6 +73,9 @@ public final class XMLParserSettings {
 	 * Parser setting specifying whether external text entities should be included.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code http://xml.org/sax/features/external-general-entities}
 	 * 
 	 * @see <a href="http://xerces.apache.org/xerces2-j/features.html">Apache XML Project - Features</a>
 	 * @see <a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet">XXE
@@ -74,6 +88,9 @@ public final class XMLParserSettings {
 	 * Parser setting specifying whether external parameter entities should be included.
 	 * <p>
 	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code http://xml.org/sax/features/external-parameter-entities}
 	 * 
 	 * @see <a href="http://xerces.apache.org/xerces2-j/features.html">Apache XML Project - Features</a>
 	 * @see <a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet">XXE
@@ -98,6 +115,8 @@ public final class XMLParserSettings {
 	 * Parser setting to determine whether to ignore non-fatal errors that come from SAX parsers.
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.fail_on_sax_non_fatal_errors}
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_SAX_NON_FATAL_ERRORS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.fail_on_sax_non_fatal_errors", "Fail on SAX non-fatal errors", true);
@@ -106,6 +125,9 @@ public final class XMLParserSettings {
 	 * Parser setting to determine whether to ignore non-standard attributes that are found in an XML document.
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property
+	 * {@code org.eclipse.rdf4j.rio.fail_on_non_standard_attributes}
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_NON_STANDARD_ATTRIBUTES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.fail_on_non_standard_attributes", "Fail on non-standard attributes", true);
@@ -114,6 +136,8 @@ public final class XMLParserSettings {
 	 * Parser setting to determine whether to ignore XML documents containing invalid NCNAMEs.
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.fail_on_invalid_ncname}
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_INVALID_NCNAME = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.fail_on_invalid_ncname", "Fail on invalid NCName", true);
@@ -122,6 +146,8 @@ public final class XMLParserSettings {
 	 * Parser setting to determine whether to throw an error for duplicate uses of rdf:ID in a single document.
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.fail_on_duplicate_rdf_id}
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_DUPLICATE_RDF_ID = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.fail_on_duplicate_rdf_id", "Fail on duplicate RDF ID", true);
@@ -130,6 +156,8 @@ public final class XMLParserSettings {
 	 * Parser setting to determine whether to ignore XML documents containing invalid QNAMEs.
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.fail_on_invalid_qname}
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_INVALID_QNAME = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.fail_on_invalid_qname", "Fail on invalid QName", true);
@@ -138,6 +166,8 @@ public final class XMLParserSettings {
 	 * Parser setting to determine whether to throw an error for XML documents containing mismatched tags
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.fail_on_mismatched_tags}
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_MISMATCHED_TAGS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.fail_on_mismatched_tags", "Fail on mismatched tags", true);
@@ -147,6 +177,8 @@ public final class XMLParserSettings {
 	 * rdf:RDF element is optional if it contains just one element.
 	 * <p>
 	 * Defaults to true
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.parse_standalone_documents}
 	 */
 	public static final RioSetting<Boolean> PARSE_STANDALONE_DOCUMENTS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.parse_standalone_documents", "Parse standalone documents", true);

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLParserSettings.java
@@ -32,7 +32,7 @@ public final class XMLParserSettings {
 	 *      "http://docs.oracle.com/javase/6/docs/api/javax/xml/XMLConstants.html#FEATURE_SECURE_PROCESSING">
 	 *      XMLConstants.FEATURE_SECURE_PROCESSING</a>
 	 */
-	public static final RioSetting<Boolean> SECURE_PROCESSING = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> SECURE_PROCESSING = new BooleanRioSetting(
 			XMLConstants.FEATURE_SECURE_PROCESSING, "Secure processing feature of XMLConstants", true);
 
 	/**
@@ -44,7 +44,7 @@ public final class XMLParserSettings {
 	 * @see <a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet">XXE
 	 *      Prevention Cheat Sheet</a>
 	 */
-	public static final RioSetting<Boolean> DISALLOW_DOCTYPE_DECL = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> DISALLOW_DOCTYPE_DECL = new BooleanRioSetting(
 			"http://apache.org/xml/features/disallow-doctype-decl", "Disallow DOCTYPE declaration in document",
 			true);
 
@@ -55,7 +55,7 @@ public final class XMLParserSettings {
 	 * 
 	 * @see <a href="http://xerces.apache.org/xerces2-j/features.html">Apache XML Project - Features</a>
 	 */
-	public static final RioSetting<Boolean> LOAD_EXTERNAL_DTD = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> LOAD_EXTERNAL_DTD = new BooleanRioSetting(
 			"http://apache.org/xml/features/nonvalidating/load-external-dtd", "Load External DTD", false);
 
 	/**
@@ -67,7 +67,7 @@ public final class XMLParserSettings {
 	 * @see <a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet">XXE
 	 *      Prevention Cheat Sheet</a>
 	 */
-	public static final RioSetting<Boolean> EXTERNAL_GENERAL_ENTITIES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> EXTERNAL_GENERAL_ENTITIES = new BooleanRioSetting(
 			"http://xml.org/sax/features/external-general-entities", "Include external general entities", false);
 
 	/**
@@ -79,7 +79,7 @@ public final class XMLParserSettings {
 	 * @see <a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet">XXE
 	 *      Prevention Cheat Sheet</a>
 	 */
-	public static final RioSetting<Boolean> EXTERNAL_PARAMETER_ENTITIES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> EXTERNAL_PARAMETER_ENTITIES = new BooleanRioSetting(
 			"http://xml.org/sax/features/external-parameter-entities", "Include external parameter entities",
 			false);
 
@@ -99,7 +99,7 @@ public final class XMLParserSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_SAX_NON_FATAL_ERRORS = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_SAX_NON_FATAL_ERRORS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonsaxnonfatalerrors", "Fail on SAX non-fatal errors", true);
 
 	/**
@@ -107,7 +107,7 @@ public final class XMLParserSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_NON_STANDARD_ATTRIBUTES = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_NON_STANDARD_ATTRIBUTES = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonnonstandardattributes", "Fail on non-standard attributes", true);
 
 	/**
@@ -115,7 +115,7 @@ public final class XMLParserSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_INVALID_NCNAME = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_INVALID_NCNAME = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failoninvalidncname", "Fail on invalid NCName", true);
 
 	/**
@@ -123,7 +123,7 @@ public final class XMLParserSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_DUPLICATE_RDF_ID = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_DUPLICATE_RDF_ID = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonduplicaterdfid", "Fail on duplicate RDF ID", true);
 
 	/**
@@ -131,7 +131,7 @@ public final class XMLParserSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_INVALID_QNAME = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_INVALID_QNAME = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failoninvalidqname", "Fail on invalid QName", true);
 
 	/**
@@ -139,7 +139,7 @@ public final class XMLParserSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> FAIL_ON_MISMATCHED_TAGS = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> FAIL_ON_MISMATCHED_TAGS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.failonmismatchedtags", "Fail on mismatched tags", true);
 
 	/**
@@ -148,7 +148,7 @@ public final class XMLParserSettings {
 	 * <p>
 	 * Defaults to true
 	 */
-	public static final RioSetting<Boolean> PARSE_STANDALONE_DOCUMENTS = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> PARSE_STANDALONE_DOCUMENTS = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.parsestandalonedocuments", "Parse standalone documents", true);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLParserSettings.java
@@ -100,7 +100,7 @@ public final class XMLParserSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_SAX_NON_FATAL_ERRORS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonsaxnonfatalerrors", "Fail on SAX non-fatal errors", true);
+			"org.eclipse.rdf4j.rio.fail_on_sax_non_fatal_errors", "Fail on SAX non-fatal errors", true);
 
 	/**
 	 * Parser setting to determine whether to ignore non-standard attributes that are found in an XML document.
@@ -108,7 +108,7 @@ public final class XMLParserSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_NON_STANDARD_ATTRIBUTES = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonnonstandardattributes", "Fail on non-standard attributes", true);
+			"org.eclipse.rdf4j.rio.fail_on_non_standard_attributes", "Fail on non-standard attributes", true);
 
 	/**
 	 * Parser setting to determine whether to ignore XML documents containing invalid NCNAMEs.
@@ -116,7 +116,7 @@ public final class XMLParserSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_INVALID_NCNAME = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failoninvalidncname", "Fail on invalid NCName", true);
+			"org.eclipse.rdf4j.rio.fail_on_invalid_ncname", "Fail on invalid NCName", true);
 
 	/**
 	 * Parser setting to determine whether to throw an error for duplicate uses of rdf:ID in a single document.
@@ -124,7 +124,7 @@ public final class XMLParserSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_DUPLICATE_RDF_ID = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonduplicaterdfid", "Fail on duplicate RDF ID", true);
+			"org.eclipse.rdf4j.rio.fail_on_duplicate_rdf_id", "Fail on duplicate RDF ID", true);
 
 	/**
 	 * Parser setting to determine whether to ignore XML documents containing invalid QNAMEs.
@@ -132,7 +132,7 @@ public final class XMLParserSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_INVALID_QNAME = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failoninvalidqname", "Fail on invalid QName", true);
+			"org.eclipse.rdf4j.rio.fail_on_invalid_qname", "Fail on invalid QName", true);
 
 	/**
 	 * Parser setting to determine whether to throw an error for XML documents containing mismatched tags
@@ -140,7 +140,7 @@ public final class XMLParserSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_MISMATCHED_TAGS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.failonmismatchedtags", "Fail on mismatched tags", true);
+			"org.eclipse.rdf4j.rio.fail_on_mismatched_tags", "Fail on mismatched tags", true);
 
 	/**
 	 * Flag indicating whether the parser parses stand-alone RDF documents. In stand-alone documents, the
@@ -149,7 +149,7 @@ public final class XMLParserSettings {
 	 * Defaults to true
 	 */
 	public static final RioSetting<Boolean> PARSE_STANDALONE_DOCUMENTS = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.parsestandalonedocuments", "Parse standalone documents", true);
+			"org.eclipse.rdf4j.rio.parse_standalone_documents", "Parse standalone documents", true);
 
 	/**
 	 * Private constructor

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLWriterSettings.java
@@ -28,7 +28,7 @@ public class XMLWriterSettings {
 	 *      specification</a>
 	 */
 	public static final RioSetting<Boolean> INCLUDE_XML_PI = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.includexmlpi", "Include XML Processing Instruction", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.include_xml_pi", "Include XML Processing Instruction", Boolean.TRUE);
 
 	/**
 	 * Boolean setting for RDF/XML Writer to determine whether the rdf:RDF root tag is to be written. The tag
@@ -40,7 +40,7 @@ public class XMLWriterSettings {
 	 *      specification</a>
 	 */
 	public static final RioSetting<Boolean> INCLUDE_ROOT_RDF_TAG = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.includerootrdftag", "Include Root RDF Tag", Boolean.TRUE);
+			"org.eclipse.rdf4j.rio.include_root_rdf_tag", "Include Root RDF Tag", Boolean.TRUE);
 
 	/**
 	 * Private default constructor.

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLWriterSettings.java
@@ -12,9 +12,6 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * A class encapsulating writer settings that XML writers may support.
- * <p>
- * Several of these settings can be overridden by means of a system property, but only if specified at JVM
- * startup time.
  * 
  * @author Peter Ansell
  */

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLWriterSettings.java
@@ -27,7 +27,7 @@ public class XMLWriterSettings {
 	 * @see <a href="http://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-complete-document">RDF/XML
 	 *      specification</a>
 	 */
-	public static final RioSetting<Boolean> INCLUDE_XML_PI = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> INCLUDE_XML_PI = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.includexmlpi", "Include XML Processing Instruction", Boolean.TRUE);
 
 	/**
@@ -39,7 +39,7 @@ public class XMLWriterSettings {
 	 * @see <a href="http://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-complete-document">RDF/XML
 	 *      specification</a>
 	 */
-	public static final RioSetting<Boolean> INCLUDE_ROOT_RDF_TAG = new RioSettingImpl<Boolean>(
+	public static final RioSetting<Boolean> INCLUDE_ROOT_RDF_TAG = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.includerootrdftag", "Include Root RDF Tag", Boolean.TRUE);
 
 	/**

--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLWriterSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLWriterSettings.java
@@ -12,6 +12,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * A class encapsulating writer settings that XML writers may support.
+ * <p>
+ * Several of these settings can be overridden by means of a system property, but only if specified at JVM
+ * startup time.
  * 
  * @author Peter Ansell
  */
@@ -23,6 +26,8 @@ public class XMLWriterSettings {
 	 * {@link RDFWriter#startRDF()} for the document to be valid XML.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property {@codeorg.eclipse.rdf4j.rio.include_xml_pi}
 	 * 
 	 * @see <a href="http://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-complete-document">RDF/XML
 	 *      specification</a>
@@ -31,10 +36,12 @@ public class XMLWriterSettings {
 			"org.eclipse.rdf4j.rio.include_xml_pi", "Include XML Processing Instruction", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for RDF/XML Writer to determine whether the rdf:RDF root tag is to be written. The tag
-	 * is optional in the RDF/XML specification, but a standalone RDF/XML document typically includes it.
+	 * Boolean setting for RDF/XML Writer to determine whether the rdf:RDF root tag is to be written. The tag is
+	 * optional in the RDF/XML specification, but a standalone RDF/XML document typically includes it.
 	 * <p>
 	 * Defaults to true.
+	 * <p>
+	 * Can be overridden by setting system property {@codeorg.eclipse.rdf4j.rio.include_root_rdf_tag}
 	 * 
 	 * @see <a href="http://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-complete-document">RDF/XML
 	 *      specification</a>

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioConfigTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioConfigTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.rio.helpers.BooleanRioSetting;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RioConfigTest {
+
+	private RioConfig config;
+
+	private String key = "org.eclipse.rdf4j.rio.rioconfig.test";
+	
+	private BooleanRioSetting testSetting = new BooleanRioSetting(key, "test setting", true);
+	
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		config = new RioConfig();
+	}
+	
+	@After
+	public void cleanup() {
+		System.clearProperty(key);
+	}
+
+	@Test
+	public void testIsSetDefault()
+		throws Exception
+	{
+		assertThat(config.isSet(testSetting)).isFalse();
+	}
+
+	@Test
+	public void testIsSetWithSystemPropertyOverride()
+		throws Exception
+	{
+		System.setProperty(key, "false");
+		assertThat(config.isSet(testSetting)).isTrue();
+	}
+	
+	@Test
+	public void testIsSetWithExplicitSet()
+		throws Exception
+	{
+		config.set(testSetting, false);
+		assertThat(config.isSet(testSetting)).isTrue();
+	}
+	
+	@Test
+	public void testUseDefaultsNoOverride() throws Exception
+	{
+		config.set(testSetting, false);
+		config.useDefaults();
+		assertThat(config.isSet(testSetting)).isFalse();
+	}
+	
+	
+	@Test
+	public void testUseDefaultsWithOverride() throws Exception
+	{
+		System.setProperty(key, "false");
+		config.useDefaults();
+		assertThat(config.isSet(testSetting)).isTrue();
+	}
+}

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioConfigTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioConfigTest.java
@@ -47,7 +47,7 @@ public class RioConfigTest {
 		throws Exception
 	{
 		System.setProperty(key, "false");
-		assertThat(config.isSet(testSetting)).isFalse();
+		assertThat(config.isSet(testSetting)).isTrue();
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class RioConfigTest {
 	{
 		System.setProperty(key, "false");
 		config.useDefaults();
-		assertThat(config.isSet(testSetting)).isFalse();
+		assertThat(config.isSet(testSetting)).isTrue();
 	}
 
 	@Test

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioConfigTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioConfigTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.rio;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.eclipse.rdf4j.rio.helpers.AbstractRioSetting;
 import org.eclipse.rdf4j.rio.helpers.BooleanRioSetting;
 import org.junit.After;
 import org.junit.Before;
@@ -19,16 +20,16 @@ public class RioConfigTest {
 	private RioConfig config;
 
 	private String key = "org.eclipse.rdf4j.rio.rioconfig.test";
-	
+
 	private BooleanRioSetting testSetting = new BooleanRioSetting(key, "test setting", true);
-	
+
 	@Before
 	public void setUp()
 		throws Exception
 	{
 		config = new RioConfig();
 	}
-	
+
 	@After
 	public void cleanup() {
 		System.clearProperty(key);
@@ -46,9 +47,9 @@ public class RioConfigTest {
 		throws Exception
 	{
 		System.setProperty(key, "false");
-		assertThat(config.isSet(testSetting)).isTrue();
+		assertThat(config.isSet(testSetting)).isFalse();
 	}
-	
+
 	@Test
 	public void testIsSetWithExplicitSet()
 		throws Exception
@@ -56,21 +57,64 @@ public class RioConfigTest {
 		config.set(testSetting, false);
 		assertThat(config.isSet(testSetting)).isTrue();
 	}
-	
+
 	@Test
-	public void testUseDefaultsNoOverride() throws Exception
+	public void testUseDefaultsNoOverride()
+		throws Exception
 	{
 		config.set(testSetting, false);
 		config.useDefaults();
 		assertThat(config.isSet(testSetting)).isFalse();
 	}
-	
-	
+
 	@Test
-	public void testUseDefaultsWithOverride() throws Exception
+	public void testUseDefaultsWithOverride()
+		throws Exception
 	{
 		System.setProperty(key, "false");
 		config.useDefaults();
-		assertThat(config.isSet(testSetting)).isTrue();
+		assertThat(config.isSet(testSetting)).isFalse();
 	}
+
+	@Test
+	public void testGetWithSystemPropertyOverride()
+		throws Exception
+	{
+		System.setProperty(key, "false");
+		assertThat(config.get(testSetting)).as("default setting overridden by system prop").isFalse();
+
+		config.set(testSetting, true);
+		assertThat(config.get(testSetting)).as(
+				"explicit user-configured setting overriding system prop").isTrue();
+
+		config.useDefaults();
+		assertThat(config.get(testSetting)).as("default setting overridden by sytem prop").isFalse();
+		
+		System.clearProperty(key);
+		assertThat(config.get(testSetting)).as("default setting overridden by system prop").isFalse();
+
+		config.useDefaults();
+		assertThat(config.get(testSetting)).as("default setting").isTrue();
+	}
+	
+	@Test
+	public void testGetWithUnsupportedConversionType()
+		throws Exception
+	{
+		// we deliberately do not use StringRioSetting as that supports conversion of system property values
+		AbstractRioSetting<String> nonConvertableSetting = new AbstractRioSetting<String>(key, "test setting",
+				"default value")
+		{
+			private static final long serialVersionUID = 1L;
+		};
+
+		assertThat(config.get(nonConvertableSetting)).isEqualTo("default value");
+		
+		System.setProperty(key, "system property value");
+
+		// system property should be ignored
+		assertThat(config.get(nonConvertableSetting)).isEqualTo("default value");
+
+	}
+
 }

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSettingTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSettingTest.java
@@ -7,38 +7,57 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.rdf4j.rio.RioSetting;
-import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
-public class BooleanRioSettingTest {
-	
-	private static final String TEST_KEY = "org.eclipse.rio.boolean_rio_setting_test";
+public class BooleanRioSettingTest extends RioSettingTest<Boolean> {
 
-	private static final String TEST_DESCRIPTION = "test rio setting";
-	
-	@After
-	public void resetEnvVar() {
-		System.clearProperty(TEST_KEY);
-	}
-	
 	@Test
-	public void testDefaultValueNoSystemProp()
+	@Override
+	@Ignore
+	public void testConvertIllegal()
 		throws Exception
 	{
-		RioSetting<Boolean> subject = new BooleanRioSetting(TEST_KEY, TEST_DESCRIPTION, false);
-		assertThat(subject.getDefaultValue()).isFalse();
 	}
-	
+
 	@Test
-	public void testOverridingSystemProp()
+	public void testConvertLegalStringVariants()
 		throws Exception
 	{
-		System.setProperty(TEST_KEY, "true");
-		RioSetting<Boolean> subject = new BooleanRioSetting(TEST_KEY, TEST_DESCRIPTION, false);
-		assertThat(subject.getDefaultValue()).isTrue();
+		assertThat(subject.convert("True")).isTrue();
+		assertThat(subject.convert("Foo")).isFalse();
+		assertThat(subject.convert("false")).isFalse();
+		assertThat(subject.convert("1")).isFalse();
 	}
+	
+	@Override
+	protected Boolean getDefaultValue() {
+		return true;
+	}
+
+	@Override
+	protected String getLegalStringValue() {
+		return "TRUE";
+	}
+
+	@Override
+	protected Boolean getConvertedStringValue() {
+		return true;
+	}
+
+	@Override
+	protected String getIllegalStringValue() {
+		throw new UnsupportedOperationException("no illegal value exists for boolean-type conversion");
+	}
+
+	@Override
+	protected RioSetting<Boolean> createRioSetting(String key, String description, Boolean defaultValue) {
+		return new BooleanRioSetting(key, description, defaultValue);
+	}
+
 
 }

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSettingTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSettingTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.junit.After;
+import org.junit.Test;
+
+public class BooleanRioSettingTest {
+	
+	private static final String TEST_KEY = "org.eclipse.rio.boolean_rio_setting_test";
+
+	private static final String TEST_DESCRIPTION = "test rio setting";
+	
+	@After
+	public void resetEnvVar() {
+		System.clearProperty(TEST_KEY);
+	}
+	
+	@Test
+	public void testDefaultValueNoSystemProp()
+		throws Exception
+	{
+		RioSetting<Boolean> subject = new BooleanRioSetting(TEST_KEY, TEST_DESCRIPTION, false);
+		assertThat(subject.getDefaultValue()).isFalse();
+	}
+	
+	@Test
+	public void testOverridingSystemProp()
+		throws Exception
+	{
+		System.setProperty(TEST_KEY, "true");
+		RioSetting<Boolean> subject = new BooleanRioSetting(TEST_KEY, TEST_DESCRIPTION, false);
+		assertThat(subject.getDefaultValue()).isTrue();
+	}
+
+}

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/LongRioSettingTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/LongRioSettingTest.java
@@ -7,54 +7,33 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
 import org.eclipse.rdf4j.rio.RioSetting;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
-public class LongRioSettingTest {
+public class LongRioSettingTest extends RioSettingTest<Long> {
 
-	private static final String TEST_KEY = "org.eclipse.rio.long_rio_setting_test";
-
-	private static final String TEST_DESCRIPTION = "test rio setting";
-
-	@After
-	public void resetEnvVar() {
-		System.clearProperty(TEST_KEY);
+	@Override
+	protected Long getDefaultValue() {
+		return 1234L;
 	}
 
-	@Test
-	public void testDefaultValueNoSystemProp()
-		throws Exception
-	{
-		RioSetting<Long> subject = new LongRioSetting(TEST_KEY, TEST_DESCRIPTION, 123456L);
-		assertThat(subject.getDefaultValue()).isEqualTo(123456L);
+	@Override
+	protected String getLegalStringValue() {
+		return "5678";
 	}
 
-	@Test
-	public void testOverridingSystemProp()
-		throws Exception
-	{
-		System.setProperty(TEST_KEY, "5678");
-		RioSetting<Long> subject = new LongRioSetting(TEST_KEY, TEST_DESCRIPTION, 123456L);
-		assertThat(subject.getDefaultValue()).isEqualTo(5678);
+	@Override
+	protected Long getConvertedStringValue() {
+		return 5678L;
 	}
 
-	@Test
-	public void testOverridingSystemPropIllegal()
-		throws Exception
-	{
-		System.setProperty(TEST_KEY, "not-a-long");
-		try {
-			RioSetting<Long> subject = new LongRioSetting(TEST_KEY, TEST_DESCRIPTION, 123456L);
-			fail("expected exception for illegal sytem property value");
-		}
-		catch (NumberFormatException e) {
-			// expected
-		}
+	@Override
+	protected String getIllegalStringValue() {
+		return "not a long";
+	}
+
+	@Override
+	protected RioSetting<Long> createRioSetting(String key, String description, Long defaultValue) {
+		return new LongRioSetting(key, description, defaultValue);
 	}
 
 }

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/LongRioSettingTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/LongRioSettingTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LongRioSettingTest {
+
+	private static final String TEST_KEY = "org.eclipse.rio.long_rio_setting_test";
+
+	private static final String TEST_DESCRIPTION = "test rio setting";
+
+	@After
+	public void resetEnvVar() {
+		System.clearProperty(TEST_KEY);
+	}
+
+	@Test
+	public void testDefaultValueNoSystemProp()
+		throws Exception
+	{
+		RioSetting<Long> subject = new LongRioSetting(TEST_KEY, TEST_DESCRIPTION, 123456L);
+		assertThat(subject.getDefaultValue()).isEqualTo(123456L);
+	}
+
+	@Test
+	public void testOverridingSystemProp()
+		throws Exception
+	{
+		System.setProperty(TEST_KEY, "5678");
+		RioSetting<Long> subject = new LongRioSetting(TEST_KEY, TEST_DESCRIPTION, 123456L);
+		assertThat(subject.getDefaultValue()).isEqualTo(5678);
+	}
+
+	@Test
+	public void testOverridingSystemPropIllegal()
+		throws Exception
+	{
+		System.setProperty(TEST_KEY, "not-a-long");
+		try {
+			RioSetting<Long> subject = new LongRioSetting(TEST_KEY, TEST_DESCRIPTION, 123456L);
+			fail("expected exception for illegal sytem property value");
+		}
+		catch (NumberFormatException e) {
+			// expected
+		}
+	}
+
+}

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioSettingTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioSettingTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class RioSettingTest<T> {
+
+	protected static final String TEST_KEY = "org.eclipse.rio.long_rio_setting_test";
+
+	protected static final String TEST_DESCRIPTION = "test rio setting";
+
+	/**
+	 * The test subject
+	 */
+	protected RioSetting<T> subject;
+
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		subject = createRioSetting(TEST_KEY, TEST_DESCRIPTION, getDefaultValue());
+	}
+
+	@Test
+	public void testDefaultValue()
+		throws Exception
+	{
+		assertThat(subject.getDefaultValue()).isEqualTo(getDefaultValue());
+	}
+
+	@Test
+	public void testConvert()
+		throws Exception
+	{
+		assertThat(subject.convert(getLegalStringValue())).isEqualTo(getConvertedStringValue());
+	}
+
+	@Test
+	public void testConvertIllegal()
+		throws Exception
+	{
+		assertThatThrownBy(() -> subject.convert(getIllegalStringValue())).isInstanceOf(
+				RioConfigurationException.class);
+	}
+
+	/**
+	 * a (legal) default value for the type T
+	 * 
+	 * @return a single legal default value.
+	 */
+	protected abstract T getDefaultValue();
+
+	/**
+	 * a legal string-represention of a setting value
+	 * 
+	 * @return a legal string-representation of a setting value.
+	 */
+	protected abstract String getLegalStringValue();
+
+	/**
+	 * the value of type T that corresponds to the value returned by {@link #getLegalStringValue()}. NB
+	 * implementors should return a hardcoded value, not doing on-the-fly conversion.
+	 * 
+	 * @return a value of type T corresponding to the the value returned by {@link #getLegalStringValue()}
+	 */
+	protected abstract T getConvertedStringValue();
+
+	/**
+	 * an illegal string-representation of a setting value.
+	 * 
+	 * @return an illegal string value;
+	 */
+	protected abstract String getIllegalStringValue();
+
+	/**
+	 * Create a new {@link RioSetting} for use as the test subject.
+	 * 
+	 * @param key
+	 *        the setting key
+	 * @param description
+	 *        the setting description
+	 * @param defaultValue
+	 *        the default value
+	 * @return a new {@link RioSetting} object
+	 */
+	protected abstract RioSetting<T> createRioSetting(String key, String description, T defaultValue);
+
+}

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/StringRioSettingTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/StringRioSettingTest.java
@@ -7,38 +7,43 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.eclipse.rdf4j.rio.RioSetting;
-import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
-public class StringRioSettingTest {
-	
-	private static final String TEST_KEY = "org.eclipse.rio.string_rio_setting_test";
+public class StringRioSettingTest extends RioSettingTest<String> {
 
-	private static final String TEST_DESCRIPTION = "test rio setting";
-	
-	@After
-	public void resetEnvVar() {
-		System.clearProperty(TEST_KEY);
-	}
-	
 	@Test
-	public void testDefaultValueNoSystemProp()
+	@Override
+	@Ignore
+	public void testConvertIllegal()
 		throws Exception
 	{
-		RioSetting<String> subject = new StringRioSetting(TEST_KEY, TEST_DESCRIPTION, "foo bar");
-		assertThat(subject.getDefaultValue()).isEqualTo("foo bar");
 	}
-	
-	@Test
-	public void testOverridingSystemProp()
-		throws Exception
-	{
-		System.setProperty(TEST_KEY, "something else");
-		RioSetting<String> subject = new StringRioSetting(TEST_KEY, TEST_DESCRIPTION, "foo bar");
-		assertThat(subject.getDefaultValue()).isEqualTo("something else");
+
+	@Override
+	protected String getDefaultValue() {
+		return "default value";
+	}
+
+	@Override
+	protected String getLegalStringValue() {
+		return "foo";
+	}
+
+	@Override
+	protected String getConvertedStringValue() {
+		return "foo";
+	}
+
+	@Override
+	protected String getIllegalStringValue() {
+		throw new UnsupportedOperationException("no illegal value exists for string-type conversion");
+	}
+
+	@Override
+	protected RioSetting<String> createRioSetting(String key, String description, String defaultValue) {
+		return new StringRioSetting(key, description, defaultValue);
 	}
 
 }

--- a/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/StringRioSettingTest.java
+++ b/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/StringRioSettingTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.junit.After;
+import org.junit.Test;
+
+public class StringRioSettingTest {
+	
+	private static final String TEST_KEY = "org.eclipse.rio.string_rio_setting_test";
+
+	private static final String TEST_DESCRIPTION = "test rio setting";
+	
+	@After
+	public void resetEnvVar() {
+		System.clearProperty(TEST_KEY);
+	}
+	
+	@Test
+	public void testDefaultValueNoSystemProp()
+		throws Exception
+	{
+		RioSetting<String> subject = new StringRioSetting(TEST_KEY, TEST_DESCRIPTION, "foo bar");
+		assertThat(subject.getDefaultValue()).isEqualTo("foo bar");
+	}
+	
+	@Test
+	public void testOverridingSystemProp()
+		throws Exception
+	{
+		System.setProperty(TEST_KEY, "something else");
+		RioSetting<String> subject = new StringRioSetting(TEST_KEY, TEST_DESCRIPTION, "foo bar");
+		assertThat(subject.getDefaultValue()).isEqualTo("something else");
+	}
+
+}

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -782,7 +782,7 @@ public class NTriplesParser extends AbstractRDFParser {
 	public Collection<RioSetting<?>> getSupportedSettings() {
 		Collection<RioSetting<?>> result = new HashSet<RioSetting<?>>(super.getSupportedSettings());
 
-		result.add(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+		result.add(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 
 		return result;
 	}

--- a/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXParser.java
+++ b/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXParser.java
@@ -107,7 +107,8 @@ public class TriXParser extends XMLReaderBasedParser implements ErrorHandler {
 		results.add(XMLParserSettings.CUSTOM_XML_READER);
 		results.add(XMLParserSettings.FAIL_ON_MISMATCHED_TAGS);
 		results.add(XMLParserSettings.FAIL_ON_SAX_NON_FATAL_ERRORS);
-
+		results.add(TriXParserSettings.FAIL_ON_INVALID_STATEMENT);
+		results.add(TriXParserSettings.FAIL_ON_MISSING_DATATYPE);
 		return results;
 	}
 
@@ -350,7 +351,7 @@ public class TriXParser extends XMLReaderBasedParser implements ErrorHandler {
 
 					if (datatype == null) {
 						reportError(DATATYPE_ATT + " attribute missing for typed literal",
-								TriXParserSettings.FAIL_ON_TRIX_MISSING_DATATYPE);
+								TriXParserSettings.FAIL_ON_MISSING_DATATYPE);
 						valueList.add(createLiteral(text, null, null));
 					}
 					else {
@@ -365,7 +366,7 @@ public class TriXParser extends XMLReaderBasedParser implements ErrorHandler {
 							// context information
 							if (valueList.size() > 1) {
 								reportError("At most 1 resource can be specified for the context",
-										TriXParserSettings.FAIL_ON_TRIX_INVALID_STATEMENT);
+										TriXParserSettings.FAIL_ON_INVALID_STATEMENT);
 							}
 							else if (valueList.size() == 1) {
 								try {
@@ -373,7 +374,7 @@ public class TriXParser extends XMLReaderBasedParser implements ErrorHandler {
 								}
 								catch (ClassCastException e) {
 									reportError("Context identifier should be a URI or blank node",
-											TriXParserSettings.FAIL_ON_TRIX_INVALID_STATEMENT);
+											TriXParserSettings.FAIL_ON_INVALID_STATEMENT);
 								}
 							}
 						}
@@ -418,7 +419,7 @@ public class TriXParser extends XMLReaderBasedParser implements ErrorHandler {
 			try {
 				if (valueList.size() != 3) {
 					reportError("exactly 3 values are required for a triple",
-							TriXParserSettings.FAIL_ON_TRIX_INVALID_STATEMENT);
+							TriXParserSettings.FAIL_ON_INVALID_STATEMENT);
 					return;
 				}
 
@@ -431,7 +432,7 @@ public class TriXParser extends XMLReaderBasedParser implements ErrorHandler {
 				}
 				catch (ClassCastException e) {
 					reportError("First value for a triple should be a URI or blank node",
-							TriXParserSettings.FAIL_ON_TRIX_INVALID_STATEMENT);
+							TriXParserSettings.FAIL_ON_INVALID_STATEMENT);
 					return;
 				}
 
@@ -440,7 +441,7 @@ public class TriXParser extends XMLReaderBasedParser implements ErrorHandler {
 				}
 				catch (ClassCastException e) {
 					reportError("Second value for a triple should be a URI",
-							TriXParserSettings.FAIL_ON_TRIX_INVALID_STATEMENT);
+							TriXParserSettings.FAIL_ON_INVALID_STATEMENT);
 					return;
 				}
 


### PR DESCRIPTION
This PR addresses GitHub issue: #1200 .

Briefly describe the changes proposed in this PR:

* added new BooleanRioSetting, StringRioSetting, LongRioSetting that support conversion from string to expected type
* added new abstract impl that adds override by means of system properties (e.g. via a `-D` flag)
* added basic unit tests

Up for discussion: should we clean up the key names for some of these settings? Some use a `org.eclipse.rio.somesetting` convention, others `org.eclipse.rio.some_setting`, and yet others have names like `http://javax.xml.XMLConstants/feature/secure-processing`. As far as I know there's no restrictions on what can be used as a command-line flag, but it's just a bit confusing I think. I am not sure though if changing existing key names for these setting will break third party compatibility. @ansell  you have any thoughts on this?
