### PR TITLE
GH-1787: integrate FedX federation support into the RDF4J workbench

### DIFF
--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -9,6 +9,7 @@
 
 	<name>RDF4J: Federation</name>
 	<description>A federation engine for virtually integrating SPARQL endpoints</description>
+	<packaging>jar</packaging>
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigBuilder.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigBuilder.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.repository;
+
+import java.util.Collection;
+
+import org.eclipse.rdf4j.federated.util.Vocabulary.FEDX;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.impl.TreeModel;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+
+/**
+ * Builder for {@link FedXRepositoryConfig}
+ * 
+ * @author Andreas Schwarte
+ */
+public class FedXRepositoryConfigBuilder {
+
+	public static FedXRepositoryConfigBuilder create() {
+		return new FedXRepositoryConfigBuilder();
+	}
+
+	private final Model members = new TreeModel();
+
+	private FedXRepositoryConfigBuilder() {
+	}
+
+	public FedXRepositoryConfigBuilder withResolvableEndpoint(String memberId) {
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		members.add(vf.createIRI(FEDX.NAMESPACE, memberId), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
+		members.add(vf.createIRI(FEDX.NAMESPACE, memberId), FEDX.REPOSITORY_NAME, vf.createLiteral(memberId));
+		return this;
+	}
+
+	public FedXRepositoryConfigBuilder withResolvableEndpoint(Collection<String> memberIds) {
+		memberIds.stream().forEach(memberId -> withResolvableEndpoint(memberId));
+		return this;
+	}
+
+	public FedXRepositoryConfigBuilder withMembers(Collection<Statement> members) {
+		this.members.addAll(members);
+		return this;
+	}
+
+	/**
+	 * Build the {@link FedXRepositoryConfig} that can be used in the {@link RepositoryConfig}.
+	 * 
+	 * @return the {@link FedXRepositoryConfig}
+	 */
+	public FedXRepositoryConfig build() {
+		FedXRepositoryConfig config = new FedXRepositoryConfig();
+		config.setMembers(members);
+		return config;
+	}
+
+	/**
+	 * Build the {@link RepositoryConfig}
+	 * 
+	 * @param repositoryId    the repository identifier
+	 * @param repositoryTitle the repository title
+	 * @return the {@link RepositoryConfig} (incorporating {@link FedXRepositoryConfig})
+	 */
+	public RepositoryConfig build(String repositoryId, String repositoryTitle) {
+		return new RepositoryConfig(repositoryId, repositoryTitle, build());
+	}
+}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXWithLocalRepositoryManagerTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXWithLocalRepositoryManagerTest.java
@@ -9,12 +9,13 @@ package org.eclipse.rdf4j.federated;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.federated.repository.FedXRepository;
 import org.eclipse.rdf4j.federated.repository.FedXRepositoryConfig;
-import org.eclipse.rdf4j.federated.util.Vocabulary.FEDX;
+import org.eclipse.rdf4j.federated.repository.FedXRepositoryConfigBuilder;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -109,15 +110,9 @@ public class FedXWithLocalRepositoryManagerTest extends FedXBaseTest {
 		addData("repo2", Lists.newArrayList(
 				vf.createStatement(vf.createIRI("http://ex.org/p2"), RDF.TYPE, FOAF.PERSON)));
 
-		Model members = new TreeModel();
-		members.add(vf.createIRI("http://ex.org/repo1"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
-		members.add(vf.createIRI("http://ex.org/repo1"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo1"));
-		members.add(vf.createIRI("http://ex.org/repo2"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
-		members.add(vf.createIRI("http://ex.org/repo2"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo2"));
-
-		FedXRepositoryConfig fedXRepoConfig = new FedXRepositoryConfig();
-		fedXRepoConfig.setMembers(members);
-
+		FedXRepositoryConfig fedXRepoConfig = FedXRepositoryConfigBuilder.create()
+				.withResolvableEndpoint(Arrays.asList("repo1", "repo2"))
+				.build();
 		repoManager.addRepositoryConfig(new RepositoryConfig("federation", fedXRepoConfig));
 
 		Repository repo = repoManager.getRepository("federation");
@@ -168,15 +163,9 @@ public class FedXWithLocalRepositoryManagerTest extends FedXBaseTest {
 				vf.createStatement(vf.createIRI("http://ex.org/p1"), FOAF.NAME, vf.createLiteral("Person 1")),
 				vf.createStatement(vf.createIRI("http://ex.org/p2"), FOAF.NAME, vf.createLiteral("Person 2"))));
 
-		Model members = new TreeModel();
-		members.add(vf.createIRI("http://ex.org/repo1"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
-		members.add(vf.createIRI("http://ex.org/repo1"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo1"));
-		members.add(vf.createIRI("http://ex.org/repo2"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
-		members.add(vf.createIRI("http://ex.org/repo2"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo2"));
-
-		FedXRepositoryConfig fedXRepoConfig = new FedXRepositoryConfig();
-		fedXRepoConfig.setMembers(members);
-
+		FedXRepositoryConfig fedXRepoConfig = FedXRepositoryConfigBuilder.create()
+				.withResolvableEndpoint(Arrays.asList("repo1", "repo2"))
+				.build();
 		repoManager.addRepositoryConfig(new RepositoryConfig("federation", fedXRepoConfig));
 
 		Repository repo = repoManager.getRepository("federation");
@@ -221,26 +210,14 @@ public class FedXWithLocalRepositoryManagerTest extends FedXBaseTest {
 		addData("repo3", Lists.newArrayList(
 				vf.createStatement(vf.createIRI("http://ex.org/p3"), RDF.TYPE, FOAF.PERSON)));
 
-		Model federation1 = new TreeModel();
-		federation1.add(vf.createIRI("http://ex.org/repo1"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
-		federation1.add(vf.createIRI("http://ex.org/repo1"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo1"));
-		federation1.add(vf.createIRI("http://ex.org/repo2"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
-		federation1.add(vf.createIRI("http://ex.org/repo2"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo2"));
-
-		FedXRepositoryConfig fedXRepo1Config = new FedXRepositoryConfig();
-		fedXRepo1Config.setMembers(federation1);
-
+		FedXRepositoryConfig fedXRepo1Config = FedXRepositoryConfigBuilder.create()
+				.withResolvableEndpoint(Arrays.asList("repo1", "repo2"))
+				.build();
 		repoManager.addRepositoryConfig(new RepositoryConfig("federation1", fedXRepo1Config));
 
-		Model federation2 = new TreeModel();
-		federation2.add(vf.createIRI("http://ex.org/repo1"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
-		federation2.add(vf.createIRI("http://ex.org/repo1"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo1"));
-		federation2.add(vf.createIRI("http://ex.org/repo3"), FEDX.STORE, vf.createLiteral("ResolvableRepository"));
-		federation2.add(vf.createIRI("http://ex.org/repo3"), FEDX.REPOSITORY_NAME, vf.createLiteral("repo3"));
-
-		FedXRepositoryConfig fedXRepo2Config = new FedXRepositoryConfig();
-		fedXRepo2Config.setMembers(federation2);
-
+		FedXRepositoryConfig fedXRepo2Config = FedXRepositoryConfigBuilder.create()
+				.withResolvableEndpoint(Arrays.asList("repo1", "repo3"))
+				.build();
 		repoManager.addRepositoryConfig(new RepositoryConfig("federation2", fedXRepo2Config));
 
 		// query federation 1 (contains person1 and person2)

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -28,6 +28,16 @@
 			<artifactId>rdf4j-config</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		
+				
+		<!-- TODO rather include into rdf4j-storage, however, 
+		requires resolving cyclic dependency on test scope -->
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-tools-federation</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		
 
 		<dependency>
 			<groupId>org.ebaysf.web</groupId>

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -33,6 +33,14 @@
 			<version>${project.version}</version>
 		</dependency>
 		
+		<!-- TODO rather include into rdf4j-storage, however, 
+		requires resolving cyclic dependency on test scope -->
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-tools-federation</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>

--- a/tools/workbench/src/main/webapp/transformations/create-federate.xsl
+++ b/tools/workbench/src/main/webapp/transformations/create-federate.xsl
@@ -68,23 +68,6 @@
 						</td>
 					</tr>
 					<tr>
-						<th>
-							<xsl:value-of select="$distinct.label" />
-						</th>
-						<td>
-							<input type="checkbox" name="distinct" value="true" />
-						</td>
-					</tr>
-					<tr>
-						<th>
-							<xsl:value-of select="$read-only.label" />
-						</th>
-						<td>
-							<input type="checkbox" name="readonly" value="true"
-								checked="true" />
-						</td>
-					</tr>
-					<tr>
 						<td></td>
 						<td>
 							<input type="button" value="{$cancel.label}" style="float:right"

--- a/tools/workbench/src/main/webapp/transformations/create.xsl
+++ b/tools/workbench/src/main/webapp/transformations/create.xsl
@@ -90,7 +90,7 @@
 								<option value="sparql">
 									SPARQL endpoint proxy
 								</option>
-								<option value="federate">Federation Store</option>
+								<option value="federate">Federation</option>
 							</select>
 						</td>
 						<td></td>


### PR DESCRIPTION
GitHub issue resolved: #1787

This change integrates the 'rdf4j-tools-federation' module into
'rdf4j-server.war' and thus makes it available in the RDF4J workbench.

For convenience we reuse the existing UI facilities to create a
federation: instead of creating a federation sail, we now create a FedX
based Federation repository.

Note that dependencies on rdfj4-tools-federated have been explicitly
added to rdf4j-server and rdf4j-workbench. Ideally the dependency could
be added to rdf4j-storage, however this currently has cyclic dependency
issues.

Signed-off-by: Andreas Schwarte <aschwarte10@gmail.com>


