### PR TITLE
#1968 support language in shacl target node, eg. "string"@en

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetNode.java
@@ -80,19 +80,22 @@ public class TargetNode extends NodeShape {
 			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
 
 		return targetNodeSet.stream()
-				.map(node -> {
-					if (node instanceof Resource) {
-						return "<" + node + ">";
+				.map(value -> {
+					if (value instanceof Resource) {
+						return "<" + value + ">";
 					}
-					if (node instanceof Literal) {
-						IRI datatype = ((Literal) node).getDatatype();
+					if (value instanceof Literal) {
+						IRI datatype = ((Literal) value).getDatatype();
 						if (datatype == null) {
-							return "\"" + node.stringValue() + "\"";
+							return "\"" + value.stringValue() + "\"";
 						}
-						return "\"" + node.stringValue() + "\"^^<" + datatype.stringValue() + ">";
+						if (((Literal) value).getLanguage().isPresent()) {
+							return "\"" + value.stringValue() + "\"@" + ((Literal) value).getLanguage().get();
+						}
+						return "\"" + value.stringValue() + "\"^^<" + datatype.stringValue() + ">";
 					}
 
-					throw new IllegalStateException(node.getClass().getSimpleName());
+					throw new IllegalStateException(value.getClass().getSimpleName());
 
 				})
 				.map(r -> "{{ select * where {BIND(" + r + " as " + subjectVariable + "). " + subjectVariable + " ?b1 "

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -88,6 +88,7 @@ abstract public class AbstractShaclTest {
 		"test-cases/datatype/simple",
 		"test-cases/datatype/targetNode",
 		"test-cases/datatype/targetNode2",
+		"test-cases/datatype/targetNodeLang",
 		"test-cases/datatype/targetObjectsOf",
 		"test-cases/datatype/targetSubjectsOf",
 		"test-cases/datatype/targetSubjectsOfSingle",

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/targetNodeLang/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/targetNodeLang/shacl.ttl
@@ -1,0 +1,13 @@
+@base <http://example.com/ns> .
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:PersonShape
+	a sh:NodeShape  ;
+	sh:targetNode "name"@en ;
+	sh:datatype rdf:langString .
+

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/targetNodeLang/valid/case1/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/targetNodeLang/valid/case1/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 ex:name "name"@en.
+
+}


### PR DESCRIPTION
GitHub issue resolved: #1968  <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* generate sparql query correctly when target is a literal with language
* 
* 
