### PR TITLE
Fix for NPE with malformed PREFIX query

### DIFF
--- a/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/parser/QueryPrologLexer.java
+++ b/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/parser/QueryPrologLexer.java
@@ -158,6 +158,9 @@ public class QueryPrologLexer {
 			case 'P':
 				// read PREFIX
 				String prefix = readPrefix(input, i);
+				if (prefix == null) {
+					prefix = ""; // prevent NPE on bad input
+				}
 				i = i + prefix.length() + 7; // 6 for prefix keyword, 1 for ':'
 				break;
 			case 'b':
@@ -167,6 +170,9 @@ public class QueryPrologLexer {
 			case '<':
 				// read IRI
 				String iri = readIRI(input, i);
+				if (iri == null) {
+					iri = ""; // prevent NPE on bad input
+				}
 				i += iri.length() + 2; // 2 for opening and closing brackets
 				break;
 			default:

--- a/core/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryPrologLexerTest.java
+++ b/core/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryPrologLexerTest.java
@@ -162,4 +162,13 @@ public class QueryPrologLexerTest {
 			fail("malformed query should not make lexer fail");
 		}
 	}
+	
+	@Test
+	public void testFinalTokenSyntaxErrorPrefix() {
+		try {
+			Token t = QueryPrologLexer.getRestOfQueryToken("PREFIX");
+		} catch (Exception e) {
+			fail("Malformed query should not make lexer throw Exception");
+		}	
+	}
 }

--- a/core/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryPrologLexerTest.java
+++ b/core/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryPrologLexerTest.java
@@ -162,13 +162,13 @@ public class QueryPrologLexerTest {
 			fail("malformed query should not make lexer fail");
 		}
 	}
-	
+
 	@Test
 	public void testFinalTokenSyntaxErrorPrefix() {
 		try {
 			Token t = QueryPrologLexer.getRestOfQueryToken("PREFIX");
 		} catch (Exception e) {
 			fail("Malformed query should not make lexer throw Exception");
-		}	
+		}
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #1511 .

Briefly describe the changes proposed in this PR:

* Make sure the QueryPrologLexer.getRestOfQueryToken does not throw NPE (e.g. when just entering "PREFIX" in the console, without anything else).

Workaround is to just use an empty string (which should be OK because the method  - with any input - does not guarantee that the returned string is syntactically correct).

 
