### PR TITLE
Fixed javadoc errors/NPE in maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,9 @@
 								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<source>8</source>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -161,6 +164,9 @@
 								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<source>8</source>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/query/src/main/java/org/eclipse/rdf4j/query/GraphQueryResult.java
+++ b/query/src/main/java/org/eclipse/rdf4j/query/GraphQueryResult.java
@@ -25,7 +25,7 @@ public interface GraphQueryResult extends QueryResult<Statement> {
 	 * The contents of the Map may be modified after it is returned, as the initial return may be performed when the
 	 * first RDF Statement is encountered.
 	 * 
-	 * @return a Map<String, String> object containing (prefix, namespace) pairs.
+	 * @return a Map&lt;String, String&gt; object containing (prefix, namespace) pairs.
 	 * @throws QueryEvaluationException
 	 */
 	public Map<String, String> getNamespaces() throws QueryEvaluationException;

--- a/query/src/main/java/org/eclipse/rdf4j/query/Operation.java
+++ b/query/src/main/java/org/eclipse/rdf4j/query/Operation.java
@@ -77,10 +77,10 @@ public interface Operation {
 	/**
 	 * Specifies the maximum time that an operation is allowed to run. The operation will be interrupted when it exceeds
 	 * the time limit. Any consecutive requests to fetch query results will result in {@link QueryInterruptedException}s
-	 * or {@link UpdateInterruptedException}s (depending on whether the operation is a query or an update).
+	 * or {@link UpdateExecutionException}s (depending on whether the operation is a query or an update).
 	 * 
-	 * @param maxQueryTime The maximum query time, measured in seconds. A negative or zero value indicates an unlimited
-	 *                     execution time (which is the default).
+	 * @param maxExecTime The maximum query time, measured in seconds. A negative or zero value indicates an unlimited
+	 *                    execution time (which is the default).
 	 */
 	public void setMaxExecutionTime(int maxExecTime);
 

--- a/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
+++ b/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
@@ -59,8 +59,8 @@ public class QueryResults extends Iterations {
 	 * Get a {@link Model} containing all elements obtained from the specified query result.
 	 * 
 	 * @param iteration the source iteration to get the statements from. This can be a {@link GraphQueryResult}, a
-	 *                  {@link RepositoryResult<Statement>}, or any other instance of {@link CloseableIteration
-	 *                  <Statement>}
+	 *                  {@link RepositoryResult&lt;Statement&gt;}, or any other instance of {@link CloseableIteration
+	 *                  &lt;Statement&gt;}
 	 * @return a {@link Model} containing all statements obtained from the specified source iteration.
 	 */
 	public static Model asModel(CloseableIteration<? extends Statement, ? extends RDF4JException> iteration)

--- a/util/src/main/java/org/eclipse/rdf4j/common/lang/FileFormat.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/lang/FileFormat.java
@@ -299,7 +299,6 @@ public class FileFormat {
 	 * @param mimeType    A MIME type, e.g. "text/plain".
 	 * @param fileFormats The file formats to match the MIME type against.
 	 * @return A FileFormat object if the MIME type was recognized, or {@link Optional#empty()} otherwise.
-	 * @see #matchMIMEType(String, Iterable, FileFormat)
 	 */
 	public static <FF extends FileFormat> Optional<FF> matchMIMEType(String mimeType, Iterable<FF> fileFormats) {
 		// First try to match with the default MIME type
@@ -325,7 +324,6 @@ public class FileFormat {
 	 * @param fileName    A file name.
 	 * @param fileFormats The file formats to match the file name extension against.
 	 * @return A FileFormat that matches the file name extension, or {@link Optional#empty()} otherwise.
-	 * @see #matchFileName(String, Iterable, FileFormat)
 	 */
 	public static <FF extends FileFormat> Optional<FF> matchFileName(String fileName, Iterable<FF> fileFormats) {
 		// Strip any directory info from the file name

--- a/util/src/main/java/org/eclipse/rdf4j/common/lang/service/FileFormatServiceRegistry.java
+++ b/util/src/main/java/org/eclipse/rdf4j/common/lang/service/FileFormatServiceRegistry.java
@@ -28,7 +28,6 @@ public abstract class FileFormatServiceRegistry<FF extends FileFormat, S> extend
 	 * 
 	 * @param mimeType A MIME type, e.g. "text/plain".
 	 * @return The matching {@link FileFormat}, or {@link Optional#empty()} if no match was found.
-	 * @see #getFileFormatForMIMEType(String, FileFormat)
 	 */
 	public Optional<FF> getFileFormatForMIMEType(String mimeType) {
 		return FileFormat.matchMIMEType(mimeType, this.getKeys());
@@ -39,7 +38,6 @@ public abstract class FileFormatServiceRegistry<FF extends FileFormat, S> extend
 	 * 
 	 * @param fileName A file name.
 	 * @return The matching {@link FileFormat}, or {@link Optional#empty()} if no match was found.
-	 * @see #getFileFormatForFileName(String, FileFormat)
 	 */
 	public Optional<FF> getFileFormatForFileName(String fileName) {
 		return FileFormat.matchFileName(fileName, this.getKeys());


### PR DESCRIPTION
This PR addresses GitHub issue: #1148 .

Briefly describe the changes proposed in this PR:

* Fixed javadoc issues preventing mvn -Passembly install with jdk11 (errors), adding source parameter as suggested in https://bugs.openjdk.java.net/browse/JDK-8212233
* Fixed unescaped LT/GT:  some jdk9+ javadoc versions seem to be more sensitive/crash-prone an can NPE on things like unescaped &lt;...&gt; (generics, see https://bugs.openjdk.java.net/browse/JDK-8181854), e.g. JDK 11.0.4 on Debian ARMv8
 