### PR TITLE
GH-1223 init is now optional

### DIFF
--- a/repository/api/src/main/java/org/eclipse/rdf4j/repository/Repository.java
+++ b/repository/api/src/main/java/org/eclipse/rdf4j/repository/Repository.java
@@ -17,9 +17,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
  * repository. Depending on the implementation of the repository, it may or may not support multiple concurrent
  * connections.
  * <p>
- * Please note that a repository needs to be initialized before it can be used and that it should be shut down before it
- * is discarded/garbage collected. Forgetting the latter can result in loss of data (depending on the Repository
- * implementation)!
+ * Please note that a repository should be shut down before it is discarded/garbage collected. Forgetting the latter can
+ * result in loss of data (depending on the Repository implementation)!
  * <p>
  * Repository implementations are thread-safe unless specifically documented otherwise.
  * 
@@ -42,7 +41,7 @@ public interface Repository {
 	public File getDataDir();
 
 	/**
-	 * Initializes this repository. A repository needs to be initialized before it can be used.
+	 * Initializes this repository.
 	 * 
 	 * @throws RepositoryException If the initialization failed.
 	 * @deprecated Use {@link #init()} instead.
@@ -51,7 +50,9 @@ public interface Repository {
 	public void initialize() throws RepositoryException;
 
 	/**
-	 * Initializes this repository. A repository needs to be initialized before it can be used.
+	 * Initializes this repository. A repository needs to be initialized before it can be used, however explicitly
+	 * calling this method is not necessary: the repository will automatically initialize itself if an operation is
+	 * executed on it that requires it to be initialized.
 	 * 
 	 * @throws RepositoryException If the initialization failed.
 	 * @since 2.5
@@ -83,20 +84,17 @@ public interface Repository {
 	/**
 	 * Opens a connection to this repository that can be used for querying and updating the contents of the repository.
 	 * Created connections need to be closed to make sure that any resources they keep hold of are released. The best
-	 * way to do this is to use a try-finally-block as follows:
+	 * way to do this is to use a try-with-resources block, as follows:
 	 * 
 	 * <pre>
-	 * Connection con = repository.getConnection();
-	 * try {
+	 * try (RepositoryConnection conn = repository.getConnection()) {
 	 * 	// perform operations on the connection
-	 * } finally {
-	 * 	con.close();
 	 * }
 	 * </pre>
 	 * 
 	 * Note that {@link RepositoryConnection} is not guaranteed to be thread-safe! The recommended pattern for
-	 * repository access in a multithreaded application is to share the Repository object between threads, but have each
-	 * thread create and use its own {@link RepositoryConnection}s.
+	 * repository access in a multi-threaded application is to share the Repository object between threads, but have
+	 * each thread create and use its own {@link RepositoryConnection}s.
 	 * 
 	 * @return A connection that allows operations on this repository.
 	 * @throws RepositoryException If something went wrong during the creation of the Connection.

--- a/repository/api/src/test/java/org/eclipse/rdf4j/repository/RepositoryTest.java
+++ b/repository/api/src/test/java/org/eclipse/rdf4j/repository/RepositoryTest.java
@@ -84,7 +84,6 @@ public abstract class RepositoryTest {
 	@Before
 	public void setUp() throws Exception {
 		testRepository = createRepository();
-		testRepository.initialize();
 
 		vf = testRepository.getValueFactory();
 
@@ -117,7 +116,7 @@ public abstract class RepositoryTest {
 
 	@Test
 	public void testShutdownFollowedByInit() throws Exception {
-
+		testRepository.init();
 		RepositoryConnection conn = testRepository.getConnection();
 		try {
 			conn.add(bob, mbox, mboxBob);
@@ -127,12 +126,24 @@ public abstract class RepositoryTest {
 		}
 
 		testRepository.shutDown();
-		testRepository.initialize();
+		testRepository.init();
 
 		conn = testRepository.getConnection();
 		try {
 			conn.add(bob, mbox, mboxBob);
 			assertTrue(conn.hasStatement(bob, mbox, mboxBob, true));
+		} finally {
+			conn.close();
+		}
+	}
+
+	@Test
+	public void testAutoInit() throws Exception {
+		RepositoryConnection conn = testRepository.getConnection();
+		try {
+			conn.add(bob, mbox, mboxBob);
+			assertTrue(conn.hasStatement(bob, mbox, mboxBob, true));
+			assertTrue(testRepository.isInitialized());
 		} finally {
 			conn.close();
 		}

--- a/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepository.java
+++ b/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepository.java
@@ -201,13 +201,16 @@ public class HTTPRepository extends AbstractRepository implements HttpClientDepe
 
 	@Override
 	public RepositoryConnection getConnection() throws RepositoryException {
+		if (!isInitialized()) {
+			init();
+		}
 		return new HTTPRepositoryConnection(this, createHTTPClient());
 	}
 
 	@Override
 	public boolean isWritable() throws RepositoryException {
 		if (!isInitialized()) {
-			throw new IllegalStateException("HTTPRepository not initialized.");
+			init();
 		}
 
 		boolean isWritable = false;

--- a/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
+++ b/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
@@ -149,7 +149,7 @@ public class SPARQLRepository extends AbstractRepository implements HttpClientDe
 	@Override
 	public RepositoryConnection getConnection() throws RepositoryException {
 		if (!isInitialized()) {
-			throw new RepositoryException("SPARQLRepository not initialized.");
+			init();
 		}
 		return new SPARQLConnection(this, createHTTPClient(), quadMode);
 	}


### PR DESCRIPTION
This PR addresses GitHub issue: #1223 .

Briefly describe the changes proposed in this PR:

* Repository API no longer requires user to explicitly call `init()`
* added testcase, and fixes for HTTPRepository and SPARQLRepository
* related fix for SailRepository (and Sail) to follow
