### PR TITLE
GH-1263 temporary workaround for test dependency issue

### DIFF
--- a/repository/manager/pom.xml
+++ b/repository/manager/pom.xml
@@ -67,16 +67,22 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
+		<!-- testing dependencies -->
+
 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-sail-memory</artifactId>
-			<version>${project.version}</version>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-repository-sail</artifactId>
+			<!-- we use a fixed version for testing purposes -->
+			<!-- FIXME this dependency should be stubbed/mocked: https://github.com/eclipse/rdf4j/issues/1263 -->
+			<version>2.4.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-repository-sail</artifactId>
-			<version>${project.version}</version>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-sail-memory</artifactId>
+			<!-- we use a fixed version for testing purposes -->
+			<!-- FIXME this dependency should be stubbed/mocked: https://github.com/eclipse/rdf4j/issues/1263 -->
+			<version>2.4.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: #1302.

Briefly describe the changes proposed in this PR:

* temporary workaround for testing circular dependency: test dependencies use a fixed older version of rdf4j. 
* documented necessity to stub out these dependencies in unit tests as per #1263
* documented need to allow injection of a `ModelFactory` for test stubbing/mocking purposes as per #1263. 
