### PR TITLE
Issues/#1544 console writeln

### DIFF
--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Clear.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Clear.java
@@ -58,7 +58,7 @@ public class Clear extends ConsoleCommand {
 		Repository repository = state.getRepository();
 
 		if (repository == null) {
-			consoleIO.writeUnopenedError();
+			writeUnopenedError();
 		} else {
 			Resource[] contexts;
 			try {

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Clear.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Clear.java
@@ -20,17 +20,12 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.RepositoryReadOnlyException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Clear command.
  * 
  * @author Dale Visser
  */
 public class Clear extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Clear.class);
-
 	@Override
 	public String getName() {
 		return "clear";

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Clear.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Clear.java
@@ -69,7 +69,7 @@ public class Clear extends ConsoleCommand {
 			try {
 				contexts = Util.getContexts(tokens, 1, repository);
 			} catch (IllegalArgumentException ioe) {
-				consoleIO.writeError(ioe.getMessage());
+				writeError(ioe.getMessage());
 				return;
 			}
 			clear(repository, contexts);
@@ -84,9 +84,9 @@ public class Clear extends ConsoleCommand {
 	 */
 	private void clear(Repository repository, Resource[] contexts) {
 		if (contexts.length == 0) {
-			consoleIO.writeln("Clearing repository...");
+			writeInfo("Clearing repository...");
 		} else {
-			consoleIO.writeln("Removing specified contexts...");
+			writeInfo("Removing specified contexts...");
 		}
 		try {
 			try (RepositoryConnection con = repository.getConnection()) {
@@ -100,18 +100,15 @@ public class Clear extends ConsoleCommand {
 				if (LockRemover.tryToRemoveLock(repository, consoleIO)) {
 					this.clear(repository, contexts);
 				} else {
-					consoleIO.writeError("Failed to clear repository");
-					LOGGER.error("Failed to clear repository", e);
+					writeError("Failed to clear repository", e);
 				}
-			} catch (RepositoryException e1) {
-				consoleIO.writeError("Unable to restart repository: " + e1.getMessage());
-				LOGGER.error("Unable to restart repository", e1);
-			} catch (IOException e1) {
-				consoleIO.writeError("Unable to remove lock: " + e1.getMessage());
+			} catch (RepositoryException re) {
+				writeError("Unable to restart repository", re);
+			} catch (IOException ioe) {
+				writeError("Unable to remove lock", ioe);
 			}
 		} catch (RepositoryException e) {
-			consoleIO.writeError("Failed to clear repository: " + e.getMessage());
-			LOGGER.error("Failed to clear repository", e);
+			writeError("Failed to clear repository", e);
 		}
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Close.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Close.java
@@ -48,7 +48,7 @@ public class Close extends ConsoleCommand {
 		if (tokens.length == 1) {
 			closeRepository(true);
 		} else {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 		}
 	}
 
@@ -62,10 +62,10 @@ public class Close extends ConsoleCommand {
 
 		if (repository == null) {
 			if (verbose) {
-				consoleIO.writeln("There are no open repositories that can be closed");
+				writeln("There are no open repositories that can be closed");
 			}
 		} else {
-			consoleIO.writeln("Closing repository '" + this.state.getRepositoryID() + "'...");
+			writeln("Closing repository '" + this.state.getRepositoryID() + "'...");
 			this.state.setRepository(null);
 			this.state.setRepositoryID(null);
 		}

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Connect.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Connect.java
@@ -71,7 +71,7 @@ public class Connect extends ConsoleCommand {
 	@Override
 	public void execute(String... tokens) {
 		if (tokens.length < 2) {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 			return;
 		}
 
@@ -132,23 +132,20 @@ public class Connect extends ConsoleCommand {
 			result = installNewManager(manager, url);
 		} catch (UnauthorizedException e) {
 			if (user != null && pass.length() > 0) {
-				consoleIO.writeError("Authentication for user '" + user + "' failed");
-				LOGGER.warn("Authentication for user '" + user + "' failed", e);
+				writeError("Authentication for user '" + user + "' failed");
 			} else {
 				// Ask user for credentials
 				try {
-					consoleIO.writeln("Authentication required");
+					writeln("Authentication required");
 					final String username = consoleIO.readln("Username: ");
 					final String password = consoleIO.readPassword("Password: ");
 					connectRemote(url, username, password);
 				} catch (IOException ioe) {
-					consoleIO.writeError("Failed to read user credentials");
-					LOGGER.warn("Failed to read user credentials", ioe);
+					writeError("Failed to read user credentials", ioe);
 				}
 			}
 		} catch (IOException | RepositoryException e) {
-			consoleIO.writeError("Failed to access the server: " + e.getMessage());
-			LOGGER.warn("Failed to access the server", e);
+			writeError("Failed to access the server", e);
 		}
 
 		return result;
@@ -166,7 +163,7 @@ public class Connect extends ConsoleCommand {
 		if (dir.exists() && dir.isDirectory()) {
 			result = installNewManager(new LocalRepositoryManager(dir), dir.toString());
 		} else {
-			consoleIO.writeError("Specified path is not an (existing) directory: " + path);
+			writeError("Specified path is not an (existing) directory: " + path);
 		}
 		return result;
 	}
@@ -183,7 +180,7 @@ public class Connect extends ConsoleCommand {
 		final String managerID = this.state.getManagerID();
 
 		if (newManagerID.equals(managerID)) {
-			consoleIO.writeln("Already connected to " + managerID);
+			writeln("Already connected to " + managerID);
 			installed = true;
 		} else {
 			try {
@@ -192,12 +189,11 @@ public class Connect extends ConsoleCommand {
 
 				this.state.setManager(newManager);
 				this.state.setManagerID(newManagerID);
-				consoleIO.writeln("Connected to " + newManagerID);
+				writeln("Connected to " + newManagerID);
 
 				installed = true;
 			} catch (RepositoryException e) {
-				consoleIO.writeError(e.getMessage());
-				LOGGER.error("Failed to install new manager", e);
+				writeError("Failed to install new manager", e);
 			}
 		}
 		return installed;

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Connect.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Connect.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
  * @author dale
  */
 public class Connect extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Connect.class);
-
 	private final Disconnect disconnect;
 
 	@Override

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/ConsoleCommand.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/ConsoleCommand.java
@@ -15,6 +15,8 @@ import org.eclipse.rdf4j.console.Command;
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract command
@@ -22,6 +24,8 @@ import org.eclipse.rdf4j.console.setting.ConsoleSetting;
  * @author Bart Hanssens
  */
 public abstract class ConsoleCommand implements Command, Help {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleCommand.class);
+
 	final ConsoleIO consoleIO;
 	final ConsoleState state;
 
@@ -118,5 +122,24 @@ public abstract class ConsoleCommand implements Command, Help {
 	@Override
 	public void execute(String... parameters) throws IOException {
 		throw new UnsupportedOperationException("Not supported yet.");
+	}
+
+	protected void writeln(String str) {
+		consoleIO.writeln(str);
+	}
+
+	protected void writeInfo(String str) {
+		consoleIO.writeln(str);
+		LOGGER.info(str);
+	}
+
+	protected void writeError(String str) {
+		consoleIO.writeln(str);
+		LOGGER.warn(str);
+	}
+
+	protected void writeError(String str, Exception e) {
+		consoleIO.writeln(str + ": " + e.getMessage());
+		LOGGER.error(str, e);
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/ConsoleCommand.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/ConsoleCommand.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.console.Command;
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * @author Bart Hanssens
  */
 public abstract class ConsoleCommand implements Command, Help {
-	private static final Logger LOGGER = LoggerFactory.getLogger(ConsoleCommand.class);
+	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	final ConsoleIO consoleIO;
 	final ConsoleState state;

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/ConsoleCommand.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/ConsoleCommand.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.console.command;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.logging.Level;
 
 import org.eclipse.rdf4j.console.Help;
 import org.eclipse.rdf4j.console.Command;
@@ -125,22 +126,75 @@ public abstract class ConsoleCommand implements Command, Help {
 		throw new UnsupportedOperationException("Not supported yet.");
 	}
 
+	/**
+	 * Write a string to the console
+	 * 
+	 * @param str text
+	 */
+	protected void write(String str) {
+		consoleIO.write(str);
+	}
+
+	/**
+	 * Write a string + newline to the console
+	 * 
+	 * @param str text
+	 */
 	protected void writeln(String str) {
 		consoleIO.writeln(str);
 	}
 
+	/**
+	 * Write a string + newline to the console and to the log at level INFO
+	 * 
+	 * @param str text
+	 */
 	protected void writeInfo(String str) {
 		consoleIO.writeln(str);
 		LOGGER.info(str);
 	}
 
+	/**
+	 * Write a string + newline to the console and to the log as an error
+	 * 
+	 * @param str text
+	 */
 	protected void writeError(String str) {
-		consoleIO.writeln(str);
-		LOGGER.warn(str);
+		consoleIO.writeError(str);
+		LOGGER.error(str);
 	}
 
+	/**
+	 * Write a string + message of exception + newline to the console and to the log as an error
+	 * 
+	 * @param str text
+	 * @param e   exception
+	 */
 	protected void writeError(String str, Exception e) {
-		consoleIO.writeln(str + ": " + e.getMessage());
+		consoleIO.writeError(str + ": " + e.getMessage());
 		LOGGER.error(str, e);
+	}
+
+	/**
+	 * Write repository not opened error
+	 */
+	protected void writeUnopenedError() {
+		consoleIO.writeUnopenedError();
+	}
+
+	/**
+	 * Ask user to proceed
+	 * 
+	 * @param str    question to ask
+	 * @param defVal default value
+	 * @return true
+	 */
+	protected boolean askProceed(String str, boolean defVal) {
+		try {
+			return consoleIO.askProceed(str, defVal);
+		} catch (IOException ex) {
+			writeError("Error reading answer", ex);
+		}
+		return defVal;
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
@@ -27,17 +27,12 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Convert RDF file from one format to another
  * 
  * @author Bart Hanssens
  */
 public class Convert extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Convert.class);
-
 	@Override
 	public String getName() {
 		return "convert";

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
@@ -72,7 +72,7 @@ public class Convert extends ConsoleCommand {
 	@Override
 	public void execute(String... tokens) {
 		if (tokens.length < 3) {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 			return;
 		}
 
@@ -98,39 +98,39 @@ public class Convert extends ConsoleCommand {
 		// check from
 		Path pathFrom = Util.getNormalizedPath(getWorkDir(), fileFrom);
 		if (pathFrom == null) {
-			consoleIO.writeError("Invalid file name (from) " + fileFrom);
+			writeError("Invalid file name (from) " + fileFrom);
 			return;
 		}
 		if (Files.notExists(pathFrom)) {
-			consoleIO.writeError("File not found (from) " + fileFrom);
+			writeError("File not found (from) " + fileFrom);
 			return;
 		}
 		Optional<RDFFormat> fmtFrom = Rio.getParserFormatForFileName(fileFrom);
 		if (!fmtFrom.isPresent()) {
-			consoleIO.writeError("No RDF parser for " + fileFrom);
+			writeError("No RDF parser for " + fileFrom);
 			return;
 		}
 
 		// check to
 		Path pathTo = Util.getNormalizedPath(getWorkDir(), fileTo);
 		if (pathTo == null) {
-			consoleIO.writeError("Invalid file name (to) " + pathTo);
+			writeError("Invalid file name (to) " + pathTo);
 			return;
 		}
 		Optional<RDFFormat> fmtTo = Rio.getWriterFormatForFileName(fileTo);
 		if (!fmtTo.isPresent()) {
-			consoleIO.writeError("No RDF writer for " + fileTo);
+			writeError("No RDF writer for " + fileTo);
 			return;
 		}
 		if (Files.exists(pathTo)) {
 			try {
 				boolean overwrite = consoleIO.askProceed("File exists, continue ?", false);
 				if (!overwrite) {
-					consoleIO.writeln("Conversion aborted");
+					writeln("Conversion aborted");
 					return;
 				}
 			} catch (IOException ioe) {
-				consoleIO.writeError("I/O error " + ioe.getMessage());
+				writeError("I/O error", ioe);
 			}
 		}
 
@@ -143,14 +143,14 @@ public class Convert extends ConsoleCommand {
 			parser.setRDFHandler(writer);
 
 			long startTime = System.nanoTime();
-			consoleIO.writeln("Converting file ...");
+			writeln("Converting file ...");
 
 			parser.parse(r, baseURI);
 
 			long diff = (System.nanoTime() - startTime) / 1_000_000;
-			consoleIO.writeln("Data has been written to file (" + diff + " ms)");
+			writeln("Data has been written to file (" + diff + " ms)");
 		} catch (IOException | RDFParseException | RDFHandlerException e) {
-			consoleIO.writeError("Failed to convert data: " + e.getMessage());
+			writeError("Failed to convert data", e);
 		}
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Convert.java
@@ -118,14 +118,10 @@ public class Convert extends ConsoleCommand {
 			return;
 		}
 		if (Files.exists(pathTo)) {
-			try {
-				boolean overwrite = consoleIO.askProceed("File exists, continue ?", false);
-				if (!overwrite) {
-					writeln("Conversion aborted");
-					return;
-				}
-			} catch (IOException ioe) {
-				writeError("I/O error", ioe);
+			boolean overwrite = askProceed("File exists, continue ?", false);
+			if (!overwrite) {
+				writeln("Conversion aborted");
+				return;
 			}
 		}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
@@ -91,7 +91,7 @@ public class Create extends ConsoleCommand {
 	@Override
 	public void execute(String... tokens) throws IOException {
 		if (tokens.length < 2) {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 		} else {
 			createRepository(tokens[1]);
 		}
@@ -198,13 +198,13 @@ public class Create extends ConsoleCommand {
 
 					String overwrite = "WARNING: you are about to overwrite the configuration of an existing repository!";
 					boolean proceedOverwrite = this.state.getManager().hasRepositoryConfig(repConfig.getID())
-							? consoleIO.askProceed(overwrite, false)
+							? askProceed(overwrite, false)
 							: true;
 
 					String suggested = this.state.getManager().getNewRepositoryID(repConfig.getID());
 					String invalid = "WARNING: There are potentially incompatible characters in the repository id.";
 					boolean proceedInvalid = !suggested.startsWith(repConfig.getID())
-							? consoleIO.askProceed(invalid, false)
+							? askProceed(invalid, false)
 							: true;
 
 					if (proceedInvalid && proceedOverwrite) {

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
@@ -50,17 +50,12 @@ import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.UserInterruptException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Create command
  *
  * @author Dale Visser
  */
 public class Create extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Create.class);
-
 	private static final String TEMPLATES_SUBDIR = "templates";
 	private static final String FILE_EXT = ".ttl";
 	private File templatesDir;

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
@@ -131,7 +131,7 @@ public class Create extends ConsoleCommand {
 		try {
 			return getOrderedTemplates(templatesDir.toPath());
 		} catch (IOException ioe) {
-			LOGGER.error("Failed to read templates directory repository ", ioe);
+			writeError("Failed to read templates directory repository ", ioe);
 		}
 		return "";
 	}
@@ -155,7 +155,7 @@ public class Create extends ConsoleCommand {
 				}
 			}
 		} catch (NullPointerException | URISyntaxException | IOException e) {
-			LOGGER.error("Could not get built-in config templates from JAR", e);
+			writeError("Could not get built-in config templates from JAR", e);
 		}
 		return "";
 	}
@@ -215,27 +215,25 @@ public class Create extends ConsoleCommand {
 					if (proceedInvalid && proceedOverwrite) {
 						try {
 							this.state.getManager().addRepositoryConfig(repConfig);
-							consoleIO.writeln("Repository created");
+							writeInfo("Repository created");
 						} catch (RepositoryReadOnlyException e) {
 							if (LockRemover.tryToRemoveLock(this.state.getManager().getSystemRepository(), consoleIO)) {
 								this.state.getManager().addRepositoryConfig(repConfig);
-								consoleIO.writeln("Repository created");
+								writeInfo("Repository created");
 							} else {
-								consoleIO.writeError("Failed to create repository");
-								LOGGER.error("Failed to create repository", e);
+								writeError("Failed to create repository", e);
 							}
 						}
 					} else {
-						consoleIO.writeln("Create aborted");
+						writeln("Create aborted");
 					}
 				}
 			}
 		} catch (EndOfFileException | UserInterruptException e) {
-			LOGGER.error("Create repository aborted", e);
+			writeError("Create repository aborted", e);
 			throw e;
 		} catch (Exception e) {
-			consoleIO.writeError(e.toString());
-			LOGGER.error("Failed to create repository", e);
+			writeError("Failed to create repository", e);
 		}
 	}
 
@@ -251,7 +249,7 @@ public class Create extends ConsoleCommand {
 	private boolean inputParameters(final Map<String, String> valueMap, final Map<String, List<String>> variableMap,
 			Map<String, String> multilineInput) throws IOException {
 		if (!variableMap.isEmpty()) {
-			consoleIO.writeln("Please specify values for the following variables:");
+			writeln("Please specify values for the following variables:");
 		}
 		boolean eof = false;
 
@@ -310,13 +308,13 @@ public class Create extends ConsoleCommand {
 			if (templateFile.canRead()) {
 				templateStream = new FileInputStream(templateFile);
 			} else {
-				consoleIO.writeError("Not allowed to read template file: " + templateFile);
+				writeError("Not allowed to read template file: " + templateFile);
 			}
 		} else {
 			// Try class path for built-ins
 			templateStream = RepositoryConfig.class.getResourceAsStream(templateFileName);
 			if (templateStream == null) {
-				consoleIO.writeError("No template called " + templateName + " found in " + templatesDir);
+				writeError("No template called " + templateName + " found in " + templatesDir);
 			}
 		}
 		return templateStream;

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Disconnect.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Disconnect.java
@@ -19,7 +19,6 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
  * @author Dale Visser
  */
 public class Disconnect extends ConsoleCommand {
-
 	private final Close close;
 
 	@Override

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Disconnect.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Disconnect.java
@@ -58,11 +58,11 @@ public class Disconnect extends ConsoleCommand {
 		final RepositoryManager manager = this.state.getManager();
 		if (manager == null) {
 			if (verbose) {
-				consoleIO.writeln("Already disconnected");
+				writeln("Already disconnected");
 			}
 		} else {
 			close.closeRepository(false);
-			consoleIO.writeln("Disconnecting from " + this.state.getManagerID());
+			writeln("Disconnecting from " + this.state.getManagerID());
 			manager.shutDown();
 			state.setManager(null);
 			state.setManagerID(null);

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Drop.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Drop.java
@@ -17,15 +17,10 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.RepositoryReadOnlyException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * @author Dale Visser
  */
 public class Drop extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Drop.class);
-
 	private final Close close;
 
 	@Override

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Drop.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Drop.java
@@ -58,29 +58,25 @@ public class Drop extends ConsoleCommand {
 	@Override
 	public void execute(String... tokens) throws IOException {
 		if (tokens.length < 2) {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 		} else {
 			final String repoID = tokens[1];
 			try {
 				dropRepository(repoID);
 			} catch (RepositoryConfigException e) {
-				consoleIO.writeError("Unable to drop repository '" + repoID + "': " + e.getMessage());
-				LOGGER.warn("Unable to drop repository '" + repoID + "'", e);
+				writeError("Unable to drop repository '" + repoID, e);
 			} catch (RepositoryReadOnlyException e) {
 				try {
 					if (LockRemover.tryToRemoveLock(state.getManager().getSystemRepository(), consoleIO)) {
 						execute(tokens);
 					} else {
-						consoleIO.writeError("Failed to drop repository");
-						LOGGER.error("Failed to drop repository", e);
+						writeError("Failed to drop repository", e);
 					}
 				} catch (RepositoryException e2) {
-					consoleIO.writeError("Failed to restart system: " + e2.getMessage());
-					LOGGER.error("Failed to restart system", e2);
+					writeError("Failed to restart system", e2);
 				}
 			} catch (RepositoryException e) {
-				consoleIO.writeError("Failed to update configuration in system repository: " + e.getMessage());
-				LOGGER.warn("Failed to update configuration in system repository", e);
+				writeError("Failed to update configuration in system repository", e);
 			}
 		}
 	}
@@ -106,12 +102,12 @@ public class Drop extends ConsoleCommand {
 			}
 			final boolean isRemoved = state.getManager().removeRepository(repoID);
 			if (isRemoved) {
-				consoleIO.writeln("Dropped repository '" + repoID + "'");
+				writeInfo("Dropped repository '" + repoID + "'");
 			} else {
-				consoleIO.writeln("Unknown repository '" + repoID + "'");
+				writeInfo("Unknown repository '" + repoID + "'");
 			}
 		} else {
-			consoleIO.writeln("Drop aborted");
+			writeln("Drop aborted");
 		}
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Drop.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Drop.java
@@ -86,9 +86,9 @@ public class Drop extends ConsoleCommand {
 	 */
 	private void dropRepository(final String repoID)
 			throws IOException, RepositoryException, RepositoryConfigException {
-		boolean proceed = consoleIO.askProceed("WARNING: you are about to drop repository '" + repoID + "'.", true);
+		boolean proceed = askProceed("WARNING: you are about to drop repository '" + repoID + "'.", true);
 		if (proceed && !state.getManager().isSafeToRemove(repoID)) {
-			proceed = consoleIO.askProceed("WARNING: dropping this repository may break another that is proxying it.",
+			proceed = askProceed("WARNING: dropping this repository may break another that is proxying it.",
 					false);
 		}
 		if (proceed) {

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
+
 /**
  * Export triples to file
  * 
@@ -71,7 +72,7 @@ public class Export extends ConsoleCommand {
 		Repository repository = state.getRepository();
 
 		if (repository == null) {
-			consoleIO.writeUnopenedError();
+			writeUnopenedError();
 			return;
 		}
 		if (tokens.length < 2) {
@@ -116,14 +117,10 @@ public class Export extends ConsoleCommand {
 		}
 
 		if (path.toFile().exists()) {
-			try {
-				boolean overwrite = consoleIO.askProceed("File exists, continue ?", false);
-				if (!overwrite) {
-					writeln("Export aborted");
-					return;
-				}
-			} catch (IOException ioe) {
-				writeError("I/O error", ioe);
+			boolean overwrite = askProceed("File exists, continue ?", false);
+			if (!overwrite) {
+				writeln("Export aborted");
+				return;
 			}
 		}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
@@ -81,7 +81,7 @@ public class Export extends ConsoleCommand {
 			return;
 		}
 		if (tokens.length < 2) {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 			return;
 		}
 
@@ -91,7 +91,7 @@ public class Export extends ConsoleCommand {
 		try {
 			contexts = Util.getContexts(tokens, 2, repository);
 		} catch (IllegalArgumentException ioe) {
-			consoleIO.writeError(ioe.getMessage());
+			writeError(ioe.getMessage());
 			return;
 		}
 		export(repository, fileName, contexts);
@@ -117,7 +117,7 @@ public class Export extends ConsoleCommand {
 	private void export(Repository repository, String fileName, Resource... contexts) {
 		Path path = Util.getNormalizedPath(getWorkDir(), fileName);
 		if (path == null) {
-			consoleIO.writeError("Invalid file name");
+			writeError("Invalid file name " + fileName);
 			return;
 		}
 
@@ -125,11 +125,11 @@ public class Export extends ConsoleCommand {
 			try {
 				boolean overwrite = consoleIO.askProceed("File exists, continue ?", false);
 				if (!overwrite) {
-					consoleIO.writeln("Export aborted");
+					writeln("Export aborted");
 					return;
 				}
 			} catch (IOException ioe) {
-				consoleIO.writeError("I/O error " + ioe.getMessage());
+				writeError("I/O error", ioe);
 			}
 		}
 
@@ -142,14 +142,14 @@ public class Export extends ConsoleCommand {
 			RDFWriter writer = Rio.createWriter(fmt, w);
 
 			long startTime = System.nanoTime();
-			consoleIO.writeln("Exporting data...");
+			writeln("Exporting data...");
 
 			conn.export(writer, contexts);
 
 			long diff = (System.nanoTime() - startTime) / 1_000_000;
-			consoleIO.writeln("Data has been written to file (" + diff + " ms)");
+			writeln("Data has been written to file (" + diff + " ms)");
 		} catch (IOException | UnsupportedRDFormatException e) {
-			consoleIO.writeError("Failed to export data: " + e.getMessage());
+			writeError("Failed to export data", e);
 		}
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Export.java
@@ -28,18 +28,12 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Export triples to file
  * 
  * @author Bart Hanssens
  */
 public class Export extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Export.class);
-
 	@Override
 	public String getName() {
 		return "export";

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Federate.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Federate.java
@@ -22,17 +22,12 @@ import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.runtime.RepositoryManagerFederator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Implements the 'federate' command for the RDF4J Console.
  *
  * @author Dale Visser
  */
 public class Federate extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Federate.class);
-
 	@Override
 	public String getName() {
 		return "federate";

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Federate.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Federate.java
@@ -77,7 +77,7 @@ public class Federate extends ConsoleCommand {
 	@Override
 	public void execute(String... parameters) throws IOException {
 		if (parameters.length < 4) {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 		} else {
 			LinkedList<String> plist = new LinkedList<>(Arrays.asList(parameters));
 			plist.remove(); // "federate"
@@ -88,7 +88,7 @@ public class Federate extends ConsoleCommand {
 				String fedID = plist.pop();
 				federate(distinct, readonly, fedID, plist);
 			} else {
-				consoleIO.writeError("Duplicate repository id's specified.");
+				writeError("Duplicate repository id's specified.");
 			}
 		}
 	}
@@ -118,17 +118,17 @@ public class Federate extends ConsoleCommand {
 		RepositoryManager manager = state.getManager();
 		try {
 			if (manager.hasRepositoryConfig(fedID)) {
-				consoleIO.writeError(fedID + " already exists.");
+				writeError(fedID + " already exists.");
 			} else if (validateMembers(manager, readonly, memberIDs)) {
 				String description = consoleIO.readln("Federation Description (optional): ");
 				RepositoryManagerFederator rmf = new RepositoryManagerFederator(manager);
 				rmf.addFed(fedID, description, memberIDs, readonly, distinct);
-				consoleIO.writeln("Federation created.");
+				writeln("Federation created.");
 			}
 		} catch (RepositoryConfigException | RepositoryException | MalformedURLException rce) {
-			consoleIO.writeError(rce.getMessage());
+			writeError("Federation failed", rce);
 		} catch (RDF4JException | IOException rce) {
-			consoleIO.writeError(rce.getMessage());
+			writeError("I/O exception on federation", rce);
 		}
 	}
 
@@ -148,16 +148,16 @@ public class Federate extends ConsoleCommand {
 					if (!readonly) {
 						if (!manager.getRepository(memberID).isWritable()) {
 							result = false;
-							consoleIO.writeError(memberID + " is read-only.");
+							writeError(memberID + " is read-only.");
 						}
 					}
 				} else {
 					result = false;
-					consoleIO.writeError(memberID + " does not exist.");
+					writeError(memberID + " does not exist.");
 				}
 			}
 		} catch (RepositoryException | RepositoryConfigException re) {
-			consoleIO.writeError(re.getMessage());
+			writeError(re.getMessage());
 		}
 		return result;
 	}

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Load.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Load.java
@@ -29,17 +29,12 @@ import org.eclipse.rdf4j.repository.RepositoryReadOnlyException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Load command
  * 
  * @author Dale Visser
  */
 public class Load extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Load.class);
-
 	@Override
 	public String getName() {
 		return "load";

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Load.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Load.java
@@ -74,7 +74,7 @@ public class Load extends ConsoleCommand {
 	public void execute(final String... tokens) {
 		Repository repository = state.getRepository();
 		if (repository == null) {
-			consoleIO.writeUnopenedError();
+			writeUnopenedError();
 		} else {
 			if (tokens.length < 2) {
 				writeln(getHelpLong());

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Load.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Load.java
@@ -82,7 +82,7 @@ public class Load extends ConsoleCommand {
 			consoleIO.writeUnopenedError();
 		} else {
 			if (tokens.length < 2) {
-				consoleIO.writeln(getHelpLong());
+				writeln(getHelpLong());
 			} else {
 				String baseURI = null;
 				String context = null;
@@ -97,7 +97,7 @@ public class Load extends ConsoleCommand {
 					index += 2;
 				}
 				if (index < tokens.length) {
-					consoleIO.writeln(getHelpLong());
+					writeln(getHelpLong());
 				} else {
 					load(repository, baseURI, context, tokens);
 				}
@@ -143,19 +143,18 @@ public class Load extends ConsoleCommand {
 		} catch (RepositoryReadOnlyException e) {
 			handleReadOnlyException(repository, e, tokens);
 		} catch (MalformedURLException e) {
-			consoleIO.writeError("Malformed URL: " + dataPath);
+			writeError("Malformed URL: " + dataPath);
 		} catch (IllegalArgumentException e) {
 			// Thrown when context URI is invalid
-			consoleIO.writeError(e.getMessage());
+			writeError(e.getMessage());
 		} catch (IOException e) {
-			consoleIO.writeError("Failed to load data: " + e.getMessage());
+			writeError("Failed to load data", e);
 		} catch (UnsupportedRDFormatException e) {
-			consoleIO.writeError("No parser available for this RDF format");
+			writeError("No parser available for this RDF format");
 		} catch (RDFParseException e) {
-			consoleIO.writeError("Malformed document: " + e.getMessage());
+			writeError("Malformed document", e);
 		} catch (RepositoryException e) {
-			consoleIO.writeError("Unable to add data to repository: " + e.getMessage());
-			LOGGER.error("Failed to add data to repository", e);
+			writeError("Unable to add data to repository", e);
 		}
 	}
 
@@ -173,14 +172,12 @@ public class Load extends ConsoleCommand {
 			if (LockRemover.tryToRemoveLock(repository, consoleIO)) {
 				execute(tokens);
 			} else {
-				consoleIO.writeError("Failed to load data");
-				LOGGER.error("Failed to load data", caught);
+				writeError("Failed to load data", caught);
 			}
-		} catch (RepositoryException e1) {
-			consoleIO.writeError("Unable to restart repository: " + e1.getMessage());
-			LOGGER.error("Unable to restart repository", e1);
-		} catch (IOException e1) {
-			consoleIO.writeError("Unable to remove lock: " + e1.getMessage());
+		} catch (RepositoryException e) {
+			writeError("Unable to restart repository", e);
+		} catch (IOException e) {
+			writeError("Unable to remove lock", e);
 		}
 	}
 
@@ -199,7 +196,7 @@ public class Load extends ConsoleCommand {
 	private void addData(Repository repository, String baseURI, String context, URL dataURL, File dataFile)
 			throws RepositoryException, IOException, RDFParseException {
 		Resource[] contexts = getContexts(repository, context);
-		consoleIO.writeln("Loading data...");
+		writeln("Loading data...");
 
 		final long startTime = System.nanoTime();
 		try (RepositoryConnection con = repository.getConnection()) {
@@ -210,7 +207,7 @@ public class Load extends ConsoleCommand {
 			}
 		}
 		final long endTime = System.nanoTime();
-		consoleIO.writeln("Data has been added to the repository (" + (endTime - startTime) / 1000000 + " ms)");
+		writeln("Data has been added to the repository (" + (endTime - startTime) / 1_000_000 + " ms)");
 	}
 
 	/**

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Open.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Open.java
@@ -63,7 +63,7 @@ public class Open extends ConsoleCommand {
 		if (tokens.length == 2) {
 			openRepository(tokens[1]);
 		} else {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 		}
 	}
 
@@ -79,28 +79,26 @@ public class Open extends ConsoleCommand {
 			final Repository newRepository = state.getManager().getRepository(repoID);
 
 			if (newRepository == null) {
-				consoleIO.writeError("Unknown repository: '" + repoID + "'");
+				writeError("Unknown repository: '" + repoID + "'");
 			} else {
 				// Close current repository, if any
 				close.closeRepository(false);
 				state.setRepository(newRepository);
 				state.setRepositoryID(repoID);
-				consoleIO.writeln("Opened repository '" + repoID + "'");
+				writeln("Opened repository '" + repoID + "'");
 			}
 		} catch (RepositoryLockedException e) {
 			try {
 				if (LockRemover.tryToRemoveLock(e, consoleIO)) {
 					openRepository(repoID);
 				} else {
-					consoleIO.writeError(OPEN_FAILURE);
-					LOGGER.error(OPEN_FAILURE, e);
+					writeError(OPEN_FAILURE, e);
 				}
-			} catch (IOException e1) {
-				consoleIO.writeError("Unable to remove lock: " + e1.getMessage());
+			} catch (IOException ioe) {
+				writeError("Unable to remove lock", ioe);
 			}
 		} catch (RepositoryConfigException | RepositoryException e) {
-			consoleIO.writeError(e.getMessage());
-			LOGGER.error(OPEN_FAILURE, e);
+			writeError(OPEN_FAILURE, e);
 		}
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Open.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Open.java
@@ -18,17 +18,12 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.RepositoryLockedException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Open command
  * 
  * @author Dale Visser
  */
 public class Open extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Open.class);
-
 	private final Close close;
 
 	@Override

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/PrintHelp.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/PrintHelp.java
@@ -59,7 +59,7 @@ public class PrintHelp extends ConsoleCommand {
 		final String target = parameters[1].toLowerCase(Locale.ENGLISH);
 		Help cmd = commands.get(target);
 		if (cmd != null) {
-			consoleIO.writeln(cmd.getHelpLong());
+			writeln(cmd.getHelpLong());
 			if (cmd instanceof ConsoleCommand) {
 				String[] uses = ((ConsoleCommand) cmd).usesSettings();
 				if (uses.length > 0) {

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/PrintHelp.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/PrintHelp.java
@@ -63,12 +63,12 @@ public class PrintHelp extends ConsoleCommand {
 			if (cmd instanceof ConsoleCommand) {
 				String[] uses = ((ConsoleCommand) cmd).usesSettings();
 				if (uses.length > 0) {
-					consoleIO.writeln();
-					consoleIO.writeln("Uses settings: " + String.join(", ", uses));
+					writeln("");
+					writeln("Uses settings: " + String.join(", ", uses));
 				}
 			}
 		} else {
-			consoleIO.writeln("No additional info available for command " + target);
+			writeln("No additional info available for command " + target);
 		}
 	}
 
@@ -76,13 +76,13 @@ public class PrintHelp extends ConsoleCommand {
 	 * Print list of commands
 	 */
 	private void printCommandOverview() {
-		consoleIO.writeln("For more information on a specific command, try 'help <command>'.");
-		consoleIO.writeln("List of all commands:");
+		writeln("For more information on a specific command, try 'help <command>'.");
+		writeln("List of all commands:");
 
 		commands.forEach((k, v) -> {
-			consoleIO.writeln(String.format("%-11s %s", k, v.getHelpShort()));
+			writeln(String.format("%-11s %s", k, v.getHelpShort()));
 		});
 
-		consoleIO.writeln("exit, quit  Exit the console");
+		writeln("exit, quit  Exit the console");
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/PrintInfo.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/PrintInfo.java
@@ -44,9 +44,9 @@ public class PrintInfo extends ConsoleCommand {
 
 	@Override
 	public void execute(String... parameters) {
-		consoleIO.writeln(state.getApplicationName());
-		consoleIO.writeln("Data dir: " + state.getDataDirectory());
+		writeln(state.getApplicationName());
+		writeln("Data dir: " + state.getDataDirectory());
 		String managerID = state.getManagerID();
-		consoleIO.writeln("Connected to: " + (managerID == null ? "-" : managerID));
+		writeln("Connected to: " + (managerID == null ? "-" : managerID));
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -60,9 +60,6 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Abstract query evaluator command
  * 
@@ -70,9 +67,6 @@ import org.slf4j.LoggerFactory;
  * @author Bart Hanssens
  */
 public abstract class QueryEvaluator extends ConsoleCommand {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(QueryEvaluator.class);
-
 	private final TupleAndGraphQueryEvaluator evaluator;
 
 	private final List<String> sparqlQueryStart = Arrays

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -29,7 +28,6 @@ import java.util.regex.Pattern;
 import org.eclipse.rdf4j.common.io.UncloseableOutputStream;
 import org.eclipse.rdf4j.console.Util;
 
-import org.eclipse.rdf4j.console.setting.ConsoleSetting;
 import org.eclipse.rdf4j.console.setting.ConsoleWidth;
 import org.eclipse.rdf4j.console.setting.Prefixes;
 import org.eclipse.rdf4j.console.setting.QueryPrefix;
@@ -185,7 +183,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 		} else if ("sparql".equals(operation)) {
 			parseAndEvaluateQuery(QueryLanguage.SPARQL, command.substring("sparql".length()));
 		} else {
-			consoleIO.writeError("Unknown command");
+			writeError("Unknown command");
 		}
 	}
 
@@ -251,12 +249,11 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 			return str;
 		}
 		try {
-			consoleIO.writeln("Enter multi-line " + queryLn.getName() + " query "
+			writeln("Enter multi-line " + queryLn.getName() + " query "
 					+ "(terminate with line containing single '.')");
 			return consoleIO.readMultiLineInput();
 		} catch (IOException e) {
-			consoleIO.writeError("I/O error: " + e.getMessage());
-			LOGGER.error("Failed to read query", e);
+			writeError("Failed to read query", e);
 		}
 		return null;
 	}
@@ -271,7 +268,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	private void parseAndEvaluateQuery(QueryLanguage queryLn, String queryText) {
 		String str = readMultiline(queryLn, queryText);
 		if (str == null || str.isEmpty()) {
-			consoleIO.writeError("Empty query string");
+			writeError("Empty query string");
 			return;
 		}
 
@@ -292,7 +289,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 					str = readFile(infile, m.group("enc")); // ignore remainder of command line query
 				}
 			} catch (IOException | IllegalArgumentException ex) {
-				consoleIO.writeError(ex.getMessage());
+				writeError(ex.getMessage());
 				return;
 			}
 		}
@@ -304,21 +301,17 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 			ParsedOperation query = QueryParserUtil.parseOperation(queryLn, queryString, null);
 			evaluateQuery(queryLn, query, path);
 		} catch (UnsupportedQueryLanguageException e) {
-			consoleIO.writeError("Unsupported query language: " + queryLn.getName());
+			writeError("Unsupported query language: " + queryLn.getName());
 		} catch (MalformedQueryException e) {
-			consoleIO.writeError("Malformed query: " + e.getMessage());
+			writeError("Malformed query", e);
 		} catch (QueryInterruptedException e) {
-			consoleIO.writeError("Query interrupted: " + e.getMessage());
-			LOGGER.error("Query interrupted", e);
+			writeError("Query interrupted", e);
 		} catch (QueryEvaluationException e) {
-			consoleIO.writeError("Query evaluation error: " + e.getMessage());
-			LOGGER.error("Query evaluation error", e);
+			writeError("Query evaluation error", e);
 		} catch (RepositoryException e) {
-			consoleIO.writeError("Failed to evaluate query: " + e.getMessage());
-			LOGGER.error("Failed to evaluate query", e);
+			writeError("Failed to evaluate query", e);
 		} catch (UpdateExecutionException e) {
-			consoleIO.writeError("Failed to execute update: " + e.getMessage());
-			LOGGER.error("Failed to execute update", e);
+			writeError("Failed to execute update", e);
 		}
 	}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -166,7 +166,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	public void executeQuery(final String command, final String operation) {
 		Repository repository = state.getRepository();
 		if (repository == null) {
-			consoleIO.writeUnopenedError();
+			writeUnopenedError();
 			return;
 		}
 
@@ -223,7 +223,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 		}
 
 		Path p = Util.getNormalizedPath(getWorkDir(), filename);
-		if (!p.toFile().exists() || consoleIO.askProceed("File exists, continue ?", false)) {
+		if (!p.toFile().exists() || askProceed("File exists, continue ?", false)) {
 			return p;
 		}
 		throw new IOException("Could not open file for output");
@@ -408,10 +408,10 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 				}
 				evaluator.executeUpdate(queryLn, queryString);
 			} else {
-				consoleIO.writeError("Unexpected query type");
+				writeError("Unexpected query type");
 			}
 		} catch (IllegalArgumentException | IOException ioe) {
-			consoleIO.writeError(ioe.getMessage());
+			writeError(ioe.getMessage());
 		}
 	}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
@@ -20,7 +20,6 @@ import org.eclipse.rdf4j.console.setting.ConsoleSetting;
  * @author dale
  */
 public class SetParameters extends ConsoleCommand {
-	private final Map<String, ConsoleSetting> settings;
 
 	@Override
 	public String getName() {
@@ -49,15 +48,14 @@ public class SetParameters extends ConsoleCommand {
 	 * @param settings
 	 */
 	public SetParameters(ConsoleIO consoleIO, ConsoleState state, Map<String, ConsoleSetting> settings) {
-		super(consoleIO, state);
-		this.settings = settings;
+		super(consoleIO, state, settings);
 	}
 
 	@Override
 	public void execute(String... tokens) {
 		switch (tokens.length) {
 		case 0:
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 			break;
 		case 1:
 			for (String setting : settings.keySet()) {
@@ -98,9 +96,9 @@ public class SetParameters extends ConsoleCommand {
 				}
 				s = builder.toString();
 			}
-			consoleIO.writeln(key + ": " + s);
+			writeln(key + ": " + s);
 		} else {
-			consoleIO.writeError("Unknown parameter: " + key);
+			writeError("Unknown parameter: " + key);
 		}
 	}
 
@@ -121,10 +119,10 @@ public class SetParameters extends ConsoleCommand {
 			try {
 				setting.setFromString(value);
 			} catch (IllegalArgumentException iae) {
-				consoleIO.writeError(iae.getMessage());
+				writeError(iae.getMessage());
 			}
 		} else {
-			consoleIO.writeError("Unknown parameter: " + key);
+			writeError("Unknown parameter: " + key);
 		}
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Show.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Show.java
@@ -86,19 +86,19 @@ public class Show extends ConsoleCommand {
 			} else {
 				writeln(OUTPUT_SEPARATOR);
 				for (String repID : repIDs) {
-					consoleIO.write("|" + repID);
+					write("|" + repID);
 
 					try {
 						final RepositoryInfo repInfo = manager.getRepositoryInfo(repID);
 						if (repInfo.getDescription() != null) {
-							consoleIO.write(" (\"" + repInfo.getDescription() + "\")");
+							write(" (\"" + repInfo.getDescription() + "\")");
 						}
 					} catch (RepositoryException e) {
-						consoleIO.write(" [ERROR: " + e.getMessage() + "]");
+						write(" [ERROR: " + e.getMessage() + "]");
 					}
 					writeln("");
 				}
-				consoleIO.writeln(OUTPUT_SEPARATOR);
+				writeln(OUTPUT_SEPARATOR);
 			}
 		} catch (RepositoryException e) {
 			writeError("Failed to get repository list", e);
@@ -111,7 +111,7 @@ public class Show extends ConsoleCommand {
 	private void showNamespaces() {
 		Repository repository = state.getRepository();
 		if (repository == null) {
-			consoleIO.writeUnopenedError();
+			writeUnopenedError();
 			return;
 		}
 
@@ -139,7 +139,7 @@ public class Show extends ConsoleCommand {
 	private void showContexts() {
 		Repository repository = state.getRepository();
 		if (repository == null) {
-			consoleIO.writeUnopenedError();
+			writeUnopenedError();
 			return;
 		}
 

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Show.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Show.java
@@ -21,18 +21,12 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.manager.RepositoryInfo;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Show command
  *
  * @author Dale Visser
  */
 public class Show extends ConsoleCommand {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(Show.class);
-
 	private static final String OUTPUT_SEPARATOR = "+----------";
 
 	@Override

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Show.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Show.java
@@ -73,10 +73,10 @@ public class Show extends ConsoleCommand {
 			} else if ("contexts".equals(target) || "c".equals(target)) {
 				showContexts();
 			} else {
-				consoleIO.writeError("Unknown target '" + tokens[1] + "'");
+				writeError("Unknown target '" + tokens[1] + "'");
 			}
 		} else {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 		}
 	}
 
@@ -88,9 +88,9 @@ public class Show extends ConsoleCommand {
 			RepositoryManager manager = state.getManager();
 			final Set<String> repIDs = manager.getRepositoryIDs();
 			if (repIDs.isEmpty()) {
-				consoleIO.writeln("--no repositories found--");
+				writeln("No repositories found");
 			} else {
-				consoleIO.writeln(OUTPUT_SEPARATOR);
+				writeln(OUTPUT_SEPARATOR);
 				for (String repID : repIDs) {
 					consoleIO.write("|" + repID);
 
@@ -102,13 +102,12 @@ public class Show extends ConsoleCommand {
 					} catch (RepositoryException e) {
 						consoleIO.write(" [ERROR: " + e.getMessage() + "]");
 					}
-					consoleIO.writeln();
+					writeln("");
 				}
 				consoleIO.writeln(OUTPUT_SEPARATOR);
 			}
 		} catch (RepositoryException e) {
-			consoleIO.writeError("Failed to get repository list: " + e.getMessage());
-			LOGGER.error("Failed to get repository list", e);
+			writeError("Failed to get repository list", e);
 		}
 	}
 
@@ -125,19 +124,18 @@ public class Show extends ConsoleCommand {
 		try (RepositoryConnection con = repository.getConnection()) {
 			try (CloseableIteration<? extends Namespace, RepositoryException> namespaces = con.getNamespaces()) {
 				if (namespaces.hasNext()) {
-					consoleIO.writeln(OUTPUT_SEPARATOR);
+					writeln(OUTPUT_SEPARATOR);
 					while (namespaces.hasNext()) {
 						final Namespace namespace = namespaces.next();
-						consoleIO.writeln("|" + namespace.getPrefix() + "  " + namespace.getName());
+						writeln("|" + namespace.getPrefix() + "  " + namespace.getName());
 					}
-					consoleIO.writeln(OUTPUT_SEPARATOR);
+					writeln(OUTPUT_SEPARATOR);
 				} else {
-					consoleIO.writeln("--no namespaces found--");
+					writeln("No namespaces found");
 				}
 			}
 		} catch (RepositoryException e) {
-			consoleIO.writeError(e.getMessage());
-			LOGGER.error("Failed to show namespaces", e);
+			writeError("Failed to show namespaces", e);
 		}
 	}
 
@@ -154,18 +152,17 @@ public class Show extends ConsoleCommand {
 		try (RepositoryConnection con = repository.getConnection()) {
 			try (CloseableIteration<? extends Resource, RepositoryException> contexts = con.getContextIDs()) {
 				if (contexts.hasNext()) {
-					consoleIO.writeln(OUTPUT_SEPARATOR);
+					writeln(OUTPUT_SEPARATOR);
 					while (contexts.hasNext()) {
-						consoleIO.writeln("|" + contexts.next().toString());
+						writeln("|" + contexts.next().toString());
 					}
-					consoleIO.writeln(OUTPUT_SEPARATOR);
+					writeln(OUTPUT_SEPARATOR);
 				} else {
-					consoleIO.writeln("--no contexts found--");
+					writeln("No contexts found");
 				}
 			}
 		} catch (RepositoryException e) {
-			consoleIO.writeError(e.getMessage());
-			LOGGER.error("Failed to show contexts", e);
+			writeError("Failed to show contexts", e);
 		}
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -94,7 +94,7 @@ public class Verify extends ConsoleCommand {
 	@Override
 	public void execute(String... tokens) {
 		if (tokens.length != 2 && tokens.length != 4) {
-			consoleIO.writeln(getHelpLong());
+			writeln(getHelpLong());
 			return;
 		}
 
@@ -129,7 +129,7 @@ public class Verify extends ConsoleCommand {
 			RDFFormat format = Rio.getParserFormatForFileName(dataPath).orElseThrow(Rio.unsupportedFormat(dataPath));
 			RDFParser parser = Rio.createParser(format);
 
-			consoleIO.writeln("RDF Format is " + parser.getRDFFormat().getName());
+			writeln("RDF Format is " + parser.getRDFFormat().getName());
 
 			VerificationListener listener = new VerificationListener(consoleIO);
 
@@ -144,7 +144,7 @@ public class Verify extends ConsoleCommand {
 
 			parser.setParseErrorListener(listener);
 			parser.setRDFHandler(listener);
-			consoleIO.writeln("Verifying data...");
+			writeln("Verifying data...");
 
 			try (InputStream dataStream = dataURL.openStream()) {
 				parser.parse(dataStream, "urn://openrdf.org/RioVerifier/");
@@ -154,24 +154,23 @@ public class Verify extends ConsoleCommand {
 			int errors = listener.getErrors();
 
 			if (warnings + errors > 0) {
-				consoleIO.writeError("Found " + warnings + " warnings and " + errors + " errors");
+				writeError("Found " + warnings + " warnings and " + errors + " errors");
 			} else {
-				consoleIO.writeln("Data verified, no errors were found");
+				writeln("Data verified, no errors were found");
 			}
 			if (errors == 0) {
-				consoleIO.writeln("File contains " + listener.getStatements() + " statements");
+				writeln("File contains " + listener.getStatements() + " statements");
 			}
 		} catch (MalformedURLException e) {
-			consoleIO.writeError("Malformed URL: " + dataPath);
+			writeError("Malformed URL: " + dataPath);
 		} catch (IOException e) {
-			consoleIO.writeError("Failed to load data: " + e.getMessage());
+			writeError("Failed to load data", e);
 		} catch (UnsupportedRDFormatException e) {
-			consoleIO.writeError("No parser available for this RDF format");
+			writeError("No parser available for this RDF format", e);
 		} catch (RDFParseException e) {
-			consoleIO.writeError("Unexpected RDFParseException" + e.getMessage());
+			writeError("Unexpected RDFParseException", e);
 		} catch (RDFHandlerException e) {
-			consoleIO.writeError("Unable to verify : " + e.getMessage());
-			LOGGER.error("Unable to verify data file", e);
+			writeError("Unable to verify", e);
 		}
 	}
 
@@ -192,7 +191,7 @@ public class Verify extends ConsoleCommand {
 		// load shapes first from a file or URL, defaults to turtle, so one can use .shacl as file extension
 		boolean loaded = false;
 		try {
-			consoleIO.writeln("Loading shapes from " + shaclPath);
+			writeln("Loading shapes from " + shaclPath);
 
 			URL shaclURL = new URL(shaclPath);
 			RDFFormat format = Rio.getParserFormatForFileName(reportFile).orElse(RDFFormat.TURTLE);
@@ -204,13 +203,13 @@ public class Verify extends ConsoleCommand {
 			}
 			loaded = true;
 		} catch (MalformedURLException e) {
-			consoleIO.writeError("Malformed URL: " + shaclPath);
+			writeError("Malformed URL: " + shaclPath, e);
 		} catch (IOException e) {
-			consoleIO.writeError("Failed to load shacl shapes: " + e.getMessage());
+			writeError("Failed to load shacl shapes", e);
 		}
 
 		if (!loaded) {
-			consoleIO.writeError("No shapes found");
+			writeError("No shapes found");
 			repo.shutDown();
 			return;
 		}
@@ -227,15 +226,15 @@ public class Verify extends ConsoleCommand {
 				conn.commit();
 			}
 
-			consoleIO.writeln("SHACL validation OK");
+			writeln("SHACL validation OK");
 		} catch (MalformedURLException e) {
-			consoleIO.writeError("Malformed URL: " + dataPath);
+			writeError("Malformed URL: " + dataPath);
 		} catch (IOException e) {
-			consoleIO.writeError("Failed to load data: " + e.getMessage());
+			writeError("Failed to load data", e);
 		} catch (RepositoryException e) {
 			Throwable cause = e.getCause();
 			if (cause instanceof ShaclSailValidationException) {
-				consoleIO.writeError("SHACL validation failed, writing report to " + reportFile);
+				writeError("SHACL validation failed, writing report to " + reportFile);
 				ShaclSailValidationException sv = (ShaclSailValidationException) cause;
 				writeReport(sv.validationReportAsModel(), reportFile);
 			}
@@ -278,7 +277,7 @@ public class Verify extends ConsoleCommand {
 		try (Writer w = Files.newBufferedWriter(Paths.get(reportFile))) {
 			Rio.write(model, w, format, cfg);
 		} catch (IOException ex) {
-			consoleIO.writeError("Could not write report to " + reportFile);
+			writeError("Could not write report to " + reportFile, ex);
 		}
 	}
 }

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -46,9 +46,6 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailValidationException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Verify command
  * 
@@ -56,8 +53,6 @@ import org.slf4j.LoggerFactory;
  * @author Bart Hanssens
  */
 public class Verify extends ConsoleCommand {
-	private static final Logger LOGGER = LoggerFactory.getLogger(Verify.class);
-
 	@Override
 	public String getName() {
 		return "verify";


### PR DESCRIPTION
This PR addresses GitHub issue: #1544 .

Briefly describe the changes proposed in this PR:

* Moved consoleIO.write / writeln / writeUnopenedError / writeError / askProceed to separate methods in abstract ConsoleCommand, which should make logging more consistent (since errors are now always written to the log) and saves a few lines (e.g. when something was written to console _and_ logged)
* Moved static logger per command to (non-static) ConsoleCommand
