### PR TITLE
Added history feature and settings

### DIFF
--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/ConsoleIO.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/ConsoleIO.java
@@ -10,12 +10,16 @@ package org.eclipse.rdf4j.console;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.rio.RDFParseException;
 
 import org.jline.reader.EndOfFileException;
+import org.jline.reader.History;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.impl.history.DefaultHistory;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 
@@ -45,7 +49,7 @@ public class ConsoleIO {
 	 */
 	public ConsoleIO(InputStream input, OutputStream out, ConsoleState info) throws IOException {
 		this.terminal = TerminalBuilder.builder().system(false).streams(input, out).build();
-		this.input = LineReaderBuilder.builder().terminal(terminal).build();
+		this.input = buildLineReader();
 		this.appInfo = info;
 	}
 
@@ -57,8 +61,32 @@ public class ConsoleIO {
 	 */
 	public ConsoleIO(ConsoleState info) throws IOException {
 		this.terminal = TerminalBuilder.terminal();
-		this.input = LineReaderBuilder.builder().terminal(terminal).build();
+		this.input = buildLineReader();
 		this.appInfo = info;
+	}
+
+	/**
+	 * Build JLine line reader with default history
+	 * 
+	 * @return line reader
+	 */
+	private LineReader buildLineReader() {
+		History history = new DefaultHistory();
+		LineReader reader = LineReaderBuilder.builder().terminal(this.terminal).history(history).build();
+
+		Path file = Paths.get(appInfo.getDataDirectory().toString(), "history.txt");
+		reader.setVariable(LineReader.HISTORY_FILE, file);
+
+		return reader;
+	}
+
+	/**
+	 * Get the JLine line reader
+	 * 
+	 * @return line reader
+	 */
+	public LineReader getLineReader() {
+		return this.input;
 	}
 
 	/**

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/ConsoleIO.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/ConsoleIO.java
@@ -73,8 +73,10 @@ public class ConsoleIO {
 	private LineReader buildLineReader() {
 		History history = new DefaultHistory();
 		LineReader reader = LineReaderBuilder.builder().terminal(this.terminal).history(history).build();
+
 		Path file = Paths.get(appInfo.getDataDirectory().toString(), "history.txt");
 		reader.setVariable(LineReader.HISTORY_FILE, file);
+
 		return reader;
 	}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/ConsoleIO.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/ConsoleIO.java
@@ -49,8 +49,8 @@ public class ConsoleIO {
 	 */
 	public ConsoleIO(InputStream input, OutputStream out, ConsoleState info) throws IOException {
 		this.terminal = TerminalBuilder.builder().system(false).streams(input, out).build();
-		this.input = buildLineReader();
 		this.appInfo = info;
+		this.input = buildLineReader();
 	}
 
 	/**
@@ -61,8 +61,8 @@ public class ConsoleIO {
 	 */
 	public ConsoleIO(ConsoleState info) throws IOException {
 		this.terminal = TerminalBuilder.terminal();
-		this.input = buildLineReader();
 		this.appInfo = info;
+		this.input = buildLineReader();
 	}
 
 	/**
@@ -73,10 +73,8 @@ public class ConsoleIO {
 	private LineReader buildLineReader() {
 		History history = new DefaultHistory();
 		LineReader reader = LineReaderBuilder.builder().terminal(this.terminal).history(history).build();
-
 		Path file = Paths.get(appInfo.getDataDirectory().toString(), "history.txt");
 		reader.setVariable(LineReader.HISTORY_FILE, file);
-
 		return reader;
 	}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Close.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Close.java
@@ -37,7 +37,7 @@ public class Close extends ConsoleCommand {
 	 * Constructor
 	 * 
 	 * @param consoleIO
-	 * @param appInfo
+	 * @param state
 	 */
 	public Close(ConsoleIO consoleIO, ConsoleState state) {
 		super(consoleIO, state);

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
@@ -12,7 +12,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.console.ConsoleIO;

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -29,8 +29,6 @@ import java.util.regex.Pattern;
 
 import org.eclipse.rdf4j.common.io.UncloseableOutputStream;
 
-import org.eclipse.rdf4j.console.ConsoleIO;
-import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
 import org.eclipse.rdf4j.console.setting.ConsoleWidth;
 import org.eclipse.rdf4j.console.setting.Prefixes;
@@ -118,39 +116,39 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	protected abstract void addQueryPrefixes(StringBuffer result, Collection<Namespace> namespaces);
 
 	/**
-	 * Get console width setting Use a new console width setting when not found.
+	 * Get console width setting.
 	 * 
-	 * @return boolean
+	 * @return width in columns
 	 */
 	private int getConsoleWidth() {
-		return ((ConsoleWidth) settings.getOrDefault(ConsoleWidth.NAME, new ConsoleWidth())).get();
+		return ((ConsoleWidth) settings.get(ConsoleWidth.NAME)).get();
 	}
 
 	/**
-	 * Get query prefix setting Use a new query prefix setting when not found.
+	 * Get query prefix setting.
 	 * 
-	 * @return boolean
+	 * @return true if prefixes are used for querying
 	 */
 	private boolean getQueryPrefix() {
-		return ((QueryPrefix) settings.getOrDefault(QueryPrefix.NAME, new QueryPrefix())).get();
+		return ((QueryPrefix) settings.get(QueryPrefix.NAME)).get();
 	}
 
 	/**
-	 * Get show prefix setting Use a new show prefix setting when not found.
+	 * Get show prefix setting.
 	 * 
-	 * @return boolean
+	 * @return true if prefixes are used for displaying.
 	 */
 	private boolean getShowPrefix() {
-		return ((ShowPrefix) settings.getOrDefault(ShowPrefix.NAME, new ShowPrefix())).get();
+		return ((ShowPrefix) settings.get(ShowPrefix.NAME)).get();
 	}
 
 	/**
-	 * Get a set of namespaces Use a list of default namespaces when not found.
+	 * Get a set of namespaces
 	 * 
-	 * @return boolean
+	 * @return set of namespace prefixes
 	 */
 	private Set<Namespace> getPrefixes() {
-		return ((Prefixes) settings.getOrDefault(Prefixes.NAME, new Prefixes())).get();
+		return ((Prefixes) settings.get(Prefixes.NAME)).get();
 	}
 
 	/**
@@ -159,7 +157,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	 * @return path of working dir
 	 */
 	private Path getWorkDir() {
-		return ((WorkDir) settings.getOrDefault(WorkDir.NAME, new WorkDir())).get();
+		return ((WorkDir) settings.get(WorkDir.NAME)).get();
 	}
 
 	/**

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Serql.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Serql.java
@@ -9,8 +9,6 @@ package org.eclipse.rdf4j.console.command;
 
 import java.util.Collection;
 
-import org.eclipse.rdf4j.console.ConsoleIO;
-import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.query.parser.serql.SeRQLUtil;
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Sparql.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Sparql.java
@@ -9,8 +9,6 @@ package org.eclipse.rdf4j.console.command;
 
 import java.util.Collection;
 
-import org.eclipse.rdf4j.console.ConsoleIO;
-import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLUtil;
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/TupleAndGraphQueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/TupleAndGraphQueryEvaluator.java
@@ -135,7 +135,7 @@ public class TupleAndGraphQueryEvaluator {
 			}
 		}
 		long endTime = System.nanoTime();
-		consoleIO.writeln(resultCount + " result(s) (" + (endTime - startTime) / 1000000 + " ms)");
+		consoleIO.writeln(resultCount + " result(s) (" + (endTime - startTime) / 1_000_000 + " ms)");
 	}
 
 	/**

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/setting/SaveHistory.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/setting/SaveHistory.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.console.setting;
+
+/**
+ * Save command history to a file.
+ * 
+ * @author Bart Hanssens
+ */
+public class SaveHistory extends ConsoleSetting<Boolean> {
+	public final static String NAME = "savehistory";
+
+	@Override
+	public String getHelpLong() {
+		return "set saveHistory=<true|false>   Toggles saving of command history to a file\n";
+	}
+
+	/**
+	 * Constructor
+	 */
+	public SaveHistory() {
+		super(true);
+	}
+
+	/**
+	 * Constructor
+	 * 
+	 * @param initValue
+	 */
+	public SaveHistory(Boolean initValue) {
+		super(initValue);
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public void setFromString(String value) throws IllegalArgumentException {
+		set(Boolean.valueOf(value));
+	}
+}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/ConsoleIOTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/ConsoleIOTest.java
@@ -15,9 +15,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.mockito.Mockito.when;
 
 public class ConsoleIOTest {
+	@Rule
+	public final TemporaryFolder LOCATION = new TemporaryFolder();
 
 	private ConsoleIO io;
 
@@ -26,6 +31,8 @@ public class ConsoleIOTest {
 		InputStream input = mock(InputStream.class);
 		OutputStream out = mock(OutputStream.class);
 		ConsoleState info = mock(ConsoleState.class);
+		when(info.getDataDirectory()).thenReturn(LOCATION.getRoot());
+
 		io = new ConsoleIO(input, out, info);
 	}
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
@@ -17,11 +17,19 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
+import org.eclipse.rdf4j.console.setting.ConsoleSetting;
+import org.eclipse.rdf4j.console.setting.ConsoleWidth;
+import org.eclipse.rdf4j.console.setting.Prefixes;
+import org.eclipse.rdf4j.console.setting.QueryPrefix;
+import org.eclipse.rdf4j.console.setting.ShowPrefix;
+import org.eclipse.rdf4j.console.setting.WorkDir;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
@@ -40,7 +48,10 @@ import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 
 import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -59,6 +70,9 @@ public class AbstractCommandTest {
 	@Rule
 	public MockitoRule abstractCommandTestMockitoRule = MockitoJUnit.rule(); // .silent();
 
+	@Rule
+	public final TemporaryFolder LOCATION = new TemporaryFolder();
+
 	protected RepositoryManager manager;
 
 	@Mock
@@ -66,6 +80,16 @@ public class AbstractCommandTest {
 
 	@Mock
 	protected ConsoleState mockConsoleState;
+
+	protected Map<String, ConsoleSetting> defaultSettings = new HashMap<>();
+
+	public void setDefaultSettings() {
+		defaultSettings.put(ConsoleWidth.NAME, new ConsoleWidth());
+		defaultSettings.put(Prefixes.NAME, new Prefixes());
+		defaultSettings.put(QueryPrefix.NAME, new QueryPrefix());
+		defaultSettings.put(ShowPrefix.NAME, new ShowPrefix());
+		defaultSettings.put(WorkDir.NAME, new WorkDir(LOCATION.getRoot().toPath()));
+	}
 
 	@After
 	public void tearDown() throws Exception {

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -11,12 +11,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.eclipse.rdf4j.RDF4JException;
-import org.eclipse.rdf4j.console.setting.ConsoleSetting;
-import org.eclipse.rdf4j.console.setting.WorkDir;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -24,9 +20,7 @@ import org.eclipse.rdf4j.rio.Rio;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertTrue;
 
@@ -45,20 +39,14 @@ public class SparqlTest extends AbstractCommandTest {
 
 	private Sparql sparql;
 
-	@Rule
-	public final TemporaryFolder LOCATION = new TemporaryFolder();
-
 	@Before
 	public void setUp() throws IOException, RDF4JException {
 		manager = new LocalRepositoryManager(LOCATION.getRoot());
-		manager.initialize();
 
 		addRepositories("sparql", MEMORY_MEMBER);
-
-		Map<String, ConsoleSetting> settings = new HashMap<>();
-		settings.put(WorkDir.NAME, new WorkDir(LOCATION.getRoot().toPath()));
-
-		TupleAndGraphQueryEvaluator tqe = new TupleAndGraphQueryEvaluator(mockConsoleIO, mockConsoleState, settings);
+		setDefaultSettings();
+		TupleAndGraphQueryEvaluator tqe = new TupleAndGraphQueryEvaluator(mockConsoleIO, mockConsoleState,
+				defaultSettings);
 		when(mockConsoleState.getRepository()).thenReturn(manager.getRepository(MEMORY_MEMBER));
 
 		sparql = new Sparql(tqe);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test verify command
@@ -46,6 +47,8 @@ public class VerifyTest extends AbstractCommandTest {
 		InputStream input = mock(InputStream.class);
 		OutputStream out = mock(OutputStream.class);
 		ConsoleState info = mock(ConsoleState.class);
+		when(info.getDataDirectory()).thenReturn(LOCATION.getRoot());
+
 		io = new ConsoleIO(input, out, info);
 
 		cmd = new Verify(io);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
@@ -38,6 +38,5 @@ public abstract class AbstractSettingTest {
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);
-		;
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/LogLevelTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/LogLevelTest.java
@@ -29,6 +29,7 @@ public class LogLevelTest extends AbstractSettingTest {
 	private Level originalLevel;
 
 	@Before
+	@Override
 	public void setUp() {
 		originalLevel = ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).getLevel();
 		settings.put(LogLevel.NAME, new LogLevel());


### PR DESCRIPTION
This PR addresses GitHub issue: #1517 .

Briefly describe the changes proposed in this PR:

* Added JLine default command history file, to be saved in Console app config directory
* Added setting to enable/disable command history while console is running (e.g. to when entering a command with user credentials or other sensitive info)
