### PR TITLE
Jakarata annotations fix

### DIFF
--- a/testsuites/benchmark/pom.xml
+++ b/testsuites/benchmark/pom.xml
@@ -68,9 +68,9 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>jakarta.annotation</groupId>
-                    <artifactId>jakarta.annotation-api</artifactId>
-                    <version>1.3.5</version>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Jakarata annotations has been problematic for a few weeks now, essentially problems downloading it from the repo. Switching to the good old javax implementation.

