### PR TITLE
eclipse/rdf4j#1389 new rdf4j protocol op for repo creation

### DIFF
--- a/http/client/pom.xml
+++ b/http/client/pom.xml
@@ -87,6 +87,25 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-binary</artifactId>
+			<scope>test</scope>
+			<version>${project.version}</version>
+		</dependency>
+
 	</dependencies>
 	<build>
 		<plugins>

--- a/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
+++ b/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
@@ -289,8 +289,7 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 	 * @throws IOException
 	 * @throws RepositoryException
 	 */
-	public void createRepository(RepositoryConfig config)
-			throws IOException, RepositoryException {
+	public void createRepository(RepositoryConfig config) throws IOException, RepositoryException {
 		String baseURI = Protocol.getRepositoryLocation(serverURL, config.getID());
 		setRepository(baseURI);
 		Resource ctx = SimpleValueFactory.getInstance().createIRI(baseURI + "#" + config.getID());

--- a/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
+++ b/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.protocol.HttpContext;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link RDF4JProtocolSession}
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class RDF4JProtocolSessionTest {
+
+	private RDF4JProtocolSession subject;
+	private HttpClient client;
+
+	@Before
+	public void setUp() throws Exception {
+		client = mock(HttpClient.class);
+		HttpResponse response = mock(HttpResponse.class);
+
+		when(client.execute(any(HttpUriRequest.class), any(HttpContext.class))).thenReturn(response);
+		when(response.getEntity()).thenReturn(mock(HttpEntity.class));
+		when(response.getStatusLine()).thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK"));
+		ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+		subject = new RDF4JProtocolSession(client, executor);
+		subject.setServerURL("http://example.org/");
+	}
+
+	@Test
+	public void testCreateRepositoryExecutesPut() throws Exception {
+		RepositoryConfig config = new RepositoryConfig("test");
+		subject.createRepository(config);
+		verify(client, times(1)).execute(any(HttpPut.class), any(HttpContext.class));
+	}
+
+}

--- a/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
+++ b/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
@@ -77,7 +77,7 @@ public abstract class Protocol {
 	/**
 	 * Protocol version.
 	 */
-	public static final String VERSION = "8";
+	public static final String VERSION = "9";
 
 	/**
 	 * Parameter name for the 'subject' parameter of a statement query.

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
-				<version>3.0.1</version>
+				<version>3.1.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>

--- a/repository/manager/pom.xml
+++ b/repository/manager/pom.xml
@@ -74,7 +74,7 @@
 			<artifactId>rdf4j-repository-sail</artifactId>
 			<!-- we use a fixed version for testing purposes -->
 			<!-- FIXME this dependency should be stubbed/mocked: https://github.com/eclipse/rdf4j/issues/1263 -->
-			<version>2.4.3</version>
+			<version>2.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -82,7 +82,7 @@
 			<artifactId>rdf4j-sail-memory</artifactId>
 			<!-- we use a fixed version for testing purposes -->
 			<!-- FIXME this dependency should be stubbed/mocked: https://github.com/eclipse/rdf4j/issues/1263 -->
-			<version>2.4.3</version>
+			<version>2.5.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -98,6 +98,30 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
+			<version>2.23.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
+++ b/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
@@ -286,7 +286,7 @@ public class RemoteRepositoryManager extends RepositoryManager {
 			httpClient.setUsernameAndPassword(username, password);
 
 			int serverProtocolVersion = Integer.parseInt(httpClient.getServerProtocol());
-			if (serverProtocolVersion < Integer.parseInt(Protocol.VERSION)) {
+			if (serverProtocolVersion < 9) { // explicit PUT create operation was introduced in Protocol version 9
 				String baseURI = Protocol.getRepositoryLocation(serverURL, config.getID());
 				Resource ctx = SimpleValueFactory.getInstance().createIRI(baseURI + "#" + config.getID());
 				httpClient.setRepository(Protocol.getRepositoryLocation(serverURL, SystemRepository.ID));

--- a/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
+++ b/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
@@ -49,29 +49,26 @@ public class RemoteRepositoryManagerTest extends RepositoryManagerTest {
 	public void testAddRepositoryConfig() throws Exception {
 		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/protocol"))
 				.willReturn(aResponse().withStatus(200).withBody(Protocol.VERSION)));
-		wireMockRule.stubFor(put(urlEqualTo("/rdf4j-server/repositories/test"))
-				.willReturn(aResponse()
-						.withStatus(204)));
+		wireMockRule
+				.stubFor(put(urlEqualTo("/rdf4j-server/repositories/test")).willReturn(aResponse().withStatus(204)));
 
 		RepositoryConfig config = new RepositoryConfig("test");
 
 		subject.addRepositoryConfig(config);
 
-		wireMockRule.verify(putRequestedFor(urlEqualTo("/rdf4j-server/repositories/test"))
-				.withRequestBody(matching("^BRDF.*"))
-				.withHeader("Content-Type", equalTo("application/x-binary-rdf")));
+		wireMockRule.verify(
+				putRequestedFor(urlEqualTo("/rdf4j-server/repositories/test")).withRequestBody(matching("^BRDF.*"))
+						.withHeader("Content-Type", equalTo("application/x-binary-rdf")));
 	}
 
 	@Test
 	public void testAddRepositoryConfigLegacy() throws Exception {
-		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/protocol"))
-				.willReturn(aResponse().withStatus(200).withBody("8")));
+		wireMockRule.stubFor(
+				get(urlEqualTo("/rdf4j-server/protocol")).willReturn(aResponse().withStatus(200).withBody("8")));
 		wireMockRule.stubFor(post(urlPathEqualTo("/rdf4j-server/repositories/SYSTEM/statements"))
-				.willReturn(aResponse()
-						.withStatus(204)));
+				.willReturn(aResponse().withStatus(204)));
 		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/repositories"))
-				.willReturn(aResponse()
-						.withHeader("Content-type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
+				.willReturn(aResponse().withHeader("Content-type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
 						.withBodyFile("repository-list-response.srx")
 						.withStatus(200)));
 

--- a/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
+++ b/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
@@ -7,7 +7,25 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.manager;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 /**
  * Unit tests for {@link RemoteRepositoryManager}
@@ -17,9 +35,52 @@ import org.junit.Before;
  */
 public class RemoteRepositoryManagerTest extends RepositoryManagerTest {
 
+	@ClassRule
+	public static WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructor defaults to port 8080
+
 	@Override
 	@Before
 	public void setUp() {
-		subject = new RemoteRepositoryManager("http://example.org/non/existent");
+		subject = new RemoteRepositoryManager("http://localhost:8089/rdf4j-server");
+		wireMockRule.resetAll();
+	}
+
+	@Test
+	public void testAddRepositoryConfig() throws Exception {
+		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/protocol"))
+				.willReturn(aResponse().withStatus(200).withBody(Protocol.VERSION)));
+		wireMockRule.stubFor(put(urlEqualTo("/rdf4j-server/repositories/test"))
+				.willReturn(aResponse()
+						.withStatus(204)));
+
+		RepositoryConfig config = new RepositoryConfig("test");
+
+		subject.addRepositoryConfig(config);
+
+		wireMockRule.verify(putRequestedFor(urlEqualTo("/rdf4j-server/repositories/test"))
+				.withRequestBody(matching("^BRDF.*"))
+				.withHeader("Content-Type", equalTo("application/x-binary-rdf")));
+	}
+
+	@Test
+	public void testAddRepositoryConfigLegacy() throws Exception {
+		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/protocol"))
+				.willReturn(aResponse().withStatus(200).withBody("8")));
+		wireMockRule.stubFor(post(urlPathEqualTo("/rdf4j-server/repositories/SYSTEM/statements"))
+				.willReturn(aResponse()
+						.withStatus(204)));
+		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/repositories"))
+				.willReturn(aResponse()
+						.withHeader("Content-type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
+						.withBodyFile("repository-list-response.srx")
+						.withStatus(200)));
+
+		RepositoryConfig config = new RepositoryConfig("test");
+
+		subject.addRepositoryConfig(config);
+
+		wireMockRule.verify(postRequestedFor(urlPathEqualTo("/rdf4j-server/repositories/SYSTEM/statements"))
+				.withRequestBody(matching("^BRDF.*"))
+				.withHeader("Content-Type", equalTo("application/x-binary-rdf")));
 	}
 }

--- a/repository/manager/src/test/resources/__files/repository-list-response.srx
+++ b/repository/manager/src/test/resources/__files/repository-list-response.srx
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sparql xmlns='http://www.w3.org/2005/sparql-results#'>
+  <head>
+         <variable name='uri'/>
+         <variable name='id'/>
+         <variable name='title'/>
+         <variable name='readable'/>
+         <variable name='writable'/>
+  </head>
+  <results ordered='false' distinct='false'>
+         <result>
+                <binding name='uri'>
+                  <uri>http://localhost/rdf4j-server/repositories/mem-rdf</uri>
+                </binding>
+                <binding name='id'>
+                  <literal>mem-rdf</literal>
+                </binding>
+                <binding name='title'>
+                  <literal>Main Memory RDF repository</literal>
+                </binding>
+                <binding name='readable'>
+                  <literal datatype='http://www.w3.org/2001/XMLSchema#boolean'>true</literal>
+                </binding>
+                <binding name='writable'>
+                  <literal datatype='http://www.w3.org/2001/XMLSchema#boolean'>false</literal>
+                </binding>
+         </result>
+  </results>
+</sparql>


### PR DESCRIPTION
This PR addresses GitHub issue: #1389 .

Briefly describe the changes proposed in this PR:

* added `createRepository` to `RDF4JProtocolSession`
* `RemoteRepositoryManager` now uses new endpoint for repo creation
* bumped RDF4J REST Protocol version number
