### PR TITLE
Use StandardCharsets.UTF_8

### DIFF
--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriter.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriter.java
@@ -72,7 +72,7 @@ public class TransactionWriter {
 	/**
 	 * Serializes the supplied operation.
 	 * 
-	 * @param op The operation to serialize
+	 * @param op        The operation to serialize
 	 * @param xmlWriter
 	 * @throws IOException
 	 */

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriter.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriter.java
@@ -9,6 +9,8 @@ package org.eclipse.rdf4j.http.protocol.transaction;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import javax.xml.bind.DatatypeConverter;
 
 import org.eclipse.rdf4j.common.xml.XMLUtil;
 import org.eclipse.rdf4j.common.xml.XMLWriter;
@@ -46,6 +48,7 @@ public class TransactionWriter {
 	 * 
 	 * @param txn the operations
 	 * @param out the output stream to write to
+	 * @throws IOException
 	 * @throws IllegalArgumentException when one of the parameters is null
 	 */
 	public void serialize(Iterable<? extends TransactionOperation> txn, OutputStream out) throws IOException {
@@ -70,6 +73,8 @@ public class TransactionWriter {
 	 * Serializes the supplied operation.
 	 * 
 	 * @param op The operation to serialize
+	 * @param xmlWriter
+	 * @throws IOException
 	 */
 	protected void serialize(TransactionOperation op, XMLWriter xmlWriter) throws IOException {
 		if (op instanceof AddStatementOperation) {
@@ -286,7 +291,7 @@ public class TransactionWriter {
 
 			if (!valid) {
 				xmlWriter.setAttribute(TransactionXMLConstants.ENCODING_ATT, "base64");
-				label = javax.xml.bind.DatatypeConverter.printBase64Binary(label.getBytes("UTF-8"));
+				label = DatatypeConverter.printBase64Binary(label.getBytes(StandardCharsets.UTF_8));
 			}
 
 			xmlWriter.textElement(TransactionXMLConstants.LITERAL_TAG, label);


### PR DESCRIPTION
GitHub issue resolved: #1805 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Use StandardCharsets constant instead of string value
* Minor javadoc changes 
