### PR TITLE
GH-1820: fix connection handling in RepositoryFederatedService

### DIFF
--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXWithLocalRepositoryManagerTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXWithLocalRepositoryManagerTest.java
@@ -138,15 +138,7 @@ public class FedXWithLocalRepositoryManagerTest extends FedXBaseTest {
 			protected FederatedService createService(String serviceUrl) throws QueryEvaluationException {
 				if (serviceUrl.equals("http://serviceRepo")) {
 					Repository serviceRepo = repoManager.getRepository("serviceRepo");
-					return new RepositoryFederatedService(serviceRepo, false) {
-						@Override
-						protected synchronized RepositoryConnection getConnection()
-								throws org.eclipse.rdf4j.repository.RepositoryException {
-							// explicitly make this method synchronized to avoid dangling
-							// connections due to parallel access
-							return super.getConnection();
-						};
-					};
+					return new RepositoryFederatedService(serviceRepo, false);
 				}
 				throw new IllegalArgumentException("Service url cannot be resolved: " + serviceUrl);
 			}


### PR DESCRIPTION
GitHub issue resolved: #1820 

This change introduces a mode in RepositoryFederatedService which allows
to always use a fresh RepositoryConnection for the actual query
invocation. In order to properly close the connection, the result
iteration is wrapped in a "CloseConnectionIteration"

The new mode is active by default, i.e. as of this change a fresh
connection is used for each SERVICE invocation.

For the re-use of the managed connection we now made sure to support
synchronized access, i.e. avoid to loose the references to created
connections.

The unit tests show that connections are properly closed. If it wasn't
the case, we would observe hanging tests for > 30s (i.e. until the
automatic timeout occurs)
