### PR TITLE
GH-1958: fix resource closing in federated service SilentIteration

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/SilentIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/SilentIteration.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
-import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
@@ -16,27 +16,16 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
  * Wrap an inner iteration and suppress exceptions silently
  * 
  * @author Andreas Schwarte
+ * 
+ * @deprecated since 3.1.2. Use {@link org.eclipse.rdf4j.common.iteration.SilentIteration } instead.
  */
-public class SilentIteration extends LookAheadIteration<BindingSet, QueryEvaluationException> {
-
-	protected CloseableIteration<BindingSet, QueryEvaluationException> iter;
+@Deprecated
+@InternalUseOnly
+public class SilentIteration
+		extends org.eclipse.rdf4j.common.iteration.SilentIteration<BindingSet, QueryEvaluationException> {
 
 	public SilentIteration(CloseableIteration<BindingSet, QueryEvaluationException> iter) {
-		super();
-		this.iter = iter;
-	}
-
-	@Override
-	protected BindingSet getNextElement() throws QueryEvaluationException {
-
-		try {
-			if (iter.hasNext())
-				return iter.next();
-		} catch (Exception e) {
-			// suppress
-		}
-
-		return null;
+		super(iter);
 	}
 
 }

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.common.iteration.SilentIteration;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.BooleanQuery;
@@ -77,8 +78,9 @@ public class RepositoryFederatedService implements FederatedService {
 
 				ArrayList<BindingSet> blockBindings = new ArrayList<>(blockSize);
 				for (int i = 0; i < blockSize; i++) {
-					if (!leftIter.hasNext())
+					if (!leftIter.hasNext()) {
 						break;
+					}
 					blockBindings.add(leftIter.next());
 				}
 				CloseableIteration<BindingSet, QueryEvaluationException> materializedIter = new CollectionIteration<>(
@@ -217,8 +219,9 @@ public class RepositoryFederatedService implements FederatedService {
 			Iterator<Binding> bIter = bindings.iterator();
 			while (bIter.hasNext()) {
 				Binding b = bIter.next();
-				if (service.getServiceVars().contains(b.getName()))
+				if (service.getServiceVars().contains(b.getName())) {
 					query.setBinding(b.getName(), b.getValue());
+				}
 			}
 
 			TupleQueryResult res = query.evaluate();
@@ -230,10 +233,11 @@ public class RepositoryFederatedService implements FederatedService {
 				result = new CloseConnectionIteration(result, conn);
 			}
 
-			if (service.isSilent())
-				return new SilentIteration(result);
-			else
+			if (service.isSilent()) {
+				return new SilentIteration<BindingSet, QueryEvaluationException>(result);
+			} else {
 				return result;
+			}
 		} catch (MalformedQueryException e) {
 			if (useFreshConnection) {
 				closeQuietly(conn);
@@ -270,8 +274,9 @@ public class RepositoryFederatedService implements FederatedService {
 			Iterator<Binding> bIter = bindings.iterator();
 			while (bIter.hasNext()) {
 				Binding b = bIter.next();
-				if (service.getServiceVars().contains(b.getName()))
+				if (service.getServiceVars().contains(b.getName())) {
 					query.setBinding(b.getName(), b.getValue());
+				}
 			}
 
 			return query.evaluate();
@@ -361,12 +366,13 @@ public class RepositoryFederatedService implements FederatedService {
 											// from actual setting?
 			res = query.evaluate();
 
-			if (relevantBindingNames.isEmpty())
+			if (relevantBindingNames.isEmpty()) {
 				result = new SPARQLCrossProductIteration(res, allBindings); // cross
-			// product
-			else
+				// product
+			} else {
 				result = new ServiceJoinConversionIteration(res, allBindings); // common
 																				// join
+			}
 
 			if (useFreshConnection) {
 				result = new CloseConnectionIteration(result, conn);
@@ -380,8 +386,9 @@ public class RepositoryFederatedService implements FederatedService {
 				closeQuietly(conn);
 			}
 			Iterations.closeCloseable(result);
-			if (service.isSilent())
+			if (service.isSilent()) {
 				return new CollectionIteration<>(allBindings);
+			}
 			throw new QueryEvaluationException(
 					"Repository for endpoint " + rep.toString() + " could not be initialized.", e);
 		} catch (MalformedQueryException e) {
@@ -398,8 +405,9 @@ public class RepositoryFederatedService implements FederatedService {
 				closeQuietly(conn);
 			}
 			Iterations.closeCloseable(result);
-			if (service.isSilent())
+			if (service.isSilent()) {
 				return new CollectionIteration<>(allBindings);
+			}
 			throw e;
 		} catch (RuntimeException e) {
 			if (useFreshConnection) {
@@ -408,8 +416,9 @@ public class RepositoryFederatedService implements FederatedService {
 			Iterations.closeCloseable(result);
 			// suppress special exceptions (e.g. UndeclaredThrowable with wrapped
 			// QueryEval) if silent
-			if (service.isSilent())
+			if (service.isSilent()) {
 				return new CollectionIteration<>(allBindings);
+			}
 			throw e;
 		}
 	}
@@ -561,8 +570,9 @@ public class RepositoryFederatedService implements FederatedService {
 
 		List<String> relevantBindingNames = new ArrayList<>(5);
 		for (String bName : bindings.get(0).getBindingNames()) {
-			if (serviceVars.contains(bName))
+			if (serviceVars.contains(bName)) {
 				relevantBindingNames.add(bName);
+			}
 		}
 
 		return relevantBindingNames;

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/SilentIteration.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/SilentIteration.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql.federation;
 
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
-import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
@@ -16,27 +16,15 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
  * Wrap an inner iteration and suppress exceptions silently
  * 
  * @author Andreas Schwarte
+ * @deprecated Use {@link org.eclipse.rdf4j.common.iteration.SilentIteration} instead.
  */
-public class SilentIteration extends LookAheadIteration<BindingSet, QueryEvaluationException> {
-
-	protected CloseableIteration<BindingSet, QueryEvaluationException> iter;
+@Deprecated
+@InternalUseOnly
+public class SilentIteration
+		extends org.eclipse.rdf4j.common.iteration.SilentIteration<BindingSet, QueryEvaluationException> {
 
 	public SilentIteration(CloseableIteration<BindingSet, QueryEvaluationException> iter) {
-		super();
-		this.iter = iter;
-	}
-
-	@Override
-	protected BindingSet getNextElement() throws QueryEvaluationException {
-
-		try {
-			if (iter.hasNext())
-				return iter.next();
-		} catch (Exception e) {
-			// suppress
-		}
-
-		return null;
+		super(iter);
 	}
 
 }

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/SilentIteration.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/iteration/SilentIteration.java
@@ -1,0 +1,65 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.common.iteration;
+
+import java.util.NoSuchElementException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link IterationWrapper} that silently ignores any errors that occur during processing.
+ * 
+ * @author Jeen Broekstra
+ */
+public class SilentIteration<T, E extends Exception> extends IterationWrapper<T, E> {
+
+	private static final Logger logger = LoggerFactory.getLogger(SilentIteration.class);
+
+	public SilentIteration(CloseableIteration<T, E> iter) {
+		super(iter);
+	}
+
+	@Override
+	public boolean hasNext() throws E {
+		try {
+			return super.hasNext();
+		} catch (Exception e) {
+			if (logger.isTraceEnabled()) {
+				logger.trace("Suppressed error in SILENT iteration: " + e.getMessage(), e);
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public T next() throws E {
+		try {
+			return super.next();
+		} catch (NoSuchElementException e) {
+			// pass through
+			throw e;
+		} catch (Exception e) {
+			if (logger.isTraceEnabled()) {
+				logger.trace("Converted error in SILENT iteration: " + e.getMessage(), e);
+			}
+			throw new NoSuchElementException(e.getMessage());
+		}
+	}
+
+	@Override
+	protected void handleClose() throws E {
+		try {
+			super.handleClose();
+		} catch (Exception e) {
+			if (logger.isTraceEnabled()) {
+				logger.trace("Suppressed error in SILENT iteration: " + e.getMessage(), e);
+			}
+		}
+	}
+}

--- a/core/util/src/test/java/org/eclipse/rdf4j/common/iteration/SilentIterationTest.java
+++ b/core/util/src/test/java/org/eclipse/rdf4j/common/iteration/SilentIterationTest.java
@@ -1,0 +1,31 @@
+package org.eclipse.rdf4j.common.iteration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+public class SilentIterationTest {
+
+	@SuppressWarnings("unchecked")
+	private CloseableIteration<Object, Exception> delegate = mock(CloseableIteration.class);
+
+	private SilentIteration<Object, Exception> subject = new SilentIteration<Object, Exception>(delegate);
+
+	@Test
+	public void hasNextSwallowsException() throws Exception {
+		when(delegate.hasNext()).thenThrow(new RuntimeException());
+		assertThat(subject.hasNext()).isFalse();
+	}
+
+	@Test
+	public void nextConvertsException() throws Exception {
+		when(delegate.next()).thenThrow(new RuntimeException());
+		assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(subject::next);
+	}
+
+}


### PR DESCRIPTION
The SilenetIteration failed to close the inner iteration, thus resulting
in resource leaks (e.g. pending connections).

Without this fix the attached unit tests takes 20s before forcefully
closing the connection. Now it correctly terminates immediately after
test execution.

Note that additionally a TRACE logger has been introduced to give users
the chance to observe errors.


GitHub issue resolved: #1958 