### PR TITLE
Updated guava dependency

### DIFF
--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava-testlib</artifactId>
-			<version>21.0</version>
+			<version>${guava.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,7 @@
 		<elasticsearch.version>6.5.4</elasticsearch.version>
 		<servlet.version>3.1.0</servlet.version>
 		<spring.version>5.2.1.RELEASE</spring.version>
+		<guava.version>23.5-jre</guava.version>
 	</properties>
 
 	<dependencyManagement>
@@ -423,7 +424,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>18.0</version>
+				<version>${guava.version}</version>
 			</dependency>
 
 			<!-- Logging: SLF4J and logback -->

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -215,7 +215,6 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>18.0</version>
 			</dependency>
 
 			<!-- Logging: SLF4J and logback -->

--- a/tools/server-spring/pom.xml
+++ b/tools/server-spring/pom.xml
@@ -69,6 +69,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
GitHub issue resolved: #1097 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Use 23.5-jre instead of 18.0
