### PR TITLE
GH-1856: support BIND clauses in FedX federation

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/JoinOrderOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/JoinOrderOptimizer.java
@@ -25,6 +25,7 @@ import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
 import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.Service;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
@@ -152,6 +153,11 @@ public class JoinOrderOptimizer {
 			return new ArrayList<>();
 		}
 
+		if (tupleExpr instanceof Extension) {
+			// for a BIND extension in our cost model we work with 0 free vars
+			return new ArrayList<String>();
+		}
+
 		throw new FedXRuntimeException("Type " + tupleExpr.getClass().getSimpleName()
 				+ " not supported for cost estimation. If you run into this, please report a bug.");
 
@@ -175,6 +181,9 @@ public class JoinOrderOptimizer {
 			return estimateCost((Projection) tupleExpr, joinVars);
 		if (tupleExpr instanceof BindingSetAssignment)
 			return 0;
+		if (tupleExpr instanceof Extension) {
+			return 0;
+		}
 
 		log.warn("No cost estimation for " + tupleExpr.getClass().getSimpleName() + " available.");
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
@@ -85,6 +85,14 @@ public class BasicTests extends SPARQLBaseTest {
 	}
 
 	@Test
+	public void testBindClause() throws Exception {
+
+		/* test query with bind clause */
+		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint2.ttl"));
+		execute("/tests/basic/query_bind.rq", "/tests/basic/query_bind.srx", false);
+	}
+
+	@Test
 	public void testFederationSubSetQuery() throws Exception {
 		String ns1 = "http://namespace1.org/";
 		String ns2 = "http://namespace2.org/";

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BindTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BindTests.java
@@ -1,0 +1,83 @@
+package org.eclipse.rdf4j.federated;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.repository.util.Repositories;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Sets;
+
+public class BindTests extends SPARQLBaseTest {
+
+	@BeforeEach
+	public void prepareData() throws Exception {
+		prepareTest(Arrays.asList("/tests/data/data1.ttl", "/tests/data/data2.ttl", "/tests/data/data3.ttl",
+				"/tests/data/data4.ttl"));
+	}
+
+	@Test
+	public void testSimple() throws Exception {
+
+		List<BindingSet> res = runQuery(
+				"SELECT * WHERE { BIND(20 AS ?age) . ?person foaf:age ?age }");
+		assertContainsAll(res, "person", Sets.newHashSet(fullIri("http://namespace1.org/Person_1")));
+	}
+
+	@Test
+	public void testConcat() throws Exception {
+
+		List<BindingSet> res = runQuery(
+				"SELECT * WHERE { <http://namespace1.org/Person_1> foaf:age ?age . BIND(CONCAT('age: ', str(?age)) AS ?outAge) }");
+
+		assertContainsAll(res, "outAge", Sets.newHashSet(l("age: 20")));
+	}
+
+	@Test
+	public void testRebind() throws Exception {
+
+		List<BindingSet> res = runQuery(
+				"SELECT * WHERE { <http://namespace1.org/Person_1> foaf:age ?age . BIND(str(?age) AS ?outAge) }");
+
+		assertContainsAll(res, "outAge", Sets.newHashSet(l("20")));
+	}
+
+	@Test
+	public void testMultiBind() throws Exception {
+
+		List<BindingSet> res = runQuery(
+				"SELECT * WHERE { BIND(20 AS ?age) . <http://namespace1.org/Person_1> foaf:age ?age . BIND(str(?age) AS ?outAge) }");
+
+		assertContainsAll(res, "outAge", Sets.newHashSet(l("20")));
+	}
+
+	protected List<BindingSet> runQuery(String query) {
+		String prefixes = "PREFIX : <http://example.org/> \n" +
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n";
+		query = prefixes + query;
+		return Repositories.tupleQueryNoTransaction(this.fedxRule.repository, query, it -> QueryResults.asList(it));
+	}
+
+	protected void assertContainsAll(List<BindingSet> res, String bindingName, Set<Value> expected) {
+		Assertions.assertEquals(expected,
+				res.stream().map(bs -> bs.getValue(bindingName)).collect(Collectors.toSet()));
+	}
+
+	protected IRI fullIri(String iri) {
+		return SimpleValueFactory.getInstance().createIRI(iri);
+	}
+
+	protected Literal l(String literal) {
+		return SimpleValueFactory.getInstance().createLiteral(literal);
+	}
+}

--- a/tools/federation/src/test/resources/tests/basic/query_bind.rq
+++ b/tools/federation/src/test/resources/tests/basic/query_bind.rq
@@ -1,0 +1,11 @@
+# make a test for BIND 
+
+PREFIX : <http://example.org/> 
+PREFIX foaf: <http://xmlns.com/foaf/0.1/> 
+
+SELECT ?s ?interest
+{
+  BIND ("Alan" as ?name) .
+  ?s foaf:name ?name .
+  ?s foaf:interest ?interest .
+} 

--- a/tools/federation/src/test/resources/tests/basic/query_bind.srx
+++ b/tools/federation/src/test/resources/tests/basic/query_bind.srx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="s"/>
+    <variable name="interest"/>
+  </head>
+  <results>
+    <result>
+      <binding name="s"><uri>http://example.org/a</uri></binding>
+      <binding name="interest"><literal>SPARQL 1.1 Basic Federated Query</literal></binding>
+    </result>
+  </results>
+</sparql>
+

--- a/tools/federation/src/test/resources/tests/data/data1.ttl
+++ b/tools/federation/src/test/resources/tests/data/data1.ttl
@@ -18,7 +18,7 @@
 :Person_3 rdf:type foaf:Person .
 :Person_3 rdf:type :Person .
 :Person_3 foaf:name "Person3" .
-:Person_1 foaf:age "30"^^xsd:integer .
+:Person_3 foaf:age "30"^^xsd:integer .
 
 :Person_4 rdf:type foaf:Person .
 :Person_4 rdf:type :Person .


### PR DESCRIPTION
GitHub issue resolved: #1856  

BIND clauses (i.e. Extensions) were not yet supported in the join order
optimizer (particularly in the cost model). In this change we add a
simple heuristic to support BIND clauses.

Evaluation is validated in a few selected unit tests.
