### PR TITLE
Fix typo in the JavaDoc of SearchQueryEvaluator#replaceQueryPatternsWithResults

### DIFF
--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchQueryEvaluator.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchQueryEvaluator.java
@@ -15,7 +15,7 @@ public interface SearchQueryEvaluator {
 	QueryModelNode getParentQueryModelNode();
 
 	/**
-	 * @param bsa if null or empty then there're no results for the query
+	 * @param bsa binding sets, pass null or empty when there are no results for the query
 	 */
 	void replaceQueryPatternsWithResults(final BindingSetAssignment bsa);
 


### PR DESCRIPTION
GitHub issue resolved: #1667 

A simple change to the JavaDoc of SearchQueryEvaluator#replaceQueryPatternsWithResults to improve its clarity (following the [suggestion](https://groups.google.com/d/msg/rdf4j-users/S8knUuL_Fsw/--_ypZmnBAAJ) by @barthanssens on the mailing list).