### PR TITLE
GH-1538: Move getFreeVars method to QueryAlgebraUtil

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/NJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/NJoin.java
@@ -11,8 +11,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.rdf4j.federated.optimizer.StatementGroupAndJoinOptimizer;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
 import org.eclipse.rdf4j.query.algebra.QueryModelVisitor;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 
@@ -55,8 +55,8 @@ public class NJoin extends NTuple implements TupleExpr {
 	public Set<String> getJoinVariables(int joinIndex) {
 
 		Set<String> joinVars = new HashSet<>();
-		joinVars.addAll(StatementGroupAndJoinOptimizer.getFreeVars(getArg(joinIndex - 1)));
-		joinVars.retainAll(StatementGroupAndJoinOptimizer.getFreeVars(getArg(joinIndex)));
+		joinVars.addAll(QueryAlgebraUtil.getFreeVars(getArg(joinIndex - 1)));
+		joinVars.retainAll(QueryAlgebraUtil.getFreeVars(getArg(joinIndex)));
 		return joinVars;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoin.java
@@ -16,8 +16,8 @@ import java.util.Set;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.iterator.LazyMutableClosableIteration;
-import org.eclipse.rdf4j.federated.optimizer.StatementGroupAndJoinOptimizer;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -48,7 +48,7 @@ public class HashJoin extends JoinExecutorBase<BindingSet> {
 		// the total number of bindings
 		int totalBindingsLeft = 0;
 		int totalBindingsRight = 0;
-		Collection<String> rightFreeVars = StatementGroupAndJoinOptimizer.getFreeVars(rightArg);
+		Collection<String> rightFreeVars = QueryAlgebraUtil.getFreeVars(rightArg);
 		Set<String> joinVars = getJoinVars();
 
 		// evaluate the right join argument

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/DefaultFedXCostModel.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/DefaultFedXCostModel.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.federated.algebra.FedXService;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
 import org.eclipse.rdf4j.federated.algebra.NUnion;
 import org.eclipse.rdf4j.federated.algebra.StatementSourcePattern;
+import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
@@ -224,7 +225,7 @@ public class DefaultFedXCostModel implements FedXCostModel {
 		/* currently the cost is the number of free vars that are executed in the join */
 
 		int count = 100;
-		for (String var : StatementGroupAndJoinOptimizer.getFreeVars(path.getPathExpression())) {
+		for (String var : QueryAlgebraUtil.getFreeVars(path.getPathExpression())) {
 			if (!joinVars.contains(var)) {
 				count++;
 			}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/StatementGroupAndJoinOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/StatementGroupAndJoinOptimizer.java
@@ -8,7 +8,6 @@
 package org.eclipse.rdf4j.federated.optimizer;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -20,20 +19,12 @@ import org.eclipse.rdf4j.federated.algebra.EmptyResult;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
-import org.eclipse.rdf4j.federated.algebra.FedXService;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
-import org.eclipse.rdf4j.federated.algebra.NTuple;
-import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
 import org.eclipse.rdf4j.federated.exception.OptimizationException;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
-import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
-import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
-import org.eclipse.rdf4j.query.algebra.Extension;
-import org.eclipse.rdf4j.query.algebra.LeftJoin;
-import org.eclipse.rdf4j.query.algebra.Projection;
+import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.Service;
-import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.slf4j.Logger;
@@ -271,7 +262,7 @@ public class StatementGroupAndJoinOptimizer extends AbstractQueryModelVisitor<Op
 				}
 			}
 
-			joinVars.addAll(getFreeVars(item));
+			joinVars.addAll(QueryAlgebraUtil.getFreeVars(item));
 			if (log.isTraceEnabled())
 				log.trace("Cost of " + item.getClass().getSimpleName() + " is determined as " + minCost);
 			optimized.add(item);
@@ -283,67 +274,5 @@ public class StatementGroupAndJoinOptimizer extends AbstractQueryModelVisitor<Op
 
 	protected double estimateCost(TupleExpr tupleExpr, Set<String> joinVars) {
 		return costModel.estimateCost(tupleExpr, joinVars);
-	}
-
-	public static Collection<String> getFreeVars(TupleExpr tupleExpr) {
-		if (tupleExpr instanceof StatementTupleExpr)
-			return ((StatementTupleExpr) tupleExpr).getFreeVars();
-
-		// determine the number of free variables in a UNION or Join
-		if (tupleExpr instanceof NTuple) {
-			HashSet<String> freeVars = new HashSet<>();
-			NTuple ntuple = (NTuple) tupleExpr;
-			for (TupleExpr t : ntuple.getArgs())
-				freeVars.addAll(getFreeVars(t));
-			return freeVars;
-		}
-
-		if (tupleExpr instanceof FedXService) {
-			return ((FedXService) tupleExpr).getFreeVars();
-		}
-
-		if (tupleExpr instanceof Service) {
-			return ((Service) tupleExpr).getServiceVars();
-		}
-
-		// can happen in SERVICE nodes, if they cannot be optimized
-		if (tupleExpr instanceof StatementPattern) {
-			List<String> freeVars = new ArrayList<>();
-			StatementPattern st = (StatementPattern) tupleExpr;
-			if (st.getSubjectVar().getValue() == null)
-				freeVars.add(st.getSubjectVar().getName());
-			if (st.getPredicateVar().getValue() == null)
-				freeVars.add(st.getPredicateVar().getName());
-			if (st.getObjectVar().getValue() == null)
-				freeVars.add(st.getObjectVar().getName());
-			return freeVars;
-		}
-
-		if (tupleExpr instanceof Projection) {
-			Projection p = (Projection) tupleExpr;
-			return new ArrayList<>(p.getBindingNames());
-		}
-
-		if (tupleExpr instanceof BindingSetAssignment) {
-			return new ArrayList<>();
-		}
-
-		if (tupleExpr instanceof Extension) {
-			// for a BIND extension in our cost model we work with 0 free vars
-			return new ArrayList<String>();
-		}
-
-		if (tupleExpr instanceof ArbitraryLengthPath) {
-			return getFreeVars(((ArbitraryLengthPath) tupleExpr).getPathExpression());
-		}
-
-		if (tupleExpr instanceof LeftJoin) {
-			// for our cost model we treat as expensive and work with 0 free vars
-			return new ArrayList<String>();
-		}
-
-		log.warn("Type " + tupleExpr.getClass().getSimpleName()
-				+ " not supported for cost estimation. If you run into this, please report a bug.");
-		return new ArrayList<String>();
 	}
 }


### PR DESCRIPTION

GitHub issue resolved: #1538

This change moves the general method that inspects TupleExpr for free
variables to QueryAlgebraUtils. Background is to have it in a more
convenient place.

In addition the computation of free variables for LeftJoin is improved.

