### PR TITLE
#1718: fix invalid cookie warnings in HttpClient from SPARQLRepository

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -17,6 +17,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -129,7 +131,11 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 		if (nextHttpClientBuilder != null) {
 			return nextHttpClientBuilder.build();
 		}
-		return HttpClientBuilder.create().useSystemProperties().disableAutomaticRetries().build();
+		return HttpClientBuilder.create()
+				.useSystemProperties()
+				.disableAutomaticRetries()
+				.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+				.build();
 	}
 
 	@Override


### PR DESCRIPTION
GitHub issue resolved: #1718 

It turns out that the default configuration of the HttpClient has a
configuration for cookie parsing which does not follow todays standards,
thus yielding to warnings in the log for certain cookies.

According to the HttpClient documentation users are advised to
explicitly use RFC 6265 compliant policies.

This is done as of this change by adjusting the CookieSpec in the
default HttpClientBuilder used in the RDF4J SPARQLRepository.

Signed-off-by: Andreas Schwarte <aschwarte10@gmail.com>

