### PR TITLE
GH-1311 config templates for native/memory + rdfs and lucene

### DIFF
--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
@@ -1,0 +1,33 @@
+#
+# RDF4J configuration template for a main-memory repository with
+# RDF Schema inferencing and Lucene index
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
+@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+
+
+[] a rep:Repository ;
+   rep:repositoryID "{%Repository ID|memory-rdfs-lucene%}" ;
+   rdfs:label "{%Repository title|Memory store with RDFS inferencing and Lucene index%}" ;
+   rep:repositoryImpl [
+      rep:repositoryType "openrdf:SailRepository" ;
+      sr:sailImpl [
+         sail:sailType "openrdf:LuceneSail";
+         sail-luc:indexDir "index/" ;
+         sail:delegate [
+                  sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+              sail:delegate [
+                  sail:sailType "openrdf:MemoryStore" ;
+	              sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+                  ms:persist {%Persist|true|false%} ;
+                  ms:syncDelay {%Sync delay|0%};
+                  sb:evaluationStrategyFactory "{%EvaluationStrategyFactory|org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory%}"
+              ]
+         ]
+      ]
+   ].

--- a/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
+++ b/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
@@ -1,0 +1,35 @@
+#
+# RDF4J configuration template for a native repository with
+# RDFS support and a Lucene index 
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix spin: <http://www.openrdf.org/config/sail/spin#>.
+@prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
+@prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
+@prefix ns: <http://www.openrdf.org/config/sail/native#>.
+@prefix sp: <http://spinrdf.org/sp#>.
+@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+
+
+[] a rep:Repository ;
+   rep:repositoryID "{%Repository ID|native-rdfs-lucene%}" ;
+   rdfs:label "{%Repository title|Native store with RDFS entailment and  Lucene Support%}" ;
+   rep:repositoryImpl [
+      rep:repositoryType "openrdf:SailRepository" ;
+      sr:sailImpl [
+          sail:sailType "openrdf:LuceneSail";
+          sail-luc:indexDir "index/" ;
+  	      sail:delegate [   
+              sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+              sail:delegate [
+                  sail:sailType "openrdf:NativeStore" ;
+                  sail:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+                  ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
+                  sb:evaluationStrategyFactory "{%EvaluationStrategyFactory|org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory%}"
+			  ]
+          ]
+      ]
+   ].


### PR DESCRIPTION
This PR addresses GitHub issue: #1311  .

Briefly describe the changes proposed in this PR:

* added config templates for native store and memory store with lucene and rdfs entailment
