### PR TITLE
Fix to allow auto-closing of linked issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-GitHub issue resolved: #<number>. 
+
+GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. This line 
+                              automatically closes the issue when the PR is merged --> 
 
 Briefly describe the changes proposed in this PR:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
-
-This PR addresses GitHub issue: # .
+GitHub issue resolved: #<number>. 
 
 Briefly describe the changes proposed in this PR:
 


### PR DESCRIPTION
See https://help.github.com/en/articles/closing-issues-using-keywords. This phrasing will ensure the corresponding issue is automatically closed when the PR is merged.



