### PR TITLE
GH-1816: improve (external) SERVICE evaluation in FedX engine

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
@@ -218,14 +218,8 @@ public class RepositoryFederatedService implements FederatedService {
 			CloseableIteration<BindingSet, QueryEvaluationException> bindings, String baseUri)
 			throws QueryEvaluationException {
 
-		// the number of bindings sent in a single subquery.
-		// if blockSize is set to 0, the entire input stream is used as block
-		// input
-		// the block size effectively determines the number of remote requests
-		int blockSize = 15; // TODO configurable block size
-
-		if (blockSize > 0) {
-			return new BatchingServiceIteration(bindings, blockSize, service);
+		if (boundJoinBlockSize > 0) {
+			return new BatchingServiceIteration(bindings, boundJoinBlockSize, service);
 		} else {
 			// if blocksize is 0 (i.e. disabled) the entire iteration is used as
 			// block

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated;
 
+import org.eclipse.rdf4j.federated.cache.MemoryCache;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.SailFederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.SparqlFederationEvalStrategy;
@@ -36,7 +37,7 @@ public class FedXConfig {
 
 	private int enforceMaxQueryTime = 30;
 
-	private boolean enableServiceAsBoundJoin = false;
+	private boolean enableServiceAsBoundJoin = true;
 
 	private boolean enableMonitoring = false;
 
@@ -246,6 +247,18 @@ public class FedXConfig {
 	 */
 	public FedXConfig withLogQueryPlan(boolean flag) {
 		this.isLogQueryPlan = flag;
+		return this;
+	}
+
+	/**
+	 * Whether external SERVICE clauses are evaluated using bound join (i.e. with the VALUES clause). Default
+	 * <i>true</i>
+	 * 
+	 * @param flag
+	 * @return the current config.
+	 */
+	public FedXConfig withEnableServiceAsBoundJoin(boolean flag) {
+		this.enableServiceAsBoundJoin = flag;
 		return this;
 	}
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategyTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategyTest.java
@@ -1,0 +1,39 @@
+package org.eclipse.rdf4j.federated.evaluation;
+
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.federated.SPARQLBaseTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FederationEvalStrategyTest extends SPARQLBaseTest {
+
+	@Test
+	public void testOptimizeSingleSourceQuery() throws Exception {
+
+		assumeSparqlEndpoint();
+
+		// federation with single member
+		prepareTest(Arrays.asList("/tests/data/data1.ttl"));
+
+		String query = "SELECT * WHERE { ?s ?o ?o }";
+		String queryPlan = federationContext().getQueryManager().getQueryPlan(query);
+
+		Assertions.assertTrue(queryPlan.startsWith("SingleSourceQuery @sparql_localhost:18080_repositories_endpoint1"));
+	}
+
+	@Test
+	public void testOptimize_SingleMember_Service() throws Exception {
+
+		assumeSparqlEndpoint();
+
+		// federation with single member
+		prepareTest(Arrays.asList("/tests/data/data1.ttl"));
+
+		// query with service, evaluate using FedX
+		String query = "SELECT * WHERE { SERVICE <http://dummy> { ?s ?o ?o } }";
+		String queryPlan = federationContext().getQueryManager().getQueryPlan(query);
+
+		Assertions.assertTrue(queryPlan.startsWith("QueryRoot"));
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #1816  

This change improves and fixes the evaluation of (external) SERVICE
clauses in FedX.

Before this change there have been issues with blocking behavior and and
hanging queries, when SERVICE queries were evaluated as bound joins. As
this was not the default, it was not yet discovered. The reason was that
HTTP slots in the background tuple results were not processed in a
suitable order.

As of this change we slightly adopted the evaluation logics: now we
basically consume the background tuple result and keep it in memory for
upcoming operators, thus process it in order.

Also the Bound Join evaluation is now activated by default.

Moreover, a slight follow up of #1802 is added: the boundJoinBlockSize
is no longer hard-coded in the RepositoryFederatedService, but now uses
the value from the field.


Always evaluate query in FedX if it contains SERVICE

If a query contains a SERVICE clause, it is now always evaluated in the
FedX engine (even if the federation onyl has a single member)
