### PR TITLE
GH-1852: support Repositories#tupleQuery in FedX repository

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
@@ -28,17 +28,17 @@ public class ReadOnlyWriteStrategy implements WriteStrategy {
 
 	@Override
 	public void begin() throws RepositoryException {
-		throw new UnsupportedOperationException("Writing not supported to a federation: the federation is readonly.");
+		// no-op
 	}
 
 	@Override
 	public void commit() throws RepositoryException {
-		throw new UnsupportedOperationException("Writing not supported to a federation: the federation is readonly.");
+		// no-op
 	}
 
 	@Override
 	public void rollback() throws RepositoryException {
-		throw new UnsupportedOperationException("Writing not supported to a federation: the federation is readonly.");
+		// no-op
 	}
 
 	@Override

--- a/tools/federation/src/test/java/demos/GettingStartedDemoMinimal.java
+++ b/tools/federation/src/test/java/demos/GettingStartedDemoMinimal.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package demos;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.federated.FedXFactory;
+import org.eclipse.rdf4j.federated.repository.FedXRepository;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.repository.util.Repositories;
+
+public class GettingStartedDemoMinimal {
+
+	public static void main(String[] args) {
+
+		FedXRepository repository = FedXFactory.newFederation()
+				.withSparqlEndpoint("http://dbpedia.org/sparql")
+				.withSparqlEndpoint("https://query.wikidata.org/sparql")
+				.create();
+
+		repository.init();
+
+		String query = "PREFIX wd: <http://www.wikidata.org/entity/> "
+				+ "PREFIX wdt: <http://www.wikidata.org/prop/direct/> "
+				+ "SELECT * WHERE { "
+				+ " ?country a <http://dbpedia.org/class/yago/WikicatMemberStatesOfTheEuropeanUnion> ."
+				+ " ?country <http://www.w3.org/2002/07/owl#sameAs> ?countrySameAs . "
+				+ " ?countrySameAs wdt:P2131 ?gdp ."
+				+ "}";
+
+		List<BindingSet> res = Repositories.tupleQuery(repository, query, it -> QueryResults.asList(it));
+		res.forEach(bs -> System.out.println(bs));
+
+		repository.shutDown();
+	}
+}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
@@ -15,9 +15,12 @@ import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.structures.FedXDataset;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.util.Repositories;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class BasicTests extends SPARQLBaseTest {
@@ -179,5 +182,21 @@ public class BasicTests extends SPARQLBaseTest {
 				throw new Exception("Expected single result due to LIMIT 1");
 			}
 		}
+	}
+
+	@Test
+	public void testBeginTransaction() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint2.ttl"));
+
+		Assertions.assertEquals(
+				1, Repositories
+						.tupleQueryNoTransaction(fedxRule.repository, "SELECT ?person WHERE { ?person ?p 'Alan' }",
+								it -> QueryResults.asList(it))
+						.size());
+
+		Assertions.assertEquals(1,
+				Repositories.tupleQuery(fedxRule.repository, "SELECT ?person WHERE { ?person ?p 'Alan' }",
+						it -> QueryResults.asList(it)).size());
 	}
 }


### PR DESCRIPTION


GitHub issue resolved: #1852 

This change adjusts the implementations of #begin(), #commit() and
#rollback() to not throw an Exception, but rather do nothing.

Thus we now can use the Repositories#tupleQuery convenience function

