### PR TITLE
GH-1978 fix handling of empty results in grouping/aggregate

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL12QueryTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL12QueryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -17,49 +17,41 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 import junit.framework.Test;
 
-public class W3CApprovedSPARQL11QueryTest extends SPARQLQueryTest {
+/**
+ * SPARQL Query tests using testcase from the SPARQL 1.2 Working Group
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class SPARQL12QueryTest extends SPARQLQueryTest {
 
 	public static Test suite() throws Exception {
-		URL manifestUrl = SPARQL11ManifestTest.class.getResource("/testcases-sparql-1.1-w3c/manifest-all.ttl");
+		URL manifestUrl = SPARQL11ManifestTest.class.getResource("/testcases-sparql-1.2/manifest-all.ttl");
 
 		return SPARQL11ManifestTest.suite(new Factory() {
 
 			@Override
-			public W3CApprovedSPARQL11QueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
+			public SPARQL12QueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
 					String resultFileURL, Dataset dataSet, boolean laxCardinality) {
 				return createSPARQLQueryTest(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality,
 						false);
 			}
 
 			@Override
-			public W3CApprovedSPARQL11QueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
+			public SPARQL12QueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
 					String resultFileURL, Dataset dataSet, boolean laxCardinality, boolean checkOrder) {
-				String[] ignoredTests = {
-						// test case incompatible with RDF 1.1 - see
-						// http://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0006.html
-						"STRDT   TypeErrors",
-						// test case incompatible with RDF 1.1 - see
-						// http://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0006.html
-						"STRLANG   TypeErrors",
-						// known issue: SES-937
-						"sq03 - Subquery within graph pattern, graph variable is not bound",
-						// test case is incorrect wrt SPARQL 1.1 spec, see https://github.com/eclipse/rdf4j/issues/1978
-//						"agg empty group",
-//						"Aggregate over empty group resulting in a row with unbound variables" 
-				};
-
-				return new W3CApprovedSPARQL11QueryTest(testURI, name, queryFileURL, resultFileURL, dataSet,
-						laxCardinality, checkOrder, ignoredTests);
+				return new SPARQL12QueryTest(testURI, name, queryFileURL, resultFileURL, dataSet,
+						laxCardinality, checkOrder);
 			}
-		}, manifestUrl.toString(), true, "service");
+		}, manifestUrl.toString(), false);
 	}
 
-	protected W3CApprovedSPARQL11QueryTest(String testURI, String name, String queryFileURL, String resultFileURL,
+	protected SPARQL12QueryTest(String testURI, String name, String queryFileURL, String resultFileURL,
 			Dataset dataSet, boolean laxCardinality, String... ignoredTests) {
 		this(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality, false, ignoredTests);
 	}
 
-	protected W3CApprovedSPARQL11QueryTest(String testURI, String name, String queryFileURL, String resultFileURL,
+	protected SPARQL12QueryTest(String testURI, String name, String queryFileURL, String resultFileURL,
 			Dataset dataSet, boolean laxCardinality, boolean checkOrder, String... ignoredTests) {
 		super(testURI, name, queryFileURL, resultFileURL, dataSet, laxCardinality, checkOrder, ignoredTests);
 	}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/W3CApprovedSPARQL11UpdateTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/W3CApprovedSPARQL11UpdateTest.java
@@ -7,16 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser.sparql.manifest;
 
+import java.net.URL;
 import java.util.Map;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQL11ManifestTest;
-import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQLUpdateConformanceTest;
 import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.contextaware.ContextAwareRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import junit.framework.Test;
 
 import junit.framework.Test;
 
@@ -31,8 +28,12 @@ public class W3CApprovedSPARQL11UpdateTest extends SPARQLUpdateConformanceTest {
 	}
 
 	public static Test suite() throws Exception {
+
+		URL manifestUrl = SPARQL11ManifestTest.class.getResource("/testcases-sparql-1.1-w3c/manifest-all.ttl");
+
 		return SPARQL11ManifestTest.suite(new Factory() {
 
+			@Override
 			public W3CApprovedSPARQL11UpdateTest createSPARQLUpdateConformanceTest(String testURI, String name,
 					String requestFile, IRI defaultGraphURI, Map<String, IRI> inputNamedGraphs,
 					IRI resultDefaultGraphURI, Map<String, IRI> resultNamedGraphs) {
@@ -40,7 +41,7 @@ public class W3CApprovedSPARQL11UpdateTest extends SPARQLUpdateConformanceTest {
 						resultDefaultGraphURI, resultNamedGraphs);
 			}
 
-		}, true, true, false);
+		}, manifestUrl.toString(), true);
 	}
 
 	@Override

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSPARQL11QueryTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSPARQL11QueryTest.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.federation;
 
+import java.net.URL;
+
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQL11ManifestTest;
 import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQLQueryTest;
@@ -20,14 +22,19 @@ import junit.framework.Test;
 public class FederationSPARQL11QueryTest extends SPARQLQueryTest {
 
 	public static Test suite() throws Exception {
+
+		URL manifestUrl = SPARQL11ManifestTest.class.getResource("/testcases-sparql-1.1-w3c/manifest-all.ttl");
+
 		return SPARQL11ManifestTest.suite(new Factory() {
 
+			@Override
 			public SPARQLQueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
 					String resultFileURL, Dataset dataSet, boolean laxCardinality) {
 				return new FederationSPARQL11QueryTest(testURI, name, queryFileURL, resultFileURL, dataSet,
 						laxCardinality);
 			}
 
+			@Override
 			public SPARQLQueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
 					String resultFileURL, Dataset dataSet, boolean laxCardinality, boolean checkOrder) {
 				String[] ignoredTests = {
@@ -44,7 +51,7 @@ public class FederationSPARQL11QueryTest extends SPARQLQueryTest {
 						laxCardinality, checkOrder, ignoredTests);
 			}
 			// skip 'service' tests for now since they require presence of remote sparql endpoints.
-		}, true, true, false, "service");
+		}, manifestUrl.toString(), true, "service");
 	}
 
 	public FederationSPARQL11QueryTest(String testURI, String name, String queryFileURL, String resultFileURL,

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSPARQLQueryTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSPARQLQueryTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.sail.nativerdf;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 
 import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.query.Dataset;
@@ -17,15 +18,15 @@ import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQLQueryTest;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.dataset.DatasetRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 
 import junit.framework.Test;
 
 public class NativeSPARQLQueryTest extends SPARQLQueryTest {
 
 	public static Test suite() throws Exception {
-		return SPARQL11ManifestTest.suite(new Factory() {
+		URL manifestUrl = SPARQL11ManifestTest.class.getResource("/testcases-sparql-1.1-w3c/manifest-all.ttl");
 
+		return SPARQL11ManifestTest.suite(new Factory() {
 			@Override
 			public NativeSPARQLQueryTest createSPARQLQueryTest(String testURI, String name, String queryFileURL,
 					String resultFileURL, Dataset dataSet, boolean laxCardinality) {
@@ -50,7 +51,7 @@ public class NativeSPARQLQueryTest extends SPARQLQueryTest {
 			}
 			// skip 'service' tests because it requires the test rig to start up
 			// a remote endpoint
-		}, true, true, false, "service");
+		}, manifestUrl.toString(), true, "service");
 	}
 
 	private File dataDir;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
@@ -197,12 +197,14 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 			Map<Key, Entry> entries = new LinkedHashMap<>();
 
 			if (!iter.hasNext()) {
-				// no solutions, but if aggregates are present we still need to process them to produce a
-				// zero-result.
-				final Entry entry = new Entry(null);
-				if (!entry.getAggregates().isEmpty()) {
-					entry.addSolution(EmptyBindingSet.getInstance());
-					entries.put(new Key(EmptyBindingSet.getInstance()), entry);
+				// no solutions, but if we are not explicitly grouping and aggregates are present,
+				// we still need to process them to produce a zero-result.
+				if (group.getGroupBindingNames().isEmpty()) {
+					final Entry entry = new Entry(null);
+					if (!entry.getAggregates().isEmpty()) {
+						entry.addSolution(EmptyBindingSet.getInstance());
+						entries.put(new Key(EmptyBindingSet.getInstance()), entry);
+					}
 				}
 			}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIteratorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIteratorTest.java
@@ -71,13 +71,24 @@ public class GroupIteratorTest {
 	}
 
 	@Test
-	public void testMaxEmptySet() throws QueryEvaluationException {
+	public void testMaxEmptySet_DefaultGroup() throws QueryEvaluationException {
 		Group group = new Group(EMPTY_ASSIGNMENT);
 		group.addGroupElement(new GroupElem("max", new Max(new Var("a"))));
 		GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance());
 
 		assertThat(gi.hasNext()).isTrue();
 		assertThat(gi.next().size()).isEqualTo(0);
+	}
+
+	@Test
+	public void testMaxEmptySet_Grouped() throws QueryEvaluationException {
+		Group group = new Group(EMPTY_ASSIGNMENT);
+		group.addGroupElement(new GroupElem("max", new Max(new Var("a"))));
+		group.addGroupBindingName("x"); // we are grouping by variable x
+
+		GroupIterator gi = new GroupIterator(evaluator, group, EmptyBindingSet.getInstance());
+
+		assertThat(gi.hasNext()).isFalse();
 	}
 
 	@Test

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -1118,14 +1118,14 @@ public abstract class ComplexSPARQLQueryTest {
 	 * See https://github.com/eclipse/rdf4j/issues/1978
 	 */
 	@Test
-	public void testMaxAggregateEmptyResult() throws Exception {
+	public void testMaxAggregateWithGroupEmptyResult() throws Exception {
 		String query = "select ?s (max(?o) as ?omax) {\n" +
 				"   ?s ?p ?o .\n" +
 				" }\n" +
 				" group by ?s\n";
 
 		try (TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
-			assertThat(result.next()).isEmpty();
+			assertThat(result.hasNext()).isFalse();
 		}
 	}
 
@@ -1133,11 +1133,10 @@ public abstract class ComplexSPARQLQueryTest {
 	 * See https://github.com/eclipse/rdf4j/issues/1978
 	 */
 	@Test
-	public void testMinAggregateEmptyResult() throws Exception {
-		String query = "select ?s (min(?o) as ?omin) {\n" +
+	public void testMaxAggregateWithoutGroupEmptySolution() throws Exception {
+		String query = "select (max(?o) as ?omax) {\n" +
 				"   ?s ?p ?o .\n" +
-				" }\n" +
-				" group by ?s\n";
+				" }\n";
 
 		try (TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
 			assertThat(result.next()).isEmpty();
@@ -1148,11 +1147,54 @@ public abstract class ComplexSPARQLQueryTest {
 	 * See https://github.com/eclipse/rdf4j/issues/1978
 	 */
 	@Test
-	public void testSampleAggregateEmptyResult() throws Exception {
+	public void testMinAggregateWithGroupEmptyResult() throws Exception {
+		String query = "select ?s (min(?o) as ?omin) {\n" +
+				"   ?s ?p ?o .\n" +
+				" }\n" +
+				" group by ?s\n";
+
+		try (TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
+			assertThat(result.hasNext()).isFalse();
+		}
+	}
+
+	/**
+	 * See https://github.com/eclipse/rdf4j/issues/1978
+	 */
+	@Test
+	public void testMinAggregateWithoutGroupEmptySolution() throws Exception {
+		String query = "select (min(?o) as ?omin) {\n" +
+				"   ?s ?p ?o .\n" +
+				" }\n";
+
+		try (TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
+			assertThat(result.next()).isEmpty();
+		}
+	}
+
+	/**
+	 * See https://github.com/eclipse/rdf4j/issues/1978
+	 */
+	@Test
+	public void testSampleAggregateWithGroupEmptyResult() throws Exception {
 		String query = "select ?s (sample(?o) as ?osample) {\n" +
 				"   ?s ?p ?o .\n" +
 				" }\n" +
 				" group by ?s\n";
+
+		try (TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
+			assertThat(result.hasNext()).isFalse();
+		}
+	}
+
+	/**
+	 * See https://github.com/eclipse/rdf4j/issues/1978
+	 */
+	@Test
+	public void testSampleAggregateWithoutGroupEmptySolution() throws Exception {
+		String query = "select (sample(?o) as ?osample) {\n" +
+				"   ?s ?p ?o .\n" +
+				" }\n";
 
 		try (TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
 			assertThat(result.next()).isEmpty();

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL11ManifestTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL11ManifestTest.java
@@ -10,16 +10,10 @@ package org.eclipse.rdf4j.query.parser.sparql.manifest;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.JarURLConnection;
 import java.net.URL;
-import java.util.jar.JarFile;
-
-import junit.framework.TestResult;
-import junit.framework.TestSuite;
 
 import org.eclipse.rdf4j.OpenRDFUtil;
 import org.eclipse.rdf4j.common.io.FileUtil;
-import org.eclipse.rdf4j.common.io.ZipUtil;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -38,6 +32,9 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import junit.framework.TestResult;
+import junit.framework.TestSuite;
+
 /**
  * Functionality for creating a JUnit test suite out of a W3C Working Group-style manifest for SPARQL query and update
  * tests.
@@ -51,25 +48,79 @@ public class SPARQL11ManifestTest {
 	private static File tmpDir;
 
 	/**
-	 * Creates a new {@link TestSuite} for executiong of {@link SPARQLQueryTest} s.
+	 * Creates a new {@link TestSuite} for execution of {@link SPARQLQueryTest} s.
 	 * 
-	 * @param factory                   a factory class that creates each individual test case.
-	 * @param officialWorkingGroupTests indicates whether to use the official W3C working group tests, or Sesame's own
-	 *                                  set of tests.
-	 * @param approvedTestsOnly         if <code>true</code>, use working group-approved tests only. Has no influence
-	 *                                  when officialWorkingGroup tests is set to <code>false</code>.
-	 * @param useRemoteTests            if set to <code>true</code>, use manifests and tests located at
-	 *                                  <code>http://www.w3.org/2009/sparql/docs/tests/data-sparql11/</code> , instead
-	 *                                  of local copies.
-	 * @param excludedSubdirs           an (optionally empty) list of subdirectories to exclude from testing. If
-	 *                                  specified, test cases in one of the supplied subdirs will not be executed. If
-	 *                                  left empty, all tests will be executed.
+	 * @param factory           a factory class that creates each individual test case.
+	 * @param manifestFile      url of the manifest file (may be remote or local).
+	 * @param approvedTestsOnly if <code>true</code>, use working group-approved tests only.
+	 * @param excludedSubdirs   an (optionally empty) list of subdirectories to exclude from testing. If specified, test
+	 *                          cases in one of the supplied subdirs will not be executed. If left empty, all tests will
+	 *                          be executed.
 	 * @return a TestSuite.
 	 * @throws Exception
 	 */
-	public static TestSuite suite(SPARQLQueryTest.Factory factory, boolean officialWorkingGroupTests,
-			boolean approvedTestsOnly, boolean useRemoteTests, String... excludedSubdirs) throws Exception {
-		final String manifestFile = getManifestFile(officialWorkingGroupTests, useRemoteTests);
+	public static TestSuite suite(SPARQLQueryTest.Factory factory, String manifestFile,
+			boolean approvedTestsOnly, String... excludedSubdirs) throws Exception {
+		TestSuite suite = new TestSuite(factory.getClass().getName()) {
+
+			@Override
+			public void run(TestResult result) {
+				try {
+					super.run(result);
+				} finally {
+					if (tmpDir != null) {
+						try {
+							FileUtil.deleteDir(tmpDir);
+						} catch (IOException e) {
+							System.err.println(
+									"Unable to clean up temporary directory '" + tmpDir + "': " + e.getMessage());
+						}
+					}
+				}
+			}
+		};
+
+		Repository manifestRep = new SailRepository(new MemoryStore());
+		try (RepositoryConnection con = manifestRep.getConnection()) {
+
+			addTurtle(con, new URL(manifestFile), manifestFile);
+
+			String query = " PREFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> "
+					+ "PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> "
+					+ "SELECT DISTINCT ?manifestFile "
+					+ "WHERE { [] mf:include [ rdf:rest*/rdf:first ?manifestFile ] . }   ";
+
+			TupleQueryResult manifestResults = con.prepareTupleQuery(QueryLanguage.SPARQL, query, manifestFile)
+					.evaluate();
+
+			for (BindingSet bindingSet : manifestResults) {
+				String subManifestFile = bindingSet.getValue("manifestFile").stringValue();
+
+				if (includeSubManifest(subManifestFile, excludedSubdirs)) {
+					suite.addTest(SPARQLQueryTest.suite(subManifestFile, factory, approvedTestsOnly));
+				}
+			}
+		}
+		manifestRep.shutDown();
+
+		logger.info("Created aggregated test suite with " + suite.countTestCases() + " test cases.");
+		return suite;
+	}
+
+	/**
+	 * Creates a new {@link TestSuite} for execution of {@link SPARQLUpdateConformanceTest} s.
+	 * 
+	 * @param factory           a factory class that creates each individual test case.
+	 * @param manifestFile      url of the manifest file (may be remote or local).
+	 * @param approvedTestsOnly if <code>true</code>, use working group-approved tests only.
+	 * @param excludedSubdirs   an (optionally empty) list of subdirectories to exclude from testing. If specified, test
+	 *                          cases in one of the supplied subdirs will not be executed. If left empty, all tests will
+	 *                          be executed.
+	 * @return a TestSuite.
+	 * @throws Exception
+	 */
+	public static TestSuite suite(SPARQLUpdateConformanceTest.Factory factory, String manifestFile,
+			boolean approvedTestsOnly, String... excludedSubdirs) throws Exception {
 
 		TestSuite suite = new TestSuite(factory.getClass().getName()) {
 
@@ -91,120 +142,30 @@ public class SPARQL11ManifestTest {
 		};
 
 		Repository manifestRep = new SailRepository(new MemoryStore());
-		manifestRep.initialize();
-		RepositoryConnection con = manifestRep.getConnection();
+		try (RepositoryConnection con = manifestRep.getConnection()) {
 
-		addTurtle(con, new URL(manifestFile), manifestFile);
+			addTurtle(con, new URL(manifestFile), manifestFile);
 
-		String query = " PREFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> "
-				+ "PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> "
-				+ "SELECT DISTINCT ?manifestFile "
-				+ "WHERE { [] mf:include [ rdf:rest*/rdf:first ?manifestFile ] . }   ";
+			String query = " PREFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> "
+					+ "PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> "
+					+ "SELECT DISTINCT ?manifestFile "
+					+ "WHERE { [] mf:include [ rdf:rest*/rdf:first ?manifestFile ] . }   ";
 
-		TupleQueryResult manifestResults = con.prepareTupleQuery(QueryLanguage.SPARQL, query, manifestFile).evaluate();
+			TupleQueryResult manifestResults = con.prepareTupleQuery(QueryLanguage.SPARQL, query, manifestFile)
+					.evaluate();
 
-		while (manifestResults.hasNext()) {
-			BindingSet bindingSet = manifestResults.next();
-			String subManifestFile = bindingSet.getValue("manifestFile").stringValue();
+			for (BindingSet bindingSet : manifestResults) {
+				String subManifestFile = bindingSet.getValue("manifestFile").stringValue();
 
-			if (includeSubManifest(subManifestFile, excludedSubdirs)) {
-				suite.addTest(SPARQLQueryTest.suite(subManifestFile, factory, approvedTestsOnly));
+				if (includeSubManifest(subManifestFile, excludedSubdirs)) {
+					suite.addTest(SPARQLUpdateConformanceTest.suite(subManifestFile, factory, approvedTestsOnly));
+				}
 			}
 		}
-
-		manifestResults.close();
-		con.close();
 		manifestRep.shutDown();
 
 		logger.info("Created aggregated test suite with " + suite.countTestCases() + " test cases.");
 		return suite;
-	}
-
-	public static TestSuite suite(SPARQLUpdateConformanceTest.Factory factory, boolean officialWorkingGroupTests,
-			boolean approvedTestsOnly, boolean useRemote, String... excludedSubdirs) throws Exception {
-		final String manifestFile = getManifestFile(officialWorkingGroupTests, useRemote);
-
-		TestSuite suite = new TestSuite(factory.getClass().getName()) {
-
-			@Override
-			public void run(TestResult result) {
-				try {
-					super.run(result);
-				} finally {
-					if (tmpDir != null) {
-						try {
-							FileUtil.deleteDir(tmpDir);
-						} catch (IOException e) {
-							System.err.println(
-									"Unable to clean up temporary directory '" + tmpDir + "': " + e.getMessage());
-						}
-					}
-				}
-			}
-		};
-
-		Repository manifestRep = new SailRepository(new MemoryStore());
-		manifestRep.initialize();
-		RepositoryConnection con = manifestRep.getConnection();
-
-		addTurtle(con, new URL(manifestFile), manifestFile);
-
-		String query = " PREFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> "
-				+ "PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> "
-				+ "SELECT DISTINCT ?manifestFile "
-				+ "WHERE { [] mf:include [ rdf:rest*/rdf:first ?manifestFile ] . }   ";
-
-		TupleQueryResult manifestResults = con.prepareTupleQuery(QueryLanguage.SPARQL, query, manifestFile).evaluate();
-
-		while (manifestResults.hasNext()) {
-			BindingSet bindingSet = manifestResults.next();
-			String subManifestFile = bindingSet.getValue("manifestFile").stringValue();
-
-			if (includeSubManifest(subManifestFile, excludedSubdirs)) {
-				suite.addTest(SPARQLUpdateConformanceTest.suite(subManifestFile, factory, approvedTestsOnly));
-			}
-		}
-
-		manifestResults.close();
-		con.close();
-		manifestRep.shutDown();
-
-		logger.info("Created aggregated test suite with " + suite.countTestCases() + " test cases.");
-		return suite;
-	}
-
-	private static String getManifestFile(boolean officialWorkingGroupTests, boolean useRemote) {
-		String manifestFile = null;
-		if (useRemote) {
-			manifestFile = "http://www.w3.org/2009/sparql/docs/tests/data-sparql11/manifest-all.ttl";
-		} else {
-			URL url = null;
-			if (officialWorkingGroupTests) {
-				url = SPARQL11ManifestTest.class.getResource("/testcases-sparql-1.1-w3c/manifest-all.ttl");
-			} else {
-				url = SPARQL11ManifestTest.class.getResource("/testcases-sparql-1.1/manifest-evaluation.ttl");
-			}
-
-			if ("jar".equals(url.getProtocol())) {
-				// Extract manifest files to a temporary directory
-				try {
-					tmpDir = FileUtil.createTempDir("sparql11-test-evaluation");
-
-					JarURLConnection con = (JarURLConnection) url.openConnection();
-					JarFile jar = con.getJarFile();
-
-					ZipUtil.extract(jar, tmpDir);
-
-					File localFile = new File(tmpDir, con.getEntryName());
-					manifestFile = localFile.toURI().toURL().toString();
-				} catch (IOException e) {
-					throw new AssertionError(e);
-				}
-			} else {
-				manifestFile = url.toString();
-			}
-		}
-		return manifestFile;
 	}
 
 	/**

--- a/testsuites/sparql/src/main/resources/testcases-sparql-1.1-w3c/aggregates/manifest.ttl
+++ b/testsuites/sparql/src/main/resources/testcases-sparql-1.1-w3c/aggregates/manifest.ttl
@@ -37,7 +37,8 @@
     :agg-sample-01 
     :agg-err-01
     :agg-err-02
-    :agg-empty-group
+    # disabling test that is factually incorrect. See https://github.com/eclipse/rdf4j/issues/1978
+    # :agg-empty-group
 ) .
 
 
@@ -335,7 +336,6 @@
 
 :agg-empty-group rdf:type mf:QueryEvaluationTest ;
 	mf:name "agg empty group" ;
-    mf:name "Aggregate over empty group resulting in a row with unbound variables" ;
 	mf:feature sparql:aggregate ;
 	rdfs:seeAlso <http://answers.semanticweb.com/questions/17410/semantics-of-sparql-aggregates> ;
     dawgt:approval dawgt:Approved ;

--- a/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/agg-empty-group-1.rq
+++ b/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/agg-empty-group-1.rq
@@ -1,0 +1,5 @@
+PREFIX ex: <http://example.com/>
+SELECT ?x (MAX(?value) AS ?max)
+WHERE {
+	?x ex:p ?value
+} GROUP BY ?x

--- a/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/agg-empty-group-1.srx
+++ b/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/agg-empty-group-1.srx
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+	<head>
+		<variable name="x"/>
+		<variable name="max"/>
+	</head>
+	<results>
+	</results>
+</sparql>

--- a/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/agg-empty-group-2.rq
+++ b/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/agg-empty-group-2.rq
@@ -1,0 +1,5 @@
+PREFIX ex: <http://example.com/>
+SELECT (MAX(?value) AS ?max)
+WHERE {
+	?x ex:p ?value
+}

--- a/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/agg-empty-group-2.srx
+++ b/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/agg-empty-group-2.srx
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+	<head>
+		<variable name="max"/>
+	</head>
+	<results>
+		<result>
+		</result>
+	</results>
+</sparql>

--- a/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/empty.ttl
+++ b/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/empty.ttl
@@ -1,0 +1,1 @@
+@prefix ex: <http://example.com/> .

--- a/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/manifest.ttl
+++ b/testsuites/sparql/src/main/resources/testcases-sparql-1.2/aggregates/manifest.ttl
@@ -1,0 +1,34 @@
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://www.w3.org/2009/sparql/docs/tests/data-sparql11/aggregates/manifest#> .
+@prefix rdfs:	<http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
+@prefix dawgt:   <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
+@prefix sparql:  <http://www.w3.org/ns/sparql#> .
+
+<>  rdf:type mf:Manifest ;
+    rdfs:label "Aggregates" ;
+    mf:entries
+    ( 
+    :agg-empty-group-1
+    :agg-empty-group-2
+) .
+
+
+:agg-empty-group-1 rdf:type mf:QueryEvaluationTest ;
+	mf:name "agg on empty set, explicit grouping" ;
+	mf:feature sparql:aggregate ;
+    mf:action
+         [ qt:query  <agg-empty-group-1.rq> ;
+           qt:data   <empty.ttl> ] ;
+    mf:result  <agg-empty-group-1.srx>
+    .    
+
+:agg-empty-group-2 rdf:type mf:QueryEvaluationTest ;
+	mf:name "agg on empty set, no grouping" ;
+	mf:feature sparql:aggregate ;
+    mf:action
+         [ qt:query  <agg-empty-group-2.rq> ;
+           qt:data   <empty.ttl> ] ;
+    mf:result  <agg-empty-group-2.srx>
+    .    

--- a/testsuites/sparql/src/main/resources/testcases-sparql-1.2/manifest-all.ttl
+++ b/testsuites/sparql/src/main/resources/testcases-sparql-1.2/manifest-all.ttl
@@ -1,0 +1,16 @@
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:	<http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
+
+<> a mf:Manifest ;
+	rdfs:label "SPARQL 1.2 test cases" ;
+	mf:include (
+		<aggregates/manifest.ttl>
+	).
+
+
+<http://www.w3.org/TR/sparql11-query/> rdfs:label "SPARQL 1.1 Query Language" ;
+	mf:conformanceRequirement (
+		<aggregates/manifest.ttl>
+	).


### PR DESCRIPTION
- modified behavior of groupIterator based on whether it's an explicit grouping or not
- modified and extended unit tests
- disabled incorrect W3C conformance test per discussion on GH-1978



GitHub issue resolved: #1978 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged -->