### PR TITLE
GH-1317 escapeUnicode param passed through correctly

### DIFF
--- a/rio/ntriples/pom.xml
+++ b/rio/ntriples/pom.xml
@@ -1,7 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
@@ -39,6 +41,17 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtil.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtil.java
@@ -221,7 +221,7 @@ public class NTriplesUtil {
 		if (value instanceof Resource) {
 			append((Resource) value, appendable);
 		} else if (value instanceof Literal) {
-			append((Literal) value, appendable, xsdStringToPlainLiteral);
+			append((Literal) value, appendable, xsdStringToPlainLiteral, escapeUnicode);
 		} else {
 			throw new IllegalArgumentException("Unknown value type: " + value.getClass());
 		}
@@ -323,7 +323,7 @@ public class NTriplesUtil {
 	public static String toNTriplesString(Literal lit, boolean xsdStringToPlainLiteral) {
 		try {
 			StringBuilder sb = new StringBuilder();
-			append(lit, sb, xsdStringToPlainLiteral);
+			append(lit, sb, xsdStringToPlainLiteral, NTriplesWriterSettings.ESCAPE_UNICODE.getDefaultValue());
 			return sb.toString();
 		} catch (IOException e) {
 			throw new AssertionError();
@@ -333,7 +333,8 @@ public class NTriplesUtil {
 	public static void append(Literal lit, Appendable appendable) throws IOException {
 		// default to false. Users must call new method directly to remove
 		// xsd:string
-		append(lit, appendable, BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL.getDefaultValue());
+		append(lit, appendable, BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL.getDefaultValue(),
+				NTriplesWriterSettings.ESCAPE_UNICODE.getDefaultValue());
 	}
 
 	/**
@@ -344,12 +345,16 @@ public class NTriplesUtil {
 	 * @param appendable              The object to append to.
 	 * @param xsdStringToPlainLiteral True to omit serialising the xsd:string datatype and false to always serialise the
 	 *                                datatype for literals.
+	 * @param escapeUnicode           True to escape non-ascii/non-printable characters using Unicode escapes
+	 *                                (<tt>&#x5C;uxxxx</tt> and <tt>&#x5C;Uxxxxxxxx</tt>), false to print without
+	 *                                escaping.
 	 * @throws IOException
 	 */
-	public static void append(Literal lit, Appendable appendable, boolean xsdStringToPlainLiteral) throws IOException {
+	public static void append(Literal lit, Appendable appendable, boolean xsdStringToPlainLiteral,
+			boolean escapeUnicode) throws IOException {
 		// Do some character escaping on the label:
 		appendable.append("\"");
-		escapeString(lit.getLabel(), appendable);
+		escapeString(lit.getLabel(), appendable, escapeUnicode);
 		appendable.append("\"");
 
 		if (Literals.isLanguageLiteral(lit)) {

--- a/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
+++ b/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
@@ -206,34 +206,7 @@ public class NTriplesWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @throws IOException
 	 */
 	private void writeLiteral(Literal lit) throws IOException {
-		// Do some character escaping on the label:
-		writer.append("\"");
-		writeString(lit.getLabel());
-		writer.append("\"");
-
-		if (Literals.isLanguageLiteral(lit)) {
-			// Append the literal's language
-			writer.append("@");
-			writer.append(lit.getLanguage().get());
-		} else {
-			// SES-1917 : In RDF-1.1, all literals have a type, and if they are not
-			// language literals we display the type for backwards compatibility
-			IRI datatype = lit.getDatatype();
-			if (!datatype.equals(XMLSchema.STRING) || !xsdStringToPlainLiteral) {
-				writer.append("^^");
-				writeIRI(lit.getDatatype());
-			}
-		}
-	}
-
-	/**
-	 * Writes a Unicode string to an N-Triples compatible character sequence. Any special characters are escaped using
-	 * backslashes (<tt>"</tt> becomes <tt>\"</tt>, etc.), and non-ascii/non-printable characters are escaped using
-	 * Unicode escapes (<tt>&#x5C;uxxxx</tt> and <tt>&#x5C;Uxxxxxxxx</tt>) if the writer config is enabled.
-	 *
-	 * @throws IOException
-	 */
-	private void writeString(String label) throws IOException {
-		NTriplesUtil.escapeString(label, writer, escapeUnicode);
+		NTriplesUtil.append(lit, writer, getWriterConfig().get(BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL),
+				escapeUnicode);
 	}
 }

--- a/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtilTest.java
+++ b/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtilTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ntriples;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link NTriplesUtil}
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class NTriplesUtilTest {
+
+	private StringBuilder appendable;
+	private ValueFactory f = SimpleValueFactory.getInstance();
+
+	@Before
+	public void setUp() throws Exception {
+		appendable = new StringBuilder();
+	}
+
+	@Test
+	public void testAppendWithoutEncoding() throws Exception {
+		Literal l = f.createLiteral("Äbc");
+		NTriplesUtil.append(l, appendable, true, false);
+		assertThat(appendable.toString()).isEqualTo("\"Äbc\"");
+	}
+
+	@Test
+	public void testAppendWithEncoding() throws Exception {
+		Literal l = f.createLiteral("Äbc");
+		NTriplesUtil.append(l, appendable, true, true);
+		assertThat(appendable.toString()).isEqualTo("\"\\u00C4bc\"");
+	}
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #1317 .

Briefly describe the changes proposed in this PR:

* NTriplesWriter now uses NTriplesUtil for serializing literals
* `escapeUnicode` param now correctly passed down through overloaded methods. 
* added regression tests. 
