### PR TITLE
GH-1484 rdfstar api proposal

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -190,12 +190,22 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
+				<artifactId>rdf4j-rio-trigstar</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-rio-trix</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-rio-turtle</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.rdf4j</groupId>
+				<artifactId>rdf4j-rio-turtlestar</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/core/client/pom.xml
+++ b/core/client/pom.xml
@@ -168,12 +168,22 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-rio-trigstar</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-rio-trix</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-rio-turtle</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-rio-turtlestar</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/Triple.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/Triple.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -8,7 +8,7 @@
 package org.eclipse.rdf4j.model;
 
 /**
- * An RDF* triple. Triples have a subject, predicate and object. Unlike @{@link Statement}, a triple never has an
+ * An RDF* triple. Triples have a subject, predicate and object. Unlike {@link Statement}, a triple never has an
  * associated context.
  *
  * @author Pavel Mihaylov

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/Triple.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/Triple.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model;
+
+/**
+ * An RDF* triple. Triples have a subject, predicate and object. Unlike @{@link Statement}, a triple never has an
+ * associated context.
+ *
+ * @author Pavel Mihaylov
+ */
+public interface Triple extends Resource {
+
+	/**
+	 * Gets the subject of this triple.
+	 *
+	 * @return The triple's subject.
+	 */
+	Resource getSubject();
+
+	/**
+	 * Gets the predicate of this triple.
+	 *
+	 * @return The triple's predicate.
+	 */
+	IRI getPredicate();
+
+	/**
+	 * Gets the object of this triple.
+	 *
+	 * @return The triple's object.
+	 */
+	Value getObject();
+}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -261,7 +261,7 @@ public interface ValueFactory {
 	}
 
 	/**
-	 * Creates a new triple with the supplied subject, predicate and object.
+	 * Creates a new RDF* triple with the supplied subject, predicate and object.
 	 *
 	 * @param subject   The statement's subject.
 	 * @param predicate The statement's predicate.

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -259,4 +259,14 @@ public interface ValueFactory {
 	public default Statement createStatement(Resource subject, URI predicate, Value object, Resource context) {
 		return createStatement(subject, (IRI) predicate, object, context);
 	}
+
+	/**
+	 * Creates a new triple with the supplied subject, predicate and object.
+	 *
+	 * @param subject   The statement's subject.
+	 * @param predicate The statement's predicate.
+	 * @param object    The statement's object.
+	 * @return The created triple.
+	 */
+	Triple createTriple(Resource subject, IRI predicate, Value object);
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/AbstractValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/AbstractValueFactory.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
@@ -124,6 +125,11 @@ public abstract class AbstractValueFactory implements ValueFactory {
 	@Override
 	public Statement createStatement(Resource subject, IRI predicate, Value object, Resource context) {
 		return new ContextStatement(subject, predicate, object, context);
+	}
+
+	@Override
+	public Triple createTriple(Resource subject, IRI predicate, Value object) {
+		return new SimpleTriple(subject, predicate, object);
 	}
 
 	/**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleTriple.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleTriple.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -91,10 +91,12 @@ public class SimpleTriple implements Triple {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (o == null || getClass() != o.getClass())
+		}
+		if (o == null || getClass() != o.getClass()) {
 			return false;
+		}
 		SimpleTriple that = (SimpleTriple) o;
 		return Objects.equals(subject, that.subject) && Objects.equals(predicate, that.predicate)
 				&& Objects.equals(object, that.object);

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleTriple.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleTriple.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model.impl;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
+
+import java.util.Objects;
+
+/**
+ * A simple default implementation of the {@link Triple} interface.
+ *
+ * @author Pavel Mihaylov
+ * @see SimpleValueFactory
+ */
+public class SimpleTriple implements Triple {
+
+	/**
+	 * The triple's subject.
+	 */
+	private Resource subject;
+
+	/**
+	 * The triple's predicate.
+	 */
+	private IRI predicate;
+
+	/**
+	 * The triple's object.
+	 */
+	private Value object;
+
+	/**
+	 * Creates a new Triple with the supplied subject, predicate and object.
+	 * <p>
+	 * Note that creating SimpleStatement objects directly via this constructor is not the recommended approach.
+	 * Instead, use an instance of {@link org.eclipse.rdf4j.model.ValueFactory} to create new Triple objects.
+	 *
+	 * @param subject   The triple's subject, must not be <tt>null</tt>.
+	 * @param predicate The triple's predicate, must not be <tt>null</tt>.
+	 * @param object    The triple's object, must not be <tt>null</tt>.
+	 * @see {@link SimpleValueFactory#createTriple(Resource, IRI, Value)
+	 */
+	protected SimpleTriple(Resource subject, IRI predicate, Value object) {
+		this.subject = Objects.requireNonNull(subject, "subject must not be null");
+		this.predicate = Objects.requireNonNull(predicate, "predicate must not be null");
+		this.object = Objects.requireNonNull(object, "object must not be null");
+	}
+
+	@Override
+	public Resource getSubject() {
+		return subject;
+	}
+
+	@Override
+	public IRI getPredicate() {
+		return predicate;
+	}
+
+	@Override
+	public Value getObject() {
+		return object;
+	}
+
+	@Override
+	public String stringValue() {
+		StringBuilder sb = new StringBuilder(256);
+
+		sb.append("<<");
+		sb.append(getSubject());
+		sb.append(" ");
+		sb.append(getPredicate());
+		sb.append(" ");
+		sb.append(getObject());
+		sb.append(">>");
+
+		return sb.toString();
+	}
+
+	@Override
+	public String toString() {
+		return stringValue();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		SimpleTriple that = (SimpleTriple) o;
+		return Objects.equals(subject, that.subject) && Objects.equals(predicate, that.predicate)
+				&& Objects.equals(object, that.object);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(subject, predicate, object);
+	}
+}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -220,6 +221,11 @@ public class ValidatingValueFactory implements ValueFactory {
 	@Override
 	public Statement createStatement(Resource subject, URI predicate, Value object, Resource context) {
 		return delegate.createStatement(subject, predicate, object, context);
+	}
+
+	@Override
+	public Triple createTriple(Resource subject, IRI predicate, Value object) {
+		return delegate.createTriple(subject, predicate, object);
 	}
 
 	private boolean isMember(int[][] set, int cp) {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/LexicalValueComparator.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/LexicalValueComparator.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.common.lang.ObjectUtil;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 
@@ -71,7 +72,20 @@ public class LexicalValueComparator implements Serializable, Comparator<Value> {
 		}
 
 		// 4. RDF literals
-		return compareLiterals((Literal) o1, (Literal) o2);
+		boolean l1 = o1 instanceof Literal;
+		boolean l2 = o2 instanceof Literal;
+		if (l1 && l2) {
+			return compareLiterals((Literal) o1, (Literal) o2);
+		}
+		if (l1) {
+			return -1;
+		}
+		if (l2) {
+			return 1;
+		}
+
+		// 5. RDF* triples
+		return compareTriples((Triple) o1, (Triple) o2);
 	}
 
 	private int compareBNodes(BNode leftBNode, BNode rightBNode) {
@@ -157,5 +171,16 @@ public class LexicalValueComparator implements Serializable, Comparator<Value> {
 			// incompatible or unordered datatypes
 			return compareURIs(leftDatatype, rightDatatype);
 		}
+	}
+
+	private int compareTriples(Triple leftTriple, Triple rightTriple) {
+		int c = compare(leftTriple.getSubject(), rightTriple.getSubject());
+		if (c == 0) {
+			c = compare(leftTriple.getPredicate(), rightTriple.getPredicate());
+			if (c == 0) {
+				c = compare(leftTriple.getObject(), rightTriple.getObject());
+			}
+		}
+		return c;
 	}
 }

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
@@ -101,6 +101,19 @@ public class RDFFormat extends FileFormat {
 			NO_CONTEXTS);
 
 	/**
+	 * The Turtle* (TurtleStar) file format, a Turtle-based RDF serialization format that supports RDF* triples.
+	 * <p>
+	 * The file extension <code>.ttls</code> is recommended for Turtle* documents. The media type is
+	 * <code>application/x-turtlestar</code> and the encoding is UTF-8.
+	 * </p>
+	 *
+	 * @see <a href="https://arxiv.org/pdf/1406.3399.pdf">Foundations of an Alternative Approach to Reification in
+	 *      RDF</a>
+	 */
+	public static final RDFFormat TURTLESTAR = new RDFFormat("Turtle*", "application/x-turtlestar",
+			StandardCharsets.UTF_8, "ttls", SUPPORTS_NAMESPACES, NO_CONTEXTS);
+
+	/**
 	 * The <a href="http://www.w3.org/TeamSubmission/n3/">N3/Notation3</a> file format.
 	 * <p>
 	 * The file extension <code>.n3</code> is recommended for N3 documents. The media type is <code>text/n3</code>, but
@@ -141,6 +154,20 @@ public class RDFFormat extends FileFormat {
 			StandardCharsets.UTF_8, Arrays.asList("trig"),
 			SimpleValueFactory.getInstance().createIRI("http://www.w3.org/ns/formats/TriG"), SUPPORTS_NAMESPACES,
 			SUPPORTS_CONTEXTS);
+
+	/**
+	 * The TriG* (TriGStar) file format, a TriG-based RDF serialization format that supports RDF* triples. This builds
+	 * upon the idea for the Turtle* format but adds support for named graphs.
+	 * <p>
+	 * The file extension <code>.trigs</code> is recommended for TriG* documents. The media type is
+	 * <code>application/x-trigstar</code> and the encoding is UTF-8.
+	 * </p>
+	 *
+	 * @see <a href="https://arxiv.org/pdf/1406.3399.pdf">Foundations of an Alternative Approach to Reification in
+	 *      RDF</a>
+	 */
+	public static final RDFFormat TRIGSTAR = new RDFFormat("TriG*", "application/x-trigstar",
+			StandardCharsets.UTF_8, "trigs", SUPPORTS_NAMESPACES, SUPPORTS_CONTEXTS);
 
 	/**
 	 * A binary RDF format.

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,6 +37,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
@@ -113,6 +115,18 @@ public abstract class RDFWriterTest {
 
 	private IRI uri5;
 
+	private Triple triple1;
+
+	private Triple triple2;
+
+	private Triple triple3;
+
+	private Triple triple4;
+
+	private Triple triple5;
+
+	private Triple triple6;
+
 	private Literal plainLit;
 
 	private Literal dtLit;
@@ -140,6 +154,10 @@ public abstract class RDFWriterTest {
 	private List<IRI> potentialPredicates;
 
 	protected RDFWriterTest(RDFWriterFactory writerF, RDFParserFactory parserF) {
+		this(writerF, parserF, false);
+	}
+
+	protected RDFWriterTest(RDFWriterFactory writerF, RDFParserFactory parserF, boolean rdfStar) {
 		rdfWriterFactory = writerF;
 		rdfParserFactory = parserF;
 
@@ -177,6 +195,15 @@ public abstract class RDFWriterTest {
 
 		litBigPlaceholder = vf.createLiteral(prng.nextDouble());
 
+		if (rdfStar) {
+			triple1 = vf.createTriple(uri1, uri2, plainLit);
+			triple2 = vf.createTriple(bnode, uri3, litWithMultipleNewlines);
+			triple3 = vf.createTriple(uri3, uri4, bnodeSingleLetter);
+			triple4 = vf.createTriple(uri5, uri1, uri3);
+			triple5 = vf.createTriple(triple1, uri3, litBigPlaceholder);
+			triple6 = vf.createTriple(triple2, uri4, triple5);
+		}
+
 		potentialSubjects = new ArrayList<>();
 		potentialSubjects.add(bnode);
 		potentialSubjects.add(bnodeEmpty);
@@ -190,6 +217,9 @@ public abstract class RDFWriterTest {
 		potentialSubjects.add(uri3);
 		potentialSubjects.add(uri4);
 		potentialSubjects.add(uri5);
+		if (rdfStar) {
+			potentialSubjects.addAll(Arrays.asList(triple1, triple2, triple2, triple3, triple4, triple5, triple6));
+		}
 		for (int i = 0; i < 50; i++) {
 			potentialSubjects.add(vf.createBNode());
 		}
@@ -212,6 +242,9 @@ public abstract class RDFWriterTest {
 		potentialObjects.add(plainLit);
 		potentialObjects.add(dtLit);
 		potentialObjects.add(langLit);
+		if (rdfStar) {
+			potentialObjects.addAll(Arrays.asList(triple1, triple2, triple2, triple3, triple4, triple5, triple6));
+		}
 		// FIXME: SES-879: The following break the RDF/XML parser/writer
 		// combination in terms of getting the same number of triples back as we
 		// start with

--- a/core/rio/pom.xml
+++ b/core/rio/pom.xml
@@ -23,6 +23,8 @@
 		<module>rdfxml</module>
 		<module>trix</module>
 		<module>turtle</module>
+		<module>turtlestar</module>
 		<module>trig</module>
+		<module>trigstar</module>
 	</modules>
 </project>

--- a/core/rio/trigstar/pom.xml
+++ b/core/rio/trigstar/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-rio</artifactId>
+		<version>3.1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>rdf4j-rio-trigstar</artifactId>
+	<name>RDF4J: Rio - TriGStar</name>
+	<description>Rio parser and writer implementation for the TriGStar file format.</description>
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-model</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-trig</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-datatypes</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-languages</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-util</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-api</artifactId>
+			<classifier>tests</classifier>
+			<type>test-jar</type>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-query</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/core/rio/trigstar/pom.xml
+++ b/core/rio/trigstar/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-trigstar</artifactId>
 	<name>RDF4J: Rio - TriGStar</name>

--- a/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParser.java
+++ b/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParser.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.trig.TriGParser;
+
+import java.io.IOException;
+
+/**
+ * RDF parser for TriG* (an extension of TriG that adds RDF* support).
+ *
+ * @author Pavel Mihaylov
+ */
+public class TriGStarParser extends TriGParser {
+	/**
+	 * Creates a new TriGStarParser that will use a {@link SimpleValueFactory} to create RDF* model objects.
+	 */
+	public TriGStarParser() {
+		super();
+	}
+
+	/**
+	 * Creates a new TriGStarParser that will use the supplied ValueFactory to create RDF* model objects.
+	 *
+	 * @param valueFactory A ValueFactory.
+	 */
+	public TriGStarParser(ValueFactory valueFactory) {
+		super(valueFactory);
+	}
+
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.TRIGSTAR;
+	}
+
+	@Override
+	protected Value parseValue() throws IOException, RDFParseException, RDFHandlerException {
+		if (peekIsTripleValue()) {
+			return parseTripleValue();
+		}
+
+		return super.parseValue();
+	}
+
+	@Override
+	protected void setContext(Resource context) {
+		if (context != null && !(context instanceof IRI || context instanceof BNode)) {
+			reportFatalError("Illegal context value: " + context);
+		}
+
+		super.setContext(context);
+	}
+}

--- a/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParser.java
+++ b/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserFactory.java
+++ b/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+
+/**
+ * An {@link RDFParserFactory} for TriG* parsers.
+ *
+ * @author Pavel Mihaylov
+ */
+public class TriGStarParserFactory implements RDFParserFactory {
+	/**
+	 * Returns {@link RDFFormat#TRIGSTAR}.
+	 */
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.TRIGSTAR;
+	}
+
+	/**
+	 * Returns a new instance of {@link TriGStarParser}.
+	 */
+	@Override
+	public RDFParser getParser() {
+		return new TriGStarParser();
+	}
+}

--- a/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserFactory.java
+++ b/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriter.java
+++ b/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriter.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.trig.TriGWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+
+/**
+ * An extension of {@link TriGWriter} that writes RDF* documents in the TriG* format by including the RDF* triples.
+ *
+ * @author Pavel Mihaylov
+ */
+public class TriGStarWriter extends TriGWriter {
+	/**
+	 * Creates a new TriGStarWriter that will write to the supplied OutputStream.
+	 *
+	 * @param out The OutputStream to write the TriG* document to.
+	 */
+	public TriGStarWriter(OutputStream out) {
+		super(out);
+	}
+
+	/**
+	 * Creates a new TriGStarWriter that will write to the supplied OutputStream using the supplied base IRI.
+	 *
+	 * @param out     The OutputStream to write the TriG* document to.
+	 * @param baseIRI The base IRI to use.
+	 */
+	public TriGStarWriter(OutputStream out, ParsedIRI baseIRI) {
+		super(out, baseIRI);
+	}
+
+	/**
+	 * Creates a new TriGStarWriter that will write to the supplied Writer.
+	 *
+	 * @param writer The Writer to write the TriG* document to.
+	 */
+	public TriGStarWriter(Writer writer) {
+		super(writer);
+	}
+
+	/**
+	 * Creates a new TriGStarWriter that will write to the supplied Writer using the supplied base IRI.
+	 *
+	 * @param writer  The Writer to write the TriG* document to.
+	 * @param baseIRI The base IRI to use.
+	 */
+	public TriGStarWriter(Writer writer, ParsedIRI baseIRI) {
+		super(writer, baseIRI);
+	}
+
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.TRIGSTAR;
+	}
+
+	@Override
+	protected void writeTriple(Triple triple, boolean canShorten) throws IOException {
+		writeTripleRDFStar(triple, canShorten);
+	}
+}

--- a/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriter.java
+++ b/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterFactory.java
+++ b/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterFactory.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+
+import java.io.OutputStream;
+import java.io.Writer;
+import java.net.URISyntaxException;
+
+/**
+ * An {@link RDFWriterFactory} for TriG* writers.
+ * 
+ * @author Pavel Mihaylov
+ */
+public class TriGStarWriterFactory implements RDFWriterFactory {
+
+	/**
+	 * Returns {@link RDFFormat#TRIGSTAR}.
+	 */
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.TRIGSTAR;
+	}
+
+	/**
+	 * Returns a new instance of {@link TriGStarWriter}.
+	 */
+	@Override
+	public RDFWriter getWriter(OutputStream out) {
+		return new TriGStarWriter(out);
+	}
+
+	/**
+	 * Returns a new instance of {@link TriGStarWriter}.
+	 *
+	 * @throws URISyntaxException
+	 */
+	@Override
+	public RDFWriter getWriter(OutputStream out, String baseURI) throws URISyntaxException {
+		return new TriGStarWriter(out, new ParsedIRI(baseURI));
+	}
+
+	/**
+	 * Returns a new instance of {@link TriGStarWriter}.
+	 */
+	@Override
+	public RDFWriter getWriter(Writer writer) {
+		return new TriGStarWriter(writer);
+	}
+
+	/**
+	 * Returns a new instance of {@link TriGStarWriter}.
+	 *
+	 * @throws URISyntaxException
+	 */
+	@Override
+	public RDFWriter getWriter(Writer writer, String baseURI) throws URISyntaxException {
+		return new TriGStarWriter(writer, new ParsedIRI(baseURI));
+	}
+}

--- a/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterFactory.java
+++ b/core/rio/trigstar/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFParserFactory
+++ b/core/rio/trigstar/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFParserFactory
@@ -1,0 +1,1 @@
+org.eclipse.rdf4j.rio.trigstar.TriGStarParserFactory

--- a/core/rio/trigstar/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
+++ b/core/rio/trigstar/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
@@ -1,0 +1,1 @@
+org.eclipse.rdf4j.rio.trigstar.TriGStarWriterFactory

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarHandlingTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarHandlingTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.rio.AbstractParserHandlingTest;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
+
+import java.io.OutputStream;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TriGStarHandlingTest extends AbstractParserHandlingTest {
+	@Override
+	protected RDFParser getParser() {
+		return new TriGStarParser();
+	}
+
+	@Override
+	protected RDFWriter createWriter(OutputStream output) {
+		return new TriGStarWriter(output);
+	}
+}

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarHandlingTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarHandlingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarMimeTypeRDFFormatTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarMimeTypeRDFFormatTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TriGStarMimeTypeRDFFormatTest {
+	private final RDFFormat expectedRDFFormat = RDFFormat.TRIGSTAR;
+
+	@Test
+	public void testApplicationXTrigStar() {
+		assertEquals(expectedRDFFormat, Rio.getParserFormatForMIMEType("application/x-trigstar")
+				.orElseThrow(Rio.unsupportedFormat(expectedRDFFormat)));
+	}
+
+	@Test
+	public void testApplicationXTrigStarUtf8() {
+		assertEquals(RDFFormat.TRIGSTAR, Rio.getParserFormatForMIMEType("application/x-trigstar;charset=UTF-8")
+				.orElseThrow(Rio.unsupportedFormat(expectedRDFFormat)));
+	}
+
+	@Test
+	public void testRDFFormatParser() {
+		assertEquals(expectedRDFFormat, new TriGStarParser().getRDFFormat());
+	}
+
+	@Test
+	public void testRDFFormatWriter() throws IOException {
+		try (Writer w = new StringWriter()) {
+			assertEquals(expectedRDFFormat, new TriGStarWriter(w).getRDFFormat());
+		}
+	}
+
+	@Test
+	public void testRDFFormatParserFactory() {
+		assertEquals(expectedRDFFormat, new TriGStarParserFactory().getRDFFormat());
+	}
+
+	@Test
+	public void testRDFFormatWriterFactory() {
+		assertEquals(expectedRDFFormat, new TriGStarWriterFactory().getRDFFormat());
+	}
+}

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarMimeTypeRDFFormatTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarMimeTypeRDFFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
@@ -72,6 +72,9 @@ public class TriGStarParserTest {
 		IRI valid = vf.createIRI("http://example.com/valid");
 		Literal abcDate = vf.createLiteral("1999-08-16", XMLSchema.DATE);
 		Literal birthDate = vf.createLiteral("1908-03-18", XMLSchema.DATE);
+		Literal titleEn = vf.createLiteral("Example book", "en");
+		Literal titleDe = vf.createLiteral("Beispielbuch", "de");
+		Literal titleEnUs = vf.createLiteral("Example Book", "en-US");
 
 		Triple bobCreatedBook = vf.createTriple(bob, DCTERMS.CREATED, book);
 		Triple aliceKnowsBobCreatedBook = vf.createTriple(alice, FOAF.KNOWS, bobCreatedBook);
@@ -80,13 +83,16 @@ public class TriGStarParserTest {
 		Triple aliceCreatedBook = vf.createTriple(alice, DCTERMS.CREATED, book);
 		Triple abc = vf.createTriple(a, b, c);
 		Triple bobBirthdayDate = vf.createTriple(bob, FOAF.BIRTHDAY, birthDate);
+		Triple bookTitleEn = vf.createTriple(book, DCTERMS.TITLE, titleEn);
+		Triple bookTitleDe = vf.createTriple(book, DCTERMS.TITLE, titleDe);
+		Triple bookTitleEnUs = vf.createTriple(book, DCTERMS.TITLE, titleEnUs);
 
 		try (InputStream in = this.getClass().getResourceAsStream("/test-rdfstar.trigs")) {
 			parser.parse(in, baseURI);
 
 			Collection<Statement> stmts = statementCollector.getStatements();
 
-			assertEquals(7, stmts.size());
+			assertEquals(10, stmts.size());
 
 			assertTrue(stmts.contains(vf.createStatement(bob, FOAF.KNOWS, aliceKnowsBobCreatedBook, graph)));
 			assertTrue(stmts.contains(vf.createStatement(bobCreatedBookKnowsAlice, DCTERMS.SOURCE, otherbook, graph)));
@@ -95,6 +101,9 @@ public class TriGStarParserTest {
 			assertTrue(stmts.contains(vf.createStatement(bookCreatorAlice, DCTERMS.REQUIRES, aliceCreatedBook, graph)));
 			assertTrue(stmts.contains(vf.createStatement(abc, valid, abcDate, graph)));
 			assertTrue(stmts.contains(vf.createStatement(bobBirthdayDate, DCTERMS.SOURCE, bobshomepage, graph)));
+			assertTrue(stmts.contains(vf.createStatement(bookTitleEn, DCTERMS.SOURCE, bobshomepage, graph)));
+			assertTrue(stmts.contains(vf.createStatement(bookTitleDe, DCTERMS.SOURCE, bobshomepage, graph)));
+			assertTrue(stmts.contains(vf.createStatement(bookTitleEnUs, DCTERMS.SOURCE, bobshomepage, graph)));
 		}
 	}
 

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TriGStarParserTest {
+	private TriGStarParser parser;
+
+	private ValueFactory vf = SimpleValueFactory.getInstance();
+
+	private final ParseErrorCollector errorCollector = new ParseErrorCollector();
+
+	private final StatementCollector statementCollector = new StatementCollector();
+
+	private final String baseURI = "http://example.org/";
+
+	private SimpleParseLocationListener locationListener = new SimpleParseLocationListener();
+
+	@Before
+	public void setUp() {
+		parser = new TriGStarParser();
+		parser.setParseErrorListener(errorCollector);
+		parser.setRDFHandler(statementCollector);
+		parser.setParseLocationListener(locationListener);
+	}
+
+	@Test
+	public void testParseRDFStarData() throws IOException {
+		IRI graph = vf.createIRI("http://example.com/rdfstar");
+
+		IRI bob = vf.createIRI("http://example.com/bob");
+		IRI alice = vf.createIRI("http://example.com/alice");
+		IRI book = vf.createIRI("http://example.com/book");
+		IRI otherbook = vf.createIRI("http://example.com/otherbook");
+		IRI bobshomepage = vf.createIRI("http://example.com/bobshomepage");
+		IRI a = vf.createIRI("http://example.org/a");
+		IRI b = vf.createIRI("http://example.com/b");
+		IRI c = vf.createIRI("http://example.com/c");
+		IRI valid = vf.createIRI("http://example.com/valid");
+		Literal abcDate = vf.createLiteral("1999-08-16", XMLSchema.DATE);
+		Literal birthDate = vf.createLiteral("1908-03-18", XMLSchema.DATE);
+
+		Triple bobCreatedBook = vf.createTriple(bob, DCTERMS.CREATED, book);
+		Triple aliceKnowsBobCreatedBook = vf.createTriple(alice, FOAF.KNOWS, bobCreatedBook);
+		Triple bobCreatedBookKnowsAlice = vf.createTriple(bobCreatedBook, FOAF.KNOWS, alice);
+		Triple bookCreatorAlice = vf.createTriple(book, DCTERMS.CREATOR, alice);
+		Triple aliceCreatedBook = vf.createTriple(alice, DCTERMS.CREATED, book);
+		Triple abc = vf.createTriple(a, b, c);
+		Triple bobBirthdayDate = vf.createTriple(bob, FOAF.BIRTHDAY, birthDate);
+
+		try (InputStream in = this.getClass().getResourceAsStream("/test-rdfstar.trigs")) {
+			parser.parse(in, baseURI);
+
+			Collection<Statement> stmts = statementCollector.getStatements();
+
+			assertEquals(7, stmts.size());
+
+			assertTrue(stmts.contains(vf.createStatement(bob, FOAF.KNOWS, aliceKnowsBobCreatedBook, graph)));
+			assertTrue(stmts.contains(vf.createStatement(bobCreatedBookKnowsAlice, DCTERMS.SOURCE, otherbook, graph)));
+			assertTrue(stmts.contains(vf.createStatement(bobshomepage, DCTERMS.SOURCE, bookCreatorAlice, graph)));
+			assertTrue(stmts.contains(vf.createStatement(bookCreatorAlice, DCTERMS.SOURCE, bobshomepage, graph)));
+			assertTrue(stmts.contains(vf.createStatement(bookCreatorAlice, DCTERMS.REQUIRES, aliceCreatedBook, graph)));
+			assertTrue(stmts.contains(vf.createStatement(abc, valid, abcDate, graph)));
+			assertTrue(stmts.contains(vf.createStatement(bobBirthdayDate, DCTERMS.SOURCE, bobshomepage, graph)));
+		}
+	}
+
+	@Test
+	public void testTripleInPredicate() throws IOException {
+		String data = "@prefix ex: <http://example.com/>.\ngraph ex:G { ex:Example <<<urn:a><urn:b><urn:c>>> \"foo\"}";
+		try (Reader r = new StringReader(data)) {
+			parser.parse(r, baseURI);
+			fail("Must fail with RDFParseException");
+		} catch (RDFParseException e) {
+			assertEquals("Illegal predicate value: <<urn:a urn:b urn:c>> [line 2]", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testTripleInGraph() throws IOException {
+		String data = "@prefix ex: <http://example.com/>.\ngraph <<<urn:a> <urn:b><urn:c>>> {ex:Example ex:p \"foo\" }";
+		try (Reader r = new StringReader(data)) {
+			parser.parse(r, baseURI);
+			fail("Must fail with RDFParseException");
+		} catch (RDFParseException e) {
+			assertEquals("Illegal context value: <<urn:a urn:b urn:c>> [line 2]", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testTripleInDatatype() throws IOException {
+		String data = "@prefix ex: <http://example.com/>.\ngraph ex:g { ex:Example ex:p \"foo\"^^<<<urn:a><urn:b><urn:c>>> }";
+		try (Reader r = new StringReader(data)) {
+			parser.parse(r, baseURI);
+			fail("Must fail with RDFParseException");
+		} catch (RDFParseException e) {
+			assertEquals("Illegal datatype value: <<urn:a urn:b urn:c>> [line 2]", e.getMessage());
+		}
+	}
+}

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarPrettyWriterTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarPrettyWriterTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TriGStarPrettyWriterTest extends RDFWriterTest {
+	public TriGStarPrettyWriterTest() {
+		super(new TriGStarWriterFactory(), new TriGStarParserFactory(), true);
+	}
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(BasicWriterSettings.PRETTY_PRINT, true);
+	}
+}

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarPrettyWriterTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarPrettyWriterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trigstar;
+
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TriGStarWriterTest extends RDFWriterTest {
+	public TriGStarWriterTest() {
+		super(new TriGStarWriterFactory(), new TriGStarParserFactory(), true);
+	}
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(BasicWriterSettings.PRETTY_PRINT, false);
+	}
+
+}

--- a/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterTest.java
+++ b/core/rio/trigstar/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/trigstar/src/test/resources/test-rdfstar.trigs
+++ b/core/rio/trigstar/src/test/resources/test-rdfstar.trigs
@@ -1,0 +1,27 @@
+@prefix ex: <http://example.com/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+
+graph ex:rdfstar {
+    ex:bob foaf:knows << ex:alice foaf:knows<<ex:bob dct:created ex:book>> >> .
+    
+    <<<< ex:bob dct:created ex:book >> foaf:knows ex:alice >> dct:source ex:otherbook .
+
+    ex:bobshomepage dct:source<< ex:book dct:creator ex:alice  >> .
+
+    << ex:book dct:creator ex:alice  >> dct:source  ex:bobshomepage .
+
+    << ex:book dct:creator ex:alice >> dct:requires << ex:alice dct:created ex:book >> .
+
+    <<<http://example.org/a>ex:b ex:c>>ex:valid "1999-08-16"^^xsd:date .
+
+    << # Start of triple
+        ex:bob # triple subject
+        foaf:birthday # triple predicate
+        "1908-03-18"^^xsd:date # triple object
+    >> # end of triple
+    dct:source ex:bobshomepage .
+}

--- a/core/rio/trigstar/src/test/resources/test-rdfstar.trigs
+++ b/core/rio/trigstar/src/test/resources/test-rdfstar.trigs
@@ -24,4 +24,9 @@ graph ex:rdfstar {
         "1908-03-18"^^xsd:date # triple object
     >> # end of triple
     dct:source ex:bobshomepage .
+
+    << ex:book dct:title "Example book"@en >> dct:source  ex:bobshomepage .
+    << ex:book dct:title "Beispielbuch"@de>> dct:source ex:bobshomepage.
+    << ex:book dct:title "Example Book"@en-US>> dct:source ex:bobshomepage.
+
 }

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -42,7 +42,7 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
  * @author James Leigh
  * @since 2.3
  */
-class ArrangedWriter implements RDFWriter {
+public class ArrangedWriter implements RDFWriter {
 
 	private final static int DEFAULT_QUEUE_SIZE = 100;
 

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -26,6 +26,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -88,6 +89,11 @@ public class ArrangedWriter implements RDFWriter {
 		if (!(o1 instanceof IRI) && o2 instanceof IRI) {
 			return -1;
 		} else if (o1 instanceof IRI && !(o2 instanceof IRI)) {
+			return 1;
+		}
+		if (!(o1 instanceof Triple) && o2 instanceof Triple) {
+			return -1;
+		} else if (o1 instanceof Triple && !(o2 instanceof Triple)) {
 			return 1;
 		}
 		int str_cmp = o1.stringValue().compareTo(o2.stringValue());

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -631,7 +631,7 @@ public class TurtleParser extends AbstractRDFParser {
 				// Turtle
 				// language tags do not need whitespace following the language
 				// tag
-				if (c == '.' || c == ';' || c == ',' || c == ')' || c == ']' || c == -1) {
+				if (c == '.' || c == ';' || c == ',' || c == ')' || c == ']' || c == '>' || c == -1) {
 					break;
 				}
 				if (verifyLanguageTag && !TurtleUtil.isLanguageChar(c)) {

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -26,6 +26,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -654,13 +655,13 @@ public class TurtleParser extends AbstractRDFParser {
 
 			// Read datatype
 			Value datatype = parseValue();
-			if (datatype instanceof Literal || datatype instanceof BNode) {
-				reportFatalError("Illegal datatype value: " + datatype);
-			} else if (datatype == null) {
+			if (datatype == null) {
 				// the datatype IRI could not be parsed. report as error only if VERIFY_URI_SYNTAX is enabled, silently
 				// skip otherwise.
 				reportError("Invalid datatype IRI for literal '" + label + "'", BasicParserSettings.VERIFY_URI_SYNTAX);
 				return null;
+			} else if (!(datatype instanceof IRI)) {
+				reportFatalError("Illegal datatype value: " + datatype);
 			}
 			return createLiteral(label, null, (IRI) datatype, getLineNumber(), -1);
 		} else {
@@ -1342,5 +1343,56 @@ public class TurtleParser extends AbstractRDFParser {
 		} else {
 			throw new IllegalArgumentException("Invalid codepoint " + codePoint);
 		}
+	}
+
+	/**
+	 * Peeks at the next two Unicode code points without advancing the reader and returns true if they indicate the
+	 * start of an RDF* triple value. Such values start with '<<'.
+	 *
+	 * @return true if the next code points indicate the beginning of an RDF* triple value, false otherwise
+	 * @throws IOException
+	 */
+	protected boolean peekIsTripleValue() throws IOException {
+		int c0 = readCodePoint();
+		int c1 = readCodePoint();
+		unread(c1);
+		unread(c0);
+
+		return c0 == '<' && c1 == '<';
+	}
+
+	/**
+	 * Parser an RDF* triple value and returns it.
+	 *
+	 * @return An RDF* triple.
+	 * @throws IOException
+	 */
+	protected Triple parseTripleValue() throws IOException {
+		verifyCharacterOrFail(readCodePoint(), "<");
+		verifyCharacterOrFail(readCodePoint(), "<");
+		skipWSC();
+		Value subject = parseValue();
+		if (subject instanceof Resource) {
+			skipWSC();
+			Value predicate = parseValue();
+			if (predicate instanceof IRI) {
+				skipWSC();
+				Value object = parseValue();
+				if (object != null) {
+					skipWSC();
+					verifyCharacterOrFail(readCodePoint(), ">");
+					verifyCharacterOrFail(readCodePoint(), ">");
+					return valueFactory.createTriple((Resource) subject, (IRI) predicate, object);
+				} else {
+					reportFatalError("Missing object in RDF* triple");
+				}
+			} else {
+				reportFatalError("Illegal predicate value in RDF* triple: " + predicate);
+			}
+		} else {
+			reportFatalError("Illegal subject val in RDF* triple: " + subject);
+		}
+
+		return null;
 	}
 }

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.SimpleIRI;
@@ -432,8 +433,10 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 	protected void writeResource(Resource res, boolean canShorten) throws IOException {
 		if (res instanceof IRI) {
 			writeURI((IRI) res);
-		} else {
+		} else if (res instanceof BNode) {
 			writeBNode((BNode) res, canShorten);
+		} else {
+			writeTriple((Triple) res, canShorten);
 		}
 	}
 
@@ -514,6 +517,28 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 				}
 			}
 		}
+	}
+
+	protected void writeTriple(Triple triple, boolean canShorten) throws IOException {
+		// Ideally RDF* triples might be serialized as RDF reification but should that happen automatically
+		// or only when requested via some way? If we do it for Turtle, should we also do it for all other non-RDF*
+		// parsers too?
+		throw new IOException(getRDFFormat().getName() + " does not support RDF* triples");
+	}
+
+	protected void writeTripleRDFStar(Triple triple, boolean canShorten) throws IOException {
+		writer.write("<<");
+		writeResource(triple.getSubject());
+		writer.write(" ");
+		writeURI(triple.getPredicate());
+		writer.write(" ");
+		Value object = triple.getObject();
+		if (object instanceof Literal) {
+			writeLiteral((Literal) object);
+		} else {
+			writeResource((Resource) object, canShorten);
+		}
+		writer.write(">>");
 	}
 
 	protected void writeLiteral(Literal lit) throws IOException {

--- a/core/rio/turtlestar/pom.xml
+++ b/core/rio/turtlestar/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-rio</artifactId>
+		<version>3.1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>rdf4j-rio-turtlestar</artifactId>
+	<name>RDF4J: Rio - TurtleStar</name>
+	<description>Rio parser and writer implementation for the TurtleStar file format.</description>
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-model</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-turtle</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-datatypes</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-languages</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-util</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-api</artifactId>
+			<classifier>tests</classifier>
+			<type>test-jar</type>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-query</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-ntriples</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/core/rio/turtlestar/pom.xml
+++ b/core/rio/turtlestar/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.2.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-turtlestar</artifactId>
 	<name>RDF4J: Rio - TurtleStar</name>

--- a/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParser.java
+++ b/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParser.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.turtle.TurtleParser;
+
+import java.io.IOException;
+
+/**
+ * RDF parser for Turtle* (an extension of Turtle that adds RDF* support).
+ *
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarParser extends TurtleParser {
+	/**
+	 * Creates a new TurtleStarParser that will use a {@link SimpleValueFactory} to create RDF* model objects.
+	 */
+	public TurtleStarParser() {
+		super();
+	}
+
+	/**
+	 * Creates a new TurtleStarParser that will use the supplied ValueFactory to create RDF* model objects.
+	 *
+	 * @param valueFactory A ValueFactory.
+	 */
+	public TurtleStarParser(ValueFactory valueFactory) {
+		super(valueFactory);
+	}
+
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.TURTLESTAR;
+	}
+
+	@Override
+	protected Value parseValue() throws IOException, RDFParseException, RDFHandlerException {
+		if (peekIsTripleValue()) {
+			return parseTripleValue();
+		}
+
+		return super.parseValue();
+	}
+}

--- a/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParser.java
+++ b/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserFactory.java
+++ b/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserFactory.java
+++ b/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+
+/**
+ * An {@link RDFParserFactory} for Turtle* parsers.
+ *
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarParserFactory implements RDFParserFactory {
+	/**
+	 * Returns {@link RDFFormat#TURTLESTAR}.
+	 */
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.TURTLESTAR;
+	}
+
+	/**
+	 * Returns a new instance of {@link TurtleStarParser}.
+	 */
+	@Override
+	public RDFParser getParser() {
+		return new TurtleStarParser();
+	}
+}

--- a/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriter.java
+++ b/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriter.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.turtle.TurtleWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+
+/**
+ * An extension of {@link TurtleWriter} that writes RDF* documents in the Turtle* format by including the RDF* triples.
+ *
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarWriter extends TurtleWriter {
+	/**
+	 * Creates a new TurtleStarWriter that will write to the supplied OutputStream.
+	 *
+	 * @param out The OutputStream to write the TurtleStar document to.
+	 */
+	public TurtleStarWriter(OutputStream out) {
+		super(out);
+	}
+
+	/**
+	 * Creates a new TurtleStarWriter that will write to the supplied OutputStream using the supplied base IRI.
+	 *
+	 * @param out     The OutputStream to write the TurtleStar document to.
+	 * @param baseIRI The base IRI to use.
+	 */
+	public TurtleStarWriter(OutputStream out, ParsedIRI baseIRI) {
+		super(out, baseIRI);
+	}
+
+	/**
+	 * Creates a new TurtleStarWriter that will write to the supplied Writer.
+	 *
+	 * @param writer The Writer to write the TurtleStar document to.
+	 */
+	public TurtleStarWriter(Writer writer) {
+		super(writer);
+	}
+
+	/**
+	 * Creates a new TurtleStarWriter that will write to the supplied Writer using the supplied base IRI.
+	 *
+	 * @param writer  The Writer to write the Turtle document to.
+	 * @param baseIRI The base IRI to use.
+	 */
+	public TurtleStarWriter(Writer writer, ParsedIRI baseIRI) {
+		super(writer, baseIRI);
+	}
+
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.TURTLESTAR;
+	}
+
+	@Override
+	protected void writeTriple(Triple triple, boolean canShorten) throws IOException {
+		writeTripleRDFStar(triple, canShorten);
+	}
+}

--- a/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriter.java
+++ b/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterFactory.java
+++ b/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterFactory.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+import org.eclipse.rdf4j.rio.turtle.ArrangedWriter;
+
+import java.io.OutputStream;
+import java.io.Writer;
+import java.net.URISyntaxException;
+
+/**
+ * An {@link RDFWriterFactory} for Turtle* writers.
+ *
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarWriterFactory implements RDFWriterFactory {
+
+	/**
+	 * Returns {@link RDFFormat#TURTLESTAR}.
+	 */
+	@Override
+	public RDFFormat getRDFFormat() {
+		return RDFFormat.TURTLESTAR;
+	}
+
+	/**
+	 * Returns a new instance of {@link TurtleStarWriter}.
+	 */
+	@Override
+	public RDFWriter getWriter(OutputStream out) {
+		return new ArrangedWriter(new TurtleStarWriter(out));
+	}
+
+	@Override
+	public RDFWriter getWriter(OutputStream out, String baseURI) throws URISyntaxException {
+		return new ArrangedWriter(new TurtleStarWriter(out, new ParsedIRI(baseURI)));
+	}
+
+	/**
+	 * Returns a new instance of {@link TurtleStarWriter}.
+	 */
+	@Override
+	public RDFWriter getWriter(Writer writer) {
+		return new ArrangedWriter(new TurtleStarWriter(writer));
+	}
+
+	@Override
+	public RDFWriter getWriter(Writer writer, String baseURI) throws URISyntaxException {
+		return new ArrangedWriter(new TurtleStarWriter(writer, new ParsedIRI(baseURI)));
+	}
+}

--- a/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterFactory.java
+++ b/core/rio/turtlestar/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFParserFactory
+++ b/core/rio/turtlestar/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFParserFactory
@@ -1,0 +1,1 @@
+org.eclipse.rdf4j.rio.turtlestar.TurtleStarParserFactory

--- a/core/rio/turtlestar/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
+++ b/core/rio/turtlestar/src/main/resources/META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory
@@ -1,0 +1,1 @@
+org.eclipse.rdf4j.rio.turtlestar.TurtleStarWriterFactory

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarHandlingTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarHandlingTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.rio.AbstractParserHandlingTest;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
+
+import java.io.OutputStream;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarHandlingTest extends AbstractParserHandlingTest {
+	@Override
+	protected RDFParser getParser() {
+		return new TurtleStarParser();
+	}
+
+	@Override
+	protected RDFWriter createWriter(OutputStream output) {
+		return new TurtleStarWriter(output);
+	}
+}

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarHandlingTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarHandlingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarMimeTypeRDFFormatTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarMimeTypeRDFFormatTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarMimeTypeRDFFormatTest {
+	private final RDFFormat expectedRDFFormat = RDFFormat.TURTLESTAR;
+
+	@Test
+	public void testApplicationXTurtleStarUtf8() {
+		assertEquals(expectedRDFFormat, Rio.getParserFormatForMIMEType("application/x-turtlestar;charset=UTF-8")
+				.orElseThrow(Rio.unsupportedFormat(expectedRDFFormat)));
+	}
+
+	@Test
+	public void testApplicationXTurtleStar() {
+		assertEquals(expectedRDFFormat, Rio.getParserFormatForMIMEType("application/x-turtlestar")
+				.orElseThrow(Rio.unsupportedFormat(expectedRDFFormat)));
+	}
+
+	@Test
+	public void testRDFFormatParser() {
+		assertEquals(expectedRDFFormat, new TurtleStarParser().getRDFFormat());
+	}
+
+	@Test
+	public void testRDFFormatWriter() throws IOException {
+		try (Writer w = new StringWriter()) {
+			assertEquals(expectedRDFFormat, new TurtleStarWriter(w).getRDFFormat());
+		}
+	}
+
+	@Test
+	public void testRDFFormatParserFactory() {
+		assertEquals(expectedRDFFormat, new TurtleStarParserFactory().getRDFFormat());
+	}
+
+	@Test
+	public void testRDFFormatWriterFactory() {
+		assertEquals(expectedRDFFormat, new TurtleStarWriterFactory().getRDFFormat());
+	}
+}

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarMimeTypeRDFFormatTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarMimeTypeRDFFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
@@ -70,6 +70,9 @@ public class TurtleStarParserTest {
 		IRI valid = vf.createIRI("http://example.com/valid");
 		Literal abcDate = vf.createLiteral("1999-08-16", XMLSchema.DATE);
 		Literal birthDate = vf.createLiteral("1908-03-18", XMLSchema.DATE);
+		Literal titleEn = vf.createLiteral("Example book", "en");
+		Literal titleDe = vf.createLiteral("Beispielbuch", "de");
+		Literal titleEnUs = vf.createLiteral("Example Book", "en-US");
 
 		Triple bobCreatedBook = vf.createTriple(bob, DCTERMS.CREATED, book);
 		Triple aliceKnowsBobCreatedBook = vf.createTriple(alice, FOAF.KNOWS, bobCreatedBook);
@@ -78,13 +81,16 @@ public class TurtleStarParserTest {
 		Triple aliceCreatedBook = vf.createTriple(alice, DCTERMS.CREATED, book);
 		Triple abc = vf.createTriple(a, b, c);
 		Triple bobBirthdayDate = vf.createTriple(bob, FOAF.BIRTHDAY, birthDate);
+		Triple bookTitleEn = vf.createTriple(book, DCTERMS.TITLE, titleEn);
+		Triple bookTitleDe = vf.createTriple(book, DCTERMS.TITLE, titleDe);
+		Triple bookTitleEnUs = vf.createTriple(book, DCTERMS.TITLE, titleEnUs);
 
 		try (InputStream in = this.getClass().getResourceAsStream("/test-rdfstar.ttls")) {
 			parser.parse(in, baseURI);
 
 			Collection<Statement> stmts = statementCollector.getStatements();
 
-			assertEquals(7, stmts.size());
+			assertEquals(10, stmts.size());
 
 			assertTrue(stmts.contains(vf.createStatement(bob, FOAF.KNOWS, aliceKnowsBobCreatedBook)));
 			assertTrue(stmts.contains(vf.createStatement(bobCreatedBookKnowsAlice, DCTERMS.SOURCE, otherbook)));
@@ -93,6 +99,9 @@ public class TurtleStarParserTest {
 			assertTrue(stmts.contains(vf.createStatement(bookCreatorAlice, DCTERMS.REQUIRES, aliceCreatedBook)));
 			assertTrue(stmts.contains(vf.createStatement(abc, valid, abcDate)));
 			assertTrue(stmts.contains(vf.createStatement(bobBirthdayDate, DCTERMS.SOURCE, bobshomepage)));
+			assertTrue(stmts.contains(vf.createStatement(bookTitleEn, DCTERMS.SOURCE, bobshomepage)));
+			assertTrue(stmts.contains(vf.createStatement(bookTitleDe, DCTERMS.SOURCE, bobshomepage)));
+			assertTrue(stmts.contains(vf.createStatement(bookTitleEnUs, DCTERMS.SOURCE, bobshomepage)));
 		}
 	}
 

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarParserTest {
+	private TurtleStarParser parser;
+
+	private ValueFactory vf = SimpleValueFactory.getInstance();
+
+	private final ParseErrorCollector errorCollector = new ParseErrorCollector();
+
+	private final StatementCollector statementCollector = new StatementCollector();
+
+	private final String baseURI = "http://example.org/";
+
+	private SimpleParseLocationListener locationListener = new SimpleParseLocationListener();
+
+	@Before
+	public void setUp() {
+		parser = new TurtleStarParser();
+		parser.setParseErrorListener(errorCollector);
+		parser.setRDFHandler(statementCollector);
+		parser.setParseLocationListener(locationListener);
+	}
+
+	@Test
+	public void testParseRDFStarData() throws IOException {
+		IRI bob = vf.createIRI("http://example.com/bob");
+		IRI alice = vf.createIRI("http://example.com/alice");
+		IRI book = vf.createIRI("http://example.com/book");
+		IRI otherbook = vf.createIRI("http://example.com/otherbook");
+		IRI bobshomepage = vf.createIRI("http://example.com/bobshomepage");
+		IRI a = vf.createIRI("http://example.org/a");
+		IRI b = vf.createIRI("http://example.com/b");
+		IRI c = vf.createIRI("http://example.com/c");
+		IRI valid = vf.createIRI("http://example.com/valid");
+		Literal abcDate = vf.createLiteral("1999-08-16", XMLSchema.DATE);
+		Literal birthDate = vf.createLiteral("1908-03-18", XMLSchema.DATE);
+
+		Triple bobCreatedBook = vf.createTriple(bob, DCTERMS.CREATED, book);
+		Triple aliceKnowsBobCreatedBook = vf.createTriple(alice, FOAF.KNOWS, bobCreatedBook);
+		Triple bobCreatedBookKnowsAlice = vf.createTriple(bobCreatedBook, FOAF.KNOWS, alice);
+		Triple bookCreatorAlice = vf.createTriple(book, DCTERMS.CREATOR, alice);
+		Triple aliceCreatedBook = vf.createTriple(alice, DCTERMS.CREATED, book);
+		Triple abc = vf.createTriple(a, b, c);
+		Triple bobBirthdayDate = vf.createTriple(bob, FOAF.BIRTHDAY, birthDate);
+
+		try (InputStream in = this.getClass().getResourceAsStream("/test-rdfstar.ttls")) {
+			parser.parse(in, baseURI);
+
+			Collection<Statement> stmts = statementCollector.getStatements();
+
+			assertEquals(7, stmts.size());
+
+			assertTrue(stmts.contains(vf.createStatement(bob, FOAF.KNOWS, aliceKnowsBobCreatedBook)));
+			assertTrue(stmts.contains(vf.createStatement(bobCreatedBookKnowsAlice, DCTERMS.SOURCE, otherbook)));
+			assertTrue(stmts.contains(vf.createStatement(bobshomepage, DCTERMS.SOURCE, bookCreatorAlice)));
+			assertTrue(stmts.contains(vf.createStatement(bookCreatorAlice, DCTERMS.SOURCE, bobshomepage)));
+			assertTrue(stmts.contains(vf.createStatement(bookCreatorAlice, DCTERMS.REQUIRES, aliceCreatedBook)));
+			assertTrue(stmts.contains(vf.createStatement(abc, valid, abcDate)));
+			assertTrue(stmts.contains(vf.createStatement(bobBirthdayDate, DCTERMS.SOURCE, bobshomepage)));
+		}
+	}
+
+	@Test
+	public void testTripleInPredicate() throws IOException {
+		String data = "@prefix ex: <http://example.com/>.\nex:Example << <urn:a> <urn:b> <urn:c> >> \"foo\" .";
+		try (Reader r = new StringReader(data)) {
+			parser.parse(r, baseURI);
+			fail("Must fail with RDFParseException");
+		} catch (RDFParseException e) {
+			assertEquals("Illegal predicate value: <<urn:a urn:b urn:c>> [line 2]", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testTripleInDatatype() throws IOException {
+		String data = "@prefix ex: <http://example.com/>.\nex:Example ex:p \"foo\"^^<< <urn:a> <urn:b> <urn:c> >> .";
+		try (Reader r = new StringReader(data)) {
+			parser.parse(r, baseURI);
+			fail("Must fail with RDFParseException");
+		} catch (RDFParseException e) {
+			assertEquals("Illegal datatype value: <<urn:a urn:b urn:c>> [line 2]", e.getMessage());
+		}
+	}
+}

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarPrettyWriterTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarPrettyWriterTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarPrettyWriterTest extends RDFWriterTest {
+	public TurtleStarPrettyWriterTest() {
+		super(new TurtleStarWriterFactory(), new TurtleStarParserFactory(), true);
+	}
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(BasicWriterSettings.PRETTY_PRINT, true);
+	}
+}

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarPrettyWriterTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarPrettyWriterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtlestar;
+
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+
+/**
+ * @author Pavel Mihaylov
+ */
+public class TurtleStarWriterTest extends RDFWriterTest {
+	public TurtleStarWriterTest() {
+		super(new TurtleStarWriterFactory(), new TurtleStarParserFactory(), true);
+	}
+
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(BasicWriterSettings.PRETTY_PRINT, false);
+	}
+}

--- a/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterTest.java
+++ b/core/rio/turtlestar/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/turtlestar/src/test/resources/test-rdfstar.ttls
+++ b/core/rio/turtlestar/src/test/resources/test-rdfstar.ttls
@@ -1,0 +1,26 @@
+@prefix ex: <http://example.com/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+
+ex:bob foaf:knows << ex:alice foaf:knows<<ex:bob dct:created ex:book>> >> .
+
+<<<< ex:bob dct:created ex:book >> foaf:knows ex:alice >> dct:source ex:otherbook .
+
+ex:bobshomepage dct:source<< ex:book dct:creator ex:alice  >> .
+
+<< ex:book dct:creator ex:alice  >> dct:source  ex:bobshomepage .
+
+<< ex:book dct:creator ex:alice >> dct:requires << ex:alice dct:created ex:book >> .
+
+<<<http://example.org/a>ex:b ex:c>>ex:valid "1999-08-16"^^xsd:date .
+
+<< # Start of triple
+    ex:bob # triple subject
+    foaf:birthday # triple predicate
+    "1908-03-18"^^xsd:date # triple object
+>> # end of triple
+dct:source ex:bobshomepage .
+

--- a/core/rio/turtlestar/src/test/resources/test-rdfstar.ttls
+++ b/core/rio/turtlestar/src/test/resources/test-rdfstar.ttls
@@ -24,3 +24,6 @@ ex:bobshomepage dct:source<< ex:book dct:creator ex:alice  >> .
 >> # end of triple
 dct:source ex:bobshomepage .
 
+<< ex:book dct:title "Example book"@en >> dct:source  ex:bobshomepage .
+<< ex:book dct:title "Beispielbuch"@de>> dct:source ex:bobshomepage.
+<< ex:book dct:title "Example Book"@en-US>> dct:source ex:bobshomepage.


### PR DESCRIPTION
## What

This is a proposal for some changes in the Java API to accommodate future full-blown support for RDF* and SPARQL* (issue #1484). My idea was minimal disruptive changes and yet a natural view of RDF* data.

It also adds parsers and writers for Turtle* and TriG*. Turtle* extends Turtle to allow for RDF* triples and is the only format mentioned in the RDF* definition document. TriG* extends TriG in a similar manner to allow for RDF* and named graphs.

## Changes in the basic model

RDF* extends RDF by allowing _triples_ in the subject and object position. This can be achieved by:
* Adding a new type of ~~Value~~ Resource called Triple
  - Triple has a Resource subject, IRI predicate and Value object.
* ~~Adding a new type of Value called SubjectValue (essentially this could be called NonLiteral too)~~
   - ~~Triple extends SubjectValue~~
   - ~~Resource extends SubjectValue~~
* ~~Statement's subject's type changes from Resource to SubjectValue~~

Note that Triple is quite different from Statement. A Triple never has a context and it is a ~~Value~~ Resource.

## ~~Changes in some APIs~~

~~All API methods that take a Statement provided by its constituent objects (Resource subject, IRI predicate, Value object, Resource... context) change their subject argument to SubjectValue: SubjectValue subject, IRI predicate, Value object, Resource... context.~~

~~All API methods that return a subject change their return type from Resource to SubjectValue.~~

## ~~Existing RDF-only code~~

~~A lot of the existing code expects subjects to be a Resource so I've added SubjectValue.asResource() which will cast its argument to a Resource if it is indeed a Resource. If it's not a Resource (then it must be a Triple) it will throw an exception about trying to handle RDF* data from within an RDF context. This allows existing code to stay RDF-only as long as needed.~~

## ~~Notes on tests~~

~~All unit tests (mvn clean install) passed.~~
~~LocalRepositoryManagerTest relies on rdf4j 2.5.2 to satisfy a circular dependency and since the API changed it no longer works. I was able to run it locally by substituting 2.5.2 with a local bootstrap version.~~