### PR TITLE
GH-1876: refactor join order optimizer and federation cost model

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/NJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/NJoin.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.rdf4j.federated.optimizer.JoinOrderOptimizer;
+import org.eclipse.rdf4j.federated.optimizer.StatementGroupAndJoinOptimizer;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.query.algebra.QueryModelVisitor;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
@@ -55,8 +55,8 @@ public class NJoin extends NTuple implements TupleExpr {
 	public Set<String> getJoinVariables(int joinIndex) {
 
 		Set<String> joinVars = new HashSet<>();
-		joinVars.addAll(JoinOrderOptimizer.getFreeVars(getArg(joinIndex - 1)));
-		joinVars.retainAll(JoinOrderOptimizer.getFreeVars(getArg(joinIndex)));
+		joinVars.addAll(StatementGroupAndJoinOptimizer.getFreeVars(getArg(joinIndex - 1)));
+		joinVars.retainAll(StatementGroupAndJoinOptimizer.getFreeVars(getArg(joinIndex)));
 		return joinVars;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/NTuple.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/NTuple.java
@@ -90,10 +90,12 @@ public abstract class NTuple extends AbstractQueryModelNode implements TupleExpr
 	public void replaceChildNode(QueryModelNode current, QueryModelNode replacement) {
 		int index = args.indexOf(current);
 
-		if (index >= 0)
+		if (index >= 0) {
 			args.set(index, (TupleExpr) replacement);
-		else
+			replacement.setParentNode(this);
+		} else {
 			super.replaceChildNode(current, replacement);
+		}
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -47,12 +47,13 @@ import org.eclipse.rdf4j.federated.evaluation.union.ParallelUnionOperatorTask;
 import org.eclipse.rdf4j.federated.evaluation.union.SynchronousWorkerUnion;
 import org.eclipse.rdf4j.federated.evaluation.union.WorkerUnionBase;
 import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
+import org.eclipse.rdf4j.federated.optimizer.DefaultFedXCostModel;
 import org.eclipse.rdf4j.federated.optimizer.FilterOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.GenericInfoOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.LimitOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.ServiceOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.SourceSelection;
-import org.eclipse.rdf4j.federated.optimizer.StatementGroupOptimizer;
+import org.eclipse.rdf4j.federated.optimizer.StatementGroupAndJoinOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.UnionOptimizer;
 import org.eclipse.rdf4j.federated.structures.FedXDataset;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
@@ -182,7 +183,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 
 		/*
 		 * TODO add some generic optimizers: - FILTER ?s=1 && ?s=2 => EmptyResult - Remove variables that are not
-		 * occuring in query stmts from filters
+		 * occurring in query stmts from filters
 		 */
 
 		/* custom optimizers, execute only when needed */
@@ -201,7 +202,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 		}
 
 		// optimize statement groups and join order
-		new StatementGroupOptimizer(queryInfo).optimize(query);
+		optimizeJoinOrder(query, queryInfo, info);
 
 		// potentially push limits (if applicable)
 		if (info.hasLimit()) {
@@ -242,7 +243,8 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 
 	protected void optimizeJoinOrder(TupleExpr query, QueryInfo queryInfo, GenericInfoOptimizer info) {
 		// optimize statement groups and join order
-		new StatementGroupOptimizer(queryInfo).optimize(query);
+		new StatementGroupAndJoinOptimizer(queryInfo, DefaultFedXCostModel.INSTANCE).optimize(query);
+
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoin.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.iterator.LazyMutableClosableIteration;
-import org.eclipse.rdf4j.federated.optimizer.JoinOrderOptimizer;
+import org.eclipse.rdf4j.federated.optimizer.StatementGroupAndJoinOptimizer;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.Binding;
@@ -48,7 +48,7 @@ public class HashJoin extends JoinExecutorBase<BindingSet> {
 		// the total number of bindings
 		int totalBindingsLeft = 0;
 		int totalBindingsRight = 0;
-		Collection<String> rightFreeVars = JoinOrderOptimizer.getFreeVars(rightArg);
+		Collection<String> rightFreeVars = StatementGroupAndJoinOptimizer.getFreeVars(rightArg);
 		Set<String> joinVars = getJoinVars();
 
 		// evaluate the right join argument

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/DefaultFedXCostModel.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/DefaultFedXCostModel.java
@@ -7,10 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.optimizer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -18,152 +14,30 @@ import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
 import org.eclipse.rdf4j.federated.algebra.FedXService;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
-import org.eclipse.rdf4j.federated.algebra.NTuple;
 import org.eclipse.rdf4j.federated.algebra.NUnion;
 import org.eclipse.rdf4j.federated.algebra.StatementSourcePattern;
-import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
-import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.Projection;
-import org.eclipse.rdf4j.query.algebra.Service;
-import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Join Order Optimizer
- * 
- * Group -> Statements according to number of free Variables
- * 
- * Additional Heuristics: - ExclusiveGroups are cheaper than any other subquery - owned statements are cheaper if they
- * have a single free variable
+ * Default implementation of the {@link FedXCostModel}
  * 
  * @author Andreas Schwarte
  *
  */
-public class JoinOrderOptimizer {
+public class DefaultFedXCostModel implements FedXCostModel {
 
-	private static final Logger log = LoggerFactory.getLogger(JoinOrderOptimizer.class);
+	public static DefaultFedXCostModel INSTANCE = new DefaultFedXCostModel();
 
-	public static List<TupleExpr> optimizeJoinOrder(List<TupleExpr> joinArgs) {
+	private static final Logger log = LoggerFactory.getLogger(DefaultFedXCostModel.class);
 
-		List<TupleExpr> optimized = new ArrayList<>(joinArgs.size());
-		List<TupleExpr> left = new LinkedList<>(joinArgs);
-		Set<String> joinVars = new HashSet<>();
-
-		while (!left.isEmpty()) {
-
-			TupleExpr item = left.get(0);
-
-			double minCost = Double.MAX_VALUE;
-			for (TupleExpr tmp : left) {
-
-				double currentCost = estimateCost(tmp, joinVars);
-				if (currentCost < minCost) {
-					item = tmp;
-					minCost = currentCost;
-				}
-			}
-
-			joinVars.addAll(getFreeVars(item));
-			if (log.isTraceEnabled())
-				log.trace("Cost of " + item.getClass().getSimpleName() + " is determined as " + minCost);
-			optimized.add(item);
-			left.remove(item);
-		}
-
-		return optimized;
-	}
-
-	public static List<ExclusiveStatement> optimizeGroupOrder(List<ExclusiveStatement> groupStmts) {
-
-		// in this case we do not have to order at all
-		if (groupStmts.size() == 1)
-			return groupStmts;
-
-		List<ExclusiveStatement> optimized = new ArrayList<>(groupStmts.size());
-		List<ExclusiveStatement> left = new LinkedList<>(groupStmts);
-		Set<String> joinVars = new HashSet<>();
-
-		while (!left.isEmpty()) {
-
-			ExclusiveStatement item = left.get(0);
-
-			double minCost = Double.MAX_VALUE;
-			for (ExclusiveStatement tmp : left) {
-
-				double currentCost = estimateCost(tmp, joinVars);
-				if (currentCost < minCost) {
-					item = tmp;
-					minCost = currentCost;
-				}
-			}
-
-			joinVars.addAll(getFreeVars(item));
-			optimized.add(item);
-			left.remove(item);
-		}
-
-		return optimized;
-	}
-
-	public static Collection<String> getFreeVars(TupleExpr tupleExpr) {
-		if (tupleExpr instanceof StatementTupleExpr)
-			return ((StatementTupleExpr) tupleExpr).getFreeVars();
-
-		// determine the number of free variables in a UNION or Join
-		if (tupleExpr instanceof NTuple) {
-			HashSet<String> freeVars = new HashSet<>();
-			NTuple ntuple = (NTuple) tupleExpr;
-			for (TupleExpr t : ntuple.getArgs())
-				freeVars.addAll(getFreeVars(t));
-			return freeVars;
-		}
-
-		if (tupleExpr instanceof FedXService) {
-			return ((FedXService) tupleExpr).getFreeVars();
-		}
-
-		if (tupleExpr instanceof Service) {
-			return ((Service) tupleExpr).getServiceVars();
-		}
-
-		// can happen in SERVICE nodes, if they cannot be optimized
-		if (tupleExpr instanceof StatementPattern) {
-			List<String> freeVars = new ArrayList<>();
-			StatementPattern st = (StatementPattern) tupleExpr;
-			if (st.getSubjectVar().getValue() == null)
-				freeVars.add(st.getSubjectVar().getName());
-			if (st.getPredicateVar().getValue() == null)
-				freeVars.add(st.getPredicateVar().getName());
-			if (st.getObjectVar().getValue() == null)
-				freeVars.add(st.getObjectVar().getName());
-			return freeVars;
-		}
-
-		if (tupleExpr instanceof Projection) {
-			Projection p = (Projection) tupleExpr;
-			return new ArrayList<>(p.getBindingNames());
-		}
-
-		if (tupleExpr instanceof BindingSetAssignment) {
-			return new ArrayList<>();
-		}
-
-		if (tupleExpr instanceof Extension) {
-			// for a BIND extension in our cost model we work with 0 free vars
-			return new ArrayList<String>();
-		}
-
-		throw new FedXRuntimeException("Type " + tupleExpr.getClass().getSimpleName()
-				+ " not supported for cost estimation. If you run into this, please report a bug.");
-
-	}
-
-	protected static double estimateCost(TupleExpr tupleExpr, Set<String> joinVars) {
+	@Override
+	public double estimateCost(TupleExpr tupleExpr, Set<String> joinVars) {
 
 		if (tupleExpr instanceof StatementSourcePattern)
 			return estimateCost((StatementSourcePattern) tupleExpr, joinVars);
@@ -190,7 +64,7 @@ public class JoinOrderOptimizer {
 		return 1000d;
 	}
 
-	protected static double estimateCost(ExclusiveGroup group, Set<String> joinVars) {
+	private double estimateCost(ExclusiveGroup group, Set<String> joinVars) {
 
 		// special heuristic: if not ordered at first place (i.e. there is a join var)
 		// use the same counting technique as for others
@@ -236,7 +110,7 @@ public class JoinOrderOptimizer {
 	 * 
 	 * @return
 	 */
-	private static double computeAdditionPatternCost(List<ExclusiveStatement> stmts) {
+	private double computeAdditionPatternCost(List<ExclusiveStatement> stmts) {
 
 		String s = null;
 		for (ExclusiveStatement st : stmts) {
@@ -248,7 +122,7 @@ public class JoinOrderOptimizer {
 		return 0.0;
 	}
 
-	protected static double estimateCost(ExclusiveStatement owned, Set<String> joinVars) {
+	private double estimateCost(ExclusiveStatement owned, Set<String> joinVars) {
 
 		/* currently the cost is the number of free vars that are executed in the join */
 
@@ -266,7 +140,7 @@ public class JoinOrderOptimizer {
 		return count;
 	}
 
-	protected static double estimateCost(FedXService service, Set<String> joinVars) {
+	private double estimateCost(FedXService service, Set<String> joinVars) {
 
 		int additionalCost = 0;
 
@@ -286,14 +160,14 @@ public class JoinOrderOptimizer {
 		return 0 + additionalCost + service.getFreeVarCount();
 	}
 
-	protected static double estimateCost(Projection projection, Set<String> joinVars) {
+	private double estimateCost(Projection projection, Set<String> joinVars) {
 
 		// cost estimator for sub query
 
 		return 0 + projection.getBindingNames().size();
 	}
 
-	protected static double estimateCost(StatementSourcePattern stmt, Set<String> joinVars) {
+	private double estimateCost(StatementSourcePattern stmt, Set<String> joinVars) {
 
 		/* currently the cost is the number of free vars that are executed in the join */
 
@@ -305,7 +179,7 @@ public class JoinOrderOptimizer {
 		return count;
 	}
 
-	protected static double estimateCost(NUnion nunion, Set<String> joinVars) {
+	private double estimateCost(NUnion nunion, Set<String> joinVars) {
 
 		// the unions cost is determined is determined by the minimum cost
 		// of the children + penalty cost of number of arguments
@@ -319,7 +193,7 @@ public class JoinOrderOptimizer {
 		return min + nunion.getNumberOfArguments() - 1;
 	}
 
-	protected static double estimateCost(NJoin join, Set<String> joinVars) {
+	private double estimateCost(NJoin join, Set<String> joinVars) {
 
 		// cost of a join is determined by the cost of the first join arg
 		// Note: the join order of this join is already determined (depth first)
@@ -328,4 +202,5 @@ public class JoinOrderOptimizer {
 
 		return cost + join.getNumberOfArguments() - 1;
 	}
+
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/FedXCostModel.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/FedXCostModel.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.optimizer;
+
+import java.util.Set;
+
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+/**
+ * Interface for a cost model used in {@link StatementGroupAndJoinOptimizer}.
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public interface FedXCostModel {
+
+	/**
+	 * Return the estimated cost for the given {@link TupleExpr}
+	 * 
+	 * @param tupleExpr
+	 * @param joinVars
+	 * @return the cost associated to the tupleExpr
+	 */
+	public double estimateCost(TupleExpr tupleExpr, Set<String> joinVars);
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/StatementGroupAndJoinOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/StatementGroupAndJoinOptimizer.java
@@ -8,18 +8,27 @@
 package org.eclipse.rdf4j.federated.optimizer;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.rdf4j.federated.algebra.EmptyNJoin;
 import org.eclipse.rdf4j.federated.algebra.EmptyResult;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
+import org.eclipse.rdf4j.federated.algebra.FedXService;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
-import org.eclipse.rdf4j.federated.algebra.TrueStatementPattern;
+import org.eclipse.rdf4j.federated.algebra.NTuple;
+import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
+import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
 import org.eclipse.rdf4j.federated.exception.OptimizationException;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
-import org.eclipse.rdf4j.federated.util.QueryStringUtil;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.Extension;
+import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.Service;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
@@ -32,20 +41,24 @@ import org.slf4j.LoggerFactory;
  * Optimizer with the following tasks:
  * 
  * 1. Group {@link ExclusiveStatement} into {@link ExclusiveGroup} 2. Adjust the join order using
- * {@link JoinOrderOptimizer}
+ * {@link DefaultFedXCostModel}
  * 
  * 
  * @author as
  */
-public class StatementGroupOptimizer extends AbstractQueryModelVisitor<OptimizationException> implements FedXOptimizer {
+public class StatementGroupAndJoinOptimizer extends AbstractQueryModelVisitor<OptimizationException>
+		implements FedXOptimizer {
 
-	private static final Logger log = LoggerFactory.getLogger(StatementGroupOptimizer.class);
+	private static final Logger log = LoggerFactory.getLogger(StatementGroupAndJoinOptimizer.class);
 
 	protected final QueryInfo queryInfo;
 
-	public StatementGroupOptimizer(QueryInfo queryInfo) {
+	private final FedXCostModel costModel;
+
+	public StatementGroupAndJoinOptimizer(QueryInfo queryInfo, FedXCostModel costModel) {
 		super();
 		this.queryInfo = queryInfo;
+		this.costModel = costModel;
 	}
 
 	@Override
@@ -70,20 +83,53 @@ public class StatementGroupOptimizer extends AbstractQueryModelVisitor<Optimizat
 
 	protected void meetNJoin(NJoin node) {
 
+		List<TupleExpr> args = node.getArgs();
+
+		// form groups
+		args = formGroups(args);
+
+		if (args.isEmpty()) {
+			node.replaceWith(new EmptyNJoin(node, queryInfo));
+			return;
+		}
+
+		// if the join args could be reduced to just one, e.g. ExclusiveGroup
+		// we can safely replace the join node
+		if (args.size() == 1) {
+			log.debug("Join arguments could be reduced to a single argument, replacing join node.");
+			node.replaceWith(args.get(0));
+			return;
+		}
+
+		// optimize the join order
+		args = optimizeJoinOrder(args);
+
+		// exchange the node
+		NJoin newNode = new NJoin(args, queryInfo);
+		node.replaceWith(newNode);
+	}
+
+	/**
+	 * Group {@link ExclusiveStatement}s having the same source into an {@link ExclusiveGroup}.
+	 * 
+	 * @param originalArgs
+	 * @return the new (potentially grouped) join arguments. If empty, the join will not produce any results.
+	 */
+	protected List<TupleExpr> formGroups(List<TupleExpr> originalArgs) {
+
 		LinkedList<TupleExpr> newArgs = new LinkedList<>();
 
-		LinkedList<TupleExpr> argsCopy = new LinkedList<>(node.getArgs());
+		LinkedList<TupleExpr> argsCopy = new LinkedList<>(originalArgs);
 		while (!argsCopy.isEmpty()) {
 
 			TupleExpr t = argsCopy.removeFirst();
 
 			/*
 			 * If one of the join arguments cannot produce results, the whole join expression does not produce results.
-			 * => replace with empty join and return
+			 * => return an null as marker to replace with empty join
 			 */
 			if (t instanceof EmptyResult) {
-				node.replaceWith(new EmptyNJoin(node, queryInfo));
-				return;
+				return Collections.emptyList();
 			}
 
 			/*
@@ -177,43 +223,109 @@ public class StatementGroupOptimizer extends AbstractQueryModelVisitor<Optimizat
 
 			}
 
-			/*
-			 * statement yields true in any case, not needed for join
-			 */
-			else if (t instanceof TrueStatementPattern) {
-				if (log.isDebugEnabled())
-					log.debug("Statement " + QueryStringUtil.toString((StatementPattern) t)
-							+ " yields results for at least one provided source, prune it.");
-			}
-
-			else
+			else {
 				newArgs.add(t);
+			}
 		}
 
-		// if the join args could be reduced to just one, e.g. OwnedGroup
-		// we can safely replace the join node
-		if (newArgs.size() == 1) {
-			log.debug("Join arguments could be reduced to a single argument, replacing join node.");
-			node.replaceWith(newArgs.get(0));
-			return;
-		}
-
-		// in rare cases the join args can be reduced to 0, e.g. if all statements are
-		// TrueStatementPatterns. We can safely replace the join node in such case
-		if (newArgs.isEmpty()) {
-			log.debug("Join could be pruned as all join statements evaluate to true, replacing join with true node.");
-			node.replaceWith(new TrueStatementPattern(new StatementPattern()));
-			return;
-		}
-
-		List<TupleExpr> optimized = newArgs;
-
-		// optimize the join order
-		optimized = JoinOrderOptimizer.optimizeJoinOrder(optimized);
-
-		// exchange the node
-		NJoin newNode = new NJoin(optimized, queryInfo);
-		node.replaceWith(newNode);
+		return newArgs;
 	}
 
+	/**
+	 * Join Order Optimizer
+	 * 
+	 * Group -> Statements according to number of free Variables
+	 * 
+	 * Additional Heuristics: - ExclusiveGroups are cheaper than any other subquery - owned statements are cheaper if
+	 * they have a single free variable
+	 * 
+	 * @param joinArgs
+	 * @return
+	 */
+	protected List<TupleExpr> optimizeJoinOrder(List<TupleExpr> joinArgs) {
+
+		List<TupleExpr> optimized = new ArrayList<>(joinArgs.size());
+		List<TupleExpr> left = new LinkedList<>(joinArgs);
+		Set<String> joinVars = new HashSet<>();
+
+		while (!left.isEmpty()) {
+
+			TupleExpr item = left.get(0);
+
+			double minCost = Double.MAX_VALUE;
+			for (TupleExpr tmp : left) {
+
+				double currentCost = estimateCost(tmp, joinVars);
+				if (currentCost < minCost) {
+					item = tmp;
+					minCost = currentCost;
+				}
+			}
+
+			joinVars.addAll(getFreeVars(item));
+			if (log.isTraceEnabled())
+				log.trace("Cost of " + item.getClass().getSimpleName() + " is determined as " + minCost);
+			optimized.add(item);
+			left.remove(item);
+		}
+
+		return optimized;
+	}
+
+	protected double estimateCost(TupleExpr tupleExpr, Set<String> joinVars) {
+		return costModel.estimateCost(tupleExpr, joinVars);
+	}
+
+	public static Collection<String> getFreeVars(TupleExpr tupleExpr) {
+		if (tupleExpr instanceof StatementTupleExpr)
+			return ((StatementTupleExpr) tupleExpr).getFreeVars();
+
+		// determine the number of free variables in a UNION or Join
+		if (tupleExpr instanceof NTuple) {
+			HashSet<String> freeVars = new HashSet<>();
+			NTuple ntuple = (NTuple) tupleExpr;
+			for (TupleExpr t : ntuple.getArgs())
+				freeVars.addAll(getFreeVars(t));
+			return freeVars;
+		}
+
+		if (tupleExpr instanceof FedXService) {
+			return ((FedXService) tupleExpr).getFreeVars();
+		}
+
+		if (tupleExpr instanceof Service) {
+			return ((Service) tupleExpr).getServiceVars();
+		}
+
+		// can happen in SERVICE nodes, if they cannot be optimized
+		if (tupleExpr instanceof StatementPattern) {
+			List<String> freeVars = new ArrayList<>();
+			StatementPattern st = (StatementPattern) tupleExpr;
+			if (st.getSubjectVar().getValue() == null)
+				freeVars.add(st.getSubjectVar().getName());
+			if (st.getPredicateVar().getValue() == null)
+				freeVars.add(st.getPredicateVar().getName());
+			if (st.getObjectVar().getValue() == null)
+				freeVars.add(st.getObjectVar().getName());
+			return freeVars;
+		}
+
+		if (tupleExpr instanceof Projection) {
+			Projection p = (Projection) tupleExpr;
+			return new ArrayList<>(p.getBindingNames());
+		}
+
+		if (tupleExpr instanceof BindingSetAssignment) {
+			return new ArrayList<>();
+		}
+
+		if (tupleExpr instanceof Extension) {
+			// for a BIND extension in our cost model we work with 0 free vars
+			return new ArrayList<String>();
+		}
+
+		throw new FedXRuntimeException("Type " + tupleExpr.getClass().getSimpleName()
+				+ " not supported for cost estimation. If you run into this, please report a bug.");
+
+	}
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXBaseTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXBaseTest.java
@@ -124,6 +124,10 @@ public abstract class FedXBaseTest {
 
 		String actualQueryPlan = federationContext().getQueryManager().getQueryPlan(readQueryString(queryFile));
 		String expectedQueryPlan = readResourceAsString(expectedPlanFile);
+		assertQueryPlanEquals(expectedQueryPlan, actualQueryPlan);
+	}
+
+	protected void assertQueryPlanEquals(String expectedQueryPlan, String actualQueryPlan) {
 
 		// make sure the comparison works cross operating system
 		expectedQueryPlan = expectedQueryPlan.replace("\r\n", "\n");
@@ -132,7 +136,6 @@ public abstract class FedXBaseTest {
 		actualQueryPlan = actualQueryPlan.replace("sparql_localhost:18080_repositories_", "");
 		actualQueryPlan = actualQueryPlan.replace("remote_", "");
 		Assertions.assertEquals(expectedQueryPlan, actualQueryPlan);
-
 	}
 
 	/**

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/JoinOptimizerTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/optimizer/JoinOptimizerTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.optimizer;
+
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.federated.SPARQLBaseTest;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class JoinOptimizerTest extends SPARQLBaseTest {
+
+	@Test
+	public void test_emptyJoinOptimizer() throws Exception {
+
+		prepareTest(
+				Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint2.ttl"));
+
+		// first part of the query produces 0 results, but make sure that this is optimized properly
+		// second half of the query is required to not have a SingleSourceQuery
+		String query = "SELECT ?person WHERE { "
+				+ "{ ?person <" + FOAF.NAME
+				+ "> ?name . ?person <urn:doesNotExistProp> ?obj . BIND(?name AS ?nameOut) } UNION { ?person <"
+				+ FOAF.INTEREST + "> ?o } }";
+
+		String actualQueryPlan = federationContext().getQueryManager().getQueryPlan(query);
+		assertQueryPlanEquals(readResourceAsString("/tests/optimizer/queryPlan_Join_1.txt"), actualQueryPlan);
+
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+			Assertions.assertEquals(2, Iterations.asList(tqr).size()); // two results from endpoint 2
+		}
+	}
+
+	@Test
+	public void test_checkedJoinOptimizer() throws Exception {
+
+		prepareTest(
+				Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint2.ttl"));
+
+		// both patterns of the query result in a exclusive statements at the respective endpoints
+		String query = "PREFIX : <http://example.org/> SELECT ?person WHERE { "
+				+ "{ :a <" + FOAF.NAME + "> 'Alan' . :a <" + FOAF.INTEREST
+				+ "> 'SPARQL 1.1 Basic Federated Query' } }";
+
+		String actualQueryPlan = federationContext().getQueryManager().getQueryPlan(query);
+		assertQueryPlanEquals(readResourceAsString("/tests/optimizer/queryPlan_Join_2.txt"), actualQueryPlan);
+
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+			Assertions.assertEquals(1, Iterations.asList(tqr).size()); // one result row, but no bindings
+		}
+	}
+}

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_1.txt
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_1.txt
@@ -1,0 +1,23 @@
+QueryRoot
+   Projection
+      ProjectionElemList
+         ProjectionElem "person"
+      NUnion
+         Extension
+            ExtensionElem (nameOut)
+               Var (name=name)
+            EmptyNJoin
+               ExclusiveStatement
+                  Var (name=person)
+                  Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
+                  Var (name=name)
+                  StatementSource (id=endpoint1, type=REMOTE)
+               EmptyStatementPattern
+                  Var (name=person)
+                  Var (name=_const_4240a169_uri, value=urn:doesNotExistProp, anonymous)
+                  Var (name=obj)
+         ExclusiveStatement
+            Var (name=person)
+            Var (name=_const_ea9562d5_uri, value=http://xmlns.com/foaf/0.1/interest, anonymous)
+            Var (name=o)
+            StatementSource (id=endpoint2, type=REMOTE)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_2.txt
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_2.txt
@@ -1,0 +1,18 @@
+QueryRoot
+   Projection
+      ProjectionElemList
+         ProjectionElem "person"
+      Extension
+         ExtensionElem (person)
+            Var (name=person)
+         NJoin
+            ExclusiveStatement
+               Var (name=_const_c0e515a0_uri, value=http://example.org/a, anonymous)
+               Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
+               Var (name=_const_1f2db8_lit_e2eec718_0, value="Alan", anonymous)
+               StatementSource (id=endpoint1, type=REMOTE)
+            ExclusiveStatement
+               Var (name=_const_c0e515a0_uri, value=http://example.org/a, anonymous)
+               Var (name=_const_ea9562d5_uri, value=http://xmlns.com/foaf/0.1/interest, anonymous)
+               Var (name=_const_5e79d277_lit_e2eec718_0, value="SPARQL 1.1 Basic Federated Query", anonymous)
+               StatementSource (id=endpoint2, type=REMOTE)


### PR DESCRIPTION
GitHub issue resolved: #1876 

Before we first release FedX I would like to use the chance to do refactoring and cleanup of code, which will help fus for future maintenance.

**The main goal of this refactoring is to**

a) have a clean definition of the cost model
b) have the grouping and optimizing done in an optimizer and avoid
static method invocations
c) provide extension points for the federation evaluation strategy to
customize the cost model

**Performed Changes:**

* StatementGroupOptimizer has been renamed to
StatementGroupAndJoinOptimizer as it was taking care for grouping and
optimizing the join order
* The large methods in the StatementGroupAndJoinOptimizer are split up
into smaller parts
* the JoinOrderOptimizer has been removed: all cost estimation functions
have been moved unchanged to DefaultFedXCostModel, the actual join order
functions have been integrated (unchanged) into
StatementGroupAndJoinOptimizer
* NTuple has been fixed to correctly set the parent node when replacing
children


