### PR TITLE
GH-1687 Fix NPE when calling Expressions.bnode().getQueryString()

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
@@ -56,7 +56,7 @@ public class Expressions {
 	 * @see <a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#func-bnode"> SPARQL BNODE Function</a>
 	 */
 	public static Expression<?> bnode() {
-		return function(BNODE, (Operand) null);
+		return function(BNODE);
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Function.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Function.java
@@ -18,6 +18,7 @@ class Function extends Expression<Function> {
 	Function(SparqlFunction function) {
 		super(function, ", ");
 		parenthesize();
+		printBodyIfEmpty(true);
 		setOperatorName(operator.getQueryString(), false);
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ExpressionsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ExpressionsTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) ${year} Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sparqlbuilder.constraint;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ExpressionsTest {
+
+	@Test
+	public void bnodeProducesProperQueryString() {
+		Expression<?> expression = Expressions.bnode("name");
+		assertEquals("BNODE( \"name\" )", expression.getQueryString());
+	}
+
+	@Test
+	public void bnodeNoArgumentProducesProperQueryString() {
+		Expression<?> expression = Expressions.bnode();
+		assertEquals("BNODE()", expression.getQueryString());
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Roman Kishchenko <rkishchenko@gmail.com>

GitHub issue resolved: #1687  