### PR TITLE
migrate httprepository/sparqlrepository compliance tests

### DIFF
--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -14,6 +14,7 @@
 	<modules>
 		<module>manager</module>
 		<module>model</module>
+                <module>repository</module>
 		<module>queryresultio</module>
 		<module>rio</module>
 	</modules>

--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -25,12 +25,6 @@
 		<dependencies>		
 			<dependency>
 				<groupId>${project.groupId}</groupId>
-				<artifactId>rdf4j-http-compliance</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>${project.groupId}</groupId>
 				<artifactId>rdf4j-rio-testsuite</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/compliance/repository/pom.xml
+++ b/compliance/repository/pom.xml
@@ -9,6 +9,7 @@
 	</parent>
 
 	<artifactId>rdf4j-repository-compliance</artifactId>
+        <packaging>war</packaging>
 
 	<name>RDF4J Repository compliance tests</name>
 	<description>Compliance testing for the Repository API implementations</description>

--- a/compliance/repository/pom.xml
+++ b/compliance/repository/pom.xml
@@ -1,0 +1,157 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-compliance</artifactId>
+		<version>2.5-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>rdf4j-repository-compliance</artifactId>
+
+	<name>RDF4J Repository compliance tests</name>
+	<description>Compliance testing for the Repository API implementations</description>
+
+        <properties>
+          <!-- use a pinned version of RDF4J Server - what we're testing is how the client operates against an endpoint -->
+          <rdf4j.server.version>2.4.2</rdf4j.server.version>
+          <jetty.version>7.0.2.v20100331</jetty.version>
+        </properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-store-testsuite</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-serql-testsuite</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sparql-testsuite</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-repository-http</artifactId>
+                        <version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-repository-sparql</artifactId>
+                        <version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-http-server</artifactId>
+                        <version>${rdf4j.server.version}</version>
+			<type>war</type>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-http-protocol</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-repository-manager</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+                        <version>${jetty.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-webapp</artifactId>
+                        <version>${jetty.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mortbay.jetty</groupId>
+			<artifactId>jetty-jsp-2.1</artifactId>
+                        <version>${jetty.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<configuration>
+					<webappDirectory>${project.build.directory}/rdf4j-server</webappDirectory>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<skipTests>true</skipTests>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>**/DataStorePerfTest.java</exclude>
+						<exclude>**/TestServer.java</exclude>
+					</excludes>
+				</configuration>
+				<executions>
+					<execution>
+						<id>integration-tests</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>integration-test</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>verify</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPMemServer.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPMemServer.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import java.io.File;
+
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.nio.BlockingChannelConnector;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
+import org.eclipse.rdf4j.repository.manager.SystemRepository;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
+import org.eclipse.rdf4j.sail.inferencer.fc.config.ForwardChainingRDFSInferencerConfig;
+import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
+
+/**
+ * @author Herko ter Horst
+ */
+public class HTTPMemServer {
+
+	private static final String HOST = "localhost";
+
+	private static final int PORT = 18080;
+
+	private static final String TEST_REPO_ID = "Test";
+
+	private static final String TEST_INFERENCE_REPO_ID = "Test-RDFS";
+
+	private static final String RDF4J_CONTEXT = "/rdf4j";
+
+	private static final String SERVER_URL = "http://" + HOST + ":" + PORT + RDF4J_CONTEXT;
+
+	public static final String REPOSITORY_URL = Protocol.getRepositoryLocation(SERVER_URL, TEST_REPO_ID);
+
+	public static String INFERENCE_REPOSITORY_URL = Protocol.getRepositoryLocation(SERVER_URL,
+			TEST_INFERENCE_REPO_ID);
+
+	private final Server jetty;
+
+	public HTTPMemServer() {
+		System.clearProperty("DEBUG");
+
+		jetty = new Server();
+
+		Connector conn = new BlockingChannelConnector();
+		conn.setHost(HOST);
+		conn.setPort(PORT);
+		jetty.addConnector(conn);
+
+		WebAppContext webapp = new WebAppContext();
+		// TODO temporarily disabled so the integration test server shows server-side logging.
+		//		webapp.addSystemClass("org.slf4j.");
+		//		webapp.addSystemClass("ch.qos.logback.");
+		webapp.setContextPath(RDF4J_CONTEXT);
+		// warPath configured in pom.xml maven-war-plugin configuration
+		webapp.setWar("./target/rdf4j-server");
+		jetty.setHandler(webapp);
+	}
+
+	public void start()
+		throws Exception
+	{
+		File dataDir = new File(System.getProperty("user.dir") + "/target/datadir");
+		dataDir.mkdirs();
+		System.setProperty("org.eclipse.rdf4j.appdata.basedir", dataDir.getAbsolutePath());
+
+		jetty.start();
+
+		createTestRepositories();
+	}
+
+	public void stop()
+		throws Exception
+	{
+		Repository systemRepo = new HTTPRepository(
+				Protocol.getRepositoryLocation(SERVER_URL, SystemRepository.ID));
+		try (RepositoryConnection con = systemRepo.getConnection()) {
+			con.clear();
+		}
+
+		jetty.stop();
+		System.clearProperty("org.mortbay.log.class");
+	}
+
+	private void createTestRepositories()
+		throws RepositoryException, RepositoryConfigException
+	{
+		Repository systemRep = new HTTPRepository(
+				Protocol.getRepositoryLocation(SERVER_URL, SystemRepository.ID));
+
+		// create a (non-inferencing) memory store
+		MemoryStoreConfig memStoreConfig = new MemoryStoreConfig();
+		SailRepositoryConfig sailRepConfig = new SailRepositoryConfig(memStoreConfig);
+		RepositoryConfig repConfig = new RepositoryConfig(TEST_REPO_ID, sailRepConfig);
+
+		RepositoryConfigUtil.updateRepositoryConfigs(systemRep, repConfig);
+
+		// create an inferencing memory store
+		ForwardChainingRDFSInferencerConfig inferMemStoreConfig = new ForwardChainingRDFSInferencerConfig(
+				new MemoryStoreConfig());
+		sailRepConfig = new SailRepositoryConfig(inferMemStoreConfig);
+		repConfig = new RepositoryConfig(TEST_INFERENCE_REPO_ID, sailRepConfig);
+
+		RepositoryConfigUtil.updateRepositoryConfigs(systemRep, repConfig);
+	}
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class HTTPRepositoryTest extends RepositoryTest {
+
+	private static HTTPMemServer server;
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+	}
+
+	@Override
+	protected Repository createRepository() {
+		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+	}
+
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTransactionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTransactionTest.java
@@ -1,0 +1,43 @@
+package org.eclipse.rdf4j.repository.http;
+
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.Test;
+
+public class HTTPRepositoryTransactionTest {
+
+	private static final String CACHE_TIMEOUT_PROPERTY = "rdf4j.server.txn.registry.timeout";
+
+	private static HTTPMemServer server;
+
+	private HTTPRepository testRepository;
+
+	@Test
+	public void testTimeout()
+		throws Exception
+	{
+		try {
+			System.setProperty(CACHE_TIMEOUT_PROPERTY, Integer.toString(2));
+			server = new HTTPMemServer();
+			try {
+				server.start();
+				testRepository = new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+				testRepository.initialize();
+			}
+			catch (Exception e) {
+				server.stop();
+				throw e;
+			}
+			try (RepositoryConnection connection = testRepository.getConnection()) {
+				connection.begin();
+				Thread.sleep(3000); // sleep for longer then the timeout
+				connection.commit(); // was transaction removed due to timeout?
+			}
+			testRepository.shutDown();
+		}
+		finally {
+			server.stop();
+			System.clearProperty(CACHE_TIMEOUT_PROPERTY);
+		}
+	}
+
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPSparqlDatasetTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPSparqlDatasetTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.SparqlDatasetTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class HTTPSparqlDatasetTest extends SparqlDatasetTest {
+
+	private static HTTPMemServer server;
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+	}
+
+	@Override
+	protected Repository newRepository() {
+		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+	}
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPSparqlSetBindingTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPSparqlSetBindingTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.SparqlSetBindingTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class HTTPSparqlSetBindingTest extends SparqlSetBindingTest {
+
+	private static HTTPMemServer server;
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+	}
+
+	@Override
+	protected Repository newRepository() {
+		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+	}
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPStoreConnectionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPStoreConnectionTest.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.StringReader;
+
+import org.eclipse.rdf4j.IsolationLevel;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnectionTest;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class HTTPStoreConnectionTest extends RepositoryConnectionTest {
+
+	private static HTTPMemServer server;
+
+	public HTTPStoreConnectionTest(IsolationLevel level) {
+		super(level);
+	}
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+	}
+
+	@Override
+	protected Repository createRepository() {
+		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+	}
+
+	@Test
+	public void testContextInTransactionAdd()
+		throws Exception
+	{
+		StringReader stringReader = new StringReader("<urn:1> <urn:1> <urn:1>.");
+		testCon.begin();
+		IRI CONTEXT = testCon.getValueFactory().createIRI("urn:context");
+		testCon.add(stringReader, "urn:baseUri", RDFFormat.NTRIPLES, CONTEXT);
+		testCon.commit();
+
+		IRI iri = testCon.getValueFactory().createIRI("urn:1");
+		assertTrue(testCon.hasStatement(iri, iri, iri, false, CONTEXT));
+	}
+
+	@Test
+	public void testUpdateExecution()
+		throws Exception
+	{
+
+		IRI foobar = vf.createIRI("foo:bar");
+
+		String sparql = "INSERT DATA { <foo:bar> <foo:bar> <foo:bar> . } ";
+
+		Update update = testCon.prepareUpdate(QueryLanguage.SPARQL, sparql);
+
+		update.execute();
+
+		assertTrue(testCon.hasStatement(foobar, foobar, foobar, true));
+
+		testCon.clear();
+
+		assertFalse(testCon.hasStatement(foobar, foobar, foobar, true));
+
+		testCon.begin();
+		update.execute();
+		testCon.commit();
+
+		assertTrue(testCon.hasStatement(foobar, foobar, foobar, true));
+
+	}
+
+	@Test
+	@Override
+	public void testAddMalformedLiteralsDefaultConfig()
+		throws Exception
+	{
+		try {
+			testCon.add(RepositoryConnectionTest.class.getResourceAsStream(
+					TEST_DIR_PREFIX + "malformed-literals.ttl"), "", RDFFormat.TURTLE);
+		}
+		catch (RDF4JException e) {
+			fail("upload of malformed literals should not fail with error in default configuration for HTTPRepository");
+		}
+	}
+
+	@Test
+	@Override
+	@Ignore("See SES-1833")
+	public void testAddMalformedLiteralsStrictConfig()
+		throws Exception
+	{
+		System.err.println(
+				"SES-1833: temporarily disabled testAddMalformedLiteralsStrictConfig() for HTTPRepository");
+	}
+
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPTupleQueryResultTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPTupleQueryResultTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.TupleQueryResultTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class HTTPTupleQueryResultTest extends TupleQueryResultTest {
+
+	private static HTTPMemServer server;
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+	}
+
+	@Override
+	protected Repository newRepository() {
+		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+	}
+
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/RDFSchemaHTTPRepositoryConnectionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/RDFSchemaHTTPRepositoryConnectionTest.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import static org.junit.Assert.fail;
+
+import org.eclipse.rdf4j.IsolationLevel;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.repository.RDFSchemaRepositoryConnectionTest;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnectionTest;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class RDFSchemaHTTPRepositoryConnectionTest extends RDFSchemaRepositoryConnectionTest {
+
+	private static HTTPMemServer server;
+
+	public RDFSchemaHTTPRepositoryConnectionTest(IsolationLevel level) {
+		super(level);
+	}
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+	}
+
+	@Override
+	protected Repository createRepository() {
+		return new HTTPRepository(HTTPMemServer.INFERENCE_REPOSITORY_URL);
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testTransactionIsolationForRead()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testTransactionIsolationForRead() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testTransactionIsolationForReadWithDeleteOperation()
+		throws Exception
+	{
+		System.err.println(
+				"temporarily disabled testTransactionIsolationForReadWithDeleteOperation() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testTransactionIsolation()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testTransactionIsolation() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testAutoCommit()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testAutoCommit() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testRollback()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testRollback() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testEmptyCommit()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testEmptyCommit() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testEmptyRollback()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testEmptyRollback() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testSizeCommit()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testSizeCommit() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testSizeRollback()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testSizeRollback() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testGetContextIDs()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testGetContextIDs() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testInferencerQueryDuringTransaction()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testInferencerDuringTransaction() for HTTPRepository");
+	}
+
+	@Ignore("temporarily disabled for HTTPRepository")
+	@Test
+	@Override
+	public void testInferencerTransactionIsolation()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testInferencerTransactionIsolation() for HTTPRepository");
+	}
+
+	@Test
+	@Override
+	public void testAddMalformedLiteralsDefaultConfig()
+		throws Exception
+	{
+		try {
+			testCon.add(RepositoryConnectionTest.class.getResourceAsStream(
+					TEST_DIR_PREFIX + "malformed-literals.ttl"), "", RDFFormat.TURTLE);
+		}
+		catch (RDF4JException e) {
+			fail("upload of malformed literals should not fail with error in default configuration for HTTPRepository");
+		}
+	}
+
+	@Test
+	@Override
+	@Ignore("See SES-1833")
+	public void testAddMalformedLiteralsStrictConfig()
+		throws Exception
+	{
+		System.err.println(
+				"SES-1833: temporarily disabled testAddMalformedLiteralsStrictConfig() for HTTPRepository");
+	}
+
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLGraphQueryResultTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLGraphQueryResultTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql;
+
+import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.repository.GraphQueryResultTest;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.http.HTTPMemServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * @author Jeen Broekstra
+ */
+public class SPARQLGraphQueryResultTest extends GraphQueryResultTest {
+
+	private static HTTPMemServer server;
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+		server = null;
+	}
+
+	@Override
+	protected Repository newRepository()
+		throws Exception
+	{
+		return new SPARQLRepository(HTTPMemServer.REPOSITORY_URL,
+				Protocol.getStatementsLocation(HTTPMemServer.REPOSITORY_URL));
+
+	}
+
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositorySparqlUpdateTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositorySparqlUpdateTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others. All rights reserved. This program and the
+ * accompanying materials are made available under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, and is available at http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql;
+
+/**
+ * @author Jeen Broekstra
+ */
+//public class SPARQLRepositorySparqlUpdateTest extends SPARQLUpdateTest {
+//
+//	private HTTPMemServer server;
+//
+//	@Override
+//	public void setUp()
+//		throws Exception
+//	{
+//		server = new HTTPMemServer();
+//		
+//		try {
+//			server.start();
+//			super.setUp();
+//		}
+//		catch (Exception e) {
+//			server.stop();
+//			throw e;
+//		}
+//	}
+//
+//	@Override
+//	public void tearDown()
+//		throws Exception
+//	{
+//		super.tearDown();
+//		server.stop();
+//	}
+//
+//	@Override
+//	protected Repository newRepository()
+//		throws Exception
+//	{
+//		return new SPARQLRepository(HTTPMemServer.REPOSITORY_URL, HTTPMemServer.REPOSITORY_URL + "/statements");
+//	}
+//
+//	@Ignore
+//	@Test
+//	@Override
+//	public void testAutoCommitHandling() 
+//	{
+//		// transaction isolation is not supported for HTTP connections. disabling test.
+//		System.err.println("temporarily disabled testAutoCommitHandling() for HTTPRepository");
+//	}
+//}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositoryTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositoryTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql;
+
+import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryTest;
+import org.eclipse.rdf4j.repository.http.HTTPMemServer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+/**
+ * @author Jeen Broekstra
+ */
+public class SPARQLRepositoryTest extends RepositoryTest {
+
+	private static HTTPMemServer server;
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+
+	}
+
+	@Before
+	@Override
+	public void setUp()
+		throws Exception
+	{
+		super.setUp();
+		// overwrite bnode test values as SPARQL endpoints do not generally work
+		// well with bnodes
+		bob = testRepository.getValueFactory().createIRI("urn:x-local:bob");
+		alice = testRepository.getValueFactory().createIRI("urn:x-local:alice");
+		alexander = testRepository.getValueFactory().createIRI("urn:x-local:alexander");
+
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+		server = null;
+	}
+
+	@Override
+	protected Repository createRepository()
+		throws Exception
+	{
+		return new SPARQLRepository(HTTPMemServer.REPOSITORY_URL,
+				Protocol.getStatementsLocation(HTTPMemServer.REPOSITORY_URL));
+
+	}
+
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLServiceEvaluationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLServiceEvaluationTest.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverImpl;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.http.HTTPMemServer;
+import org.eclipse.rdf4j.repository.http.HTTPRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
+import org.eclipse.rdf4j.sail.memory.config.MemoryStoreFactory;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test suite for evaluation of SPARQL queries involving SERVICE clauses. The test suite starts up an embedded
+ * Jetty server running Sesame, which functions as the SPARQL endpoint to test against.
+ * 
+ * @author Jeen Broekstra
+ */
+public class SPARQLServiceEvaluationTest {
+
+	static final Logger logger = LoggerFactory.getLogger(SPARQLServiceEvaluationTest.class);
+
+	private static HTTPMemServer server;
+
+	private HTTPRepository remoteRepository;
+
+	private SailRepository localRepository;
+
+	private ValueFactory f;
+
+	private IRI bob;
+
+	private IRI alice;
+
+	private IRI william;
+
+	protected static final String EX_NS = "http://example.org/";
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+	}
+
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		remoteRepository = new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+		remoteRepository.initialize();
+		loadDataSet(remoteRepository, "/testdata-query/graph1.ttl");
+		loadDataSet(remoteRepository, "/testdata-query/graph2.ttl");
+
+		localRepository = new SailRepository(new MemoryStore());
+		localRepository.initialize();
+
+		prepareLocalRepository();
+	}
+
+	private void prepareLocalRepository()
+		throws IOException
+	{
+		loadDataSet(localRepository, "/testdata-query/defaultgraph.ttl");
+
+		f = localRepository.getValueFactory();
+
+		bob = f.createIRI(EX_NS, "bob");
+		alice = f.createIRI(EX_NS, "alice");
+		william = f.createIRI(EX_NS, "william");
+	}
+
+	protected void loadDataSet(Repository rep, String datasetFile)
+		throws RDFParseException, RepositoryException, IOException
+	{
+		logger.debug("loading dataset...");
+		InputStream dataset = SPARQLServiceEvaluationTest.class.getResourceAsStream(datasetFile);
+
+		RepositoryConnection con = rep.getConnection();
+		try {
+			con.add(dataset, "", Rio.getParserFormatForFileName(datasetFile).orElseThrow(
+					Rio.unsupportedFormat(datasetFile)));
+		}
+		finally {
+			dataset.close();
+			con.close();
+		}
+		logger.debug("dataset loaded.");
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown()
+		throws Exception
+	{
+		localRepository.shutDown();
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+		server = null;
+	}
+
+	@Test
+	public void testSimpleServiceQuery()
+		throws RepositoryException
+	{
+		StringBuilder qb = new StringBuilder();
+		qb.append(" SELECT * \n");
+		qb.append(" WHERE { \n");
+		qb.append("     SERVICE <" + HTTPMemServer.REPOSITORY_URL + "> { \n");
+		qb.append("             ?X <" + FOAF.NAME + "> ?Y \n ");
+		qb.append("     } \n ");
+		qb.append("     ?X a <" + FOAF.PERSON + "> . \n");
+		qb.append(" } \n");
+
+		try (RepositoryConnection conn = localRepository.getConnection()) {
+			TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, qb.toString());
+
+			TupleQueryResult tqr = tq.evaluate();
+
+			assertNotNull(tqr);
+			assertTrue(tqr.hasNext());
+
+			int count = 0;
+			while (tqr.hasNext()) {
+				BindingSet bs = tqr.next();
+				count++;
+
+				Value x = bs.getValue("X");
+				Value y = bs.getValue("Y");
+
+				assertFalse(william.equals(x));
+
+				assertTrue(bob.equals(x) || alice.equals(x));
+				if (bob.equals(x)) {
+					f.createLiteral("Bob").equals(y);
+				}
+				else if (alice.equals(x)) {
+					f.createLiteral("Alice").equals(y);
+				}
+			}
+
+			assertEquals(2, count);
+
+		}
+		catch (MalformedQueryException e) {
+			fail(e.getMessage());
+		}
+		catch (QueryEvaluationException e) {
+			fail(e.getMessage());
+		}
+	}
+
+	/**
+	 * The provided FederatedServiceResolver should finds it way to the {@link EvaluationStrategy}
+	 */
+	@Test
+	public void testRepositoryConfigurationSetup()
+		throws Exception
+	{
+		tearDown();
+		MemoryStoreFactory factory = new MemoryStoreFactory();
+		MemoryStoreConfig config = new MemoryStoreConfig();
+		config.setEvaluationStrategyFactoryClassName(StrictEvaluationStrategyFactory.class.getName());
+		Sail sail = factory.getSail(config);
+		localRepository = new SailRepository(sail);
+		localRepository.setFederatedServiceResolver(new FederatedServiceResolverImpl());
+		localRepository.initialize();
+		prepareLocalRepository();
+		testSimpleServiceQuery();
+	}
+}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
@@ -1,0 +1,606 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
+
+import org.eclipse.rdf4j.IsolationLevel;
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnectionTest;
+import org.eclipse.rdf4j.repository.http.HTTPMemServer;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class SPARQLStoreConnectionTest extends RepositoryConnectionTest {
+
+	private static HTTPMemServer server;
+
+	public SPARQLStoreConnectionTest(IsolationLevel level) {
+		super(level);
+	}
+
+	@BeforeClass
+	public static void startServer()
+		throws Exception
+	{
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		}
+		catch (Exception e) {
+			server.stop();
+			server = null;
+			throw e;
+		}
+
+	}
+
+	@AfterClass
+	public static void stopServer()
+		throws Exception
+	{
+		server.stop();
+		server = null;
+	}
+
+	@Before
+	@Override
+	public void setUp()
+		throws Exception
+	{
+		super.setUp();
+		// overwrite bnode test values as SPARQL endpoints do not generally work
+		// well with bnodes
+		bob = testRepository.getValueFactory().createIRI("urn:x-local:bob");
+		alice = testRepository.getValueFactory().createIRI("urn:x-local:alice");
+		alexander = testRepository.getValueFactory().createIRI("urn:x-local:alexander");
+	}
+
+	@Override
+	protected Repository createRepository() {
+		return new SPARQLRepository(HTTPMemServer.REPOSITORY_URL,
+				Protocol.getStatementsLocation(HTTPMemServer.REPOSITORY_URL));
+	}
+
+	@Override
+	@Ignore
+	public void testDuplicateFilter()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testDuplicateFilter() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testAddDelete()
+		throws RDF4JException
+	{
+		System.err.println("temporarily disabled testAddDelete() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testAddRemoveInsert()
+		throws RDF4JException
+	{
+		System.err.println("temporarily disabled testAddRemoveInsert() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testSizeRollback()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testSizeRollback() for SPARQLRepository");
+	}
+
+	@Test
+	@Ignore
+	@Override
+	public void testURISerialization()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testURISerialization() for SPARQLRepository");
+	}
+
+	@Test
+	@Ignore
+	@Override
+	public void testStatementSerialization()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testStatementSerialization() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testAutoCommit()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testAutoCommit() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testRollback()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testRollback() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testEmptyRollback()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testEmptyRollback() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testEmptyCommit()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testEmptyCommit() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testPrepareSeRQLQuery()
+		throws Exception
+	{
+		System.err.println("disabled testPrepareSeRQLQuery() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testLiteralSerialization()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testLiteralSerialization() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testSizeCommit()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testSizeCommit() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testGetStatementsInMultipleContexts()
+		throws Exception
+	{
+		System.err.println(
+				"temporarily disabled testGetStatementsInMultipleContexts() for SPARQLRepository: implementation of statement context using SPARQL not yet complete");
+		// TODO see SES-1776
+	}
+
+	@Test
+	public void testGetStatementsContextHandling()
+		throws Exception
+	{
+		// enable quad mode
+		enableQuadModeOnConnection((SPARQLConnection)testCon);
+
+		testCon.clear();
+
+		testCon.begin();
+		testCon.add(alice, name, nameAlice, context1);
+		testCon.add(bob, name, nameBob);
+		testCon.commit();
+
+		List<Statement> res;
+
+		// test 1: alice statement should have context 1
+		res = Iterations.asList(testCon.getStatements(alice, null, null, false));
+		Assert.assertEquals(1, res.size());
+		Assert.assertEquals(context1, res.iterator().next().getContext());
+
+		// test 2: bob statement should have default named graph
+		res = Iterations.asList(testCon.getStatements(bob, null, null, false));
+		Assert.assertEquals(1, res.size());
+		Assert.assertEquals(null, res.iterator().next().getContext());
+
+		// test 3: bound statement should fetch context
+		res = Iterations.asList(testCon.getStatements(alice, name, nameAlice, false));
+		Assert.assertEquals(1, res.size());
+		Assert.assertEquals(context1, res.iterator().next().getContext());
+
+	}
+
+	/**
+	 * Enable the quadMode on the given connection. This is done via reflection here as the test setup already
+	 * creates the repository and connection and we do not have a chance to set the mode easily inside the
+	 * test (as quadMode is an immutable field of the connection). Note: this is only done such that we can
+	 * reuse the test infrastructure of the base class.
+	 */
+	private void enableQuadModeOnConnection(SPARQLConnection con)
+		throws Exception
+	{
+		Field quadModeField = SPARQLConnection.class.getDeclaredField("quadMode");
+		quadModeField.setAccessible(true);
+
+		// remove final modifier from field
+		Field modifiersField = Field.class.getDeclaredField("modifiers");
+		modifiersField.setAccessible(true);
+		modifiersField.setInt(quadModeField, quadModeField.getModifiers() & ~Modifier.FINAL);
+
+		quadModeField.set(con, true);
+	}
+
+	@Override
+	@Ignore
+	public void testGetStatementsInSingleContext()
+		throws Exception
+	{
+		System.err.println(
+				"temporarily disabled testGetStatementsInSingleContext() for SPARQLRepository: implementation of statement context using SPARQL not yet complete");
+		// TODO see SES-1776
+	}
+
+	@Test
+	@Override
+	@Ignore("can not execute test because required data add results in illegal SPARQL syntax")
+	public void testGetStatementsMalformedLanguageLiteral()
+		throws Exception
+	{
+		System.err.println(
+				"temporarily disabled testGetStatementsMalformedLanguageLiteral() for SPARQLRepository");
+	}
+
+	@Override
+	public void testPreparedTupleQuery()
+		throws Exception
+	{
+		testCon.add(alice, name, nameAlice, context2);
+		testCon.add(alice, mbox, mboxAlice, context2);
+		testCon.add(context2, publisher, nameAlice);
+
+		testCon.add(bob, name, nameBob, context1);
+		testCon.add(bob, mbox, mboxBob, context1);
+		testCon.add(context1, publisher, nameBob);
+
+		StringBuilder queryBuilder = new StringBuilder();
+		queryBuilder.append(" PREFIX foaf: <" + FOAF_NS + "> ");
+		queryBuilder.append(" SELECT ?name ?mbox");
+		queryBuilder.append(" WHERE { [] foaf:name ?name;");
+		queryBuilder.append("            foaf:mbox ?mbox. }");
+
+		TupleQuery query = testCon.prepareTupleQuery(QueryLanguage.SPARQL, queryBuilder.toString());
+		query.setBinding("name", nameBob);
+
+		try (TupleQueryResult result = query.evaluate()) {
+			assertTrue(result != null);
+			assertTrue(result.hasNext());
+
+			while (result.hasNext()) {
+				BindingSet solution = result.next();
+				assertTrue(solution.hasBinding("name"));
+				assertTrue(solution.hasBinding("mbox"));
+
+				Value nameResult = solution.getValue("name");
+				Value mboxResult = solution.getValue("mbox");
+
+				assertEquals("unexpected value for name: " + nameResult, nameBob, nameResult);
+				assertEquals("unexpected value for mbox: " + mboxResult, mboxBob, mboxResult);
+			}
+		}
+	}
+
+	@Override
+	@Ignore
+	public void testGetNamespaces()
+		throws Exception
+	{
+		System.err.println("disabled testGetNamespaces() as namespace retrieval is not supported by SPARQL");
+	}
+
+	@Override
+	@Ignore
+	public void testGetNamespace()
+		throws Exception
+	{
+		System.err.println("disabled testGetNamespace() as namespace retrieval is not supported by SPARQL");
+	}
+
+	@Ignore("temporarily disabled for SPARQLRepository")
+	@Test
+	@Override
+	public void testTransactionIsolationForRead()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testTransactionIsolationForRead() for SPARQLRepository");
+	}
+
+	@Ignore("temporarily disabled for SPARQLRepository")
+	@Test
+	@Override
+	public void testTransactionIsolationForReadWithDeleteOperation()
+		throws Exception
+	{
+		System.err.println(
+				"temporarily disabled testTransactionIsolationForReadWithDeleteOperation() for SPARQLRepository");
+	}
+
+	@Override
+	@Ignore
+	public void testTransactionIsolation()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testTransactionIsolation() for SPARQLRepository");
+	}
+
+	@Override
+	public void testPreparedTupleQuery2()
+		throws Exception
+	{
+		testCon.add(alice, name, nameAlice, context2);
+		testCon.add(alice, mbox, mboxAlice, context2);
+		testCon.add(context2, publisher, nameAlice);
+
+		testCon.add(bob, name, nameBob, context1);
+		testCon.add(bob, mbox, mboxBob, context1);
+		testCon.add(context1, publisher, nameBob);
+
+		StringBuilder queryBuilder = new StringBuilder();
+		queryBuilder.append(" PREFIX foaf: <" + FOAF_NS + ">");
+		queryBuilder.append(" SELECT ?name ?mbox");
+		queryBuilder.append(" WHERE {?p  foaf:name ?name ;");
+		queryBuilder.append("            foaf:mbox ?mbox .");
+		queryBuilder.append(" FILTER (?p = ?VAR) } ");
+
+		TupleQuery query = testCon.prepareTupleQuery(QueryLanguage.SPARQL, queryBuilder.toString());
+		query.setBinding("VAR", bob);
+
+		try (TupleQueryResult result = query.evaluate()) {
+			assertTrue(result != null);
+			assertTrue(result.hasNext());
+
+			while (result.hasNext()) {
+				BindingSet solution = result.next();
+				assertTrue(solution.hasBinding("name"));
+				assertTrue(solution.hasBinding("mbox"));
+
+				Value nameResult = solution.getValue("name");
+				Value mboxResult = solution.getValue("mbox");
+
+				assertEquals("unexpected value for name: " + nameResult, nameBob, nameResult);
+				assertEquals("unexpected value for mbox: " + mboxResult, mboxBob, mboxResult);
+			}
+		}
+	}
+
+	@Override
+	public void testPreparedTupleQueryUnicode()
+		throws Exception
+	{
+		testCon.add(alexander, name, Александър);
+
+		StringBuilder queryBuilder = new StringBuilder();
+		queryBuilder.append(" PREFIX foaf: <" + FOAF_NS + "> ");
+		queryBuilder.append(" SELECT ?person");
+		queryBuilder.append(" WHERE {?person foaf:name ?name . }");
+
+		TupleQuery query = testCon.prepareTupleQuery(QueryLanguage.SPARQL, queryBuilder.toString());
+		query.setBinding("name", Александър);
+
+		try (TupleQueryResult result = query.evaluate()) {
+			assertNotNull(result);
+			assertTrue(result.hasNext());
+
+			while (result.hasNext()) {
+				BindingSet solution = result.next();
+				assertTrue(solution.hasBinding("person"));
+				assertEquals(alexander, solution.getValue("person"));
+			}
+		}
+	}
+
+	@Override
+	public void testSimpleGraphQuery()
+		throws Exception
+	{
+		testCon.add(alice, name, nameAlice, context2);
+		testCon.add(alice, mbox, mboxAlice, context2);
+		testCon.add(context2, publisher, nameAlice);
+
+		testCon.add(bob, name, nameBob, context1);
+		testCon.add(bob, mbox, mboxBob, context1);
+		testCon.add(context1, publisher, nameBob);
+
+		StringBuilder queryBuilder = new StringBuilder();
+		queryBuilder.append(" PREFIX foaf: <" + FOAF_NS + ">");
+		queryBuilder.append(" CONSTRUCT ");
+		queryBuilder.append(" WHERE { [] foaf:name ?name; ");
+		queryBuilder.append("            foaf:mbox ?mbox. }");
+
+		try (GraphQueryResult result = testCon.prepareGraphQuery(QueryLanguage.SPARQL,
+			queryBuilder.toString()).evaluate()) {
+			assertTrue(result != null);
+			assertTrue(result.hasNext());
+
+			while (result.hasNext()) {
+				Statement st = result.next();
+				if (name.equals(st.getPredicate())) {
+					assertTrue(nameAlice.equals(st.getObject()) || nameBob.equals(st.getObject()));
+				}
+				else {
+					assertTrue(mbox.equals(st.getPredicate()));
+					assertTrue(mboxAlice.equals(st.getObject()) || mboxBob.equals(st.getObject()));
+				}
+			}
+		}
+	}
+
+	@Override
+	public void testPreparedGraphQuery()
+		throws Exception
+	{
+		testCon.add(alice, name, nameAlice, context2);
+		testCon.add(alice, mbox, mboxAlice, context2);
+		testCon.add(context2, publisher, nameAlice);
+
+		testCon.add(bob, name, nameBob, context1);
+		testCon.add(bob, mbox, mboxBob, context1);
+		testCon.add(context1, publisher, nameBob);
+
+		StringBuilder queryBuilder = new StringBuilder();
+		queryBuilder.append(" PREFIX foaf: <" + FOAF_NS + "> ");
+		queryBuilder.append(" CONSTRUCT ");
+		queryBuilder.append(" WHERE { [] foaf:name ?name ;");
+		queryBuilder.append("            foaf:mbox ?mbox . ");
+		queryBuilder.append(" } ");
+
+		GraphQuery query = testCon.prepareGraphQuery(QueryLanguage.SPARQL, queryBuilder.toString());
+		query.setBinding("name", nameBob);
+
+		try (GraphQueryResult result = query.evaluate()) {
+			assertTrue(result != null);
+			assertTrue(result.hasNext());
+
+			while (result.hasNext()) {
+				Statement st = result.next();
+				assertTrue(name.equals(st.getPredicate()) || mbox.equals(st.getPredicate()));
+				if (name.equals(st.getPredicate())) {
+					assertTrue("unexpected value for name: " + st.getObject(),
+							nameBob.equals(st.getObject()));
+				}
+				else {
+					assertTrue(mbox.equals(st.getPredicate()));
+					assertTrue("unexpected value for mbox: " + st.getObject(),
+							mboxBob.equals(st.getObject()));
+				}
+
+			}
+		}
+	}
+
+	@Override
+	public void testSimpleTupleQuery()
+		throws Exception
+	{
+		testCon.add(alice, name, nameAlice, context2);
+		testCon.add(alice, mbox, mboxAlice, context2);
+		testCon.add(context2, publisher, nameAlice);
+
+		testCon.add(bob, name, nameBob, context1);
+		testCon.add(bob, mbox, mboxBob, context1);
+		testCon.add(context1, publisher, nameBob);
+
+		StringBuilder queryBuilder = new StringBuilder();
+		queryBuilder.append(" PREFIX foaf: <" + FOAF_NS + "> ");
+		queryBuilder.append(" SELECT ?name ?mbox");
+		queryBuilder.append(" WHERE { [] foaf:name ?name ;");
+		queryBuilder.append("            foaf:mbox ?mbox . ");
+		queryBuilder.append(" } ");
+		try (TupleQueryResult result = testCon.prepareTupleQuery(QueryLanguage.SPARQL,
+			queryBuilder.toString()).evaluate()) {
+			assertTrue(result != null);
+			assertTrue(result.hasNext());
+
+			while (result.hasNext()) {
+				BindingSet solution = result.next();
+				assertTrue(solution.hasBinding("name"));
+				assertTrue(solution.hasBinding("mbox"));
+
+				Value nameResult = solution.getValue("name");
+				Value mboxResult = solution.getValue("mbox");
+
+				assertTrue((nameAlice.equals(nameResult) || nameBob.equals(nameResult)));
+				assertTrue((mboxAlice.equals(mboxResult) || mboxBob.equals(mboxResult)));
+			}
+		}
+	}
+
+	@Override
+	public void testSimpleTupleQueryUnicode()
+		throws Exception
+	{
+		testCon.add(alexander, name, Александър);
+
+		StringBuilder queryBuilder = new StringBuilder();
+		queryBuilder.append(" PREFIX foaf: <" + FOAF_NS + ">");
+		queryBuilder.append(" SELECT ?person");
+		queryBuilder.append(" WHERE { ?person foaf:name \"").append(Александър.getLabel()).append("\" . } ");
+
+		try (TupleQueryResult result = testCon.prepareTupleQuery(QueryLanguage.SPARQL,
+			queryBuilder.toString()).evaluate()) {
+			assertNotNull(result);
+			assertTrue(result.hasNext());
+
+			while (result.hasNext()) {
+				BindingSet solution = result.next();
+				assertTrue(solution.hasBinding("person"));
+				assertEquals(alexander, solution.getValue("person"));
+			}
+		}
+	}
+
+	@Override
+	@Ignore
+	public void testBNodeSerialization()
+		throws Exception
+	{
+		System.err.println("temporarily disabled testBNodeSerialization() for SPARQLRepository");
+	}
+
+	@Test
+	public void testUpdateExecution()
+		throws Exception
+	{
+
+		IRI foobar = vf.createIRI("foo:bar");
+
+		String sparql = "INSERT DATA { <foo:bar> <foo:bar> <foo:bar> . } ";
+
+		Update update = testCon.prepareUpdate(QueryLanguage.SPARQL, sparql);
+
+		update.execute();
+
+		assertTrue(testCon.hasStatement(foobar, foobar, foobar, true));
+
+		testCon.clear();
+
+		assertFalse(testCon.hasStatement(foobar, foobar, foobar, true));
+
+		testCon.begin();
+		update.execute();
+		testCon.commit();
+
+		assertTrue(testCon.hasStatement(foobar, foobar, foobar, true));
+
+	}
+
+}

--- a/compliance/repository/src/test/resources/log4j.properties
+++ b/compliance/repository/src/test/resources/log4j.properties
@@ -1,0 +1,14 @@
+# root logger
+log4j.rootLogger=WARN, MainLog
+
+# MainLog configuration
+log4j.appender.MainLog=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.MainLog.DatePattern='.'yyyy-MM-dd
+# Real filename is set in AppConfiguration, relative to dataDir
+log4j.appender.MainLog.File=target/combined-client-server.log
+
+# MainLog uses a custom PatternLayout that also outputs stack traces
+log4j.appender.MainLog.layout=org.eclipse.rdf4j.common.logging.file.logback.StackTracePatternLayout
+
+# RDF4J logging
+log4j.logger.org.eclipse.rdf4j=DEBUG

--- a/compliance/repository/src/test/resources/logback-test.xml
+++ b/compliance/repository/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %msg%n</pattern>
+		</encoder>
+	</appender>
+	
+	<root>
+		<level value="info" />
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>
+


### PR DESCRIPTION
This PR addresses GitHub issue: #1230 .

Briefly describe the changes proposed in this PR:

* migrated compliance tests for SPARQLRepository and HTTPRepository
* removed reference to obsolete module

