### PR TITLE
GH-1795 MemoryStore computes next snapshot number on commit

### DIFF
--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
@@ -7,6 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.base;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -38,10 +42,6 @@ import org.eclipse.rdf4j.sail.helpers.NotifyingSailConnectionBase;
 import org.eclipse.rdf4j.sail.inferencer.InferencerConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * A {@link SailConnection} implementation that is based on an {@link SailStore} .
@@ -336,9 +336,7 @@ public abstract class SailSourceConnection extends NotifyingSailConnectionBase
 	@Override
 	protected void commitInternal() throws SailException {
 		SailSource toCloseInferredBranch = includeInferredBranch;
-		explicitOnlyBranch = null;
-		inferredOnlyBranch = null;
-		includeInferredBranch = null;
+		clearBranchReferences();
 		try {
 			if (toCloseInferredBranch != null) {
 				toCloseInferredBranch.flush();
@@ -673,6 +671,19 @@ public abstract class SailSourceConnection extends NotifyingSailConnectionBase
 	@Override
 	public void flushUpdates() throws SailException {
 		flush();
+	}
+
+	protected SailSource getIncludeInferredBranch() {
+		return includeInferredBranch;
+	}
+
+	/**
+	 * Sets internal branch references to {@code null} to allow garbage collection.
+	 */
+	protected void clearBranchReferences() {
+		explicitOnlyBranch = null;
+		inferredOnlyBranch = null;
+		includeInferredBranch = null;
 	}
 
 	@Override

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerIsolationLevelTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerIsolationLevelTest.java
@@ -7,10 +7,24 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.inferencer.fc;
 
+import org.eclipse.rdf4j.IsolationLevel;
+import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailConflictException;
+import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailIsolationLevelTest;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * An extension of {@link SailIsolationLevelTest} for testing the {@link SchemaCachingRDFSInferencer}.
@@ -25,6 +39,83 @@ public class SchemaCachingRDFSInferencerIsolationLevelTest extends SailIsolation
 	protected Sail createSail() throws SailException {
 		// TODO we are testing the inferencer, not the store. We should use a mock here instead of a real memory store.
 		return new SchemaCachingRDFSInferencer(new MemoryStore());
+	}
+
+	/*
+	 * Checks that there is no leak between transactions. When one transactions adds a lot of data to the store another
+	 * transaction should see either nothing added or everything added. Nothing in between.
+	 */
+	@Override
+	public void testLargeTransaction(IsolationLevel isolationLevel, int count) throws InterruptedException {
+
+		long triplesInEmptyStore;
+
+		try (SailConnection connection = store.getConnection()) {
+			connection.begin(IsolationLevels.NONE);
+			connection.clear();
+			connection.commit();
+
+			triplesInEmptyStore = connection.getStatements(null, null, null, true).stream().count();
+		}
+
+		AtomicBoolean failure = new AtomicBoolean(false);
+
+		Runnable runnable = () -> {
+
+			try (SailConnection connection = store.getConnection()) {
+				while (true) {
+					try {
+
+						connection.begin(isolationLevel);
+						List<Statement> statements = Iterations
+								.asList(connection.getStatements(null, null, null, true));
+						connection.commit();
+						if (statements.size() != triplesInEmptyStore) {
+							if (statements.size() != count * 2 + triplesInEmptyStore) {
+								logger.error("Size was {}. Expected 0 or {}", statements.size(),
+										count * 2 + triplesInEmptyStore);
+								logger.error("\n[\n\t{}\n]",
+										statements.stream()
+												.map(Object::toString)
+												.reduce((a, b) -> a + " , \n\t" + b)
+												.get());
+
+								failure.set(true);
+							}
+							break;
+
+						}
+					} catch (SailConflictException ignored) {
+						connection.rollback();
+					}
+
+					Thread.yield();
+				}
+			}
+		};
+
+		Thread thread = new Thread(runnable);
+		thread.start();
+
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+
+		try (SailConnection connection = store.getConnection()) {
+			connection.begin(isolationLevel);
+			for (int i = 0; i < count; i++) {
+				connection.addStatement(vf.createBNode(), RDFS.LABEL, vf.createLiteral(i));
+			}
+			logger.debug("Commit");
+			connection.commit();
+
+			assertEquals(count, connection.size());
+
+		}
+
+		logger.debug("Joining thread");
+		thread.join();
+
+		assertFalse(failure.get());
+
 	}
 
 }

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerIsolationLevelTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerIsolationLevelTest.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.inferencer.fc;
 
-import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailIsolationLevelTest;
@@ -28,8 +27,4 @@ public class SchemaCachingRDFSInferencerIsolationLevelTest extends SailIsolation
 		return new SchemaCachingRDFSInferencer(new MemoryStore());
 	}
 
-	@Override
-	public void testLargeTransaction(IsolationLevel isolationLevel, int count) throws InterruptedException {
-		// See: https://github.com/eclipse/rdf4j/issues/1795
-	}
 }

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerIsolationLevelTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerIsolationLevelTest.java
@@ -72,7 +72,7 @@ public class SchemaCachingRDFSInferencerIsolationLevelTest extends SailIsolation
 						connection.commit();
 						if (statements.size() != triplesInEmptyStore) {
 							if (statements.size() != count * 2 + triplesInEmptyStore) {
-								logger.error("Size was {}. Expected 0 or {}", statements.size(),
+								logger.error("Size was {}. Expected {} or {}", statements.size(), triplesInEmptyStore,
 										count * 2 + triplesInEmptyStore);
 								logger.error("\n[\n\t{}\n]",
 										statements.stream()

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerNativeIsolationLevelTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerNativeIsolationLevelTest.java
@@ -44,11 +44,6 @@ public class SchemaCachingRDFSInferencerNativeIsolationLevelTest extends SailIso
 	}
 
 	@Override
-	public void testLargeTransactionSerializable() throws InterruptedException {
-		// ignored since test is slow
-	}
-
-	@Override
 	public void testSnapshot() throws Exception {
 		// see: https://github.com/eclipse/rdf4j/issues/1794
 	}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -750,14 +750,9 @@ class MemorySailStore implements SailStore {
 	 * increments the current snapshot by 1 and schedules a snapshot cleanup if necessary.
 	 */
 	protected void incrementSnapshot() {
-		txnLockManager.lock();
-		try {
-			currentSnapshot++;
-			if (requireCleanup) {
-				scheduleSnapshotCleanup();
-			}
-		} finally {
-			txnLockManager.unlock();
+		currentSnapshot++;
+		if (requireCleanup) {
+			scheduleSnapshotCleanup();
 		}
 	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -352,7 +352,7 @@ class MemorySailStore implements SailStore {
 				return new MemorySailDataset(explicit);
 			} else {
 				// isolation level NONE
-				return new MemorySailDataset(explicit, currentSnapshot + 1);
+				return new MemorySailDataset(explicit, Integer.MAX_VALUE - 1);
 			}
 		}
 	}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -750,9 +750,14 @@ class MemorySailStore implements SailStore {
 	 * increments the current snapshot by 1 and schedules a snapshot cleanup if necessary.
 	 */
 	protected void incrementSnapshot() {
-		currentSnapshot++;
-		if (requireCleanup) {
-			scheduleSnapshotCleanup();
+		txnLockManager.lock();
+		try {
+			currentSnapshot++;
+			if (requireCleanup) {
+				scheduleSnapshotCleanup();
+			}
+		} finally {
+			txnLockManager.unlock();
 		}
 	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
@@ -278,6 +278,8 @@ public class MemoryStore extends AbstractNotifyingSail implements FederatedServi
 					SailSink inferred = store.getInferredSailSource().sink(IsolationLevels.NONE);
 					try {
 						new FileIO(store.getValueFactory()).read(dataFile, explicit, inferred);
+						// explicitly increment snapshot to be able to read restored data.
+						((MemorySailStore) store).incrementSnapshot();
 						logger.debug("Data file read successfully");
 					} catch (IOException e) {
 						logger.error("Failed to read data file", e);

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
@@ -65,8 +65,10 @@ public class MemoryStoreConnection extends SailSourceConnection {
 			if (toCloseInferredBranch != null) {
 				toCloseInferredBranch.flush();
 			}
-			// after flushing, the MemorySailStore needs its internal snapshot counter updated
-			((MemorySailStore) sail.getSailStore()).incrementSnapshot();
+			if (sailChangedEvent.statementsAdded() || sailChangedEvent.statementsRemoved()) {
+				// after flushing, the MemorySailStore needs its internal snapshot counter updated
+				((MemorySailStore) sail.getSailStore()).incrementSnapshot();
+			}
 		} finally {
 			if (toCloseInferredBranch != null) {
 				toCloseInferredBranch.close();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -8,11 +8,28 @@
 
 package org.eclipse.rdf4j.sail.shacl;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.io.IOUtil;
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -31,28 +48,12 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
 import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 /**
  * @author Håvard Ottestad
@@ -61,6 +62,9 @@ import static org.junit.Assert.assertFalse;
 abstract public class AbstractShaclTest {
 
 	private static final Logger logger = LoggerFactory.getLogger(AbstractShaclTest.class);
+
+	@Rule
+	public Timeout globalTimeout = Timeout.seconds(10); // 10 seconds max per method tested
 
 	// @formatter:off
 	// formatter doesn't understand that the trailing ) needs to be on a new line.

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclIsolationLevelTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclIsolationLevelTest.java
@@ -8,7 +8,6 @@
 
 package org.eclipse.rdf4j.sail.shacl;
 
-import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailIsolationLevelTest;
@@ -25,10 +24,5 @@ public class ShaclIsolationLevelTest extends SailIsolationLevelTest {
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 		shaclSail.setIgnoreNoShapesLoadedException(true);
 		return shaclSail;
-	}
-
-	@Override
-	public void testLargeTransaction(IsolationLevel isolationLevel, int count) throws InterruptedException {
-		// see: https://github.com/eclipse/rdf4j/issues/1795
 	}
 }

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailIsolationLevelTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailIsolationLevelTest.java
@@ -7,6 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -28,14 +36,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 /**
  * Simple tests to sanity check that Sail correctly supports claimed isolation levels.

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailIsolationLevelTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailIsolationLevelTest.java
@@ -49,7 +49,7 @@ public abstract class SailIsolationLevelTest {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	private final Logger logger = LoggerFactory.getLogger(SailIsolationLevelTest.class);
+	protected final Logger logger = LoggerFactory.getLogger(SailIsolationLevelTest.class);
 
 	/*-----------*
 	 * Variables *


### PR DESCRIPTION
This avoids transaction leak issues when two sinks flush to the same
store (for example as part of a UnionSailSource)

GitHub issue resolved: #1795  <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* MemoryStoreConnection computes the next snapshot number on commit, instead of it happening as part of the sink flushing - this avoids it being incremented twice in the same txn.
* Tweaked SailSourceConnection with a couple of protected methods to allow customization/overriding of behavior of `commitInternal`. 
* Minor tweak in handling of restore of persisted data on Sail init to make sure the snapshot number is set correctly after restore.
* Re-enabled relevant integration tests to check this fixes the problem.
