### PR TITLE
GH-2031 remove test dependency

### DIFF
--- a/compliance/model/pom.xml
+++ b/compliance/model/pom.xml
@@ -44,11 +44,5 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.eclipse.rdf4j</groupId>
-            <artifactId>rdf4j-sail-base</artifactId>
-            <version>3.1.1-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
GitHub issue resolved: #2031 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* remove test dependency that pulls in a fixed version of the RDF4J sail
* no further changes are necessary as nothing actually uses this dependency

