### PR TITLE
ID-1538: restructure the FedX algebra interface hierarchy

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXTupleExpr.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXTupleExpr.java
@@ -7,21 +7,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.algebra;
 
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
 /**
- * Interface representing nodes that can exclusively be evaluated at a single {@link StatementSource}.
- * <p>
- * Implementations are recommended to additionally implement {@link ExclusiveTupleExprRenderer}
- * </p>
+ * Interface marking known FedX algebra nodes.
  * 
  * @author Andreas Schwarte
- * @see ExclusiveStatement
+ * @see StatementTupleExpr
+ * @see ExclusiveTupleExpr
  */
-public interface ExclusiveTupleExpr extends FedXTupleExpr {
+public interface FedXTupleExpr extends TupleExpr, VariableExpr, QueryRef {
 
 	/**
-	 * 
-	 * @return the owner for this expression
+	 * @return the number of free (i.e. unbound) variables in this expression
 	 */
-	public StatementSource getOwner();
-
+	public default int getFreeVarCount() {
+		return getFreeVars().size();
+	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementTupleExpr.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementTupleExpr.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
-import org.eclipse.rdf4j.query.algebra.TupleExpr;
 
 /**
  * Interface for any expression that can be evaluated
@@ -23,22 +22,12 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
  * @see ExclusiveStatement
  * @see ExclusiveGroup
  */
-public interface StatementTupleExpr extends TupleExpr, QueryRef {
+public interface StatementTupleExpr extends FedXTupleExpr, QueryRef {
 
 	/**
 	 * @return the id of this expr
 	 */
 	public String getId();
-
-	/**
-	 * @return a list of free (i.e. unbound) variables in this expression
-	 */
-	public List<String> getFreeVars();
-
-	/**
-	 * @return the number of free (i.e. unbound) variables in this expression
-	 */
-	public int getFreeVarCount();
 
 	/**
 	 * @return a list of sources that are relevant for evaluation of this expression

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/VariableExpr.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/VariableExpr.java
@@ -7,21 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.algebra;
 
+import java.util.List;
+
+import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
+
 /**
- * Interface representing nodes that can exclusively be evaluated at a single {@link StatementSource}.
- * <p>
- * Implementations are recommended to additionally implement {@link ExclusiveTupleExprRenderer}
- * </p>
+ * Interface for algebra nodes that can return the free variables of the expression.
  * 
  * @author Andreas Schwarte
- * @see ExclusiveStatement
+ * @see QueryAlgebraUtil#getFreeVars(org.eclipse.rdf4j.query.algebra.TupleExpr)
  */
-public interface ExclusiveTupleExpr extends FedXTupleExpr {
+public interface VariableExpr {
 
 	/**
-	 * 
-	 * @return the owner for this expression
+	 * @return a list of free (i.e. unbound) variables in this expression
 	 */
-	public StatementSource getOwner();
-
+	public List<String> getFreeVars();
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/DefaultFedXCostModel.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/DefaultFedXCostModel.java
@@ -65,7 +65,7 @@ public class DefaultFedXCostModel implements FedXCostModel {
 			return estimateCost((ArbitraryLengthPath) tupleExpr, joinVars);
 		}
 
-		log.warn("No cost estimation for " + tupleExpr.getClass().getSimpleName() + " available.");
+		log.debug("No cost estimation for " + tupleExpr.getClass().getSimpleName() + " available.");
 
 		return 1000d;
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryAlgebraUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryAlgebraUtil.java
@@ -19,9 +19,10 @@ import org.eclipse.rdf4j.federated.algebra.ExclusiveStatement;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExprRenderer;
 import org.eclipse.rdf4j.federated.algebra.FedXService;
+import org.eclipse.rdf4j.federated.algebra.FedXTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
+import org.eclipse.rdf4j.federated.algebra.VariableExpr;
 import org.eclipse.rdf4j.federated.algebra.NTuple;
-import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
 import org.eclipse.rdf4j.federated.exception.IllegalQueryException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
@@ -522,10 +523,17 @@ public class QueryAlgebraUtil {
 	 * 
 	 * @param tupleExpr the expression
 	 * @return the free variables
+	 * @see VariableExpr
 	 */
 	public static Collection<String> getFreeVars(TupleExpr tupleExpr) {
-		if (tupleExpr instanceof StatementTupleExpr)
-			return ((StatementTupleExpr) tupleExpr).getFreeVars();
+
+		if (tupleExpr instanceof FedXTupleExpr) {
+			return ((FedXTupleExpr) tupleExpr).getFreeVars();
+		}
+
+		if (tupleExpr instanceof VariableExpr) {
+			return ((VariableExpr) tupleExpr).getFreeVars();
+		}
 
 		// determine the number of free variables in a UNION or Join
 		if (tupleExpr instanceof NTuple) {
@@ -583,8 +591,8 @@ public class QueryAlgebraUtil {
 			return freeVars;
 		}
 
-		log.warn("Type " + tupleExpr.getClass().getSimpleName()
-				+ " not supported for cost estimation. If you run into this, please report a bug.");
+		log.debug("Type " + tupleExpr.getClass().getSimpleName()
+				+ " not supported for computing free vars. If you run into this, please report a bug.");
 		return new ArrayList<String>();
 	}
 }


### PR DESCRIPTION
This change restructures the FedX algebra interface hierarchy to share
common methods of all nodes.

The most top-level interface for any FedX specific algebra node is now a
FedXTupleExpr.

In addition, we have the new interface VariableExpr which can be used to
determine the free variables (e.g. during cost estimation).

Note that the logging severity for unknown nodes is reduced to DEBUG as
the fallback values are sufficient for most cases.

