### PR TITLE
Fix typo "SPARQLREpository" in javadoc

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
@@ -66,7 +66,7 @@ public class SPARQLRepository extends AbstractRepository implements HttpClientDe
 	}
 
 	/**
-	 * Create a new SPARQLREpository using the supplied query endpoint URL for queries, and the supplied update endpoint
+	 * Create a new SPARQLRepository using the supplied query endpoint URL for queries, and the supplied update endpoint
 	 * URL for updates.
 	 * 
 	 * @param queryEndpointUrl  a SPARQL endpoint URL for queries. May not be null.


### PR DESCRIPTION
GitHub issue resolved: 

Briefly describe the changes proposed in this PR:

* Fix typo `SPARQLREpository` in javadoc
