### PR TITLE
GH-1882: basic support for property path in FedX engine

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/DefaultFedXCostModel.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/DefaultFedXCostModel.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.federated.algebra.NJoin;
 import org.eclipse.rdf4j.federated.algebra.NUnion;
 import org.eclipse.rdf4j.federated.algebra.StatementSourcePattern;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
+import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.Projection;
@@ -57,6 +58,9 @@ public class DefaultFedXCostModel implements FedXCostModel {
 			return 0;
 		if (tupleExpr instanceof Extension) {
 			return 0;
+		}
+		if (tupleExpr instanceof ArbitraryLengthPath) {
+			return estimateCost((ArbitraryLengthPath) tupleExpr, joinVars);
 		}
 
 		log.warn("No cost estimation for " + tupleExpr.getClass().getSimpleName() + " available.");
@@ -203,4 +207,17 @@ public class DefaultFedXCostModel implements FedXCostModel {
 		return cost + join.getNumberOfArguments() - 1;
 	}
 
+	private double estimateCost(ArbitraryLengthPath path, Set<String> joinVars) {
+
+		/* currently the cost is the number of free vars that are executed in the join */
+
+		int count = 100;
+		for (String var : StatementGroupAndJoinOptimizer.getFreeVars(path.getPathExpression())) {
+			if (!joinVars.contains(var)) {
+				count++;
+			}
+		}
+
+		return count;
+	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/StatementGroupAndJoinOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/StatementGroupAndJoinOptimizer.java
@@ -23,9 +23,9 @@ import org.eclipse.rdf4j.federated.algebra.FedXService;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
 import org.eclipse.rdf4j.federated.algebra.NTuple;
 import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
-import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
 import org.eclipse.rdf4j.federated.exception.OptimizationException;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.Projection;
@@ -324,8 +324,12 @@ public class StatementGroupAndJoinOptimizer extends AbstractQueryModelVisitor<Op
 			return new ArrayList<String>();
 		}
 
-		throw new FedXRuntimeException("Type " + tupleExpr.getClass().getSimpleName()
-				+ " not supported for cost estimation. If you run into this, please report a bug.");
+		if (tupleExpr instanceof ArbitraryLengthPath) {
+			return getFreeVars(((ArbitraryLengthPath) tupleExpr).getPathExpression());
+		}
 
+		log.warn("Type " + tupleExpr.getClass().getSimpleName()
+				+ " not supported for cost estimation. If you run into this, please report a bug.");
+		return new ArrayList<String>();
 	}
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/PropertyPathTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/PropertyPathTests.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.SKOS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Sets;
+
+public class PropertyPathTests extends SPARQLBaseTest {
+
+	private static final String EXAMPLE_NAMESPACE = "http://example.org/";
+
+	@BeforeEach
+	public void before() {
+		QueryManager qm = federationContext().getQueryManager();
+		qm.addPrefixDeclaration("owl", OWL.NAMESPACE);
+		qm.addPrefixDeclaration("rdfs", RDFS.NAMESPACE);
+		qm.addPrefixDeclaration("skos", SKOS.NAMESPACE);
+		qm.addPrefixDeclaration("", EXAMPLE_NAMESPACE);
+	}
+
+	@Test
+	public void testArbitratyLengthPath() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/propertypath/data1.ttl", "/tests/propertypath/data2.ttl"));
+
+		String query = "SELECT * WHERE { ?subClass rdfs:subClassOf+ :MyClass . ?subClass rdfs:label ?label }";
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+
+			List<BindingSet> res = Iterations.asList(tqr);
+			assertContainsAll(res, "subClass",
+					Sets.newHashSet(iri("MySubClass1"), iri("MySubClass2"), iri("MySubSubClass1")));
+		}
+	}
+
+	@Test
+	public void testPropertyPath() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/propertypath/data1.ttl", "/tests/propertypath/data2.ttl"));
+
+		String query = "SELECT * WHERE { ?subClass rdfs:subClassOf/rdfs:label ?label }";
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+
+			List<BindingSet> res = Iterations.asList(tqr);
+			assertContainsAll(res, "subClass",
+					Sets.newHashSet(iri("MySubClass1"), iri("MySubClass2"), iri("MySubSubClass1")));
+		}
+	}
+
+	@Test
+	public void testPropertyPath_Alternatives() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/propertypath/data1.ttl", "/tests/propertypath/data2.ttl"));
+
+		String query = "SELECT * WHERE { ?concept a :MyClass . ?concept rdfs:label|skos:altLabel ?label }";
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+
+			List<BindingSet> res = Iterations.asList(tqr);
+
+			assertContainsAll(res, "label",
+					Sets.newHashSet(l("Concept1"), l("Concept1 AltLabel"), l("Concept2"), l("Concept2 AltLabel"),
+							l("Concept3"), l("Concept3 AltLabel")));
+		}
+	}
+
+	protected void assertContainsAll(List<BindingSet> res, String bindingName, Set<Value> expected) {
+		Assertions.assertEquals(expected,
+				res.stream().map(bs -> bs.getValue(bindingName)).collect(Collectors.toSet()));
+		Assertions.assertEquals(expected.size(), res.size());
+	}
+
+	private Literal l(String value) {
+		return SimpleValueFactory.getInstance().createLiteral(value);
+	}
+
+	private IRI iri(String localName) {
+		return SimpleValueFactory.getInstance().createIRI(EXAMPLE_NAMESPACE, localName);
+	}
+}

--- a/tools/federation/src/test/resources/tests/propertypath/data1.ttl
+++ b/tools/federation/src/test/resources/tests/propertypath/data1.ttl
@@ -1,0 +1,23 @@
+@prefix : <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . 
+@prefix owl:  <http://www.w3.org/2002/07/owl#> . 
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+:MyClass a owl:Class ;
+	rdfs:label "My Class" .
+	
+:MySubClass1 a owl:Class ;
+	rdfs:label "My Sub Class 1" ;
+	rdfs:subClassOf :MyClass .
+
+
+:Concept1 a :MyClass ;
+	rdfs:label "Concept1" ;
+	skos:altLabel "Concept1 AltLabel" .
+
+# note: we define altLabel in data2.ttl	
+:Concept2 a :MyClass ;
+	rdfs:label "Concept2" .

--- a/tools/federation/src/test/resources/tests/propertypath/data2.ttl
+++ b/tools/federation/src/test/resources/tests/propertypath/data2.ttl
@@ -1,0 +1,22 @@
+@prefix : <http://example.org/> .
+@prefix ns3: <http://namespace3.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . 
+@prefix owl:  <http://www.w3.org/2002/07/owl#> . 
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+:MySubClass2 a owl:Class ;
+	rdfs:label "My Sub Class 2" ;
+	rdfs:subClassOf :MyClass .
+
+:MySubSubClass1 a owl:Class ;
+	rdfs:label "My Sub Sub Class 1" ;
+	rdfs:subClassOf :MySubClass2 .
+	
+:Concept2 skos:altLabel "Concept2 AltLabel" .
+
+:Concept3 a :MyClass ;
+	rdfs:label "Concept3" ;
+	skos:altLabel "Concept3 AltLabel" .


### PR DESCRIPTION

GitHub issue resolved: #1882

This change adds basic support for property paths in the federation
engine.

Example patterns:

* `?subClass rdfs:subClassOf/rdfs:label ?label`
* `?class rdfs:subClassOf+ ?class`
* `?concept rdfs:label|skos:altLabel ?label`

Note that some adjustments to queryalgebra PathIteration were required:

* as in FedX we generate SPARQL query strings, variables must not
contain the "-" character (which is invalid for SPARQL queries). This
character is replaced with _
* in the FedX engine we are not seeing "QueryBindingSet" instances, but
"MapBindingSet" instances. The addBinding method is made robust to
support both instance types
* in remote settings we even see ListBindingSet. In the check we make
sure to convert the BindingSet instance if required

Note also that the cost model estimation now only shows a warning if the
type of the node is unknown.


