### PR TITLE
allow optional injection of ValueFactory in RDFCollections

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -36,6 +36,16 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/model/src/test/java/org/eclipse/rdf4j/model/util/RDFCollectionsTest.java
+++ b/model/src/test/java/org/eclipse/rdf4j/model/util/RDFCollectionsTest.java
@@ -11,6 +11,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,6 +100,14 @@ public class RDFCollectionsTest {
 		} catch (ModelException e) {
 			// fall through, expected
 		}
+	}
+
+	@Test
+	public void testInjectedValueFactoryIsUsed() {
+		Resource head = vf.createBNode();
+		ValueFactory injected = mock(SimpleValueFactory.class, CALLS_REAL_METHODS);
+		RDFCollections.asRDF(values, head, new TreeModel(), injected);
+		verify(injected, atLeastOnce()).createStatement(any(), any(), any());
 	}
 
 	@Test


### PR DESCRIPTION
This PR addresses GitHub issue: #1348 .

Briefly describe the changes proposed in this PR:

* overload `asRDF()` and `consumeCollection` to accept optional `ValueFactory`.
* added regression test

