### PR TITLE
GH-1904: fix ThredPool initialization in FedX

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ControlledWorkerScheduler.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ControlledWorkerScheduler.java
@@ -112,8 +112,10 @@ public class ControlledWorkerScheduler<T> implements Scheduler<T> {
 
 	protected void initWorkerThreads() {
 
-		executor = new ThreadPoolExecutor(Math.min(10, nWorkers / 2), nWorkers, 30L, TimeUnit.SECONDS, _taskQueue,
+		ThreadPoolExecutor _executor = new ThreadPoolExecutor(nWorkers, nWorkers, 60L, TimeUnit.SECONDS, _taskQueue,
 				new NamingThreadFactory(name));
+		_executor.allowCoreThreadTimeOut(true);
+		this.executor = _executor;
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ControlledWorkerScheduler.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ControlledWorkerScheduler.java
@@ -38,14 +38,14 @@ import org.slf4j.LoggerFactory;
  */
 public class ControlledWorkerScheduler<T> implements Scheduler<T> {
 
-	protected static final Logger log = LoggerFactory.getLogger(ControlledWorkerScheduler.class);
+	private static final Logger log = LoggerFactory.getLogger(ControlledWorkerScheduler.class);
 
-	protected ExecutorService executor;
+	private final ExecutorService executor;
 
-	protected LinkedBlockingQueue<Runnable> _taskQueue = new LinkedBlockingQueue<>();
+	private final LinkedBlockingQueue<Runnable> _taskQueue = new LinkedBlockingQueue<>();
 
-	protected int nWorkers;
-	protected String name;
+	private final int nWorkers;
+	private final String name;
 
 	/**
 	 * Construct a new instance with 20 workers.
@@ -63,7 +63,7 @@ public class ControlledWorkerScheduler<T> implements Scheduler<T> {
 	public ControlledWorkerScheduler(int nWorkers, String name) {
 		this.nWorkers = nWorkers;
 		this.name = name;
-		initWorkerThreads();
+		this.executor = createExecutorService();
 	}
 
 	/**
@@ -110,12 +110,12 @@ public class ControlledWorkerScheduler<T> implements Scheduler<T> {
 		return _taskQueue.size();
 	}
 
-	protected void initWorkerThreads() {
+	private ExecutorService createExecutorService() {
 
-		ThreadPoolExecutor _executor = new ThreadPoolExecutor(nWorkers, nWorkers, 60L, TimeUnit.SECONDS, _taskQueue,
+		ThreadPoolExecutor executor = new ThreadPoolExecutor(nWorkers, nWorkers, 60L, TimeUnit.SECONDS, _taskQueue,
 				new NamingThreadFactory(name));
-		_executor.allowCoreThreadTimeOut(true);
-		this.executor = _executor;
+		executor.allowCoreThreadTimeOut(true);
+		return executor;
 	}
 
 	@Override
@@ -179,13 +179,11 @@ public class ControlledWorkerScheduler<T> implements Scheduler<T> {
 		throw new RuntimeException("Unsupported Operation for this scheduler.");
 	}
 
-	protected class WorkerRunnable implements Runnable {
+	class WorkerRunnable implements Runnable {
 
-		protected final ParallelTask<T> task;
+		private final ParallelTask<T> task;
 
-		protected boolean inTask = false;
-
-		protected boolean aborted = false;
+		private boolean aborted = false;
 
 		public WorkerRunnable(ParallelTask<T> task) {
 			super();
@@ -201,12 +199,10 @@ public class ControlledWorkerScheduler<T> implements Scheduler<T> {
 			ParallelExecutor<T> taskControl = task.getControl();
 
 			try {
-				inTask = true;
 				if (log.isTraceEnabled()) {
 					log.trace("Performing task " + task.toString() + " in " + Thread.currentThread().getName());
 				}
 				CloseableIteration<T, QueryEvaluationException> res = task.performTask();
-				inTask = false;
 				taskControl.addResult(res);
 
 				taskControl.done(); // in most cases this is a no-op


### PR DESCRIPTION
GitHub issue resolved: #1904 

In FedX we use configurable threadpools for executing join and union sub
queries, as well as other remote requests. Also the pool size is meant
to be configurable via FedXConfig setters.

However, due to a bug in the construction of the ThreadPoolExecutor the
size is always set to a most 10 threads. This is because we have an
unbound queue and set the minimumCoreSize to 10. In such setting new
threads are only created if the core size of the pool is not reached.

We now explicitly set the core pool size to the configured number of
workers, and in addition configure the pool in such a way that idle
threads can get destroyed. The idle timeout is set to 60s.
