### PR TITLE
GH-1820: fix RepositoryFederatedService to always close connection

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
@@ -245,6 +245,11 @@ public class RepositoryFederatedService implements FederatedService {
 			}
 			throw new QueryEvaluationException(
 					"Repository for endpoint " + rep.toString() + " could not be initialized.", e);
+		} catch (RuntimeException e) {
+			if (useFreshConnection) {
+				closeQuietly(conn);
+			}
+			throw e;
 		}
 	}
 
@@ -371,6 +376,9 @@ public class RepositoryFederatedService implements FederatedService {
 			return result;
 
 		} catch (RepositoryException e) {
+			if (useFreshConnection) {
+				closeQuietly(conn);
+			}
 			Iterations.closeCloseable(result);
 			if (service.isSilent())
 				return new CollectionIteration<>(allBindings);

--- a/tools/federation/src/test/resources/tests/service/query11_error_a.rq
+++ b/tools/federation/src/test/resources/tests/service/query11_error_a.rq
@@ -1,0 +1,11 @@
+PREFIX ns1: <http://namespace1.org/>
+PREFIX ns4: <http://namespace4.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+
+SELECT ?person ?name WHERE {
+	SERVICE <http://localhost:18080/repositories/endpoint1> {
+ 		?person foaf:name ?name .
+ 	}
+}

--- a/tools/federation/src/test/resources/tests/service/query11_error_b.rq
+++ b/tools/federation/src/test/resources/tests/service/query11_error_b.rq
@@ -1,0 +1,13 @@
+PREFIX ns1: <http://namespace1.org/>
+PREFIX ns4: <http://namespace4.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+
+SELECT ?person ?name WHERE {
+	?author a ns4:Author .
+	?author owl:sameAs ?person .
+	SERVICE <http://localhost:18080/repositories/endpoint1> {
+ 		?person foaf:name ?name .
+ 	}
+}


### PR DESCRIPTION
GitHub issue resolved: #1820 

This change makes sure to always fresh connections in any kind of
RuntimeExceptions. Before we missed the case where the service
repository could have thrown a QueryEvaluationException.

Also we add some unit test in the federation repository which partially
cover this issue.
