### PR TITLE
GH-790 quality plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,35 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>com.github.spotbugs</groupId>
+						<artifactId>spotbugs-maven-plugin</artifactId>
+						<version>3.1.12</version>
+						<configuration>
+							<effort>Max</effort>
+							<threshold>Low</threshold>
+							<failOnError>false</failOnError>
+							<plugins>
+								<plugin>
+									<groupId>com.mebigfatguy.fb-contrib</groupId>
+									<artifactId>fb-contrib</artifactId>
+									<version>7.4.7</version>
+								</plugin>
+								<plugin>
+									<groupId>com.h3xstream.findsecbugs</groupId>
+									<artifactId>findsecbugs-plugin</artifactId>
+									<version>1.9.0</version>
+								</plugin>
+							</plugins>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
 						<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -138,35 +138,6 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>com.github.spotbugs</groupId>
-						<artifactId>spotbugs-maven-plugin</artifactId>
-						<version>3.1.12</version>
-						<configuration>
-							<effort>Max</effort>
-							<threshold>Low</threshold>
-							<failOnError>false</failOnError>
-							<plugins>
-								<plugin>
-									<groupId>com.mebigfatguy.fb-contrib</groupId>
-									<artifactId>fb-contrib</artifactId>
-									<version>7.4.7</version>
-								</plugin>
-								<plugin>
-									<groupId>com.h3xstream.findsecbugs</groupId>
-									<artifactId>findsecbugs-plugin</artifactId>
-									<version>1.9.0</version>
-								</plugin>
-							</plugins>
-						</configuration>
-						<executions>
-							<execution>
-								<goals>
-									<goal>check</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
 						<executions>
@@ -543,6 +514,35 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>com.github.spotbugs</groupId>
+					<artifactId>spotbugs-maven-plugin</artifactId>
+					<version>3.1.12</version>
+					<configuration>
+						<effort>Max</effort>
+						<threshold>Low</threshold>
+						<failOnError>false</failOnError>
+						<plugins>
+							<plugin>
+								<groupId>com.mebigfatguy.fb-contrib</groupId>
+								<artifactId>fb-contrib</artifactId>
+								<version>7.4.7</version>
+							</plugin>
+							<plugin>
+								<groupId>com.h3xstream.findsecbugs</groupId>
+								<artifactId>findsecbugs-plugin</artifactId>
+								<version>1.9.0</version>
+							</plugin>
+						</plugins>
+					</configuration>
+					<executions>
+						<execution>
+							<goals>
+								<goal>check</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-antrun-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -518,6 +518,13 @@
 					<groupId>com.github.spotbugs</groupId>
 					<artifactId>spotbugs-maven-plugin</artifactId>
 					<version>4.0.0</version>
+					<dependencies>
+						<dependency>
+							<groupId>com.github.spotbugs</groupId>
+							<artifactId>spotbugs</artifactId>
+							<version>4.0.3</version>
+						</dependency>
+					</dependencies>
 					<configuration>
 						<effort>Max</effort>
 						<threshold>Low</threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -517,21 +517,21 @@
 				<plugin>
 					<groupId>com.github.spotbugs</groupId>
 					<artifactId>spotbugs-maven-plugin</artifactId>
-					<version>3.1.12</version>
+					<version>4.0.0</version>
 					<configuration>
 						<effort>Max</effort>
 						<threshold>Low</threshold>
 						<failOnError>false</failOnError>
 						<plugins>
 							<plugin>
-								<groupId>com.mebigfatguy.fb-contrib</groupId>
-								<artifactId>fb-contrib</artifactId>
+								<groupId>com.mebigfatguy.sb-contrib</groupId>
+								<artifactId>sb-contrib</artifactId>
 								<version>7.4.7</version>
 							</plugin>
 							<plugin>
 								<groupId>com.h3xstream.findsecbugs</groupId>
 								<artifactId>findsecbugs-plugin</artifactId>
-								<version>1.9.0</version>
+								<version>1.10.1</version>
 							</plugin>
 						</plugins>
 					</configuration>


### PR DESCRIPTION
GitHub issue resolved: #790 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

This may partially solve the issue since I did not touch the Jenkins config, though there seems to be a plugin that can use the XML output from these plugins (https://wiki.jenkins.io/display/JENKINS/Warnings+Next+Generation+Plugin) to generate nicer looking reports.

See also https://spotbugs.readthedocs.io/en/latest/maven.html and https://spotbugs.github.io/

SpotBugs will generate reports in xml format, that can be loaded in some IDEs (apparently from within Eclipse/Intellij), or by invoking the standalone GUI via mvn spotbugs:gui and opening the files manually.

Note that SpotBugs is a _bytecode_ analyzer, which means that one has to compile the sources first, and only then the plugin can be used to perform an analysis (mvn spotbugs:spotbugs)

Apparently there might also be some false positives when "final" fields are involved, but it appears to provide some interesting feedback, though I haven't compared the results with e.g. PMD or other tools.