### PR TITLE
Issues/#1271 client cpu

### DIFF
--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -56,7 +56,8 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 
 	public SharedHttpClientSessionManager() {
 		final ThreadFactory backingThreadFactory = Executors.defaultThreadFactory();
-		this.executor = Executors.newScheduledThreadPool(1, new ThreadFactory() {
+		int cores = (System.getProperty("org.rdf4j.client.executors.jdkbug") != null) ? 1 : 0;
+		this.executor = Executors.newScheduledThreadPool(cores, new ThreadFactory() {
 
 			@Override
 			public Thread newThread(Runnable runnable) {

--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -56,7 +56,7 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 
 	public SharedHttpClientSessionManager() {
 		final ThreadFactory backingThreadFactory = Executors.defaultThreadFactory();
-		this.executor = Executors.newScheduledThreadPool(0, new ThreadFactory() {
+		this.executor = Executors.newScheduledThreadPool(1, new ThreadFactory() {
 
 			@Override
 			public Thread newThread(Runnable runnable) {


### PR DESCRIPTION
This PR addresses GitHub issue: #1271 .

Briefly describe the changes proposed in this PR:

* Workaround for openjdk8 bug, changing executors cores to 1 when `org.rdf4j.client.executors.jdkbug `system property is set
