### PR TITLE
Added jakarta dependency javax.annotation

### DIFF
--- a/testsuites/benchmark/pom.xml
+++ b/testsuites/benchmark/pom.xml
@@ -61,6 +61,23 @@
 		</dependency>
     </dependencies>
 
+	<profiles>
+		<profile>
+			<id>jdk9</id>
+			<activation>
+				<jdk>[1.9,9,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>jakarta.annotation</groupId>
+					<artifactId>jakarta.annotation-api</artifactId>
+					<version>1.3.4</version>
+					<scope>compile</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
+
     <properties>
         <jmhVersion>0.9.3</jmhVersion>
     </properties>


### PR DESCRIPTION
This PR addresses GitHub issue: #1148 .

Briefly describe the changes proposed in this PR:

* Added a jdk9+ profile with jakarta/javax.annotation dependency for benchmark

CQ not required, since the jakarta version of javax is part of Jakarta Eclipse EE 8
