### PR TITLE
GH-2043 make more imports optional of runtime-osgi

### DIFF
--- a/tools/runtime-osgi/pom.xml
+++ b/tools/runtime-osgi/pom.xml
@@ -35,7 +35,16 @@
 					<instructions>
 						<Bundle-SymbolicName>org.eclipse.rdf4j</Bundle-SymbolicName>
 						<Export-Package>!*text-base,!*prop-base,org.eclipse.rdf4j.*</Export-Package>
-						<Import-Package>org.slf4j.*, org.eclipse.rdf4j.*;version=0, javax.*;resolution:=optional, org.apache.*;resolution:=optional, org.springframework.*;resolution:=optional, *</Import-Package>
+						<Import-Package>
+							org.slf4j.*,
+							javax.*;resolution:=optional,
+							org.apache.*;resolution:=optional,
+							org.springframework.*;resolution:=optional,
+							org.locationtech;resolution:=optional,
+							org.elasticsearch;resolution:=optional,
+							ch.qos.logback;resolution:=optional,
+							*
+						</Import-Package>
 						<Embed-Dependency>*; groupId=org.eclipse.rdf4j; scope=compile|runtime; type=!pom; inline=true</Embed-Dependency>
 						<Embed-Transitive>true</Embed-Transitive>
 					</instructions>


### PR DESCRIPTION
GitHub issue resolved: #2043 

Changed BND instructions to also make following imports optional:
* org.locationtech
* org.elasticsearch
* ch.qos.logback