### PR TITLE
GH-1844 GH-1847 optimistic repository isolation tests and bugfix

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryOptimisticIsolationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryOptimisticIsolationTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import org.eclipse.rdf4j.repository.OptimisticIsolationTest;
+import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
+import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryConfig;
+import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * @author jeen
+ *
+ */
+public class HTTPRepositoryOptimisticIsolationTest extends OptimisticIsolationTest {
+
+	private static HTTPMemServer server;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
+
+		server = new HTTPMemServer();
+		try {
+			server.start();
+		} catch (Exception e) {
+			server.stop();
+			throw e;
+		}
+
+		setRepositoryFactory(new HTTPRepositoryFactory() {
+
+			@Override
+			public RepositoryImplConfig getConfig() {
+				return new HTTPRepositoryConfig(HTTPMemServer.REPOSITORY_URL);
+			}
+
+		});
+	}
+
+	@AfterClass
+	public static void tearDown() throws Exception {
+		setRepositoryFactory(null);
+		server.stop();
+	}
+
+}

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
@@ -1033,7 +1033,10 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 		List<NameValuePair> queryParams = new ArrayList<>();
 
 		queryParams.add(new BasicNameValuePair(Protocol.QUERY_LANGUAGE_PARAM_NAME, ql.getName()));
-		queryParams.add(new BasicNameValuePair(Protocol.UPDATE_PARAM_NAME, update));
+
+		if (update != null) {
+			queryParams.add(new BasicNameValuePair(Protocol.UPDATE_PARAM_NAME, update));
+		}
 
 		if (baseURI != null) {
 			queryParams.add(new BasicNameValuePair(Protocol.BASEURI_PARAM_NAME, baseURI));

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/OptimisticIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/OptimisticIsolationTest.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.repository.optimistic.LinearTest;
 import org.eclipse.rdf4j.repository.optimistic.ModificationTest;
 import org.eclipse.rdf4j.repository.optimistic.MonotonicTest;
 import org.eclipse.rdf4j.repository.optimistic.RemoveIsolationTest;
-import org.eclipse.rdf4j.repository.optimistic.SailIsolationLevelTest;
+import org.eclipse.rdf4j.repository.optimistic.IsolationLevelTest;
 import org.eclipse.rdf4j.repository.optimistic.SerializableTest;
 import org.eclipse.rdf4j.repository.optimistic.SnapshotTest;
 import org.junit.BeforeClass;
@@ -31,10 +31,9 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author James Leigh
  */
 @RunWith(Suite.class)
-@SuiteClasses({ MonotonicTest.class })
-//@SuiteClasses({ DeadLockTest.class, DeleteInsertTest.class, LinearTest.class, ModificationTest.class,
-//		RemoveIsolationTest.class, SailIsolationLevelTest.class, MonotonicTest.class, SnapshotTest.class,
-//		SerializableTest.class })
+@SuiteClasses({ DeadLockTest.class, DeleteInsertTest.class, LinearTest.class, ModificationTest.class,
+		RemoveIsolationTest.class, IsolationLevelTest.class, MonotonicTest.class, SnapshotTest.class,
+		SerializableTest.class })
 public abstract class OptimisticIsolationTest {
 
 	@BeforeClass

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/DeleteInsertTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/DeleteInsertTest.java
@@ -21,6 +21,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * Test that a complex delete-insert SPARQL query gets correctly executed.
+ *
+ */
 public class DeleteInsertTest {
 
 	@BeforeClass

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/IsolationLevelTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/IsolationLevelTest.java
@@ -36,18 +36,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test that Sail correctly supports claimed isolation levels.
+ * Test that the Repository correctly supports claimed isolation levels.
  * 
  * @author James Leigh
  */
-public class SailIsolationLevelTest {
+public class IsolationLevelTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	private final Logger logger = LoggerFactory.getLogger(SailIsolationLevelTest.class);
+	private final Logger logger = LoggerFactory.getLogger(IsolationLevelTest.class);
 
 	/*-----------*
 	 * Variables *
@@ -65,7 +65,7 @@ public class SailIsolationLevelTest {
 
 	@Before
 	public void setUp() throws Exception {
-		store = OptimisticIsolationTest.getEmptyInitializedRepository(SailIsolationLevelTest.class);
+		store = OptimisticIsolationTest.getEmptyInitializedRepository(IsolationLevelTest.class);
 		failed = null;
 	}
 

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/LinearTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/LinearTest.java
@@ -33,6 +33,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * Various tests on linear execution of updates.
+ *
+ */
 public class LinearTest {
 
 	@BeforeClass

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/RemoveIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/RemoveIsolationTest.java
@@ -25,6 +25,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * Test isolation behavior on removal operations
+ * 
+ * @author jeen
+ *
+ */
 public class RemoveIsolationTest {
 
 	@BeforeClass

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/SerializableTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/SerializableTest.java
@@ -34,6 +34,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+/**
+ * Tests on behavior of SERIALIZABLE transactions.
+ * 
+ * @author jeen
+ *
+ */
 public class SerializableTest {
 
 	@BeforeClass
@@ -182,7 +188,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			b.rollback();
 		}
 	}
@@ -250,7 +257,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			assertEquals(0, size(a, null, RDF.TYPE, PAINTING, false));
 		} finally {
 			b.rollback();
@@ -278,7 +286,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			b.rollback();
 		}
 		assertEquals(0, size(a, null, RDF.TYPE, PAINTING, false));
@@ -352,7 +361,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			b.rollback();
 		}
 		assertEquals(7, size(a, null, null, null, false));
@@ -379,7 +389,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			b.rollback();
 		}
 		assertEquals(7, size(a, null, null, null, false));
@@ -408,7 +419,8 @@ public class SerializableTest {
 			assertEquals(10, size(a, null, null, null, false));
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			assertEquals(7, size(a, null, null, null, false));
 			b.rollback();
 		}
@@ -435,7 +447,8 @@ public class SerializableTest {
 			assertEquals(10, size(a, null, null, null, false));
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			assertEquals(7, size(a, null, null, null, false));
 			b.rollback();
 		}
@@ -467,7 +480,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			b.rollback();
 		}
 		assertEquals(9, size(a, null, null, null, false));
@@ -497,7 +511,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			b.rollback();
 		}
 		assertEquals(9, size(a, null, null, null, false));
@@ -532,7 +547,8 @@ public class SerializableTest {
 			assertEquals(17, size(a, null, null, null, false));
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			assertEquals(13, size(a, null, null, null, false));
 			b.rollback();
 		}
@@ -566,7 +582,8 @@ public class SerializableTest {
 			assertEquals(17, size(a, null, null, null, false));
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			assertEquals(13, size(a, null, null, null, false));
 			b.rollback();
 		}
@@ -601,7 +618,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			b.rollback();
 		}
 		assertEquals(13, size(a, null, null, null, false));
@@ -636,7 +654,8 @@ public class SerializableTest {
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();
-			assertTrue(e.getCause() instanceof SailConflictException);
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
 			b.rollback();
 		}
 		assertEquals(13, size(a, null, null, null, false));

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
@@ -319,7 +319,7 @@ class Transaction implements AutoCloseable {
 	void executeUpdate(QueryLanguage queryLn, String sparqlUpdateString, String baseURI, boolean includeInferred,
 			Dataset dataset, Map<String, Value> bindings) throws InterruptedException, ExecutionException {
 		Future<Boolean> result = submit(() -> {
-			Update update = txnConnection.prepareUpdate(queryLn, sparqlUpdateString);
+			Update update = txnConnection.prepareUpdate(queryLn, sparqlUpdateString, baseURI);
 			update.setIncludeInferred(includeInferred);
 			if (dataset != null) {
 				update.setDataset(dataset);


### PR DESCRIPTION


GitHub issue resolved: #1844 and #1847 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

- re-enable previously disabled tests in the suite
- add compliance test for the HTTPRepository
- fixes issue #1847: a bug in transactional handling of SPARQL updates over the REST API.
