### PR TITLE
guava dependency declared in tools pom

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -214,6 +214,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
 
       <!-- Logging: SLF4J and logback -->

--- a/tools/server-spring/pom.xml
+++ b/tools/server-spring/pom.xml
@@ -69,7 +69,6 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Briefly describe the changes proposed in this PR:

* added guava dep version to dependencyManagement section in tools pom

Btw reason I did this is that I suddenly started getting errors on commandline maven builds. 
