### PR TITLE
GH-1949: fix INSERT DATA query handling for writable FedX federation

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -280,7 +280,7 @@ public class FedXConnection extends AbstractSailConnection {
 
 	@Override
 	protected void removeNamespaceInternal(String prefix) throws SailException {
-		throw new UnsupportedOperationException("Not supported. the federation is readonly.");
+		// do not support this feature, but also do not throw an exception
 	}
 
 	@Override
@@ -304,7 +304,7 @@ public class FedXConnection extends AbstractSailConnection {
 
 	@Override
 	protected void setNamespaceInternal(String prefix, String name) throws SailException {
-		throw new UnsupportedOperationException("Not supported. the federation is readonly.");
+		// do not support this feature, but also do not throw an exception
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -65,6 +65,7 @@ import org.eclipse.rdf4j.federated.optimizer.StatementGroupAndJoinOptimizer;
 import org.eclipse.rdf4j.federated.optimizer.UnionOptimizer;
 import org.eclipse.rdf4j.federated.structures.FedXDataset;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.structures.QueryType;
 import org.eclipse.rdf4j.federated.util.FedXUtil;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.model.IRI;
@@ -187,7 +188,8 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 		info.optimize(query);
 
 		// if the federation has a single member only, evaluate the entire query there
-		if (members.size() == 1 && queryInfo.getQuery() != null && !info.hasService())
+		if (members.size() == 1 && queryInfo.getQuery() != null && !info.hasService()
+				&& queryInfo.getQueryType() != QueryType.UPDATE)
 			return new SingleSourceQuery(expr, members.get(0), queryInfo);
 
 		if (log.isTraceEnabled()) {
@@ -207,8 +209,10 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 		/* custom optimizers, execute only when needed */
 
 		// if the query has a single relevant source (and if it is no a SERVICE query), evaluate at this source only
+		// Note: UPDATE queries are always handled in the federation engine to adhere to the configured
+		// write strategy
 		Set<Endpoint> relevantSources = performSourceSelection(members, cache, queryInfo, info);
-		if (relevantSources.size() == 1 && !info.hasService())
+		if (relevantSources.size() == 1 && !info.hasService() && queryInfo.getQueryType() != QueryType.UPDATE)
 			return new SingleSourceQuery(query, relevantSources.iterator().next(), queryInfo);
 
 		if (info.hasService())

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConnection.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.federated.structures.QueryType;
 import org.eclipse.rdf4j.federated.util.FedXUtil;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.Operation;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -112,16 +113,18 @@ public class FedXRepositoryConnection extends SailRepositoryConnection {
 	}
 
 	@Override
-	public Update prepareUpdate(QueryLanguage ql, String update, String baseURI)
+	public Update prepareUpdate(QueryLanguage ql, String updateString, String baseURI)
 			throws RepositoryException, MalformedQueryException {
-		return super.prepareUpdate(ql, update, baseURI);
+		Update update = super.prepareUpdate(ql, updateString, baseURI);
+		insertOriginalQueryString(update, updateString, QueryType.UPDATE);
+		return update;
 	}
 
 	private void setIncludeInferredDefault(SailQuery query) {
 		query.setIncludeInferred(federationContext.getConfig().getIncludeInferredDefault());
 	}
 
-	private void insertOriginalQueryString(SailQuery query, String queryString, QueryType qt) {
+	private void insertOriginalQueryString(Operation query, String queryString, QueryType qt) {
 		query.setBinding(BINDING_ORIGINAL_QUERY, FedXUtil.literal(queryString));
 		query.setBinding(BINDING_ORIGINAL_QUERY_TYPE, FedXUtil.literal(qt.name()));
 	}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/WriteTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/WriteTest.java
@@ -114,6 +114,27 @@ public class WriteTest extends SPARQLBaseTest {
 	}
 
 	@Test
+	public void testSimpleUpdateQuery_insertData() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/basic/data_emptyStore.ttl", "/tests/basic/data_emptyStore.ttl"));
+
+		Iterator<Endpoint> iter = federationContext().getEndpointManager().getAvailableEndpoints().iterator();
+		EndpointBase ep1 = (EndpointBase) iter.next();
+		ep1.setWritable(true);
+
+		try (RepositoryConnection conn = fedxRule.getRepository().getConnection()) {
+			Update update = conn.prepareUpdate(QueryLanguage.SPARQL,
+					"PREFIX ex: <http://example.org/> INSERT DATA { ex:subject a ex:Person } ");
+			update.execute();
+
+			// test that statement is returned from federation
+			List<Statement> stmts = Iterations.asList(conn.getStatements(null, null, null, true));
+			Assertions.assertEquals(1, stmts.size());
+			Assertions.assertEquals(RDF.TYPE, stmts.get(0).getPredicate());
+		}
+	}
+
+	@Test
 	public void testSimpleRemove() throws Exception {
 		prepareTest(Arrays.asList("/tests/basic/data_emptyStore.ttl", "/tests/basic/data_emptyStore.ttl"));
 


### PR DESCRIPTION
* do not throw UnsupportedOperationException for internal namespace
handling methods
* pass information on the original update string to the engine
* UPDATE queries are always handled inside the federation engine to
adhere to the configured write strategy
* cover this by unit tests

GitHub issue resolved: #1949 

