### PR TITLE
fix typo in source branch of github action

### DIFF
--- a/.github/workflows/merge_master_to_develop.yml
+++ b/.github/workflows/merge_master_to_develop.yml
@@ -11,7 +11,7 @@ jobs:
     - name: pull-request
       uses: repo-sync/pull-request@v2
       with:
-        source_branch: "masster"              # If blank, default: triggered branch
+        source_branch: "master"               # If blank, default: triggered branch
         destination_branch: "develop"         # If blank, default: master
         pr_title: "Merge ${{ github.ref }} into develop"
         pr_body: "Automatically generated PR to keep develop in sync with master. See .github/workflows/merge_master_to_develop.yml"  # Full markdown support, requires pr_title to be set


### PR DESCRIPTION
this job failed for me just now. See https://github.com/eclipse/rdf4j/commit/f8ead84c7f5c93c8518b0e7ff9f221ea77ea4e86/checks?check_suite_id=347622360 

Not sure if this typo was the cause but it looks incorrect to me.

