### PR TITLE
GH-2015 lucene-spatial-extras dep optional so we don't distribute it by default

### DIFF
--- a/core/sail/lucene-spin/pom.xml
+++ b/core/sail/lucene-spin/pom.xml
@@ -20,6 +20,12 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-spatial-extras</artifactId>
+			<version>${lucene.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-sail-spin</artifactId>
 			<version>${project.version}</version>

--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -9,9 +9,7 @@
 	<artifactId>rdf4j-sail-lucene</artifactId>
 	<name>RDF4J Lucene Sail Index</name>
 	<description>StackableSail implementation offering full-text search on literals, based on Apache Lucene.</description>
-	<properties>
-		<lucene.version>7.5.0</lucene.version>
-	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -53,6 +53,7 @@
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-spatial-extras</artifactId>
 			<version>${lucene.version}</version>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>

--- a/core/sail/pom.xml
+++ b/core/sail/pom.xml
@@ -10,6 +10,12 @@
 	<packaging>pom</packaging>
 	<name>RDF4J: Sail</name>
 	<description>Sail API and implementations.</description>
+	
+	<properties>
+		<!--  various Sail implementations depend on Apache Lucene. declare single shared version here -->
+		<lucene.version>7.5.0</lucene.version>
+	</properties>
+	
 	<modules>
 		<module>api</module>
 		<module>base</module>


### PR DESCRIPTION
This makes sure we don't distribute the lucene-spatial-extras library or its transitive dependencies by default, which makes maintaining our IP log easier (as we no longer have to log CQs for its transitive dependencies).