### PR TITLE
#1747 repositoryresult and queryresult iterable

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResult.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResult.java
@@ -8,6 +8,9 @@
 package org.eclipse.rdf4j.query;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iterator.CloseableIterationIterator;
+
+import java.util.Iterator;
 
 /**
  * Super type of all query result types (TupleQueryResult, GraphQueryResult, etc.).
@@ -15,6 +18,10 @@ import org.eclipse.rdf4j.common.iteration.CloseableIteration;
  * @author Jeen Broekstra
  * @author Arjohn Kampman
  */
-public interface QueryResult<T> extends CloseableIteration<T, QueryEvaluationException> {
+public interface QueryResult<T> extends CloseableIteration<T, QueryEvaluationException>, Iterable<T> {
 
+	@Override
+	default Iterator<T> iterator() {
+		return new CloseableIterationIterator<T>(this);
+	}
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -807,6 +807,23 @@ public interface RepositoryConnection extends AutoCloseable {
 			throws RepositoryException, E;
 
 	/**
+	 * Adds the supplied statements to this repository, optionally to one or more named contexts.
+	 *
+	 * @param statements The statements to add. The @{link RepositoryResult} will be closed before this method returns.
+	 * @param contexts   The contexts to add the statements to. Note that this parameter is a vararg and as such is
+	 *                   optional. If no contexts are specified, each statement is added to any context specified in the
+	 *                   statement, or if the statement contains no context, it is added without context. If one or more
+	 *                   contexts are specified each statement is added to these contexts, ignoring any context
+	 *                   information in the statement itself. ignored.
+	 * @throws RepositoryException If the statements could not be added to the repository, for example because the
+	 *                             repository is not writable.
+	 */
+	default void add(RepositoryResult<Statement> statements, Resource... contexts)
+			throws RepositoryException {
+		add((Iteration<Statement, RepositoryException>) statements, contexts);
+	}
+
+	/**
 	 * Removes the statement(s) with the specified subject, predicate and object from the repository, optionally
 	 * restricted to the specified contexts.
 	 * 
@@ -878,6 +895,23 @@ public interface RepositoryConnection extends AutoCloseable {
 	 */
 	public <E extends Exception> void remove(Iteration<? extends Statement, E> statements, Resource... contexts)
 			throws RepositoryException, E;
+
+	/**
+	 * Removes the supplied statements from a specific context in this repository, ignoring any context information
+	 * carried by the statements themselves.
+	 *
+	 * @param statements The statements to remove. The {@link RepositoryResult} will be closed before this method
+	 *                   returns.
+	 * @param contexts   The context(s) to remove the data from. Note that this parameter is a vararg and as such is
+	 *                   optional. If no contexts are supplied the method operates on the contexts associated with the
+	 *                   statement itself, and if no context is associated with the statement, on the entire repository.
+	 * @throws RepositoryException If the statements could not be removed from the repository, for example because the
+	 *                             repository is not writable.
+	 */
+	default void remove(RepositoryResult<Statement> statements, Resource... contexts)
+			throws RepositoryException {
+		remove((Iteration<Statement, RepositoryException>) statements, contexts);
+	}
 
 	/**
 	 * Removes all statements from a specific contexts in the repository.

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryResult.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryResult.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.repository;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.rdf4j.common.iteration.AbstractCloseableIteration;
@@ -16,6 +17,7 @@ import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.DistinctIteration;
 import org.eclipse.rdf4j.common.iteration.Iteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.common.iterator.CloseableIterationIterator;
 
 /**
  * A RepositoryResult is a result collection of objects (for example {@link org.eclipse.rdf4j.model.Statement} ,
@@ -37,7 +39,7 @@ import org.eclipse.rdf4j.common.iteration.Iterations;
  * @author Jeen Broekstra
  * @author Arjohn Kampman
  */
-public class RepositoryResult<T> extends AbstractCloseableIteration<T, RepositoryException> {
+public class RepositoryResult<T> extends AbstractCloseableIteration<T, RepositoryException> implements Iterable<T> {
 
 	private volatile Iteration<? extends T, RepositoryException> wrappedIter;
 
@@ -123,5 +125,10 @@ public class RepositoryResult<T> extends AbstractCloseableIteration<T, Repositor
 		} finally {
 			close();
 		}
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		return new CloseableIterationIterator<T>(this);
 	}
 }

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnectionTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnectionTest.java
@@ -833,6 +833,27 @@ public abstract class RepositoryConnectionTest {
 	}
 
 	@Test
+	public void testGetStatementsIterable() throws Exception {
+		testCon.add(bob, name, nameBob);
+
+		assertTrue("Repository should contain statement", testCon.hasStatement(bob, name, nameBob, false));
+
+		try (RepositoryResult<Statement> result = testCon.getStatements(null, name, null, false);) {
+			assertThat(result).isNotNull();
+			assertThat(result).isNotEmpty();
+
+			for (Statement st : result) {
+				assertThat(st.getContext()).isNull();
+				assertThat(st.getPredicate()).isEqualTo(name);
+			}
+
+			assertThat(result).isEmpty();
+			assertThat(result.isClosed()).isTrue();
+		}
+
+	}
+
+	@Test
 	public void testGetStatementsMalformedTypedLiteral() throws Exception {
 		Literal invalidIntegerLiteral = vf.createLiteral("the number four", XMLSchema.INTEGER);
 		try {


### PR DESCRIPTION
GitHub issue resolved: #1747  <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* RepositoryResult and QueryResult extend java.lang.Iterable
* added method overloads to avoid ambiguous calls in RepositoryConnection
