### PR TITLE
#1621: inject RepositoryResolver into FedX repository

### DIFF
--- a/tools/federation/build/test/rdf4j-server/WEB-INF/rdf4j-http-server-servlet.xml
+++ b/tools/federation/build/test/rdf4j-server/WEB-INF/rdf4j-http-server-servlet.xml
@@ -32,9 +32,9 @@ http://www.springframework.org/schema/aop http://www.springframework.org/schema/
 		</constructor-arg>
 	</bean>
 	
-	<!-- Inject the local repository manager as RepositoryResolver into FedX -->
+	<!-- Inject the local repository manager as RepositoryResolver into FedX for tests -->
 	<bean id="fedxRepositoryResolver"
-		class="org.eclipse.rdf4j.federated.repository.FedXRepositoryResolverBean"
+		class="org.eclipse.rdf4j.federated.server.FedXRepositoryResolverBean"
 		scope="singleton" init-method="init" destroy-method="destroy">
 		<property name="repositoryResolver" ref="rdf4jRepositoryManager" />
 	</bean>

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -1,119 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-  <artifactId>rdf4j-tools-federation</artifactId>
-  
-  <name>RDF4J: Federation</name>
-  <description>A federation engine for virtually integrating SPARQL endpoints</description>
-  
-  <parent>
-	<groupId>org.eclipse.rdf4j</groupId>
-	<artifactId>rdf4j-tools</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
-  </parent>
-	
+	<artifactId>rdf4j-tools-federation</artifactId>
 
-  
-  <properties>
+	<name>RDF4J: Federation</name>
+	<description>A federation engine for virtually integrating SPARQL endpoints</description>
+
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-tools</artifactId>
+		<version>3.1.0-SNAPSHOT</version>
+	</parent>
+
+
+
+	<properties>
 		<jetty.version>9.4.19.v20190610</jetty.version>
 	</properties>
-  
-  
-  <build>
-    <plugins>
-      <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <excludes>
-              <exclude>demos/**</exclude>
-              <exclude>local/**</exclude>
-              <exclude>performance/**</exclude>
-            </excludes>
-            <systemPropertyVariables>
-              <repositoryType>SPARQLREPOSITORY</repositoryType>
-            </systemPropertyVariables>
-          </configuration>
-          
-          <executions>
-            <execution>
-             <id>run-tests-native</id>
-             <phase>test</phase>
-             <goals>
-               <goal>test</goal>
-             </goals>
-             <configuration>
-               <systemPropertyVariables>
-                 <repositoryType>NATIVE</repositoryType>
-               </systemPropertyVariables>
-             </configuration>
-           </execution>
-           
-           <execution>
-             <id>run-tests-remote</id>
-             <phase>test</phase>
-             <goals>
-               <goal>test</goal>
-             </goals>
-             <configuration>
-               <systemPropertyVariables>
-                 <repositoryType>REMOTEREPOSITORY</repositoryType>
-               </systemPropertyVariables>
-             </configuration>
-           </execution>
-          </executions>
-          
-      </plugin>
-    </plugins>
-  </build>
-    
-  
-  <dependencies>
-  
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rdf4j-repository-sail</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rdf4j-queryresultio-sparqljson</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rdf4j-queryresultio-sparqlxml</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rdf4j-sail-nativerdf</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rdf4j-repository-http</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-        <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rdf4j-rio-n3</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
 
-  
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>rdf4j-http-server-spring</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    
-    <!--  TODO ideally reuse repository-compliace -->
-    
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>demos/**</exclude>
+						<exclude>local/**</exclude>
+						<exclude>performance/**</exclude>
+					</excludes>
+					<systemPropertyVariables>
+						<repositoryType>SPARQLREPOSITORY</repositoryType>
+					</systemPropertyVariables>
+				</configuration>
+
+				<executions>
+					<execution>
+						<id>run-tests-native</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<systemPropertyVariables>
+								<repositoryType>NATIVE</repositoryType>
+							</systemPropertyVariables>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>run-tests-remote</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<systemPropertyVariables>
+								<repositoryType>REMOTEREPOSITORY</repositoryType>
+							</systemPropertyVariables>
+						</configuration>
+					</execution>
+				</executions>
+
+			</plugin>
+		</plugins>
+	</build>
+
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-repository-manager</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-repository-sail</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-queryresultio-sparqljson</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-queryresultio-sparqlxml</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sail-nativerdf</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-repository-http</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-n3</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-http-server-spring</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- TODO ideally reuse repository-compliace -->
+
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
@@ -128,45 +132,45 @@
 			<scope>test</scope>
 		</dependency>
 
-    
-    <dependency>
-      <groupId>com.github.ziplet</groupId>
-      <artifactId>ziplet</artifactId>
-      <version>2.0.0</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+
+		<dependency>
+			<groupId>com.github.ziplet</groupId>
+			<artifactId>ziplet</artifactId>
+			<version>2.0.0</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>*</artifactId>
+					<groupId>*</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
 
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>5.4.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.4.2</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <version>1.4.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <version>1.4.2</version>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.4.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.4.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>1.4.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-runner</artifactId>
+			<version>1.4.2</version>
+			<scope>test</scope>
+		</dependency>
 
-  </dependencies>
+	</dependencies>
 </project>

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
@@ -251,11 +251,10 @@ public class FedXFactory {
 	protected void initializeResolvableEndpoints() {
 		for (Endpoint e : members) {
 			if (e instanceof ResolvableEndpoint) {
-				if (repositoryResolver == null) {
-					throw new IllegalStateException(
-							"Repository resolver is required for a resolvable endpoint, but not configured.");
+				if (repositoryResolver != null) {
+					// configure the explicitly set repository resolver, if any
+					((ResolvableEndpoint) e).setRepositoryResolver(repositoryResolver);
 				}
-				((ResolvableEndpoint) e).setRepositoryResolver(repositoryResolver);
 			}
 		}
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryFactory.java
@@ -7,17 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.repository;
 
-import java.io.File;
-
-import org.eclipse.rdf4j.federated.Config;
-import org.eclipse.rdf4j.federated.FedXFactory;
-import org.eclipse.rdf4j.federated.endpoint.ResolvableEndpoint;
-import org.eclipse.rdf4j.federated.exception.FedXException;
-import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryException;
-import org.eclipse.rdf4j.repository.RepositoryResolver;
-import org.eclipse.rdf4j.repository.base.RepositoryWrapper;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.config.RepositoryFactory;
 import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
@@ -25,18 +15,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A {@link RepositoryFactory} to use FedX in the RDF4J workbench. See {@link FedXRepositoryConfig} for the
- * configuration.
+ * A {@link RepositoryFactory} to use FedX in settings with a repository manager, e.g. in the RDF4J workbench.
+ * </p>
  * 
  * <p>
- * Note that this initialization obtains a {@link RepositoryResolver} from {@link FedXRepositoryResolverBean} (if any).
- * This is used for the initialization of all {@link ResolvableEndpoint}s via
- * {@link FedXFactory#withRepositoryResolver(RepositoryResolver)}.
+ * See {@link FedXRepositoryConfig} for the configuration.
  * </p>
  * 
  * @author Andreas Schwarte
  * @see FedXRepositoryConfig
- * @see FedXRepositoryResolverBean
  *
  */
 public class FedXRepositoryFactory implements RepositoryFactory {
@@ -70,98 +57,7 @@ public class FedXRepositoryFactory implements RepositoryFactory {
 		// => RDF4J repository manager requires control over the repository instance
 		// Note: data dir is handled by RDF4J repository manager and used as a
 		// base directory.
-		return new RepositoryWrapper() {
-
-			File dataDir;
-
-			@Override
-			public void setDataDir(File dataDir) {
-				this.dataDir = dataDir;
-			}
-
-			@Override
-			public File getDataDir() {
-				return dataDir;
-			}
-
-			@Override
-			public boolean isInitialized() {
-				if (getDelegate() == null) {
-					return false;
-				}
-				return super.isInitialized();
-			}
-
-			@Override
-			public void initialize() throws RepositoryException {
-
-				if (getDelegate() != null) {
-					super.initialize();
-					return;
-				}
-
-				File baseDir = getDataDir();
-				if (baseDir == null) {
-					baseDir = new File(".");
-				}
-				try {
-					if (fedXConfig.getFedxConfig() != null) {
-						Config.initialize(new File(baseDir, fedXConfig.getFedxConfig()));
-					} else {
-						Config.initialize();
-					}
-				} catch (FedXException e) {
-					throw new RepositoryException("Failed to initialize config: " + e.getMessage(), e);
-				}
-
-				// explicit federation members model
-				Model members = fedXConfig.getMembers();
-
-				// optional data config
-				File dataConfigFile = null;
-				if (fedXConfig.getDataConfig() != null) {
-					dataConfigFile = new File(baseDir, fedXConfig.getDataConfig());
-				} else if (Config.getConfig().getDataConfig() != null) {
-					dataConfigFile = new File(baseDir, Config.getConfig().getDataConfig());
-				}
-
-				if (members == null && dataConfigFile == null) {
-					throw new RepositoryException(
-							"No federation members defined: neither explicitly nor via data config.");
-				}
-
-				FedXRepository fedxRepo;
-				try {
-					// apply a repository resolver (if any) from FedXRepositoryResolverBean
-					FedXFactory factory = FedXFactory.newFederation()
-							.withFedXBaseDir(baseDir)
-							.withRepositoryResolver(FedXRepositoryResolverBean.getRepositoryResolver());
-
-					if (dataConfigFile != null) {
-						factory.withMembers(dataConfigFile);
-					}
-
-					if (members != null) {
-						factory.withMembers(members);
-					}
-
-					fedxRepo = factory.create();
-				} catch (Exception e) {
-					throw new RepositoryException(e);
-				}
-				setDelegate(fedxRepo);
-				super.initialize();
-			}
-
-			@Override
-			public void shutDown() throws RepositoryException {
-				if (!isInitialized()) {
-					return;
-				}
-				super.shutDown();
-				setDelegate(null);
-			}
-		};
+		return new FedXRepositoryWrapper(fedXConfig);
 	}
 
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryWrapper.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryWrapper.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.repository;
+
+import java.io.File;
+
+import org.eclipse.rdf4j.federated.Config;
+import org.eclipse.rdf4j.federated.FedXFactory;
+import org.eclipse.rdf4j.federated.exception.FedXException;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.RepositoryResolver;
+import org.eclipse.rdf4j.repository.RepositoryResolverClient;
+import org.eclipse.rdf4j.repository.base.RepositoryWrapper;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
+
+/**
+ * Wrapper for the {@link FedXRepository} in order to allow for lazy initialization.
+ * 
+ * <p>
+ * The wrapper is used from {@link FedXRepositoryFactory} in environments with a {@link RepositoryManager}, e.g. in the
+ * RDF4J workbench. The background is that the RDF4J repository manager requires control over the repository instance.
+ * </p>
+ * 
+ * <p>
+ * The data directory and the {@link RepositoryResolver} are handled by RDF4J {@link RepositoryManager}.
+ * </p>
+ * 
+ * @author Andreas Schwarte
+ * @see FedXFactory
+ *
+ */
+/* package */ class FedXRepositoryWrapper extends RepositoryWrapper implements RepositoryResolverClient {
+
+	private final FedXRepositoryConfig fedXConfig;
+
+	private File dataDir;
+
+	private RepositoryResolver repositoryResolver;
+
+	/* package */ FedXRepositoryWrapper(FedXRepositoryConfig fedXConfig) {
+		super();
+		this.fedXConfig = fedXConfig;
+	}
+
+	@Override
+	public void setDataDir(File dataDir) {
+		this.dataDir = dataDir;
+	}
+
+	@Override
+	public File getDataDir() {
+		return dataDir;
+	}
+
+	@Override
+	public boolean isInitialized() {
+		if (getDelegate() == null) {
+			return false;
+		}
+		return super.isInitialized();
+	}
+
+	@Override
+	public void initialize() throws RepositoryException {
+
+		if (getDelegate() != null) {
+			return;
+		}
+
+		File baseDir = getDataDir();
+		if (baseDir == null) {
+			baseDir = new File(".");
+		}
+		try {
+			if (fedXConfig.getFedxConfig() != null) {
+				Config.initialize(new File(baseDir, fedXConfig.getFedxConfig()));
+			} else {
+				Config.initialize();
+			}
+		} catch (FedXException e) {
+			throw new RepositoryException("Failed to initialize config: " + e.getMessage(), e);
+		}
+
+		// explicit federation members model
+		Model members = fedXConfig.getMembers();
+
+		// optional data config
+		File dataConfigFile = null;
+		if (fedXConfig.getDataConfig() != null) {
+			dataConfigFile = new File(baseDir, fedXConfig.getDataConfig());
+		} else if (Config.getConfig().getDataConfig() != null) {
+			dataConfigFile = new File(baseDir, Config.getConfig().getDataConfig());
+		}
+
+		if (members == null && dataConfigFile == null) {
+			throw new RepositoryException(
+					"No federation members defined: neither explicitly nor via data config.");
+		}
+
+		FedXRepository fedxRepo;
+		try {
+			// apply a repository resolver (if any) set from RepositoryManager
+			FedXFactory factory = FedXFactory.newFederation()
+					.withRepositoryResolver(repositoryResolver)
+					.withFedXBaseDir(baseDir);
+
+			if (dataConfigFile != null) {
+				factory.withMembers(dataConfigFile);
+			}
+
+			if (members != null) {
+				factory.withMembers(members);
+			}
+
+			fedxRepo = factory.create();
+		} catch (Exception e) {
+			throw new RepositoryException(e);
+		}
+		setDelegate(fedxRepo);
+	}
+
+	@Override
+	public void shutDown() throws RepositoryException {
+		if (!isInitialized()) {
+			return;
+		}
+		super.shutDown();
+		setDelegate(null);
+	}
+
+	@Override
+	public void setRepositoryResolver(RepositoryResolver resolver) {
+		this.repositoryResolver = resolver;
+	}
+}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXWithLocalRepositoryManagerTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXWithLocalRepositoryManagerTest.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.federated.repository.FedXRepositoryConfig;
+import org.eclipse.rdf4j.federated.util.Vocabulary.FEDX;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.impl.TreeModel;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
+import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
+import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.github.jsonldjava.shaded.com.google.common.collect.Lists;
+
+public class FedXWithLocalRepositoryManagerTest extends FedXBaseTest {
+
+	@TempDir
+	Path tempDir;
+
+	private LocalRepositoryManager repoManager;
+
+	@BeforeEach
+	public void before() throws Exception {
+		File baseDir = new File(tempDir.toFile(), "data");
+		repoManager = new LocalRepositoryManager(baseDir);
+		repoManager.init();
+	}
+
+	@AfterEach
+	public void after() throws Exception {
+		repoManager.shutDown();
+	}
+
+	@Test
+	public void testWithLocalRepositoryManager() throws Exception {
+
+		addMemoryStore("repo1");
+		addMemoryStore("repo2");
+
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		addData("repo1", Lists.newArrayList(
+				vf.createStatement(vf.createIRI("http://ex.org/p1"), RDF.TYPE, FOAF.PERSON)));
+		addData("repo2", Lists.newArrayList(
+				vf.createStatement(vf.createIRI("http://ex.org/p2"), RDF.TYPE, FOAF.PERSON)));
+
+		Repository repo = FedXFactory.newFederation()
+				.withResolvableEndpoint("repo1")
+				.withResolvableEndpoint("repo2")
+				.withRepositoryResolver(repoManager)
+				.create();
+		try {
+
+			try (RepositoryConnection conn = repo.getConnection()) {
+
+				List<Statement> sts = Iterations.asList(conn.getStatements(null, RDF.TYPE, FOAF.PERSON));
+				Assertions.assertEquals(2, sts.size()); // two persons
+			}
+
+		} finally {
+			repo.shutDown();
+		}
+
+	}
+
+	@Test
+	public void testWithLocalRepositoryManager_FactoryInitialization() throws Exception {
+
+		addMemoryStore("repo1");
+		addMemoryStore("repo2");
+
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		addData("repo1", Lists.newArrayList(
+				vf.createStatement(vf.createIRI("http://ex.org/p1"), RDF.TYPE, FOAF.PERSON)));
+		addData("repo2", Lists.newArrayList(
+				vf.createStatement(vf.createIRI("http://ex.org/p2"), RDF.TYPE, FOAF.PERSON)));
+
+		Model members = new TreeModel();
+		members.add(vf.createIRI("http://ex.org/repo1"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
+		members.add(vf.createIRI("http://ex.org/repo1"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo1"));
+		members.add(vf.createIRI("http://ex.org/repo2"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
+		members.add(vf.createIRI("http://ex.org/repo2"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo2"));
+
+		FedXRepositoryConfig fedXRepoConfig = new FedXRepositoryConfig();
+		fedXRepoConfig.setMembers(members);
+
+		repoManager.addRepositoryConfig(new RepositoryConfig("federation", fedXRepoConfig));
+
+		Repository repo = repoManager.getRepository("federation");
+
+		try (RepositoryConnection conn = repo.getConnection()) {
+
+			List<Statement> sts = Iterations.asList(conn.getStatements(null, RDF.TYPE, FOAF.PERSON));
+			Assertions.assertEquals(2, sts.size()); // two persons
+		}
+
+	}
+
+	protected void addMemoryStore(String repoId) throws Exception {
+
+		RepositoryImplConfig implConfig = new SailRepositoryConfig(new MemoryStoreConfig());
+		RepositoryConfig config = new RepositoryConfig(repoId, implConfig);
+		repoManager.addRepositoryConfig(config);
+	}
+
+	protected void addData(String repoId, Iterable<Statement> model) {
+
+		Repository repo = repoManager.getRepository(repoId);
+
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.add(model);
+		}
+	}
+
+}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/server/FedXRepositoryResolverBean.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/server/FedXRepositoryResolverBean.java
@@ -5,13 +5,12 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.federated.repository;
+package org.eclipse.rdf4j.federated.server;
 
 import org.eclipse.rdf4j.repository.RepositoryResolver;
 
 /**
- * A resolver bean that provides static access to a {@link RepositoryResolver}. Is used in the initialization process
- * via {@link FedXRepositoryFactory}.
+ * A resolver bean that provides static access to a {@link RepositoryResolver}.
  * 
  * <p>
  * For use in the RDF4J workbench the following Spring bean can be registered:
@@ -20,7 +19,7 @@ import org.eclipse.rdf4j.repository.RepositoryResolver;
  * <pre>
  * &lt;!-- Inject the local repository manager as RepositoryResolver into FedX --&gt;
  * &lt;bean id="fedxRepositoryResolver"
- *  	class="org.eclipse.rdf4j.federated.repository.FedXRepositoryResolverBean"
+ *  	class="org.eclipse.rdf4j.federated.server.FedXRepositoryResolverBean"
  *  	scope="singleton" init-method="init" destroy-method="destroy"&gt;
  *  	&lt;property name="repositoryResolver" ref="rdf4jRepositoryManager" /&gt;
  * &lt;/bean&gt;

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/server/SPARQLEmbeddedServer.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/server/SPARQLEmbeddedServer.java
@@ -14,7 +14,6 @@ import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.endpoint.EndpointFactory;
 import org.eclipse.rdf4j.federated.repository.ConfigurableSailRepository;
 import org.eclipse.rdf4j.federated.repository.ConfigurableSailRepositoryFactory;
-import org.eclipse.rdf4j.federated.repository.FedXRepositoryResolverBean;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.RepositoryResolver;


### PR DESCRIPTION
GitHub issue resolved: #1621

As of this change the RepositoryResolver (e.g. the reference to the
repository manager) is automatically injected to the FedXRepository, if
FedX is managed from a RepositoryManager.

This is for instance the case when FedX is used in the RDF4J workbench.


