### PR TITLE
Fixes: #1729. Add dateTimeStamp to the XMLSchema vocabulary

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -84,7 +84,8 @@ public class XMLDatatypeUtil {
 				|| datatype.equals(XMLSchema.NON_NEGATIVE_INTEGER) || datatype.equals(XMLSchema.POSITIVE_INTEGER)
 				|| datatype.equals(XMLSchema.UNSIGNED_LONG) || datatype.equals(XMLSchema.UNSIGNED_INT)
 				|| datatype.equals(XMLSchema.UNSIGNED_SHORT) || datatype.equals(XMLSchema.UNSIGNED_BYTE)
-				|| datatype.equals(XMLSchema.DAYTIMEDURATION) || datatype.equals(XMLSchema.YEARMONTHDURATION);
+				|| datatype.equals(XMLSchema.DAYTIMEDURATION) || datatype.equals(XMLSchema.YEARMONTHDURATION)
+				|| datatype.equals(XMLSchema.DATETIMESTAMP);
 	}
 
 	/**
@@ -140,7 +141,7 @@ public class XMLDatatypeUtil {
 		return datatype.equals(XMLSchema.DATETIME) || datatype.equals(XMLSchema.DATE) || datatype.equals(XMLSchema.TIME)
 				|| datatype.equals(XMLSchema.GYEARMONTH) || datatype.equals(XMLSchema.GMONTHDAY)
 				|| datatype.equals(XMLSchema.GYEAR) || datatype.equals(XMLSchema.GMONTH)
-				|| datatype.equals(XMLSchema.GDAY);
+				|| datatype.equals(XMLSchema.GDAY) || datatype.equals(XMLSchema.DATETIMESTAMP);
 
 	}
 
@@ -213,6 +214,8 @@ public class XMLDatatypeUtil {
 			result = isValidBoolean(value);
 		} else if (datatype.equals(XMLSchema.DATETIME)) {
 			result = isValidDateTime(value);
+		} else if (datatype.equals(XMLSchema.DATETIMESTAMP)) {
+			result = isValidDateTimeStamp(value);
 		} else if (datatype.equals(XMLSchema.DATE)) {
 			result = isValidDate(value);
 		} else if (datatype.equals(XMLSchema.TIME)) {
@@ -426,6 +429,18 @@ public class XMLDatatypeUtil {
 			@SuppressWarnings("unused")
 			XMLDateTime dt = new XMLDateTime(value);
 			return true;
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	public static boolean isValidDateTimeStamp(String value) {
+		try {
+			@SuppressWarnings("unused")
+			XMLDateTime dt = new XMLDateTime(value);
+			String timeZoneRegex = ".*(Z|[+-]((0\\d|1[0-3]):[0-5]\\d|14:00))$";
+			boolean hasExplicitTimeZone = value.matches(timeZoneRegex);
+			return hasExplicitTimeZone;
 		} catch (IllegalArgumentException e) {
 			return false;
 		}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/XMLSchema.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/XMLSchema.java
@@ -14,9 +14,9 @@ import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
- * Constants for the standard <a href="http://www.w3.org/TR/xmlschema-2/">XML Schema datatypes</a>.
+ * Constants for the standard <a href="https://www.w3.org/TR/xmlschema11-2/">XML Schema datatypes</a>.
  * 
- * @see <a href="http://www.w3.org/TR/xmlschema-2/">XML Schema Part 2: Datatypes Second Edition</a>
+ * @see <a href="https://www.w3.org/TR/xmlschema11-2/">XML Schema Part 2: Datatypes Second Edition</a>
  */
 public class XMLSchema {
 
@@ -46,6 +46,9 @@ public class XMLSchema {
 
 	/** <tt>http://www.w3.org/2001/XMLSchema#dateTime</tt> */
 	public final static IRI DATETIME;
+
+	/** <tt>http://www.w3.org/2001/XMLSchema#dateTimeStamp</tt> */
+	public final static IRI DATETIMESTAMP;
 
 	/** <tt>http://www.w3.org/2001/XMLSchema#dayTimeDuration</tt> */
 	public static final IRI DAYTIMEDURATION;
@@ -189,6 +192,8 @@ public class XMLSchema {
 		DURATION = factory.createIRI(XMLSchema.NAMESPACE, "duration");
 
 		DATETIME = factory.createIRI(XMLSchema.NAMESPACE, "dateTime");
+
+		DATETIMESTAMP = factory.createIRI(XMLSchema.NAMESPACE, "dateTimeStamp");
 
 		DAYTIMEDURATION = factory.createIRI(NAMESPACE, "dayTimeDuration");
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
@@ -10,6 +10,9 @@ package org.eclipse.rdf4j.model.datatypes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import junit.textui.TestRunner;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.junit.Test;
@@ -19,7 +22,7 @@ import org.junit.Test;
  * 
  * @author Jeen Broekstra
  */
-public class XMLDatatypeUtilTest {
+public class XMLDatatypeUtilTest extends TestCase {
 
 	private static final String[] VALID_FLOATS = { "1", "1.0", "1.0E6", "-1.0E6", "15.00001E2", "1500000000000",
 			"1E104", "0.1E105", "INF", "-INF", "NaN" };
@@ -44,6 +47,14 @@ public class XMLDatatypeUtilTest {
 	/** invalid xsd:time values */
 	private static final String[] INVALID_TIMES = { "foo", "21:32", "9:15:16", "09:15:10.", "09:15:10.x",
 			"2001-10-10:10:10:10", "-10:00:00", "25:25:25" };
+
+	/** valid xsd:dateTimeStamp values */
+	private static final String[] VALID_DATETIMESTAMPS = { "2001-01-01T11:11:11Z", "2001-01-01T10:00:01+06:00",
+			"2001-01-01T10:01:58-06:00" };
+
+	/** valid xsd:dateTimeStamp values */
+	private static final String[] INVALID_DATETIMESTAMPS = { "2001-01-01T13:00:00", "2001-01-01T09:15:10",
+			"2001-01-01T09:15:10.01", "2001-01-01T09:15:10.12345" };
 
 	/** valid xsd:gYear values */
 	private static final String[] VALID_GYEAR = { "2001", "2001+02:00", "2001Z", "-2001", "-20000", "20000" };
@@ -117,6 +128,10 @@ public class XMLDatatypeUtilTest {
 		assertEquals("-1.011E2", XMLDatatypeUtil.normalize("-101.1", XMLSchema.DOUBLE));
 	}
 
+	public static void main(String[] args) {
+		TestRunner.run(new TestSuite(XMLDatatypeUtilTest.class));
+	}
+
 	/**
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil#isValidValue(java.lang.String, org.eclipse.rdf4j.model.IRI)}
@@ -133,6 +148,9 @@ public class XMLDatatypeUtilTest {
 
 		testValidation(VALID_TIMES, XMLSchema.TIME, true);
 		testValidation(INVALID_TIMES, XMLSchema.TIME, false);
+
+		testValidation(VALID_DATETIMESTAMPS, XMLSchema.DATETIMESTAMP, true);
+		testValidation(INVALID_DATETIMESTAMPS, XMLSchema.DATETIMESTAMP, false);
 
 		testValidation(VALID_GDAY, XMLSchema.GDAY, true);
 		testValidation(INVALID_GDAY, XMLSchema.GDAY, false);


### PR DESCRIPTION
GitHub issue resolved: #1729 

* Adds the definition for xsd:dateTimeStamp as defined in https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp 
* Provides some testing for the validation of such type.