### PR TITLE
GH-1962-hdt-improvements

### DIFF
--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTArrayLog64.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTArrayLog64.java
@@ -50,7 +50,7 @@ class HDTArrayLog64 extends HDTArray {
 		long val = 0L;
 		// little-endian to big-endian
 		for (int j = 0; j < tmplen; j++) {
-			val |= (buffer[bytePos + j] & 0xFF) << (j * 8);
+			val |= (buffer[bytePos + j] & 0xFFL) << (j * 8);
 		}
 
 		val >>= bitPos;

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTDictionarySection.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTDictionarySection.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.hdt;
 
+import java.io.IOException;
+
 /**
  * HDT DictionarySection part. Various encodings exist.
  * 
@@ -44,5 +46,15 @@ abstract class HDTDictionarySection extends HDTPart {
 	 * @param i zero-based index
 	 * @return
 	 */
-	protected abstract byte[] get(int i);
+	protected abstract byte[] get(int i) throws IOException;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param pos  position
+	 * @param name name
+	 */
+	protected HDTDictionarySection(String name, long pos) {
+		super(name, pos);
+	}
 }

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTDictionarySectionFactory.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTDictionarySectionFactory.java
@@ -16,12 +16,21 @@ import java.io.InputStream;
  * @author Bart Hanssens
  */
 class HDTDictionarySectionFactory {
-	protected static HDTDictionarySection parse(InputStream is) throws IOException {
+	/**
+	 * Create a dictionary section from input stream. The name an starting position are provided for debugging purposes.
+	 * 
+	 * @param is   input stream
+	 * @param name name
+	 * @param pos  starting position
+	 * @return dictionary section
+	 * @throws IOException
+	 */
+	protected static HDTDictionarySection parse(InputStream is, String name, long pos) throws IOException {
 		int dtype = is.read();
 		if (dtype != HDTDictionarySection.Type.FRONT.getValue()) {
-			throw new UnsupportedOperationException("Dictionary section: encoding " + Long.toHexString(dtype) +
-					", but only front encoding is supported");
+			throw new UnsupportedOperationException("Dictionary " + name + ": encoding "
+					+ Long.toHexString(dtype) + ", but only front encoding is supported");
 		}
-		return new HDTDictionarySectionPFC();
+		return new HDTDictionarySectionPFC(name, pos);
 	}
 }

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTPart.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTPart.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.rio.hdt;
 
 import java.io.IOException;
 import java.io.InputStream;
+
 import java.nio.charset.StandardCharsets;
 
 import java.util.Arrays;
@@ -55,10 +56,12 @@ abstract class HDTPart {
 
 	protected final static byte[] COOKIE = "$HDT".getBytes(StandardCharsets.US_ASCII);
 
-	protected Map<String, String> properties;
-
 	// TODO: make configurable, buffer for reading object values
 	private final static int BUFLEN = 1 * 1024 * 1024;
+	// for debugging purposes
+	protected final String name;
+	protected final long pos;
+	protected Map<String, String> properties;
 
 	/**
 	 * Parse from input stream
@@ -75,6 +78,36 @@ abstract class HDTPart {
 	 */
 	protected Map<String, String> getProperties() {
 		return properties;
+	}
+
+	/**
+	 * Constructor
+	 * 
+	 * @param name part name
+	 * @param pos  starting position in input stream
+	 */
+	protected HDTPart(String name, long pos) {
+		this.name = name;
+		this.pos = pos;
+	}
+
+	/**
+	 * Constructor
+	 */
+	protected HDTPart() {
+		this("", -1);
+	}
+
+	/**
+	 * Get a string for debugging purposes, containing the name and starting position of this part.
+	 * 
+	 * @return string
+	 */
+	protected String getDebugPartStr() {
+		if (name == null || name.isEmpty()) {
+			return "";
+		}
+		return (pos != -1) ? name + " (starts at byte " + pos + ")" : name;
 	}
 
 	/**
@@ -132,6 +165,22 @@ abstract class HDTPart {
 			throw new IOException("Buffer for reading properties exceeded, max " + BUFLEN);
 		}
 		return Arrays.copyOf(buf, len);
+	}
+
+	/**
+	 * Get the first position of the NULL byte within an array of bytes
+	 * 
+	 * @param b     byte array
+	 * @param start position to start from
+	 * @return position of first NULL byte
+	 */
+	protected static int countToNull(byte[] b, int start) throws IOException {
+		for (int i = start; i < b.length; i++) {
+			if (b[i] == 0b00) {
+				return i;
+			}
+		}
+		throw new IOException("No null byte found in buffer starting at byte " + start);
 	}
 
 	/**

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/VByte.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/VByte.java
@@ -58,7 +58,7 @@ public class VByte {
 	}
 
 	/**
-	 * Decode a maximum of 8 bytes from the inputstream.
+	 * Decode a maximum of 8 bytes from the input stream.
 	 * 
 	 * @param is input stream
 	 * @return decode value
@@ -72,5 +72,45 @@ public class VByte {
 			buffer[i] = (byte) is.read();
 		} while (i < buffer.length && hasNext(buffer[i++]));
 		return decode(buffer, i);
+	}
+
+	/**
+	 * Decode a maximum of 8 bytes from a byte array.
+	 * 
+	 * @param b     byte array
+	 * @param start starting position
+	 * @return decode value
+	 * @throws IOException
+	 */
+	public static long decodeFrom(byte[] b, int start) throws IOException {
+		byte[] buffer = new byte[8];
+
+		int i = 0;
+		do {
+			buffer[i] = b[start + i];
+		} while (i < buffer.length && hasNext(buffer[i++]));
+		return decode(buffer, i);
+	}
+
+	/**
+	 * Calculate the number of bytes needed for encoding a value
+	 * 
+	 * @param value numeric value
+	 * @return number of bytes
+	 */
+	public static int encodedLength(long value) {
+		if (value < 127) {
+			return 1;
+		}
+		if (value < 16_384) {
+			return 2;
+		}
+		if (value < 2_097_152) {
+			return 3;
+		}
+		if (value < 268_435_456) {
+			return 4;
+		}
+		return 5;
 	}
 }

--- a/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/HDTParserTest.java
+++ b/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/HDTParserTest.java
@@ -8,15 +8,12 @@
 package org.eclipse.rdf4j.rio.hdt;
 
 import java.io.InputStream;
-import java.io.StringWriter;
-import java.util.Comparator;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 


### PR DESCRIPTION
GitHub issue resolved: #1962 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Removed bufferedinputstream (so buffering happens outside, like other parsers)
* Added a caching mechanism for PFC: first store the PFC-encoded dictionaries into memory, and only start decoding them after the inputstream is fully processed. Then the decoding happens one block at the time, when a string in that block is requested (with a cached of the 100 most recently accessed blocks)
* Fixed another datetype parsing issue
* Fixed issue for logarray64 incorrectly decoding large(r) values across 5 bytes: add 'L' for long mask instead of int
* Some minor improvements for debugging
