### PR TITLE
GH-1883 unhandled namespaces of statement subjects for TurtleWriter

### DIFF
--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -332,6 +332,10 @@ class ArrangedWriter implements RDFWriter {
 
 	private void getUsedNamespaces(Set<Statement> stmts, Set<String> used) {
 		for (Statement st : stmts) {
+			if (st.getSubject() instanceof IRI) {
+				IRI uri = (IRI) st.getSubject();
+				used.add(uri.getNamespace());
+			}
 			used.add(st.getPredicate().getNamespace());
 			if (st.getObject() instanceof IRI) {
 				IRI uri = (IRI) st.getObject();

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriterTest.java
@@ -5,7 +5,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
 import org.eclipse.rdf4j.rio.Rio;
@@ -52,7 +51,6 @@ public class ArrangedWriterTest {
 
 		input.setNamespace("org", exNs);
 		input.setNamespace("net", otherNs);
-		input.setNamespace(RDF.NS);
 
 		ByteArrayOutputStream outputWriter = new ByteArrayOutputStream();
 		write(input, outputWriter);
@@ -66,7 +64,7 @@ public class ArrangedWriterTest {
 
 	private void write(Model model, OutputStream writer) {
 		RDFWriter rdfWriter = writerFactory.getWriter(writer);
-		// without "pretty print" namespace-handling is delegated to TurtleWriter
+		// "pretty print" forces ArrangedWriter to handle namespaces
 		rdfWriter.getWriterConfig().set(BasicWriterSettings.PRETTY_PRINT, true);
 		Rio.write(model, rdfWriter);
 	}

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriterTest.java
@@ -1,0 +1,73 @@
+package org.eclipse.rdf4j.rio.turtle;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author TriangularIT
+ */
+public class ArrangedWriterTest {
+	private ValueFactory vf;
+
+	private IRI uri1;
+
+	private IRI uri2;
+
+	private String exNs;
+
+	private RDFWriterFactory writerFactory;
+
+	public ArrangedWriterTest() {
+		vf = SimpleValueFactory.getInstance();
+
+		exNs = "http://example.org/";
+
+		uri1 = vf.createIRI(exNs, "uri1");
+		uri2 = vf.createIRI(exNs, "uri2");
+
+		writerFactory = new TurtleWriterFactory();
+	}
+
+	@Test
+	public void testWriteSingleStatementWithSubjectNamespace() {
+		String otherNs = "http://example.net/";
+		IRI uri0 = vf.createIRI(otherNs, "uri0");
+
+		Model input = new LinkedHashModel();
+		input.add(vf.createStatement(uri0, uri1, uri2));
+
+		input.setNamespace("org", exNs);
+		input.setNamespace("net", otherNs);
+		input.setNamespace(RDF.NS);
+
+		ByteArrayOutputStream outputWriter = new ByteArrayOutputStream();
+		write(input, outputWriter);
+
+		String expectedResult = "@prefix net: <http://example.net/> .\n" +
+				"@prefix org: <http://example.org/> .\n\n" +
+				"net:uri0 org:uri1 org:uri2 .\n";
+
+		assertEquals(expectedResult, outputWriter.toString());
+	}
+
+	private void write(Model model, OutputStream writer) {
+		RDFWriter rdfWriter = writerFactory.getWriter(writer);
+		// without "pretty print" namespace-handling is delegated to TurtleWriter
+		rdfWriter.getWriterConfig().set(BasicWriterSettings.PRETTY_PRINT, true);
+		Rio.write(model, rdfWriter);
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #1883

This change amends the pretty-printer of the TurtleWriter to take the namespaces of subjects of statements into account.