### PR TITLE
GH-1944: fix filter evaluation for exclusive groups in FedX

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXStatementPattern.java
@@ -9,7 +9,6 @@ package org.eclipse.rdf4j.federated.algebra;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
@@ -126,6 +125,11 @@ public abstract class FedXStatementPattern extends StatementPattern
 	@Override
 	public FilterValueExpr getFilterExpr() {
 		return filterExpr;
+	}
+
+	@Override
+	public BindingSet getBoundFilters() {
+		return this.boundFilters;
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FilterTuple.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FilterTuple.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.federated.algebra;
 import java.util.List;
 
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
 
 /**
  * Expressions implementing this interface can apply some {@link FilterValueExpr} during evaluation.
@@ -61,4 +62,11 @@ public interface FilterTuple {
 	 * @return the free variables of this expression
 	 */
 	public List<String> getFreeVars();
+
+	/**
+	 * Returns bound filter bindings, that need to be added as additional bindings to the final result
+	 * 
+	 * @return the bound filters, or <code>null</code>
+	 */
+	public BindingSet getBoundFilters();
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/FilterOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/FilterOptimizer.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.eclipse.rdf4j.federated.algebra.EmptyResult;
+import org.eclipse.rdf4j.federated.algebra.ExclusiveGroup;
 import org.eclipse.rdf4j.federated.algebra.FilterExpr;
 import org.eclipse.rdf4j.federated.algebra.FilterTuple;
 import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
@@ -204,6 +205,11 @@ public class FilterOptimizer extends AbstractQueryModelVisitor<OptimizationExcep
 		public void meetOther(QueryModelNode node) {
 
 			if (node instanceof FilterTuple) {
+				if (node instanceof ExclusiveGroup) {
+					// for ExclusiveGroup also visit the children to insert
+					// filter expressions and bound values
+					node.visitChildren(this);
+				}
 				handleFilter((FilterTuple) node, filterExpr);
 			}
 


### PR DESCRIPTION
The previous implementation did not correctly handle the optimization of
filter expressions in presence of ExclusiveGroups: if it was attempted,
an UnsupportedOperationException was thrown.

Now the appropriate methods are handled in the ExclusiveGroup and
filters as well as bound bindings are properly handled


GitHub issue resolved: #1944 
