### PR TITLE
Fix eclipse/rdf4j#1283: remove duplicated root nodes jsonld hierarchy

### DIFF
--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalProcessor.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalProcessor.java
@@ -92,7 +92,7 @@ public class JSONLDHierarchicalProcessor {
 
 		Set<String> visited = new HashSet<>();
 		List<String> sortedNodes = getNodesOrder(graph);
-        Set<String> children = new HashSet<>();
+		Set<String> children = new HashSet<>();
 
 		while (visited.size() < graph.size()) {
 			Object rootNode = graph.get(getNextRoot(visited, sortedNodes));
@@ -113,8 +113,9 @@ public class JSONLDHierarchicalProcessor {
 								if (graph.containsKey(objectsPredId)
 										&& !currentNode.get(ID).equals(objectsPredId)
 										&& !currentTreeNode.hasPassedThrough(objectsPredId)) {
-                                    children.add(objectsPredId);
-                                    objectsPredSubjPairs.set(i, (Map<String, Object>) graph.get(objectsPredId));
+									children.add(objectsPredId);
+									objectsPredSubjPairs.set(i,
+											(Map<String, Object>)graph.get(objectsPredId));
 									frontier.add(new TreeNode(objectsPredSubjPairs.get(i), currentTreeNode));
 								}
 							}
@@ -124,12 +125,12 @@ public class JSONLDHierarchicalProcessor {
 			}
 		}
 
-        expanded.removeIf(o -> {
-            if (o instanceof Map<?, ?>) {
-                return children.contains(((Map<String, Object>) o).get(ID).toString());
-            }
-            return false;
-        });
+		expanded.removeIf(o -> {
+			if (o instanceof Map<?, ?>) {
+				return children.contains(((Map<String, Object>)o).get(ID).toString());
+			}
+			return false;
+		});
 		return expanded;
 	}
 

--- a/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalProcessor.java
+++ b/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalProcessor.java
@@ -92,6 +92,7 @@ public class JSONLDHierarchicalProcessor {
 
 		Set<String> visited = new HashSet<>();
 		List<String> sortedNodes = getNodesOrder(graph);
+        Set<String> children = new HashSet<>();
 
 		while (visited.size() < graph.size()) {
 			Object rootNode = graph.get(getNextRoot(visited, sortedNodes));
@@ -112,7 +113,8 @@ public class JSONLDHierarchicalProcessor {
 								if (graph.containsKey(objectsPredId)
 										&& !currentNode.get(ID).equals(objectsPredId)
 										&& !currentTreeNode.hasPassedThrough(objectsPredId)) {
-									objectsPredSubjPairs.set(i, (Map<String, Object>) graph.get(objectsPredId));
+                                    children.add(objectsPredId);
+                                    objectsPredSubjPairs.set(i, (Map<String, Object>) graph.get(objectsPredId));
 									frontier.add(new TreeNode(objectsPredSubjPairs.get(i), currentTreeNode));
 								}
 							}
@@ -122,6 +124,12 @@ public class JSONLDHierarchicalProcessor {
 			}
 		}
 
+        expanded.removeIf(o -> {
+            if (o instanceof Map<?, ?>) {
+                return children.contains(((Map<String, Object>) o).get(ID).toString());
+            }
+            return false;
+        });
 		return expanded;
 	}
 

--- a/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
+++ b/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
@@ -16,20 +16,17 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.model.ModelFactory;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -264,8 +261,6 @@ public class JSONLDHierarchicalWriterTest {
 	 */
 	@Test
 	public void testOrder() throws IOException {
-		ModelFactory mf = new LinkedHashModelFactory();
-
 		IRI child = vf.createIRI("urn:child");
 		IRI b = vf.createIRI("urn:B");
 		IRI c = vf.createIRI("urn:C");
@@ -276,6 +271,21 @@ public class JSONLDHierarchicalWriterTest {
 		
 		verifyOutput();
 	}
+
+    @Test
+    public void testOrderDuplicatedChild() throws IOException {
+        IRI child = vf.createIRI("urn:child");
+        IRI b = vf.createIRI("urn:B");
+        IRI c = vf.createIRI("urn:C");
+        IRI e = vf.createIRI("urn:E");
+        IRI d = vf.createIRI("urn:D");
+
+        addStatement(e, child, b);
+        addStatement(b, child, c);
+        addStatement(d, child, b);
+
+        verifyOutput();
+    }
 
 	private void addStatement(Resource subject, URI predicate, Value object, Resource context) {
 		model.add(vf.createStatement(subject, predicate, object, context));

--- a/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
+++ b/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
@@ -7,8 +7,29 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.jsonld;
 
-import org.eclipse.rdf4j.model.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ModelFactory;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -17,13 +38,6 @@ import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Arrays;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Yasen Marinov
@@ -240,6 +254,26 @@ public class JSONLDHierarchicalWriterTest {
 		addStatement(vf.createIRI("sch:node2"), vf.createIRI("sch:pred2"), vf.createIRI("sch:node3"));
 
 		writerConfig.set(JSONLDSettings.HIERARCHICAL_VIEW, false);
+		verifyOutput();
+	}
+	
+	/**
+	 * Verify output hierarchy does not duplicate nodes B and C. 
+	 * @throws IOException
+	 * @see https://github.com/eclipse/rdf4j/issues/1283
+	 */
+	@Test
+	public void testOrder() throws IOException {
+		ModelFactory mf = new LinkedHashModelFactory();
+
+		IRI child = vf.createIRI("urn:child");
+		IRI b = vf.createIRI("urn:B");
+		IRI c = vf.createIRI("urn:C");
+		IRI e = vf.createIRI("urn:E");
+
+		addStatement(e, child, b);
+		addStatement(b, child, c);
+		
 		verifyOutput();
 	}
 

--- a/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
+++ b/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
@@ -253,9 +253,10 @@ public class JSONLDHierarchicalWriterTest {
 		writerConfig.set(JSONLDSettings.HIERARCHICAL_VIEW, false);
 		verifyOutput();
 	}
-	
+
 	/**
-	 * Verify output hierarchy does not duplicate nodes B and C. 
+	 * Verify output hierarchy does not duplicate nodes B and C.
+	 * 
 	 * @throws IOException
 	 * @see https://github.com/eclipse/rdf4j/issues/1283
 	 */
@@ -268,24 +269,24 @@ public class JSONLDHierarchicalWriterTest {
 
 		addStatement(e, child, b);
 		addStatement(b, child, c);
-		
+
 		verifyOutput();
 	}
 
-    @Test
-    public void testOrderDuplicatedChild() throws IOException {
-        IRI child = vf.createIRI("urn:child");
-        IRI b = vf.createIRI("urn:B");
-        IRI c = vf.createIRI("urn:C");
-        IRI e = vf.createIRI("urn:E");
-        IRI d = vf.createIRI("urn:D");
+	@Test
+	public void testOrderDuplicatedChild() throws IOException {
+		IRI child = vf.createIRI("urn:child");
+		IRI b = vf.createIRI("urn:B");
+		IRI c = vf.createIRI("urn:C");
+		IRI e = vf.createIRI("urn:E");
+		IRI d = vf.createIRI("urn:D");
 
-        addStatement(e, child, b);
-        addStatement(b, child, c);
-        addStatement(d, child, b);
+		addStatement(e, child, b);
+		addStatement(b, child, c);
+		addStatement(d, child, b);
 
-        verifyOutput();
-    }
+		verifyOutput();
+	}
 
 	private void addStatement(Resource subject, URI predicate, Value object, Resource context) {
 		model.add(vf.createStatement(subject, predicate, object, context));

--- a/rio/jsonld/src/test/resources/serialized/testOrder.json
+++ b/rio/jsonld/src/test/resources/serialized/testOrder.json
@@ -1,0 +1,9 @@
+[ {
+  "@id" : "urn:E",
+  "urn:child" : [ {
+    "@id" : "urn:B",
+    "urn:child" : [ {
+      "@id" : "urn:C"
+    } ]
+  } ]
+} ]

--- a/rio/jsonld/src/test/resources/serialized/testOrderDuplicatedChild.json
+++ b/rio/jsonld/src/test/resources/serialized/testOrderDuplicatedChild.json
@@ -1,0 +1,17 @@
+[ {
+  "@id" : "urn:D",
+  "urn:child" : [ {
+    "@id" : "urn:B",
+    "urn:child" : [ {
+      "@id" : "urn:C"
+    } ]
+  } ]
+}, {
+  "@id" : "urn:E",
+  "urn:child" : [ {
+    "@id" : "urn:B",
+    "urn:child" : [ {
+      "@id" : "urn:C"
+    } ]
+  } ]
+} ]

--- a/rio/jsonld/src/test/resources/serialized/testRootIsNotTheParentNode.json
+++ b/rio/jsonld/src/test/resources/serialized/testRootIsNotTheParentNode.json
@@ -1,12 +1,4 @@
 [ {
-  "@id" : "sch:node2",
-  "sch:pred2" : [ {
-    "@id" : "sch:node3"
-  } ],
-  "sch:pred3" : [ {
-    "@value" : "literal1"
-  } ]
-}, {
   "@id" : "sch:node1",
   "sch:pred1" : [ {
     "@id" : "sch:node2",

--- a/rio/jsonld/src/test/resources/serialized/testRootIsNotTheParentNodeInContext.json
+++ b/rio/jsonld/src/test/resources/serialized/testRootIsNotTheParentNodeInContext.json
@@ -1,13 +1,5 @@
 [ {
   "@graph" : [ {
-    "@id" : "sch:node2",
-    "sch:pred2" : [ {
-      "@id" : "sch:node3"
-    } ],
-    "sch:pred3" : [ {
-      "@value" : "literal1"
-    } ]
-  }, {
     "@id" : "sch:node1",
     "sch:pred1" : [ {
       "@id" : "sch:node2",


### PR DESCRIPTION
This PR addresses GitHub issue: #1283  .

Briefly describe the changes proposed in this PR:

* Adds a filter to the `expanded` list in `JSONLDHierarchicalProcessor` that removes all root nodes that are also children within the hierarchy.
* Adds two tests for ordering in the hierarchy to `JSONLDHierarchicalWriterTest` that ensures children nodes are not duplicated at the root level.
* Updates `testRootIsNotTheParentNode` and `testRootIsNotTheParentNodeInContext` in `JSONLDHierarchicalWriterTest` to remove children nodes from the root level.
