### PR TITLE
GH-1202 allow doctype declarations by default

### DIFF
--- a/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLParserSettings.java
+++ b/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLParserSettings.java
@@ -38,7 +38,7 @@ public final class XMLParserSettings {
 	/**
 	 * Parser setting specifying whether DOCTYPE declaration should be disallowed.
 	 * <p>
-	 * Defaults to true.
+	 * Defaults to false.
 	 * 
 	 * @see <a href="http://xerces.apache.org/xerces2-j/features.html">Apache XML Project - Features</a>
 	 * @see <a href="https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet">XXE
@@ -46,7 +46,7 @@ public final class XMLParserSettings {
 	 */
 	public static final RioSetting<Boolean> DISALLOW_DOCTYPE_DECL = new RioSettingImpl<Boolean>(
 			"http://apache.org/xml/features/disallow-doctype-decl", "Disallow DOCTYPE declaration in document",
-			true);
+			false);
 
 	/**
 	 * Parser setting specifying whether external DTDs should be loaded.

--- a/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
+++ b/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
@@ -132,9 +132,7 @@ public class RDFXMLParserTest {
 		PrintStream oldOut = System.out;
 		ByteArrayOutputStream tempOut = new ByteArrayOutputStream();
 		System.setOut(new PrintStream(tempOut));
-		
-		// configure parser to allow doctype declarations
-		parser.getParserConfig().set(XMLParserSettings.DISALLOW_DOCTYPE_DECL, false);
+
 		try (final InputStream in = this.getClass().getResourceAsStream(
 				"/org/eclipse/rdf4j/rio/rdfxml/rdfxml-external-general-entity.rdf");)
 		{
@@ -179,6 +177,10 @@ public class RDFXMLParserTest {
 		PrintStream oldOut = System.out;
 		ByteArrayOutputStream tempOut = new ByteArrayOutputStream();
 		System.setOut(new PrintStream(tempOut));
+		
+		// configure parser to disallow doctype declarations
+		parser.getParserConfig().set(XMLParserSettings.DISALLOW_DOCTYPE_DECL, true);
+
 		try (final InputStream in = this.getClass().getResourceAsStream(
 				"/org/eclipse/rdf4j/rio/rdfxml/rdfxml-external-param-entity.rdf");)
 		{

--- a/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
+++ b/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
@@ -75,6 +75,10 @@ public class TriXParserTest {
 		PrintStream oldOut = System.out;
 		ByteArrayOutputStream tempOut = new ByteArrayOutputStream();
 		System.setOut(new PrintStream(tempOut));
+		
+		// configure parser to disallow doctype declarations
+		parser.getParserConfig().set(XMLParserSettings.DISALLOW_DOCTYPE_DECL, true);
+	
 		try (final InputStream in = this.getClass().getResourceAsStream(
 				"/org/eclipse/rdf4j/rio/trix/trix-xxe-external-entity.trix");)
 		{
@@ -118,8 +122,6 @@ public class TriXParserTest {
 		ByteArrayOutputStream tempOut = new ByteArrayOutputStream();
 		System.setOut(new PrintStream(tempOut));
 		
-		// configure parser to allow doctype declarations
-		parser.getParserConfig().set(XMLParserSettings.DISALLOW_DOCTYPE_DECL, false);
 		try (final InputStream in = this.getClass().getResourceAsStream(
 				"/org/eclipse/rdf4j/rio/trix/trix-xxe-external-entity.trix");)
 		{


### PR DESCRIPTION
This PR addresses GitHub issue: #1202 .

Briefly describe the changes proposed in this PR:

* re-allow doctype declarations in XML parsing by default - a lot of well-known sources of RDF data include a doctype, current default makes these documents unparsable. 
* external entities and DTDs still disallowed/ignored to protected against XXE.

