### PR TITLE
Deprecate PreferEmptyContainer, not MinimalContainer

### DIFF
--- a/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/LDP.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/LDP.java
@@ -121,13 +121,13 @@ public class LDP {
 	public static final IRI PREFER_CONTAINMENT;
 
 	/** ldp:PreferEmptyContainer */
+	@Deprecated
 	public static final IRI PREFER_EMPTY_CONTAINER;
 
 	/** ldp:PreferMembership */
 	public static final IRI PREFER_MEMBERSHIP;
 
 	/** ldp:PreferMinimalContainer */
-	@Deprecated
 	public static final IRI PREFER_MINIMAL_CONTAINER;
 
 


### PR DESCRIPTION
This PR addresses GitHub issue: #1285  .

Briefly describe the changes proposed in this PR:

* Deprecate correct term