### PR TITLE
GH-1124 update to jetty 9.4 / servlet api 3.1

### DIFF
--- a/compliance/repository/pom.xml
+++ b/compliance/repository/pom.xml
@@ -17,7 +17,7 @@
 	<description>Compliance testing for the Repository API implementations</description>
 
 	<properties>
-		<jetty.version>7.0.2.v20100331</jetty.version>
+		<jetty.version>9.4.19.v20190610</jetty.version>
 	</properties>
 
 	<dependencies>
@@ -72,13 +72,6 @@
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
 			<version>${jetty.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty-jsp-2.1</artifactId>
-			<version>${jetty.version}</version>
-			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPMemServer.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPMemServer.java
@@ -10,9 +10,7 @@ package org.eclipse.rdf4j.repository.http;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.nio.BlockingChannelConnector;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.repository.Repository;
@@ -29,7 +27,7 @@ public class HTTPMemServer {
 
 	private static final String HOST = "localhost";
 
-	private static final int PORT = 18080;
+	private static final int PORT = 18081;
 
 	private static final String TEST_REPO_ID = "Test";
 
@@ -48,17 +46,9 @@ public class HTTPMemServer {
 	public HTTPMemServer() {
 		System.clearProperty("DEBUG");
 
-		jetty = new Server();
-
-		Connector conn = new BlockingChannelConnector();
-		conn.setHost(HOST);
-		conn.setPort(PORT);
-		jetty.addConnector(conn);
+		jetty = new Server(PORT);
 
 		WebAppContext webapp = new WebAppContext();
-		// TODO temporarily disabled so the integration test server shows server-side logging.
-		// webapp.addSystemClass("org.slf4j.");
-		// webapp.addSystemClass("ch.qos.logback.");
 		webapp.setContextPath(RDF4J_CONTEXT);
 		// warPath configured in pom.xml maven-war-plugin configuration
 		webapp.setWar("./target/rdf4j-server");


### PR DESCRIPTION
This PR addresses GitHub issue: #1124  .

Briefly describe the changes proposed in this PR:

* bumped version of jetty used by compliance tests to 9.4.

Reason this is necessary is that Rdf4j Server now uses servlet api 3.1, and is no longer compatible with our ancient version of Jetty (which still used servlet api 2.5). 
