### PR TITLE
GH-1882: optimization for property paths with an exclusive endpoint

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveArbitraryLengthPath.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveArbitraryLengthPath.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.algebra;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
+import org.eclipse.rdf4j.federated.util.QueryStringUtil;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+import com.google.common.collect.Lists;
+
+/**
+ * An {@link ArbitraryLengthPath} node which can be evaluated at a single node.
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public class ExclusiveArbitraryLengthPath extends ArbitraryLengthPath
+		implements ExclusiveTupleExpr, ExclusiveTupleExprRenderer {
+
+	private static final long serialVersionUID = 5743134085306940200L;
+
+	private final StatementSource owner;
+
+	private final QueryInfo queryInfo;
+
+	private final List<String> freeVars;
+
+	public ExclusiveArbitraryLengthPath(ArbitraryLengthPath path, StatementSource owner, QueryInfo queryInfo) {
+		super(path.getScope(), path.getSubjectVar(), path.getPathExpression(), path.getObjectVar(),
+				path.getContextVar(), path.getMinLength());
+		this.owner = owner;
+		this.queryInfo = queryInfo;
+		this.freeVars = computeFreeVars();
+	}
+
+	private List<String> computeFreeVars() {
+		if (this.getPathExpression() instanceof StatementTupleExpr) {
+			return ((StatementTupleExpr) this.getPathExpression()).getFreeVars();
+		}
+		List<String> freeVars = Lists.newArrayList();
+		if (!getSubjectVar().hasValue()) {
+			freeVars.add(getSubjectVar().getName());
+		}
+		if (!getObjectVar().hasValue()) {
+			freeVars.add(getObjectVar().getName());
+		}
+		return freeVars;
+	}
+
+	@Override
+	public StatementSource getOwner() {
+		return owner;
+	}
+
+	@Override
+	public ExclusiveArbitraryLengthPath clone() {
+		return new ExclusiveArbitraryLengthPath(super.clone(), owner, queryInfo);
+	}
+
+	@Override
+	public String toQueryString(Set<String> varNames, BindingSet bindings) {
+		return QueryStringUtil.toString(this, varNames, bindings);
+	}
+
+	@Override
+	public TupleExpr toQueryAlgebra(Set<String> varNames, BindingSet bindings) {
+		return QueryAlgebraUtil.toTupleExpr(this, varNames, bindings);
+	}
+
+	@Override
+	public List<String> getFreeVars() {
+		return freeVars;
+	}
+
+	@Override
+	public QueryInfo getQueryInfo() {
+		return this.queryInfo;
+	}
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveStatement.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveStatement.java
@@ -29,7 +29,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
  * 
  * @author Andreas Schwarte
  */
-public class ExclusiveStatement extends FedXStatementPattern {
+public class ExclusiveStatement extends FedXStatementPattern implements ExclusiveTupleExpr {
 
 	private static final long serialVersionUID = -6963394279179263763L;
 
@@ -38,6 +38,7 @@ public class ExclusiveStatement extends FedXStatementPattern {
 		statementSources.add(owner);
 	}
 
+	@Override
 	public StatementSource getOwner() {
 		return getStatementSources().get(0);
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveTupleExpr.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveTupleExpr.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.algebra;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+/**
+ * Interface representing nodes that can exclusively be evaluated at a single {@link StatementSource}.
+ * <p>
+ * Implementations are recommended to additionally implement {@link ExclusiveTupleExprRenderer}
+ * </p>
+ * 
+ * @author Andreas Schwarte
+ * @see ExclusiveStatement
+ */
+public interface ExclusiveTupleExpr extends TupleExpr, QueryRef {
+
+	/**
+	 * 
+	 * @return the owner for this expression
+	 */
+	public StatementSource getOwner();
+
+	/**
+	 * @return a list of free (i.e. unbound) variables in this expression
+	 */
+	public List<String> getFreeVars();
+
+	/**
+	 * @return the number of free (i.e. unbound) variables in this expression
+	 */
+	public default int getFreeVarCount() {
+		return getFreeVars().size();
+	}
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveTupleExprRenderer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveTupleExprRenderer.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.algebra;
+
+import java.util.Set;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+/**
+ * A specialization of {@link ExclusiveTupleExpr} which provides definitions how the expressions can be rendered to a
+ * sub-query.
+ * 
+ * <p>
+ * This is required for the evaluation of sub queries.
+ * </p>
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public interface ExclusiveTupleExprRenderer extends ExclusiveTupleExpr {
+
+	/**
+	 * Returns a SPARQL string representation of this expression that can be inserted into a SELECT query.
+	 * <p>
+	 * Implementations are required to create a valid query string for this expression where the given bindings are
+	 * inserted.
+	 * </p>
+	 * 
+	 * @param varNames the set of resulting (unbound) variables from this expression
+	 * @param bindings the optional input bindings
+	 * @return the query string part
+	 */
+	public String toQueryString(Set<String> varNames, BindingSet bindings);
+
+	/**
+	 * Returns a SPARQL algebra representation of this expression that can be inserted into a SELECT {@link TupleExpr}
+	 * <p>
+	 * Implementations are required to create a new equivalent expression or clone, where any provided input bindings
+	 * are inserted. The free variable names after insertion need to be added to the provided set.
+	 * </p>
+	 * 
+	 * @param varNames the set of resulting (unbound) variables from this expression
+	 * @param bindings the input bindings that need to be inserted
+	 * @return the algebra expression
+	 */
+	public TupleExpr toQueryAlgebra(Set<String> varNames, BindingSet bindings);
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlTripleSource.java
@@ -12,7 +12,7 @@ import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.federated.FederationContext;
-import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.endpoint.SparqlEndpointConfiguration;
@@ -177,7 +177,7 @@ public class SparqlTripleSource extends TripleSourceBase implements TripleSource
 	}
 
 	@Override
-	public boolean hasStatements(ExclusiveGroup group,
+	public boolean hasStatements(ExclusiveTupleExpr expr,
 			BindingSet bindings)
 			throws RepositoryException, MalformedQueryException,
 			QueryEvaluationException {
@@ -186,9 +186,9 @@ public class SparqlTripleSource extends TripleSourceBase implements TripleSource
 
 			/* remote select limit 1 query */
 			try (RepositoryConnection conn = endpoint.getConnection()) {
-				String queryString = QueryStringUtil.selectQueryStringLimit1(group, bindings);
+				String queryString = QueryStringUtil.selectQueryStringLimit1(expr, bindings);
 				TupleQuery query = conn.prepareTupleQuery(QueryLanguage.SPARQL, queryString);
-				configureInference(query, group.getQueryInfo());
+				configureInference(query, expr.getQueryInfo());
 				applyMaxExecutionTimeUpperBound(query);
 
 				monitorRemoteRequest();
@@ -204,7 +204,7 @@ public class SparqlTripleSource extends TripleSourceBase implements TripleSource
 		}
 
 		// default handling: use ASK query
-		return super.hasStatements(group, bindings);
+		return super.hasStatements(expr, bindings);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.federated.evaluation;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.federated.structures.QueryType;
@@ -149,18 +150,19 @@ public interface TripleSource {
 			throws RepositoryException;
 
 	/**
-	 * Check if the repository can return results for the given {@link ExclusiveGroup}, i.e. a list of Statements
+	 * Check if the repository can return results for the given {@link ExclusiveTupleExpr}, e.g. for an
+	 * {@link ExclusiveGroup} with a list of Statements.
 	 * 
 	 * @param bindings
 	 * @return whether the repository can return results
 	 * @throws RepositoryException
 	 */
-	public boolean hasStatements(ExclusiveGroup group, BindingSet bindings)
+	public boolean hasStatements(ExclusiveTupleExpr expr, BindingSet bindings)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 
 	/**
 	 * 
-	 * @return true if a prepared query is to be used preferrably, false otherwise
+	 * @return true if a prepared query is to be used preferably, false otherwise
 	 */
 	public boolean usePreparedQuery();
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
@@ -13,7 +13,7 @@ import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.federated.FederationContext;
-import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.iterator.CloseDependentConnectionIteration;
 import org.eclipse.rdf4j.federated.evaluation.iterator.GraphToBindingSetConversionIteration;
@@ -105,7 +105,7 @@ public abstract class TripleSourceBase implements TripleSource {
 	}
 
 	@Override
-	public boolean hasStatements(ExclusiveGroup group, BindingSet bindings)
+	public boolean hasStatements(ExclusiveTupleExpr group, BindingSet bindings)
 			throws RepositoryException, MalformedQueryException,
 			QueryEvaluationException {
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/ExclusiveTupleExprOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/ExclusiveTupleExprOptimizer.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.optimizer;
+
+import org.eclipse.rdf4j.federated.algebra.ExclusiveArbitraryLengthPath;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
+import org.eclipse.rdf4j.federated.exception.OptimizationException;
+import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
+import org.eclipse.rdf4j.query.algebra.Service;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+
+/**
+ * A specialized optimizer which identifies and marks {@link ExclusiveTupleExpr}.
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public class ExclusiveTupleExprOptimizer extends AbstractQueryModelVisitor<OptimizationException>
+		implements FedXOptimizer {
+
+	@Override
+	public void optimize(TupleExpr tupleExpr) {
+		tupleExpr.visit(this);
+	}
+
+	@Override
+	public void meet(ArbitraryLengthPath node) throws OptimizationException {
+
+		if (node.getPathExpression() instanceof ExclusiveStatement) {
+			ExclusiveStatement st = (ExclusiveStatement) node.getPathExpression();
+			ExclusiveArbitraryLengthPath eNode = new ExclusiveArbitraryLengthPath(node, st.getOwner(),
+					st.getQueryInfo());
+			node.replaceWith(eNode);
+			return;
+		}
+		super.meet(node);
+	}
+
+	@Override
+	public void meet(Service node) throws OptimizationException {
+		// do not optimize anything within SERVICE
+	}
+
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/StatementGroupAndJoinOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/StatementGroupAndJoinOptimizer.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.federated.algebra.EmptyNJoin;
 import org.eclipse.rdf4j.federated.algebra.EmptyResult;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.FedXService;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
 import org.eclipse.rdf4j.federated.algebra.NTuple;
@@ -133,81 +134,32 @@ public class StatementGroupAndJoinOptimizer extends AbstractQueryModelVisitor<Op
 			}
 
 			/*
-			 * for exclusive statements find those belonging to the same source (if any) and form exclusive group
-			 */
-			else if (t instanceof ExclusiveStatement) {
-				ExclusiveStatement current = (ExclusiveStatement) t;
-
-				List<ExclusiveStatement> l = null;
-				List<ExclusiveGroup> toRemoveFromArgs = null; // contains exclusive groups have to be removed
-				for (TupleExpr te : argsCopy) {
-					/*
-					 * in the remaining join args find exclusive statements having the same source, and add to a list
-					 * which is later used to form an exclusive group
-					 */
-					if (te instanceof ExclusiveStatement) {
-						ExclusiveStatement check = (ExclusiveStatement) te;
-						if (check.getOwner().equals(current.getOwner())) {
-							if (l == null) {
-								l = new ArrayList<>();
-								l.add(current);
-							}
-							l.add(check);
-						}
-					}
-					/*
-					 * also scan for exclusive groups having the same owner
-					 */
-					else if (te instanceof ExclusiveGroup) {
-						ExclusiveGroup check = (ExclusiveGroup) te;
-						if (check.getOwner().equals(current.getOwner())) {
-							if (l == null) {
-								l = new ArrayList<>();
-								l.add(current);
-							}
-							if (toRemoveFromArgs == null) {
-								toRemoveFromArgs = new ArrayList<>();
-							}
-							toRemoveFromArgs.add(check);
-							l.addAll(check.getStatements());
-						}
-					}
-				}
-
-				// check if we can construct a group, otherwise add directly
-				if (l != null) {
-					argsCopy.removeAll(l);
-					if (toRemoveFromArgs != null) {
-						argsCopy.removeAll(toRemoveFromArgs);
-					}
-					newArgs.add(new ExclusiveGroup(l, current.getOwner(), queryInfo));
-				} else {
-					newArgs.add(current);
-				}
-			}
-
-			/*
-			 * for (existing) exclusive groups (e.g. created by SERVICE clauses) add potential ExclusiveStatements with
+			 * for (existing) exclusive groups (e.g. created by SERVICE clauses) add potential ExclusiveTupleExpr with
 			 * the same source to the group
 			 */
 			else if (t instanceof ExclusiveGroup) {
 
 				ExclusiveGroup current = (ExclusiveGroup) t;
 
-				List<ExclusiveStatement> l = null;
+				List<ExclusiveTupleExpr> l = null;
 				for (TupleExpr te : argsCopy) {
+
 					/*
-					 * in the remaining join args find exclusive statements having the same source, and add to a list
-					 * which is later used to form an exclusive group
+					 * in the remaining join args find exclusive statements / expressions having the same source, and
+					 * add to a list which is later used to form an exclusive group
 					 */
-					if (te instanceof ExclusiveStatement) {
-						ExclusiveStatement check = (ExclusiveStatement) te;
+					if (te instanceof ExclusiveTupleExpr) {
+						ExclusiveTupleExpr check = (ExclusiveTupleExpr) te;
 						if (check.getOwner().equals(current.getOwner())) {
 							if (l == null) {
 								l = new ArrayList<>();
-								l.addAll(current.getStatements());
+								l.addAll(current.getExclusiveExpressions());
 							}
-							l.add(check);
+							if (check instanceof ExclusiveGroup) {
+								l.addAll((((ExclusiveGroup) check).getExclusiveExpressions()));
+							} else {
+								l.add(check);
+							}
 						}
 					}
 				}
@@ -221,6 +173,62 @@ public class StatementGroupAndJoinOptimizer extends AbstractQueryModelVisitor<Op
 					newArgs.add(current);
 				}
 
+			}
+
+			/*
+			 * for exclusive statements find those belonging to the same source (if any) and form exclusive group
+			 */
+			else if (t instanceof ExclusiveTupleExpr) {
+				ExclusiveTupleExpr current = (ExclusiveTupleExpr) t;
+
+				List<ExclusiveTupleExpr> l = null;
+				List<ExclusiveGroup> toRemoveFromArgs = null; // contains exclusive groups have to be removed
+				for (TupleExpr te : argsCopy) {
+					/*
+					 * scan for exclusive groups having the same owner and flatten
+					 */
+					if (te instanceof ExclusiveGroup) {
+						ExclusiveGroup check = (ExclusiveGroup) te;
+						if (check.getOwner().equals(current.getOwner())) {
+							if (l == null) {
+								l = new ArrayList<>();
+								l.add(current);
+							}
+							if (toRemoveFromArgs == null) {
+								toRemoveFromArgs = new ArrayList<>();
+							}
+							toRemoveFromArgs.add(check);
+							l.addAll(check.getExclusiveExpressions());
+						}
+					}
+
+					/*
+					 * in the remaining join args find exclusive expressions‚ having the same source, and add to a list
+					 * which is later used to form an exclusive group
+					 */
+					else if (te instanceof ExclusiveTupleExpr) {
+						ExclusiveTupleExpr check = (ExclusiveTupleExpr) te;
+						if (check.getOwner().equals(current.getOwner())) {
+							if (l == null) {
+								l = new ArrayList<>();
+								l.add(current);
+							}
+							l.add(check);
+						}
+					}
+
+				}
+
+				// check if we can construct a group, otherwise add directly
+				if (l != null) {
+					argsCopy.removeAll(l);
+					if (toRemoveFromArgs != null) {
+						argsCopy.removeAll(toRemoveFromArgs);
+					}
+					newArgs.add(new ExclusiveGroup(l, current.getOwner(), queryInfo));
+				} else {
+					newArgs.add(current);
+				}
 			}
 
 			else {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
@@ -20,6 +20,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExprRenderer;
 import org.eclipse.rdf4j.federated.algebra.FedXStatementPattern;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
 import org.eclipse.rdf4j.federated.evaluation.SparqlFederationEvalStrategyWithValues;
@@ -31,6 +33,8 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
+import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
@@ -87,6 +91,42 @@ public class QueryStringUtil {
 		sb.append("; ");
 		appendVar(sb, stmt.getObjectVar(), new HashSet<>(), EmptyBindingSet.getInstance());
 		sb.append("}");
+		return sb.toString();
+	}
+
+	/**
+	 * Converts an {@link ArbitraryLengthPath} node to a sub query string and makes sure to insert any bindings.
+	 * 
+	 * <p>
+	 * This method assumes that the {@link ArbitraryLengthPath#getPathExpression()} is a {@link StatementPattern}.
+	 * </p>
+	 * 
+	 * @param node
+	 * @param varNames
+	 * @param bindings
+	 * @return the query string
+	 */
+	public static String toString(ArbitraryLengthPath node, Set<String> varNames, BindingSet bindings) {
+
+		// assumes that the path expr is a statement pattern
+		if (!(node.getPathExpression() instanceof StatementPattern)) {
+			throw new IllegalArgumentException("Can only handle path expressions of type StatementPattern, was "
+					+ node.getPathExpression().getClass());
+		}
+
+		StatementPattern stmt = (StatementPattern) node.getPathExpression();
+
+		StringBuilder sb = new StringBuilder();
+
+		sb = appendVar(sb, stmt.getSubjectVar(), varNames, bindings).append(" ");
+
+		// append the path expression with the modifier
+		sb = appendVar(sb, stmt.getPredicateVar(), varNames, bindings);
+		sb.append(node.getMinLength() == 0 ? "*" : "+");
+		sb.append(" ");
+
+		sb = appendVar(sb, stmt.getObjectVar(), varNames, bindings).append(" . ");
+
 		return sb.toString();
 	}
 
@@ -162,6 +202,58 @@ public class QueryStringUtil {
 	}
 
 	/**
+	 * Construct a SELECT query for the provided {@link ExclusiveTupleExprRenderer}
+	 * 
+	 * @param stmt
+	 * @param bindings
+	 * @param filterExpr
+	 * @param evaluated  parameter can be used outside this method to check whether FILTER has been evaluated, false in
+	 *                   beginning
+	 * 
+	 * @return the SELECT query
+	 * @throws IllegalQueryException if the query does not have any free variables
+	 */
+	public static String selectQueryString(ExclusiveTupleExprRenderer expr, BindingSet bindings,
+			FilterValueExpr filterExpr,
+			AtomicBoolean evaluated) throws IllegalQueryException {
+
+		Set<String> varNames = new HashSet<>();
+		String s = constructJoinArg(expr, varNames, bindings);
+
+		StringBuilder res = new StringBuilder();
+
+		res.append("SELECT ");
+
+		if (varNames.isEmpty())
+			throw new IllegalQueryException("SELECT query needs at least one projection!");
+
+		for (String var : varNames)
+			res.append(" ?").append(var);
+
+		res.append(" WHERE { ").append(s);
+
+		if (filterExpr != null) {
+			try {
+				String filter = FilterUtils.toSparqlString(filterExpr);
+				res.append("FILTER ").append(filter);
+				evaluated.set(true);
+			} catch (Exception e) {
+				log.debug("Filter could not be evaluated remotely. " + e.getMessage());
+				log.trace("Details: ", e);
+			}
+		}
+
+		res.append(" }");
+
+		// TODO add support for this in ExclusiveTupleExprRenderer
+//		long upperLimit = stmt.getUpperLimit();
+//		if (upperLimit > 0) {
+//			res.append(" LIMIT ").append(upperLimit);
+//		}
+		return res.toString();
+	}
+
+	/**
 	 * Construct a SELECT query for the provided {@link ExclusiveGroup}. Note that bindings and filterExpr are applied
 	 * whenever possible.
 	 * 
@@ -181,8 +273,8 @@ public class QueryStringUtil {
 		StringBuilder sb = new StringBuilder();
 		Set<String> varNames = new HashSet<>();
 
-		for (ExclusiveStatement s : group.getStatements())
-			sb.append(constructStatement(s, varNames, bindings));
+		for (ExclusiveTupleExpr s : group.getExclusiveExpressions())
+			sb.append(constructJoinArg(s, varNames, bindings));
 
 		if (varNames.isEmpty())
 			throw new IllegalQueryException("SELECT query needs at least one projection!");
@@ -212,23 +304,19 @@ public class QueryStringUtil {
 	}
 
 	/**
-	 * Transform the exclusive group into a ASK query string
+	 * Transform the {@link ExclusiveTupleExpr} into a ASK query string
 	 * 
-	 * @param group
+	 * @param expr
 	 * @param bindings
 	 * @return the ASK query string
 	 * @throws IllegalQueryException
 	 */
-	public static String askQueryString(ExclusiveGroup group, BindingSet bindings) {
+	public static String askQueryString(ExclusiveTupleExpr expr, BindingSet bindings) {
 
-		StringBuilder sb = new StringBuilder();
 		Set<String> varNames = new HashSet<>();
 
-		for (ExclusiveStatement s : group.getStatements())
-			sb.append(constructStatement(s, varNames, bindings));
-
 		StringBuilder res = new StringBuilder();
-		res.append("ASK { ").append(sb.toString()).append(" }");
+		res.append("ASK { ").append(constructJoinArg(expr, varNames, bindings)).append(" }");
 		return res.toString();
 	}
 
@@ -402,6 +490,42 @@ public class QueryStringUtil {
 	}
 
 	/**
+	 * Construct a query substring from the {@link ExclusiveTupleExpr} that can be used as an argument to a
+	 * {@link Join}.
+	 * <p>
+	 * This method can only be used for {@link ExclusiveTupleExpr} that additionally provide
+	 * {@link ExclusiveTupleExprRenderer} capabilities. An exception to this is if the given expression is a
+	 * {@link StatementPattern}, e.g. an {@link ExclusiveStatement} or {@link ExclusiveGroup}.
+	 * </p>
+	 * 
+	 * @param exclusiveExpr
+	 * @param varNames
+	 * @param bindings
+	 * @return the query string with bindings inserted
+	 */
+	protected static String constructJoinArg(ExclusiveTupleExpr exclusiveExpr, Set<String> varNames,
+			BindingSet bindings) {
+
+		if (exclusiveExpr instanceof StatementPattern) {
+			return constructStatement((StatementPattern) exclusiveExpr, varNames, bindings);
+		}
+
+		if (exclusiveExpr instanceof ExclusiveGroup) {
+			StringBuilder sb = new StringBuilder();
+			for (ExclusiveTupleExpr s : ((ExclusiveGroup) exclusiveExpr).getExclusiveExpressions()) {
+				sb.append(constructJoinArg(s, varNames, bindings));
+			}
+			return sb.toString();
+		}
+
+		if (!(exclusiveExpr instanceof ExclusiveTupleExprRenderer)) {
+			throw new IllegalStateException("Cannot render tupl expr of type " + exclusiveExpr.getClass());
+		}
+
+		return ((ExclusiveTupleExprRenderer) exclusiveExpr).toQueryString(varNames, bindings);
+	}
+
+	/**
 	 * Construct a boolean ASK query for the provided statement.
 	 * 
 	 * @param stmt
@@ -443,6 +567,31 @@ public class QueryStringUtil {
 	}
 
 	/**
+	 * Construct a SELECT query for the provided expr with LIMIT 1. Such query can be used for source selection instead
+	 * of ASK queries.
+	 * 
+	 * @param stmt
+	 * @param bindings
+	 * @return the SELECT query string
+	 */
+	public static String selectQueryStringLimit1(ExclusiveTupleExpr expr, BindingSet bindings) {
+
+		if (expr instanceof ExclusiveGroup) {
+			return selectQueryStringLimit1((ExclusiveGroup) expr, bindings);
+		}
+
+		Set<String> varNames = new HashSet<>();
+		String s = constructJoinArg(expr, varNames, bindings);
+
+		StringBuilder res = new StringBuilder();
+
+		res.append("SELECT * WHERE {");
+		res.append(s).append(" } LIMIT 1");
+
+		return res.toString();
+	}
+
+	/**
 	 * Construct a SELECT query for the provided {@link ExclusiveGroup} with LIMIT 1. Such query can be used for source
 	 * selection instead of ASK queries.
 	 * 
@@ -457,8 +606,8 @@ public class QueryStringUtil {
 
 		res.append("SELECT * WHERE { ");
 
-		for (ExclusiveStatement s : group.getStatements())
-			res.append(constructStatement(s, varNames, bindings));
+		for (ExclusiveTupleExpr s : group.getExclusiveExpressions())
+			res.append(constructJoinArg(s, varNames, bindings));
 
 		res.append(" } LIMIT 1");
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/PropertyPathTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/PropertyPathTests.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
@@ -38,6 +39,7 @@ public class PropertyPathTests extends SPARQLBaseTest {
 		qm.addPrefixDeclaration("owl", OWL.NAMESPACE);
 		qm.addPrefixDeclaration("rdfs", RDFS.NAMESPACE);
 		qm.addPrefixDeclaration("skos", SKOS.NAMESPACE);
+		qm.addPrefixDeclaration("foaf", FOAF.NAMESPACE);
 		qm.addPrefixDeclaration("", EXAMPLE_NAMESPACE);
 	}
 
@@ -65,7 +67,7 @@ public class PropertyPathTests extends SPARQLBaseTest {
 
 			List<BindingSet> res = Iterations.asList(tqr);
 			assertContainsAll(res, "subClass",
-					Sets.newHashSet(iri("MySubClass1"), iri("MySubClass2"), iri("MySubSubClass1")));
+					Sets.newHashSet(iri("MySubClass1"), iri("MySubClass2"), iri("MySubSubClass1"), FOAF.PERSON));
 		}
 	}
 
@@ -83,6 +85,67 @@ public class PropertyPathTests extends SPARQLBaseTest {
 					Sets.newHashSet(l("Concept1"), l("Concept1 AltLabel"), l("Concept2"), l("Concept2 AltLabel"),
 							l("Concept3"), l("Concept3 AltLabel")));
 		}
+	}
+
+	@Test
+	public void testPropertyPath_ExclusiveGroup() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/propertypath/data1.ttl", "/tests/propertypath/data2.ttl"));
+
+		String query = "SELECT * WHERE { ?concept a skos:Concept . ?concept skos:broader+ :mammals . ?concept rdfs:label ?label}";
+
+		String actualQueryPlan = federationContext().getQueryManager().getQueryPlan(query);
+		assertQueryPlanEquals(readResourceAsString("/tests/propertypath/query_path_exclusiveGroup.qp"),
+				actualQueryPlan);
+
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+
+			List<BindingSet> res = Iterations.asList(tqr);
+
+			assertContainsAll(res, "label",
+					Sets.newHashSet(l("Bovinae"), l("Cows")));
+			assertContainsAll(res, "concept",
+					Sets.newHashSet(iri("bovinae"), iri("cows")));
+		}
+	}
+
+	@Test
+	public void testPropertyPath_ExclusivePath() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/propertypath/data1.ttl", "/tests/propertypath/data2.ttl"));
+
+		String query = "SELECT * WHERE { ?x rdf:type/rdfs:subClassOf* foaf:Agent . ?x rdfs:label ?label}";
+
+		String actualQueryPlan = federationContext().getQueryManager().getQueryPlan(query);
+
+		// Note: we currently cannot compare the query plan, because the queryplan contains generated
+		// variable name identifiers for anonymous nodes.
+//		assertQueryPlanEquals(readResourceAsString("/tests/propertypath/query_path_exclusivePath.qp"),
+//				actualQueryPlan);
+		Assertions.assertTrue(actualQueryPlan.contains("ExclusiveArbitraryLengthPath"));
+
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+
+			List<BindingSet> res = Iterations.asList(tqr);
+
+			assertContainsAll(res, "label",
+					Sets.newHashSet(l("Person 1"), l("Person 2")));
+		}
+	}
+
+	@Test
+	public void testPropertyPath_BoundInJoin() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/propertypath/data1.ttl", "/tests/propertypath/data2.ttl"));
+
+		String query = "SELECT * WHERE { BIND(foaf:Person AS ?subClass) . ?subClass rdfs:subClassOf+ foaf:Agent . ?subClass rdfs:label ?label }";
+		try (TupleQueryResult tqr = federationContext().getQueryManager().prepareTupleQuery(query).evaluate()) {
+
+			List<BindingSet> res = Iterations.asList(tqr);
+			assertContainsAll(res, "subClass", Sets.newHashSet(FOAF.PERSON));
+			assertContainsAll(res, "label", Sets.newHashSet(l("Person")));
+		}
+
 	}
 
 	protected void assertContainsAll(List<BindingSet> res, String bindingName, Set<Value> expected) {

--- a/tools/federation/src/test/resources/tests/propertypath/data1.ttl
+++ b/tools/federation/src/test/resources/tests/propertypath/data1.ttl
@@ -21,3 +21,23 @@
 # note: we define altLabel in data2.ttl	
 :Concept2 a :MyClass ;
 	rdfs:label "Concept2" .
+
+# data for exclusive path
+foaf:Agent a owl:Class ; 
+	rdfs:label "Agent" .
+foaf:Person rdfs:subClassOf foaf:Agent ;
+	rdfs:label "Person" .
+:Person1 a foaf:Agent ;
+	rdfs:label "Person 1" .
+:Person2 a foaf:Person ;
+	rdfs:label "Person 2" .
+	
+:SubConcept1 a :MySubClass1 ;
+	rdfs:label "Sub Concept 1" .
+
+# small taxonomie
+:mammals rdf:type skos:Concept .
+:bovinae rdf:type skos:Concept ;
+	skos:broader :mammals .
+:cows rdf:type skos:Concept ;
+	skos:broader :bovinae .

--- a/tools/federation/src/test/resources/tests/propertypath/data2.ttl
+++ b/tools/federation/src/test/resources/tests/propertypath/data2.ttl
@@ -20,3 +20,8 @@
 :Concept3 a :MyClass ;
 	rdfs:label "Concept3" ;
 	skos:altLabel "Concept3 AltLabel" .
+
+# labels for SKOS concepts
+:mammals rdfs:label "Mammals" .
+:bovinae rdfs:label "Bovinae" .
+:cows rdfs:label "Cows" .

--- a/tools/federation/src/test/resources/tests/propertypath/query_path_exclusiveGroup.qp
+++ b/tools/federation/src/test/resources/tests/propertypath/query_path_exclusiveGroup.qp
@@ -1,0 +1,26 @@
+QueryRoot
+   Projection
+      ProjectionElemList
+         ProjectionElem "concept"
+         ProjectionElem "label"
+      NJoin
+         ExclusiveGroup
+            ExclusiveStatement
+               Var (name=concept)
+               Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
+               Var (name=_const_4171603_uri, value=http://www.w3.org/2004/02/skos/core#Concept, anonymous)
+               StatementSource (id=endpoint1, type=REMOTE)
+            ExclusiveArbitraryLengthPath
+               Var (name=concept)
+               ExclusiveStatement
+                  Var (name=concept)
+                  Var (name=_const_7123f66a_uri, value=http://www.w3.org/2004/02/skos/core#broader, anonymous)
+                  Var (name=_const_da6a40f3_uri, value=http://example.org/mammals, anonymous)
+                  StatementSource (id=endpoint1, type=REMOTE)
+               Var (name=_const_da6a40f3_uri, value=http://example.org/mammals, anonymous)
+         StatementSourcePattern
+            Var (name=concept)
+            Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
+            Var (name=label)
+            StatementSource (id=endpoint1, type=REMOTE)
+            StatementSource (id=endpoint2, type=REMOTE)

--- a/tools/federation/src/test/resources/tests/propertypath/query_path_exclusivePath.qp
+++ b/tools/federation/src/test/resources/tests/propertypath/query_path_exclusivePath.qp
@@ -1,0 +1,26 @@
+QueryRoot
+   Projection
+      ProjectionElemList
+         ProjectionElem "x"
+         ProjectionElem "label"
+      NJoin
+         ExclusiveArbitraryLengthPath
+            Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
+            ExclusiveStatement
+               Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
+               Var (name=_const_4592be07_uri, value=http://www.w3.org/2000/01/rdf-schema#subClassOf, anonymous)
+               Var (name=_const_50c92f1a_uri, value=http://xmlns.com/foaf/0.1/Agent, anonymous)
+               StatementSource (id=endpoint1, type=REMOTE)
+            Var (name=_const_50c92f1a_uri, value=http://xmlns.com/foaf/0.1/Agent, anonymous)
+         StatementSourcePattern
+            Var (name=x)
+            Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
+            Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
+            StatementSource (id=endpoint1, type=REMOTE)
+            StatementSource (id=endpoint2, type=REMOTE)
+         StatementSourcePattern
+            Var (name=x)
+            Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
+            Var (name=label)
+            StatementSource (id=endpoint1, type=REMOTE)
+            StatementSource (id=endpoint2, type=REMOTE)


### PR DESCRIPTION
This change provides an optimization for property path expressions that
yield results at a single endpoint. Similarly to the concept of
ExclusiveStatement we now use a marker for them.

We introduce the interface ExclusiveTuplExpr which can now be used to
declare any exclusive TupleExpr. Note that the existing
ExclusiveStatement and ExclusiveGroup nodes have also become instances
of ExclusiveTupleExpr.

For rendering such nodes in sub-queries the ExclusiveTupleExprRenderer
interface is defined. Additionally, some rendering logic is introduced
in the Query utility classes.

Note that ExclusiveGroups are now generalized such that they can contain
any ExclusiveTupleExpr (and not only ExclusiveStatements).

Notes:

* the if/else branches in StatementGroupAndJoinOptimizer were shuffled
around such that the instanceOf check is working correctly
(ExclusiveGroup is now an instanceof ExclusiveTuplExpr)


GitHub issue resolved: #1882 