### PR TITLE
GH-400 passthrough result

### DIFF
--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
@@ -7,8 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio;
 
+import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
@@ -22,11 +24,21 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 public abstract class AbstractQueryResultWriter implements QueryResultWriter {
 
 	private WriterConfig writerConfig = new WriterConfig();
+	private final OutputStream outputStream;
 
 	/**
 	 * Default constructor.
 	 */
 	protected AbstractQueryResultWriter() {
+		this(null);
+	}
+
+	protected AbstractQueryResultWriter(OutputStream out) {
+		this.outputStream = out;
+	}
+
+	public Optional<OutputStream> getOutputStream() {
+		return Optional.ofNullable(outputStream);
 	}
 
 	@Override

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultWriter.java
@@ -7,7 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio;
 
+import java.io.OutputStream;
 import java.util.Collection;
+import java.util.Optional;
 
 import org.eclipse.rdf4j.query.QueryResultHandler;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
@@ -25,6 +27,13 @@ public interface QueryResultWriter extends QueryResultHandler {
 	 * Gets the query result format that this writer uses.
 	 */
 	QueryResultFormat getQueryResultFormat();
+
+	/**
+	 * Gets the {@link OutputStream} this writer writes to, if it uses one.
+	 * 
+	 * @return an optional OutputStream
+	 */
+	Optional<OutputStream> getOutputStream();
 
 	/**
 	 * Handles a namespace prefix declaration. If this is called, it should be called before {@link #startDocument()} to

--- a/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultWriter.java
+++ b/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultWriter.java
@@ -88,6 +88,7 @@ public class BinaryQueryResultWriter extends AbstractQueryResultWriter implement
 	 *--------------*/
 
 	public BinaryQueryResultWriter(OutputStream out) {
+		super(out);
 		this.out = new DataOutputStream(out);
 	}
 

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
@@ -78,6 +78,7 @@ abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implem
 	private final JsonGenerator jg;
 
 	protected AbstractSPARQLJSONWriter(OutputStream out) {
+		super(out);
 		try {
 			jg = JSON_FACTORY.createGenerator(new OutputStreamWriter(out, StandardCharsets.UTF_8));
 		} catch (IOException e) {

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
@@ -94,7 +94,9 @@ abstract class AbstractSPARQLXMLWriter extends AbstractQueryResultWriter impleme
 	 *--------------*/
 
 	protected AbstractSPARQLXMLWriter(OutputStream out) {
-		this(new XMLWriter(out));
+		super(out);
+		this.xmlWriter = new XMLWriter(out);
+		this.xmlWriter.setPrettyPrint(true);
 	}
 
 	protected AbstractSPARQLXMLWriter(XMLWriter xmlWriter) {

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
@@ -45,6 +45,7 @@ public class SPARQLResultsCSVWriter extends AbstractQueryResultWriter implements
 	 * @param out
 	 */
 	public SPARQLResultsCSVWriter(OutputStream out) {
+		super(out);
 		Writer w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
 		writer = new BufferedWriter(w, 1024);
 	}

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
@@ -49,6 +49,7 @@ public class SPARQLResultsTSVWriter extends AbstractQueryResultWriter implements
 	 * @param out
 	 */
 	public SPARQLResultsTSVWriter(OutputStream out) {
+		super(out);
 		Writer w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
 		writer = new BufferedWriter(w, 1024);
 	}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFWriter.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.rio;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * An interface for RDF document writers. To allow RDF document writers to be created through reflection, all
@@ -22,6 +23,13 @@ public interface RDFWriter extends RDFHandler {
 	 * Gets the RDF format that this RDFWriter uses.
 	 */
 	public RDFFormat getRDFFormat();
+
+	/**
+	 * Gets the {@link OutputStream} this writer writes to, if it uses one.
+	 * 
+	 * @return an optional OutputStream
+	 */
+	public Optional<OutputStream> getOutputStream();
 
 	/**
 	 * Sets all supplied writer configuration options.

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
@@ -7,9 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
+import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -26,17 +29,29 @@ public abstract class AbstractRDFWriter implements RDFWriter {
 	/**
 	 * Mapping from namespace prefixes to namespace names.
 	 */
-	protected Map<String, String> namespaceTable;
+	protected Map<String, String> namespaceTable = new LinkedHashMap<>();
 
 	/**
 	 * A collection of configuration options for this writer.
 	 */
 	private WriterConfig writerConfig = new WriterConfig();
 
+	private final OutputStream outputStream;
+
 	/**
 	 * Default constructor.
 	 */
 	protected AbstractRDFWriter() {
+		this(null);
+	}
+
+	protected AbstractRDFWriter(OutputStream out) {
+		this.outputStream = out;
+	}
+
+	@Override
+	public Optional<OutputStream> getOutputStream() {
+		return Optional.ofNullable(outputStream);
 	}
 
 	@Override

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
@@ -66,6 +66,7 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter {
 	}
 
 	public BinaryRDFWriter(OutputStream out, int bufferSize) {
+		super(out);
 		this.out = new DataOutputStream(new BufferedOutputStream(out));
 		this.statementQueue = new ArrayBlockingQueue<>(bufferSize);
 		this.valueFreq = new HashMap<>(3 * bufferSize);

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -13,6 +13,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -25,6 +26,7 @@ import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
@@ -37,8 +39,6 @@ import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.core.JsonLdProcessor;
 import com.github.jsonldjava.utils.JsonUtils;
-import java.util.Collection;
-import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * An RDFWriter that links to {@link JSONLDInternalRDFParser}.
@@ -65,13 +65,15 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
 	}
 
 	/**
-	 * Create a SesameJSONLDWriter using a {@link java.io.OutputStream}
+	 * Create a JSONLDWriter using a {@link java.io.OutputStream}
 	 *
 	 * @param outputStream The OutputStream to write to.
 	 * @param baseURI      base URI
 	 */
 	public JSONLDWriter(OutputStream outputStream, String baseURI) {
-		this(new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)), baseURI);
+		super(outputStream);
+		this.baseURI = baseURI;
+		this.writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
@@ -50,6 +50,7 @@ public class N3Writer extends AbstractRDFWriter implements RDFWriter {
 	 * @param baseIRI used to relativize IRIs to relative IRIs.
 	 */
 	public N3Writer(OutputStream out, ParsedIRI baseIRI) {
+		super(out);
 		ttlWriter = new TurtleWriter(out, baseIRI);
 	}
 

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.rdf4j.common.text.ASCIIUtil;
-
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -53,7 +52,9 @@ public class NTriplesWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @param out The OutputStream to write the N-Triples document to.
 	 */
 	public NTriplesWriter(OutputStream out) {
-		this(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+		super(out);
+		this.writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+		this.writingStarted = false;
 	}
 
 	/**

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -54,6 +54,7 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	private final RDFFormat actualFormat;
 
 	public RDFJSONWriter(final OutputStream out, final RDFFormat actualFormat) {
+		super(out);
 		this.outputStream = out;
 		this.actualFormat = actualFormat;
 	}

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
@@ -43,11 +43,11 @@ public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter {
 	protected ParsedIRI baseIRI;
 	protected Writer writer;
 	protected String defaultNamespace;
-	protected boolean writingStarted;
-	protected boolean headerWritten;
-	protected Resource lastWrittenSubject;
-	protected char quote;
-	protected boolean entityQuote;
+	protected boolean writingStarted = false;
+	protected boolean headerWritten = false;
+	protected Resource lastWrittenSubject = null;
+	protected char quote = '"';
+	protected boolean entityQuote = false;
 
 	/**
 	 * Creates a new RDFXMLWriter that will write to the supplied OutputStream.
@@ -65,7 +65,10 @@ public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @param baseIRI base URI
 	 */
 	public RDFXMLWriter(OutputStream out, ParsedIRI baseIRI) {
-		this(new OutputStreamWriter(out, StandardCharsets.UTF_8), baseIRI);
+		super(out);
+		this.baseIRI = baseIRI;
+		this.writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+		namespaceTable = new LinkedHashMap<>();
 	}
 
 	/**
@@ -87,11 +90,6 @@ public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter {
 		this.baseIRI = baseIRI;
 		this.writer = writer;
 		namespaceTable = new LinkedHashMap<>();
-		writingStarted = false;
-		headerWritten = false;
-		lastWrittenSubject = null;
-		quote = '"';
-		entityQuote = false;
 	}
 
 	@Override

--- a/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
+++ b/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
@@ -50,11 +50,11 @@ public class TriXWriter extends AbstractRDFWriter implements RDFWriter {
 
 	private XMLWriter xmlWriter;
 
-	private boolean writingStarted;
+	private boolean writingStarted = false;
 
-	private boolean inActiveContext;
+	private boolean inActiveContext = false;
 
-	private Resource currentContext;
+	private Resource currentContext = null;
 
 	/*--------------*
 	 * Constructors *
@@ -66,7 +66,9 @@ public class TriXWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @param out The OutputStream to write the RDF/XML document to.
 	 */
 	public TriXWriter(OutputStream out) {
-		this(new XMLWriter(out));
+		super(out);
+		this.xmlWriter = new XMLWriter(out);
+		this.xmlWriter.setPrettyPrint(true);
 	}
 
 	/**
@@ -81,10 +83,6 @@ public class TriXWriter extends AbstractRDFWriter implements RDFWriter {
 	protected TriXWriter(XMLWriter xmlWriter) {
 		this.xmlWriter = xmlWriter;
 		this.xmlWriter.setPrettyPrint(true);
-
-		writingStarted = false;
-		inActiveContext = false;
-		currentContext = null;
 	}
 
 	/*---------*

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -34,6 +34,7 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 /**
@@ -42,7 +43,7 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
  * @author James Leigh
  * @since 2.3
  */
-class ArrangedWriter implements RDFWriter {
+class ArrangedWriter extends AbstractRDFWriter {
 
 	private final static int DEFAULT_QUEUE_SIZE = 100;
 
@@ -112,6 +113,7 @@ class ArrangedWriter implements RDFWriter {
 	}
 
 	public ArrangedWriter(RDFWriter delegate, int size, boolean repeatBlankNodes) {
+		super(delegate.getOutputStream().orElse(null));
 		this.delegate = delegate;
 		this.targetQueueSize = size;
 		this.repeatBlankNodes = repeatBlankNodes;

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -13,7 +13,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Deque;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -62,12 +61,12 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 
 	protected ParsedIRI baseIRI;
 	protected IndentingWriter writer;
-	protected boolean writingStarted;
+	protected boolean writingStarted = false;
 
 	/**
 	 * Flag indicating whether the last written statement has been closed.
 	 */
-	protected boolean statementClosed;
+	protected boolean statementClosed = true;
 	protected Resource lastWrittenSubject;
 	protected IRI lastWrittenPredicate;
 
@@ -104,7 +103,9 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @param baseIRI
 	 */
 	public TurtleWriter(OutputStream out, ParsedIRI baseIRI) {
-		this(new OutputStreamWriter(out, StandardCharsets.UTF_8), baseIRI);
+		super(out);
+		this.baseIRI = baseIRI;
+		this.writer = new IndentingWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
 	}
 
 	/**
@@ -125,11 +126,6 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 	public TurtleWriter(Writer writer, ParsedIRI baseIRI) {
 		this.baseIRI = baseIRI;
 		this.writer = new IndentingWriter(writer);
-		namespaceTable = new LinkedHashMap<>();
-		writingStarted = false;
-		statementClosed = true;
-		lastWrittenSubject = null;
-		lastWrittenPredicate = null;
 	}
 
 	/*---------*

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/util/ConsoleRDFWriter.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/util/ConsoleRDFWriter.java
@@ -12,10 +12,8 @@ import java.util.Map;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.Util;
-
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
-
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;


### PR DESCRIPTION
GitHub issue resolved: #400 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Allow ProtocolSession to bypass handler and stream response data directly to Outputstream if applicable
* added getOutputStream method to make wrapped outputstream accessible to protocol session.

