### PR TITLE
Issues/#1510 console workdir

### DIFF
--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/Command.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/Command.java
@@ -22,4 +22,11 @@ public interface Command {
 	 * @throws IOException if a problem occurs reading or writing
 	 */
 	void execute(String... parameters) throws IOException;
+
+	/**
+	 * Return the names of the settings used.
+	 * 
+	 * @return string array of settings
+	 */
+	String[] usesSettings();
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/Console.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/Console.java
@@ -319,13 +319,12 @@ public class Console {
 	 * @throws IOException
 	 */
 	public void start() throws IOException {
-		consoleIO.writeln(APP_CFG.getFullName());
-		consoleIO.writeln();
-		consoleIO.writeln(RDF4J.getVersion());
-		consoleIO.writeln("Type 'help' for help.");
-
 		loadSettings();
 		loadHistory();
+		
+		consoleIO.writeln(APP_CFG.getFullName());
+		consoleIO.writeln("Working dir: " + settingMap.get(WorkDir.NAME).getAsString());
+		consoleIO.writeln("Type 'help' for help.");
 
 		int exitCode = 0;
 		try {

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/Console.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/Console.java
@@ -321,7 +321,7 @@ public class Console {
 	public void start() throws IOException {
 		loadSettings();
 		loadHistory();
-		
+
 		consoleIO.writeln(APP_CFG.getFullName());
 		consoleIO.writeln("Working dir: " + settingMap.get(WorkDir.NAME).getAsString());
 		consoleIO.writeln("Type 'help' for help.");

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/Console.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/Console.java
@@ -239,11 +239,11 @@ public class Console {
 		register(new Create(consoleIO, STATE));
 		register(new Drop(consoleIO, STATE, close));
 		// handling data
-		register(new Verify(consoleIO));
-		register(new Load(consoleIO, STATE));
+		register(new Verify(consoleIO, settingMap));
+		register(new Load(consoleIO, STATE, settingMap));
 		register(new Clear(consoleIO, STATE));
-		register(new Export(consoleIO, STATE));
-		register(new Convert(consoleIO, STATE));
+		register(new Export(consoleIO, STATE, settingMap));
+		register(new Convert(consoleIO, STATE, settingMap));
 		// parameters
 		register(new SetParameters(consoleIO, STATE, settingMap));
 	}

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -110,9 +110,6 @@ public class Util {
 		if (!path.isAbsolute() && (workDir != null)) {
 			path = workDir.resolve(file);
 		}
-		System.err.println(path.toString());
-		System.err.println(path.normalize());
-
 		return path.normalize();
 	}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -13,6 +13,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import org.eclipse.rdf4j.console.setting.WorkDir;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -84,6 +85,32 @@ public class Util {
 			}
 		}
 		return path;
+	}
+
+	/**
+	 * Check if a string looks like a HTTP, HTTPS or file URI.
+	 * 
+	 * @param str string
+	 * @return true if
+	 */
+	public static boolean isHttpOrFile(String str) {
+		String lower = str.toLowerCase();
+		return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("file://");
+	}
+
+	/**
+	 * Get path from file string if it's absolute, or from working directory if the file is relative.
+	 * 
+	 * @param workDir working dir
+	 * @param file    file name
+	 * @return path normalized path
+	 */
+	public static Path getNormalizedPath(Path workDir, String file) {
+		Path path = Paths.get(file);
+		if (!path.isAbsolute() && (workDir != null)) {
+			path = workDir.resolve(file);
+		}
+		return path.normalize();
 	}
 
 	/**

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -13,7 +13,6 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
-import org.eclipse.rdf4j.console.setting.WorkDir;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -111,6 +110,9 @@ public class Util {
 		if (!path.isAbsolute() && (workDir != null)) {
 			path = workDir.resolve(file);
 		}
+		System.err.println(path.toString());
+		System.err.println(path.normalize());
+
 		return path.normalize();
 	}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -73,6 +73,7 @@ public class Util {
 	 * @param file file name
 	 * @return path or null
 	 */
+	@Deprecated
 	public static Path getPath(String file) {
 		Path path = null;
 		try {

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/ConsoleCommand.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/ConsoleCommand.java
@@ -8,11 +8,13 @@
 package org.eclipse.rdf4j.console.command;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.eclipse.rdf4j.console.Help;
 import org.eclipse.rdf4j.console.Command;
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
+import org.eclipse.rdf4j.console.setting.ConsoleSetting;
 
 /**
  * Abstract command
@@ -23,10 +25,12 @@ public abstract class ConsoleCommand implements Command, Help {
 	final ConsoleIO consoleIO;
 	final ConsoleState state;
 
+	final Map<String, ConsoleSetting> settings;
+
 	/**
 	 * Get console IO
 	 * 
-	 * @return
+	 * @return console IO
 	 */
 	public ConsoleIO getConsoleIO() {
 		return this.consoleIO;
@@ -35,10 +39,19 @@ public abstract class ConsoleCommand implements Command, Help {
 	/**
 	 * Get console state
 	 * 
-	 * @return
+	 * @return console state
 	 */
 	public ConsoleState getConsoleState() {
 		return this.state;
+	}
+
+	/**
+	 * Get console settings map
+	 * 
+	 * @return map of console settings
+	 */
+	public Map<String, ConsoleSetting> getConsoleSettings() {
+		return this.settings;
 	}
 
 	/**
@@ -62,8 +75,8 @@ public abstract class ConsoleCommand implements Command, Help {
 	}
 
 	@Override
-	public void execute(String... parameters) throws IOException {
-		throw new UnsupportedOperationException("Not supported yet.");
+	public String[] usesSettings() {
+		return new String[0];
 	}
 
 	/**
@@ -74,6 +87,7 @@ public abstract class ConsoleCommand implements Command, Help {
 	public ConsoleCommand(ConsoleIO consoleIO) {
 		this.consoleIO = consoleIO;
 		this.state = null;
+		this.settings = null;
 	}
 
 	/**
@@ -85,6 +99,24 @@ public abstract class ConsoleCommand implements Command, Help {
 	public ConsoleCommand(ConsoleIO consoleIO, ConsoleState state) {
 		this.consoleIO = consoleIO;
 		this.state = state;
+		this.settings = null;
 	}
 
+	/**
+	 * Constructor
+	 * 
+	 * @param consoleIO console IO
+	 * @param state     console state
+	 * @param settings  console settings
+	 */
+	public ConsoleCommand(ConsoleIO consoleIO, ConsoleState state, Map<String, ConsoleSetting> settings) {
+		this.consoleIO = consoleIO;
+		this.state = state;
+		this.settings = settings;
+	}
+
+	@Override
+	public void execute(String... parameters) throws IOException {
+		throw new UnsupportedOperationException("Not supported yet.");
+	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
@@ -96,7 +96,7 @@ public class Convert extends ConsoleCommand {
 	 */
 	private void convert(String fileFrom, String fileTo) {
 		// check from
-		Path pathFrom = Util.getPath(fileFrom);
+		Path pathFrom = Util.getNormalizedPath(getWorkDir(), fileFrom);
 		if (pathFrom == null) {
 			consoleIO.writeError("Invalid file name (from) " + fileFrom);
 			return;
@@ -112,7 +112,7 @@ public class Convert extends ConsoleCommand {
 		}
 
 		// check to
-		Path pathTo = Util.getPath(fileTo);
+		Path pathTo = Util.getNormalizedPath(getWorkDir(), fileTo);
 		if (pathTo == null) {
 			consoleIO.writeError("Invalid file name (to) " + pathTo);
 			return;

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
@@ -12,11 +12,14 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.Util;
+import org.eclipse.rdf4j.console.setting.ConsoleSetting;
+import org.eclipse.rdf4j.console.setting.WorkDir;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
@@ -51,6 +54,22 @@ public class Convert extends ConsoleCommand {
 	}
 
 	@Override
+	public String[] usesSettings() {
+		return new String[] { WorkDir.NAME };
+	}
+
+	/**
+	 * Constructor
+	 * 
+	 * @param consoleIO
+	 * @param state
+	 * @param settings
+	 */
+	public Convert(ConsoleIO consoleIO, ConsoleState state, Map<String, ConsoleSetting> settings) {
+		super(consoleIO, state, settings);
+	}
+
+	@Override
 	public void execute(String... tokens) {
 		if (tokens.length < 3) {
 			consoleIO.writeln(getHelpLong());
@@ -58,6 +77,15 @@ public class Convert extends ConsoleCommand {
 		}
 
 		convert(tokens[1], tokens[2]);
+	}
+
+	/**
+	 * Get working dir setting.
+	 * 
+	 * @return path of working dir
+	 */
+	private Path getWorkDir() {
+		return ((WorkDir) settings.get(WorkDir.NAME)).get();
 	}
 
 	/**
@@ -124,15 +152,5 @@ public class Convert extends ConsoleCommand {
 		} catch (IOException | RDFParseException | RDFHandlerException e) {
 			consoleIO.writeError("Failed to convert data: " + e.getMessage());
 		}
-	}
-
-	/**
-	 * Constructor
-	 * 
-	 * @param consoleIO
-	 * @param state
-	 */
-	public Convert(ConsoleIO consoleIO, ConsoleState state) {
-		super(consoleIO, state);
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Drop.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Drop.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.console.command;
 
 import java.io.IOException;
+
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.LockRemover;

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
@@ -13,10 +13,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Map;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.Util;
+import org.eclipse.rdf4j.console.setting.ConsoleSetting;
+import org.eclipse.rdf4j.console.setting.WorkDir;
 
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.repository.Repository;
@@ -54,6 +57,22 @@ public class Export extends ConsoleCommand {
 	}
 
 	@Override
+	public String[] usesSettings() {
+		return new String[] { WorkDir.NAME };
+	}
+
+	/**
+	 * Constructor
+	 * 
+	 * @param consoleIO
+	 * @param state
+	 * @param settings
+	 */
+	public Export(ConsoleIO consoleIO, ConsoleState state, Map<String, ConsoleSetting> settings) {
+		super(consoleIO, state, settings);
+	}
+
+	@Override
 	public void execute(String... tokens) {
 		Repository repository = state.getRepository();
 
@@ -76,6 +95,15 @@ public class Export extends ConsoleCommand {
 			return;
 		}
 		export(repository, fileName, contexts);
+	}
+
+	/**
+	 * Get working dir setting.
+	 * 
+	 * @return path of working dir
+	 */
+	private Path getWorkDir() {
+		return ((WorkDir) settings.get(WorkDir.NAME)).get();
 	}
 
 	/**
@@ -123,15 +151,5 @@ public class Export extends ConsoleCommand {
 		} catch (IOException | UnsupportedRDFormatException e) {
 			consoleIO.writeError("Failed to export data: " + e.getMessage());
 		}
-	}
-
-	/**
-	 * Constructor
-	 * 
-	 * @param consoleIO
-	 * @param state
-	 */
-	public Export(ConsoleIO consoleIO, ConsoleState state) {
-		super(consoleIO, state);
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
@@ -115,7 +115,7 @@ public class Export extends ConsoleCommand {
 	 * @throws UnsupportedRDFormatException
 	 */
 	private void export(Repository repository, String fileName, Resource... contexts) {
-		Path path = Util.getPath(fileName);
+		Path path = Util.getNormalizedPath(getWorkDir(), fileName);
 		if (path == null) {
 			consoleIO.writeError("Invalid file name");
 			return;

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/PrintHelp.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/PrintHelp.java
@@ -60,6 +60,13 @@ public class PrintHelp extends ConsoleCommand {
 		Help cmd = commands.get(target);
 		if (cmd != null) {
 			consoleIO.writeln(cmd.getHelpLong());
+			if (cmd instanceof ConsoleCommand) {
+				String[] uses = ((ConsoleCommand) cmd).usesSettings();
+				if (uses.length > 0) {
+					consoleIO.writeln();
+					consoleIO.writeln("Uses settings: " + String.join(", ", uses));
+				}
+			}
 		} else {
 			consoleIO.writeln("No additional info available for command " + target);
 		}

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -231,7 +231,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 		}
 
 		Path p = Util.getNormalizedPath(getWorkDir(), filename);
-		if (!p.toFile().exists() || consoleIO.askProceed("File " + p + " exists", false)) {
+		if (!p.toFile().exists() || consoleIO.askProceed("File exists, continue ?", false)) {
 			return p;
 		}
 		throw new IOException("Could not open file for output");

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -14,7 +14,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 
 import java.util.Arrays;
@@ -28,6 +27,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.rdf4j.common.io.UncloseableOutputStream;
+import org.eclipse.rdf4j.console.Util;
 
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
 import org.eclipse.rdf4j.console.setting.ConsoleWidth;
@@ -115,6 +115,13 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	 */
 	protected abstract void addQueryPrefixes(StringBuffer result, Collection<Namespace> namespaces);
 
+	@Override
+	public String[] usesSettings() {
+		return new String[] { ConsoleWidth.NAME,
+				Prefixes.NAME, QueryPrefix.NAME, ShowPrefix.NAME,
+				WorkDir.NAME };
+	}
+
 	/**
 	 * Get console width setting.
 	 * 
@@ -199,10 +206,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 		}
 		Charset charset = (cset == null || cset.isEmpty()) ? StandardCharsets.UTF_8 : Charset.forName(cset);
 
-		Path p = Paths.get(filename);
-		if (!p.isAbsolute()) {
-			p = getWorkDir().resolve(p);
-		}
+		Path p = Util.getNormalizedPath(getWorkDir(), filename);
 		if (!p.toFile().canRead()) {
 			throw new IOException("Cannot read file " + p);
 		}
@@ -228,11 +232,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 			throw new IllegalArgumentException("Empty file name");
 		}
 
-		Path p = Paths.get(filename);
-		if (!p.isAbsolute()) {
-			p = getWorkDir().resolve(filename);
-		}
-
+		Path p = Util.getNormalizedPath(getWorkDir(), filename);
 		if (!p.toFile().exists() || consoleIO.askProceed("File " + p + " exists", false)) {
 			return p;
 		}

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -75,7 +75,6 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(QueryEvaluator.class);
 
-	private final Map<String, ConsoleSetting> settings;
 	private final TupleAndGraphQueryEvaluator evaluator;
 
 	private final List<String> sparqlQueryStart = Arrays
@@ -94,8 +93,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	 * @param evaluator
 	 */
 	public QueryEvaluator(TupleAndGraphQueryEvaluator evaluator) {
-		super(evaluator.getConsoleIO(), evaluator.getConsoleState());
-		this.settings = evaluator.getConsoleSettings();
+		super(evaluator.getConsoleIO(), evaluator.getConsoleState(), evaluator.getConsoleSettings());
 		this.evaluator = evaluator;
 	}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -13,12 +13,14 @@ import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
 import org.eclipse.rdf4j.IsolationLevels;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
+import org.eclipse.rdf4j.console.Util;
 import org.eclipse.rdf4j.console.VerificationListener;
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
 import org.eclipse.rdf4j.console.setting.WorkDir;
@@ -105,6 +107,15 @@ public class Verify extends ConsoleCommand {
 
 			shacl(dataPath, shaclPath, reportFile);
 		}
+	}
+
+	/**
+	 * Get working dir setting.
+	 * 
+	 * @return path of working dir
+	 */
+	private Path getWorkDir() {
+		return ((WorkDir) settings.get(WorkDir.NAME)).get();
 	}
 
 	/**
@@ -239,15 +250,15 @@ public class Verify extends ConsoleCommand {
 	 * @return URL path as string
 	 */
 	private String parseDataPath(String str) {
-		StringBuilder dataPath = new StringBuilder(str);
+		String path = str;
 		try {
-			new URL(dataPath.toString());
+			new URL(str);
 			// dataPath is a URI
 		} catch (MalformedURLException e) {
 			// File path specified, convert to URL
-			dataPath.insert(0, "file:");
+			path = "file:" + Util.getNormalizedPath(getWorkDir(), str).toString();
 		}
-		return dataPath.toString();
+		return path;
 	}
 
 	/**

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -14,11 +14,14 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Map;
 
 import org.eclipse.rdf4j.IsolationLevels;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.VerificationListener;
+import org.eclipse.rdf4j.console.setting.ConsoleSetting;
+import org.eclipse.rdf4j.console.setting.WorkDir;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
@@ -71,13 +74,19 @@ public class Verify extends ConsoleCommand {
 				+ "Verifies the validity of the specified data file\n";
 	}
 
+	@Override
+	public String[] usesSettings() {
+		return new String[] { WorkDir.NAME };
+	}
+
 	/**
 	 * Constructor
 	 * 
 	 * @param consoleIO
+	 * @param settings
 	 */
-	public Verify(ConsoleIO consoleIO) {
-		super(consoleIO);
+	public Verify(ConsoleIO consoleIO, Map<String, ConsoleSetting> settings) {
+		super(consoleIO, null, settings);
 	}
 
 	@Override

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/setting/WorkDir.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/setting/WorkDir.java
@@ -26,7 +26,7 @@ public class WorkDir extends ConsoleSetting<Path> {
 	/**
 	 * Constructor
 	 * 
-	 * Default dir is "."
+	 * Default dir is system property user.dir (= current directory)
 	 */
 	public WorkDir() {
 		super(Paths.get(System.getProperty("user.dir")));

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
@@ -48,8 +48,6 @@ import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 
 import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
@@ -16,6 +16,7 @@ import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -187,5 +188,15 @@ public class AbstractCommandTest {
 				.stringValue();
 
 		return repId;
+	}
+
+	/**
+	 * Set working dir setting to root of temporarily folder
+	 * 
+	 * @param cmd console command
+	 */
+	protected void setWorkingDir(ConsoleCommand cmd) {
+		WorkDir location = new WorkDir(Paths.get(LOCATION.getRoot().getAbsolutePath()));
+		cmd.settings.put(WorkDir.NAME, location);
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
@@ -17,8 +17,9 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.common.io.IOUtil;
@@ -79,15 +80,13 @@ public class AbstractCommandTest {
 	@Mock
 	protected ConsoleState mockConsoleState;
 
-	protected Map<String, ConsoleSetting> defaultSettings = new HashMap<>();
-
-	public void setDefaultSettings() {
-		defaultSettings.put(ConsoleWidth.NAME, new ConsoleWidth());
-		defaultSettings.put(Prefixes.NAME, new Prefixes());
-		defaultSettings.put(QueryPrefix.NAME, new QueryPrefix());
-		defaultSettings.put(ShowPrefix.NAME, new ShowPrefix());
-		defaultSettings.put(WorkDir.NAME, new WorkDir(LOCATION.getRoot().toPath()));
-	}
+	protected Map<String, ConsoleSetting> defaultSettings = Stream.of(new Object[][] {
+			{ ConsoleWidth.NAME, new ConsoleWidth() },
+			{ Prefixes.NAME, new Prefixes() },
+			{ QueryPrefix.NAME, new QueryPrefix() },
+			{ ShowPrefix.NAME, new ShowPrefix() },
+			{ WorkDir.NAME, new WorkDir() }
+	}).collect(Collectors.toMap(m -> (String) m[0], m -> (ConsoleSetting) m[1]));
 
 	@After
 	public void tearDown() throws Exception {

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -12,20 +12,16 @@ import com.github.jsonldjava.utils.JsonUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.RDF4JException;
-import org.eclipse.rdf4j.console.setting.WorkDir;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertTrue;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,16 +30,13 @@ import static org.mockito.Mockito.when;
  */
 public class ConvertTest extends AbstractCommandTest {
 
-	private Convert convert;
+	private Convert cmd;
 	private File from;
-
-	@Rule
-	public final TemporaryFolder LOCATION = new TemporaryFolder();
 
 	@Before
 	public void prepare() throws IOException, RDF4JException {
 		when(mockConsoleIO.askProceed("File exists, continue ?", false)).thenReturn(Boolean.TRUE);
-		convert = new Convert(mockConsoleIO, mockConsoleState, defaultSettings);
+		cmd = new Convert(mockConsoleIO, mockConsoleState, defaultSettings);
 
 		from = LOCATION.newFile("alien.ttl");
 		copyFromResource("convert/alien.ttl", from);
@@ -58,7 +51,7 @@ public class ConvertTest extends AbstractCommandTest {
 	@Test
 	public final void testConvert() throws IOException {
 		File json = LOCATION.newFile("alien.jsonld");
-		convert.execute("convert", from.getAbsolutePath(), json.getAbsolutePath());
+		cmd.execute("convert", from.getAbsolutePath(), json.getAbsolutePath());
 
 		assertTrue("File is empty", json.length() > 0);
 
@@ -73,11 +66,10 @@ public class ConvertTest extends AbstractCommandTest {
 
 	@Test
 	public final void testConvertWorkDir() throws IOException {
-		WorkDir location = new WorkDir(Paths.get(LOCATION.getRoot().getAbsolutePath()));
-		convert.settings.put(WorkDir.NAME, location);
+		setWorkingDir(cmd);
 
 		File json = LOCATION.newFile("alien.jsonld");
-		convert.execute("convert", from.getName(), json.getName());
+		cmd.execute("convert", from.getName(), json.getName());
 
 		assertTrue("File is empty", json.length() > 0);
 
@@ -96,14 +88,14 @@ public class ConvertTest extends AbstractCommandTest {
 		Files.write(wrong.toPath(), "error".getBytes());
 		File json = LOCATION.newFile("empty.jsonld");
 
-		convert.execute("convert", wrong.toString(), json.toString());
+		cmd.execute("convert", wrong.toString(), json.toString());
 		verify(mockConsoleIO).writeError(anyString());
 	}
 
 	@Test
 	public final void testConvertInvalidFormat() throws IOException {
 		File qyx = LOCATION.newFile("alien.qyx");
-		convert.execute("convert", from.toString(), qyx.toString());
+		cmd.execute("convert", from.toString(), qyx.toString());
 		verify(mockConsoleIO).writeError("No RDF writer for " + qyx.toString());
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import org.eclipse.rdf4j.RDF4JException;
 
 import org.junit.After;
+import static org.junit.Assert.assertFalse;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -90,6 +91,7 @@ public class ConvertTest extends AbstractCommandTest {
 
 		cmd.execute("convert", wrong.toString(), json.toString());
 		verify(mockConsoleIO).writeError(anyString());
+		assertFalse(mockConsoleIO.wasErrorWritten());
 	}
 
 	@Test

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -41,7 +41,7 @@ public class ConvertTest extends AbstractCommandTest {
 	@Before
 	public void prepare() throws IOException, RDF4JException {
 		when(mockConsoleIO.askProceed("File exists, continue ?", false)).thenReturn(Boolean.TRUE);
-		convert = new Convert(mockConsoleIO, mockConsoleState);
+		convert = new Convert(mockConsoleIO, mockConsoleState, defaultSettings);
 
 		from = LOCATION.newFile("alien.ttl");
 		copyFromResource("convert/alien.ttl", from);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -11,9 +11,13 @@ import com.github.jsonldjava.utils.JsonUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.console.setting.WorkDir;
 
 import org.junit.After;
 import org.junit.Before;
@@ -55,6 +59,25 @@ public class ConvertTest extends AbstractCommandTest {
 
 	@Test
 	public final void testConvert() throws IOException {
+		File json = LOCATION.newFile("alien.jsonld");
+		convert.execute("convert", from.getAbsolutePath(), json.getAbsolutePath());
+
+		assertTrue("File is empty", json.length() > 0);
+
+		Object o = null;
+		try {
+			o = JsonUtils.fromInputStream(Files.newInputStream(json.toPath()));
+		} catch (IOException ioe) {
+			//
+		}
+		assertTrue("Invalid JSON", o != null);
+	}
+
+	@Test
+	public final void testConvertWorkDir() throws IOException {
+		WorkDir location = new WorkDir(Paths.get(LOCATION.toString()));
+		convert.settings.put(WorkDir.NAME, location);
+
 		File json = LOCATION.newFile("alien.jsonld");
 		convert.execute("convert", from.toString(), json.toString());
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -11,9 +11,7 @@ import com.github.jsonldjava.utils.JsonUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.RDF4JException;
@@ -75,11 +73,11 @@ public class ConvertTest extends AbstractCommandTest {
 
 	@Test
 	public final void testConvertWorkDir() throws IOException {
-		WorkDir location = new WorkDir(Paths.get(LOCATION.toString()));
+		WorkDir location = new WorkDir(Paths.get(LOCATION.getRoot().getAbsolutePath()));
 		convert.settings.put(WorkDir.NAME, location);
 
 		File json = LOCATION.newFile("alien.jsonld");
-		convert.execute("convert", from.toString(), json.toString());
+		convert.execute("convert", from.getName(), json.getName());
 
 		assertTrue("File is empty", json.length() > 0);
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -34,7 +34,7 @@ public class ConvertTest extends AbstractCommandTest {
 	private File from;
 
 	@Before
-	public void prepare() throws IOException, RDF4JException {
+	public void setup() throws IOException, RDF4JException {
 		when(mockConsoleIO.askProceed("File exists, continue ?", false)).thenReturn(Boolean.TRUE);
 		cmd = new Convert(mockConsoleIO, mockConsoleState, defaultSettings);
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
@@ -45,7 +45,7 @@ public class DropTest extends AbstractCommandTest {
 
 		addRepositories("drop", MEMORY_MEMBER_ID1);
 		manager.addRepositoryConfig(new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));
-	
+
 		ConsoleState state = mock(ConsoleState.class);
 		when(state.getManager()).thenReturn(manager);
 		drop = new Drop(mockConsoleIO, state, new Close(mockConsoleIO, state));

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
@@ -44,8 +44,8 @@ public class DropTest extends AbstractCommandTest {
 		manager = new LocalRepositoryManager(LOCATION.getRoot());
 
 		addRepositories("drop", MEMORY_MEMBER_ID1);
-
 		manager.addRepositoryConfig(new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));
+	
 		ConsoleState state = mock(ConsoleState.class);
 		when(state.getManager()).thenReturn(manager);
 		drop = new Drop(mockConsoleIO, state, new Close(mockConsoleIO, state));

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
@@ -25,11 +25,8 @@ import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
 import org.eclipse.rdf4j.repository.sail.config.ProxyRepositoryConfig;
 
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Dale Visser
@@ -42,13 +39,9 @@ public class DropTest extends AbstractCommandTest {
 
 	private Drop drop;
 
-	@Rule
-	public final TemporaryFolder LOCATION = new TemporaryFolder();
-
 	@Before
 	public void setUp() throws UnsupportedEncodingException, IOException, RDF4JException {
 		manager = new LocalRepositoryManager(LOCATION.getRoot());
-		manager.initialize();
 
 		addRepositories("drop", MEMORY_MEMBER_ID1);
 
@@ -61,12 +54,6 @@ public class DropTest extends AbstractCommandTest {
 	private void setUserDropConfirm(boolean confirm) throws IOException {
 		when(mockConsoleIO.askProceed(startsWith("WARNING: you are about to drop repository '"), anyBoolean()))
 				.thenReturn(confirm);
-	}
-
-	@After
-	@Override
-	public void tearDown() throws RDF4JException {
-		manager.shutDown();
 	}
 
 	@Test

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -77,11 +77,11 @@ public class ExportTest extends AbstractCommandTest {
 
 	@Test
 	public final void testExportWorkDir() throws RepositoryException, IOException {
-		WorkDir location = new WorkDir(Paths.get(LOCATION.toString()));
+		WorkDir location = new WorkDir(Paths.get(LOCATION.getRoot().getAbsolutePath()));
 		export.settings.put(WorkDir.NAME, location);
 
 		File nq = LOCATION.newFile("all.nq");
-		export.execute("export", "all.nq");
+		export.execute("export", nq.getName());
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
 		assertTrue("File is empty", nq.length() > 0);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -71,8 +71,6 @@ public class ExportTest extends AbstractCommandTest {
 
 		assertTrue("File is empty", nq.length() > 0);
 		assertEquals("Number of contexts incorrect", 3, exp.contexts().size());
-
-		nq.delete();
 	}
 
 	@Test
@@ -85,7 +83,5 @@ public class ExportTest extends AbstractCommandTest {
 
 		assertEquals("Number of contexts incorrect", 2, exp.contexts().size());
 		assertEquals("Number of triples incorrect", 4, exp.size());
-
-		nq.delete();
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -16,8 +16,10 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.console.setting.WorkDir;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
@@ -45,7 +47,6 @@ public class ExportTest extends AbstractCommandTest {
 	@Before
 	public void setUp() throws IOException, RDF4JException {
 		manager = new LocalRepositoryManager(LOCATION.getRoot());
-		manager.initialize();
 
 		addRepositories("export", MEMORY_MEMBER);
 
@@ -65,7 +66,22 @@ public class ExportTest extends AbstractCommandTest {
 	@Test
 	public final void testExportAll() throws RepositoryException, IOException {
 		File nq = LOCATION.newFile("all.nq");
-		export.execute("export", nq.toString());
+		export.execute("export", nq.getAbsolutePath());
+		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
+
+		assertTrue("File is empty", nq.length() > 0);
+		assertEquals("Number of contexts incorrect", 3, exp.contexts().size());
+
+		nq.delete();
+	}
+
+	@Test
+	public final void testExportWorkDir() throws RepositoryException, IOException {
+		WorkDir location = new WorkDir(Paths.get(LOCATION.toString()));
+		export.settings.put(WorkDir.NAME, location);
+
+		File nq = LOCATION.newFile("all.nq");
+		export.execute("export", "all.nq");
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
 		assertTrue("File is empty", nq.length() > 0);
@@ -77,7 +93,7 @@ public class ExportTest extends AbstractCommandTest {
 	@Test
 	public final void testExportContexts() throws RepositoryException, IOException {
 		File nq = LOCATION.newFile("default.nq");
-		export.execute("export", nq.toString(), "null", "http://example.org/ns/context/resurrection");
+		export.execute("export", nq.getAbsolutePath(), "null", "http://example.org/ns/context/resurrection");
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
 		assertTrue("File is empty", nq.length() > 0);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -53,7 +53,7 @@ public class ExportTest extends AbstractCommandTest {
 		when(mockConsoleState.getManager()).thenReturn(manager);
 		when(mockConsoleState.getRepository()).thenReturn(manager.getRepository(MEMORY_MEMBER));
 
-		export = new Export(mockConsoleIO, mockConsoleState);
+		export = new Export(mockConsoleIO, mockConsoleState, defaultSettings);
 	}
 
 	@After

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -16,21 +16,16 @@ import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.RDF4JException;
-import org.eclipse.rdf4j.console.setting.WorkDir;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Bart Hanssens
@@ -39,10 +34,7 @@ public class ExportTest extends AbstractCommandTest {
 
 	private static final String MEMORY_MEMBER = "alienquads";
 
-	private Export export;
-
-	@Rule
-	public final TemporaryFolder LOCATION = new TemporaryFolder();
+	private Export cmd;
 
 	@Before
 	public void setUp() throws IOException, RDF4JException {
@@ -54,19 +46,13 @@ public class ExportTest extends AbstractCommandTest {
 		when(mockConsoleState.getManager()).thenReturn(manager);
 		when(mockConsoleState.getRepository()).thenReturn(manager.getRepository(MEMORY_MEMBER));
 
-		export = new Export(mockConsoleIO, mockConsoleState, defaultSettings);
-	}
-
-	@After
-	@Override
-	public void tearDown() throws RDF4JException {
-		manager.shutDown();
+		cmd = new Export(mockConsoleIO, mockConsoleState, defaultSettings);
 	}
 
 	@Test
 	public final void testExportAll() throws RepositoryException, IOException {
 		File nq = LOCATION.newFile("all.nq");
-		export.execute("export", nq.getAbsolutePath());
+		cmd.execute("export", nq.getAbsolutePath());
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
 		assertTrue("File is empty", nq.length() > 0);
@@ -77,11 +63,10 @@ public class ExportTest extends AbstractCommandTest {
 
 	@Test
 	public final void testExportWorkDir() throws RepositoryException, IOException {
-		WorkDir location = new WorkDir(Paths.get(LOCATION.getRoot().getAbsolutePath()));
-		export.settings.put(WorkDir.NAME, location);
+		setWorkingDir(cmd);
 
 		File nq = LOCATION.newFile("all.nq");
-		export.execute("export", nq.getName());
+		cmd.execute("export", nq.getName());
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
 		assertTrue("File is empty", nq.length() > 0);
@@ -93,7 +78,7 @@ public class ExportTest extends AbstractCommandTest {
 	@Test
 	public final void testExportContexts() throws RepositoryException, IOException {
 		File nq = LOCATION.newFile("default.nq");
-		export.execute("export", nq.getAbsolutePath(), "null", "http://example.org/ns/context/resurrection");
+		cmd.execute("export", nq.getAbsolutePath(), "null", "http://example.org/ns/context/resurrection");
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
 		assertTrue("File is empty", nq.length() > 0);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/FederateTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/FederateTest.java
@@ -82,7 +82,6 @@ public class FederateTest extends AbstractCommandTest {
 		((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
 
 		manager = new LocalRepositoryManager(tempDir.newFolder("federate-test-repository-manager"));
-		manager.initialize();
 		addRepositories("federate", MEMORY_MEMBER_ID1, MEMORY_MEMBER_ID2, HTTP_MEMBER_ID, HTTP2_MEMBER_ID,
 				SPARQL_MEMBER_ID, SPARQL2_MEMBER_ID);
 		when(mockConsoleState.getManager()).thenReturn(manager);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/LoadTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/LoadTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.console.command;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.console.ConsoleState;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
+import org.eclipse.rdf4j.repository.sail.config.ProxyRepositoryConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Bart Hanssens
+ */
+public class LoadTest extends AbstractCommandTest {
+
+	private static final String MEMORY_MEMBER_ID1 = "alien";
+
+	private static final String PROXY_ID = "proxyID";
+
+	private Load cmd;
+
+	@Before
+	public void setUp() throws UnsupportedEncodingException, IOException, RDF4JException {
+		manager = new LocalRepositoryManager(LOCATION.getRoot());
+
+		addRepositories("load", MEMORY_MEMBER_ID1);
+
+		manager.addRepositoryConfig(new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));
+		ConsoleState state = mock(ConsoleState.class);
+		when(state.getManager()).thenReturn(manager);
+		cmd = new Load(mockConsoleIO, state, defaultSettings);
+	}
+
+	@Test
+	public final void testLoad() throws RepositoryException, IOException {
+		File f = LOCATION.newFile("alien.ttl");
+		copyFromResource("load/alien.ttl", f);
+
+		cmd.execute("load", f.getAbsolutePath());
+		verify(mockConsoleIO, never()).writeError(anyString());
+	}
+
+	@Test
+	public final void testLoadWorkDir() throws RepositoryException, IOException {
+		setWorkingDir(cmd);
+
+		File f = LOCATION.newFile("alien.ttl");
+		copyFromResource("load/alien.ttl", f);
+
+		cmd.execute("load", "ez");
+		verify(mockConsoleIO, never()).writeError(anyString());
+	}
+}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/LoadTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/LoadTest.java
@@ -43,8 +43,8 @@ public class LoadTest extends AbstractCommandTest {
 		manager = new LocalRepositoryManager(LOCATION.getRoot());
 
 		addRepositories("load", MEMORY_MEMBER_ID1);
-
 		manager.addRepositoryConfig(new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));
+
 		ConsoleState state = mock(ConsoleState.class);
 		when(state.getManager()).thenReturn(manager);
 		cmd = new Load(mockConsoleIO, state, defaultSettings);
@@ -66,7 +66,7 @@ public class LoadTest extends AbstractCommandTest {
 		File f = LOCATION.newFile("alien.ttl");
 		copyFromResource("load/alien.ttl", f);
 
-		cmd.execute("load", "ez");
+		cmd.execute("load", f.getName());
 		verify(mockConsoleIO, never()).writeError(anyString());
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -44,7 +44,6 @@ public class SparqlTest extends AbstractCommandTest {
 		manager = new LocalRepositoryManager(LOCATION.getRoot());
 
 		addRepositories("sparql", MEMORY_MEMBER);
-		setDefaultSettings();
 		TupleAndGraphQueryEvaluator tqe = new TupleAndGraphQueryEvaluator(mockConsoleIO, mockConsoleState,
 				defaultSettings);
 		when(mockConsoleState.getRepository()).thenReturn(manager.getRepository(MEMORY_MEMBER));

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -135,6 +136,7 @@ public class SparqlTest extends AbstractCommandTest {
 				" outfile=\"" + fout.getAbsolutePath() + "\"", "sparql");
 
 		verify(mockConsoleIO, never()).writeError(anyString());
+		assertFalse(mockConsoleIO.wasErrorWritten());
 
 		assertTrue("File does not exist", fout.exists());
 		assertTrue("Empty file", fout.length() > 0);
@@ -151,6 +153,7 @@ public class SparqlTest extends AbstractCommandTest {
 				" outfile=\"" + fout.getAbsolutePath() + "\"", "sparql");
 
 		verify(mockConsoleIO, never()).writeError(anyString());
+		assertFalse(mockConsoleIO.wasErrorWritten());
 
 		assertTrue("File does not exist", fout.exists());
 		assertTrue("Empty file", fout.length() > 0);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.console.command;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.model.Model;
@@ -46,6 +45,7 @@ public class SparqlTest extends AbstractCommandTest {
 		TupleAndGraphQueryEvaluator tqe = new TupleAndGraphQueryEvaluator(mockConsoleIO, mockConsoleState,
 				defaultSettings);
 		when(mockConsoleState.getRepository()).thenReturn(manager.getRepository(MEMORY_MEMBER));
+		when(mockConsoleIO.askProceed("File exists, continue ?", false)).thenReturn(Boolean.TRUE);
 
 		cmd = new Sparql(tqe);
 	}
@@ -115,7 +115,7 @@ public class SparqlTest extends AbstractCommandTest {
 
 	@Test
 	public final void testOutputFileWrongFormat() throws IOException {
-		File f = LOCATION.newFile("outwf.ttl");
+		File f = LOCATION.newFile("out.ttl");
 
 		// SELECT should use sparql result format, not a triple file format
 		cmd.executeQuery("sparql OUTFILE=\"" + f.getAbsolutePath() + "\" select ?s ?p ?o where { ?s ?p ?o }",
@@ -142,17 +142,17 @@ public class SparqlTest extends AbstractCommandTest {
 
 	@Test
 	public final void testInputOutputFilePrefix() throws IOException {
-		File f = LOCATION.newFile("select-prefix.qr");
-		copyFromResource("sparql/select-prefix.qr", f);
+		File fin = LOCATION.newFile("select-prefix.qr");
+		copyFromResource("sparql/select-prefix.qr", fin);
 
-		cmd.executeQuery("sparql infile=\"select-prefix.qr\" outfile=\"out.srj\"", "sparql");
+		File fout = LOCATION.newFile("out.srj");
+
+		cmd.executeQuery("sparql infile=\"" + fin.getAbsolutePath() + "\"" +
+				" outfile=\"" + fout.getAbsolutePath() + "\"", "sparql");
 
 		verify(mockConsoleIO, never()).writeError(anyString());
 
-		String dir = LOCATION.getRoot().toString();
-		File srj = Paths.get(dir, "out.srj").toFile();
-
-		assertTrue("File does not exist", srj.exists());
-		assertTrue("Empty file", srj.length() > 0);
+		assertTrue("File does not exist", fout.exists());
+		assertTrue("Empty file", fout.length() > 0);
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -14,20 +14,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 import org.eclipse.rdf4j.RDF4JException;
 import static org.junit.Assert.assertFalse;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
-import org.eclipse.rdf4j.console.setting.WorkDir;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -40,9 +36,6 @@ import static org.mockito.Mockito.when;
 public class VerifyTest extends AbstractCommandTest {
 	private Verify cmd;
 	private ConsoleIO io;
-
-	@Rule
-	public final TemporaryFolder LOCATION = new TemporaryFolder();
 
 	@Before
 	public void prepare() throws IOException, RDF4JException {
@@ -84,8 +77,8 @@ public class VerifyTest extends AbstractCommandTest {
 
 	@Test
 	public final void testVerifyOKWorkDir() throws IOException {
-		WorkDir location = new WorkDir(Paths.get(LOCATION.toString()));
-		cmd.settings.put(WorkDir.NAME, location);
+		setWorkingDir(cmd);
+
 		copyFromRes("ok.ttl");
 
 		cmd.execute("verify", "ok.ttl");
@@ -134,8 +127,8 @@ public class VerifyTest extends AbstractCommandTest {
 
 	@Test
 	public final void testShaclValidWorkDir() throws IOException {
-		WorkDir location = new WorkDir(Paths.get(LOCATION.toString()));
-		cmd.settings.put(WorkDir.NAME, location);
+		setWorkingDir(cmd);
+
 		copyFromRes("ok.ttl");
 		copyFromRes("shacl_valid.ttl");
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -51,7 +51,7 @@ public class VerifyTest extends AbstractCommandTest {
 
 		io = new ConsoleIO(input, out, info);
 
-		cmd = new Verify(io);
+		cmd = new Verify(io, defaultSettings);
 	}
 
 	/**

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -38,7 +38,7 @@ public class VerifyTest extends AbstractCommandTest {
 	private ConsoleIO io;
 
 	@Before
-	public void prepare() throws IOException, RDF4JException {
+	public void setUp() throws IOException, RDF4JException {
 		InputStream input = mock(InputStream.class);
 		OutputStream out = mock(OutputStream.class);
 		ConsoleState info = mock(ConsoleState.class);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
 import org.eclipse.rdf4j.RDF4JException;
@@ -26,6 +27,7 @@ import org.junit.rules.TemporaryFolder;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
+import org.eclipse.rdf4j.console.setting.WorkDir;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -81,6 +83,16 @@ public class VerifyTest extends AbstractCommandTest {
 	}
 
 	@Test
+	public final void testVerifyOKWorkDir() throws IOException {
+		WorkDir location = new WorkDir(Paths.get(LOCATION.toString()));
+		cmd.settings.put(WorkDir.NAME, location);
+		copyFromRes("ok.ttl");
+
+		cmd.execute("verify", "ok.ttl");
+		assertFalse(io.wasErrorWritten());
+	}
+
+	@Test
 	public final void testVerifyBrokenFile() throws IOException {
 		cmd.execute("verify", copyFromRes("broken.ttl"));
 		assertTrue(io.wasErrorWritten());
@@ -116,6 +128,20 @@ public class VerifyTest extends AbstractCommandTest {
 	public final void testShaclValid() throws IOException {
 		File report = LOCATION.newFile();
 		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_valid.ttl"), report.toString());
+		assertFalse(Files.size(report.toPath()) > 0);
+		assertFalse(io.wasErrorWritten());
+	}
+
+	@Test
+	public final void testShaclValidWorkDir() throws IOException {
+		WorkDir location = new WorkDir(Paths.get(LOCATION.toString()));
+		cmd.settings.put(WorkDir.NAME, location);
+		copyFromRes("ok.ttl");
+		copyFromRes("shacl_valid.ttl");
+
+		File report = LOCATION.newFile();
+		cmd.execute("verify", "ok.ttl", "shacl_valid.ttl", report.getName());
+
 		assertFalse(Files.size(report.toPath()) > 0);
 		assertFalse(io.wasErrorWritten());
 	}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -24,8 +24,11 @@ import org.junit.Test;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
+import static org.mockito.ArgumentMatchers.anyString;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -58,8 +61,7 @@ public class VerifyTest extends AbstractCommandTest {
 	 */
 	private String copyFromRes(String str) throws IOException {
 		File f = LOCATION.newFile(str);
-		Files.copy(this.getClass().getResourceAsStream("/verify/" + str), f.toPath(),
-				StandardCopyOption.REPLACE_EXISTING);
+		copyFromResource("verify/" + str, f);
 		return f.getAbsolutePath();
 	}
 
@@ -121,6 +123,8 @@ public class VerifyTest extends AbstractCommandTest {
 	public final void testShaclValid() throws IOException {
 		File report = LOCATION.newFile();
 		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_valid.ttl"), report.toString());
+
+		verify(mockConsoleIO, never()).writeError(anyString());
 		assertFalse(Files.size(report.toPath()) > 0);
 		assertFalse(io.wasErrorWritten());
 	}
@@ -135,6 +139,7 @@ public class VerifyTest extends AbstractCommandTest {
 		File report = LOCATION.newFile();
 		cmd.execute("verify", "ok.ttl", "shacl_valid.ttl", report.getName());
 
+		verify(mockConsoleIO, never()).writeError(anyString());
 		assertFalse(Files.size(report.toPath()) > 0);
 		assertFalse(io.wasErrorWritten());
 	}

--- a/tools/console/src/test/resources/load/alien-config.ttl
+++ b/tools/console/src/test/resources/load/alien-config.ttl
@@ -1,0 +1,17 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+
+[] a rep:Repository ;
+   rep:repositoryID "alien" ;
+   rdfs:label "Worthwhile Alien Movies" ;
+   rep:repositoryImpl [
+      rep:repositoryType "openrdf:SailRepository" ;
+      sr:sailImpl [
+         sail:sailType "openrdf:MemoryStore" ;
+         ms:persist true ;
+         ms:syncDelay 0
+      ]
+   ].

--- a/tools/console/src/test/resources/load/alien.ttl
+++ b/tools/console/src/test/resources/load/alien.ttl
@@ -1,0 +1,14 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.org/ns/> .
+
+<alien> dc:title "Alien"@en ;
+        dc:date "1979-05-25T00:00:00Z"^^xsd:dateTime .
+<aliens> dc:title "Aliens"@en ;
+         dc:date "1986-07-18T00:00:00Z"^^xsd:dateTime .
+<alien3> dc:title "Alien³"@en ;
+         dc:date "1992-05-22T00:00:00Z"^^xsd:dateTime .
+<resurrection> dc:title "Alien: Resurrection"@en ;
+               dc:date "1997-11-26T00:00:00Z"^^xsd:dateTime .
+<prometheus> dc:title "Prometheus"@en ; 
+             dc:date "2012-06-08T00:00:00Z"^^xsd:dateTime .


### PR DESCRIPTION
This PR addresses GitHub issue: #1510  .

Briefly describe the changes proposed in this PR:

* Let the commands Convert, Export, Load, Sparql, Verify all use the existing Workdir setting
* Added usesSettings method to commands, return the names of the settings a Command relies on
* Display the workdir setting at Console startup
* Added additional tests + some cleaning of existing tests
