### PR TITLE
GH-1405 query planner uses hashjoin when scoped group pattern

### DIFF
--- a/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -41,7 +41,6 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 		this.parent = parent;
 	}
 
-
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -61,7 +60,7 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 	public void setGraphPatternGroup(boolean isGraphPatternGroup) {
 		this.isGraphPatternGroup = isGraphPatternGroup;
 	}
-	
+
 	/**
 	 * Dummy implementation of {@link QueryModelNode#visitChildren} that does nothing. Subclasses should override this
 	 * method when they have child nodes.

--- a/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.query.algebra.helpers.QueryModelTreePrinter;
 /**
  * Base implementation of {@link QueryModelNode}.
  */
-public abstract class AbstractQueryModelNode implements QueryModelNode {
+public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPatternGroupable {
 
 	/*-----------*
 	 * Variables *
@@ -24,6 +24,8 @@ public abstract class AbstractQueryModelNode implements QueryModelNode {
 	private static final long serialVersionUID = 3006199552086476178L;
 
 	private QueryModelNode parent;
+
+	private boolean isGraphPatternGroup;
 
 	/*---------*
 	 * Methods *
@@ -39,6 +41,27 @@ public abstract class AbstractQueryModelNode implements QueryModelNode {
 		this.parent = parent;
 	}
 
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.rdf4j.query.algebra.GraphPatternGroupable#isGraphPatternGroup()
+	 */
+	@Override
+	public boolean isGraphPatternGroup() {
+		return isGraphPatternGroup;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.rdf4j.query.algebra.GraphPatternGroupable#setGraphPatternGroup(boolean)
+	 */
+	@Override
+	public void setGraphPatternGroup(boolean isGraphPatternGroup) {
+		this.isGraphPatternGroup = isGraphPatternGroup;
+	}
+	
 	/**
 	 * Dummy implementation of {@link QueryModelNode#visitChildren} that does nothing. Subclasses should override this
 	 * method when they have child nodes.

--- a/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/GraphPatternGroupable.java
+++ b/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/GraphPatternGroupable.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra;
+
+/**
+ * {@link QueryModelNode}s that can represent a full graph pattern group.
+ * 
+ * Although the notion of a graph pattern group is strictly not relevant at the algebra level, it gives an indication to
+ * evaluation strategy implementations on how they can optimize join patterns wrt variable scope.
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public interface GraphPatternGroupable {
+
+	/**
+	 * indicates if the node represents the root of a graph pattern group.
+	 * 
+	 * @return true iff the node represents the node of a graph pattern group.
+	 *
+	 */
+	public boolean isGraphPatternGroup();
+
+	/**
+	 * Set the value of {@link #isGraphPatternGroup()} to true or false.
+	 */
+	public void setGraphPatternGroup(boolean isGraphPatternGroup);
+
+}

--- a/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/TupleExpr.java
+++ b/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/TupleExpr.java
@@ -29,7 +29,6 @@ public interface TupleExpr extends QueryModelNode {
 	 */
 	public Set<String> getAssuredBindingNames();
 
-
 	@Override
 	public TupleExpr clone();
 }

--- a/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/TupleExpr.java
+++ b/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/TupleExpr.java
@@ -29,6 +29,7 @@ public interface TupleExpr extends QueryModelNode {
 	 */
 	public Set<String> getAssuredBindingNames();
 
+
 	@Override
 	public TupleExpr clone();
 }

--- a/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
+++ b/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
@@ -22,7 +22,7 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 	 * The operator's argument.
 	 */
 	protected TupleExpr arg;
-	
+
 	private boolean isGraphPatternGroup;
 
 	/*--------------*
@@ -44,17 +44,17 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 	/*---------*
 	 * Methods *
 	 *---------*/
-	
+
 	@Override
 	public boolean isGraphPatternGroup() {
 		return isGraphPatternGroup;
 	}
-	
+
 	@Override
 	public void setGraphPatternGroup(boolean isGraphPatternGroup) {
 		this.isGraphPatternGroup = isGraphPatternGroup;
 	}
-	
+
 	/**
 	 * Gets the argument of this unary tuple operator.
 	 * 

--- a/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
+++ b/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * An abstract superclass for unary tuple operators which, by definition, has one argument.
  */
-public abstract class UnaryTupleOperator extends AbstractQueryModelNode implements TupleExpr {
+public abstract class UnaryTupleOperator extends AbstractQueryModelNode implements TupleExpr, GraphPatternGroupable {
 
 	/*-----------*
 	 * Variables *
@@ -22,6 +22,8 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 	 * The operator's argument.
 	 */
 	protected TupleExpr arg;
+	
+	private boolean isGraphPatternGroup;
 
 	/*--------------*
 	 * Constructors *
@@ -42,7 +44,17 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 	/*---------*
 	 * Methods *
 	 *---------*/
-
+	
+	@Override
+	public boolean isGraphPatternGroup() {
+		return isGraphPatternGroup;
+	}
+	
+	@Override
+	public void setGraphPatternGroup(boolean isGraphPatternGroup) {
+		this.isGraphPatternGroup = isGraphPatternGroup;
+	}
+	
 	/**
 	 * Gets the argument of this unary tuple operator.
 	 * 

--- a/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprs.java
+++ b/queryalgebra-model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprs.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.algebra.GraphPatternGroupable;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
@@ -51,6 +52,20 @@ public class TupleExprs {
 			} else {
 				queue.addAll(getChildren(n));
 			}
+		}
+		return false;
+	}
+
+	/**
+	 * Verifies if the supplied {@link TupleExpr} represents a group graph pattern.
+	 * 
+	 * @param expr a {@link TupleExpr}
+	 * @return <code>true</code> if the {@link TupleExpr} is {@link GraphPatternGroupable} and has its graph pattern
+	 *         group flag set to <code>true</code>, <code>false</code> otherwise.
+	 */
+	public static boolean isGraphPatternGroup(TupleExpr expr) {
+		if (expr instanceof GraphPatternGroupable) {
+			return ((GraphPatternGroupable) expr).isGraphPatternGroup();
 		}
 		return false;
 	}

--- a/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
+++ b/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
@@ -185,7 +185,7 @@ public class GraphPattern {
 		for (ValueExpr constraint : constraints) {
 			result = new Filter(result, constraint);
 		}
-		
+
 		return result;
 	}
 

--- a/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
+++ b/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
@@ -164,13 +164,7 @@ public class GraphPattern {
 
 			for (int i = 1; i < requiredTEs.size(); i++) {
 				TupleExpr te = requiredTEs.get(i);
-				// if (containsProjection(te) || containsProjection(result))
-				// {
-				// result = new BottomUpJoin(result, te);
-				// }
-				// else {
 				result = new Join(result, te);
-				// }
 			}
 		}
 
@@ -191,7 +185,7 @@ public class GraphPattern {
 		for (ValueExpr constraint : constraints) {
 			result = new Filter(result, constraint);
 		}
-
+		
 		return result;
 	}
 

--- a/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -47,6 +47,7 @@ import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.ExtensionElem;
 import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.FunctionCall;
+import org.eclipse.rdf4j.query.algebra.GraphPatternGroupable;
 import org.eclipse.rdf4j.query.algebra.Group;
 import org.eclipse.rdf4j.query.algebra.GroupConcat;
 import org.eclipse.rdf4j.query.algebra.GroupElem;
@@ -1023,6 +1024,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		// bindings external to the group
 		TupleExpr te = graphPattern.buildTupleExpr();
 
+		((GraphPatternGroupable)te).setGraphPatternGroup(true);
+		
 		parentGP.addRequiredTE(te);
 
 		graphPattern = parentGP;

--- a/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -1024,8 +1024,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		// bindings external to the group
 		TupleExpr te = graphPattern.buildTupleExpr();
 
-		((GraphPatternGroupable)te).setGraphPatternGroup(true);
-		
+		((GraphPatternGroupable) te).setGraphPatternGroup(true);
+
 		parentGP.addRequiredTE(te);
 
 		graphPattern = parentGP;


### PR DESCRIPTION
This PR addresses GitHub issue: #1405  .

Briefly describe the changes proposed in this PR:

* Introduced `GraphPatternGroupable` behavioral interface
* TupleExprBuilder marks TupleExprs that from a group graph pattern
* EvaluationStrategy bases join evaluation strategy on this. 
