### PR TITLE
#1929 introduce a SimpleUpgradeableModel

### DIFF
--- a/compliance/model/pom.xml
+++ b/compliance/model/pom.xml
@@ -44,5 +44,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-sail-base</artifactId>
+            <version>3.1.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/compliance/model/src/test/java/org/eclipse/rdf4j/model/SimpleUpgradeableModelTest.java
+++ b/compliance/model/src/test/java/org/eclipse/rdf4j/model/SimpleUpgradeableModelTest.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model;
+
+import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
+import org.eclipse.rdf4j.sail.base.SimpleUpgradeableModel;
+
+public class SimpleUpgradeableModelTest extends AbstractModelTest {
+
+	@Override
+	protected Model getNewModel() {
+		return new SimpleUpgradeableModel(new LinkedHashModelFactory());
+	}
+
+}

--- a/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/IsomorphicBenchmark.java
+++ b/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/IsomorphicBenchmark.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 201 Eclipse RDF4J contributors.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/IsomorphicTest.java
+++ b/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/IsomorphicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 201 Eclipse RDF4J contributors.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/Main.java
+++ b/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/Main.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 201 Eclipse RDF4J contributors.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceIntegrationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceIntegrationTest.java
@@ -33,7 +33,7 @@ import com.google.common.collect.Lists;
 
 /**
  * Integration tests for {@link RepositoryFederatedService}
- * 
+ *
  * @author Andreas Schwarte
  *
  */
@@ -101,7 +101,7 @@ public class RepositoryFederatedServiceIntegrationTest {
 				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
 				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
 
-		String query = "SELECT ?var WHERE { VALUES ?var { 'val1' 'val2' } . SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 1000  } }";
+		String query = "SELECT ?var WHERE { VALUES ?var { 'val1' 'val2' } . SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 1000  } } order by ?var";
 
 		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2")));
 	}
@@ -129,7 +129,7 @@ public class RepositoryFederatedServiceIntegrationTest {
 				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
 				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
 
-		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { ?s ?p ?var } . SERVICE <urn:dummy> {  ?s ?p ?var  } }";
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { ?s ?p ?var } . SERVICE <urn:dummy> {  ?s ?p ?var  } } order by ?var";
 
 		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2"), l("val3")));
 	}
@@ -143,7 +143,7 @@ public class RepositoryFederatedServiceIntegrationTest {
 				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
 
 		// Note: here we apply a workaround and explicitly project "?__rowIdx"
-		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 3 } . SERVICE <urn:dummy> { SELECT ?s ?var ?__rowIdx { ?s ?p ?var } LIMIT 3  } }";
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 3 } . SERVICE <urn:dummy> { SELECT ?s ?var ?__rowIdx { ?s ?p ?var } LIMIT 3  } } order by ?var";
 
 		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2"), l("val3")));
 	}
@@ -156,7 +156,7 @@ public class RepositoryFederatedServiceIntegrationTest {
 				vf.createStatement(iri("s2"), RDFS.LABEL, l("val2")),
 				vf.createStatement(iri("s3"), RDFS.LABEL, l("val3"))));
 
-		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 3 } . SERVICE <urn:dummy> { SELECT ?s ?var { ?s ?p ?var } LIMIT 3  } }";
+		String query = "SELECT ?var WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 3 } . SERVICE <urn:dummy> { SELECT ?s ?var { ?s ?p ?var } LIMIT 3  } } order by ?var";
 
 		assertResultEquals(evaluateQuery(query), "var", Lists.newArrayList(l("val1"), l("val2"), l("val3")));
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/LinkedHashModelFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/LinkedHashModelFactory.java
@@ -9,12 +9,16 @@ package org.eclipse.rdf4j.model.impl;
 
 import org.eclipse.rdf4j.model.ModelFactory;
 
+import java.io.Serializable;
+
 /**
  * Creates {@link LinkedHashModel}.
- * 
+ *
  * @author James Leigh
  */
-public class LinkedHashModelFactory implements ModelFactory {
+public class LinkedHashModelFactory implements ModelFactory, Serializable {
+
+	private static final long serialVersionUID = -9152104133818783614L;
 
 	@Override
 	public LinkedHashModel createEmptyModel() {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleUpgradeableModelFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleUpgradeableModelFactory.java
@@ -1,19 +1,22 @@
 /*******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.model;
+package org.eclipse.rdf4j.model.impl;
 
-import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
-import org.eclipse.rdf4j.model.impl.SimpleUpgradeableModel;
+import org.eclipse.rdf4j.model.ModelFactory;
 
-public class SimpleUpgradeableModelTest extends AbstractModelTest {
+/**
+ * Creates {@link SimpleUpgradeableModel}.
+ *
+ */
+public class SimpleUpgradeableModelFactory implements ModelFactory {
 
 	@Override
-	protected Model getNewModel() {
+	public SimpleUpgradeableModel createEmptyModel() {
 		return new SimpleUpgradeableModel(new LinkedHashModelFactory());
 	}
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/ModelCollectionTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/ModelCollectionTest.java
@@ -8,6 +8,8 @@
 package org.eclipse.rdf4j.model;
 
 import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
+import org.eclipse.rdf4j.model.impl.SimpleUpgradeableModel;
+import org.eclipse.rdf4j.model.impl.SimpleUpgradeableModelFactory;
 import org.eclipse.rdf4j.model.impl.TreeModelFactory;
 
 import com.google.common.collect.testing.SetTestSuiteBuilder;
@@ -20,7 +22,7 @@ import junit.framework.TestSuite;
 
 /**
  * Unit tests for {@link Model} implementations to check conformance with Java Collection Framework.
- * 
+ *
  * @author Jeen Broekstra
  *
  */
@@ -33,6 +35,7 @@ public class ModelCollectionTest {
 		TestSuite suite = new TestSuite("org.eclipse.rdf4j.model.ModelCollectionTest");
 		suite.addTest(testModelImpl("LinkedHashModel", new LinkedHashModelFactory()));
 		suite.addTest(testModelImpl("TreeModel", new TreeModelFactory()));
+		suite.addTest(testModelImpl("SimpleUpgradeableModel", new SimpleUpgradeableModelFactory()));
 		return suite;
 	}
 

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParseBenchmark.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParseBenchmark.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 201 Eclipse RDF4J contributors.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/Changeset.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/Changeset.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.model.ModelFactory;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleUpgradeableModel;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.sail.SailConflictException;

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/Changeset.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/Changeset.java
@@ -228,7 +228,7 @@ abstract class Changeset implements SailSink, ModelFactory {
 			deprecated.remove(subj, pred, obj, ctx);
 		}
 		if (approved == null) {
-			approved = createEmptyModel();
+			approved = new SimpleUpgradeableModel(this);
 		}
 		approved.add(subj, pred, obj, ctx);
 		if (ctx != null) {
@@ -245,7 +245,7 @@ abstract class Changeset implements SailSink, ModelFactory {
 			deprecated.remove(statement);
 		}
 		if (approved == null) {
-			approved = createEmptyModel();
+			approved = new SimpleUpgradeableModel(this);
 		}
 		approved.add(statement);
 		if (statement.getContext() != null) {
@@ -262,7 +262,7 @@ abstract class Changeset implements SailSink, ModelFactory {
 			approved.remove(statement);
 		}
 		if (deprecated == null) {
-			deprecated = createEmptyModel();
+			deprecated = new SimpleUpgradeableModel(this);
 		}
 		deprecated.add(statement);
 		Resource ctx = statement.getContext();

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/Changeset.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/Changeset.java
@@ -202,7 +202,7 @@ abstract class Changeset implements SailSink, ModelFactory {
 	public synchronized void clear(Resource... contexts) {
 		if (contexts != null && contexts.length == 0) {
 			if (approved != null) {
-				approved.remove(null, null, null);
+				approved.clear();
 			}
 			if (approvedContexts != null) {
 				approvedContexts.clear();

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
@@ -82,13 +82,17 @@ public class SimpleUpgradeableModel implements Model {
 
 	@Override
 	public boolean remove(Resource subj, IRI pred, Value obj, Resource... contexts) {
+		if (subj == null || pred == null || obj == null || contexts.length == 0) {
+			upgrade();
+		}
+
 		if (model == null) {
-			boolean added = false;
+			boolean removed = false;
 			for (Resource context : contexts) {
-				added = added
+				removed = removed
 						| statements.remove(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, context));
 			}
-			return added;
+			return removed;
 		} else {
 			return model.remove(subj, pred, obj, contexts);
 		}

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
@@ -229,8 +229,9 @@ public class SimpleUpgradeableModel implements Model {
 	public void clear() {
 		if (model == null) {
 			statements.clear();
+		} else {
+			model.clear();
 		}
-		model.clear();
 	}
 
 	@Override

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.base;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ModelFactory;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SimpleUpgradeableModel implements Model {
+
+	private Set<Statement> statements = ConcurrentHashMap.newKeySet();
+
+	private Model model = null;
+
+	private final ModelFactory modelFactory;
+
+	public SimpleUpgradeableModel(ModelFactory modelFactory) {
+		this.modelFactory = modelFactory;
+	}
+
+
+	@Override
+	public Model unmodifiable() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Namespace setNamespace(String prefix, String name) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void setNamespace(Namespace namespace) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Optional<Namespace> removeNamespace(String prefix) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean contains(Resource subj, IRI pred, Value obj, Resource... contexts) {
+		upgrade();
+		return model.contains(subj, pred, obj, contexts);
+	}
+
+
+	@Override
+	public boolean add(Resource subj, IRI pred, Value obj, Resource... contexts) {
+		if (model == null) {
+			boolean added = false;
+			for (Resource context : contexts) {
+				added = added | statements.add(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, context));
+			}
+			return added;
+		} else {
+			return model.add(subj, pred, obj, contexts);
+		}
+	}
+
+
+	@Override
+	public boolean clear(Resource... context) {
+		upgrade();
+		return model.clear(context);
+	}
+
+	@Override
+	public boolean remove(Resource subj, IRI pred, Value obj, Resource... contexts) {
+		if (model == null) {
+			boolean added = false;
+			for (Resource context : contexts) {
+				added = added | statements.remove(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, context));
+			}
+			return added;
+		} else {
+			return model.remove(subj, pred, obj, contexts);
+		}
+	}
+
+
+	@Override
+	public Model filter(Resource subj, IRI pred, Value obj, Resource... contexts) {
+		upgrade();
+		return model.filter(subj, pred, obj, contexts);
+	}
+
+
+	@Override
+	public Set<Resource> subjects() {
+		upgrade();
+		return model.subjects();
+	}
+
+	@Override
+	public Set<IRI> predicates() {
+		upgrade();
+		return model.predicates();
+	}
+
+	@Override
+	public Set<Value> objects() {
+		upgrade();
+		return model.objects();
+	}
+
+	@Override
+	public Set<Resource> contexts() {
+		upgrade();
+		return model.contexts();
+	}
+
+	@Override
+	public int size() {
+		if (model == null) {
+			return statements.size();
+		}
+		return model.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		if (model == null) {
+			return statements.isEmpty();
+		}
+		return model.isEmpty();
+	}
+
+	@Override
+	public boolean contains(Object o) {
+		if (model == null) {
+			return statements.contains(o);
+		}
+		return model.contains(o);
+	}
+
+	@Override
+	public Iterator<Statement> iterator() {
+		if (model == null) {
+			return statements.iterator();
+		}
+
+		return model.iterator();
+	}
+
+	@Override
+	public Object[] toArray() {
+		if (model == null) {
+			return statements.toArray();
+		}
+		return model.toArray();
+	}
+
+	@Override
+	public <T> T[] toArray(T[] a) {
+		if (model == null) {
+			return statements.toArray(a);
+		}
+		return model.toArray(a);
+	}
+
+
+	@Override
+	public boolean add(Statement statement) {
+		if (model == null) {
+			return statements.add(statement);
+		}
+		return model.add(statement);
+	}
+
+	@Override
+	public boolean remove(Object o) {
+		if (model == null) {
+			return statements.remove(o);
+		}
+		return model.remove(o);
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		if (model == null) {
+			return statements.containsAll(c);
+		}
+		return model.containsAll(c);
+	}
+
+	@Override
+	public boolean addAll(Collection<? extends Statement> c) {
+		if (model == null) {
+			return statements.addAll(c);
+		}
+		return model.addAll(c);
+	}
+
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		if (model == null) {
+			return statements.retainAll(c);
+		}
+		return model.retainAll(c);
+	}
+
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		if (model == null) {
+			return statements.removeAll(c);
+		}
+		return model.removeAll(c);
+	}
+
+	@Override
+	public void clear() {
+		if (model == null) {
+			statements.clear();
+		}
+		model.clear();
+	}
+
+
+	@Override
+	public Set<Namespace> getNamespaces() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Optional<Namespace> getNamespace(String prefix) {
+		throw new UnsupportedOperationException();
+	}
+
+	synchronized private void upgrade() {
+		if (model == null) {
+			Model tempModel = modelFactory.createEmptyModel();
+			tempModel.addAll(statements);
+			statements = null;
+			model = tempModel;
+		}
+	}
+
+}

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
@@ -5,6 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
+
 package org.eclipse.rdf4j.sail.base;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -18,11 +19,14 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class SimpleUpgradeableModel implements Model {
+
+	private static final Resource[] NULL_CTX = new Resource[] { null };
 
 	private Set<Statement> statements = ConcurrentHashMap.newKeySet();
 
@@ -62,6 +66,10 @@ public class SimpleUpgradeableModel implements Model {
 
 	@Override
 	public boolean add(Resource subj, IRI pred, Value obj, Resource... contexts) {
+		if (contexts.length == 0) {
+			contexts = NULL_CTX;
+		}
+
 		if (model == null) {
 			boolean added = false;
 			for (Resource context : contexts) {

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SimpleUpgradeableModel.java
@@ -34,7 +34,6 @@ public class SimpleUpgradeableModel implements Model {
 		this.modelFactory = modelFactory;
 	}
 
-
 	@Override
 	public Model unmodifiable() {
 		throw new UnsupportedOperationException();
@@ -61,20 +60,19 @@ public class SimpleUpgradeableModel implements Model {
 		return model.contains(subj, pred, obj, contexts);
 	}
 
-
 	@Override
 	public boolean add(Resource subj, IRI pred, Value obj, Resource... contexts) {
 		if (model == null) {
 			boolean added = false;
 			for (Resource context : contexts) {
-				added = added | statements.add(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, context));
+				added = added
+						| statements.add(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, context));
 			}
 			return added;
 		} else {
 			return model.add(subj, pred, obj, contexts);
 		}
 	}
-
 
 	@Override
 	public boolean clear(Resource... context) {
@@ -87,7 +85,8 @@ public class SimpleUpgradeableModel implements Model {
 		if (model == null) {
 			boolean added = false;
 			for (Resource context : contexts) {
-				added = added | statements.remove(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, context));
+				added = added
+						| statements.remove(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, context));
 			}
 			return added;
 		} else {
@@ -95,13 +94,11 @@ public class SimpleUpgradeableModel implements Model {
 		}
 	}
 
-
 	@Override
 	public Model filter(Resource subj, IRI pred, Value obj, Resource... contexts) {
 		upgrade();
 		return model.filter(subj, pred, obj, contexts);
 	}
-
 
 	@Override
 	public Set<Resource> subjects() {
@@ -176,7 +173,6 @@ public class SimpleUpgradeableModel implements Model {
 		return model.toArray(a);
 	}
 
-
 	@Override
 	public boolean add(Statement statement) {
 		if (model == null) {
@@ -232,7 +228,6 @@ public class SimpleUpgradeableModel implements Model {
 		}
 		model.clear();
 	}
-
 
 	@Override
 	public Set<Namespace> getNamespaces() {

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -512,7 +512,8 @@ class MemorySailStore implements SailStore {
 			requireCleanup = true;
 			if (statement instanceof MemStatement) {
 				MemStatement toDeprecate = (MemStatement) statement;
-				if (toDeprecate.getTillSnapshot() > nextSnapshot && toDeprecate.isExplicit() == explicit) {
+				if ((nextSnapshot < 0 || toDeprecate.isInSnapshot(nextSnapshot))
+						&& toDeprecate.isExplicit() == explicit) {
 					toDeprecate.setTillSnapshot(nextSnapshot);
 				}
 			} else if (statement instanceof LinkedHashModel.ModelStatement
@@ -520,7 +521,8 @@ class MemorySailStore implements SailStore {
 				// The Changeset uses a LinkedHashModel to store it's changes. It still keeps a reference to the
 				// original statement that can be retrieved here.
 				MemStatement toDeprecate = (MemStatement) ((LinkedHashModel.ModelStatement) statement).getStatement();
-				if (toDeprecate.getTillSnapshot() > nextSnapshot && toDeprecate.isExplicit() == explicit) {
+				if ((nextSnapshot < 0 || toDeprecate.isInSnapshot(nextSnapshot))
+						&& toDeprecate.isExplicit() == explicit) {
 					toDeprecate.setTillSnapshot(nextSnapshot);
 				}
 			} else {

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -511,7 +511,10 @@ class MemorySailStore implements SailStore {
 			acquireExclusiveTransactionLock();
 			requireCleanup = true;
 			if (statement instanceof MemStatement) {
-				((MemStatement) statement).setTillSnapshot(nextSnapshot);
+				MemStatement toDeprecate = (MemStatement) statement;
+				if (toDeprecate.getTillSnapshot() > nextSnapshot && toDeprecate.isExplicit() == explicit) {
+					toDeprecate.setTillSnapshot(nextSnapshot);
+				}
 			} else if (statement instanceof LinkedHashModel.ModelStatement
 					&& ((LinkedHashModel.ModelStatement) statement).getStatement() instanceof MemStatement) {
 				// The Changeset uses a LinkedHashModel to store it's changes. It still keeps a reference to the


### PR DESCRIPTION
GitHub issue resolved: #1929 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Use SimpleUpgradeableModel in Changeset which will upgrade from a HashSet to a Model if it encounters queries that it can't answer.
* Adding 1000 statements in SNAPSHOT takes ~6 ms instead of ~9ms 
