### PR TITLE
Issues/1369 early escape linked hash model

### DIFF
--- a/model/src/main/java/org/eclipse/rdf4j/model/impl/LinkedHashModel.java
+++ b/model/src/main/java/org/eclipse/rdf4j/model/impl/LinkedHashModel.java
@@ -170,6 +170,10 @@ public class LinkedHashModel extends AbstractModel {
 	@Override
 	public boolean remove(Object o) {
 		if (o instanceof Statement) {
+			if (statements.isEmpty()) {
+				return false;
+			}
+
 			Iterator iter = find((Statement) o);
 			if (iter.hasNext()) {
 				iter.next();


### PR DESCRIPTION
This PR addresses GitHub issue: #1369  .

Briefly describe the changes proposed in this PR:

* #1369 proposed implemented by calling the remove method on a LinkedHashModel, this method is inefficient when the model is empty, now returns early if the model is empty
* 
* 