### PR TITLE
Use SchemaCachingInferencer as default in config templates

### DIFF
--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
@@ -18,7 +18,7 @@
       sr:sailImpl [
          sail:sailType "openrdf:DirectTypeHierarchyInferencer" ;
          sail:delegate [
-            sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+            sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
             sail:delegate [
                sail:sailType "openrdf:MemoryStore" ;
 	       sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
@@ -12,11 +12,11 @@
 
 [] a rep:Repository ;
    rep:repositoryID "{%Repository ID|memory-rdfs-new%}" ;
-   rdfs:label "{%Repository title|Memory store with Schema-caching RDFS inferencing%}" ;
+   rdfs:label "{%Repository title|Memory store with RDFS inferencing (legacy reasoner)%}" ;
    rep:repositoryImpl [
       rep:repositoryType "openrdf:SailRepository" ;
       sr:sailImpl [
-         sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+               sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
          sail:delegate [
             sail:sailType "openrdf:MemoryStore" ;
 	    	sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-new.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-new.ttl
@@ -1,0 +1,28 @@
+#
+# Configuration template for a main-memory repository with
+# RDF Schema inferencing
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+
+
+[] a rep:Repository ;
+   rep:repositoryID "{%Repository ID|memory-rdfs-new%}" ;
+   rdfs:label "{%Repository title|Memory store with Schema-caching RDFS inferencing%}" ;
+   rep:repositoryImpl [
+      rep:repositoryType "openrdf:SailRepository" ;
+      sr:sailImpl [
+         sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+         sail:delegate [
+            sail:sailType "openrdf:MemoryStore" ;
+	    	sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+            ms:persist {%Persist|true|false%} ;
+            ms:syncDelay {%Sync delay|0%};
+            sb:evaluationStrategyFactory "{%EvaluationStrategyFactory|org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory%}"
+         ]
+      ]
+   ].

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
@@ -12,14 +12,14 @@
 
 [] a rep:Repository ;
    rep:repositoryID "{%Repository ID|memory-rdfs%}" ;
-   rdfs:label "{%Repository title|Memory store with RDF Schema inferencing%}" ;
+   rdfs:label "{%Repository title|Memory store with RDFS inferencing%}" ;
    rep:repositoryImpl [
       rep:repositoryType "openrdf:SailRepository" ;
       sr:sailImpl [
-         sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+         sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
          sail:delegate [
             sail:sailType "openrdf:MemoryStore" ;
-	    sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+	        sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
             ms:persist {%Persist|true|false%} ;
             ms:syncDelay {%Sync delay|0%};
             sb:evaluationStrategyFactory "{%EvaluationStrategyFactory|org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory%}"

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-spin-rdfs-lucene.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-spin-rdfs-lucene.ttl
@@ -22,7 +22,7 @@
 			  sail:sailType "openrdf:SpinSail" ;
 			  spin:axiomClosureNeeded false ;
 			  sail:delegate [
-				     sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+				     sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
 				     sail:delegate [
 					     sail:sailType "openrdf:DedupingInferencer" ;
 					     sail:delegate [

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-spin-rdfs.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-spin-rdfs.ttl
@@ -18,7 +18,7 @@
          sail:sailType "openrdf:SpinSail" ;
          spin:axiomClosureNeeded false ;
          sail:delegate [
-			 sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+			 sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
 			 sail:delegate [
 			 	 sail:sailType "openrdf:DedupingInferencer" ;
 				 sail:delegate [

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
@@ -18,7 +18,7 @@
       sr:sailImpl [
          sail:sailType "openrdf:DirectTypeHierarchyInferencer" ;
          sail:delegate [
-            sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+            sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
             sail:delegate [
                sail:sailType "openrdf:NativeStore" ;
 	       sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
@@ -16,7 +16,7 @@
    rep:repositoryImpl [
       rep:repositoryType "openrdf:SailRepository" ;
       sr:sailImpl [
-         sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+         sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
          sail:delegate [
             sail:sailType "openrdf:NativeStore" ;
 	    sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-spin-rdfs-lucene.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-spin-rdfs-lucene.ttl
@@ -26,7 +26,7 @@
                 sail:sailType "openrdf:SpinSail" ;
                 spin:axiomClosureNeeded false ;
                 sail:delegate [
-			 sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+			 sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
 			 sail:delegate [
 			 	 sail:sailType "openrdf:DedupingInferencer" ;
 				 sail:delegate [

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-spin-rdfs.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-spin-rdfs.ttl
@@ -22,7 +22,7 @@
          sail:sailType "openrdf:SpinSail" ;
          spin:axiomClosureNeeded false ;
          sail:delegate [
-			 sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+			 sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
 			 sail:delegate [
 			 	 sail:sailType "openrdf:DedupingInferencer" ;
 				 sail:delegate [


### PR DESCRIPTION
This PR addresses GitHub issue: #1226 .

Briefly describe the changes proposed in this PR:

* all config templates use the SchemaCachingInferencer as the default RDFS reasoner
