### PR TITLE
#1585: support inline definition of federation members

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
@@ -16,11 +16,15 @@ import org.eclipse.rdf4j.federated.cache.MemoryCache;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.endpoint.EndpointFactory;
 import org.eclipse.rdf4j.federated.endpoint.ResolvableEndpoint;
+import org.eclipse.rdf4j.federated.endpoint.provider.NativeRepositoryInformation;
+import org.eclipse.rdf4j.federated.endpoint.provider.ResolvableRepositoryInformation;
+import org.eclipse.rdf4j.federated.endpoint.provider.SPARQLRepositoryInformation;
 import org.eclipse.rdf4j.federated.exception.FedXException;
 import org.eclipse.rdf4j.federated.repository.FedXRepository;
 import org.eclipse.rdf4j.federated.statistics.Statistics;
 import org.eclipse.rdf4j.federated.statistics.StatisticsImpl;
 import org.eclipse.rdf4j.federated.util.FileUtil;
+import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.repository.RepositoryResolver;
 import org.eclipse.rdf4j.sail.Sail;
 import org.slf4j.Logger;
@@ -127,6 +131,23 @@ public class FedXFactory {
 	public FedXFactory withMembers(File dataConfig) {
 		log.info("Loading federation members from dataConfig " + dataConfig + ".");
 		members.addAll(EndpointFactory.loadFederationMembers(dataConfig));
+		return this;
+	}
+
+	/**
+	 * Initialize the federation with members from the model.
+	 * <p>
+	 * Currently the types NativeStore, ResolvableEndpoint and SPARQLEndpoint are supported. For details please refer to
+	 * the documentation in {@link NativeRepositoryInformation}, {@link ResolvableRepositoryInformation} and
+	 * {@link SPARQLRepositoryInformation}.
+	 * </p>
+	 * 
+	 * @param model the model defining the federation members
+	 * @return the factory
+	 */
+	public FedXFactory withMembers(Model model) {
+		log.debug("Loading federation members from model.");
+		members.addAll(EndpointFactory.loadFederationMembers(model));
 		return this;
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
@@ -194,10 +194,14 @@ public class EndpointFactory {
 	}
 
 	/**
-	 * Utility function to load federation members from a data configuration file. A data configuration file provides
-	 * information about federation members in form of turtle. Currently the types NativeStore and SPARQLEndpoint are
-	 * supported. For details please refer to the documentation in {@link NativeRepositoryInformation} and
+	 * Utility function to load federation members from a data configuration file.
+	 * 
+	 * <p>
+	 * A data configuration file provides information about federation members in form of turtle. Currently the types
+	 * NativeStore, ResolvableEndpoint and SPARQLEndpoint are supported. For details please refer to the documentation
+	 * in {@link NativeRepositoryInformation}, {@link ResolvableRepositoryInformation} and
 	 * {@link SPARQLRepositoryInformation}.
+	 * </p>
 	 * 
 	 * @param dataConfig
 	 * 
@@ -221,9 +225,26 @@ public class EndpointFactory {
 			throw new FedXException("Unable to parse dataconfig " + dataConfig + ":" + e.getMessage());
 		}
 
+		return loadFederationMembers(graph);
+	}
+
+	/**
+	 * Utility function to load federation members from a model.
+	 * <p>
+	 * Currently the types NativeStore, ResolvableEndpoint and SPARQLEndpoint are supported. For details please refer to
+	 * the documentation in {@link NativeRepositoryInformation}, {@link ResolvableRepositoryInformation} and
+	 * {@link SPARQLRepositoryInformation}.
+	 * </p>
+	 * 
+	 * @param members
+	 * @return
+	 * @throws FedXException
+	 */
+	public static List<Endpoint> loadFederationMembers(Model members) throws FedXException {
+
 		List<Endpoint> res = new ArrayList<>();
-		for (Statement st : graph.filter(null, Vocabulary.FEDX.STORE, null)) {
-			Endpoint e = loadEndpoint(graph, st.getSubject(), st.getObject());
+		for (Statement st : members.filter(null, Vocabulary.FEDX.STORE, null)) {
+			Endpoint e = loadEndpoint(members, st.getSubject(), st.getObject());
 			res.add(e);
 		}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfig.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.federated.repository;
 
 import java.util.Set;
 
+import org.eclipse.rdf4j.federated.util.Vocabulary.FEDX;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
@@ -73,9 +74,9 @@ public class FedXRepositoryConfig extends AbstractRepositoryImplConfig {
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
 	/**
-	 * FedX schema namespace (<tt>http://www.fluidops.com/config/fedx#</tt>).
+	 * FedX schema namespace (<tt>http://rdf4j.org/config/federation#</tt>).
 	 */
-	public static final String NAMESPACE = "http://www.fluidops.com/config/fedx#";
+	public static final String NAMESPACE = FEDX.NAMESPACE;
 
 	/**
 	 * IRI of the property pointing to the FedX configuration

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigTest.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.repository;
+
+import java.io.InputStream;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.federated.util.Vocabulary.FEDX;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.TreeModel;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.github.jsonldjava.shaded.com.google.common.collect.Sets;
+
+public class FedXRepositoryConfigTest {
+
+	@Test
+	public void testParseConfig() throws Exception {
+
+		Model model = readConfig("/tests/rdf4jserver/config.ttl");
+
+		FedXRepositoryConfig config = new FedXRepositoryConfig();
+		config.parse(model, implNode(model));
+		
+		Assertions.assertEquals("fedxConfig.prop", config.getFedxConfig());
+		Assertions.assertNull(config.getDataConfig());
+		
+		Model members = config.getMembers();
+		Assertions.assertEquals(2, members.filter(null, FEDX.STORE, null).size()); // 2 members
+		Assertions.assertEquals(Sets.newHashSet("endpoint1", "endpoint2"),
+				members.filter(null, FEDX.REPOSITORY_NAME, null)
+						.objects()
+						.stream()
+						.map(v -> v.stringValue())
+						.collect(Collectors.toSet()));
+
+	}
+
+	@Test
+	public void testParseConfig_DataConfig() throws Exception {
+
+		Model model = readConfig("/tests/rdf4jserver/config-withDataConfig.ttl");
+
+		FedXRepositoryConfig config = new FedXRepositoryConfig();
+		config.parse(model, implNode(model));
+
+		Assertions.assertEquals("fedxConfig.prop", config.getFedxConfig());
+		Assertions.assertEquals("dataConfig.ttl", config.getDataConfig());
+
+		Assertions.assertNull(config.getMembers());
+
+	}
+
+	@Test
+	public void testExport() throws Exception {
+
+		Model model = readConfig("/tests/rdf4jserver/config.ttl");
+
+		FedXRepositoryConfig config = new FedXRepositoryConfig();
+		config.parse(model, implNode(model));
+
+		// export into model
+		Model export = new TreeModel();
+		Resource implNode = config.export(export);
+
+		Assertions.assertEquals(2, export.filter(implNode, FedXRepositoryConfig.MEMBER, null).size()); // 2 members
+		Assertions.assertEquals(Sets.newHashSet("endpoint1", "endpoint2"),
+				export.filter(null, FEDX.REPOSITORY_NAME, null)
+						.objects()
+						.stream()
+						.map(v -> v.stringValue())
+						.collect(Collectors.toSet()));
+	}
+
+	protected Model readConfig(String configResource) throws Exception {
+		try (InputStream in = FedXRepositoryConfigTest.class.getResourceAsStream(configResource)) {
+			return Rio.parse(in, "http://example.org/", RDFFormat.TURTLE);
+		}
+	}
+
+	protected Resource implNode(Model model) {
+		return Models.subject(model.filter(null, RepositoryConfigSchema.REPOSITORYTYPE, null)).get();
+	}
+
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/Vocabulary.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/Vocabulary.java
@@ -29,7 +29,7 @@ public class Vocabulary {
 	 */
 	public static class FEDX {
 
-		public static final String NAMESPACE = "http://www.fluidops.com/config/fedx#";
+		public static final String NAMESPACE = "http://rdf4j.org/config/federation#";
 
 		/*
 		 * Properties

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXInRDF4JWorkbenchTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXInRDF4JWorkbenchTest.java
@@ -43,6 +43,54 @@ public class FedXInRDF4JWorkbenchTest extends SPARQLServerBaseTest {
 		fedXDataDir.mkdirs();
 
 		FileUtils.copyFile(toFile("/tests/rdf4jserver/config.ttl"), new File(fedXDataDir, "config.ttl"));
+		FileUtils.copyFile(toFile("/tests/rdf4jserver/fedxConfig.prop"), new File(fedXDataDir, "fedxConfig.prop"));
+
+		String fedXSparqlUrl = rdf4jServer.getRepositoryUrl(repositoryId);
+		SPARQLRepository repo = new SPARQLRepository(fedXSparqlUrl);
+		repo.init();
+
+		try (RepositoryConnection conn = repo.getConnection()) {
+			// simple check: make sure that expected data is present
+			Assertions.assertEquals(30, conn.size());
+		}
+
+		repo.shutDown();
+
+		// check that cache is persisted in the expected location
+		FederationManager.getInstance().getCache().persist();
+		Assertions.assertTrue(new File(fedXDataDir, "cache.db").isFile());
+
+		// temporary workaround: shutdown the federation repository explicitly here to
+		// avoid a long running test. This is because the federation keeps an open
+		// connection to other endpoints hosted in the same server, and the shutdown
+		// sequence is arbitrary.
+		Repository fedx = rdf4jServer.getRepositoryResolver().getRepository(repositoryId);
+		fedx.shutDown();
+	}
+
+	@Test
+	public void testFederation_WithDataConfig() throws Exception {
+
+		assumeSparqlEndpoint();
+
+		// load some data into endpoint1 and endpoint2
+		loadDataSet(server.getRepository(1), "/tests/medium/data1.ttl");
+		loadDataSet(server.getRepository(2), "/tests/medium/data2.ttl");
+
+		final String repositoryId = "my-federation";
+		final SPARQLEmbeddedServer rdf4jServer = (SPARQLEmbeddedServer) server;
+		final File dataDir = rdf4jServer.getDataDir();
+		String repoPath = "server/repositories";
+		if (PlatformFactory.getPlatform().dataDirPreserveCase()) {
+			repoPath = "Server/repositories";
+		}
+		final File repositoriesDir = new File(dataDir, repoPath);
+
+		// preparation: add configuration files to the repository
+		File fedXDataDir = new File(repositoriesDir, repositoryId);
+		fedXDataDir.mkdirs();
+
+		FileUtils.copyFile(toFile("/tests/rdf4jserver/config-withDataConfig.ttl"), new File(fedXDataDir, "config.ttl"));
 		FileUtils.copyFile(toFile("/tests/rdf4jserver/dataConfig.ttl"), new File(fedXDataDir, "dataConfig.ttl"));
 		FileUtils.copyFile(toFile("/tests/rdf4jserver/fedxConfig.prop"), new File(fedXDataDir, "fedxConfig.prop"));
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigTest.java
@@ -32,10 +32,10 @@ public class FedXRepositoryConfigTest {
 
 		FedXRepositoryConfig config = new FedXRepositoryConfig();
 		config.parse(model, implNode(model));
-		
+
 		Assertions.assertEquals("fedxConfig.prop", config.getFedxConfig());
 		Assertions.assertNull(config.getDataConfig());
-		
+
 		Model members = config.getMembers();
 		Assertions.assertEquals(2, members.filter(null, FEDX.STORE, null).size()); // 2 members
 		Assertions.assertEquals(Sets.newHashSet("endpoint1", "endpoint2"),

--- a/tools/federation/src/test/resources/tests/dataconfig/endpointfactoryTest.ttl
+++ b/tools/federation/src/test/resources/tests/dataconfig/endpointfactoryTest.ttl
@@ -1,5 +1,5 @@
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix fedx: <http://www.fluidops.com/config/fedx#>.
+@prefix fedx: <http://rdf4j.org/config/federation#>.
 
 <http://dbpedia> a sd:Service ;
 	fedx:store "SPARQLEndpoint";

--- a/tools/federation/src/test/resources/tests/dataconfig/resolvableRepositories.ttl
+++ b/tools/federation/src/test/resources/tests/dataconfig/resolvableRepositories.ttl
@@ -1,5 +1,5 @@
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix fedx: <http://www.fluidops.com/config/fedx#>.
+@prefix fedx: <http://rdf4j.org/config/federation#>.
 
 <http://endpoint1> a sd:Service ;
 	fedx:store "ResolvableRepository" ;

--- a/tools/federation/src/test/resources/tests/rdf4jserver/config-withDataConfig.ttl
+++ b/tools/federation/src/test/resources/tests/rdf4jserver/config-withDataConfig.ttl
@@ -9,14 +9,7 @@
    rep:repositoryImpl [
       rep:repositoryType "fedx:FedXRepository" ;
       fedx:fedxConfig "fedxConfig.prop" ;
-      fedx:member [
-         fedx:store "ResolvableRepository" ;
-         fedx:repositoryName "endpoint1" 
-      ] ,
-      [
-         fedx:store "ResolvableRepository" ;
-         fedx:repositoryName "endpoint2" 
-      ]
+      fedx:dataConfig "dataConfig.ttl" ;
    ];
    rep:repositoryID "my-federation" ;
    rdfs:label "FedX Federation" .

--- a/tools/federation/src/test/resources/tests/rdf4jserver/config-withDataConfig.ttl
+++ b/tools/federation/src/test/resources/tests/rdf4jserver/config-withDataConfig.ttl
@@ -3,7 +3,7 @@
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix fedx: <http://www.fluidops.com/config/fedx#>.
+@prefix fedx: <http://rdf4j.org/config/federation#>.
 
 [] a rep:Repository ;
    rep:repositoryImpl [

--- a/tools/federation/src/test/resources/tests/rdf4jserver/config.ttl
+++ b/tools/federation/src/test/resources/tests/rdf4jserver/config.ttl
@@ -3,7 +3,7 @@
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix fedx: <http://www.fluidops.com/config/fedx#>.
+@prefix fedx: <http://rdf4j.org/config/federation#>.
 
 [] a rep:Repository ;
    rep:repositoryImpl [

--- a/tools/federation/src/test/resources/tests/rdf4jserver/dataConfig.ttl
+++ b/tools/federation/src/test/resources/tests/rdf4jserver/dataConfig.ttl
@@ -1,5 +1,5 @@
 @prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
-@prefix fedx: <http://www.fluidops.com/config/fedx#>.
+@prefix fedx: <http://rdf4j.org/config/federation#>.
 
 <http://endpoint1> a sd:Service ;
 	fedx:store "ResolvableRepository" ;


### PR DESCRIPTION
GitHub issue resolved: #1585 

Briefly describe the changes proposed in this PR:

As of this change tbe federation members can be specified inline in the
repository config turtle file, i.e. no separate dataConfig.ttl file is
required.

