### PR TITLE
ExtensibleStore read cache

### DIFF
--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStore.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStore.java
@@ -58,6 +58,11 @@ public class ElasticsearchStore extends ExtensibleStore<ElasticsearchDataStructu
 	private String index;
 
 	public ElasticsearchStore(String hostname, int port, String clusterName, String index) {
+		this(hostname, port, clusterName, index, true);
+	}
+
+	public ElasticsearchStore(String hostname, int port, String clusterName, String index, boolean cacheEnabled) {
+		super(cacheEnabled);
 		this.hostname = hostname;
 		this.port = port;
 		this.clusterName = clusterName;
@@ -76,6 +81,12 @@ public class ElasticsearchStore extends ExtensibleStore<ElasticsearchDataStructu
 	}
 
 	public ElasticsearchStore(ClientProvider clientPool, String index) {
+		this(clientPool, index, true);
+
+	}
+
+	public ElasticsearchStore(ClientProvider clientPool, String index, boolean cacheEnabled) {
+		super(cacheEnabled);
 		this.clientProvider = new UnclosableClientProvider(clientPool);
 
 		dataStructure = new ElasticsearchDataStructure(this.clientProvider, index);

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/UserProvidedClientProvider.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/UserProvidedClientProvider.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.elasticsearchstore;
+
+import org.elasticsearch.client.Client;
+
+/**
+ * Used by the user to provide an Elasticsearch Client to the ElasticsearchStore instead of providing host, port,
+ * cluster information. The client provided by the user is not closed by the ElasticsearchStore.
+ *
+ * @author Håvard Mikkelsen Ottestad
+ */
+public class UserProvidedClientProvider implements ClientProvider {
+
+	final private Client client;
+
+	transient boolean closed;
+
+	public UserProvidedClientProvider(Client client) {
+		this.client = client;
+	}
+
+	@Override
+	public Client getClient() {
+		return client;
+	}
+
+	@Override
+	public boolean isClosed() {
+		return closed;
+	}
+
+	@Override
+	synchronized public void close() throws Exception {
+		if (!closed) {
+			closed = true;
+		}
+	}
+}

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/AddBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/AddBenchmark.java
@@ -58,7 +58,8 @@ public class AddBenchmark {
 				"/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home");
 
 		elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex"));
+				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex",
+						false));
 
 		System.gc();
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/DeleteBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/DeleteBenchmark.java
@@ -63,7 +63,8 @@ public class DeleteBenchmark {
 				"/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home");
 
 		elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex"));
+				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex",
+						false));
 
 		System.gc();
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/InitBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/InitBenchmark.java
@@ -71,7 +71,8 @@ public class InitBenchmark {
 	public void initWithElasticsearchClientCreation() {
 
 		SailRepository elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex"));
+				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex",
+						false));
 
 		try (SailRepositoryConnection connection = elasticsearchStore.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
@@ -87,7 +88,7 @@ public class InitBenchmark {
 	public void initWithoutElasticsearchClientCreation() {
 
 		SailRepository elasticsearchStore = new SailRepository(
-				new ElasticsearchStore(clientPool, "testindex"));
+				new ElasticsearchStore(clientPool, "testindex", false));
 
 		try (SailRepositoryConnection connection = elasticsearchStore.getConnection()) {
 			connection.begin(IsolationLevels.NONE);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/QueryBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/QueryBenchmark.java
@@ -90,7 +90,8 @@ public class QueryBenchmark {
 				"/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home");
 
 		repository = new SailRepository(
-				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex"));
+				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex",
+						false));
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
 			connection.add(getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl"), "", RDFFormat.TURTLE);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/ReadCacheBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/ReadCacheBenchmark.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.elasticsearchstore.benchmark;
+
+import org.apache.commons.io.IOUtils;
+import org.assertj.core.util.Files;
+import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
+import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import pl.allegro.tech.embeddedelasticsearch.EmbeddedElastic;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 20)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms8G", "-Xmx8G", "-Xmn4G", "-XX:+UseSerialGC" })
+//@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G", "-Xmn4G", "-XX:+UseSerialGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ReadCacheBenchmark {
+
+	private static EmbeddedElastic embeddedElastic;
+
+	private static File installLocation = Files.newTemporaryFolder();
+
+	private SailRepository repoWithoutCache;
+	private SailRepository repoWithCache;
+
+	private static final String query1;
+	private static final String query5;
+	private static final String query6;
+
+	static {
+		try {
+			query1 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query1.qr"), StandardCharsets.UTF_8);
+			query5 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query5.qr"), StandardCharsets.UTF_8);
+			query6 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query6.qr"), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private List<Statement> statementList;
+
+	@Setup(Level.Trial)
+	public void beforeClass() throws IOException, InterruptedException {
+
+		embeddedElastic = TestHelpers.startElasticsearch(installLocation,
+				"/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home");
+
+		repoWithoutCache = new SailRepository(
+				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex1",
+						false));
+
+		repoWithCache = new SailRepository(
+				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex2",
+						true));
+
+		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
+			connection.begin(IsolationLevels.NONE);
+			connection.clear();
+			connection.add(getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl"), "", RDFFormat.TURTLE);
+			connection.commit();
+		}
+
+		try (SailRepositoryConnection connection = repoWithoutCache.getConnection()) {
+			connection.begin(IsolationLevels.NONE);
+			connection.clear();
+			connection.add(getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl"), "", RDFFormat.TURTLE);
+			connection.commit();
+
+		}
+
+		System.gc();
+
+	}
+
+	private static InputStream getResourceAsStream(String name) {
+		return ReadCacheBenchmark.class.getClassLoader().getResourceAsStream(name);
+	}
+
+	@TearDown(Level.Trial)
+	public void afterClass() {
+
+		repoWithoutCache.shutDown();
+		TestHelpers.stopElasticsearch(embeddedElastic, installLocation);
+
+	}
+
+	@Benchmark
+	public List<BindingSet> groupByQueryWithoutCache() {
+
+		try (SailRepositoryConnection connection = repoWithoutCache.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query1)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> groupByQueryWithCache() {
+
+		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query1)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> groupByQueryWithCacheCleared() {
+		clearCache();
+
+		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query1)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> complexQueryWithoutCache() {
+
+		try (SailRepositoryConnection connection = repoWithoutCache.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query5)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> complexQueryWithCache() {
+
+		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query5)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> complexQueryWithCacheCleared() {
+		clearCache();
+
+		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query5)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> pathQueryWithoutCache() {
+
+		try (SailRepositoryConnection connection = repoWithoutCache.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query6)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> pathQueryWithCache() {
+
+		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query6)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> pathQueryWithCacheCleared() {
+
+		clearCache();
+
+		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
+
+			return Iterations.asList(connection
+					.prepareTupleQuery(query6)
+					.evaluate());
+		}
+	}
+
+	private void clearCache() {
+		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
+			connection.begin();
+			Literal literal = SimpleValueFactory.getInstance().createLiteral("jfiewojifjewo");
+			connection.add(RDFS.RESOURCE, RDFS.LABEL, literal);
+			connection.commit();
+			connection.begin();
+			connection.remove(RDFS.RESOURCE, RDFS.LABEL, literal);
+			connection.commit();
+		}
+	}
+
+}

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/TransactionBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/TransactionBenchmark.java
@@ -72,7 +72,8 @@ public class TransactionBenchmark {
 				"/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home");
 
 		repository = new SailRepository(
-				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex"));
+				new ElasticsearchStore("localhost", embeddedElastic.getTransportTcpPort(), "cluster1", "testindex",
+						false));
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
 			connection.add(getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl"), "", RDFFormat.TURTLE);

--- a/core/sail/elasticsearch-store/src/test/resources/benchmarkFiles/query5.qr
+++ b/core/sail/elasticsearch-store/src/test/resources/benchmarkFiles/query5.qr
@@ -1,0 +1,41 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX eu-lang: <http://publications.europa.eu/resource/authority/language/>
+
+SELECT * where {
+
+        ?dataset a dcat:Dataset;
+                dct:language eu-lang:ENG ;
+                dct:title ?title ;
+                dct:publisher ?publisher .
+
+        ?publisher foaf:name ?name .
+
+
+        OPTIONAL {
+                ?dataset dcat:distribution ?distribution .
+                OPTIONAL {
+                        ?distribution dct:format ?format .
+                }
+                OPTIONAL {
+                        ?distribution dcat:mediaType ?mediaType .
+                }
+                OPTIONAL {
+                        ?distribution dcat:accessURL ?accessURL .
+                }
+        }
+
+
+        FILTER(NOT EXISTS {?dataset dct:spatial ?spatial}).
+}
+

--- a/core/sail/elasticsearch-store/src/test/resources/benchmarkFiles/query6.qr
+++ b/core/sail/elasticsearch-store/src/test/resources/benchmarkFiles/query6.qr
@@ -1,0 +1,17 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+
+SELECT distinct ?a where {
+       ?a dcat:dataset / dcat:distribution / dct:format / rdfs:label "XML".
+}
+

--- a/core/sail/elasticsearch-store/src/test/resources/logback.xml
+++ b/core/sail/elasticsearch-store/src/test/resources/logback.xml
@@ -14,7 +14,7 @@
 		<appender-ref ref="CONSOLE"/>
 	</root>
 
-    <logger name="org.eclipse.rdf4j.sail.extensiblestore" level="DEBUG"/>
+    <logger name="org.eclipse.rdf4j.sail.extensiblestore" level="INFO"/>
 
 
 

--- a/core/sail/extensible-store/pom.xml
+++ b/core/sail/extensible-store/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.4</version>
         </dependency>
 
         <dependency>

--- a/core/sail/extensible-store/pom.xml
+++ b/core/sail/extensible-store/pom.xml
@@ -22,6 +22,13 @@
             <artifactId>rdf4j-sail-base</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+        </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>rdf4j-sail-memory</artifactId>
@@ -29,9 +36,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.rdf4j</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>rdf4j-repository-sail</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/PartialStatement.java
+++ b/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/PartialStatement.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.extensiblestore;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class PartialStatement {
+
+	Resource subject;
+	IRI predicate;
+	Value object;
+	Resource[] context;
+
+	public PartialStatement(Resource subject, IRI predicate, Value object, Resource... context) {
+		this.subject = subject;
+		this.predicate = predicate;
+		this.object = object;
+		this.context = context;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		PartialStatement that = (PartialStatement) o;
+		return Objects.equals(subject, that.subject) &&
+				Objects.equals(predicate, that.predicate) &&
+				Objects.equals(object, that.object) &&
+				Arrays.equals(context, that.context);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Objects.hash(subject, predicate, object);
+		result = 31 * result + Arrays.hashCode(context);
+		return result;
+	}
+}

--- a/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/ReadCache.java
+++ b/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/ReadCache.java
@@ -1,0 +1,188 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.extensiblestore;
+
+import org.apache.commons.collections4.map.ReferenceMap;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.sail.SailException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class ReadCache implements DataStructureInterface {
+
+	private static final Logger logger = LoggerFactory.getLogger(ReadCache.class);
+
+	DataStructureInterface delegate;
+
+	final int STATEMENTS_PER_CACHE_ITEM_LIMIT = 100000;
+
+	// ReferenceMap defaults to hard reference for key and soft reference for value. This means that a value may be
+	// garbage collected, but unlike a weak ref it will only be garbage collected if we run out of memory. This is a
+	// memory sensitive cache.
+	ReferenceMap<PartialStatement, List<Statement>> cache = new ReferenceMap<>();
+
+	// The cache ticket is incremented every time the cache is cleared. A getStatements operation retrieves the current
+	// cacheTicket when the iteration is opened. When the iteration is closed it checks the retrieved ticket against the
+	// currentTicket, if they are the same then the statements can be cached. If the tickets don't match it means that
+	// there was a write operation at some point after the iteration was opened, and the statements accumulated in the
+	// iteration are stale and can not be cached.
+	private volatile long cacheTicket = Long.MIN_VALUE;
+
+	public ReadCache(DataStructureInterface delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void addStatement(Statement statement) {
+		delegate.addStatement(statement);
+		clearCache();
+	}
+
+	@Override
+	public void removeStatement(Statement statement) {
+		delegate.removeStatement(statement);
+		clearCache();
+	}
+
+	@Override
+	public CloseableIteration<? extends Statement, SailException> getStatements(Resource subject, IRI predicate,
+			Value object, Resource... context) {
+
+		PartialStatement partialStatement = new PartialStatement(subject, predicate, object, context);
+		CloseableIteration<? extends Statement, SailException> cached = getCached(partialStatement);
+		if (cached != null) {
+			logger.trace("cache hit");
+			return cached;
+		}
+
+		long localCacheTicket = cacheTicket;
+
+		return new CloseableIteration<Statement, SailException>() {
+
+			CloseableIteration<? extends Statement, SailException> statements = delegate.getStatements(subject,
+					predicate, object, context);
+			List<Statement> cache = new ArrayList<>();
+
+			@Override
+			public boolean hasNext() throws SailException {
+				return statements.hasNext();
+			}
+
+			@Override
+			public Statement next() throws SailException {
+
+				Statement next = statements.next();
+
+				if (cache != null) {
+					cache.add(next);
+					if (cache.size() > STATEMENTS_PER_CACHE_ITEM_LIMIT) {
+						cache = null;
+						logger.trace("cache limit");
+					}
+				}
+
+				return next;
+			}
+
+			@Override
+			public void remove() throws SailException {
+
+			}
+
+			@Override
+			public void close() throws SailException {
+				if (!statements.hasNext()) {
+					submitToCache(localCacheTicket, partialStatement, cache);
+				} else {
+					logger.trace("iteration was not fully consumed before being closed and could not be cached");
+				}
+				statements.close();
+
+			}
+		};
+
+	}
+
+	synchronized private CloseableIteration<? extends Statement, SailException> getCached(
+			PartialStatement partialStatement) {
+		List<Statement> statements = cache.get(partialStatement);
+
+		if (statements != null) {
+
+			return new LookAheadIteration<Statement, SailException>() {
+				Iterator<Statement> iterator = statements.iterator();
+
+				@Override
+				protected Statement getNextElement() throws SailException {
+					if (iterator.hasNext()) {
+						return iterator.next();
+					}
+					return null;
+				}
+			};
+
+		}
+
+		return null;
+	}
+
+	@Override
+	public void flushForReading() {
+		delegate.flushForReading();
+	}
+
+	@Override
+	public void init() {
+		delegate.init();
+	}
+
+	@Override
+	public void clear(Resource[] contexts) {
+		delegate.clear(contexts);
+		clearCache();
+	}
+
+	@Override
+	public void flushForCommit() {
+		delegate.flushForCommit();
+		clearCache();
+	}
+
+	@Override
+	public boolean removeStatementsByQuery(Resource subj, IRI pred, Value obj, Resource[] contexts) {
+		boolean removed = delegate.removeStatementsByQuery(subj, pred, obj, contexts);
+		clearCache();
+		return removed;
+	}
+
+	synchronized public void clearCache() {
+		if (!cache.isEmpty()) {
+			cache.clear();
+		}
+
+		// overflow is not a problem since we use == to compare in submitToCache
+		cacheTicket++;
+	}
+
+	synchronized public void submitToCache(Long localCacheTicket, PartialStatement partialStatement,
+			List<Statement> statements) {
+		if (localCacheTicket == cacheTicket && statements != null) {
+			cache.put(partialStatement, statements);
+		}
+
+	}
+}

--- a/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestoreimpl/ExtensibleStoreConnectionImplForTests.java
+++ b/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestoreimpl/ExtensibleStoreConnectionImplForTests.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.extensiblestoreimpl;
 
 import org.eclipse.rdf4j.sail.extensiblestore.ExtensibleStoreConnection;

--- a/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestoreimpl/ExtensibleStoreImplForTests.java
+++ b/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestoreimpl/ExtensibleStoreImplForTests.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.extensiblestoreimpl;
 
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;

--- a/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestoreimpl/NaiveHashSetDataStructure.java
+++ b/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestoreimpl/NaiveHashSetDataStructure.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.extensiblestoreimpl;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;

--- a/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestoreimpl/TransactionIsolationAndWalTests.java
+++ b/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestoreimpl/TransactionIsolationAndWalTests.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.extensiblestoreimpl;
+
+import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class TransactionIsolationAndWalTests {
+
+	/*
+	 * Checks that there is no leak between transactions. When one transactions adds a lot of data to the store another
+	 * transaction should see either nothing added or everything added. Nothing in between.
+	 */
+	@Test
+	@Ignore
+	public void testReadCommittedLargeTransaction() throws InterruptedException {
+		SailRepository repository = new SailRepository(new ExtensibleStoreImplForTests());
+
+		int count = 100000;
+
+		AtomicBoolean failure = new AtomicBoolean(false);
+
+		Runnable runnable = () -> {
+
+			try (SailRepositoryConnection connection = repository.getConnection()) {
+				while (true) {
+					connection.begin(IsolationLevels.READ_COMMITTED);
+					long size = connection.size();
+					connection.commit();
+					if (size != 0) {
+						if (size != count) {
+							System.out.println("Size was " + size + ". Expected " + count);
+							failure.set(true);
+						}
+						break;
+					}
+					Thread.yield();
+				}
+			}
+		};
+
+		Thread thread = new Thread(runnable);
+		thread.start();
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(IsolationLevels.READ_COMMITTED);
+			for (int i = 0; i < count; i++) {
+				connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral(i));
+			}
+			connection.commit();
+
+			assertEquals(count, connection.size());
+
+		}
+
+		thread.join();
+
+		assertFalse(failure.get());
+
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,12 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>4.4</version>
+      </dependency>
+
       <!-- Jackson Bill-of-Materials -->
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
GitHub issue resolved: #1731 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* a read cache that wraps a DataStructureInterface and provides caching of all read operations and write through for write operations
* automatic cache clearing
* lazy caching (getStatement iterations are still lazy)
* memory sensitive cache that will be garbage collected if the JVM runs low on memory
