### PR TITLE
GH-389 bug fix in W3C DAWG test parsing

### DIFF
--- a/query/src/main/java/org/eclipse/rdf4j/query/dawg/DAWGTestResultSetParser.java
+++ b/query/src/main/java/org/eclipse/rdf4j/query/dawg/DAWGTestResultSetParser.java
@@ -134,7 +134,7 @@ public class DAWGTestResultSetParser extends AbstractRDFHandler {
 	private Binding getBinding(Resource bindingNode) {
 		Literal name = Models.getPropertyLiteral(graph, bindingNode, VARIABLE)
 				.orElseThrow(() -> new RDFHandlerException("missing variable name for binding " + bindingNode));
-		Value value = Models.getPropertyLiteral(graph, bindingNode, VALUE)
+		Value value = Models.getProperty(graph, bindingNode, VALUE)
 				.orElseThrow(() -> new RDFHandlerException("missing variable value for binding " + bindingNode));
 		return new SimpleBinding(name.getLabel(), value);
 	}


### PR DESCRIPTION
This PR addresses GitHub issue: #389  .

Briefly describe the changes proposed in this PR:

* bugfix in the DAWG result processor which caused 144 W3C compliance tests to fail.
