### PR TITLE
Updated maven-bundle-plugin to avoid the embedding of pom dependencie…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -643,7 +643,7 @@
           <plugin>
             <groupId>org.apache.felix</groupId>
             <artifactId>maven-bundle-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>4.2.1</version>
             <extensions>true</extensions>
             <configuration>
               <instructions>

--- a/tools/runtime-osgi/pom.xml
+++ b/tools/runtime-osgi/pom.xml
@@ -60,13 +60,6 @@
 						<Embed-Transitive>true</Embed-Transitive>
 					</instructions>
 				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>biz.aQute.bnd</groupId>
-						<artifactId>bndlib</artifactId>
-						<version>2.4.0</version>
-					</dependency>
-				</dependencies>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
GitHub issue resolved: #1674

This PR updates `maven-bundle-plugin` from version to 3.3.0 to 4.2.1.
The rationale of the change is as follows:
* the runtime OSGi depends on the modules `rdf4j-client` and `rdf4j-storage`
* those dependencies were turned into pom-typed artifact (while they used to be simple `jar`s)
* the instructions guiding  `maven-bundle-plugin` excluded pom dependencies from being inlined (indeed, there is no jar to unpack)
* however, the version `3.3.0` of the plugin seems to ignore the transitive dependencies of the ignored artifact, thus producing an almost empty runtime-osgi
* conversely, the version `4.2.1` of the plugin (which is the latest one) seems to continue processing the transitive dependencies of the artifacts being excluded

 I've verified the produced  OSGi bundle, by using it as a temporary dependency of [VocBench 3](http://vocbench.uniroma2.it/).
Additionally, I compared the contents of the bundle with the contents of the version `3.0.0` (by using [Beyond Compare](https://www.scootersoftware.com/) to perform a folder comparison and only show orphan files).

Below you can find a manually edited report of the comparison.
![immagine](https://user-images.githubusercontent.com/20649935/70362729-47f2cc00-1886-11ea-913f-2b72f2883cc1.png)

Beyond some anonymous and inner classes, which might have changed between the two versions, I've noticed that the poms of `rdf4j-client` and `rdf4-storage` are no longer includes (because these dependencies have been excluded).

