### PR TITLE
GH-1963-rio-hdt-lang-fix

### DIFF
--- a/core/rio/hdt/pom.xml
+++ b/core/rio/hdt/pom.xml
@@ -21,5 +21,11 @@
             <artifactId>rdf4j-rio-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>rdf4j-rio-ntriples</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTParser.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTParser.java
@@ -257,11 +257,11 @@ public class HDTParser extends AbstractRDFParser {
 			for (; i > 1 && b[i] != '"'; i--) {
 				if (b[i] == '@') {
 					String lang = new String(b, i + 1, b.length - i - 1, StandardCharsets.US_ASCII);
-					valueFactory.createLiteral(new String(b, 1, i - 2, StandardCharsets.UTF_8), lang);
+					return valueFactory.createLiteral(new String(b, 1, i - 2, StandardCharsets.UTF_8), lang);
 				} else if (b[i] == '^') {
 					IRI datatype = valueFactory
 							.createIRI(new String(b, i + i, b.length - i - 1, StandardCharsets.US_ASCII));
-					valueFactory.createLiteral(new String(b, 1, i - 3, StandardCharsets.UTF_8), datatype);
+					return valueFactory.createLiteral(new String(b, 1, i - 3, StandardCharsets.UTF_8), datatype);
 				}
 			}
 			return valueFactory.createLiteral(new String(b, 1, i - 1, StandardCharsets.UTF_8));

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTPart.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTPart.java
@@ -131,7 +131,7 @@ abstract class HDTPart {
 		if (len == BUFLEN) {
 			throw new IOException("Buffer for reading properties exceeded, max " + BUFLEN);
 		}
-		return Arrays.copyOf(buf, len + 1);
+		return Arrays.copyOf(buf, len);
 	}
 
 	/**

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTTriplesSectionBitmap.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTTriplesSectionBitmap.java
@@ -50,8 +50,6 @@ class HDTTriplesSectionBitmap extends HDTTriplesSection {
 	private int posY = 0;
 	private int posZ = 0;
 
-	private int toggleY = 0;
-
 	@Override
 	public boolean hasNext() {
 		// we only need to check if we've reach the end of the "lowest" level
@@ -60,22 +58,19 @@ class HDTTriplesSectionBitmap extends HDTTriplesSection {
 
 	@Override
 	public int[] next() {
-		int x = posX;
-		// move to next X position (subject) when there is no Y (predicate) left
-		// EXCEPT when there are more Z (objects) to process, e.g. very last one in the bitmap
-		// otherwise the P,O will be attached to the wrong S, or the S won't be found at all
-		if (bitmapY.get(posY) == 1 && posY != toggleY && posY != sizeY - 1) {
-			toggleY = posY;
-			posX++;
-		}
-
-		// move to next Y position (predicate) when there is no Z (predicate) left
+		int z = arrZ.get(posZ);
 		int y = arrY.get(posY);
-		if (bitmapZ.get(posZ) == 1) {
+		int x = posX;
+
+		if (bitmapZ.get(posZ) == 1 && posZ < sizeZ) {
+			// move to next Y position (predicate) when there is no Z (predicate) left
+			if (bitmapY.get(posY) == 1 && posY < sizeY) {
+				// move to next X position (subject) when there is no Y (predicate) left
+				posX++;
+			}
 			posY++;
 		}
-
-		int z = arrZ.get(posZ++);
+		posZ++;
 
 		return new int[] { x, y, z };
 	}

--- a/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/HDTParserTest.java
+++ b/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/HDTParserTest.java
@@ -8,13 +8,15 @@
 package org.eclipse.rdf4j.rio.hdt;
 
 import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.Comparator;
 
 import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 
@@ -37,8 +39,17 @@ public class HDTParserTest {
 
 	@Test
 	public void parseSimpleSPO() {
-		Model m = new LinkedHashModel();
+		// load original N-Triples file
+		Model orig = new LinkedHashModel();
+		try (InputStream is = HDTParserTest.class.getResourceAsStream("/test-orig.nt")) {
+			RDFParser nt = Rio.createParser(RDFFormat.NTRIPLES);
+			nt.setRDFHandler(new StatementCollector(orig));
+			nt.parse(is, "");
+		} catch (Exception e) {
+			fail(e.getMessage());
+		}
 
+		Model m = new LinkedHashModel();
 		try (InputStream is = HDTParserTest.class.getResourceAsStream("/test.hdt")) {
 			parser.setRDFHandler(new StatementCollector(m));
 			parser.parse(is, "");
@@ -46,6 +57,9 @@ public class HDTParserTest {
 		} catch (Exception e) {
 			fail(e.getMessage());
 		}
+
+		orig.removeAll(m);
+		assertEquals("HDT model does not match original NT file", 0, orig.size());
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #1963 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

* Improved test
* Fix issues with language and datatypes not being decoded
* Fix incorrect generation of incorrect triples