### PR TITLE
GH-1538: do not require existence of base directory at FedX construction

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
@@ -169,13 +169,10 @@ public class FedXFactory {
 	/**
 	 * Configure the FedX base directory at federation construction time.
 	 * 
-	 * @param fedxBaseDir the existing fedx base directory
+	 * @param fedxBaseDir the fedx base directory
 	 * @return the {@link FedXFactory} instance
 	 */
 	public FedXFactory withFedXBaseDir(File fedxBaseDir) {
-		if (!fedxBaseDir.isDirectory()) {
-			throw new IllegalArgumentException("Base directory does not exist: " + fedxBaseDir);
-		}
 		this.fedxBaseDir = fedxBaseDir;
 		return this;
 	}


### PR DESCRIPTION
At construction time of the FedX factory we actually do not require the
existence of the base directory.

Actually the base directory is only required to exist in rare federation
setups (e.g. with a managed NativeStore). This is because FedX currently
does not persist files to disk. Note that this was recently changed by
switching to an in-memory cache.

To make the federation factory work with different implementations of a
RepositoryManager and to not require the existence of potentially empty
directories we no longer throw an Exception.


GitHub issue resolved: #1538 
