### PR TITLE
Only get statements from remaining (current - deprecated) contexts

### DIFF
--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
@@ -261,7 +261,7 @@ class SailDatasetImpl implements SailDataset {
 		} else if (contexts.length > 0 && deprecatedContexts != null) {
 			List<Resource> remaining = new ArrayList<>(Arrays.asList(contexts));
 			remaining.removeAll(deprecatedContexts);
-			iter = derivedFrom.getStatements(subj, pred, obj, (Resource[]) remaining.toArray());
+			iter = derivedFrom.getStatements(subj, pred, obj, remaining.toArray(Resource[]::new));
 		} else {
 			iter = derivedFrom.getStatements(subj, pred, obj, contexts);
 		}

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
@@ -261,7 +261,7 @@ class SailDatasetImpl implements SailDataset {
 		} else if (contexts.length > 0 && deprecatedContexts != null) {
 			List<Resource> remaining = new ArrayList<>(Arrays.asList(contexts));
 			remaining.removeAll(deprecatedContexts);
-			iter = derivedFrom.getStatements(subj, pred, obj, contexts);
+			iter = derivedFrom.getStatements(subj, pred, obj, (Resource[]) remaining.toArray());
 		} else {
 			iter = derivedFrom.getStatements(subj, pred, obj, contexts);
 		}

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
@@ -261,7 +261,7 @@ class SailDatasetImpl implements SailDataset {
 		} else if (contexts.length > 0 && deprecatedContexts != null) {
 			List<Resource> remaining = new ArrayList<>(Arrays.asList(contexts));
 			remaining.removeAll(deprecatedContexts);
-			iter = derivedFrom.getStatements(subj, pred, obj, remaining.toArray(Resource[]::new));
+			iter = derivedFrom.getStatements(subj, pred, obj, remaining.toArray(new Resource[0]));
 		} else {
 			iter = derivedFrom.getStatements(subj, pred, obj, contexts);
 		}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/LimitedSizeNativeStoreConnectionTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/LimitedSizeNativeStoreConnectionTest.java
@@ -25,8 +25,6 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnectionTest;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.eclipse.rdf4j.sail.nativerdf.LimitedSizeNativeStore;
-import org.eclipse.rdf4j.sail.nativerdf.LimitedSizeNativeStoreConnection;
 import org.junit.Test;
 
 public class LimitedSizeNativeStoreConnectionTest extends RepositoryConnectionTest {
@@ -59,12 +57,14 @@ public class LimitedSizeNativeStoreConnectionTest extends RepositoryConnectionTe
 		ValueFactory vf = testCon.getValueFactory();
 		IRI context1 = vf.createIRI("http://my.context.1");
 		IRI context2 = vf.createIRI("http://my.context.2");
+		IRI context3 = vf.createIRI("http://my.context.3");
 		IRI predicate = vf.createIRI("http://my.predicate");
 		IRI object = vf.createIRI("http://my.object");
 
 		for (int j = 0; j < 1000; j++) {
 			testCon.add(vf.createIRI("http://my.subject" + j), predicate, object, context1);
 			testCon.add(vf.createIRI("http://my.subject" + j), predicate, object, context2);
+			testCon.add(vf.createIRI("http://my.subject" + j), predicate, object, context3);
 		}
 		assertEquals(1000, Iterations.asList(testCon.getStatements(null, null, null, false, context1)).size());
 		assertEquals(1000, Iterations.asList(testCon.getStatements(null, null, null, false, context2)).size());
@@ -73,6 +73,8 @@ public class LimitedSizeNativeStoreConnectionTest extends RepositoryConnectionTe
 		testCon.clear(context1);
 		assertEquals(0, Iterations.asList(testCon.getStatements(null, null, null, false, context1)).size());
 		assertEquals(1000, Iterations.asList(testCon.getStatements(null, null, null, false, context2)).size());
+		assertEquals(2000,
+				Iterations.asList(testCon.getStatements(null, null, null, false, context2, context3)).size());
 		testCon.commit();
 
 		// check context content using fresh connection


### PR DESCRIPTION
GitHub issue resolved: #1665 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Only get statements from remaining contexts (current one minus deprecated) instead of full array of contexts
