### PR TITLE
Added dependencies for javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
 		<jaxb.version>2.3.0</jaxb.version>
 		<solr.version>7.5.0</solr.version>
 		<elasticsearch.version>6.5.4</elasticsearch.version>
+		<servlet.version>3.1.0</servlet.version>
 	</properties>
 
 	<dependencyManagement>
@@ -357,7 +358,7 @@
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
-				<version>3.1.0</version>
+				<version>${servlet.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -166,7 +166,7 @@
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
-				<version>3.1.0</version>
+				<version>${servlet.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>

--- a/tools/runtime/pom.xml
+++ b/tools/runtime/pom.xml
@@ -362,6 +362,33 @@
 					<source>1.8</source>
 					<quiet>true</quiet>
 					<additionalparam>${javadoc.opts}</additionalparam>
+					<additionnalDependencies>
+						<additionnalDependency>
+							<groupId>javax.servlet</groupId>
+							<artifactId>javax.servlet-api</artifactId>
+							<version>${servlet.version}</version>
+						</additionnalDependency>
+						<additionnalDependency>
+							<groupId>org.elasticsearch</groupId>
+							<artifactId>elasticsearch</artifactId>
+							<version>${elasticsearch.version}</version>
+						</additionnalDependency>
+						<additionnalDependency>
+							<groupId>org.elasticsearch</groupId>
+							<artifactId>elasticsearch-x-content</artifactId>
+							<version>${elasticsearch.version}</version>
+						</additionnalDependency>
+						<additionnalDependency>
+							<groupId>org.elasticsearch.client</groupId>
+							<artifactId>transport</artifactId>
+							<version>${elasticsearch.version}</version>
+						</additionnalDependency>
+						<additionnalDependency>
+							<groupId>org.apache.solr</groupId>
+							<artifactId>solr-core</artifactId>
+							<version>${solr.version}</version>
+						</additionnalDependency>
+					</additionnalDependencies>
 					<includeDependencySources>true</includeDependencySources>
 					<dependencySourceIncludes>
 						<dependencySourceIncludes>org.eclipse.rdf4j:*</dependencySourceIncludes>


### PR DESCRIPTION
This PR addresses GitHub issue: #1148 .

Briefly describe the changes proposed in this PR:

* Added additional dependencies to unbreak the JDK11 javadoc /  maven plugin
