### PR TITLE
Issues/1618 assertion error in abstract sail connection

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
@@ -343,7 +343,7 @@ public abstract class AbstractSailConnection implements SailConnection {
 	}
 
 	@Override
-	synchronized public void flush() throws SailException {
+	public void flush() throws SailException {
 		if (isActive()) {
 			endUpdate(null);
 			startUpdate(null);
@@ -815,7 +815,7 @@ public abstract class AbstractSailConnection implements SailConnection {
 	 *
 	 * @throws SailException
 	 */
-	private void flushPendingUpdates() throws SailException {
+	synchronized private void flushPendingUpdates() throws SailException {
 		if (!isActiveOperation()
 				|| isActive() && !getTransactionIsolation().isCompatibleWith(IsolationLevels.SNAPSHOT_READ)) {
 			flush();

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
@@ -343,7 +343,7 @@ public abstract class AbstractSailConnection implements SailConnection {
 	}
 
 	@Override
-	public void flush() throws SailException {
+	synchronized public void flush() throws SailException {
 		if (isActive()) {
 			endUpdate(null);
 			startUpdate(null);

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/Federation.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/Federation.java
@@ -52,7 +52,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
  * Union multiple (possibly remote) Repositories into a single RDF store.
- * 
+ *
  * @author James Leigh
  * @author Arjohn Kampman
  */
@@ -108,7 +108,7 @@ public class Federation implements Sail, Executor, FederatedServiceResolverClien
 
 	/**
 	 * Returns the members of this federation.
-	 * 
+	 *
 	 * @return unmodifiable list of federation members.
 	 */
 	protected List<Repository> getMembers() {
@@ -118,7 +118,7 @@ public class Federation implements Sail, Executor, FederatedServiceResolverClien
 
 	/**
 	 * Sets an optional {@link RepositoryBloomFilter} to use with the given {@link Repository}.
-	 * 
+	 *
 	 * @param filter the filter to use or null to not use a filter.
 	 */
 	public void setBloomFilter(Repository member, RepositoryBloomFilter filter) {
@@ -127,7 +127,7 @@ public class Federation implements Sail, Executor, FederatedServiceResolverClien
 
 	/**
 	 * Returns the configured {@link RepositoryBloomFilter}s (if any).
-	 * 
+	 *
 	 * @return unmodifiable map of repositories to bloom filters.
 	 */
 	protected Map<Repository, RepositoryBloomFilter> getBloomFilters() {
@@ -182,8 +182,8 @@ public class Federation implements Sail, Executor, FederatedServiceResolverClien
 	/**
 	 * Overrides the {@link FederatedServiceResolver} used by this instance, but the given resolver is not shutDown when
 	 * this instance is.
-	 * 
-	 * @param reslover The SERVICE resolver to set.
+	 *
+	 * @param resolver The SERVICE resolver to set.
 	 */
 	@Override
 	public synchronized void setFederatedServiceResolver(FederatedServiceResolver resolver) {

--- a/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationConnectionTest.java
+++ b/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationConnectionTest.java
@@ -100,9 +100,9 @@ public class FederationConnectionTest {
 	}
 
 	private static void assertHasStatement(String message, Resource subject, URI predicate, Value object,
-										   SailConnection connection) throws SailException {
+			SailConnection connection) throws SailException {
 		try (CloseableIteration<? extends Statement, SailException> statements = connection.getStatements(subject,
-			(IRI) predicate, object, true)) {
+				(IRI) predicate, object, true)) {
 			assertTrue(message, statements.hasNext());
 		}
 	}
@@ -173,23 +173,23 @@ public class FederationConnectionTest {
 
 			ModelBuilder builder = new ModelBuilder();
 			builder
-				.setNamespace("ex", "http://example.org/")
-				.subject("ex:Picasso")
-				.add(RDF.TYPE, "ex:Artist")
-				.add(FOAF.FIRST_NAME, "Pablo")
-				.add("ex:homeAddress", address)
-				.subject("ex:AnotherArtist")
-				.add(RDF.TYPE, "ex:Artist")
-				.add(FOAF.FIRST_NAME, "AnotherArtist")
-				.add("ex:homeAddress", anotherAddress)
-				.subject(address)
-				.add("ex:street", "31 Art Gallery")
-				.add("ex:city", "Madrid")
-				.add("ex:country", "Spain")
-				.subject(anotherAddress)
-				.add("ex:street", "32 Art Gallery")
-				.add("ex:city", "London")
-				.add("ex:country", "UK");
+					.setNamespace("ex", "http://example.org/")
+					.subject("ex:Picasso")
+					.add(RDF.TYPE, "ex:Artist")
+					.add(FOAF.FIRST_NAME, "Pablo")
+					.add("ex:homeAddress", address)
+					.subject("ex:AnotherArtist")
+					.add(RDF.TYPE, "ex:Artist")
+					.add(FOAF.FIRST_NAME, "AnotherArtist")
+					.add("ex:homeAddress", anotherAddress)
+					.subject(address)
+					.add("ex:street", "31 Art Gallery")
+					.add("ex:city", "Madrid")
+					.add("ex:country", "Spain")
+					.subject(anotherAddress)
+					.add("ex:street", "32 Art Gallery")
+					.add("ex:city", "London")
+					.add("ex:country", "UK");
 
 			Model model = builder.build();
 			Repository repo1 = new SailRepository(new MemoryStore());
@@ -207,17 +207,17 @@ public class FederationConnectionTest {
 
 			String ex = "http://example.org/";
 			String queryString = "PREFIX rdf: <" + RDF.NAMESPACE + ">\n" +
-				"PREFIX foaf: <" + FOAF.NAMESPACE + ">\n" +
-				"PREFIX ex: <" + ex + ">\n" +
-				"select (count(?persons) as ?count) {\n" +
-				"   ?persons rdf:type ex:Artist ;\n"
-				+ "          ex:homeAddress ?country .\n"
-				+ " ?country ex:country \"Spain\" . }";
+					"PREFIX foaf: <" + FOAF.NAMESPACE + ">\n" +
+					"PREFIX ex: <" + ex + ">\n" +
+					"select (count(?persons) as ?count) {\n" +
+					"   ?persons rdf:type ex:Artist ;\n"
+					+ "          ex:homeAddress ?country .\n"
+					+ " ?country ex:country \"Spain\" . }";
 
 			SailRepository fedRepo = new SailRepository(fed);
 			fedRepo.init();
 
-			IntStream.range(0,100).parallel().forEach(j -> {
+			IntStream.range(0, 100).parallel().forEach(j -> {
 
 				try (SailRepositoryConnection fedRepoConn = fedRepo.getConnection()) {
 
@@ -232,12 +232,10 @@ public class FederationConnectionTest {
 						}
 					}
 
-
 					fedRepoConn.commit();
 				}
 
 			});
-
 
 			fedRepo.shutDown();
 		}


### PR DESCRIPTION
GitHub issue resolved: #1618

Briefly describe the changes proposed in this PR:

 - Added synchronization to flushPendingUpdates() because this method is called from read operations and should be thread safe. The federation sail has a parallel join operation that assumes the all read operations against the base sails are thread safe.