### PR TITLE
GH-1237 invalid datatype IRI only fatal is VERIFY_URI_SYNTAX is enabled and fatal

### DIFF
--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -39,17 +39,15 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.TurtleParserSettings;
 
 /**
- * RDF parser for <a href="https://www.w3.org/TR/turtle/">RDF-1.1 Turtle</a>
- * files. This parser is not thread-safe, therefore its public methods are
- * synchronized.
+ * RDF parser for <a href="https://www.w3.org/TR/turtle/">RDF-1.1 Turtle</a> files. This parser is not
+ * thread-safe, therefore its public methods are synchronized.
  * <p>
- * <li>Normalization of integer, floating point and boolean values is dependent
- * on the specified datatype handling. According to the specification, integers
- * and booleans should be normalized, but floats don't.</li>
- * <li>Comments can be used anywhere in the document, and extend to the end of
- * the line. The Turtle grammar doesn't allow comments to be used inside triple
- * constructs that extend over multiple lines, but the author's own parser
- * deviates from this too.</li>
+ * <li>Normalization of integer, floating point and boolean values is dependent on the specified datatype
+ * handling. According to the specification, integers and booleans should be normalized, but floats
+ * don't.</li>
+ * <li>Comments can be used anywhere in the document, and extend to the end of the line. The Turtle grammar
+ * doesn't allow comments to be used inside triple constructs that extend over multiple lines, but the
+ * author's own parser deviates from this too.</li>
  * </ul>
  * 
  * @author Arjohn Kampman
@@ -70,6 +68,7 @@ public class TurtleParser extends AbstractRDFParser {
 	protected Value object;
 
 	private int lineNumber = 1;
+
 	private final StringBuilder parsingBuilder = new StringBuilder();
 
 	/*--------------*
@@ -77,19 +76,17 @@ public class TurtleParser extends AbstractRDFParser {
 	 *--------------*/
 
 	/**
-	 * Creates a new TurtleParser that will use a {@link SimpleValueFactory} to
-	 * create RDF model objects.
+	 * Creates a new TurtleParser that will use a {@link SimpleValueFactory} to create RDF model objects.
 	 */
 	public TurtleParser() {
 		super();
 	}
 
 	/**
-	 * Creates a new TurtleParser that will use the supplied ValueFactory to
-	 * create RDF model objects.
+	 * Creates a new TurtleParser that will use the supplied ValueFactory to create RDF model objects.
 	 *
 	 * @param valueFactory
-	 *            A ValueFactory.
+	 *        A ValueFactory.
 	 */
 	public TurtleParser(ValueFactory valueFactory) {
 		super(valueFactory);
@@ -111,29 +108,27 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Implementation of the <tt>parse(InputStream, String)</tt> method defined
-	 * in the RDFParser interface.
+	 * Implementation of the <tt>parse(InputStream, String)</tt> method defined in the RDFParser interface.
 	 *
 	 * @param in
-	 *            The InputStream from which to read the data, must not be
-	 *            <tt>null</tt>. The InputStream is supposed to contain UTF-8
-	 *            encoded Unicode characters, as per the Turtle specification.
+	 *        The InputStream from which to read the data, must not be <tt>null</tt>. The InputStream is
+	 *        supposed to contain UTF-8 encoded Unicode characters, as per the Turtle specification.
 	 * @param baseURI
-	 *            The URI associated with the data in the InputStream, must not
-	 *            be <tt>null</tt>.
+	 *        The URI associated with the data in the InputStream, must not be <tt>null</tt>.
 	 * @throws IOException
-	 *             If an I/O error occurred while data was read from the
-	 *             InputStream.
+	 *         If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException
-	 *             If the parser has found an unrecoverable parse error.
+	 *         If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException
-	 *             If the configured statement handler encountered an
-	 *             unrecoverable error.
+	 *         If the configured statement handler encountered an unrecoverable error.
 	 * @throws IllegalArgumentException
-	 *             If the supplied input stream or base URI is <tt>null</tt>.
+	 *         If the supplied input stream or base URI is <tt>null</tt>.
 	 */
 	public synchronized void parse(InputStream in, String baseURI)
-			throws IOException, RDFParseException, RDFHandlerException {
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		if (in == null) {
 			throw new IllegalArgumentException("Input stream must not be 'null'");
 		}
@@ -141,37 +136,36 @@ public class TurtleParser extends AbstractRDFParser {
 
 		try {
 			parse(new InputStreamReader(new BOMInputStream(in, false), StandardCharsets.UTF_8), baseURI);
-		} catch (UnsupportedEncodingException e) {
+		}
+		catch (UnsupportedEncodingException e) {
 			// Every platform should support the UTF-8 encoding...
 			throw new RuntimeException(e);
 		}
 	}
 
 	/**
-	 * Implementation of the <tt>parse(Reader, String)</tt> method defined in
-	 * the RDFParser interface.
+	 * Implementation of the <tt>parse(Reader, String)</tt> method defined in the RDFParser interface.
 	 *
 	 * @param reader
-	 *            The Reader from which to read the data, must not be
-	 *            <tt>null</tt>.
+	 *        The Reader from which to read the data, must not be <tt>null</tt>.
 	 * @param baseURI
-	 *            The URI associated with the data in the Reader, must not be
-	 *            <tt>null</tt>.
+	 *        The URI associated with the data in the Reader, must not be <tt>null</tt>.
 	 * @throws IOException
-	 *             If an I/O error occurred while data was read from the
-	 *             InputStream.
+	 *         If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException
-	 *             If the parser has found an unrecoverable parse error.
+	 *         If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException
-	 *             If the configured statement handler encountered an
-	 *             unrecoverable error.
+	 *         If the configured statement handler encountered an unrecoverable error.
 	 * @throws IllegalArgumentException
-	 *             If the supplied reader or base URI is <tt>null</tt>.
+	 *         If the supplied reader or base URI is <tt>null</tt>.
 	 */
 	public synchronized void parse(Reader reader, String baseURI)
-			throws IOException, RDFParseException, RDFHandlerException {
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		clear();
-		
+
 		try {
 			if (reader == null) {
 				throw new IllegalArgumentException("Reader must not be 'null'");
@@ -201,7 +195,8 @@ public class TurtleParser extends AbstractRDFParser {
 				parseStatement();
 				c = skipWSC();
 			}
-		} finally {
+		}
+		finally {
 			clear();
 		}
 
@@ -210,7 +205,11 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseStatement() throws IOException, RDFParseException, RDFHandlerException {
+	protected void parseStatement()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 
 		StringBuilder sb = new StringBuilder(8);
 
@@ -223,18 +222,22 @@ public class TurtleParser extends AbstractRDFParser {
 				break;
 			}
 			appendCodepoint(sb, codePoint);
-		} while (sb.length() < 8);
+		}
+		while (sb.length() < 8);
 
 		String directive = sb.toString();
 
-		if (directive.startsWith("@") || directive.equalsIgnoreCase("prefix") || directive.equalsIgnoreCase("base")) {
+		if (directive.startsWith("@") || directive.equalsIgnoreCase("prefix")
+				|| directive.equalsIgnoreCase("base"))
+		{
 			parseDirective(directive);
 			skipWSC();
 			// SPARQL BASE and PREFIX lines do not end in .
 			if (directive.startsWith("@")) {
 				verifyCharacterOrFail(readCodePoint(), ".");
 			}
-		} else {
+		}
+		else {
 			unread(directive);
 			parseTriples();
 			skipWSC();
@@ -242,18 +245,24 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseDirective(String directive) throws IOException, RDFParseException, RDFHandlerException {
+	protected void parseDirective(String directive)
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		if (directive.length() >= 7 && directive.substring(0, 7).equals("@prefix")) {
 			if (directive.length() > 7) {
 				unread(directive.substring(7));
 			}
 			parsePrefixID();
-		} else if (directive.length() >= 5 && directive.substring(0, 5).equals("@base")) {
+		}
+		else if (directive.length() >= 5 && directive.substring(0, 5).equals("@base")) {
 			if (directive.length() > 5) {
 				unread(directive.substring(5));
 			}
 			parseBase();
-		} else if (directive.length() >= 6 && directive.substring(0, 6).equalsIgnoreCase("prefix")) {
+		}
+		else if (directive.length() >= 6 && directive.substring(0, 6).equalsIgnoreCase("prefix")) {
 			// SPARQL doesn't require whitespace after directive, so must unread
 			// if
 			// we found part of the prefixID
@@ -261,12 +270,14 @@ public class TurtleParser extends AbstractRDFParser {
 				unread(directive.substring(6));
 			}
 			parsePrefixID();
-		} else if ((directive.length() >= 4 && directive.substring(0, 4).equalsIgnoreCase("base"))) {
+		}
+		else if ((directive.length() >= 4 && directive.substring(0, 4).equalsIgnoreCase("base"))) {
 			if (directive.length() > 4) {
 				unread(directive.substring(4));
 			}
 			parseBase();
-		} else if (directive.length() >= 7 && directive.substring(0, 7).equalsIgnoreCase("@prefix")) {
+		}
+		else if (directive.length() >= 7 && directive.substring(0, 7).equalsIgnoreCase("@prefix")) {
 			if (!this.getParserConfig().get(TurtleParserSettings.CASE_INSENSITIVE_DIRECTIVES)) {
 				reportFatalError("Cannot strictly support case-insensitive @prefix directive in compliance mode.");
 			}
@@ -274,7 +285,8 @@ public class TurtleParser extends AbstractRDFParser {
 				unread(directive.substring(7));
 			}
 			parsePrefixID();
-		} else if (directive.length() >= 5 && directive.substring(0, 5).equalsIgnoreCase("@base")) {
+		}
+		else if (directive.length() >= 5 && directive.substring(0, 5).equalsIgnoreCase("@base")) {
 			if (!this.getParserConfig().get(TurtleParserSettings.CASE_INSENSITIVE_DIRECTIVES)) {
 				reportFatalError("Cannot strictly support case-insensitive @base directive in compliance mode.");
 			}
@@ -282,14 +294,20 @@ public class TurtleParser extends AbstractRDFParser {
 				unread(directive.substring(5));
 			}
 			parseBase();
-		} else if (directive.length() == 0) {
+		}
+		else if (directive.length() == 0) {
 			reportFatalError("Directive name is missing, expected @prefix or @base");
-		} else {
+		}
+		else {
 			reportFatalError("Unknown directive \"" + directive + "\"");
 		}
 	}
 
-	protected void parsePrefixID() throws IOException, RDFParseException, RDFHandlerException {
+	protected void parsePrefixID()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		skipWSC();
 
 		// Read prefix ID (e.g. "rdf:" or ":")
@@ -301,9 +319,11 @@ public class TurtleParser extends AbstractRDFParser {
 			if (c == ':') {
 				unread(c);
 				break;
-			} else if (TurtleUtil.isWhitespace(c)) {
+			}
+			else if (TurtleUtil.isWhitespace(c)) {
 				break;
-			} else if (c == -1) {
+			}
+			else if (c == -1) {
 				throwEOFException();
 			}
 
@@ -330,7 +350,11 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseBase() throws IOException, RDFParseException, RDFHandlerException {
+	protected void parseBase()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		skipWSC();
 
 		IRI baseURI = parseURI();
@@ -338,7 +362,11 @@ public class TurtleParser extends AbstractRDFParser {
 		setBaseURI(baseURI.toString());
 	}
 
-	protected void parseTriples() throws IOException, RDFParseException, RDFHandlerException {
+	protected void parseTriples()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		int c = peekCodePoint();
 
 		// If the first character is an open bracket we need to decide which of
@@ -352,7 +380,8 @@ public class TurtleParser extends AbstractRDFParser {
 				subject = createNode();
 				skipWSC();
 				parsePredicateObjectList();
-			} else {
+			}
+			else {
 				unread('[');
 				subject = parseImplicitBlank();
 			}
@@ -366,7 +395,8 @@ public class TurtleParser extends AbstractRDFParser {
 			if (c != '.') {
 				parsePredicateObjectList();
 			}
-		} else {
+		}
+		else {
 			parseSubject();
 			skipWSC();
 			parsePredicateObjectList();
@@ -377,7 +407,11 @@ public class TurtleParser extends AbstractRDFParser {
 		object = null;
 	}
 
-	protected void parsePredicateObjectList() throws IOException, RDFParseException, RDFHandlerException {
+	protected void parsePredicateObjectList()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		predicate = parsePredicate();
 
 		skipWSC();
@@ -391,11 +425,12 @@ public class TurtleParser extends AbstractRDFParser {
 
 			if (c == '.' || // end of triple
 					c == ']' || c == '}') // end of predicateObjectList inside
-											// blank
+			// blank
 			// node
 			{
 				break;
-			} else if (c == ';') {
+			}
+			else if (c == ';') {
 				// empty predicateObjectList, skip to next
 				continue;
 			}
@@ -408,7 +443,11 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseObjectList() throws IOException, RDFParseException, RDFHandlerException {
+	protected void parseObjectList()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		parseObject();
 
 		while (skipWSC() == ',') {
@@ -418,25 +457,36 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseSubject() throws IOException, RDFParseException, RDFHandlerException {
+	protected void parseSubject()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		int c = peekCodePoint();
 
 		if (c == '(') {
 			subject = parseCollection();
-		} else if (c == '[') {
+		}
+		else if (c == '[') {
 			subject = parseImplicitBlank();
-		} else {
+		}
+		else {
 			Value value = parseValue();
 
 			if (value instanceof Resource) {
-				subject = (Resource) value;
-			} else if (value != null) {
+				subject = (Resource)value;
+			}
+			else if (value != null) {
 				reportFatalError("Illegal subject value: " + value);
 			}
 		}
 	}
 
-	protected IRI parsePredicate() throws IOException, RDFParseException, RDFHandlerException {
+	protected IRI parsePredicate()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		// Check if the short-cut 'a' is used
 		int c1 = readCodePoint();
 
@@ -456,8 +506,9 @@ public class TurtleParser extends AbstractRDFParser {
 		// Predicate is a normal resource
 		Value predicate = parseValue();
 		if (predicate instanceof IRI) {
-			return (IRI) predicate;
-		} else {
+			return (IRI)predicate;
+		}
+		else {
 			reportFatalError("Illegal predicate value: " + predicate);
 			return null;
 		}
@@ -468,9 +519,13 @@ public class TurtleParser extends AbstractRDFParser {
 	 *
 	 * @throws IOException
 	 * @throws RDFParseException
-	 * @throws RDFHandlerException 
+	 * @throws RDFHandlerException
 	 */
-	protected void parseObject() throws IOException, RDFParseException, RDFHandlerException {
+	protected void parseObject()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		int c = peekCodePoint();
 
 		switch (c) {
@@ -490,7 +545,11 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses a collection, e.g. <tt>( item1 item2 item3 )</tt>.
 	 */
-	protected Resource parseCollection() throws IOException, RDFParseException, RDFHandlerException {
+	protected Resource parseCollection()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		verifyCharacterOrFail(readCodePoint(), "(");
 
 		int c = skipWSC();
@@ -502,7 +561,8 @@ public class TurtleParser extends AbstractRDFParser {
 				reportStatement(subject, predicate, RDF.NIL);
 			}
 			return RDF.NIL;
-		} else {
+		}
+		else {
 			Resource listRoot = createNode();
 			if (subject != null) {
 				reportStatement(subject, predicate, listRoot);
@@ -546,10 +606,14 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses an implicit blank node. This method parses the token <tt>[]</tt>
-	 * and predicateObjectLists that are surrounded by square brackets.
+	 * Parses an implicit blank node. This method parses the token <tt>[]</tt> and predicateObjectLists that are
+	 * surrounded by square brackets.
 	 */
-	protected Resource parseImplicitBlank() throws IOException, RDFParseException, RDFHandlerException {
+	protected Resource parseImplicitBlank()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		verifyCharacterOrFail(readCodePoint(), "[");
 
 		Resource bNode = createNode();
@@ -588,41 +652,54 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses an RDF value. This method parses uriref, qname, node ID, quoted
-	 * literal, integer, double and boolean.
+	 * Parses an RDF value. This method parses uriref, qname, node ID, quoted literal, integer, double and
+	 * boolean.
 	 */
-	protected Value parseValue() throws IOException, RDFParseException, RDFHandlerException {
+	protected Value parseValue()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		int c = peekCodePoint();
 
 		if (c == '<') {
 			// uriref, e.g. <foo://bar>
 			return parseURI();
-		} else if (c == ':' || TurtleUtil.isPrefixStartChar(c)) {
+		}
+		else if (c == ':' || TurtleUtil.isPrefixStartChar(c)) {
 			// qname or boolean
 			return parseQNameOrBoolean();
-		} else if (c == '_') {
+		}
+		else if (c == '_') {
 			// node ID, e.g. _:n1
 			return parseNodeID();
-		} else if (c == '"' || c == '\'') {
+		}
+		else if (c == '"' || c == '\'') {
 			// quoted literal, e.g. "foo" or """foo""" or 'foo' or '''foo'''
 			return parseQuotedLiteral();
-		} else if (ASCIIUtil.isNumber(c) || c == '.' || c == '+' || c == '-') {
+		}
+		else if (ASCIIUtil.isNumber(c) || c == '.' || c == '+' || c == '-') {
 			// integer or double, e.g. 123 or 1.2e3
 			return parseNumber();
-		} else if (c == -1) {
+		}
+		else if (c == -1) {
 			throwEOFException();
 			return null;
-		} else {
+		}
+		else {
 			reportFatalError("Expected an RDF value here, found '" + new String(Character.toChars(c)) + "'");
 			return null;
 		}
 	}
 
 	/**
-	 * Parses a quoted string, optionally followed by a language tag or
-	 * datatype.
+	 * Parses a quoted string, optionally followed by a language tag or datatype.
 	 */
-	protected Literal parseQuotedLiteral() throws IOException, RDFParseException, RDFHandlerException {
+	protected Literal parseQuotedLiteral()
+		throws IOException,
+		RDFParseException,
+		RDFHandlerException
+	{
 		String label = parseQuotedString();
 
 		// Check for presence of a language tag or datatype
@@ -669,7 +746,8 @@ public class TurtleParser extends AbstractRDFParser {
 			unread(c);
 
 			return createLiteral(label, lang.toString(), null, getLineNumber(), -1);
-		} else if (c == '^') {
+		}
+		else if (c == '^') {
 			readCodePoint();
 
 			// next character should be another '^'
@@ -680,25 +758,40 @@ public class TurtleParser extends AbstractRDFParser {
 			// Read datatype
 			Value datatype = parseValue();
 			if (datatype instanceof IRI) {
-				return createLiteral(label, null, (IRI) datatype, getLineNumber(), -1);
-			} else {
+				return createLiteral(label, null, (IRI)datatype, getLineNumber(), -1);
+			}
+			else if (datatype != null) {
 				reportFatalError("Illegal datatype value: " + datatype);
 				return null;
 			}
-		} else {
+			else {
+				if (getParserConfig().get(BasicParserSettings.VERIFY_URI_SYNTAX)
+						&& !getParserConfig().isNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX))
+				{
+					// only report a missing/illegal datatype when IRI verification is a fatal error.
+					reportFatalError("Illegal datatype value: " + datatype);
+				}
+				return null;
+			}
+		}
+		else
+
+		{
 			return createLiteral(label, null, null, getLineNumber(), -1);
 		}
 	}
 
 	/**
-	 * Parses a quoted string, which is either a "normal string" or a """long
-	 * string""".
+	 * Parses a quoted string, which is either a "normal string" or a """long string""".
 	 * 
 	 * @return string
 	 * @throws IOException
 	 * @throws RDFParseException
 	 */
-	protected String parseQuotedString() throws IOException, RDFParseException {
+	protected String parseQuotedString()
+		throws IOException,
+		RDFParseException
+	{
 		String result = null;
 
 		int c1 = readCodePoint();
@@ -713,7 +806,8 @@ public class TurtleParser extends AbstractRDFParser {
 		if ((c1 == '"' && c2 == '"' && c3 == '"') || (c1 == '\'' && c2 == '\'' && c3 == '\'')) {
 			// Long string
 			result = parseLongString(c2);
-		} else {
+		}
+		else {
 			// Normal string
 			unread(c3);
 			unread(c2);
@@ -724,7 +818,8 @@ public class TurtleParser extends AbstractRDFParser {
 		// Unescape any escape sequences
 		try {
 			result = TurtleUtil.decodeString(result);
-		} catch (IllegalArgumentException e) {
+		}
+		catch (IllegalArgumentException e) {
 			reportError(e.getMessage(), BasicParserSettings.VERIFY_DATATYPE_VALUES);
 		}
 
@@ -732,14 +827,16 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses a "normal string". This method requires that the opening character
-	 * has already been parsed.
+	 * Parses a "normal string". This method requires that the opening character has already been parsed.
 	 * 
 	 * @return parsed string
 	 * @throws IOException
 	 * @throws RDFParseException
 	 */
-	protected String parseString(int closingCharacter) throws IOException, RDFParseException {
+	protected String parseString(int closingCharacter)
+		throws IOException,
+		RDFParseException
+	{
 		StringBuilder sb = getBuilder();
 
 		while (true) {
@@ -747,10 +844,11 @@ public class TurtleParser extends AbstractRDFParser {
 
 			if (c == closingCharacter) {
 				break;
-			} else if (c == -1) {
+			}
+			else if (c == -1) {
 				throwEOFException();
 			}
-			
+
 			if (c == '\r' || c == '\n') {
 				reportFatalError("Illegal carriage return or new line in literal");
 			}
@@ -771,10 +869,13 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses a """long string""". This method requires that the first three
-	 * characters have already been parsed.
+	 * Parses a """long string""". This method requires that the first three characters have already been
+	 * parsed.
 	 */
-	protected String parseLongString(int closingCharacter) throws IOException, RDFParseException {
+	protected String parseLongString(int closingCharacter)
+		throws IOException,
+		RDFParseException
+	{
 		StringBuilder sb = getBuilder();
 
 		int doubleQuoteCount = 0;
@@ -785,9 +886,11 @@ public class TurtleParser extends AbstractRDFParser {
 
 			if (c == -1) {
 				throwEOFException();
-			} else if (c == closingCharacter) {
+			}
+			else if (c == closingCharacter) {
 				doubleQuoteCount++;
-			} else {
+			}
+			else {
 				doubleQuoteCount = 0;
 			}
 
@@ -806,7 +909,10 @@ public class TurtleParser extends AbstractRDFParser {
 		return sb.substring(0, sb.length() - 3);
 	}
 
-	protected Literal parseNumber() throws IOException, RDFParseException {
+	protected Literal parseNumber()
+		throws IOException,
+		RDFParseException
+	{
 		StringBuilder value = getBuilder();
 		IRI datatype = XMLSchema.INTEGER;
 
@@ -832,7 +938,8 @@ public class TurtleParser extends AbstractRDFParser {
 					// We're parsing an integer that did not have a space before
 					// the
 					// period to end the statement
-				} else {
+				}
+				else {
 					appendCodepoint(value, c);
 
 					c = readCodePoint();
@@ -850,7 +957,8 @@ public class TurtleParser extends AbstractRDFParser {
 					// We're parsing a decimal or a double
 					datatype = XMLSchema.DECIMAL;
 				}
-			} else {
+			}
+			else {
 				if (value.length() == 0) {
 					// We've only parsed an 'e' or 'E'
 					reportFatalError("Object for statement missing");
@@ -901,7 +1009,10 @@ public class TurtleParser extends AbstractRDFParser {
 		return createLiteral(value.toString(), null, datatype, getLineNumber(), -1);
 	}
 
-	protected IRI parseURI() throws IOException, RDFParseException {
+	protected IRI parseURI()
+		throws IOException,
+		RDFParseException
+	{
 		StringBuilder uriBuf = getBuilder();
 
 		// First character should be '<'
@@ -915,7 +1026,8 @@ public class TurtleParser extends AbstractRDFParser {
 
 			if (c == '>') {
 				break;
-			} else if (c == -1) {
+			}
+			else if (c == -1) {
 				throwEOFException();
 			}
 
@@ -957,7 +1069,8 @@ public class TurtleParser extends AbstractRDFParser {
 				// be
 				// invalid according to test <turtle-syntax-bad-uri-04.ttl>
 				uri = TurtleUtil.decodeString(uri);
-			} catch (IllegalArgumentException e) {
+			}
+			catch (IllegalArgumentException e) {
 				reportError(e.getMessage(), BasicParserSettings.VERIFY_DATATYPE_VALUES);
 			}
 
@@ -968,10 +1081,12 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses qnames and boolean values, which have equivalent starting
-	 * characters.
+	 * Parses qnames and boolean values, which have equivalent starting characters.
 	 */
-	protected Value parseQNameOrBoolean() throws IOException, RDFParseException {
+	protected Value parseQNameOrBoolean()
+		throws IOException,
+		RDFParseException
+	{
 		// First character should be a ':' or a letter
 		int c = readCodePoint();
 		if (c == -1) {
@@ -987,7 +1102,8 @@ public class TurtleParser extends AbstractRDFParser {
 		if (c == ':') {
 			// qname using default namespace
 			namespace = getNamespace("");
-		} else {
+		}
+		else {
 			// c is the first letter of the prefix
 			StringBuilder prefix = new StringBuilder(8);
 			appendCodepoint(prefix, c);
@@ -1003,8 +1119,8 @@ public class TurtleParser extends AbstractRDFParser {
 				// '.' is a legal prefix name char, but can not appear at the end
 				unread(c);
 				c = previousChar;
-				prefix.setLength(prefix.length() -1);
-				previousChar = prefix.codePointAt(prefix.codePointCount(0, prefix.length()) -1);
+				prefix.setLength(prefix.length() - 1);
+				previousChar = prefix.codePointAt(prefix.codePointCount(0, prefix.length()) - 1);
 			}
 
 			if (c != ':') {
@@ -1014,7 +1130,8 @@ public class TurtleParser extends AbstractRDFParser {
 				if (value.equals("true")) {
 					unread(c);
 					return createLiteral("true", null, XMLSchema.BOOLEAN, getLineNumber(), -1);
-				} else if (value.equals("false")) {
+				}
+				else if (value.equals("false")) {
 					unread(c);
 					return createLiteral("false", null, XMLSchema.BOOLEAN, getLineNumber(), -1);
 				}
@@ -1031,7 +1148,8 @@ public class TurtleParser extends AbstractRDFParser {
 		if (TurtleUtil.isNameStartChar(c)) {
 			if (c == '\\') {
 				localName.append(readLocalEscapedChar());
-			} else {
+			}
+			else {
 				appendCodepoint(localName, c);
 			}
 
@@ -1040,7 +1158,8 @@ public class TurtleParser extends AbstractRDFParser {
 			while (TurtleUtil.isNameChar(c)) {
 				if (c == '\\') {
 					localName.append(readLocalEscapedChar());
-				} else {
+				}
+				else {
 					appendCodepoint(localName, c);
 				}
 				previousChar = c;
@@ -1057,7 +1176,8 @@ public class TurtleParser extends AbstractRDFParser {
 				unread(previousChar);
 				localName.deleteCharAt(localName.length() - 1);
 			}
-		} else {
+		}
+		else {
 			// Unread last character
 			unread(c);
 		}
@@ -1067,7 +1187,8 @@ public class TurtleParser extends AbstractRDFParser {
 		for (int i = 0; i < localNameString.length(); i++) {
 			if (localNameString.charAt(i) == '%') {
 				if (i > localNameString.length() - 3 || !ASCIIUtil.isHex(localNameString.charAt(i + 1))
-						|| !ASCIIUtil.isHex(localNameString.charAt(i + 2))) {
+						|| !ASCIIUtil.isHex(localNameString.charAt(i + 2)))
+				{
 					reportFatalError("Found incomplete percent-encoded sequence: " + localNameString);
 				}
 			}
@@ -1081,12 +1202,16 @@ public class TurtleParser extends AbstractRDFParser {
 		return createURI(namespace + localNameString);
 	}
 
-	private char readLocalEscapedChar() throws RDFParseException, IOException {
+	private char readLocalEscapedChar()
+		throws RDFParseException,
+		IOException
+	{
 		int c = readCodePoint();
 
 		if (TurtleUtil.isLocalEscapedChar(c)) {
-			return (char) c;
-		} else {
+			return (char)c;
+		}
+		else {
 			throw new RDFParseException("found '" + new String(Character.toChars(c)) + "', expected one of: "
 					+ Arrays.toString(TurtleUtil.LOCAL_ESCAPED_CHARS));
 		}
@@ -1095,7 +1220,10 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses a blank node ID, e.g. <tt>_:node1</tt>.
 	 */
-	protected Resource parseNodeID() throws IOException, RDFParseException {
+	protected Resource parseNodeID()
+		throws IOException,
+		RDFParseException
+	{
 		// Node ID should start with "_:"
 		verifyCharacterOrFail(readCodePoint(), "_");
 		verifyCharacterOrFail(readCodePoint(), ":");
@@ -1104,8 +1232,9 @@ public class TurtleParser extends AbstractRDFParser {
 		int c = readCodePoint();
 		if (c == -1) {
 			throwEOFException();
-		} else if (!TurtleUtil.isBLANK_NODE_LABEL_StartChar(c)) {
-			reportError("Expected a letter, found '" + (char) c + "'", BasicParserSettings.PRESERVE_BNODE_IDS);
+		}
+		else if (!TurtleUtil.isBLANK_NODE_LABEL_StartChar(c)) {
+			reportError("Expected a letter, found '" + (char)c + "'", BasicParserSettings.PRESERVE_BNODE_IDS);
 		}
 
 		StringBuilder name = getBuilder();
@@ -1137,7 +1266,10 @@ public class TurtleParser extends AbstractRDFParser {
 		return createNode(name.toString());
 	}
 
-	protected void reportStatement(Resource subj, IRI pred, Value obj) throws RDFParseException, RDFHandlerException {
+	protected void reportStatement(Resource subj, IRI pred, Value obj)
+		throws RDFParseException,
+		RDFHandlerException
+	{
 		if (subj != null && pred != null && obj != null) {
 			Statement st = createStatement(subj, pred, obj);
 			if (rdfHandler != null) {
@@ -1147,11 +1279,12 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Verifies that the supplied character code point <tt>codePoint</tt> is one
-	 * of the expected characters specified in <tt>expected</tt>. This method
-	 * will throw a <tt>ParseException</tt> if this is not the case.
+	 * Verifies that the supplied character code point <tt>codePoint</tt> is one of the expected characters
+	 * specified in <tt>expected</tt>. This method will throw a <tt>ParseException</tt> if this is not the case.
 	 */
-	protected void verifyCharacterOrFail(int codePoint, String expected) throws RDFParseException {
+	protected void verifyCharacterOrFail(int codePoint, String expected)
+		throws RDFParseException
+	{
 		if (codePoint == -1) {
 			throwEOFException();
 		}
@@ -1178,21 +1311,23 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Consumes any white space characters (space, tab, line feed, newline) and
-	 * comments (#-style) from <tt>reader</tt>. After this method has been
-	 * called, the first character that is returned by <tt>reader</tt> is either
-	 * a non-ignorable character, or EOF. For convenience, this character is
-	 * also returned by this method.
+	 * Consumes any white space characters (space, tab, line feed, newline) and comments (#-style) from
+	 * <tt>reader</tt>. After this method has been called, the first character that is returned by
+	 * <tt>reader</tt> is either a non-ignorable character, or EOF. For convenience, this character is also
+	 * returned by this method.
 	 *
-	 * @return The next character code point that will be returned by
-	 *         <tt>reader</tt>.
+	 * @return The next character code point that will be returned by <tt>reader</tt>.
 	 */
-	protected int skipWSC() throws IOException, RDFHandlerException {
+	protected int skipWSC()
+		throws IOException,
+		RDFHandlerException
+	{
 		int c = readCodePoint();
 		while (TurtleUtil.isWhitespace(c) || c == '#') {
 			if (c == '#') {
 				processComment();
-			} else if (c == '\n') {
+			}
+			else if (c == '\n') {
 				// we only count line feeds (LF), not carriage return (CR), as
 				// normally a CR is immediately followed by a LF.
 				lineNumber++;
@@ -1208,10 +1343,13 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Consumes characters from reader until the first EOL has been read. This
-	 * line of text is then passed to the {@link #rdfHandler} as a comment.
+	 * Consumes characters from reader until the first EOL has been read. This line of text is then passed to
+	 * the {@link #rdfHandler} as a comment.
 	 */
-	protected void processComment() throws IOException, RDFHandlerException {
+	protected void processComment()
+		throws IOException,
+		RDFHandlerException
+	{
 		StringBuilder comment = getBuilder();
 		int c = readCodePoint();
 		while (c != -1 && c != 0xD && c != 0xA) {
@@ -1242,69 +1380,74 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Reads the next Unicode code point.
 	 *
-	 * @return the next Unicode code point, or -1 if the end of the stream has
-	 *         been reached.
+	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
 	 * @throws IOException
 	 */
-	protected int readCodePoint() throws IOException {
+	protected int readCodePoint()
+		throws IOException
+	{
 		int next = reader.read();
-		if (Character.isHighSurrogate((char) next)) {
-			next = Character.toCodePoint((char) next, (char) reader.read());
+		if (Character.isHighSurrogate((char)next)) {
+			next = Character.toCodePoint((char)next, (char)reader.read());
 		}
 		return next;
 	}
 
 	/**
-	 * Pushes back a single code point by copying it to the front of the buffer.
-	 * After this method returns, a call to {@link #readCodePoint()} will return
-	 * the same code point c again.
+	 * Pushes back a single code point by copying it to the front of the buffer. After this method returns, a
+	 * call to {@link #readCodePoint()} will return the same code point c again.
 	 *
 	 * @param codePoint
-	 *            a single Unicode code point.
+	 *        a single Unicode code point.
 	 * @throws IOException
 	 */
-	protected void unread(int codePoint) throws IOException {
+	protected void unread(int codePoint)
+		throws IOException
+	{
 		if (codePoint != -1) {
 			if (Character.isSupplementaryCodePoint(codePoint)) {
 				final char[] surrogatePair = Character.toChars(codePoint);
 				reader.unread(surrogatePair);
-			} else {
+			}
+			else {
 				reader.unread(codePoint);
 			}
 		}
 	}
 
 	/**
-	 * Pushes back the supplied string by copying it to the front of the buffer.
-	 * After this method returns, successive calls to {@link #readCodePoint()}
-	 * will return the code points in the supplied string again, starting at the
-	 * first in the String..
+	 * Pushes back the supplied string by copying it to the front of the buffer. After this method returns,
+	 * successive calls to {@link #readCodePoint()} will return the code points in the supplied string again,
+	 * starting at the first in the String..
 	 *
 	 * @param string
-	 *            the string to un-read.
+	 *        the string to un-read.
 	 * @throws IOException
 	 */
-	protected void unread(String string) throws IOException {
+	protected void unread(String string)
+		throws IOException
+	{
 		for (int i = string.codePointCount(0, string.length()); i >= 1; i--) {
 			final int codePoint = string.codePointBefore(i);
 			if (Character.isSupplementaryCodePoint(codePoint)) {
 				final char[] surrogatePair = Character.toChars(codePoint);
 				reader.unread(surrogatePair);
-			} else {
+			}
+			else {
 				reader.unread(codePoint);
 			}
 		}
 	}
 
 	/**
-	 * Peeks at the next Unicode code point without advancing the reader, and
-	 * returns its value.
+	 * Peeks at the next Unicode code point without advancing the reader, and returns its value.
 	 *
-	 * @return the next Unicode code point, or -1 if the end of the stream has
-	 *         been reached.
+	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
 	 * @throws IOException
 	 */
-	protected int peekCodePoint() throws IOException {
+	protected int peekCodePoint()
+		throws IOException
+	{
 		int result = readCodePoint();
 		unread(result);
 		return result;
@@ -1315,8 +1458,7 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Overrides {@link AbstractRDFParser#reportWarning(String)}, adding line
-	 * number information to the error.
+	 * Overrides {@link AbstractRDFParser#reportWarning(String)}, adding line number information to the error.
 	 */
 	@Override
 	protected void reportWarning(String msg) {
@@ -1324,33 +1466,41 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Overrides {@link AbstractRDFParser#reportError(String, RioSetting)},
-	 * adding line number information to the error.
+	 * Overrides {@link AbstractRDFParser#reportError(String, RioSetting)}, adding line number information to
+	 * the error.
 	 */
 	@Override
-	protected void reportError(String msg, RioSetting<Boolean> setting) throws RDFParseException {
+	protected void reportError(String msg, RioSetting<Boolean> setting)
+		throws RDFParseException
+	{
 		reportError(msg, getLineNumber(), -1, setting);
 	}
 
 	/**
-	 * Overrides {@link AbstractRDFParser#reportFatalError(String)}, adding line
-	 * number information to the error.
+	 * Overrides {@link AbstractRDFParser#reportFatalError(String)}, adding line number information to the
+	 * error.
 	 */
 	@Override
-	protected void reportFatalError(String msg) throws RDFParseException {
+	protected void reportFatalError(String msg)
+		throws RDFParseException
+	{
 		reportFatalError(msg, getLineNumber(), -1);
 	}
 
 	/**
-	 * Overrides {@link AbstractRDFParser#reportFatalError(Exception)}, adding
-	 * line number information to the error.
+	 * Overrides {@link AbstractRDFParser#reportFatalError(Exception)}, adding line number information to the
+	 * error.
 	 */
 	@Override
-	protected void reportFatalError(Exception e) throws RDFParseException {
+	protected void reportFatalError(Exception e)
+		throws RDFParseException
+	{
 		reportFatalError(e, getLineNumber(), -1);
 	}
 
-	protected void throwEOFException() throws RDFParseException {
+	protected void throwEOFException()
+		throws RDFParseException
+	{
 		throw new RDFParseException("Unexpected end of file");
 	}
 
@@ -1364,22 +1514,23 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Appends the characters from codepoint into the string builder. This is
-	 * the same as Character#toChars but prevents the additional char array
-	 * garbage for BMP codepoints.
+	 * Appends the characters from codepoint into the string builder. This is the same as Character#toChars but
+	 * prevents the additional char array garbage for BMP codepoints.
 	 * 
 	 * @param dst
-	 *            the destination in which to append the characters
+	 *        the destination in which to append the characters
 	 * @param codePoint
-	 *            the codepoint to be appended
+	 *        the codepoint to be appended
 	 */
 	private static void appendCodepoint(StringBuilder dst, int codePoint) {
 		if (Character.isBmpCodePoint(codePoint)) {
-			dst.append((char) codePoint);
-		} else if (Character.isValidCodePoint(codePoint)) {
+			dst.append((char)codePoint);
+		}
+		else if (Character.isValidCodePoint(codePoint)) {
 			dst.append(Character.highSurrogate(codePoint));
 			dst.append(Character.lowSurrogate(codePoint));
-		} else {
+		}
+		else {
 			throw new IllegalArgumentException("Invalid codepoint " + codePoint);
 		}
 	}

--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.apache.commons.io.input.BOMInputStream;
 import org.eclipse.rdf4j.common.text.ASCIIUtil;
+import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -237,7 +238,9 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseDirective(String directive) throws IOException, RDFParseException, RDFHandlerException {
+	protected void parseDirective(String directive)
+		throws IOException, RDFParseException, RDFHandlerException
+	{
 		if (directive.length() >= 7 && directive.substring(0, 7).equals("@prefix")) {
 			if (directive.length() > 7) {
 				unread(directive.substring(7));
@@ -267,7 +270,8 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 		else if (directive.length() >= 7 && directive.substring(0, 7).equalsIgnoreCase("@prefix")) {
 			if (!this.getParserConfig().get(TurtleParserSettings.CASE_INSENSITIVE_DIRECTIVES)) {
-				reportFatalError("Cannot strictly support case-insensitive @prefix directive in compliance mode.");
+				reportFatalError(
+						"Cannot strictly support case-insensitive @prefix directive in compliance mode.");
 			}
 			if (directive.length() > 7) {
 				unread(directive.substring(7));
@@ -276,7 +280,8 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 		else if (directive.length() >= 5 && directive.substring(0, 5).equalsIgnoreCase("@base")) {
 			if (!this.getParserConfig().get(TurtleParserSettings.CASE_INSENSITIVE_DIRECTIVES)) {
-				reportFatalError("Cannot strictly support case-insensitive @base directive in compliance mode.");
+				reportFatalError(
+						"Cannot strictly support case-insensitive @base directive in compliance mode.");
 			}
 			if (directive.length() > 5) {
 				unread(directive.substring(5));
@@ -558,8 +563,8 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parses an implicit blank node. This method parses the token <tt>[]</tt> and predicateObjectLists that are
-	 * surrounded by square brackets.
+	 * Parses an implicit blank node. This method parses the token <tt>[]</tt> and predicateObjectLists that
+	 * are surrounded by square brackets.
 	 */
 	protected Resource parseImplicitBlank() throws IOException, RDFParseException, RDFHandlerException {
 		verifyCharacterOrFail(readCodePoint(), "[");
@@ -697,26 +702,17 @@ public class TurtleParser extends AbstractRDFParser {
 
 			// Read datatype
 			Value datatype = parseValue();
-			if (datatype instanceof IRI) {
-				return createLiteral(label, null, (IRI)datatype, getLineNumber(), -1);
-			}
-			else if (datatype != null) {
+			if (datatype instanceof Literal || datatype instanceof BNode) {
 				reportFatalError("Illegal datatype value: " + datatype);
+			}
+			else if (datatype == null) {
+				// the datatype IRI could not be parsed. report as error only if VERIFY_URI_SYNTAX is enabled, silently skip otherwise.
+				reportError("Invalid datatype IRI for literal '" + label + "'", BasicParserSettings.VERIFY_URI_SYNTAX);
 				return null;
 			}
-			else {
-				if (getParserConfig().get(BasicParserSettings.VERIFY_URI_SYNTAX)
-						&& !getParserConfig().isNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX))
-				{
-					// only report a missing/illegal datatype when IRI verification is a fatal error.
-					reportFatalError("Illegal datatype value: " + datatype);
-				}
-				return null;
-			}
+			return createLiteral(label, null, (IRI)datatype, getLineNumber(), -1);
 		}
-		else
-
-		{
+		else {
 			return createLiteral(label, null, null, getLineNumber(), -1);
 		}
 	}
@@ -957,7 +953,8 @@ public class TurtleParser extends AbstractRDFParser {
 			}
 
 			if (c == ' ') {
-				reportError("IRI included an unencoded space: '" + c + "'", BasicParserSettings.VERIFY_URI_SYNTAX);
+				reportError("IRI included an unencoded space: '" + c + "'",
+						BasicParserSettings.VERIFY_URI_SYNTAX);
 				uriIsIllegal = true;
 			}
 
@@ -970,7 +967,8 @@ public class TurtleParser extends AbstractRDFParser {
 					throwEOFException();
 				}
 				if (c != 'u' && c != 'U') {
-					reportError("IRI includes string escapes: '\\" + c + "'", BasicParserSettings.VERIFY_URI_SYNTAX);
+					reportError("IRI includes string escapes: '\\" + c + "'",
+							BasicParserSettings.VERIFY_URI_SYNTAX);
 					uriIsIllegal = true;
 				}
 				appendCodepoint(uriBuf, c);
@@ -1195,7 +1193,8 @@ public class TurtleParser extends AbstractRDFParser {
 
 	/**
 	 * Verifies that the supplied character code point <tt>codePoint</tt> is one of the expected characters
-	 * specified in <tt>expected</tt>. This method will throw a <tt>ParseException</tt> if this is not the case.
+	 * specified in <tt>expected</tt>. This method will throw a <tt>ParseException</tt> if this is not the
+	 * case.
 	 */
 	protected void verifyCharacterOrFail(int codePoint, String expected) throws RDFParseException {
 		if (codePoint == -1) {
@@ -1405,8 +1404,8 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Appends the characters from codepoint into the string builder. This is the same as Character#toChars but
-	 * prevents the additional char array garbage for BMP codepoints.
+	 * Appends the characters from codepoint into the string builder. This is the same as Character#toChars
+	 * but prevents the additional char array garbage for BMP codepoints.
 	 * 
 	 * @param dst
 	 *        the destination in which to append the characters

--- a/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -125,9 +125,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 *         If the supplied input stream or base URI is <tt>null</tt>.
 	 */
 	public synchronized void parse(InputStream in, String baseURI)
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
+		throws IOException, RDFParseException, RDFHandlerException
 	{
 		if (in == null) {
 			throw new IllegalArgumentException("Input stream must not be 'null'");
@@ -160,9 +158,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 *         If the supplied reader or base URI is <tt>null</tt>.
 	 */
 	public synchronized void parse(Reader reader, String baseURI)
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
+		throws IOException, RDFParseException, RDFHandlerException
 	{
 		clear();
 
@@ -205,11 +201,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseStatement()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parseStatement() throws IOException, RDFParseException, RDFHandlerException {
 
 		StringBuilder sb = new StringBuilder(8);
 
@@ -245,11 +237,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseDirective(String directive)
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parseDirective(String directive) throws IOException, RDFParseException, RDFHandlerException {
 		if (directive.length() >= 7 && directive.substring(0, 7).equals("@prefix")) {
 			if (directive.length() > 7) {
 				unread(directive.substring(7));
@@ -303,11 +291,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parsePrefixID()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parsePrefixID() throws IOException, RDFParseException, RDFHandlerException {
 		skipWSC();
 
 		// Read prefix ID (e.g. "rdf:" or ":")
@@ -350,11 +334,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseBase()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parseBase() throws IOException, RDFParseException, RDFHandlerException {
 		skipWSC();
 
 		IRI baseURI = parseURI();
@@ -362,11 +342,7 @@ public class TurtleParser extends AbstractRDFParser {
 		setBaseURI(baseURI.toString());
 	}
 
-	protected void parseTriples()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parseTriples() throws IOException, RDFParseException, RDFHandlerException {
 		int c = peekCodePoint();
 
 		// If the first character is an open bracket we need to decide which of
@@ -407,11 +383,7 @@ public class TurtleParser extends AbstractRDFParser {
 		object = null;
 	}
 
-	protected void parsePredicateObjectList()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parsePredicateObjectList() throws IOException, RDFParseException, RDFHandlerException {
 		predicate = parsePredicate();
 
 		skipWSC();
@@ -443,11 +415,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseObjectList()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parseObjectList() throws IOException, RDFParseException, RDFHandlerException {
 		parseObject();
 
 		while (skipWSC() == ',') {
@@ -457,11 +425,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected void parseSubject()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parseSubject() throws IOException, RDFParseException, RDFHandlerException {
 		int c = peekCodePoint();
 
 		if (c == '(') {
@@ -482,11 +446,7 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	protected IRI parsePredicate()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected IRI parsePredicate() throws IOException, RDFParseException, RDFHandlerException {
 		// Check if the short-cut 'a' is used
 		int c1 = readCodePoint();
 
@@ -521,11 +481,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * @throws RDFParseException
 	 * @throws RDFHandlerException
 	 */
-	protected void parseObject()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected void parseObject() throws IOException, RDFParseException, RDFHandlerException {
 		int c = peekCodePoint();
 
 		switch (c) {
@@ -545,11 +501,7 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses a collection, e.g. <tt>( item1 item2 item3 )</tt>.
 	 */
-	protected Resource parseCollection()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected Resource parseCollection() throws IOException, RDFParseException, RDFHandlerException {
 		verifyCharacterOrFail(readCodePoint(), "(");
 
 		int c = skipWSC();
@@ -609,11 +561,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * Parses an implicit blank node. This method parses the token <tt>[]</tt> and predicateObjectLists that are
 	 * surrounded by square brackets.
 	 */
-	protected Resource parseImplicitBlank()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected Resource parseImplicitBlank() throws IOException, RDFParseException, RDFHandlerException {
 		verifyCharacterOrFail(readCodePoint(), "[");
 
 		Resource bNode = createNode();
@@ -655,11 +603,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * Parses an RDF value. This method parses uriref, qname, node ID, quoted literal, integer, double and
 	 * boolean.
 	 */
-	protected Value parseValue()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected Value parseValue() throws IOException, RDFParseException, RDFHandlerException {
 		int c = peekCodePoint();
 
 		if (c == '<') {
@@ -695,11 +639,7 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses a quoted string, optionally followed by a language tag or datatype.
 	 */
-	protected Literal parseQuotedLiteral()
-		throws IOException,
-		RDFParseException,
-		RDFHandlerException
-	{
+	protected Literal parseQuotedLiteral() throws IOException, RDFParseException, RDFHandlerException {
 		String label = parseQuotedString();
 
 		// Check for presence of a language tag or datatype
@@ -788,10 +728,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * @throws IOException
 	 * @throws RDFParseException
 	 */
-	protected String parseQuotedString()
-		throws IOException,
-		RDFParseException
-	{
+	protected String parseQuotedString() throws IOException, RDFParseException {
 		String result = null;
 
 		int c1 = readCodePoint();
@@ -833,10 +770,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * @throws IOException
 	 * @throws RDFParseException
 	 */
-	protected String parseString(int closingCharacter)
-		throws IOException,
-		RDFParseException
-	{
+	protected String parseString(int closingCharacter) throws IOException, RDFParseException {
 		StringBuilder sb = getBuilder();
 
 		while (true) {
@@ -872,10 +806,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * Parses a """long string""". This method requires that the first three characters have already been
 	 * parsed.
 	 */
-	protected String parseLongString(int closingCharacter)
-		throws IOException,
-		RDFParseException
-	{
+	protected String parseLongString(int closingCharacter) throws IOException, RDFParseException {
 		StringBuilder sb = getBuilder();
 
 		int doubleQuoteCount = 0;
@@ -909,10 +840,7 @@ public class TurtleParser extends AbstractRDFParser {
 		return sb.substring(0, sb.length() - 3);
 	}
 
-	protected Literal parseNumber()
-		throws IOException,
-		RDFParseException
-	{
+	protected Literal parseNumber() throws IOException, RDFParseException {
 		StringBuilder value = getBuilder();
 		IRI datatype = XMLSchema.INTEGER;
 
@@ -1009,10 +937,7 @@ public class TurtleParser extends AbstractRDFParser {
 		return createLiteral(value.toString(), null, datatype, getLineNumber(), -1);
 	}
 
-	protected IRI parseURI()
-		throws IOException,
-		RDFParseException
-	{
+	protected IRI parseURI() throws IOException, RDFParseException {
 		StringBuilder uriBuf = getBuilder();
 
 		// First character should be '<'
@@ -1083,10 +1008,7 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses qnames and boolean values, which have equivalent starting characters.
 	 */
-	protected Value parseQNameOrBoolean()
-		throws IOException,
-		RDFParseException
-	{
+	protected Value parseQNameOrBoolean() throws IOException, RDFParseException {
 		// First character should be a ':' or a letter
 		int c = readCodePoint();
 		if (c == -1) {
@@ -1202,10 +1124,7 @@ public class TurtleParser extends AbstractRDFParser {
 		return createURI(namespace + localNameString);
 	}
 
-	private char readLocalEscapedChar()
-		throws RDFParseException,
-		IOException
-	{
+	private char readLocalEscapedChar() throws RDFParseException, IOException {
 		int c = readCodePoint();
 
 		if (TurtleUtil.isLocalEscapedChar(c)) {
@@ -1220,10 +1139,7 @@ public class TurtleParser extends AbstractRDFParser {
 	/**
 	 * Parses a blank node ID, e.g. <tt>_:node1</tt>.
 	 */
-	protected Resource parseNodeID()
-		throws IOException,
-		RDFParseException
-	{
+	protected Resource parseNodeID() throws IOException, RDFParseException {
 		// Node ID should start with "_:"
 		verifyCharacterOrFail(readCodePoint(), "_");
 		verifyCharacterOrFail(readCodePoint(), ":");
@@ -1267,8 +1183,7 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	protected void reportStatement(Resource subj, IRI pred, Value obj)
-		throws RDFParseException,
-		RDFHandlerException
+		throws RDFParseException, RDFHandlerException
 	{
 		if (subj != null && pred != null && obj != null) {
 			Statement st = createStatement(subj, pred, obj);
@@ -1282,9 +1197,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * Verifies that the supplied character code point <tt>codePoint</tt> is one of the expected characters
 	 * specified in <tt>expected</tt>. This method will throw a <tt>ParseException</tt> if this is not the case.
 	 */
-	protected void verifyCharacterOrFail(int codePoint, String expected)
-		throws RDFParseException
-	{
+	protected void verifyCharacterOrFail(int codePoint, String expected) throws RDFParseException {
 		if (codePoint == -1) {
 			throwEOFException();
 		}
@@ -1318,10 +1231,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 *
 	 * @return The next character code point that will be returned by <tt>reader</tt>.
 	 */
-	protected int skipWSC()
-		throws IOException,
-		RDFHandlerException
-	{
+	protected int skipWSC() throws IOException, RDFHandlerException {
 		int c = readCodePoint();
 		while (TurtleUtil.isWhitespace(c) || c == '#') {
 			if (c == '#') {
@@ -1346,10 +1256,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * Consumes characters from reader until the first EOL has been read. This line of text is then passed to
 	 * the {@link #rdfHandler} as a comment.
 	 */
-	protected void processComment()
-		throws IOException,
-		RDFHandlerException
-	{
+	protected void processComment() throws IOException, RDFHandlerException {
 		StringBuilder comment = getBuilder();
 		int c = readCodePoint();
 		while (c != -1 && c != 0xD && c != 0xA) {
@@ -1383,9 +1290,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
 	 * @throws IOException
 	 */
-	protected int readCodePoint()
-		throws IOException
-	{
+	protected int readCodePoint() throws IOException {
 		int next = reader.read();
 		if (Character.isHighSurrogate((char)next)) {
 			next = Character.toCodePoint((char)next, (char)reader.read());
@@ -1401,9 +1306,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 *        a single Unicode code point.
 	 * @throws IOException
 	 */
-	protected void unread(int codePoint)
-		throws IOException
-	{
+	protected void unread(int codePoint) throws IOException {
 		if (codePoint != -1) {
 			if (Character.isSupplementaryCodePoint(codePoint)) {
 				final char[] surrogatePair = Character.toChars(codePoint);
@@ -1424,9 +1327,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 *        the string to un-read.
 	 * @throws IOException
 	 */
-	protected void unread(String string)
-		throws IOException
-	{
+	protected void unread(String string) throws IOException {
 		for (int i = string.codePointCount(0, string.length()); i >= 1; i--) {
 			final int codePoint = string.codePointBefore(i);
 			if (Character.isSupplementaryCodePoint(codePoint)) {
@@ -1445,9 +1346,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * @return the next Unicode code point, or -1 if the end of the stream has been reached.
 	 * @throws IOException
 	 */
-	protected int peekCodePoint()
-		throws IOException
-	{
+	protected int peekCodePoint() throws IOException {
 		int result = readCodePoint();
 		unread(result);
 		return result;
@@ -1470,9 +1369,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * the error.
 	 */
 	@Override
-	protected void reportError(String msg, RioSetting<Boolean> setting)
-		throws RDFParseException
-	{
+	protected void reportError(String msg, RioSetting<Boolean> setting) throws RDFParseException {
 		reportError(msg, getLineNumber(), -1, setting);
 	}
 
@@ -1481,9 +1378,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * error.
 	 */
 	@Override
-	protected void reportFatalError(String msg)
-		throws RDFParseException
-	{
+	protected void reportFatalError(String msg) throws RDFParseException {
 		reportFatalError(msg, getLineNumber(), -1);
 	}
 
@@ -1492,15 +1387,11 @@ public class TurtleParser extends AbstractRDFParser {
 	 * error.
 	 */
 	@Override
-	protected void reportFatalError(Exception e)
-		throws RDFParseException
-	{
+	protected void reportFatalError(Exception e) throws RDFParseException {
 		reportFatalError(e, getLineNumber(), -1);
 	}
 
-	protected void throwEOFException()
-		throws RDFParseException
-	{
+	protected void throwEOFException() throws RDFParseException {
 		throw new RDFParseException("Unexpected end of file");
 	}
 

--- a/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
+++ b/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
@@ -158,7 +158,7 @@ public class TurtleParserTest {
 
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
 		parser.parse(new StringReader(data), baseURI);
-		assertThat(errorCollector.getErrors()).hasSize(1);
+		assertThat(errorCollector.getErrors()).hasSize(2);
 		assertThat(errorCollector.getFatalErrors()).isEmpty();
 		assertThat(statementCollector.getStatements()).isNotEmpty();
 		assertThat(statementCollector.getStatements()).hasSize(2).overridingErrorMessage(

--- a/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
+++ b/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
@@ -69,9 +69,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseDots()
-		throws IOException
-	{
+	public void testParseDots() throws IOException {
 		String data = prefixes + " ex:foo.bar ex:\\~foo.bar ex:foobar. ";
 
 		parser.parse(new StringReader(data), baseURI);
@@ -89,9 +87,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseIllegalURIFatal()
-		throws IOException
-	{
+	public void testParseIllegalURIFatal() throws IOException {
 		String data = " <urn:foo_bar\\r> <urn:foo> <urn:bar> ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		try {
@@ -104,9 +100,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseIllegalURINonFatal()
-		throws IOException
-	{
+	public void testParseIllegalURINonFatal() throws IOException {
 		String data = " <urn:foo_bar\\r> <urn:foo> <urn:bar> ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
@@ -119,9 +113,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseIllegalURINoVerify()
-		throws IOException
-	{
+	public void testParseIllegalURINoVerify() throws IOException {
 		String data = " <urn:foo_bar\\r> <urn:foo> <urn:bar> ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		parser.getParserConfig().set(BasicParserSettings.VERIFY_URI_SYNTAX, false);
@@ -135,9 +127,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseIllegalDatatypeURIFatal()
-		throws IOException
-	{
+	public void testParseIllegalDatatypeURIFatal() throws IOException {
 		String data = " <urn:foo_bar> <urn:foo> \"a\"^^<urn:foo bar> ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		try {
@@ -150,9 +140,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseIllegalDatatypeValueFatalIRI()
-		throws IOException
-	{
+	public void testParseIllegalDatatypeValueFatalIRI() throws IOException {
 		String data = " <urn:foo_bar> <urn:foo> \"a\"^^\"b\" ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		try {
@@ -165,9 +153,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseIllegalDatatypeURINonFatal()
-		throws IOException
-	{
+	public void testParseIllegalDatatypeURINonFatal() throws IOException {
 		String data = " <urn:foo_bar> <urn:foo> \"a\"^^<urn:foo bar> ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
@@ -180,9 +166,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseIllegalDatatypValueINonFatalIRI()
-		throws IOException
-	{
+	public void testParseIllegalDatatypValueINonFatalIRI() throws IOException {
 		String data = " <urn:foo_bar> <urn:foo> \"a\"^^\"b\" ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		try {
@@ -196,9 +180,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseIllegalDatatypeURINoVerify()
-		throws IOException
-	{
+	public void testParseIllegalDatatypeURINoVerify() throws IOException {
 		String data = " <urn:foo_bar> <urn:foo> \"a\"^^<urn:foo bar> ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		parser.getParserConfig().set(BasicParserSettings.VERIFY_URI_SYNTAX, false);
@@ -210,11 +192,9 @@ public class TurtleParserTest {
 		assertThat(statementCollector.getStatements()).hasSize(3).overridingErrorMessage(
 				"all triples should have been reported");
 	}
-	
+
 	@Test
-	public void testParseIllegalDatatypValueINoVerify()
-		throws IOException
-	{
+	public void testParseIllegalDatatypValueINoVerify() throws IOException {
 		String data = " <urn:foo_bar> <urn:foo> \"a\"^^\"b\" ; <urn:foo2> <urn:bar2> . <urn:foobar> <urn:food> <urn:barf> . ";
 
 		try {
@@ -227,11 +207,8 @@ public class TurtleParserTest {
 		}
 	}
 
-
 	@Test
-	public void testUnparsableIRIFatal()
-		throws IOException
-	{
+	public void testUnparsableIRIFatal() throws IOException {
 		// subject IRI is not processable by ParsedIRI
 		String data = " <http://www:example.org/> <urn:foo> <urn:bar> . ";
 
@@ -246,9 +223,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testUnparsableIRINonFatal()
-		throws IOException
-	{
+	public void testUnparsableIRINonFatal() throws IOException {
 		// subject IRI is not processable by ParsedIRI
 		String data = " <http://www:example.org/> <urn:foo> <urn:bar> . <urn:foo2> <urn:foo> <urn:bar> .";
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
@@ -262,9 +237,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testUnparsableIRINoVerify()
-		throws IOException
-	{
+	public void testUnparsableIRINoVerify() throws IOException {
 		// subject IRI is not processable by ParsedIRI
 		String data = " <http://www:example.org/> <urn:foo> <urn:bar> . <urn:foo2> <urn:foo> <urn:bar> .";
 		parser.getParserConfig().set(BasicParserSettings.VERIFY_URI_SYNTAX, false);
@@ -279,9 +252,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseBNodes()
-		throws IOException
-	{
+	public void testParseBNodes() throws IOException {
 		String data = prefixes + " [ :p  :o1,:2 ] . ";
 
 		parser.parse(new StringReader(data), baseURI);
@@ -299,9 +270,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReporting()
-		throws IOException
-	{
+	public void testLineNumberReporting() throws IOException {
 		InputStream in = this.getClass().getResourceAsStream("/test-newlines.ttl");
 		try {
 			parser.parse(in, baseURI);
@@ -319,9 +288,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReportingNoErrorsSingleLine()
-		throws IOException
-	{
+	public void testLineNumberReportingNoErrorsSingleLine() throws IOException {
 		assertEquals(0, locationListener.getLineNo());
 		assertEquals(0, locationListener.getColumnNo());
 		Reader in = new StringReader("<urn:a> <urn:b> <urn:c>.");
@@ -331,9 +298,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReportingNoErrorsSingleLineEndNewline()
-		throws IOException
-	{
+	public void testLineNumberReportingNoErrorsSingleLineEndNewline() throws IOException {
 		assertEquals(0, locationListener.getLineNo());
 		assertEquals(0, locationListener.getColumnNo());
 		Reader in = new StringReader("<urn:a> <urn:b> <urn:c>.\n");
@@ -343,9 +308,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReportingNoErrorsMultipleLinesNoEndNewline()
-		throws IOException
-	{
+	public void testLineNumberReportingNoErrorsMultipleLinesNoEndNewline() throws IOException {
 		assertEquals(0, locationListener.getLineNo());
 		assertEquals(0, locationListener.getColumnNo());
 		Reader in = new StringReader("<urn:a> <urn:b> <urn:c>.\n<urn:a> <urn:b> <urn:d>.");
@@ -355,9 +318,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReportingNoErrorsMultipleLinesEndNewline()
-		throws IOException
-	{
+	public void testLineNumberReportingNoErrorsMultipleLinesEndNewline() throws IOException {
 		assertEquals(0, locationListener.getLineNo());
 		assertEquals(0, locationListener.getColumnNo());
 		Reader in = new StringReader("<urn:a> <urn:b> <urn:c>.\n<urn:a> <urn:b> <urn:d>.\n");
@@ -367,9 +328,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReportingOnlySingleCommentNoEndline()
-		throws IOException
-	{
+	public void testLineNumberReportingOnlySingleCommentNoEndline() throws IOException {
 		assertEquals(0, locationListener.getLineNo());
 		assertEquals(0, locationListener.getColumnNo());
 		Reader in = new StringReader("# This is just a comment");
@@ -379,9 +338,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReportingOnlySingleCommentEndline()
-		throws IOException
-	{
+	public void testLineNumberReportingOnlySingleCommentEndline() throws IOException {
 		assertEquals(0, locationListener.getLineNo());
 		assertEquals(0, locationListener.getColumnNo());
 		Reader in = new StringReader("# This is just a comment\n");
@@ -391,9 +348,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReportingOnlySingleCommentCarriageReturn()
-		throws IOException
-	{
+	public void testLineNumberReportingOnlySingleCommentCarriageReturn() throws IOException {
 		assertEquals(0, locationListener.getLineNo());
 		assertEquals(0, locationListener.getColumnNo());
 		Reader in = new StringReader("# This is just a comment\r");
@@ -403,9 +358,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLineNumberReportingOnlySingleCommentCarriageReturnNewline()
-		throws IOException
-	{
+	public void testLineNumberReportingOnlySingleCommentCarriageReturnNewline() throws IOException {
 		assertEquals(0, locationListener.getLineNo());
 		assertEquals(0, locationListener.getColumnNo());
 		Reader in = new StringReader("# This is just a comment\r\n");
@@ -415,9 +368,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseBooleanLiteralComma()
-		throws IOException
-	{
+	public void testParseBooleanLiteralComma() throws IOException {
 		String data = "<urn:a> <urn:b> true, false .";
 		Reader r = new StringReader(data);
 
@@ -431,9 +382,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseBooleanLiteralWhitespaceComma()
-		throws IOException
-	{
+	public void testParseBooleanLiteralWhitespaceComma() throws IOException {
 		String data = "<urn:a> <urn:b> true , false .";
 		Reader r = new StringReader(data);
 
@@ -447,9 +396,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseBooleanLiteralSemicolumn()
-		throws IOException
-	{
+	public void testParseBooleanLiteralSemicolumn() throws IOException {
 		String data = "<urn:a> <urn:b> true; <urn:c> false .";
 		Reader r = new StringReader(data);
 
@@ -463,9 +410,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testParseBooleanLiteralWhitespaceSemicolumn()
-		throws IOException
-	{
+	public void testParseBooleanLiteralWhitespaceSemicolumn() throws IOException {
 		String data = "<urn:a> <urn:b> true ; <urn:c> false .";
 		Reader r = new StringReader(data);
 
@@ -479,9 +424,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void rdfXmlLoadedFromInsideAJarResolvesRelativeUris()
-		throws IOException
-	{
+	public void rdfXmlLoadedFromInsideAJarResolvesRelativeUris() throws IOException {
 		URL zipfileUrl = TurtleParserTest.class.getResource("sample-with-turtle-data.zip");
 
 		assertNotNull("The sample-with-turtle-data.zip file must be present for this test", zipfileUrl);
@@ -527,9 +470,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testIllegalNewlineInQuotedObjectLiteral()
-		throws IOException
-	{
+	public void testIllegalNewlineInQuotedObjectLiteral() throws IOException {
 		String data = "<urn:a> <urn:b> \"not\nallowed\" .";
 		Reader r = new StringReader(data);
 
@@ -543,9 +484,7 @@ public class TurtleParserTest {
 	}
 
 	@Test
-	public void testLegalNewlineInTripleQuotedObjectLiteral()
-		throws IOException
-	{
+	public void testLegalNewlineInTripleQuotedObjectLiteral() throws IOException {
 		String data = "<urn:a> <urn:b> \"\"\"is\nallowed\"\"\" .";
 		Reader r = new StringReader(data);
 


### PR DESCRIPTION
This PR addresses GitHub issue: #1237 .

Briefly describe the changes proposed in this PR:

* if VERIFY_URI_SYNTAX is set but non-fatal, an illegal datatype URI should result in a skipped line, not a fatal error
* distinguish between unparsable datatype IRIs and datatypes that are something else (e.g. literals)
* regression tests added to cover cases (renamed test class for consistency)
