### PR TITLE
Generate html5 javadoc when using JDK9 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,10 +241,19 @@
     <profile>
       <id>doclint-java8-disable</id>
       <activation>
-        <jdk>[1.8,9,)</jdk>
+        <jdk>1.8</jdk>
       </activation>
       <properties>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+    <profile>
+      <id>doclint-java9-disable</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none -html5</javadoc.opts>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
GitHub issue resolved: #1526 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Generate HTML5 when using JDK9 or newer