### PR TITLE
GH-1970: fix logger name in SPARQLProtocolSession

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -148,7 +148,7 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	 */
 	private final int maximumUrlLength;
 
-	final Logger logger = LoggerFactory.getLogger(this.getClass());
+	final Logger logger = LoggerFactory.getLogger(SPARQLProtocolSession.class);
 
 	/*-----------*
 	 * Variables *


### PR DESCRIPTION
The SparqlProtocolSession uses this.getClass() as a name for the logger.

When having an extension of the class, this leads to misleading log
output. Particularly the logging levels are also harder to control
(w.r.t namespacing and packaging).

The general recommendation for logger names should be to use the class
name, at least it should adhere to the rdf4j package structure.


GitHub issue resolved: #1970 