### PR TITLE
GH-2044 store cardinality in query model node

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -7,13 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.Extension;
@@ -27,6 +20,13 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.algebra.helpers.StatementPatternCollector;
 import org.eclipse.rdf4j.query.algebra.helpers.TupleExprs;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A query optimizer that re-orders nested Joins.
@@ -109,7 +109,9 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 					Map<TupleExpr, List<Var>> varsMap = new HashMap<>();
 
 					for (TupleExpr tupleExpr : joinArgs) {
-						cardinalityMap.put(tupleExpr, statistics.getCardinality(tupleExpr));
+						double cardinality = statistics.getCardinality(tupleExpr);
+						tupleExpr.setCardinality(cardinality);
+						cardinalityMap.put(tupleExpr, cardinality);
 						if (tupleExpr instanceof ZeroLengthPath) {
 							varsMap.put(tupleExpr, ((ZeroLengthPath) tupleExpr).getVarList());
 						} else {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -110,7 +110,7 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 
 					for (TupleExpr tupleExpr : joinArgs) {
 						double cardinality = statistics.getCardinality(tupleExpr);
-						tupleExpr.setCardinality(cardinality);
+						tupleExpr.setEstimatedRows(cardinality);
 						cardinalityMap.put(tupleExpr, cardinality);
 						if (tupleExpr instanceof ZeroLengthPath) {
 							varsMap.put(tupleExpr, ((ZeroLengthPath) tupleExpr).getVarList());

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -110,7 +110,7 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 
 					for (TupleExpr tupleExpr : joinArgs) {
 						double cardinality = statistics.getCardinality(tupleExpr);
-						tupleExpr.setEstimatedRows(cardinality);
+						tupleExpr.setResultSizeEstimate(cardinality);
 						cardinalityMap.put(tupleExpr, cardinality);
 						if (tupleExpr instanceof ZeroLengthPath) {
 							varsMap.put(tupleExpr, ((ZeroLengthPath) tupleExpr).getVarList());

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -27,7 +27,7 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 
 	private boolean isGraphPatternGroup;
 
-	private double cardinality = -1;
+	private double estimatedRows = -1;
 
 	/*---------*
 	 * Methods *
@@ -136,32 +136,32 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 	}
 
 	@Override
-	public double getCardinality() {
-		return cardinality;
+	public double getEstimatedRows() {
+		return estimatedRows;
 	}
 
 	@Override
-	public void setCardinality(double cardinality) {
-		this.cardinality = cardinality;
+	public void setEstimatedRows(double estimatedRows) {
+		this.estimatedRows = estimatedRows;
 	}
 
 	/**
 	 *
-	 * @return Human readable cardinality. Eg. 12.1M for 1212213.4 and UNKNOWN for -1.
+	 * @return Human readable number. Eg. 12.1M for 1212213.4 and UNKNOWN for -1.
 	 */
-	String getCardinalityString() {
-		String cardinalityString;
-		if (getCardinality() > 1_000_000) {
-			cardinalityString = Math.round(getCardinality() / 100_000) / 10.0 + "M";
-		} else if (getCardinality() > 1_000) {
-			cardinalityString = Math.round(getCardinality() / 100) / 10.0 + "K";
-		} else if (getCardinality() > 0) {
-			cardinalityString = Math.round(getCardinality()) + "";
+	static String toHumanReadbleNumber(double number) {
+		String humanReadbleString;
+		if (number > 1_000_000) {
+			humanReadbleString = Math.round(number / 100_000) / 10.0 + "M";
+		} else if (number > 1_000) {
+			humanReadbleString = Math.round(number / 100) / 10.0 + "K";
+		} else if (number > 0) {
+			humanReadbleString = Math.round(number) + "";
 		} else {
-			cardinalityString = "UNKNOWN";
+			humanReadbleString = "UNKNOWN";
 		}
 
-		return cardinalityString;
+		return humanReadbleString;
 	}
 
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -27,7 +27,7 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 
 	private boolean isGraphPatternGroup;
 
-	private double estimatedRows = -1;
+	private double resultSizeEstimate = -1;
 
 	/*---------*
 	 * Methods *
@@ -136,13 +136,13 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 	}
 
 	@Override
-	public double getEstimatedRows() {
-		return estimatedRows;
+	public double getResultSizeEstimate() {
+		return resultSizeEstimate;
 	}
 
 	@Override
-	public void setEstimatedRows(double estimatedRows) {
-		this.estimatedRows = estimatedRows;
+	public void setResultSizeEstimate(double resultSizeEstimate) {
+		this.resultSizeEstimate = resultSizeEstimate;
 	}
 
 	/**

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -27,6 +27,8 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 
 	private boolean isGraphPatternGroup;
 
+	private double cardinality = -1;
+
 	/*---------*
 	 * Methods *
 	 *---------*/
@@ -43,7 +45,7 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.rdf4j.query.algebra.GraphPatternGroupable#isGraphPatternGroup()
 	 */
 	@Override
@@ -53,7 +55,7 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.rdf4j.query.algebra.GraphPatternGroupable#setGraphPatternGroup(boolean)
 	 */
 	@Override
@@ -132,4 +134,34 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 	protected boolean nullEquals(Object o1, Object o2) {
 		return o1 == o2 || o1 != null && o1.equals(o2);
 	}
+
+	@Override
+	public double getCardinality() {
+		return cardinality;
+	}
+
+	@Override
+	public void setCardinality(double cardinality) {
+		this.cardinality = cardinality;
+	}
+
+	/**
+	 *
+	 * @return Human readable cardinality. Eg. 12.1M for 1212213.4 and UNKNOWN for -1.
+	 */
+	String getCardinalityString() {
+		String cardinalityString;
+		if (getCardinality() > 1_000_000) {
+			cardinalityString = Math.round(getCardinality() / 100_000) / 10.0 + "M";
+		} else if (getCardinality() > 1_000) {
+			cardinalityString = Math.round(getCardinality() / 100) / 10.0 + "K";
+		} else if (getCardinality() > 0) {
+			cardinalityString = Math.round(getCardinality()) + "";
+		} else {
+			cardinalityString = "UNKNOWN";
+		}
+
+		return cardinalityString;
+	}
+
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNode.java
@@ -26,21 +26,21 @@ public interface QueryModelNode extends Cloneable, Serializable {
 
 	/**
 	 * Gets the node's parent.
-	 * 
+	 *
 	 * @return The parent node, if any.
 	 */
 	public QueryModelNode getParentNode();
 
 	/**
 	 * Sets the node's parent.
-	 * 
+	 *
 	 * @param parent The parent node for this node.
 	 */
 	public void setParentNode(QueryModelNode parent);
 
 	/**
 	 * Replaces one of the child nodes with a new node.
-	 * 
+	 *
 	 * @param current     The current child node.
 	 * @param replacement The new child node.
 	 * @throws IllegalArgumentException If <tt>current</tt> is not one of node's children.
@@ -50,7 +50,7 @@ public interface QueryModelNode extends Cloneable, Serializable {
 
 	/**
 	 * Substitutes this node with a new node in the query model tree.
-	 * 
+	 *
 	 * @param replacement The new node.
 	 * @throws IllegalStateException If this node does not have a parent node.
 	 * @throws ClassCastException    If <tt>replacement</tt> is of an incompatible type.
@@ -73,7 +73,7 @@ public interface QueryModelNode extends Cloneable, Serializable {
 	/**
 	 * Returns the signature of this query model node. Signatures normally include the node's name and any parameters,
 	 * but not parent or child nodes. This method is used by {@link #toString()}.
-	 * 
+	 *
 	 * @return The node's signature, e.g. <tt>SLICE (offset=10, limit=10)</tt>.
 	 */
 	public String getSignature();
@@ -81,8 +81,19 @@ public interface QueryModelNode extends Cloneable, Serializable {
 	/**
 	 * Returns a (deep) clone of this query model node. This method recursively clones the entire node tree, starting
 	 * from this nodes.
-	 * 
+	 *
 	 * @return A deep clone of this query model node.
 	 */
 	public QueryModelNode clone();
+
+	/**
+	 * Returns the number of outputs that this QueryNode predicts will be outputted. For a StatementPattern this would
+	 * be the estimated cardinality provided by the EvaluationStatistics. For a Join the would be the resulting number
+	 * of joined tuples.
+	 * 
+	 * @return cardinality
+	 */
+	public double getCardinality();
+
+	public void setCardinality(double cardinality);
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNode.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import org.eclipse.rdf4j.common.annotation.Experimental;
+
 import java.io.Serializable;
 
 /**
@@ -87,13 +89,19 @@ public interface QueryModelNode extends Cloneable, Serializable {
 	public QueryModelNode clone();
 
 	/**
-	 * Returns the number of outputs that this QueryNode predicts will be outputted. For a StatementPattern this would
-	 * be the estimated cardinality provided by the EvaluationStatistics. For a Join the would be the resulting number
-	 * of joined tuples.
-	 * 
-	 * @return cardinality
+	 * Returns the number of tuples that this QueryNode predicts will be outputted. For a StatementPattern this would be
+	 * the estimated cardinality provided by the EvaluationStatistics. For a Join the would be the resulting number of
+	 * joined tuples.
+	 *
+	 * @return rows
 	 */
-	public double getCardinality();
+	@Experimental
+	default double getEstimatedRows() {
+		return -1;
+	}
 
-	public void setCardinality(double cardinality);
+	@Experimental
+	default void setEstimatedRows(double rows) {
+		// no-op for backwards compatibility
+	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNode.java
@@ -96,12 +96,12 @@ public interface QueryModelNode extends Cloneable, Serializable {
 	 * @return rows
 	 */
 	@Experimental
-	default double getEstimatedRows() {
+	default double getResultSizeEstimate() {
 		return -1;
 	}
 
 	@Experimental
-	default void setEstimatedRows(double rows) {
+	default void setResultSizeEstimate(double rows) {
 		// no-op for backwards compatibility
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
@@ -255,6 +255,8 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 			sb.append(" FROM NAMED CONTEXT");
 		}
 
+		sb.append(" ( cost=").append(getCardinalityString()).append(" )");
+
 		return sb.toString();
 	}
 
@@ -289,6 +291,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		clone.setSubjectVar(getSubjectVar().clone());
 		clone.setPredicateVar(getPredicateVar().clone());
 		clone.setObjectVar(getObjectVar().clone());
+		clone.setCardinality(getCardinality());
 
 		if (getContextVar() != null) {
 			clone.setContextVar(getContextVar().clone());
@@ -296,4 +299,5 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 
 		return clone;
 	}
+
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
@@ -255,7 +255,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 			sb.append(" FROM NAMED CONTEXT");
 		}
 
-		sb.append(" ( rows=").append(toHumanReadbleNumber(getEstimatedRows())).append(" )");
+		sb.append(" (resultSizeEstimate=").append(toHumanReadbleNumber(getResultSizeEstimate())).append(")");
 
 		return sb.toString();
 	}
@@ -291,7 +291,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		clone.setSubjectVar(getSubjectVar().clone());
 		clone.setPredicateVar(getPredicateVar().clone());
 		clone.setObjectVar(getObjectVar().clone());
-		clone.setEstimatedRows(getEstimatedRows());
+		clone.setResultSizeEstimate(getResultSizeEstimate());
 
 		if (getContextVar() != null) {
 			clone.setContextVar(getContextVar().clone());

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
@@ -255,7 +255,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 			sb.append(" FROM NAMED CONTEXT");
 		}
 
-		sb.append(" ( cost=").append(getCardinalityString()).append(" )");
+		sb.append(" ( rows=").append(toHumanReadbleNumber(getEstimatedRows())).append(" )");
 
 		return sb.toString();
 	}
@@ -291,7 +291,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		clone.setSubjectVar(getSubjectVar().clone());
 		clone.setPredicateVar(getPredicateVar().clone());
 		clone.setObjectVar(getObjectVar().clone());
-		clone.setCardinality(getCardinality());
+		clone.setEstimatedRows(getEstimatedRows());
 
 		if (getContextVar() != null) {
 			clone.setContextVar(getContextVar().clone());

--- a/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNodeTest.java
+++ b/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNodeTest.java
@@ -18,35 +18,35 @@ public class AbstractQueryModelNodeTest {
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			String cardinalityString = statementPattern.getCardinalityString();
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
 			assertEquals("UNKNOWN", cardinalityString);
 		}
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			statementPattern.setCardinality(1234);
-			String cardinalityString = statementPattern.getCardinalityString();
+			statementPattern.setEstimatedRows(1234);
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
 			assertEquals("1.2K", cardinalityString);
 		}
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			statementPattern.setCardinality(1910000);
-			String cardinalityString = statementPattern.getCardinalityString();
+			statementPattern.setEstimatedRows(1910000);
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
 			assertEquals("1.9M", cardinalityString);
 		}
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			statementPattern.setCardinality(1990000);
-			String cardinalityString = statementPattern.getCardinalityString();
+			statementPattern.setEstimatedRows(1990000);
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
 			assertEquals("2.0M", cardinalityString);
 		}
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			statementPattern.setCardinality(912000);
-			String cardinalityString = statementPattern.getCardinalityString();
+			statementPattern.setEstimatedRows(912000);
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
 			assertEquals("912.0K", cardinalityString);
 		}
 

--- a/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNodeTest.java
+++ b/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNodeTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AbstractQueryModelNodeTest {
+
+	@Test
+	public void getCardinalityString() {
+
+		{
+			StatementPattern statementPattern = new StatementPattern();
+			String cardinalityString = statementPattern.getCardinalityString();
+			assertEquals("UNKNOWN", cardinalityString);
+		}
+
+		{
+			StatementPattern statementPattern = new StatementPattern();
+			statementPattern.setCardinality(1234);
+			String cardinalityString = statementPattern.getCardinalityString();
+			assertEquals("1.2K", cardinalityString);
+		}
+
+		{
+			StatementPattern statementPattern = new StatementPattern();
+			statementPattern.setCardinality(1910000);
+			String cardinalityString = statementPattern.getCardinalityString();
+			assertEquals("1.9M", cardinalityString);
+		}
+
+		{
+			StatementPattern statementPattern = new StatementPattern();
+			statementPattern.setCardinality(1990000);
+			String cardinalityString = statementPattern.getCardinalityString();
+			assertEquals("2.0M", cardinalityString);
+		}
+
+		{
+			StatementPattern statementPattern = new StatementPattern();
+			statementPattern.setCardinality(912000);
+			String cardinalityString = statementPattern.getCardinalityString();
+			assertEquals("912.0K", cardinalityString);
+		}
+
+	}
+}

--- a/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNodeTest.java
+++ b/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNodeTest.java
@@ -18,35 +18,35 @@ public class AbstractQueryModelNodeTest {
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getResultSizeEstimate());
 			assertEquals("UNKNOWN", cardinalityString);
 		}
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			statementPattern.setEstimatedRows(1234);
-			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
+			statementPattern.setResultSizeEstimate(1234);
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getResultSizeEstimate());
 			assertEquals("1.2K", cardinalityString);
 		}
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			statementPattern.setEstimatedRows(1910000);
-			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
+			statementPattern.setResultSizeEstimate(1910000);
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getResultSizeEstimate());
 			assertEquals("1.9M", cardinalityString);
 		}
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			statementPattern.setEstimatedRows(1990000);
-			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
+			statementPattern.setResultSizeEstimate(1990000);
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getResultSizeEstimate());
 			assertEquals("2.0M", cardinalityString);
 		}
 
 		{
 			StatementPattern statementPattern = new StatementPattern();
-			statementPattern.setEstimatedRows(912000);
-			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getEstimatedRows());
+			statementPattern.setResultSizeEstimate(912000);
+			String cardinalityString = statementPattern.toHumanReadbleNumber(statementPattern.getResultSizeEstimate());
 			assertEquals("912.0K", cardinalityString);
 		}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
@@ -41,7 +41,7 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 	protected final String id;
 	protected final QueryInfo queryInfo;
 
-	private double estimatedRows = -1;
+	private double resultSizeEstimate = -1;
 
 	public CheckStatementPattern(StatementTupleExpr stmt, QueryInfo queryInfo) {
 		super();
@@ -133,13 +133,13 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 	}
 
 	@Override
-	public double getEstimatedRows() {
-		return estimatedRows;
+	public double getResultSizeEstimate() {
+		return resultSizeEstimate;
 	}
 
 	@Override
-	public void setEstimatedRows(double estimatedRows) {
-		this.estimatedRows = estimatedRows;
+	public void setResultSizeEstimate(double resultSizeEstimate) {
+		this.resultSizeEstimate = resultSizeEstimate;
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
@@ -28,9 +28,9 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 /**
  * A statement pattern with no free variables when provided with some particular BindingSet in evaluate. For evaluation
  * a boolean ASK query is performed.
- * 
+ *
  * Wraps a StatementTupleExpr
- * 
+ *
  * @author Andreas Schwarte
  */
 public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTupleExpr {
@@ -40,6 +40,8 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 	protected final StatementTupleExpr stmt;
 	protected final String id;
 	protected final QueryInfo queryInfo;
+
+	private double cardinality = -1;
 
 	public CheckStatementPattern(StatementTupleExpr stmt, QueryInfo queryInfo) {
 		super();
@@ -128,6 +130,16 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 	@Override
 	public CheckStatementPattern clone() {
 		throw new RuntimeException("Operation not supported on this node!");
+	}
+
+	@Override
+	public double getCardinality() {
+		return cardinality;
+	}
+
+	@Override
+	public void setCardinality(double cardinality) {
+		this.cardinality = cardinality;
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
@@ -41,7 +41,7 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 	protected final String id;
 	protected final QueryInfo queryInfo;
 
-	private double cardinality = -1;
+	private double estimatedRows = -1;
 
 	public CheckStatementPattern(StatementTupleExpr stmt, QueryInfo queryInfo) {
 		super();
@@ -133,13 +133,13 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 	}
 
 	@Override
-	public double getCardinality() {
-		return cardinality;
+	public double getEstimatedRows() {
+		return estimatedRows;
 	}
 
 	@Override
-	public void setCardinality(double cardinality) {
-		this.cardinality = cardinality;
+	public void setEstimatedRows(double estimatedRows) {
+		this.estimatedRows = estimatedRows;
 	}
 
 	@Override

--- a/tools/federation/src/test/resources/tests/basic/query_limit01.qp
+++ b/tools/federation/src/test/resources/tests/basic/query_limit01.qp
@@ -3,7 +3,7 @@ QueryRoot
       Projection
          ProjectionElemList
             ProjectionElem "person"
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)

--- a/tools/federation/src/test/resources/tests/filter/query01.qp
+++ b/tools/federation/src/test/resources/tests/filter/query01.qp
@@ -3,7 +3,7 @@ QueryRoot
       ProjectionElemList
          ProjectionElem "s"
          ProjectionElem "name"
-      StatementSourcePattern
+      StatementSourcePattern (resultSizeEstimate=UNKNOWN)
          Var (name=s)
          Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
          Var (name=name, value="Person1")

--- a/tools/federation/src/test/resources/tests/filter/query01a.qp
+++ b/tools/federation/src/test/resources/tests/filter/query01a.qp
@@ -4,13 +4,13 @@ QueryRoot
          ProjectionElem "person"
          ProjectionElem "name"
       NJoin
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person, value=http://namespace1.org/Person_1)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_d7b490e6_uri, value=http://namespace1.org/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
             BoundFilters (person=http://namespace1.org/Person_1)
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=person, value=http://namespace1.org/Person_1)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)

--- a/tools/federation/src/test/resources/tests/medium/query03.qp
+++ b/tools/federation/src/test/resources/tests/medium/query03.qp
@@ -7,28 +7,28 @@ QueryRoot
          ProjectionElem "name"
       NJoin
          ExclusiveGroup
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=project)
                Var (name=_const_e5fa3827_uri, value=http://namespace3.org/responsible, anonymous)
                Var (name=person)
                StatementSource (id=endpoint3, type=REMOTE)
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=project)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_11e414aa_uri, value=http://namespace3.org/Project, anonymous)
                StatementSource (id=endpoint3, type=REMOTE)
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=project)
                Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
                Var (name=label)
                StatementSource (id=endpoint3, type=REMOTE)
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
             StatementSource (id=endpoint2, type=REMOTE)
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_1.txt
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_1.txt
@@ -7,16 +7,16 @@ QueryRoot
             ExtensionElem (nameOut)
                Var (name=name)
             EmptyNJoin
-               ExclusiveStatement
+               ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                   Var (name=person)
                   Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                   Var (name=name)
                   StatementSource (id=endpoint1, type=REMOTE)
-               EmptyStatementPattern
+               EmptyStatementPattern (resultSizeEstimate=UNKNOWN)
                   Var (name=person)
                   Var (name=_const_4240a169_uri, value=urn:doesNotExistProp, anonymous)
                   Var (name=obj)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_ea9562d5_uri, value=http://xmlns.com/foaf/0.1/interest, anonymous)
             Var (name=o)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_2.txt
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_2.txt
@@ -6,12 +6,12 @@ QueryRoot
          ExtensionElem (person)
             Var (name=person)
          NJoin
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=_const_c0e515a0_uri, value=http://example.org/a, anonymous)
                Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                Var (name=_const_1f2db8_lit_e2eec718_0, value="Alan", anonymous)
                StatementSource (id=endpoint1, type=REMOTE)
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=_const_c0e515a0_uri, value=http://example.org/a, anonymous)
                Var (name=_const_ea9562d5_uri, value=http://xmlns.com/foaf/0.1/interest, anonymous)
                Var (name=_const_5e79d277_lit_e2eec718_0, value="SPARQL 1.1 Basic Federated Query", anonymous)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Optional1
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Optional1
@@ -5,13 +5,13 @@ QueryRoot
          ProjectionElem "o"
          ProjectionElem "o2"
       FedXLeftJoin
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=s)
             Var (name=_const_99282aab_uri, value=http://purl.org/dc/terms/source, anonymous)
             Var (name=o)
             StatementSource (id=endpoint1, type=REMOTE)
             StatementSource (id=endpoint2, type=REMOTE)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=s)
             Var (name=_const_dbb1cdc8_uri, value=http://purl.org/dc/terms/title, anonymous)
             Var (name=o2)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Optional2
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Optional2
@@ -4,13 +4,13 @@ QueryRoot
          ProjectionElem "o"
          ProjectionElem "o2"
       FedXLeftJoin
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=s)
             Var (name=_const_99282aab_uri, value=http://purl.org/dc/terms/source, anonymous)
             Var (name=o)
             StatementSource (id=endpoint1, type=REMOTE)
             StatementSource (id=endpoint2, type=REMOTE)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=s)
             Var (name=_const_dbb1cdc8_uri, value=http://purl.org/dc/terms/title, anonymous)
             Var (name=o2)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_query01
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_query01
@@ -4,7 +4,7 @@ QueryRoot
          ProjectionElem "s"
          ProjectionElem "p"
          ProjectionElem "o"
-      StatementSourcePattern
+      StatementSourcePattern (resultSizeEstimate=UNKNOWN)
          Var (name=s)
          Var (name=p)
          Var (name=o)

--- a/tools/federation/src/test/resources/tests/propertypath/query_path_exclusiveGroup.qp
+++ b/tools/federation/src/test/resources/tests/propertypath/query_path_exclusiveGroup.qp
@@ -5,20 +5,20 @@ QueryRoot
          ProjectionElem "label"
       NJoin
          ExclusiveGroup
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=concept)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_4171603_uri, value=http://www.w3.org/2004/02/skos/core#Concept, anonymous)
                StatementSource (id=endpoint1, type=REMOTE)
             ExclusiveArbitraryLengthPath
                Var (name=concept)
-               ExclusiveStatement
+               ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                   Var (name=concept)
                   Var (name=_const_7123f66a_uri, value=http://www.w3.org/2004/02/skos/core#broader, anonymous)
                   Var (name=_const_da6a40f3_uri, value=http://example.org/mammals, anonymous)
                   StatementSource (id=endpoint1, type=REMOTE)
                Var (name=_const_da6a40f3_uri, value=http://example.org/mammals, anonymous)
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=concept)
             Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
             Var (name=label)

--- a/tools/federation/src/test/resources/tests/propertypath/query_path_exclusivePath.qp
+++ b/tools/federation/src/test/resources/tests/propertypath/query_path_exclusivePath.qp
@@ -6,19 +6,19 @@ QueryRoot
       NJoin
          ExclusiveArbitraryLengthPath
             Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
                Var (name=_const_4592be07_uri, value=http://www.w3.org/2000/01/rdf-schema#subClassOf, anonymous)
                Var (name=_const_50c92f1a_uri, value=http://xmlns.com/foaf/0.1/Agent, anonymous)
                StatementSource (id=endpoint1, type=REMOTE)
             Var (name=_const_50c92f1a_uri, value=http://xmlns.com/foaf/0.1/Agent, anonymous)
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=x)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
             StatementSource (id=endpoint2, type=REMOTE)
-         StatementSourcePattern
+         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
             Var (name=x)
             Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
             Var (name=label)

--- a/tools/federation/src/test/resources/tests/service/query01.qp
+++ b/tools/federation/src/test/resources/tests/service/query01.qp
@@ -4,12 +4,12 @@ QueryRoot
          ProjectionElem "person"
          ProjectionElem "name"
       ExclusiveGroup
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)

--- a/tools/federation/src/test/resources/tests/service/query02.qp
+++ b/tools/federation/src/test/resources/tests/service/query02.qp
@@ -4,17 +4,17 @@ QueryRoot
          ProjectionElem "person"
          ProjectionElem "name"
       ExclusiveGroup
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_d7b490e6_uri, value=http://namespace1.org/Person, anonymous)

--- a/tools/federation/src/test/resources/tests/service/query02a.qp
+++ b/tools/federation/src/test/resources/tests/service/query02a.qp
@@ -4,17 +4,17 @@ QueryRoot
          ProjectionElem "person"
          ProjectionElem "name"
       ExclusiveGroup
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_d7b490e6_uri, value=http://namespace1.org/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=person)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)

--- a/tools/federation/src/test/resources/tests/service/query04.qp
+++ b/tools/federation/src/test/resources/tests/service/query04.qp
@@ -7,28 +7,28 @@ QueryRoot
          ProjectionElem "name"
       NJoin
          ExclusiveGroup
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=person)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
                StatementSource (id=endpoint2, type=REMOTE)
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=person)
                Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                Var (name=name)
                StatementSource (id=endpoint2, type=REMOTE)
          ExclusiveGroup
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=project)
                Var (name=_const_e5fa3827_uri, value=http://namespace3.org/responsible, anonymous)
                Var (name=person)
                StatementSource (id=endpoint3, type=REMOTE)
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=project)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_11e414aa_uri, value=http://namespace3.org/Project, anonymous)
                StatementSource (id=endpoint3, type=REMOTE)
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=project)
                Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
                Var (name=label)

--- a/tools/federation/src/test/resources/tests/service/query08.qp
+++ b/tools/federation/src/test/resources/tests/service/query08.qp
@@ -6,17 +6,17 @@ QueryRoot
          ProjectionElem "author"
       NJoin
          ExclusiveGroup
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=person)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
                StatementSource (id=endpoint1, type=REMOTE)
-            ExclusiveStatement
+            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
                Var (name=person)
                Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                Var (name=name)
                StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement
+         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
             Var (name=author)
             Var (name=_const_9f24f144_uri, value=http://www.w3.org/2002/07/owl#sameAs, anonymous)
             Var (name=person)


### PR DESCRIPTION
Related GitHub issue: #2044 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* introduce getter and setter for cardinality in QueryModelNode
* default implementation in AbstractQueryModelNode
* include cardinality in signature for StatementPattern
    * prints `StatementPattern (resultSizeEstimate=1)` instead of just `StatementPattern`


Eg:

```
Projection
   ProjectionElemList
      ProjectionElem "name"
      ProjectionElem "mbox"
   Filter
      Regex
         Str
            Var (name=mbox)
         Var (name=pattern)
         Var (name=flags)
      Join
         StatementPattern (resultSizeEstimate=1)
            Var (name=y)
            Var (name=_const_2c03e873_uri, value=http://example.org/ns#pattern, anonymous)
            Var (name=pattern)
         Join
            StatementPattern (resultSizeEstimate=1)
               Var (name=y)
               Var (name=_const_144ac82a_uri, value=http://example.org/ns#flags, anonymous)
               Var (name=flags)
            Join
               StatementPattern (resultSizeEstimate=3)
                  Var (name=x)
                  Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                  Var (name=name)
               StatementPattern (resultSizeEstimate=3)
                  Var (name=x)
                  Var (name=_const_23b75369_uri, value=http://xmlns.com/foaf/0.1/mbox, anonymous)
                  Var (name=mbox)
```