### PR TITLE
#1108 transaction status now uses single byte for higher TPS

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TxnStatusFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TxnStatusFile.java
@@ -24,30 +24,35 @@ class TxnStatusFile {
 		 * No active transaction. This occurs if no transaction has been started yet, or if all transactions have been
 		 * committed or rolled back.
 		 */
-		NONE,
+		NONE((byte) 1),
 
 		/**
 		 * A transaction has been started, but was not yet committed or rolled back.
 		 */
-		ACTIVE,
+		ACTIVE((byte) 2),
 
 		/**
 		 * A transaction is being committed.
 		 */
-		COMMITTING,
+		COMMITTING((byte) 3),
 
 		/**
 		 * A transaction is being rolled back.
 		 */
-		ROLLING_BACK,
+		ROLLING_BACK((byte) 4),
 
 		/**
 		 * The transaction status is unknown.
 		 */
-		UNKNOWN;
-	}
+		UNKNOWN((byte) 5);
 
-	private static final Charset US_ASCII = Charset.forName("US-ASCII");
+		byte[] onDisk;
+
+		TxnStatus(byte onDisk) {
+			this.onDisk = new byte[1];
+			this.onDisk[0] = onDisk;
+		}
+	}
 
 	/**
 	 * The name of the transaction status file.
@@ -58,7 +63,7 @@ class TxnStatusFile {
 
 	/**
 	 * Creates a new transaction status file. New files are initialized with {@link TxnStatus#NONE}.
-	 * 
+	 *
 	 * @param dataDir The directory for the transaction status file.
 	 * @throws IOException If the file did not yet exist and could not be written to.
 	 */
@@ -77,37 +82,48 @@ class TxnStatusFile {
 
 	/**
 	 * Writes the specified transaction status to file.
-	 * 
+	 *
 	 * @param txnStatus The transaction status to write.
 	 * @throws IOException If the transaction status could not be written to file.
 	 */
 	public void setTxnStatus(TxnStatus txnStatus) throws IOException {
-		byte[] bytes = txnStatus.name().getBytes(US_ASCII);
+		byte[] bytes = txnStatus.onDisk;
 		nioFile.truncate(bytes.length);
 		nioFile.writeBytes(bytes, 0);
 	}
 
 	/**
 	 * Reads the transaction status from file.
-	 * 
+	 *
 	 * @return The read transaction status, or {@link TxnStatus#UNKNOWN} when the file contains an unrecognized status
 	 *         string.
 	 * @throws IOException If the transaction status file could not be read.
 	 */
 	public TxnStatus getTxnStatus() throws IOException {
 		byte[] bytes = nioFile.readBytes(0, (int) nioFile.size());
-		String s = new String(bytes, US_ASCII);
-		try {
-			return TxnStatus.valueOf(s);
-		} catch (IllegalArgumentException e) {
-			// use platform encoding for backwards compatibility with versions
-			// older than 2.6.6:
-			s = new String(bytes);
-			try {
-				return TxnStatus.valueOf(s);
-			} catch (IllegalArgumentException e2) {
-				return TxnStatus.UNKNOWN;
+		TxnStatus status = TxnStatus.UNKNOWN;
+
+		if (bytes.length == 1) {
+			switch (bytes[0]) {
+			case 1:
+				status = TxnStatus.NONE;
+				break;
+			case 2:
+				status = TxnStatus.ACTIVE;
+				break;
+			case 3:
+				status = TxnStatus.COMMITTING;
+				break;
+			case 4:
+				status = TxnStatus.ROLLING_BACK;
+				break;
+			case 5:
+				status = TxnStatus.UNKNOWN;
+				break;
 			}
 		}
+
+		return status;
+
 	}
 }

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TxnStatusFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TxnStatusFile.java
@@ -7,11 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import org.eclipse.rdf4j.common.io.NioFile;
+
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
-
-import org.eclipse.rdf4j.common.io.NioFile;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
@@ -19,63 +18,52 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
  * Writes transaction statuses to a file.
  */
 class TxnStatusFile {
-	public static final byte NONE_BYTE = (byte) 0b00000001;
-	public static final byte ACTIVE_BYTE = (byte) 0b00000010;
-	public static final byte COMMITTING_BYTE = (byte) 0b00000100;
-	public static final byte ROLLING_BACK_BYTE = (byte) 0b00001000;
-	public static final byte UNKNOWN_BYTE = (byte) 0b00010000;
 
-	public static enum TxnStatus {
+	public enum TxnStatus {
 
 		/**
 		 * No active transaction. This occurs if no transaction has been started yet, or if all transactions have been
 		 * committed or rolled back.
 		 */
-		NONE(NONE_BYTE),
+		NONE(TxnStatus.NONE_BYTE),
 
 		/**
 		 * A transaction has been started, but was not yet committed or rolled back.
 		 */
-		ACTIVE(ACTIVE_BYTE),
+		ACTIVE(TxnStatus.ACTIVE_BYTE),
 
 		/**
 		 * A transaction is being committed.
 		 */
-		COMMITTING(COMMITTING_BYTE),
+		COMMITTING(TxnStatus.COMMITTING_BYTE),
 
 		/**
 		 * A transaction is being rolled back.
 		 */
-		ROLLING_BACK(ROLLING_BACK_BYTE),
+		ROLLING_BACK(TxnStatus.ROLLING_BACK_BYTE),
 
 		/**
 		 * The transaction status is unknown.
 		 */
-		UNKNOWN(UNKNOWN_BYTE);
+		UNKNOWN(TxnStatus.UNKNOWN_BYTE);
 
-		byte[] onDisk;
+		private final byte[] onDisk;
 
 		TxnStatus(byte onDisk) {
 			this.onDisk = new byte[1];
 			this.onDisk[0] = onDisk;
 		}
 
-	}
-
-	// THIS CODE BLOCK CAN BE REMOVED IN RDF4J release 4.0!!!
-	// check that none of the new TxnStatus conflict with the old ones, ie. if the first byte for the old values are the
-	// same as the first byte for the new values
-	{
-		boolean assertsEnabled = TxnStatus.class.desiredAssertionStatus();
-		if (assertsEnabled) {
-			for (TxnStatus value1 : TxnStatus.values()) {
-				for (TxnStatus value2 : TxnStatus.values()) {
-					byte firstByteInOldValue = value1.name().getBytes(US_ASCII)[0];
-					byte firstByteInNewValue = value2.onDisk[0];
-					assert firstByteInOldValue != firstByteInNewValue;
-				}
-			}
+		byte[] getOnDisk() {
+			return onDisk;
 		}
+
+		private static final byte NONE_BYTE = (byte) 0b00000001;
+		private static final byte ACTIVE_BYTE = (byte) 0b00000010;
+		private static final byte COMMITTING_BYTE = (byte) 0b00000100;
+		private static final byte ROLLING_BACK_BYTE = (byte) 0b00001000;
+		private static final byte UNKNOWN_BYTE = (byte) 0b00010000;
+
 	}
 
 	/**
@@ -129,19 +117,19 @@ class TxnStatusFile {
 		TxnStatus status;
 
 		switch (bytes[0]) {
-		case NONE_BYTE:
+		case TxnStatus.NONE_BYTE:
 			status = TxnStatus.NONE;
 			break;
-		case ACTIVE_BYTE:
+		case TxnStatus.ACTIVE_BYTE:
 			status = TxnStatus.ACTIVE;
 			break;
-		case COMMITTING_BYTE:
+		case TxnStatus.COMMITTING_BYTE:
 			status = TxnStatus.COMMITTING;
 			break;
-		case ROLLING_BACK_BYTE:
+		case TxnStatus.ROLLING_BACK_BYTE:
 			status = TxnStatus.ROLLING_BACK;
 			break;
-		case UNKNOWN_BYTE:
+		case TxnStatus.UNKNOWN_BYTE:
 			status = TxnStatus.UNKNOWN;
 			break;
 		default:

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TxnStatusFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TxnStatusFile.java
@@ -19,6 +19,11 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
  * Writes transaction statuses to a file.
  */
 class TxnStatusFile {
+	public static final byte NONE_BYTE = (byte) 0b00000001;
+	public static final byte ACTIVE_BYTE = (byte) 0b00000010;
+	public static final byte COMMITTING_BYTE = (byte) 0b00000100;
+	public static final byte ROLLING_BACK_BYTE = (byte) 0b00001000;
+	public static final byte UNKNOWN_BYTE = (byte) 0b00010000;
 
 	public static enum TxnStatus {
 
@@ -26,33 +31,50 @@ class TxnStatusFile {
 		 * No active transaction. This occurs if no transaction has been started yet, or if all transactions have been
 		 * committed or rolled back.
 		 */
-		NONE((byte) 1),
+		NONE(NONE_BYTE),
 
 		/**
 		 * A transaction has been started, but was not yet committed or rolled back.
 		 */
-		ACTIVE((byte) 2),
+		ACTIVE(ACTIVE_BYTE),
 
 		/**
 		 * A transaction is being committed.
 		 */
-		COMMITTING((byte) 3),
+		COMMITTING(COMMITTING_BYTE),
 
 		/**
 		 * A transaction is being rolled back.
 		 */
-		ROLLING_BACK((byte) 4),
+		ROLLING_BACK(ROLLING_BACK_BYTE),
 
 		/**
 		 * The transaction status is unknown.
 		 */
-		UNKNOWN((byte) 5);
+		UNKNOWN(UNKNOWN_BYTE);
 
 		byte[] onDisk;
 
 		TxnStatus(byte onDisk) {
 			this.onDisk = new byte[1];
 			this.onDisk[0] = onDisk;
+		}
+
+	}
+
+	// THIS CODE BLOCK CAN BE REMOVED IN RDF4J release 4.0!!!
+	// check that none of the new TxnStatus conflict with the old ones, ie. if the first byte for the old values are the
+	// same as the first byte for the new values
+	{
+		boolean assertsEnabled = TxnStatus.class.desiredAssertionStatus();
+		if (assertsEnabled) {
+			for (TxnStatus value1 : TxnStatus.values()) {
+				for (TxnStatus value2 : TxnStatus.values()) {
+					byte firstByteInOldValue = value1.name().getBytes(US_ASCII)[0];
+					byte firstByteInNewValue = value2.onDisk[0];
+					assert firstByteInOldValue != firstByteInNewValue;
+				}
+			}
 		}
 	}
 
@@ -107,19 +129,19 @@ class TxnStatusFile {
 		TxnStatus status;
 
 		switch (bytes[0]) {
-		case 1:
+		case NONE_BYTE:
 			status = TxnStatus.NONE;
 			break;
-		case 2:
+		case ACTIVE_BYTE:
 			status = TxnStatus.ACTIVE;
 			break;
-		case 3:
+		case COMMITTING_BYTE:
 			status = TxnStatus.COMMITTING;
 			break;
-		case 4:
+		case ROLLING_BACK_BYTE:
 			status = TxnStatus.ROLLING_BACK;
 			break;
-		case 5:
+		case UNKNOWN_BYTE:
 			status = TxnStatus.UNKNOWN;
 			break;
 		default:

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTxnTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTxnTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.nio.file.Files;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -143,6 +144,10 @@ public class NativeStoreTxnTest {
 		} finally {
 			tripleStore.close();
 		}
+
+		TxnStatusFile.TxnStatus currentStatus = new TxnStatusFile(repo.getDataDir()).getTxnStatus();
+
+		assertEquals(TxnStatusFile.TxnStatus.NONE, currentStatus);
 
 	}
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
@@ -73,7 +73,7 @@ public class QueryBenchmark {
 	List<Statement> statementList;
 
 	@Setup(Level.Trial)
-	public void beforeClass() throws IOException, InterruptedException {
+	public void beforeClass() throws IOException {
 
 		file = Files.newTemporaryFolder();
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
@@ -48,7 +48,7 @@ public class TransactionsPerSecondBenchmark {
 	private SailRepository repository;
 	private File file;
 
-	@Param({ "100", "1000", "10000", "100000" })
+	@Param({ "100", "1000", "10000" })
 	public String numberOfTransactions;
 
 	@Setup(Level.Invocation)

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.nativerdf.benchmark;
+
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.util.Files;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 20)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms8G", "-Xmx8G", "-Xmn4G", "-XX:+UseSerialGC" })
+//@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G", "-Xmn4G", "-XX:+UseSerialGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class TransactionsPerSecondBenchmark {
+
+	private SailRepository repository;
+	private File file;
+
+	@Param({ "100", "1000", "10000", "100000" })
+	public String numberOfTransactions;
+
+	@Setup(Level.Invocation)
+	public void beforeClass() throws IOException, InterruptedException {
+
+		file = Files.newTemporaryFolder();
+
+		repository = new SailRepository(new NativeStore(file, "spoc,ospc,psoc"));
+
+		System.gc();
+
+	}
+
+	@TearDown(Level.Invocation)
+	public void afterClass() throws IOException {
+
+		repository.shutDown();
+		FileUtils.deleteDirectory(file);
+
+	}
+
+	@Benchmark
+	public void transactions() {
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			IntStream.range(0, Integer.parseInt(numberOfTransactions)).forEach(i -> {
+				connection.begin();
+				connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral(i));
+				connection.commit();
+			});
+		}
+
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #1108 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* use single bytes for transaction status for higher TPS
* 
* 
