### PR TITLE
GH-1867 pass parserconfig to protocol session

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -63,6 +63,7 @@ import org.eclipse.rdf4j.repository.sparql.query.SPARQLGraphQuery;
 import org.eclipse.rdf4j.repository.sparql.query.SPARQLTupleQuery;
 import org.eclipse.rdf4j.repository.sparql.query.SPARQLUpdate;
 import org.eclipse.rdf4j.repository.util.RDFLoader;
+import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandler;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
@@ -107,6 +108,12 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 	@Override
 	public String toString() {
 		return client.getQueryURL();
+	}
+
+	@Override
+	public void setParserConfig(ParserConfig parserConfig) {
+		client.setParserConfig(parserConfig);
+		super.setParserConfig(parserConfig);
 	}
 
 	@Override

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
+import org.eclipse.rdf4j.rio.ParserConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SPARQLConnectionTest {
+
+	private SPARQLConnection subject;
+	private SPARQLProtocolSession client;
+
+	@Before
+	public void setUp() throws Exception {
+		client = mock(SPARQLProtocolSession.class);
+		subject = new SPARQLConnection(null, client);
+	}
+
+	@Test
+	public void setParserConfigPassesToProtocolSession() throws Exception {
+		ParserConfig config = new ParserConfig();
+
+		subject.setParserConfig(config);
+		verify(client, times(1)).setParserConfig(config);
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #1867 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* SPARQLConnection passes its parser config on to client so it can be used for tweaking strictness of result processing.
* added simple unit test
