### PR TITLE
GH-1236 include minimally-conforming query result formats for compliance

### DIFF
--- a/http/client/pom.xml
+++ b/http/client/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -44,6 +46,18 @@
 			<artifactId>rdf4j-util</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-queryresultio-binary</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-queryresultio-sparqlxml</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
@@ -74,12 +88,12 @@
 		</dependency>
 
 	</dependencies>
-        <build>
-                <plugins>
-                        <plugin>
-                                <groupId>com.github.siom79.japicmp</groupId>
-                                <artifactId>japicmp-maven-plugin</artifactId>
-                        </plugin>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -170,7 +170,7 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 
 	private ParserConfig parserConfig = new ParserConfig();
 
-	private TupleQueryResultFormat preferredTQRFormat = TupleQueryResultFormat.BINARY;
+	private TupleQueryResultFormat preferredTQRFormat = TupleQueryResultFormat.SPARQL;
 
 	private BooleanQueryResultFormat preferredBQRFormat = BooleanQueryResultFormat.TEXT;
 

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTestCase.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTestCase.java
@@ -60,8 +60,6 @@ public abstract class RDFXMLParserTestCase {
 
 	private static String W3C_MANIFEST_FILE = W3C_TESTS_DIR + "Manifest.rdf";
 
-	private static String OPENRDF_MANIFEST_FILE = LOCAL_TESTS_DIR + "openrdf/Manifest.rdf";
-
 	/*--------------------*
 	 * Static initializer *
 	 *--------------------*/
@@ -75,10 +73,6 @@ public abstract class RDFXMLParserTestCase {
 		// Add W3C's manifest
 		URL w3cManifest = resolveURL(W3C_MANIFEST_FILE);
 		con.add(w3cManifest, base(W3C_MANIFEST_FILE), RDFFormat.RDFXML);
-
-		// Add our own manifest
-		URL localManifest = resolveURL(OPENRDF_MANIFEST_FILE);
-		con.add(localManifest, base(localManifest.toString()), RDFFormat.RDFXML);
 
 		// Create test suite
 		TestSuite suite = new TestSuite(RDFXMLParserTestCase.class.getName());


### PR DESCRIPTION
This PR addresses GitHub issue: #1236 .

Briefly describe the changes proposed in this PR:

* ensure httpclient includes sparqlxml and binary result formats (necessary for minimal compliance)
* fix sparqlrepo to prefer SPARQL/XML over rdf4j's binary format

