### PR TITLE
GH-1986 use line separator

### DIFF
--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriterTest.java
@@ -62,9 +62,10 @@ public class ArrangedWriterTest {
 		ByteArrayOutputStream outputWriter = new ByteArrayOutputStream();
 		write(input, outputWriter);
 
-		String expectedResult = "@prefix net: <http://example.net/> .\n" +
-				"@prefix org: <http://example.org/> .\n\n" +
-				"net:uri0 org:uri1 org:uri2 .\n";
+		String sep = System.lineSeparator();
+		String expectedResult = "@prefix net: <http://example.net/> ." + sep +
+				"@prefix org: <http://example.org/> ." + sep + sep +
+				"net:uri0 org:uri1 org:uri2 ." + sep;
 
 		assertEquals(expectedResult, outputWriter.toString());
 	}


### PR DESCRIPTION
GitHub issue resolved: #1986 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* (backport) use line separator when comparing output
