### PR TITLE
GH-1974 sync jetty version

### DIFF
--- a/compliance/repository/pom.xml
+++ b/compliance/repository/pom.xml
@@ -10,9 +10,6 @@
 	<packaging>war</packaging>
 	<name>RDF4J Repository compliance tests</name>
 	<description>Compliance testing for the Repository API implementations</description>
-	<properties>
-		<jetty.version>9.4.19.v20190610</jetty.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/compliance/sparql/pom.xml
+++ b/compliance/sparql/pom.xml
@@ -10,9 +10,6 @@
 	<packaging>war</packaging>
 	<name>RDF4J SPARQL query parser compliance tests</name>
 	<description>Tests for the SPARQL query language implementation</description>
-	<properties>
-		<jetty.version>9.4.19.v20190610</jetty.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,7 @@
 		<solr.version>7.7.2</solr.version>
 		<elasticsearch.version>6.8.8</elasticsearch.version>
 		<servlet.version>3.1.0</servlet.version>
+		<jetty.version>9.4.24.v20191120</jetty.version>
 		<spring.version>5.2.4.RELEASE</spring.version>
 		<guava.version>18.0</guava.version>
 		<jmhVersion>1.21</jmhVersion>

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -10,9 +10,6 @@
 		<artifactId>rdf4j-tools</artifactId>
 		<version>3.3.0-SNAPSHOT</version>
 	</parent>
-	<properties>
-		<jetty.version>9.4.19.v20190610</jetty.version>
-	</properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -10,9 +10,6 @@
 	<packaging>war</packaging>
 	<name>RDF4J: HTTP server</name>
 	<description>HTTP server implementing a REST-style protocol</description>
-	<properties>
-		<jetty.version>9.2.28.v20190418</jetty.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -84,7 +81,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-jsp</artifactId>
+			<artifactId>apache-jsp</artifactId>
 			<version>${jetty.version}</version>
 			<scope>test</scope>
 			<exclusions>


### PR DESCRIPTION
GitHub issue resolved: #1974 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* Upgrade to latest (9.4.27) Eclipse Jetty server
