### PR TITLE
GH-1990: fix FedX initialization order for RepositoryManager environment

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepository.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepository.java
@@ -87,9 +87,10 @@ public class FedXRepository extends SailRepository {
 				fedxServiceResolver, monitoring, fedXConfig);
 		federation.setFederationContext(federationContext);
 
+		federationManager.init(federation, federationContext);
+
 		super.initializeInternal();
 
-		federationManager.init(federation, federationContext);
 		queryManager.init(this, federationContext);
 		fedxServiceResolver.initialize();
 	}


### PR DESCRIPTION
Due to a wrong initialization order in an environment where the
federation is initialized through a RepositoryManager, references to the
evaluation strategy instance are not available in the Endpoint.

This in turn caused an NPE in the filter evaluation.

This change fixes the issue by first initializing the manager, and only
after that the federation members.


GitHub issue resolved: #1990 
