### PR TITLE
new endpoint for repo config retrieval

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
@@ -284,7 +284,7 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 	}
 
 	/**
-	 * Create a new repository or update its configuration.
+	 * Create a new repository.
 	 * 
 	 * @param config the repository configuration
 	 * @throws IOException

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -964,7 +964,7 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 				return response; // everything OK, control flow can continue
 			} else {
 				// trying to contact a non-SPARQL server?
-				throw new RepositoryException("Failed to get server protocol; no such resource on this server: "
+				throw new RepositoryException("Request failed with status " + httpCode + ": "
 						+ method.getURI().toString());
 			}
 		} finally {

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
@@ -21,16 +21,21 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.protocol.HttpContext;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Unit tests for {@link RDF4JProtocolSession}
@@ -81,12 +86,31 @@ public class RDF4JProtocolSessionTest {
 	}
 
 	@Test
+	public void testGetRepositoryConfig() throws Exception {
+		ArgumentCaptor<HttpGet> method = ArgumentCaptor.forClass(HttpGet.class);
+
+		Header h = new BasicHeader("Content-Type", RDFFormat.NTRIPLES.getDefaultMIMEType());
+		when(response.getHeaders("Content-Type")).thenReturn(new Header[] { h });
+		InputStreamEntity responseData = new InputStreamEntity(
+				getClass().getResourceAsStream("/fixtures/repository-config.nt"));
+		when(response.getEntity()).thenReturn(responseData);
+
+		subject.getRepositoryConfig(mock(StatementCollector.class));
+
+		verify(httpclient).execute(method.capture(), any(HttpClientContext.class));
+		assertThat(method.getValue().getURI().toASCIIString())
+				.isEqualTo("http://localhost/rdf4j-server/repositories/test/config");
+
+		verifyHeaders();
+	}
+
+	@Test
 	public void testRepositoryList() throws Exception {
 		Header h = new BasicHeader("Content-Type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType());
 		when(response.getHeaders("Content-Type")).thenReturn(new Header[] { h });
-		InputStreamEntity reponseData = new InputStreamEntity(
+		InputStreamEntity responseData = new InputStreamEntity(
 				getClass().getResourceAsStream("/fixtures/repository-list.xml"));
-		when(response.getEntity()).thenReturn(reponseData);
+		when(response.getEntity()).thenReturn(responseData);
 
 		assertThat(subject.getRepositoryList().getBindingNames()).contains("id");
 		verifyHeaders();

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
@@ -22,6 +22,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -74,6 +75,14 @@ public class RDF4JProtocolSessionTest {
 		RepositoryConfig config = new RepositoryConfig("test");
 		subject.createRepository(config);
 		verify(httpclient).execute(any(HttpPut.class), any(HttpContext.class));
+		verifyHeaders();
+	}
+
+	@Test
+	public void testUpdateRepositoryExecutesPost() throws Exception {
+		RepositoryConfig config = new RepositoryConfig("test");
+		subject.updateRepository(config);
+		verify(httpclient).execute(any(HttpPost.class), any(HttpContext.class));
 		verifyHeaders();
 	}
 

--- a/core/http/client/src/test/resources/fixtures/repository-config.nt
+++ b/core/http/client/src/test/resources/fixtures/repository-config.nt
@@ -1,0 +1,1 @@
+_:node1 <http://www.openrdf.org/config/repository#repositoryID> "test" .

--- a/core/http/protocol/pom.xml
+++ b/core/http/protocol/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -44,6 +46,11 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
@@ -76,8 +76,13 @@ public abstract class Protocol {
 
 	/**
 	 * Protocol version.
+	 * 
+	 * <ul>
+	 * <li>10: since RDF4J 3.1.0</li>
+	 * <li>9: since RDF4J 3.0.0</li>
+	 * </ul>
 	 */
-	public static final String VERSION = "9";
+	public static final String VERSION = "10";
 
 	/**
 	 * Parameter name for the 'subject' parameter of a statement query.
@@ -307,6 +312,17 @@ public abstract class Protocol {
 	 */
 	public static final String getRepositoryLocation(String serverLocation, String repositoryID) {
 		return getRepositoriesLocation(serverLocation) + "/" + repositoryID;
+	}
+
+	/**
+	 * Get the location of the config of a specific repository resource.
+	 * 
+	 * @param repositoryLocation the location of a repository implementing this REST protocol.
+	 * @return the location of the configuration resource for the specified repository
+	 * 
+	 */
+	public static final String getRepositoryConfigLocation(String repositoryLocation) {
+		return repositoryLocation + "/" + CONFIG;
 	}
 
 	/**

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/error/ErrorType.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/error/ErrorType.java
@@ -25,6 +25,8 @@ public class ErrorType {
 
 	public static final ErrorType UNSUPPORTED_FILE_FORMAT = register("UNSUPPORTED FILE FORMAT");
 
+	public static final ErrorType REPOSITORY_EXISTS = register("REPOSITORY EXISTS");
+
 	protected static ErrorType register(String label) {
 		synchronized (registry) {
 			ErrorType errorType = registry.get(label);

--- a/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/ProtocolTest.java
+++ b/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/ProtocolTest.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.http.protocol;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.rdf4j.http.protocol.Protocol.CONFIG;
 import static org.eclipse.rdf4j.http.protocol.Protocol.CONTEXTS;
 import static org.eclipse.rdf4j.http.protocol.Protocol.NAMESPACES;
@@ -18,6 +19,7 @@ import static org.eclipse.rdf4j.http.protocol.Protocol.getContextsLocation;
 import static org.eclipse.rdf4j.http.protocol.Protocol.getNamespacesLocation;
 import static org.eclipse.rdf4j.http.protocol.Protocol.getProtocolLocation;
 import static org.eclipse.rdf4j.http.protocol.Protocol.getRepositoriesLocation;
+import static org.eclipse.rdf4j.http.protocol.Protocol.getRepositoryConfigLocation;
 import static org.eclipse.rdf4j.http.protocol.Protocol.getRepositoryID;
 import static org.eclipse.rdf4j.http.protocol.Protocol.getRepositoryLocation;
 import static org.eclipse.rdf4j.http.protocol.Protocol.getServerLocation;
@@ -40,19 +42,19 @@ public class ProtocolTest {
 	@Test
 	public void testGetProtocolLocation() {
 		String result = getProtocolLocation(serverLocation);
-		assertEquals(result, serverLocation + "/" + PROTOCOL);
+		assertThat(result).isEqualTo(serverLocation + "/" + PROTOCOL);
 	}
 
 	@Test
 	public void testGetConfigLocation() {
 		String result = getConfigLocation(serverLocation);
-		assertEquals(result, serverLocation + "/" + CONFIG);
+		assertThat(result).isEqualTo(serverLocation + "/" + CONFIG);
 	}
 
 	@Test
 	public void testGetRepositoriesLocation() {
 		String result = getRepositoriesLocation(serverLocation);
-		assertEquals(result, serverLocation + "/" + REPOSITORIES);
+		assertThat(result).isEqualTo(serverLocation + "/" + REPOSITORIES);
 	}
 
 	@Test
@@ -74,19 +76,25 @@ public class ProtocolTest {
 	@Test
 	public void testGetRepositoryLocation() {
 		String result = getRepositoryLocation(serverLocation, repositoryID);
-		assertEquals(result, repositoryLocation);
+		assertThat(result).isEqualTo(repositoryLocation);
+	}
+
+	@Test
+	public void testGetRepositoryConfigLocation() {
+		String result = getRepositoryConfigLocation(repositoryLocation);
+		assertThat(result).isEqualTo(repositoryLocation + "/" + CONFIG);
 	}
 
 	@Test
 	public void testGetContextsLocation() {
 		String result = getContextsLocation(repositoryLocation);
-		assertEquals(result, repositoryLocation + "/" + CONTEXTS);
+		assertThat(result).isEqualTo(repositoryLocation + "/" + CONTEXTS);
 	}
 
 	@Test
 	public void testGetNamespacesLocation() {
 		String result = getNamespacesLocation(repositoryLocation);
-		assertEquals(result, repositoryLocation + "/" + NAMESPACES);
+		assertThat(result).isEqualTo(repositoryLocation + "/" + NAMESPACES);
 	}
 
 	@Test

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
@@ -309,7 +309,7 @@ public class RemoteRepositoryManager extends RepositoryManager {
 				}
 			} else {
 				if (hasRepositoryConfig(config.getID())) {
-					// update existing
+					protocolSession.updateRepository(config);
 				} else {
 					protocolSession.createRepository(config);
 				}

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
@@ -308,7 +308,11 @@ public class RemoteRepositoryManager extends RepositoryManager {
 							ctx);
 				}
 			} else {
-				protocolSession.createRepository(config);
+				if (hasRepositoryConfig(config.getID())) {
+					// update existing
+				} else {
+					protocolSession.createRepository(config);
+				}
 			}
 		} catch (IOException | QueryEvaluationException | UnauthorizedException | NumberFormatException e) {
 			throw new RepositoryException(e);

--- a/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
+++ b/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.repository.manager;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -21,6 +22,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -59,6 +62,21 @@ public class RemoteRepositoryManagerTest extends RepositoryManagerTest {
 		wireMockRule.verify(
 				putRequestedFor(urlEqualTo("/rdf4j-server/repositories/test")).withRequestBody(matching("^BRDF.*"))
 						.withHeader("Content-Type", equalTo("application/x-binary-rdf")));
+	}
+
+	@Test
+	public void testGetRepositoryConfig() throws Exception {
+		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/protocol"))
+				.willReturn(aResponse().withStatus(200).withBody(Protocol.VERSION)));
+		wireMockRule
+				.stubFor(get(urlEqualTo("/rdf4j-server/repositories/test/config"))
+						.willReturn(aResponse().withStatus(200)
+								.withHeader("Content-type", RDFFormat.NTRIPLES.getDefaultMIMEType())
+								.withBody("_:node1 <" + RepositoryConfigSchema.REPOSITORYID + "> \"test\" . ")));
+
+		subject.getRepositoryConfig("test");
+
+		wireMockRule.verify(getRequestedFor(urlEqualTo("/rdf4j-server/repositories/test/config")));
 	}
 
 	@Test

--- a/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
+++ b/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
@@ -54,6 +54,10 @@ public class RemoteRepositoryManagerTest extends RepositoryManagerTest {
 				.willReturn(aResponse().withStatus(200).withBody(Protocol.VERSION)));
 		wireMockRule
 				.stubFor(put(urlEqualTo("/rdf4j-server/repositories/test")).willReturn(aResponse().withStatus(204)));
+		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/repositories"))
+				.willReturn(aResponse().withHeader("Content-type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
+						.withBodyFile("repository-list-response.srx")
+						.withStatus(200)));
 
 		RepositoryConfig config = new RepositoryConfig("test");
 
@@ -61,6 +65,28 @@ public class RemoteRepositoryManagerTest extends RepositoryManagerTest {
 
 		wireMockRule.verify(
 				putRequestedFor(urlEqualTo("/rdf4j-server/repositories/test")).withRequestBody(matching("^BRDF.*"))
+						.withHeader("Content-Type", equalTo("application/x-binary-rdf")));
+	}
+
+	@Test
+	public void testAddRepositoryConfigExisting() throws Exception {
+		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/protocol"))
+				.willReturn(aResponse().withStatus(200).withBody(Protocol.VERSION)));
+		wireMockRule
+				.stubFor(post(urlEqualTo("/rdf4j-server/repositories/mem-rdf/config"))
+						.willReturn(aResponse().withStatus(204)));
+		wireMockRule.stubFor(get(urlEqualTo("/rdf4j-server/repositories"))
+				.willReturn(aResponse().withHeader("Content-type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
+						.withBodyFile("repository-list-response.srx")
+						.withStatus(200)));
+
+		RepositoryConfig config = new RepositoryConfig("mem-rdf"); // this repo already exists
+
+		subject.addRepositoryConfig(config);
+
+		wireMockRule.verify(
+				postRequestedFor(urlEqualTo("/rdf4j-server/repositories/mem-rdf/config"))
+						.withRequestBody(matching("^BRDF.*"))
 						.withHeader("Content-Type", equalTo("application/x-binary-rdf")));
 	}
 

--- a/tools/server-spring/pom.xml
+++ b/tools/server-spring/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -18,20 +20,20 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-client</artifactId>
 			<version>${project.version}</version>
-                        <type>pom</type>
+			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-storage</artifactId>
 			<version>${project.version}</version>
-                        <type>pom</type>
+			<type>pom</type>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-config</artifactId>
 			<version>${project.version}</version>
 		</dependency>
- 
+
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
@@ -58,27 +60,36 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/config/ConfigController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/config/ConfigController.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.rdf4j.http.server.ProtocolUtil;
+import org.eclipse.rdf4j.http.server.repository.RepositoryInterceptor;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ModelFactory;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+import org.eclipse.rdf4j.rio.RDFWriterRegistry;
+import org.springframework.context.ApplicationContextException;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.AbstractController;
+
+/**
+ * Handles requests related to repository configuration.
+ * 
+ * @author Jeen Broekstra
+ */
+public class ConfigController extends AbstractController {
+
+	private RepositoryManager repositoryManager;
+
+	private ModelFactory modelFactory = new LinkedHashModelFactory();
+
+	public ConfigController() throws ApplicationContextException {
+		setSupportedMethods(new String[] { METHOD_GET, METHOD_HEAD });
+	}
+
+	public void setRepositoryManager(RepositoryManager repositoryManager) {
+		this.repositoryManager = repositoryManager;
+	}
+
+	@Override
+	protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
+			throws Exception {
+
+		RDFWriterFactory rdfWriterFactory = ProtocolUtil.getAcceptableService(request, response,
+				RDFWriterRegistry.getInstance());
+
+		RepositoryConfig repositoryConfig = repositoryManager
+				.getRepositoryConfig(RepositoryInterceptor.getRepositoryID(request));
+
+		Model configData = modelFactory.createEmptyModel();
+		String baseURI = request.getRequestURL().toString();
+		Resource ctx = SimpleValueFactory.getInstance().createIRI(baseURI + "#" + repositoryConfig.getID());
+
+		repositoryConfig.export(configData, ctx);
+		Map<String, Object> model = new HashMap<>();
+		model.put(ConfigView.FORMAT_KEY, rdfWriterFactory.getRDFFormat());
+		model.put(ConfigView.CONFIG_DATA_KEY, configData);
+		model.put(ConfigView.HEADERS_ONLY, METHOD_HEAD.equals(request.getMethod()));
+		return new ModelAndView(ConfigView.getInstance(), model);
+	}
+
+}

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/config/ConfigController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/config/ConfigController.java
@@ -75,9 +75,8 @@ public class ConfigController extends AbstractController {
 
 		RDFWriterFactory rdfWriterFactory = ProtocolUtil.getAcceptableService(request, response,
 				RDFWriterRegistry.getInstance());
-
-		RepositoryConfig repositoryConfig = repositoryManager
-				.getRepositoryConfig(RepositoryInterceptor.getRepositoryID(request));
+		String repId = RepositoryInterceptor.getRepositoryID(request);
+		RepositoryConfig repositoryConfig = repositoryManager.getRepositoryConfig(repId);
 
 		Model configData = modelFactory.createEmptyModel();
 		String baseURI = request.getRequestURL().toString();

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/config/ConfigView.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/config/ConfigView.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository.config;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.rdf4j.http.server.ServerHTTPException;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.springframework.web.servlet.View;
+
+/**
+ * View used to export a repository config. Renders the statements as RDF using a serialization specified using a
+ * parameter or Accept header.
+ * 
+ * @author Jeen Broekstra
+ */
+public class ConfigView implements View {
+
+	public static final String CONFIG_DATA_KEY = "configData";
+
+	public static final String FORMAT_KEY = "format";
+
+	public static final String HEADERS_ONLY = "headersOnly";
+
+	private static final ConfigView INSTANCE = new ConfigView();
+
+	public static ConfigView getInstance() {
+		return INSTANCE;
+	}
+
+	private ConfigView() {
+	}
+
+	@Override
+	public String getContentType() {
+		return null;
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public void render(Map model, HttpServletRequest request, HttpServletResponse response) throws Exception {
+		boolean headersOnly = (Boolean) model.get(HEADERS_ONLY);
+
+		RDFFormat rdfFormat = (RDFFormat) model.get(FORMAT_KEY);
+
+		try {
+			try (OutputStream out = response.getOutputStream()) {
+
+				response.setStatus(SC_OK);
+
+				String mimeType = rdfFormat.getDefaultMIMEType();
+				if (rdfFormat.hasCharset()) {
+					Charset charset = rdfFormat.getCharset();
+					mimeType += "; charset=" + charset.name();
+				}
+				response.setContentType(mimeType);
+
+				String filename = "config";
+				if (rdfFormat.getDefaultFileExtension() != null) {
+					filename += "." + rdfFormat.getDefaultFileExtension();
+				}
+				response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+
+				if (!headersOnly) {
+					Model configuration = (Model) model.get(CONFIG_DATA_KEY);
+					Rio.write(configuration, out, rdfFormat);
+				}
+			}
+		} catch (RDFHandlerException e) {
+			throw new ServerHTTPException("Serialization error: " + e.getMessage(), e);
+		} catch (RepositoryException e) {
+			throw new ServerHTTPException("Repository error: " + e.getMessage(), e);
+		}
+	}
+
+}

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigControllerTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.ModelAndView;
+
+public class ConfigControllerTest {
+
+	@Test
+	public void retrievesConfiguration() throws Exception {
+		ConfigController controller = new ConfigController();
+
+		String repositoryId = "test-config";
+
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod(HttpMethod.GET.name());
+		request.addHeader("Accept", RDFFormat.NTRIPLES.getDefaultMIMEType());
+
+		RepositoryConfig config = new RepositoryConfig(repositoryId, new SailRepositoryConfig(new MemoryStoreConfig()));
+		RepositoryManager manager = mock(RepositoryManager.class);
+		when(manager.getRepositoryConfig(repositoryId)).thenReturn(config);
+		controller.setRepositoryManager(manager);
+
+		// repository interceptor uses this attribute
+		request.setAttribute("repositoryID", repositoryId);
+
+		ModelAndView result = controller.handleRequest(request, new MockHttpServletResponse());
+
+		verify(manager).getRepositoryConfig(repositoryId);
+		assertThat(result.getModel().containsKey(ConfigView.CONFIG_DATA_KEY));
+
+		Model resultData = (Model) result.getModel().get(ConfigView.CONFIG_DATA_KEY);
+		RepositoryConfig resultConfig = RepositoryConfigUtil.getRepositoryConfig(resultData, repositoryId);
+		assertThat(resultConfig).isNotNull();
+	}
+
+}

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigControllerTest.java
@@ -27,12 +27,11 @@ import org.springframework.web.servlet.ModelAndView;
 
 public class ConfigControllerTest {
 
+	final String repositoryId = "test-config";
+	final ConfigController controller = new ConfigController();
+
 	@Test
-	public void retrievesConfiguration() throws Exception {
-		ConfigController controller = new ConfigController();
-
-		String repositoryId = "test-config";
-
+	public void getRequestRetrievesConfiguration() throws Exception {
 		final MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod(HttpMethod.GET.name());
 		request.addHeader("Accept", RDFFormat.NTRIPLES.getDefaultMIMEType());
@@ -55,4 +54,10 @@ public class ConfigControllerTest {
 		assertThat(resultConfig).isNotNull();
 	}
 
+	@Test
+	public void postRequestModifiesConfiguration() throws Exception {
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod(HttpMethod.POST.name());
+		request.setContentType(RDFFormat.NTRIPLES.getDefaultMIMEType());
+	}
 }

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigViewTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigViewTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class ConfigViewTest {
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testRender() throws Exception {
+
+		ConfigView configView = ConfigView.getInstance();
+
+		Model configData = new LinkedHashModelFactory().createEmptyModel();
+		configData.add(RDF.ALT, RDF.TYPE, RDFS.CLASS);
+
+		Map<Object, Object> map = new LinkedHashMap<>();
+		map.put(ConfigView.HEADERS_ONLY, false);
+		map.put(ConfigView.CONFIG_DATA_KEY, configData);
+		map.put(ConfigView.FORMAT_KEY, RDFFormat.NTRIPLES);
+
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod(HttpMethod.GET.name());
+		request.addHeader("Accept", RDFFormat.NTRIPLES.getDefaultMIMEType());
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		configView.render(map, request, response);
+
+		String ntriplesData = response.getContentAsString();
+		Model renderedData = Rio.parse(new StringReader(ntriplesData), "", RDFFormat.NTRIPLES);
+		assertThat(renderedData).isNotEmpty();
+	}
+
+}

--- a/tools/server/src/main/webapp/WEB-INF/rdf4j-http-server-servlet.xml
+++ b/tools/server/src/main/webapp/WEB-INF/rdf4j-http-server-servlet.xml
@@ -85,6 +85,7 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 			<props>
 				<prop key="/repositories/*/namespaces/*">rdf4jRepositoryNamespaceController</prop>
 				<prop key="/repositories/*/namespaces">rdf4jRepositoryNamespacesController</prop>
+				<prop key="/repositories/*/config">rdf4jRepositoryConfigController</prop>
 				<prop key="/repositories/*/contexts">rdf4jRepositoryContextsController</prop>
 				<prop key="/repositories/*/statements">rdf4jRepositoryStatementsController</prop>
 				<prop key="/repositories/*/rdf-graphs">rdf4jRepositoryContextsController</prop>
@@ -131,6 +132,9 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		<property name="repositoryManager" ref="rdf4jRepositoryManager" />
 	</bean>
 	<bean id="rdf4jRepositoryController" class="org.eclipse.rdf4j.http.server.repository.RepositoryController">
+		<property name="repositoryManager" ref="rdf4jRepositoryManager" />
+	</bean>
+	<bean id="rdf4jRepositoryConfigController" class="org.eclipse.rdf4j.http.server.repository.config.ConfigController">
 		<property name="repositoryManager" ref="rdf4jRepositoryManager" />
 	</bean>
 	<bean id="rdf4jRepositoryContextsController"


### PR DESCRIPTION
This PR addresses GitHub issue: #1541 .

Briefly describe the changes proposed in this PR:

* new endpoint for retrieval of repository config
* new endpoint for changing existing repo config
* modified `PUT /repo/<ID>` endpoint to only accept if repository does not yet exist. 
