### PR TITLE
GH-1113 added shared constant vocabulary for SHACL shape graph

### DIFF
--- a/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/RDF4J.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/RDF4J.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+
+/**
+ * Defines constants for the RDF4J namespace. These constants include things like implementation-specific
+ * named graph identifiers or properties.
+ * 
+ * @author Jeen Broekstra
+ */
+public class RDF4J {
+
+	/**
+	 * The RDF4J namespace ( <tt>http://rdf4j.org/schema/rdf4j#</tt>).
+	 */
+	public static final String NAMESPACE = "http://rdf4j.org/schema/rdf4j#";
+
+	/**
+	 * Recommended prefix for the RDF4J namespace: "rdf4j"
+	 */
+	public static final String PREFIX = "rdf4j";
+
+	/**
+	 * An immutable {@link Namespace} constant that represents the RDF4J namespace.
+	 */
+	public static final Namespace NS = new SimpleNamespace(PREFIX, NAMESPACE);
+
+	/**
+	 * Context identifier for persisting SHACL shape data in the {@link ShaclSail}.
+	 * <tt>http://rdf4j.org/schema/rdf4j#SHACLShapeGraph</tt>
+	 */
+	public final static IRI SHACL_SHAPE_GRAPH = SimpleValueFactory.getInstance().createIRI(NAMESPACE,
+			"SHACLShapeGraph");
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #1113 .

Briefly describe the changes proposed in this PR:

* constant vocabulary class RDF4J added as future successor for SESAME vocab.
* added RDF4J.SHACL_SHAPE_GRAPH as constant for the context identifier used in the ShaclSail.

This is trivial enough that I'll do an immediate merge (I need it to get the refactor PR stable) but please do not let that stop you from reviewing and commenting. 
