### PR TITLE
GH-1692 mark LuceneSpinSail as deprecated

### DIFF
--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/LuceneSpinSail.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/LuceneSpinSail.java
@@ -17,6 +17,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -39,7 +41,11 @@ import org.slf4j.LoggerFactory;
  * connection from baseSail by wrapped which modify SearchIndex.
  *
  * @author jacek grzebyta
+ * 
+ * @deprecated since 3.0. The experimental LuceneSpinSail is scheduled to be removed by the next major release.
  */
+@Deprecated
+@Experimental
 public class LuceneSpinSail extends NotifyingSailWrapper {
 
 	private final Logger log = LoggerFactory.getLogger(LuceneSpinSail.class);

--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/LuceneSpinSailConnection.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/LuceneSpinSailConnection.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -37,7 +38,11 @@ import org.eclipse.rdf4j.sail.lucene.SearchIndex;
  * @author sauermann
  * @author christian.huetter
  * @author jacek grzebyta
+ * 
+ * @deprecated since 3.0. The experimental LuceneSpinSail is scheduled to be removed by the next major release.
  */
+@Deprecated
+@Experimental
 public class LuceneSpinSailConnection extends NotifyingSailConnectionWrapper {
 
 	private static final Logger logger = LoggerFactory.getLogger(LuceneSpinSailConnection.class);

--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/config/package-info.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/config/package-info.java
@@ -1,0 +1,10 @@
+@Deprecated
+@Experimental
+/**
+ * The Lucene SPIN Sail - configuration
+ * 
+ * @deprecated since 3.0. This prototype Sail implementation will be removed in a future major release of RDF4J.
+ */
+package org.eclipse.rdf4j.lucene.spin.config;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;

--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/package-info.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/package-info.java
@@ -1,0 +1,10 @@
+@Deprecated
+@Experimental
+/**
+ * The Lucene SPIN Sail
+ * 
+ * @deprecated since 3.0. This prototype Sail implementation will be removed in a future major release of RDF4J.
+ */
+package org.eclipse.rdf4j.lucene.spin;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;

--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/DistanceTupleFunction.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/DistanceTupleFunction.java
@@ -47,7 +47,10 @@ import org.eclipse.rdf4j.sail.lucene.SearchQueryEvaluator;
  * <li>distance is the distance to the shape if search:distance is present.</li>
  * <li>context is the context if search:context is present.</li>
  * </ol>
+ * 
+ * @deprecated since 3.0. The LuceneSpinSail is to removed in the next major release.
  */
+@Deprecated
 public class DistanceTupleFunction implements TupleFunction {
 
 	@Override

--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/QueryTupleFunction.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/QueryTupleFunction.java
@@ -47,7 +47,9 @@ import org.eclipse.rdf4j.sail.lucene.SearchQueryEvaluator;
  * <li>score is included if the scorePredicate is search:score else omitted.</li>
  * <li>snippet is included if the snippetPredicate is search:snippet else omitted.</li>
  * </ol>
+ * @deprecated since 3.0. The LucenSpinSail is to be removed in the next major release.
  */
+@Deprecated
 public class QueryTupleFunction implements TupleFunction {
 
 	@Override

--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/QueryTupleFunction.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/QueryTupleFunction.java
@@ -47,6 +47,7 @@ import org.eclipse.rdf4j.sail.lucene.SearchQueryEvaluator;
  * <li>score is included if the scorePredicate is search:score else omitted.</li>
  * <li>snippet is included if the snippetPredicate is search:snippet else omitted.</li>
  * </ol>
+ * 
  * @deprecated since 3.0. The LucenSpinSail is to be removed in the next major release.
  */
 @Deprecated


### PR DESCRIPTION
GitHub issue resolved: #1692 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* marked LuceneSpinSail and related classes deprecated. Stated intent to remove in next major release.
