### PR TITLE
GH-1515 re-enable optimistic repository compliance tests

### DIFF
--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/OptimisticIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/OptimisticIsolationTest.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.repository.optimistic.LinearTest;
 import org.eclipse.rdf4j.repository.optimistic.ModificationTest;
 import org.eclipse.rdf4j.repository.optimistic.MonotonicTest;
 import org.eclipse.rdf4j.repository.optimistic.RemoveIsolationTest;
-import org.eclipse.rdf4j.repository.optimistic.SailIsolationLevelTest;
+import org.eclipse.rdf4j.repository.optimistic.IsolationLevelTest;
 import org.eclipse.rdf4j.repository.optimistic.SerializableTest;
 import org.eclipse.rdf4j.repository.optimistic.SnapshotTest;
 import org.junit.BeforeClass;
@@ -31,10 +31,9 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author James Leigh
  */
 @RunWith(Suite.class)
-@SuiteClasses({ MonotonicTest.class })
-//@SuiteClasses({ DeadLockTest.class, DeleteInsertTest.class, LinearTest.class, ModificationTest.class,
-//		RemoveIsolationTest.class, SailIsolationLevelTest.class, MonotonicTest.class, SnapshotTest.class,
-//		SerializableTest.class })
+@SuiteClasses({ DeadLockTest.class, DeleteInsertTest.class, LinearTest.class, ModificationTest.class,
+		RemoveIsolationTest.class, IsolationLevelTest.class, MonotonicTest.class, SnapshotTest.class,
+		SerializableTest.class })
 public abstract class OptimisticIsolationTest {
 
 	@BeforeClass

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/DeleteInsertTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/DeleteInsertTest.java
@@ -21,6 +21,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * Test that a complex delete-insert SPARQL query gets correctly executed.
+ *
+ */
 public class DeleteInsertTest {
 
 	@BeforeClass

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/IsolationLevelTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/IsolationLevelTest.java
@@ -36,18 +36,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test that Sail correctly supports claimed isolation levels.
+ * Test that the Repository correctly supports claimed isolation levels.
  * 
  * @author James Leigh
  */
-public class SailIsolationLevelTest {
+public class IsolationLevelTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	private final Logger logger = LoggerFactory.getLogger(SailIsolationLevelTest.class);
+	private final Logger logger = LoggerFactory.getLogger(IsolationLevelTest.class);
 
 	/*-----------*
 	 * Variables *
@@ -65,7 +65,7 @@ public class SailIsolationLevelTest {
 
 	@Before
 	public void setUp() throws Exception {
-		store = OptimisticIsolationTest.getEmptyInitializedRepository(SailIsolationLevelTest.class);
+		store = OptimisticIsolationTest.getEmptyInitializedRepository(IsolationLevelTest.class);
 		failed = null;
 	}
 

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/LinearTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/LinearTest.java
@@ -33,6 +33,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * Various tests on linear execution of updates.
+ *
+ */
 public class LinearTest {
 
 	@BeforeClass

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/RemoveIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/RemoveIsolationTest.java
@@ -25,6 +25,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * Test isolation behavior on removal operations
+ * 
+ * @author jeen
+ *
+ */
 public class RemoveIsolationTest {
 
 	@BeforeClass

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/SerializableTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/SerializableTest.java
@@ -34,6 +34,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * Tests on behavior of SERIALIZABLE transactions.
+ * 
+ * @author jeen
+ *
+ */
 public class SerializableTest {
 
 	@BeforeClass


### PR DESCRIPTION
GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* optimistic repository test cases were accidentally disabled as part of test cleanup
* did some javadoc editing and renaming while I was at it

