### PR TITLE
#1299 - Random order of conditions in where clause prevents query optimization

### DIFF
--- a/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/QueryElementCollection.java
+++ b/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/QueryElementCollection.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
  *            the type of {@link QueryElement}s in the collection
  */
 public abstract class QueryElementCollection<T extends QueryElement> implements QueryElement {
-	protected Collection<T> elements = new HashSet<>();
+	protected Collection<T> elements = new LinkedHashSet<>();
 	private String delimiter = "\n";
 
 	protected QueryElementCollection() { }


### PR DESCRIPTION
This PR addresses GitHub issue: #1299.

Briefly describe the changes proposed in this PR:

Replace default HashSet with a LinkedHashSet - same set behavior but elements remain in the general order in which the user code adds them. This permits the user code to optimize queries by placing fast patterns before slow patterns.
