### PR TITLE
tweak gpg sign plugin for running on new Jenkins CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
+								<configuration>
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
As documented in https://wiki.eclipse.org/Jenkins#How_can_artifacts_be_deployed_to_OSSRH_.2F_Maven_Central.3F

I'm focusing on getting the new Jenkins environment in working order for running deployments. I'm vaguely hoping that the new infrastructure will help with the many failures in deployment as well.

I'll run some test deployments from this branch, for which I will (temporarily) disable the autorelease feature of the staging plugin.