### PR TITLE
GH-1814: support to configure inference on federation queries

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -15,6 +15,8 @@ import org.eclipse.rdf4j.federated.evaluation.SparqlFederationEvalStrategyWithVa
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
 import org.eclipse.rdf4j.federated.monitoring.QueryLog;
 import org.eclipse.rdf4j.federated.monitoring.QueryPlanLog;
+import org.eclipse.rdf4j.query.Operation;
+import org.eclipse.rdf4j.query.Query;
 
 /**
  * Configuration class for FedX
@@ -48,6 +50,8 @@ public class FedXConfig {
 	private boolean debugQueryPlan = false;
 
 	private boolean enableJmx = false;
+
+	private boolean includeInferredDefault = true;
 
 	private Class<? extends FederationEvalStrategy> sailEvaluationStrategy = SailFederationEvalStrategy.class;
 
@@ -127,6 +131,17 @@ public class FedXConfig {
 	 */
 	public FedXConfig withEnforceMaxQueryTime(int enforceMaxQueryTime) {
 		this.enforceMaxQueryTime = enforceMaxQueryTime;
+		return this;
+	}
+
+	/**
+	 * Set the default value supplied to {@link Query#setIncludeInferred(boolean)}
+	 * 
+	 * @param flag
+	 * @return the current config
+	 */
+	public FedXConfig withIncludeInferredDefault(boolean flag) {
+		this.includeInferredDefault = flag;
 		return this;
 	}
 
@@ -340,6 +355,14 @@ public class FedXConfig {
 	 */
 	public int getEnforceMaxQueryTime() {
 		return enforceMaxQueryTime;
+	}
+
+	/**
+	 * 
+	 * @return the default for {@link Operation#getIncludeInferred()}
+	 */
+	public boolean getIncludeInferredDefault() {
+		return includeInferredDefault;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -97,7 +97,7 @@ public class FedXConnection extends AbstractSailConnection {
 			if (queryString == null)
 				log.warn("Query string is null. Please check your FedX setup.");
 			queryInfo = new QueryInfo(queryString, getOriginalQueryType(bindings),
-					getOriginalMaxExecutionTime(bindings), federationContext);
+					getOriginalMaxExecutionTime(bindings), includeInferred, federationContext);
 
 			if (log.isDebugEnabled()) {
 				log.debug("Optimization start (Query: " + queryInfo.getQueryID() + ")");
@@ -193,7 +193,8 @@ public class FedXConnection extends AbstractSailConnection {
 
 		FederationEvalStrategy strategy = federationContext.getStrategy();
 		final WorkerUnionBase<Resource> union = new SynchronousWorkerUnion<>(strategy,
-				new QueryInfo("getContextIDsInternal", QueryType.UNKNOWN, 0, federationContext));
+				new QueryInfo("getContextIDsInternal", QueryType.UNKNOWN, 0,
+						federationContext.getConfig().getIncludeInferredDefault(), federationContext));
 
 		for (final Endpoint e : federation.getMembers()) {
 			union.addTask(new ParallelTask<Resource>() {
@@ -249,7 +250,7 @@ public class FedXConnection extends AbstractSailConnection {
 
 		try {
 			FederationEvalStrategy strategy = federationContext.getStrategy();
-			QueryInfo queryInfo = new QueryInfo(subj, pred, obj, federationContext);
+			QueryInfo queryInfo = new QueryInfo(subj, pred, obj, includeInferred, federationContext);
 			federationContext.getMonitoringService().monitorQuery(queryInfo);
 			CloseableIteration<Statement, QueryEvaluationException> res = strategy.getStatements(queryInfo, subj, pred,
 					obj, contexts);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/QueryManager.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/QueryManager.java
@@ -270,7 +270,7 @@ public class QueryManager {
 
 			/*
 			 * we have to check for prefixes in the query to not add duplicate entries. In case duplicates are present
-			 * Sesame throws a MalformedQueryException
+			 * RDF4J throws a MalformedQueryException
 			 */
 			if (prefixCheck.matcher(queryString).matches())
 				queryString = getPrefixDeclarationsCheck(queryString) + queryString;
@@ -282,7 +282,8 @@ public class QueryManager {
 		if (!(query instanceof ParsedQuery))
 			throw new MalformedQueryException("Not a ParsedQuery: " + query.getClass());
 		// we use a dummy query info object here
-		QueryInfo qInfo = new QueryInfo(queryString, QueryType.SELECT, federationContext);
+		QueryInfo qInfo = new QueryInfo(queryString, QueryType.SELECT,
+				federationContext.getConfig().getIncludeInferredDefault(), federationContext);
 		TupleExpr tupleExpr = ((ParsedQuery) query).getTupleExpr();
 		try {
 			FederationEvaluationStatistics evaluationStatistics = new FederationEvaluationStatistics(qInfo,

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
@@ -143,7 +143,7 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 						.getEndpointManager()
 						.getEndpoint(source.getEndpointID());
 				TripleSource t = ownedEndpoint.getTripleSource();
-				if (t.hasStatements(st, bindings))
+				if (t.hasStatements(st, bindings, queryInfo))
 					return new SingleBindingSetIteration(bindings);
 			}
 		} catch (RepositoryException | MalformedQueryException e) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveStatement.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveStatement.java
@@ -70,7 +70,7 @@ public class ExclusiveStatement extends FedXStatementPattern {
 				} catch (IllegalQueryException e1) {
 					// TODO there might be an issue with filters being evaluated => investigate
 					/* all vars are bound, this must be handled as a check query, can occur in joins */
-					if (t.hasStatements(this, bindings)) {
+					if (t.hasStatements(this, bindings, queryInfo)) {
 						res = new SingleBindingSetIteration(bindings);
 						if (boundFilters != null) {
 							// make sure to insert any values from FILTER expressions that are directly
@@ -82,10 +82,10 @@ public class ExclusiveStatement extends FedXStatementPattern {
 					return new EmptyIteration<>();
 				}
 
-				res = t.getStatements(preparedQuery, bindings, (isEvaluated.get() ? null : filterExpr));
+				res = t.getStatements(preparedQuery, bindings, (isEvaluated.get() ? null : filterExpr), queryInfo);
 
 			} else {
-				res = t.getStatements(this, bindings, filterExpr);
+				res = t.getStatements(this, bindings, filterExpr, queryInfo);
 			}
 
 			if (boundFilters != null) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
@@ -93,10 +93,10 @@ public class StatementSourcePattern extends FedXStatementPattern {
 					}
 
 					union.addTask(new ParallelPreparedUnionTask(union, preparedQuery, ownedEndpoint, bindings,
-							(isEvaluated.get() ? null : filterExpr)));
+							(isEvaluated.get() ? null : filterExpr), queryInfo));
 
 				} else {
-					union.addTask(new ParallelUnionTask(union, this, ownedEndpoint, bindings, filterExpr));
+					union.addTask(new ParallelUnionTask(union, this, ownedEndpoint, bindings, filterExpr, queryInfo));
 				}
 
 			}
@@ -127,7 +127,7 @@ public class StatementSourcePattern extends FedXStatementPattern {
 					.getEndpointManager()
 					.getEndpoint(source.getEndpointID());
 			TripleSource t = ownedEndpoint.getTripleSource();
-			if (t.hasStatements(this, bindings))
+			if (t.hasStatements(this, bindings, queryInfo))
 				return new SingleBindingSetIteration(bindings);
 		}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/CacheUtils.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/CacheUtils.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.federated.cache.Cache.StatementSourceAssurance;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.TripleSource;
 import org.eclipse.rdf4j.federated.exception.OptimizationException;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.federated.structures.SubQuery;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
@@ -33,11 +34,12 @@ public class CacheUtils {
 	 * @return
 	 * @throws OptimizationException
 	 */
-	private static boolean checkEndpointForResults(Cache cache, Endpoint endpoint, Resource subj, IRI pred, Value obj)
+	private static boolean checkEndpointForResults(Cache cache, Endpoint endpoint, Resource subj, IRI pred, Value obj,
+			QueryInfo queryInfo)
 			throws OptimizationException {
 		try {
 			TripleSource t = endpoint.getTripleSource();
-			boolean hasResults = t.hasStatements(subj, pred, obj);
+			boolean hasResults = t.hasStatements(subj, pred, obj, queryInfo);
 
 			CacheEntry entry = createCacheEntry(endpoint, hasResults);
 			cache.updateEntry(new SubQuery(subj, pred, obj), entry);
@@ -67,7 +69,7 @@ public class CacheUtils {
 	 * @return whether some endpoint can provide results
 	 */
 	public static boolean checkCacheUpdateCache(Cache cache, List<Endpoint> endpoints, Resource subj, IRI pred,
-			Value obj) {
+			Value obj, QueryInfo queryInfo) {
 
 		SubQuery q = new SubQuery(subj, pred, obj);
 
@@ -77,7 +79,7 @@ public class CacheUtils {
 					|| a == StatementSourceAssurance.HAS_REMOTE_STATEMENTS)
 				return true;
 			if (a == StatementSourceAssurance.POSSIBLY_HAS_STATEMENTS
-					&& checkEndpointForResults(cache, e, subj, pred, obj))
+					&& checkEndpointForResults(cache, e, subj, pred, obj, queryInfo))
 				return true;
 		}
 		return false;
@@ -96,7 +98,7 @@ public class CacheUtils {
 	 * @return the list of relevant statement sources
 	 */
 	public static List<StatementSource> checkCacheForStatementSourcesUpdateCache(Cache cache, List<Endpoint> endpoints,
-			Resource subj, IRI pred, Value obj) {
+			Resource subj, IRI pred, Value obj, QueryInfo queryInfo) {
 
 		SubQuery q = new SubQuery(subj, pred, obj);
 		List<StatementSource> sources = new ArrayList<>(endpoints.size());
@@ -111,7 +113,7 @@ public class CacheUtils {
 			} else if (a == StatementSourceAssurance.POSSIBLY_HAS_STATEMENTS) {
 
 				// check if the endpoint has results (statistics + ask request)
-				if (CacheUtils.checkEndpointForResults(cache, e, subj, pred, obj))
+				if (CacheUtils.checkEndpointForResults(cache, e, subj, pred, obj, queryInfo))
 					sources.add(new StatementSource(e.getId(), StatementSourceType.REMOTE));
 			}
 		}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailFederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailFederationEvalStrategy.java
@@ -123,7 +123,7 @@ public class SailFederationEvalStrategy extends FederationEvalStrategy {
 		AtomicBoolean isEvaluated = new AtomicBoolean(false);
 		TupleExpr preparedQuery = QueryAlgebraUtil.selectQuery(group, bindings, group.getFilterExpr(), isEvaluated);
 		return tripleSource.getStatements(preparedQuery, bindings,
-				(isEvaluated.get() ? null : group.getFilterExpr()));
+				(isEvaluated.get() ? null : group.getFilterExpr()), group.getQueryInfo());
 
 		// other option (which might be faster for sesame native stores): join over the statements
 		// TODO implement this and evaluate if it is faster ..

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
@@ -125,7 +125,7 @@ public class SparqlFederationEvalStrategy extends FederationEvalStrategy {
 			String preparedQuery = QueryStringUtil.selectQueryString(group, bindings, group.getFilterExpr(),
 					isEvaluated);
 			return tripleSource.getStatements(preparedQuery, bindings,
-					(isEvaluated.get() ? null : group.getFilterExpr()));
+					(isEvaluated.get() ? null : group.getFilterExpr()), group.getQueryInfo());
 		} catch (IllegalQueryException e) {
 			/* no projection vars, e.g. local vars only, can occur in joins */
 			if (tripleSource.hasStatements(group, bindings))

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.federated.evaluation;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.federated.structures.QueryType;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
@@ -48,7 +49,7 @@ public interface TripleSource {
 	 * @throws QueryEvaluationException
 	 */
 	public CloseableIteration<BindingSet, QueryEvaluationException> getStatements(TupleExpr preparedQuery,
-			final BindingSet bindings, FilterValueExpr filterExpr)
+			final BindingSet bindings, FilterValueExpr filterExpr, QueryInfo queryInfo)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 
 	/**
@@ -65,7 +66,7 @@ public interface TripleSource {
 	 * @throws QueryEvaluationException
 	 */
 	public CloseableIteration<BindingSet, QueryEvaluationException> getStatements(String preparedQuery,
-			final BindingSet bindings, FilterValueExpr filterExpr)
+			final BindingSet bindings, FilterValueExpr filterExpr, QueryInfo queryInfo)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 
 	/**
@@ -73,13 +74,15 @@ public interface TripleSource {
 	 * 
 	 * @param preparedQuery
 	 * @param queryType
+	 * @param queryInfo
 	 * @return the statements
 	 * @throws RepositoryException
 	 * @throws MalformedQueryException
 	 * @throws QueryEvaluationException
 	 */
 	public CloseableIteration<BindingSet, QueryEvaluationException> getStatements(String preparedQuery,
-			QueryType queryType) throws RepositoryException, MalformedQueryException, QueryEvaluationException;
+			QueryType queryType, QueryInfo queryInfo)
+			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 
 	/**
 	 * Evaluate the query expression on the provided endpoint.
@@ -95,7 +98,7 @@ public interface TripleSource {
 	 * @throws QueryEvaluationException
 	 */
 	public CloseableIteration<BindingSet, QueryEvaluationException> getStatements(StatementPattern stmt,
-			final BindingSet bindings, FilterValueExpr filterExpr)
+			final BindingSet bindings, FilterValueExpr filterExpr, QueryInfo queryInfo)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 
 	/**
@@ -106,14 +109,14 @@ public interface TripleSource {
 	 * @param obj
 	 * @param contexts
 	 * 
-	 * @return the resulting itereation
+	 * @return the resulting iteration
 	 * 
 	 * @throws RepositoryException
 	 * @throws MalformedQueryException
 	 * @throws QueryEvaluationException
 	 */
 	public CloseableIteration<Statement, QueryEvaluationException> getStatements(
-			Resource subj, IRI pred, Value obj, Resource... contexts)
+			Resource subj, IRI pred, Value obj, QueryInfo queryInfo, Resource... contexts)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 
 	/**
@@ -128,7 +131,7 @@ public interface TripleSource {
 	 * @throws MalformedQueryException
 	 * @throws QueryEvaluationException
 	 */
-	public boolean hasStatements(StatementPattern stmt, BindingSet bindings)
+	public boolean hasStatements(StatementPattern stmt, BindingSet bindings, QueryInfo queryInfo)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 
 	/**
@@ -137,11 +140,12 @@ public interface TripleSource {
 	 * @param subj
 	 * @param pred
 	 * @param obj
+	 * @param includeInferred
 	 * @param contexts
 	 * @return whether the source can provide results
 	 * @throws RepositoryException
 	 */
-	public boolean hasStatements(Resource subj, IRI pred, Value obj, Resource... contexts)
+	public boolean hasStatements(Resource subj, IRI pred, Value obj, QueryInfo queryInfo, Resource... contexts)
 			throws RepositoryException;
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelGetStatementsTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelGetStatementsTask.java
@@ -12,6 +12,7 @@ import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.TripleSource;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelExecutor;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTaskBase;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -32,17 +33,19 @@ public class ParallelGetStatementsTask extends ParallelTaskBase<Statement> {
 
 	protected final IRI pred;
 	protected final Value obj;
+	protected final QueryInfo queryInfo;
 	protected Resource[] contexts;
 
 	public ParallelGetStatementsTask(ParallelExecutor<Statement> unionControl,
 			Endpoint endpoint,
-			Resource subj, IRI pred, Value obj, Resource... contexts) {
+			Resource subj, IRI pred, Value obj, QueryInfo queryInfo, Resource... contexts) {
 		super();
 		this.unionControl = unionControl;
 		this.endpoint = endpoint;
 		this.subj = subj;
 		this.pred = pred;
 		this.obj = obj;
+		this.queryInfo = queryInfo;
 		this.contexts = contexts;
 
 	}
@@ -56,6 +59,6 @@ public class ParallelGetStatementsTask extends ParallelTaskBase<Statement> {
 	public CloseableIteration<Statement, QueryEvaluationException> performTask()
 			throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
-		return tripleSource.getStatements(subj, pred, obj, contexts);
+		return tripleSource.getStatements(subj, pred, obj, queryInfo, contexts);
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelPreparedAlgebraUnionTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelPreparedAlgebraUnionTask.java
@@ -13,6 +13,7 @@ import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.TripleSource;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelExecutor;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTaskBase;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
@@ -30,20 +31,22 @@ public class ParallelPreparedAlgebraUnionTask extends ParallelTaskBase<BindingSe
 	protected final BindingSet bindings;
 	protected final ParallelExecutor<BindingSet> unionControl;
 	protected final FilterValueExpr filterExpr;
+	protected final QueryInfo queryInfo;
 
 	public ParallelPreparedAlgebraUnionTask(ParallelExecutor<BindingSet> unionControl, TupleExpr preparedQuery,
-			Endpoint endpoint, BindingSet bindings, FilterValueExpr filterExpr) {
+			Endpoint endpoint, BindingSet bindings, FilterValueExpr filterExpr, QueryInfo queryInfo) {
 		this.endpoint = endpoint;
 		this.preparedQuery = preparedQuery;
 		this.bindings = bindings;
 		this.unionControl = unionControl;
 		this.filterExpr = filterExpr;
+		this.queryInfo = queryInfo;
 	}
 
 	@Override
 	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
-		return tripleSource.getStatements(preparedQuery, bindings, filterExpr);
+		return tripleSource.getStatements(preparedQuery, bindings, filterExpr, queryInfo);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelPreparedUnionTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelPreparedUnionTask.java
@@ -13,6 +13,7 @@ import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.TripleSource;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelExecutor;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTaskBase;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
@@ -29,20 +30,22 @@ public class ParallelPreparedUnionTask extends ParallelTaskBase<BindingSet> {
 	protected final BindingSet bindings;
 	protected final ParallelExecutor<BindingSet> unionControl;
 	protected final FilterValueExpr filterExpr;
+	protected final QueryInfo queryInfo;
 
 	public ParallelPreparedUnionTask(ParallelExecutor<BindingSet> unionControl, String preparedQuery, Endpoint endpoint,
-			BindingSet bindings, FilterValueExpr filterExpr) {
+			BindingSet bindings, FilterValueExpr filterExpr, QueryInfo queryInfo) {
 		this.endpoint = endpoint;
 		this.preparedQuery = preparedQuery;
 		this.bindings = bindings;
 		this.unionControl = unionControl;
 		this.filterExpr = filterExpr;
+		this.queryInfo = queryInfo;
 	}
 
 	@Override
 	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
-		return tripleSource.getStatements(preparedQuery, bindings, filterExpr);
+		return tripleSource.getStatements(preparedQuery, bindings, filterExpr, queryInfo);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelUnionTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelUnionTask.java
@@ -13,6 +13,7 @@ import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.TripleSource;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelExecutor;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTaskBase;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -30,20 +31,22 @@ public class ParallelUnionTask extends ParallelTaskBase<BindingSet> {
 	protected final BindingSet bindings;
 	protected final ParallelExecutor<BindingSet> unionControl;
 	protected final FilterValueExpr filterExpr;
+	protected final QueryInfo queryInfo;
 
 	public ParallelUnionTask(ParallelExecutor<BindingSet> unionControl, StatementPattern stmt, Endpoint endpoint,
-			BindingSet bindings, FilterValueExpr filterExpr) {
+			BindingSet bindings, FilterValueExpr filterExpr, QueryInfo queryInfo) {
 		this.endpoint = endpoint;
 		this.stmt = stmt;
 		this.bindings = bindings;
 		this.unionControl = unionControl;
 		this.filterExpr = filterExpr;
+		this.queryInfo = queryInfo;
 	}
 
 	@Override
 	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
-		return tripleSource.getStatements(stmt, bindings, filterExpr);
+		return tripleSource.getStatements(stmt, bindings, filterExpr, queryInfo);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConnection.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.federated.repository;
 import java.util.Collections;
 import java.util.Set;
 
+import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.structures.FedXBooleanQuery;
 import org.eclipse.rdf4j.federated.structures.FedXGraphQuery;
 import org.eclipse.rdf4j.federated.structures.FedXTupleQuery;
@@ -23,7 +24,6 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailBooleanQuery;
 import org.eclipse.rdf4j.repository.sail.SailGraphQuery;
 import org.eclipse.rdf4j.repository.sail.SailQuery;
-import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailTupleQuery;
 import org.eclipse.rdf4j.sail.SailConnection;
@@ -58,9 +58,12 @@ public class FedXRepositoryConnection extends SailRepositoryConnection {
 	public static final Set<String> FEDX_BINDINGS = Collections.unmodifiableSet(
 			Sets.newHashSet(BINDING_ORIGINAL_QUERY, BINDING_ORIGINAL_QUERY_TYPE, BINDING_ORIGINAL_MAX_EXECUTION_TIME));
 
-	protected FedXRepositoryConnection(SailRepository repository,
+	private final FederationContext federationContext;
+
+	protected FedXRepositoryConnection(FedXRepository repository,
 			SailConnection sailConnection) {
 		super(repository, sailConnection);
+		this.federationContext = repository.getFederationContext();
 	}
 
 	@Override
@@ -77,6 +80,7 @@ public class FedXRepositoryConnection extends SailRepositoryConnection {
 			insertOriginalQueryString(q, queryString, QueryType.ASK);
 			q = new FedXBooleanQuery((SailBooleanQuery) q);
 		}
+		setIncludeInferredDefault(q);
 		return q;
 	}
 
@@ -85,6 +89,7 @@ public class FedXRepositoryConnection extends SailRepositoryConnection {
 			String queryString, String baseURI) throws MalformedQueryException {
 		SailTupleQuery q = super.prepareTupleQuery(ql, queryString, baseURI);
 		insertOriginalQueryString(q, queryString, QueryType.SELECT);
+		setIncludeInferredDefault(q);
 		return new FedXTupleQuery(q);
 	}
 
@@ -93,6 +98,7 @@ public class FedXRepositoryConnection extends SailRepositoryConnection {
 			String queryString, String baseURI) throws MalformedQueryException {
 		SailGraphQuery q = super.prepareGraphQuery(ql, queryString, baseURI);
 		insertOriginalQueryString(q, queryString, QueryType.CONSTRUCT);
+		setIncludeInferredDefault(q);
 		return new FedXGraphQuery(q);
 	}
 
@@ -101,6 +107,7 @@ public class FedXRepositoryConnection extends SailRepositoryConnection {
 			String queryString, String baseURI) throws MalformedQueryException {
 		SailBooleanQuery q = super.prepareBooleanQuery(ql, queryString, baseURI);
 		insertOriginalQueryString(q, queryString, QueryType.ASK);
+		setIncludeInferredDefault(q);
 		return new FedXBooleanQuery(q);
 	}
 
@@ -108,6 +115,10 @@ public class FedXRepositoryConnection extends SailRepositoryConnection {
 	public Update prepareUpdate(QueryLanguage ql, String update, String baseURI)
 			throws RepositoryException, MalformedQueryException {
 		return super.prepareUpdate(ql, update, baseURI);
+	}
+
+	private void setIncludeInferredDefault(SailQuery query) {
+		query.setIncludeInferred(federationContext.getConfig().getIncludeInferredDefault());
 	}
 
 	private void insertOriginalQueryString(SailQuery query, String queryString, QueryType qt) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
@@ -42,6 +42,7 @@ public class QueryInfo {
 	private final QueryType queryType;
 	private final long maxExecutionTimeMs;
 	private final long start;
+	private final boolean includeInferred;
 
 	private final FederationContext federationContext;
 
@@ -49,8 +50,9 @@ public class QueryInfo {
 
 	protected Set<ParallelTask<?>> scheduledSubtasks = ConcurrentHashMap.newKeySet();
 
-	public QueryInfo(String query, QueryType queryType, FederationContext federationContext) {
-		this(query, queryType, 0, federationContext);
+	public QueryInfo(String query, QueryType queryType, boolean incluedInferred,
+			FederationContext federationContext) {
+		this(query, queryType, 0, incluedInferred, federationContext);
 	}
 
 	/**
@@ -59,9 +61,11 @@ public class QueryInfo {
 	 * @param queryType
 	 * @param maxExecutionTime  the maximum explicit query time in seconds, if 0 use
 	 *                          {@link FedXConfig#getEnforceMaxQueryTime())
+	 * @param includeInferred   whether to include inferred statements
 	 * @param federationContext the {@link FederationContext}
 	 */
-	public QueryInfo(String query, QueryType queryType, int maxExecutionTime, FederationContext federationContext) {
+	public QueryInfo(String query, QueryType queryType, int maxExecutionTime, boolean includeInferred,
+			FederationContext federationContext) {
 		super();
 		this.queryID = federationContext.getQueryManager().getNextQueryId();
 
@@ -73,11 +77,14 @@ public class QueryInfo {
 		int _maxExecutionTime = maxExecutionTime <= 0 ? federationContext.getConfig().getEnforceMaxQueryTime()
 				: maxExecutionTime;
 		this.maxExecutionTimeMs = _maxExecutionTime * 1000;
+		this.includeInferred = includeInferred;
 		this.start = System.currentTimeMillis();
 	}
 
-	public QueryInfo(Resource subj, IRI pred, Value obj, FederationContext federationContext) {
-		this(QueryStringUtil.toString(subj, (IRI) pred, obj), QueryType.GET_STATEMENTS, federationContext);
+	public QueryInfo(Resource subj, IRI pred, Value obj, boolean includeInferred,
+			FederationContext federationContext) {
+		this(QueryStringUtil.toString(subj, (IRI) pred, obj), QueryType.GET_STATEMENTS, includeInferred,
+				federationContext);
 	}
 
 	public BigInteger getQueryID() {
@@ -90,6 +97,10 @@ public class QueryInfo {
 
 	public QueryType getQueryType() {
 		return queryType;
+	}
+
+	public boolean getIncludeInferred() {
+		return includeInferred;
 	}
 
 	/**

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXWithInferenceTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXWithInferenceTest.java
@@ -1,0 +1,165 @@
+package org.eclipse.rdf4j.federated;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.federated.repository.FedXRepository;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
+import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
+import org.eclipse.rdf4j.sail.inferencer.fc.config.SchemaCachingRDFSInferencerConfig;
+import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.github.jsonldjava.shaded.com.google.common.collect.Lists;
+
+public class FedXWithInferenceTest extends FedXBaseTest {
+
+	@TempDir
+	Path tempDir;
+
+	private LocalRepositoryManager repoManager;
+
+	@BeforeEach
+	public void before() throws Exception {
+		File baseDir = new File(tempDir.toFile(), "data");
+		repoManager = new LocalRepositoryManager(baseDir);
+		repoManager.init();
+	}
+
+	@AfterEach
+	public void after() throws Exception {
+		repoManager.shutDown();
+	}
+
+	@Test
+	public void testFederationWithRDFSInference() throws Exception {
+
+		addMemoryStoreWithRDFS("repo1");
+		addMemoryStore("repo2");
+
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		addData("repo1", Lists.newArrayList(
+				vf.createStatement(vf.createIRI("http://ex.org/p1"), RDF.TYPE, FOAF.PERSON),
+				vf.createStatement(vf.createIRI("http://ex.org/p2"), RDF.TYPE, vf.createIRI("http://ex.org/Manager")),
+				vf.createStatement(vf.createIRI("http://ex.org/Manager"), RDFS.SUBCLASSOF, FOAF.PERSON)));
+		addData("repo2", Lists.newArrayList(
+				vf.createStatement(vf.createIRI("http://ex.org/p3"), RDF.TYPE, FOAF.PERSON)));
+
+		FedXRepository repo = FedXFactory.newFederation()
+				.withResolvableEndpoint("repo1")
+				.withResolvableEndpoint("repo2")
+				.withRepositoryResolver(repoManager)
+				.create();
+
+		try {
+
+			repo.init();
+			try (RepositoryConnection conn = repo.getConnection()) {
+
+				// 1. get statements
+				List<Statement> sts = Iterations.asList(conn.getStatements(null, RDF.TYPE, FOAF.PERSON));
+				Assertions.assertEquals(3, sts.size()); // three persons
+
+				sts = Iterations.asList(conn.getStatements(null, RDF.TYPE, FOAF.PERSON, true));
+				Assertions.assertEquals(3, sts.size()); // three persons
+
+				sts = Iterations.asList(conn.getStatements(null, RDF.TYPE, FOAF.PERSON, false));
+				Assertions.assertEquals(2, sts.size()); // two persons
+
+				// 2. simple SELECT
+				TupleQuery tq = conn.prepareTupleQuery("SELECT * WHERE { ?p a <http://xmlns.com/foaf/0.1/Person> }");
+				try (TupleQueryResult tqr = tq.evaluate()) {
+					List<BindingSet> res = Iterations.asList(tqr);
+					Assertions.assertEquals(3, res.size()); // three persons
+				}
+
+				tq.setIncludeInferred(true);
+				try (TupleQueryResult tqr = tq.evaluate()) {
+					List<BindingSet> res = Iterations.asList(tqr);
+					Assertions.assertEquals(3, res.size()); // three persons
+				}
+
+				tq.setIncludeInferred(false);
+				try (TupleQueryResult tqr = tq.evaluate()) {
+					List<BindingSet> res = Iterations.asList(tqr);
+					Assertions.assertEquals(2, res.size()); // two persons
+				}
+
+				// 3. simple CONSTRUCT
+				GraphQuery gq = conn.prepareGraphQuery(
+						"CONSTRUCT { ?p a <http://xmlns.com/foaf/0.1/Person> } WHERE { ?p a <http://xmlns.com/foaf/0.1/Person> }");
+				try (GraphQueryResult gqr = gq.evaluate()) {
+					List<Statement> res = Iterations.asList(gqr);
+					Assertions.assertEquals(3, res.size()); // three persons
+				}
+
+				gq.setIncludeInferred(true);
+				try (GraphQueryResult gqr = gq.evaluate()) {
+					List<Statement> res = Iterations.asList(gqr);
+					Assertions.assertEquals(3, res.size()); // three persons
+				}
+
+				gq.setIncludeInferred(false);
+				try (GraphQueryResult gqr = gq.evaluate()) {
+					List<Statement> res = Iterations.asList(gqr);
+					Assertions.assertEquals(2, res.size()); // three persons
+				}
+			}
+
+		} finally {
+			repo.shutDown();
+		}
+
+	}
+
+	protected void addMemoryStore(String repoId) throws Exception {
+
+		RepositoryImplConfig implConfig = new SailRepositoryConfig(new MemoryStoreConfig());
+		RepositoryConfig config = new RepositoryConfig(repoId, implConfig);
+		repoManager.addRepositoryConfig(config);
+	}
+
+	protected void addMemoryStoreWithRDFS(String repoId) throws Exception {
+
+		RepositoryImplConfig implConfig = new SailRepositoryConfig(
+				new SchemaCachingRDFSInferencerConfig(new MemoryStoreConfig()));
+		RepositoryConfig config = new RepositoryConfig(repoId, implConfig);
+		repoManager.addRepositoryConfig(config);
+	}
+
+	protected void addData(String repoId, Iterable<Statement> model) {
+
+		Repository repo = repoManager.getRepository(repoId);
+
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.add(model);
+		}
+	}
+
+	@Override
+	protected FederationContext federationContext() {
+		throw new UnsupportedOperationException("Not available in this context.");
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #1814 

As of this change it is possible to configure inference on federation
queries using Query#setIncludeInferred. By default the value is set to
'true', similar to the SailQuery.

The corresponding value is now passed to the TripleSource and is thus
considered for all sub-queries sent to the relevant endpoints.

Functionality for the query types is validated in a unit test.

