### PR TITLE
GH-2009 Update to java 13 for Github Actions

### DIFF
--- a/.github/workflows/develop-status.yml
+++ b/.github/workflows/develop-status.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest    
     strategy:
       matrix:
-        jdk: [1.8, 11]
+        jdk: [1.8, 13]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/master-status.yml
+++ b/.github/workflows/master-status.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest    
     strategy:
       matrix:
-        jdk: [1.8, 11]
+        jdk: [1.8, 13]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [1.8, 11]
+        jdk: [1.8, 13]
 
     steps:
     - uses: actions/checkout@v1

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.List;
 
 import org.eclipse.rdf4j.IsolationLevel;
@@ -192,12 +191,6 @@ public class SPARQLStoreConnectionTest extends RepositoryConnectionTest {
 	private void enableQuadModeOnConnection(SPARQLConnection con) throws Exception {
 		Field quadModeField = SPARQLConnection.class.getDeclaredField("quadMode");
 		quadModeField.setAccessible(true);
-
-		// remove final modifier from field
-		Field modifiersField = Field.class.getDeclaredField("modifiers");
-		modifiersField.setAccessible(true);
-		modifiersField.setInt(quadModeField, quadModeField.getModifiers() & ~Modifier.FINAL);
-
 		quadModeField.set(con, true);
 	}
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/TestHelpers.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/TestHelpers.java
@@ -23,7 +23,7 @@ import pl.allegro.tech.embeddedelasticsearch.PopularProperties;
 public class TestHelpers {
 
 	private final static Random random = new Random();
-	public static final String VERSION = "6.8.7";
+	public static final String VERSION = "6.8.8";
 	public static final String CLUSTER = "cluster1";
 	public static final String ELASTICSEARCH_DOWNLOAD_DIRECTORY = "tempElasticsearchDownload";
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/TestHelpers.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/TestHelpers.java
@@ -23,7 +23,7 @@ import pl.allegro.tech.embeddedelasticsearch.PopularProperties;
 public class TestHelpers {
 
 	private final static Random random = new Random();
-	public static final String VERSION = "6.5.4";
+	public static final String VERSION = "6.8.7";
 	public static final String CLUSTER = "cluster1";
 	public static final String ELASTICSEARCH_DOWNLOAD_DIRECTORY = "tempElasticsearchDownload";
 


### PR DESCRIPTION
GitHub issue resolved: #2009 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* bumps build on Java 11 to Java 13
* bumps version of elasticsearch (see also #2016 )
* fixes issue in SPARQLStoreConnectionTest with use of reflection
