### PR TITLE
#1294: Fix resource leak in txncache file deletion

### DIFF
--- a/util/src/main/java/org/eclipse/rdf4j/common/io/NioFile.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/io/NioFile.java
@@ -137,12 +137,9 @@ public final class NioFile implements Closeable {
 	public boolean delete()
 		throws IOException
 	{
-		try {
-			return file.delete();
-		}
-		finally {
-			close();
-		}
+		// make sure to close file handles prior to deletion
+		close();
+		return file.delete();
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses GitHub issue: #1294

The temporary txncache.dat file cannot be deleted on Windows as the file
is still locked while attempting the deletion.

Closing the resource handle properly makes sure that deletion works.

