### PR TITLE
GH-1802 Fix vectored evaluation using VALUES in RepositoryFederatedService

### DIFF
--- a/compliance/repository/pom.xml
+++ b/compliance/repository/pom.xml
@@ -59,6 +59,20 @@
 			<artifactId>rdf4j-repository-manager</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-repository-sail</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sail-memory</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceIntegrationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceIntegrationTest.java
@@ -1,0 +1,290 @@
+package org.eclipse.rdf4j.repository.sparql.federation;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedService;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Integration tests for {@link RepositoryFederatedService}
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public class RepositoryFederatedServiceIntegrationTest {
+
+	private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+	private SailRepository serviceRepo;
+	private SailRepository localRepo;
+	private RepositoryFederatedService federatedService;
+
+	@Before
+	public void before() {
+		serviceRepo = new SailRepository(new MemoryStore());
+		serviceRepo.init();
+
+		federatedService = new RepositoryFederatedService(serviceRepo);
+
+		localRepo = new SailRepository(new MemoryStore());
+		localRepo.setFederatedServiceResolver(new FederatedServiceResolver() {
+
+			@Override
+			public FederatedService getService(String serviceUrl) throws QueryEvaluationException {
+				return federatedService;
+			}
+		});
+		localRepo.init();
+	}
+
+	@After
+	public void after() {
+		federatedService.shutdown();
+		localRepo.shutDown();
+		serviceRepo.shutDown();
+	}
+
+	@Test
+	public void test() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+
+		String query = "SELECT ?var WHERE { VALUES ?var { 'val1' 'val2' } . SERVICE <urn:dummy> { ?s ?p ?var  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1")));
+	}
+
+	@Test
+	public void test2() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(
+				vf.createStatement(iri("s1"), RDFS.LABEL, l("val1")),
+				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
+				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
+
+		String query = "SELECT ?var WHERE { VALUES ?var { 'val1' 'val2' } . SERVICE <urn:dummy> { ?s ?p ?var  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2")));
+	}
+
+	@Test
+	public void test3() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(
+				vf.createStatement(iri("s1"), RDFS.LABEL, l("val1")),
+				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
+				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
+
+		String query = "SELECT ?var WHERE { VALUES ?var { 'val1' 'val2' } . SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 1000  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2")));
+	}
+
+	@Test
+	public void test3a() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(
+				vf.createStatement(iri("s1"), RDFS.LABEL, l("val1")),
+				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
+				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
+
+		String query = "SELECT ?s ?var WHERE { VALUES ?var { 'val1' 'val2' } . OPTIONAL { SERVICE <urn:dummy> { SELECT ?s ?var { ?s ?p ?var . FILTER (?var='val2') } LIMIT 1  } } }";
+
+		List<BindingSet> res = evaluateQuery(query);
+		assertResultEquals(res, "var", Lists.newArrayList(l("val1"), l("val2")));
+		assertResultEquals(res, "s", Lists.newArrayList(null, (iri("s2"))));
+	}
+
+	@Test
+	public void test4() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(
+				vf.createStatement(iri("s1"), RDFS.LABEL, l("val1")),
+				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
+				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
+
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { ?s ?p ?var } . SERVICE <urn:dummy> {  ?s ?p ?var  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2"), l("val3")));
+	}
+
+	@Test
+	public void test4a() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(
+				vf.createStatement(iri("s1"), RDFS.LABEL, l("val1")),
+				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
+				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
+
+		// Note: here we apply a workaround and explicitly project "?__rowIdx"
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 3 } . SERVICE <urn:dummy> { SELECT ?s ?var ?__rowIdx { ?s ?p ?var } LIMIT 3  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2"), l("val3")));
+	}
+
+	@Test
+	public void test4b() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(
+				vf.createStatement(iri("s1"), RDFS.LABEL, l("val1")),
+				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
+				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
+
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 3 } . SERVICE <urn:dummy> { SELECT ?s ?var { ?s ?p ?var } LIMIT 3  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2"), l("val3")));
+	}
+
+	@Test
+	public void test5() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+
+		String query = "SELECT ?var ?output WHERE { VALUES ?var { 'val1' 'val2' } . SERVICE <urn:dummy> { BIND(CONCAT(?var, '_processed') AS ?output) } }";
+
+		List<BindingSet> res = evaluateQuery(query);
+		assertResultEquals(res, "var", Lists.newArrayList(l("val1"), l("val2")));
+		assertResultEquals(res, "output", Lists.newArrayList(l("val1_processed"), l("val2_processed")));
+	}
+
+	@Test
+	public void test5a() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s2"), RDFS.LABEL, l("val2"))));
+
+		// Note: here we apply a workaround and explicitly project "?__rowIdx"
+		String query = "SELECT ?var ?output WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 3 }  . SERVICE <urn:dummy> { SELECT (CONCAT(?var, '_processed') AS ?output) ?__rowIdx WHERE { } } }";
+
+		List<BindingSet> res = evaluateQuery(query);
+		assertResultEquals(res, "var", Lists.newArrayList(l("val1"), l("val2")));
+		assertResultEquals(res, "output", Lists.newArrayList(l("val1_processed"), l("val2_processed")));
+	}
+
+	@Test
+	public void test5b() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s2"), RDFS.LABEL, l("val2"))));
+
+		String query = "SELECT ?var ?output WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 3 }  . SERVICE <urn:dummy> { SELECT (CONCAT(?var, '_processed') AS ?output) WHERE { } } }";
+
+		List<BindingSet> res = evaluateQuery(query);
+		assertResultEquals(res, "var", Lists.newArrayList(l("val1"), l("val2")));
+		assertResultEquals(res, "output", Lists.newArrayList(l("val1_processed"), l("val2_processed")));
+	}
+
+	@Test
+	public void test6() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s2"), RDFS.LABEL, l("val2"))));
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
+
+		String query = "SELECT ?var ?cnt WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 2 }  . SERVICE <urn:dummy> { SELECT ?var ?cnt ?__rowIdx WHERE { SELECT (COUNT(?s2) AS ?cnt) WHERE { ?s2 ?p2 ?var  } } } }";
+
+		List<BindingSet> res = evaluateQuery(query);
+		Assert.assertEquals(2, res.size());
+		BindingSet b1 = res.get(0);
+		Assert.assertEquals(l("val1"), b1.getValue("var"));
+		Assert.assertEquals(1, ((Literal) b1.getValue("cnt")).intValue());
+	}
+
+	@Test
+	public void test6b() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s2"), RDFS.LABEL, l("val2"))));
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
+
+		String query = "SELECT ?var ?cnt WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 1 }  . SERVICE <urn:dummy> { SELECT ?var ?cnt ?__rowIdx WHERE { SELECT (COUNT(?s2) AS ?cnt) WHERE { ?s2 ?p2 ?var  } } } }";
+
+		List<BindingSet> res = evaluateQuery(query);
+		Assert.assertEquals(1, res.size());
+		BindingSet b1 = res.get(0);
+		Assert.assertEquals(l("val1"), b1.getValue("var"));
+		Assert.assertEquals(1, ((Literal) b1.getValue("cnt")).intValue());
+	}
+
+	@Test
+	public void test7_CrossProduct() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("serviceVal"))));
+
+		String query = "SELECT ?var ?o WHERE { VALUES ?var { 'val1' 'val2' } . SERVICE <urn:dummy> { ?s ?p ?o  } }";
+
+		List<BindingSet> res = evaluateQuery(query);
+		assertResultEquals(res, "var", Lists.newArrayList(l("val1"), l("val2")));
+		assertResultEquals(res, "o", Lists.newArrayList(l("serviceVal"), l("serviceVal")));
+	}
+
+	@Test
+	public void test8_subSelectAll() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { SELECT ?var WHERE { VALUES ?var { 'val1' 'val2' } } } . SERVICE <urn:dummy> { SELECT * WHERE { ?s ?p ?var }  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1")));
+	}
+
+	@Test
+	public void test8a_subSelectAll() throws Exception {
+
+		addData(serviceRepo, Lists.newArrayList(vf.createStatement(iri("s1"), RDFS.LABEL, l("val1"))));
+
+		// query has multiple whitespaces "SELECT *", thus does not insert "?__rowIdx" and goes into fallback evaluation
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { SELECT ?var WHERE { VALUES ?var { 'val1' 'val2' } } } . SERVICE <urn:dummy> { SELECT   * WHERE { ?s ?p ?var }  } }";
+
+		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1")));
+	}
+
+	private void addData(Repository repo, Collection<? extends Statement> m) {
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.add(m);
+		}
+	}
+
+	private List<BindingSet> evaluateQuery(String query) {
+		try (RepositoryConnection conn = localRepo.getConnection()) {
+			try (TupleQueryResult tqr = conn.prepareTupleQuery(query).evaluate()) {
+				return Iterations.asList(tqr);
+			}
+		}
+	}
+
+	private IRI iri(String localName) {
+		return vf.createIRI("http://example.org/resource/", localName);
+	}
+
+	private Literal l(String literal) {
+		return vf.createLiteral(literal);
+	}
+
+	private void assertResultEquals(List<BindingSet> res, String bindingName, List<Value> expected) {
+		Assert.assertEquals(expected, res.stream().map(b -> b.getValue(bindingName)).collect(Collectors.toList()));
+	}
+}

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
  */
 public class RepositoryFederatedService implements FederatedService {
 
+	private static final String ROW_IDX_VAR = "__rowIdx";
+
 	final static Logger logger = LoggerFactory.getLogger(RepositoryFederatedService.class);
 
 	/**
@@ -86,7 +88,45 @@ public class RepositoryFederatedService implements FederatedService {
 		}
 	}
 
+	/**
+	 * Helper iteration to evaluate a block of {@link BindingSet}s using the simple
+	 * {@link RepositoryFederatedService#select(Service, Set, BindingSet, String)} routine.
+	 * 
+	 * @author Andreas Schwarte
+	 *
+	 */
+	private class FallbackServiceIteration extends JoinExecutorBase<BindingSet> {
+
+		private final Service service;
+		private final List<BindingSet> allBindings;
+		private final String baseUri;
+
+		public FallbackServiceIteration(Service service,
+				List<BindingSet> allBindings, String baseUri) {
+			super(null, null, null);
+			this.service = service;
+			this.allBindings = allBindings;
+			this.baseUri = baseUri;
+			run();
+		}
+
+		@Override
+		protected void handleBindings() throws Exception {
+			Set<String> projectionVars = new HashSet<>(service.getServiceVars());
+			for (BindingSet b : allBindings) {
+				addResult(select(service, projectionVars, b, baseUri));
+			}
+		}
+	}
+
 	protected final Repository rep;
+
+	/**
+	 * The number of bindings sent in a single subquery in {@link #evaluate(Service, CloseableIteration, String)} If
+	 * blockSize is set to 0, the entire input stream is used as block input the block size effectively determines the
+	 * number of remote requests
+	 */
+	protected int boundJoinBlockSize = 15;
 
 	// flag indicating whether the repository shall be closed in #shutdown()
 	protected boolean shutDown = true;
@@ -195,7 +235,7 @@ public class RepositoryFederatedService implements FederatedService {
 
 	/**
 	 * Evaluate the SPARQL query that can be constructed from the SERVICE node at the initialized {@link Repository} of
-	 * this {@link FederatedService}. Use specified bindings as constraints to the query. Try to evaluate using BINDINGS
+	 * this {@link FederatedService}. Use specified bindings as constraints to the query. Try to evaluate using VALUES
 	 * clause, if this yields an exception fall back to the naive implementation. This method deals with SILENT
 	 * SERVICEs.
 	 */
@@ -231,24 +271,24 @@ public class RepositoryFederatedService implements FederatedService {
 			// To be able to insert the input bindings again later on, we need some
 			// means to identify the row of each binding. hence, we use an
 			// additional
-			// projection variable, which is also passed in the BINDINGS clause
+			// projection variable, which is also passed in the VALUES clause
 			// with the value of the actual row. The value corresponds to the index
 			// of the binding in the index list
-			projectionVars.add("__rowIdx");
+			projectionVars.add(ROW_IDX_VAR);
 
 			String queryString = service.getSelectQueryString(projectionVars);
 
 			List<String> relevantBindingNames = getRelevantBindingNames(allBindings, service.getServiceVars());
 
 			if (!relevantBindingNames.isEmpty()) {
-				// append the VALUES clause to the query
-				queryString += buildVALUESClause(allBindings, relevantBindingNames);
+				// insert VALUES clause into the query
+				queryString = insertValuesClause(queryString, buildVALUESClause(allBindings, relevantBindingNames));
 			}
 
 			TupleQuery query = getConnection().prepareTupleQuery(QueryLanguage.SPARQL, queryString, baseUri);
 			TupleQueryResult res = null;
-			query.setMaxQueryTime(60); // TODO how to retrieve max query value
-										// from actual setting?
+			query.setMaxExecutionTime(60); // TODO how to retrieve max query value
+											// from actual setting?
 			res = query.evaluate();
 
 			if (relevantBindingNames.isEmpty())
@@ -269,7 +309,10 @@ public class RepositoryFederatedService implements FederatedService {
 					"Repository for endpoint " + rep.toString() + " could not be initialized.", e);
 		} catch (MalformedQueryException e) {
 			// this exception must not be silenced, bug in our code
-			throw new QueryEvaluationException(e);
+			// => try a fallback to the simple evaluation
+			logger.debug("Encounted malformed query exception: " + e.getMessage()
+					+ ". Falling back to simple SERVICE evaluation.");
+			return evaluateInternalFallback(service, allBindings, baseUri);
 		} catch (QueryEvaluationException e) {
 			Iterations.closeCloseable(result);
 			if (service.isSilent())
@@ -285,10 +328,55 @@ public class RepositoryFederatedService implements FederatedService {
 		}
 	}
 
+	/**
+	 * Evaluate the service expression for the given lists of bindings using {@link FallbackServiceIteration}, i.e.
+	 * basically as a simple join without VALUES clause.
+	 * 
+	 * @param service     the SERVICE
+	 * @param allBindings all bindings to be processed
+	 * @param baseUri     the base URI
+	 * @return resulting iteration
+	 */
+	private CloseableIteration<BindingSet, QueryEvaluationException> evaluateInternalFallback(Service service,
+			List<BindingSet> allBindings, String baseUri) {
+
+		CloseableIteration<BindingSet, QueryEvaluationException> res = new FallbackServiceIteration(service,
+				allBindings, baseUri);
+
+		if (service.isSilent()) {
+			res = new SilentIteration(res);
+		}
+		return res;
+
+	}
+
+	/**
+	 * Insert the constructed VALUES clause in the beginning of the WHERE block. Also adds the {@link #ROW_IDX_VAR}
+	 * projection if it is not already present.
+	 * 
+	 * @param queryString  the SELECT query string from the SERVICE node
+	 * @param valuesClause the constructed VALUES clause
+	 * @return the final String
+	 */
+	protected String insertValuesClause(String queryString, String valuesClause) {
+		StringBuilder sb = new StringBuilder(queryString);
+		if (sb.indexOf(ROW_IDX_VAR) == -1) {
+			// Note: we also explicitly check on "SELECT *", however, this
+			// check is heuristics based. If the generated query is invalid
+			// after this, the fallback evaluation will jump in
+			// This currently does not cover things like "SELECT *"
+			if (sb.indexOf("SELECT * ") == -1) {
+				sb.insert(sb.indexOf("SELECT") + 6, " ?" + ROW_IDX_VAR);
+			}
+		}
+		sb.insert(sb.indexOf("{") + 1, " " + valuesClause);
+		return sb.toString();
+	}
+
 	@Override
 	public void initialize() throws QueryEvaluationException {
 		try {
-			rep.initialize();
+			rep.init();
 		} catch (RepositoryException e) {
 			throw new QueryEvaluationException(e);
 		}
@@ -299,13 +387,16 @@ public class RepositoryFederatedService implements FederatedService {
 		return rep.isInitialized();
 	}
 
-	private void closeQuietly(TupleQueryResult res) {
-		try {
-			if (res != null)
-				res.close();
-		} catch (Exception e) {
-			logger.debug("Could not close connection properly: " + e.getMessage(), e);
-		}
+	public int getBoundJoinBlockSize() {
+		return boundJoinBlockSize;
+	}
+
+	/**
+	 * 
+	 * @param boundJoinBlockSize the bound join block size, 0 to evaluate all in a single request
+	 */
+	public void setBoundJoinBlockSize(int boundJoinBlockSize) {
+		this.boundJoinBlockSize = boundJoinBlockSize;
 	}
 
 	@Override

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceTest.java
@@ -1,0 +1,48 @@
+package org.eclipse.rdf4j.repository.sparql.federation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RepositoryFederatedServiceTest {
+
+	@Test
+	public void testInsertValuesClause() throws Exception {
+
+		// dummy instance for test
+		RepositoryFederatedService inst = new RepositoryFederatedService(null);
+
+		Assert.assertEquals(
+				"SELECT ?s ?var ?__rowIdx WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?var }",
+				inst.insertValuesClause("SELECT ?s ?var ?__rowIdx WHERE { ?s ?p ?var }",
+						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
+
+		Assert.assertEquals(
+				"SELECT ?s ?var ?__rowIdx WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }?s ?p ?var}",
+				inst.insertValuesClause("SELECT ?s ?var ?__rowIdx WHERE {?s ?p ?var}",
+						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
+
+		Assert.assertEquals(
+				"SELECT ?s ?var ?__rowIdx { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?varv}",
+				inst.insertValuesClause("SELECT ?s ?var ?__rowIdx { ?s ?p ?varv}",
+						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
+
+		// test insertion of ?__rowIdx projection
+		Assert.assertEquals(
+				"SELECT ?__rowIdx ?s ?var WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?var }",
+				inst.insertValuesClause("SELECT ?s ?var WHERE { ?s ?p ?var }",
+						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
+
+		Assert.assertEquals(
+				"SELECT * WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?var }",
+				inst.insertValuesClause("SELECT * WHERE { ?s ?p ?var }",
+						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
+
+		// Query pattern contains "SELECT *" with whitespace, which we do not match
+		// => we currently generate an invalid query which is then evaluated using
+		// the fallback to simple evaluation
+		Assert.assertEquals(
+				"SELECT ?__rowIdx   * WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?var }",
+				inst.insertValuesClause("SELECT   * WHERE { ?s ?p ?var }",
+						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #1802 

This change adjusts the optimized evaluation of SERVICE queries using
the VALUES clause.

In order to address performance and correctness issues, the VALUES
clause is now inserted in the beginning of the WHERE block (instead of
appending it to the generated query).

This change also does some cleanup to the RepositoryFederatedService
implementation (e.g. replacing deprecated code)

Change is covered by numerous integration unit tests

See #1802 for full details
