### PR TITLE
make invalid context different from unknown/all context + added test

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
@@ -520,12 +520,18 @@ class NativeSailStore implements SailStore {
 				}
 
 				final int[] contextIds = new int[contexts.length == 0 ? 1 : contexts.length];
-				if (contexts.length == 0) {
+				if (contexts.length == 0) { // remove from all contexts
 					contextIds[0] = NativeValue.UNKNOWN_ID;
 				} else {
 					for (int i = 0; i < contexts.length; i++) {
 						Resource context = contexts[i];
-						contextIds[i] = context == null ? 0 : valueStore.getID(context);
+						if (context == null) {
+							contextIds[i] = 0;
+						} else {
+							int id = valueStore.getID(context);
+							// unknown_id cannot be used (would result in removal from all contexts)
+							contextIds[i] = (id != NativeValue.UNKNOWN_ID) ? id : Integer.MIN_VALUE;
+						}
 					}
 				}
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStoreTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStoreTest.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import java.io.File;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * An extension of RDFStoreTest for testing the class {@link NativeStore}.
+ */
+public class NativeSailStoreTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	protected Repository repo;
+
+	protected final ValueFactory F = SimpleValueFactory.getInstance();
+
+	protected final IRI CTX_1 = F.createIRI("urn:one");
+	protected final IRI CTX_2 = F.createIRI("urn:two");
+	protected final IRI CTX_INV = F.createIRI("urn:invalid");
+
+	protected final Statement S0 = F.createStatement(F.createIRI("http://example.org/0"), RDFS.LABEL,
+			F.createLiteral("zero"));
+	protected final Statement S1 = F.createStatement(F.createIRI("http://example.org/1"), RDFS.LABEL,
+			F.createLiteral("one"));
+	protected final Statement S2 = F.createStatement(F.createIRI("http://example.org/2"), RDFS.LABEL,
+			F.createLiteral("two"));
+
+	@Before
+	public void before() throws Exception {
+		File dataDir = tempFolder.newFolder("dbmodel");
+		repo = new SailRepository(new NativeStore(dataDir, "spoc,posc"));
+		repo.init();
+
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.add(S0);
+			conn.add(S1, CTX_1);
+			conn.add(S2, CTX_2);
+		}
+	}
+
+	@Test
+	public void testRemoveValidContext() {
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.remove((IRI) null, null, null, CTX_1);
+		}
+		try (RepositoryConnection conn = repo.getConnection()) {
+			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
+			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
+			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+		}
+	}
+
+	@Test
+	public void testRemoveEmptyContext() {
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.remove((IRI) null, null, null, (Resource) null);
+		}
+		try (RepositoryConnection conn = repo.getConnection()) {
+			assertFalse("Statement 0 still not removed", conn.hasStatement(S0, false));
+			assertTrue("Statement 1 incorrectly removed", conn.hasStatement(S1, false, CTX_1));
+			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+		}
+	}
+
+	@Test
+	public void testRemoveInvalidContext() {
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.remove((IRI) null, null, null, CTX_INV);
+		}
+		try (RepositoryConnection conn = repo.getConnection()) {
+			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
+			assertTrue("Statement 1 incorrectly removed", conn.hasStatement(S1, false, CTX_1));
+			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+		}
+	}
+
+	@Test
+	public void testRemoveMultipleValidContext() {
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.remove((IRI) null, null, null, CTX_1, CTX_2);
+		}
+		try (RepositoryConnection conn = repo.getConnection()) {
+			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
+			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
+			assertFalse("Statement 2 still not removed", conn.hasStatement(S2, false, CTX_2));
+		}
+	}
+
+	@Test
+	public void testClearMultipleValidContext() {
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.clear(CTX_1, CTX_2);
+		}
+		try (RepositoryConnection conn = repo.getConnection()) {
+			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
+			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
+			assertFalse("Statement 2 still not removed", conn.hasStatement(S2, false, CTX_2));
+		}
+	}
+
+	@After
+	public void after() throws Exception {
+		repo.shutDown();
+	}
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #1548 .

Briefly describe the changes proposed in this PR:

Isn't a problem with invalid/not found, S/P/O, because removeStatements immediately returns when
a search for an S/P/O yields UNKNOWN_ID
But for contexts, zero or more contexts can be given + the UNKNOW_ID (-1) is used when zero contexts are selected, effectively removing statements from all contexts + zero is used for empty context.

* use MIN-INT number for context not in the store
* added a test

Another way to solve this would be using a List  + converting it back to int array, or  use System.arraycopy to return only the array of found contexts, but that seems less clear IMHO.