### PR TITLE
GH-1403 wildcard processor skips binds and filter constraints

### DIFF
--- a/queryparser/sparql/pom.xml
+++ b/queryparser/sparql/pom.xml
@@ -43,6 +43,12 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/WildcardProjectionProcessor.java
+++ b/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/WildcardProjectionProcessor.java
@@ -11,6 +11,8 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.parser.sparql.ast.ASTBind;
+import org.eclipse.rdf4j.query.parser.sparql.ast.ASTConstraint;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTDescribe;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTDescribeQuery;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTOperation;
@@ -142,6 +144,26 @@ public class WildcardProjectionProcessor extends AbstractASTVisitor {
 			} else {
 				return super.visit(node, data);
 			}
+		}
+
+		@Override
+		public Object visit(ASTBind node, Object data) throws VisitorException {
+			// only include the actual alias from a BIND
+			Node aliasNode = node.jjtGetChild(1);
+			String alias = ((ASTVar) aliasNode).getName();
+
+			if (alias != null) {
+				variableNames.add(alias);
+				return null;
+			} else {
+				return super.visit(node, data);
+			}
+		}
+
+		@Override
+		public Object visit(ASTConstraint node, Object data) throws VisitorException {
+			// ignore variables in filter expressions
+			return null;
 		}
 
 		@Override

--- a/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/WildcardProjectionProcessorTest.java
+++ b/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/WildcardProjectionProcessorTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.parser.sparql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.query.parser.sparql.ast.ASTProjectionElem;
+import org.eclipse.rdf4j.query.parser.sparql.ast.ASTQueryContainer;
+import org.eclipse.rdf4j.query.parser.sparql.ast.ASTSelectQuery;
+import org.eclipse.rdf4j.query.parser.sparql.ast.ASTVar;
+import org.eclipse.rdf4j.query.parser.sparql.ast.SyntaxTreeBuilder;
+import org.junit.Test;
+
+public class WildcardProjectionProcessorTest {
+
+	@Test
+	public void testVarInFilter() throws Exception {
+		String queryStr = "SELECT * {\n" + "    FILTER (!bound(?a))\n" + "}";
+		ASTQueryContainer qc = SyntaxTreeBuilder.parseQuery(queryStr);
+		WildcardProjectionProcessor.process(qc);
+
+		List<ASTProjectionElem> projection = ((ASTSelectQuery) qc.getQuery()).getSelect().getProjectionElemList();
+
+		assertThat(projection).isEmpty();
+	}
+
+	@Test
+	public void testVarInBGP() throws Exception {
+		String queryStr = "SELECT * {\n" + "    ?a <ex:p> <ex:o> . \n" + "    FILTER (!bound(?a))\n" + "}";
+		ASTQueryContainer qc = SyntaxTreeBuilder.parseQuery(queryStr);
+		WildcardProjectionProcessor.process(qc);
+
+		List<ASTProjectionElem> projection = ((ASTSelectQuery) qc.getQuery()).getSelect().getProjectionElemList();
+
+		assertThat(projection.size()).isEqualTo(1);
+		assertThat(((ASTVar) projection.get(0).jjtGetChild(0)).getName()).isEqualTo("a");
+	}
+
+	@Test
+	public void testVarInBind() throws Exception {
+		String queryStr = "SELECT * {\n" + "    BIND (?a AS ?b)\n" + "}";
+		ASTQueryContainer qc = SyntaxTreeBuilder.parseQuery(queryStr);
+		WildcardProjectionProcessor.process(qc);
+
+		List<ASTProjectionElem> projection = ((ASTSelectQuery) qc.getQuery()).getSelect().getProjectionElemList();
+
+		assertThat(projection.size()).isEqualTo(1);
+		assertThat(((ASTVar) projection.get(0).jjtGetChild(0)).getName()).isEqualTo("b");
+	}
+
+	@Test
+	public void testVarInSubselect() throws Exception {
+		String queryStr = "SELECT * {\n" + "    { SELECT ?a { ?a ?p ?o } }\n" + "}";
+		ASTQueryContainer qc = SyntaxTreeBuilder.parseQuery(queryStr);
+		WildcardProjectionProcessor.process(qc);
+
+		List<ASTProjectionElem> projection = ((ASTSelectQuery) qc.getQuery()).getSelect().getProjectionElemList();
+
+		assertThat(projection.size()).isEqualTo(1);
+		assertThat(((ASTVar) projection.get(0).jjtGetChild(0)).getName()).isEqualTo("a");
+	}
+
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #1403 .

Briefly describe the changes proposed in this PR:

* WildcardProjectionProcessor skips filter constraints and BIND expressions when collecting variables for projection
* added regression tests

