### PR TITLE
GH-1409: Unnecessary parsing of IRIs every time an RDF parser is used

### DIFF
--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
@@ -440,7 +440,7 @@ public class CustomTurtleParserTest {
 		assertEquals(1, model.size());
 		model.filter(null, RDF.TYPE, null)
 				.objects()
-				.forEach(obj -> assertEquals("http://purl.bioontology.org/ontology/UATC/%20SERINE%20%20",
+				.forEach(obj -> assertEquals("http://purl.bioontology.org/ontology/UATC/ SERINE  ",
 						obj.stringValue()));
 	}
 

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
@@ -440,8 +440,7 @@ public class CustomTurtleParserTest {
 		assertEquals(1, model.size());
 		model.filter(null, RDF.TYPE, null)
 				.objects()
-				.forEach(obj -> assertEquals("http://purl.bioontology.org/ontology/UATC/ SERINE  ",
-						obj.stringValue()));
+				.forEach(obj -> assertEquals("http://purl.bioontology.org/ontology/UATC/ SERINE  ", obj.stringValue()));
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Pavel Mihaylov <pavel@ontotext.com>


This PR addresses GitHub issue: #1409

Also fixes an issue in AbstractRDFParser.createURI() where non-fatal validation of IRIs didn't return null (this was masked by old code in resolveURI()).