### PR TITLE
Protocol and binary RDF result for RDF*

### DIFF
--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFConstants.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFConstants.java
@@ -48,4 +48,6 @@ class BinaryRDFConstants {
 	static final int DATATYPE_LITERAL_VALUE = 5;
 
 	static final int VALUE_REF = 6;
+
+	static final int TRIPLE_VALUE = 7;
 }

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFParser.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFParser.java
@@ -18,6 +18,7 @@ import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.NAMESPACE_DECL;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.NULL_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.PLAIN_LITERAL_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.STATEMENT;
+import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.TRIPLE_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.URI_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.VALUE_DECL;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.VALUE_REF;
@@ -34,6 +35,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
@@ -202,6 +204,8 @@ public class BinaryRDFParser extends AbstractRDFParser {
 			return readLangLiteral();
 		case DATATYPE_LITERAL_VALUE:
 			return readDatatypeLiteral();
+		case TRIPLE_VALUE:
+			return readTriple();
 		default:
 			reportFatalError("Unknown value type: " + valueType);
 			return null;
@@ -239,6 +243,21 @@ public class BinaryRDFParser extends AbstractRDFParser {
 		String datatype = readString();
 		IRI dtUri = createURI(datatype);
 		return createLiteral(label, null, dtUri, -1, -1);
+	}
+
+	private Triple readTriple() throws IOException {
+		Value subject = readValue();
+		if (subject instanceof Resource) {
+			Value predicate = readValue();
+			if (predicate instanceof IRI) {
+				Value object = readValue();
+
+				return valueFactory.createTriple((Resource) subject, (IRI) predicate, object);
+			}
+		}
+
+		reportFatalError("Invalid RDF* triple value");
+		return null;
 	}
 
 	private String readString() throws IOException {

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
@@ -17,6 +17,7 @@ import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.MAGIC_NUMBER;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.NAMESPACE_DECL;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.NULL_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.STATEMENT;
+import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.TRIPLE_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.URI_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.VALUE_REF;
 
@@ -35,6 +36,7 @@ import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -259,6 +261,8 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter {
 			writeBNode((BNode) value);
 		} else if (value instanceof Literal) {
 			writeLiteral((Literal) value);
+		} else if (value instanceof Triple) {
+			writeTriple((Triple) value);
 		} else {
 			throw new RDFHandlerException("Unknown Value object type: " + value.getClass());
 		}
@@ -287,6 +291,13 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter {
 			writeString(label);
 			writeString(datatype.toString());
 		}
+	}
+
+	private void writeTriple(Triple triple) throws IOException {
+		out.writeByte(TRIPLE_VALUE);
+		writeValue(triple.getSubject());
+		writeValue(triple.getPredicate());
+		writeValue(triple.getObject());
 	}
 
 	private void writeString(String s) throws IOException {

--- a/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
+++ b/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.rio.RDFWriterTest;
 public class BinaryRDFWriterBackgroundTest extends RDFWriterTest {
 
 	public BinaryRDFWriterBackgroundTest() {
-		super(new BinaryRDFWriterFactory(), new BinaryRDFParserFactory());
+		super(new BinaryRDFWriterFactory(), new BinaryRDFParserFactory(), true);
 	}
 
 	@Override

--- a/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterTest.java
+++ b/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterTest.java
@@ -15,6 +15,6 @@ import org.eclipse.rdf4j.rio.RDFWriterTest;
 public class BinaryRDFWriterTest extends RDFWriterTest {
 
 	public BinaryRDFWriterTest() {
-		super(new BinaryRDFWriterFactory(), new BinaryRDFParserFactory());
+		super(new BinaryRDFWriterFactory(), new BinaryRDFParserFactory(), true);
 	}
 }

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtilTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesUtilTest.java
@@ -8,12 +8,21 @@
 package org.eclipse.rdf4j.rio.ntriples;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.function.Function;
 
 /**
  * Unit tests for {@link NTriplesUtil}
@@ -43,5 +52,93 @@ public class NTriplesUtilTest {
 		Literal l = f.createLiteral("Äbc");
 		NTriplesUtil.append(l, appendable, true, true);
 		assertThat(appendable.toString()).isEqualTo("\"\\u00C4bc\"");
+	}
+
+	@Test
+	public void testSerializeTriple() throws IOException {
+		Object[] triples = new Object[] {
+				f.createTriple(f.createIRI("urn:a"), f.createIRI("urn:b"), f.createIRI("urn:c")),
+				"<<<urn:a> <urn:b> <urn:c>>>",
+				//
+				f.createTriple(f.createTriple(f.createIRI("urn:a"), f.createIRI("urn:b"), f.createIRI("urn:c")),
+						DC.SOURCE, f.createLiteral("news")),
+				"<<<<<urn:a> <urn:b> <urn:c>>> <http://purl.org/dc/elements/1.1/source> \"news\">>",
+				//
+				f.createTriple(f.createBNode("bnode1"), f.createIRI("urn:x"),
+						f.createTriple(f.createIRI("urn:a"), f.createIRI("urn:b"), f.createIRI("urn:c"))),
+				"<<_:bnode1 <urn:x> <<<urn:a> <urn:b> <urn:c>>>>>"
+		};
+
+		for (int i = 0; i < triples.length; i += 2) {
+			assertEquals(triples[i + 1], NTriplesUtil.toNTriplesString((Triple) triples[i]));
+			assertEquals(triples[i + 1], NTriplesUtil.toNTriplesString((Resource) triples[i]));
+			assertEquals(triples[i + 1], NTriplesUtil.toNTriplesString((Value) triples[i]));
+			NTriplesUtil.append((Triple) triples[i], appendable);
+			assertEquals(triples[i + 1], appendable.toString());
+			appendable = new StringBuilder();
+			NTriplesUtil.append((Resource) triples[i], appendable);
+			assertEquals(triples[i + 1], appendable.toString());
+			appendable = new StringBuilder();
+			NTriplesUtil.append((Value) triples[i], appendable);
+			assertEquals(triples[i + 1], appendable.toString());
+			appendable = new StringBuilder();
+		}
+	}
+
+	@Test
+	public void testParseTriple() {
+		String[] triples = new String[] {
+				"<<<http://foo.com/bar#baz%20><http://example.com/test><<<urn:foo><urn:\\u0440>\"täst\"@de-DE>>>>",
+				"<<http://foo.com/bar#baz%20 http://example.com/test <<urn:foo urn:р \"täst\"@de-DE>>>>",
+				//
+				"<< <http://foo.com/bar#baz%20>  <http://example.com/test>  <<  <urn:foo>  <urn:\\u0440> \"täst\"@de-DE  >>  >>",
+				"<<http://foo.com/bar#baz%20 http://example.com/test <<urn:foo urn:р \"täst\"@de-DE>>>>",
+				//
+				"<<<<_:bnode1foobar<urn:täst>\"literál за проба\"^^<urn:test\\u0444\\U00000444>>><http://test/baz>\"test\\\\\\\"lit\">>",
+				"<<<<_:bnode1foobar urn:täst \"literál за проба\"^^<urn:testфф>>> http://test/baz \"test\\\"lit\">>",
+				//
+				"<<  <<_:bnode1foobar<urn:täst> \"literál за проба\"^^<urn:test\\u0444\\U00000444>  >>  <http://test/baz> \"test\\\\\\\"lit\" >>",
+				"<<<<_:bnode1foobar urn:täst \"literál за проба\"^^<urn:testфф>>> http://test/baz \"test\\\"lit\">>",
+				// test surrogate pair range in bnode
+				"<<_:test_\uD800\uDC00_\uD840\uDC00_bnode <urn:x> <urn:y>>>",
+				"<<_:test_\uD800\uDC00_\uD840\uDC00_bnode urn:x urn:y>>",
+				// invalid: missing closing >> for inner triple
+				"<<<<_:bnode1foobar<urn:täst>\"literál за проба\"^^<urn:test\\u0444\\U00000444><http://test/baz>\"test\\\\\\\"lit\">>",
+				null,
+				// invalid: missing closing >> for outer triple
+				"<<<<_:bnode1foobar<urn:täst>\"literál за проба\"^^<urn:test\\u0444\\U00000444>>><http://test/baz>\"test\\\\\\\"lit\"",
+				null,
+				// invalid: literal subject
+				"<<\"test\" <urn:test> \"test\">>",
+				null,
+				// invalid: bnode predicate
+				"<<<urn:test> _:test \"test\">>",
+				null,
+				// invalid: triple predicate
+				"<<<urn:a> <<<urn:1> <urn:2> <urn:3>>> <urn:b>>>",
+				null
+		};
+
+		for (int i = 0; i < triples.length; i += 2) {
+			parseTriple(triples[i], triples[i + 1], (t) -> NTriplesUtil.parseTriple(t, f));
+			parseTriple(triples[i], triples[i + 1], (t) -> (Triple) NTriplesUtil.parseValue(t, f));
+			parseTriple(triples[i], triples[i + 1], (t) -> (Triple) NTriplesUtil.parseResource(t, f));
+		}
+	}
+
+	private void parseTriple(String triple, String expected, Function<String, Triple> parser) {
+		try {
+			Triple t = parser.apply(triple);
+			assertEquals(expected, t.stringValue());
+		} catch (IllegalArgumentException e) {
+			if (expected != null) {
+				fail("Unexpected exception for valid triple: " + triple);
+			}
+		}
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testParseIRIvsTriple() {
+		NTriplesUtil.parseURI("<<<urn:a><urn:b><urn:c>>>", f);
 	}
 }


### PR DESCRIPTION
Adds support for RDF* to the HTTP protocol (e.g. passing triples to subj, pred, obj parameters on /statements GET). This also changes how an old workaround for SES-2129 is handled.

Adds support for RDF* to the binary RDF result format. The version stays the same and triples are handled as a new value type. This should offer the most compatibility for users who mix client and server versions.