### PR TITLE
Moved spring version property to main pom.xml + upgrade to 5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
 		<solr.version>7.5.0</solr.version>
 		<elasticsearch.version>6.5.4</elasticsearch.version>
 		<servlet.version>3.1.0</servlet.version>
+		<spring.version>5.2.1.RELEASE</spring.version>
 	</properties>
 
 	<dependencyManagement>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -17,10 +17,6 @@
 	<name>RDF4J Tools</name>
 	<description>Server, Workbench, Console and other end-user tools for RDF4J.</description>
 
-	<properties>
-		<spring.version>5.1.7.RELEASE</spring.version>
-	</properties>
-
 	<modules>
 		<module>config</module>
 		<module>console</module>


### PR DESCRIPTION
GitHub issue resolved: #1640 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Spring version property now part of main pom.xml
* Use version Spring Framework 5.2.1
