### PR TITLE
JMH runner ignores lock to avoid parallel builds failing

### DIFF
--- a/core/sail/shacl/pom.xml
+++ b/core/sail/shacl/pom.xml
@@ -107,4 +107,22 @@
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<encoding>UTF-8</encoding>
+					<systemProperties>
+						<property>
+							<name>jmh.ignoreLock</name>
+							<value>true</value>
+						</property>
+					</systemProperties>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>


### PR DESCRIPTION
This PR addresses GitHub issue: #1529  .

Briefly describe the changes proposed in this PR:

* configured surefire plugin set `jmh.ignoreLock` to `true` to avoid benchmark execution failing
* ran local parallel test, seems to solve the issue (but proof is in Jenkins obviously)

