### PR TITLE
GH-1518: sparqlbuilder padding of empty string

### DIFF
--- a/core/sparqlbuilder/pom.xml
+++ b/core/sparqlbuilder/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -26,6 +27,16 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtils.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtils.java
@@ -88,8 +88,6 @@ public class SparqlBuilderUtils {
 			if (pad) {
 				es.insert(open.length(), PAD).append(PAD);
 			}
-		} else {
-			es.append(PAD);
 		}
 		es.append(close);
 

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.rdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
+import org.junit.Test;
+
+public class RdfLiteralTest {
+
+	@Test
+	public void emptyStringLiteralIsNotPadded() {
+		StringLiteral literal = new StringLiteral("");
+		assertThat(literal.getQueryString()).isEqualTo("\"\"");
+	}
+	
+	@Test
+	public void simpleStringLiteralIsNotPadded() {
+		StringLiteral literal = new StringLiteral("foo");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\"");
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
@@ -19,7 +19,7 @@ public class RdfLiteralTest {
 		StringLiteral literal = new StringLiteral("");
 		assertThat(literal.getQueryString()).isEqualTo("\"\"");
 	}
-	
+
 	@Test
 	public void simpleStringLiteralIsNotPadded() {
 		StringLiteral literal = new StringLiteral("foo");

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtilsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtilsTest.java
@@ -8,12 +8,10 @@
 package org.eclipse.rdf4j.sparqlbuilder.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
 public class SparqlBuilderUtilsTest {
-
 
 	@Test
 	public void getBracedStringReturnsBracedWithPadding() {
@@ -29,7 +27,7 @@ public class SparqlBuilderUtilsTest {
 	public void getQuotedStringReturnsQuotedNoPadding() {
 		assertThat(SparqlBuilderUtils.getQuotedString("string")).isEqualTo("\"string\"");
 	}
-	
+
 	@Test
 	public void getQuotedStringOnEmptyAddsNoPadding() {
 		assertThat(SparqlBuilderUtils.getQuotedString("")).isEqualTo("\"\"");

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtilsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtilsTest.java
@@ -7,55 +7,37 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sparqlbuilder.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
 public class SparqlBuilderUtilsTest {
 
+
 	@Test
-	public void testGetOrCreateAndModifyOptional() {
-		fail("Not yet implemented");
+	public void getBracedStringReturnsBracedWithPadding() {
+		assertThat(SparqlBuilderUtils.getBracedString("string")).isEqualTo("{ string }");
 	}
 
 	@Test
-	public void testAppendAndNewlineIfPresent() {
-		fail("Not yet implemented");
+	public void getBracketedStringReturnsBracketedWithPadding() {
+		assertThat(SparqlBuilderUtils.getBracketedString("string")).isEqualTo("[ string ]");
 	}
 
 	@Test
-	public void testAppendQueryElementIfPresent() {
-		fail("Not yet implemented");
+	public void getQuotedStringReturnsQuotedNoPadding() {
+		assertThat(SparqlBuilderUtils.getQuotedString("string")).isEqualTo("\"string\"");
+	}
+	
+	@Test
+	public void getQuotedStringOnEmptyAddsNoPadding() {
+		assertThat(SparqlBuilderUtils.getQuotedString("")).isEqualTo("\"\"");
 	}
 
 	@Test
-	public void testAppendStringIfPresent() {
-		fail("Not yet implemented");
-	}
-
-	@Test
-	public void testGetBracedString() {
-		fail("Not yet implemented");
-	}
-
-	@Test
-	public void testGetBracketedString() {
-		fail("Not yet implemented");
-	}
-
-	@Test
-	public void testGetParenthesizedString() {
-		fail("Not yet implemented");
-	}
-
-	@Test
-	public void testGetQuotedString() {
-		fail("Not yet implemented");
-	}
-
-	@Test
-	public void testGetLongQuotedString() {
-		fail("Not yet implemented");
+	public void getLongQuotedStringReturnsTripleSingleQuotes() {
+		assertThat(SparqlBuilderUtils.getLongQuotedString("string")).isEqualTo("'''string'''");
 	}
 
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtilsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtilsTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.util;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class SparqlBuilderUtilsTest {
+
+	@Test
+	public void testGetOrCreateAndModifyOptional() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testAppendAndNewlineIfPresent() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testAppendQueryElementIfPresent() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testAppendStringIfPresent() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testGetBracedString() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testGetBracketedString() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testGetParenthesizedString() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testGetQuotedString() {
+		fail("Not yet implemented");
+	}
+
+	@Test
+	public void testGetLongQuotedString() {
+		fail("Not yet implemented");
+	}
+
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #1518 .

Briefly describe the changes proposed in this PR:

* do not pad empty string literals
* added regression tests and basic setup for more unit testing in sparqlbuilder

