### PR TITLE
Issues/#1148 jdk11 javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,15 +192,6 @@
 				<module>compliance</module>
 			</modules>
 		</profile>
-		<profile>
-			<id>doclint-java8-disable</id>
-			<activation>
-				<jdk>[1.8,9,)</jdk>
-			</activation>
-			<properties>
-				<javadoc.opts>-Xdoclint:none</javadoc.opts>
-			</properties>
-		</profile>
 	</profiles>
 
 	<properties>


### PR DESCRIPTION
This PR addresses GitHub issue: #1148 .

Briefly describe the changes proposed in this PR:

* Seems like the -Xdoclint:none is not needed (or not anymore, at least not on JDK11), though there are some warnings
