### PR TITLE
GH-2024 rdfstar support in memorystore

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleTriple.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleTriple.java
@@ -7,12 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.impl;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
-
-import java.util.Objects;
 
 /**
  * A simple default implementation of the {@link Triple} interface.
@@ -94,12 +94,12 @@ public class SimpleTriple implements Triple {
 		if (this == o) {
 			return true;
 		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
+		if (o instanceof Triple) {
+			Triple that = (Triple) o;
+			return Objects.equals(subject, that.getSubject()) && Objects.equals(predicate, that.getPredicate())
+					&& Objects.equals(object, that.getObject());
 		}
-		SimpleTriple that = (SimpleTriple) o;
-		return Objects.equals(subject, that.subject) && Objects.equals(predicate, that.predicate)
-				&& Objects.equals(object, that.object);
+		return false;
 	}
 
 	@Override

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemTriple.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemTriple.java
@@ -1,0 +1,223 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.model;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
+
+import com.google.common.base.Objects;
+
+/**
+ * A MemoryStore-specific implementation of {@link Triple}.
+ * 
+ * @author Jeen Broekstra
+ */
+public class MemTriple implements Triple, MemResource {
+
+	private static final long serialVersionUID = -9085188980084028689L;
+
+	transient private final Object creator;
+
+	private final MemResource subject;
+	private final MemIRI predicate;
+	private final MemValue object;
+
+	/**
+	 * The list of statements for which this MemTriple is the subject.
+	 */
+	transient private volatile MemStatementList subjectStatements = null;
+
+	/**
+	 * The list of statements for which this MemTriple is the object.
+	 */
+	transient private volatile MemStatementList objectStatements = null;
+
+	public MemTriple(Object creator, MemResource subject, MemIRI predicate, MemValue object) {
+		this.creator = creator;
+		this.subject = subject;
+		this.predicate = predicate;
+		this.object = object;
+	}
+
+	@Override
+	public String stringValue() {
+		StringBuilder sb = new StringBuilder(256);
+
+		sb.append("<<");
+		sb.append(getSubject());
+		sb.append(" ");
+		sb.append(getPredicate());
+		sb.append(" ");
+		sb.append(getObject());
+		sb.append(">>");
+
+		return sb.toString();
+	}
+
+	@Override
+	public String toString() {
+		return stringValue();
+	}
+
+	@Override
+	public Object getCreator() {
+		return creator;
+	}
+
+	@Override
+	public boolean hasStatements() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public MemStatementList getObjectStatementList() {
+		if (objectStatements == null) {
+			return EMPTY_LIST;
+		}
+		return objectStatements;
+	}
+
+	@Override
+	public int getObjectStatementCount() {
+		return getObjectStatementList().size();
+	}
+
+	@Override
+	public void addObjectStatement(MemStatement st) {
+		if (objectStatements == null) {
+			objectStatements = new MemStatementList(4);
+		}
+		objectStatements.add(st);
+	}
+
+	@Override
+	public void removeObjectStatement(MemStatement st) {
+		objectStatements.remove(st);
+
+		if (objectStatements.isEmpty()) {
+			objectStatements = null;
+		}
+
+	}
+
+	@Override
+	public void cleanSnapshotsFromObjectStatements(int currentSnapshot) {
+		if (objectStatements != null) {
+			objectStatements.cleanSnapshots(currentSnapshot);
+
+			if (objectStatements.isEmpty()) {
+				objectStatements = null;
+			}
+		}
+	}
+
+	@Override
+	public MemStatementList getSubjectStatementList() {
+		if (subjectStatements == null) {
+			return EMPTY_LIST;
+		}
+		return subjectStatements;
+	}
+
+	@Override
+	public int getSubjectStatementCount() {
+		return getSubjectStatementList().size();
+	}
+
+	@Override
+	public void addSubjectStatement(MemStatement st) {
+		if (subjectStatements == null) {
+			subjectStatements = new MemStatementList(4);
+		}
+		subjectStatements.add(st);
+	}
+
+	@Override
+	public void removeSubjectStatement(MemStatement st) {
+		subjectStatements.remove(st);
+
+		if (subjectStatements.isEmpty()) {
+			subjectStatements = null;
+		}
+	}
+
+	@Override
+	public void cleanSnapshotsFromSubjectStatements(int currentSnapshot) {
+		if (subjectStatements != null) {
+			subjectStatements.cleanSnapshots(currentSnapshot);
+
+			if (subjectStatements.isEmpty()) {
+				subjectStatements = null;
+			}
+		}
+	}
+
+	@Override
+	public MemStatementList getContextStatementList() {
+		return EMPTY_LIST;
+	}
+
+	@Override
+	public int getContextStatementCount() {
+		return 0;
+	}
+
+	@Override
+	public void addContextStatement(MemStatement st) {
+		throw new UnsupportedOperationException("RDF* triples can not be used as context identifier");
+	}
+
+	@Override
+	public void removeContextStatement(MemStatement st) {
+		// no-op
+	}
+
+	@Override
+	public void cleanSnapshotsFromContextStatements(int currentSnapshot) {
+		// no-op
+	}
+
+	@Override
+	public Resource getSubject() {
+		return subject;
+	}
+
+	@Override
+	public IRI getPredicate() {
+		return predicate;
+	}
+
+	@Override
+	public Value getObject() {
+		return object;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(subject, predicate, object);
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (this == other) {
+			return true;
+		}
+
+		if (other instanceof Triple) {
+			Triple that = (Triple) other;
+			return this.subject.equals(that.getSubject()) && this.predicate.equals(that.getPredicate())
+					&& this.object.equals(that.getObject());
+		}
+
+		return false;
+	}
+
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryRDFStarSupportTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryRDFStarSupportTest.java
@@ -1,0 +1,25 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import org.eclipse.rdf4j.repository.RDFStarSupportTest;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+
+/**
+ * @author jeen
+ *
+ */
+public class MemoryRDFStarSupportTest extends RDFStarSupportTest {
+
+	@Override
+	protected Repository createRepository() {
+		return new SailRepository(new MemoryStore());
+	}
+
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/model/MemTripleTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/model/MemTripleTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.impl.SimpleTriple;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the memory-specific implementation of the {@link Triple} interface.
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class MemTripleTest {
+
+	private MemTriple triple;
+	private MemIRI subject, predicate, object;
+
+	private IRI s1, p1, o1;
+
+	@Before
+	public void setUp() throws Exception {
+
+		SimpleValueFactory svf = SimpleValueFactory.getInstance();
+
+		s1 = svf.createIRI("foo:s1");
+		p1 = svf.createIRI("foo:p1");
+		o1 = svf.createIRI("foo:o1");
+
+		subject = new MemIRI(this, s1.getNamespace(), s1.getLocalName());
+		predicate = new MemIRI(this, p1.getNamespace(), p1.getLocalName());
+		object = new MemIRI(this, o1.getNamespace(), o1.getLocalName());
+		triple = new MemTriple(this, subject, predicate, object);
+	}
+
+	@Test
+	public void testStringValue() {
+		assertThat(triple.stringValue())
+				.startsWith("<<")
+				.contains(s1.stringValue())
+				.contains(p1.stringValue())
+				.contains(o1.stringValue())
+				.endsWith(">>");
+	}
+
+	@Test
+	public void testEquals() {
+		SimpleTriple equalTriple = (SimpleTriple) SimpleValueFactory.getInstance().createTriple(s1, p1, o1);
+		assertThat(triple).isEqualTo(equalTriple);
+
+		SimpleTriple unequalTriple = (SimpleTriple) SimpleValueFactory.getInstance().createTriple(s1, o1, p1);
+		assertThat(triple).isNotEqualTo(unequalTriple);
+	}
+
+}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
@@ -1,0 +1,131 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+/**
+ * Test cases for RDF* support in the Repository.
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public abstract class RDFStarSupportTest {
+	/**
+	 * Timeout all individual tests after 10 minutes.
+	 */
+	@Rule
+	public Timeout to = new Timeout(10, TimeUnit.MINUTES);
+
+	private Repository testRepository;
+
+	private RepositoryConnection testCon;
+
+	private ValueFactory vf;
+
+	private BNode bob;
+
+	private BNode alice;
+
+	private BNode alexander;
+
+	private Literal nameAlice;
+
+	private Literal nameBob;
+
+	private Literal mboxAlice;
+
+	private Literal mboxBob;
+
+	private IRI context1;
+
+	private IRI context2;
+
+	@Before
+	public void setUp() throws Exception {
+		testRepository = createRepository();
+
+		testCon = testRepository.getConnection();
+		testCon.clear();
+		testCon.clearNamespaces();
+
+		vf = testRepository.getValueFactory();
+
+		// Initialize values
+		bob = vf.createBNode();
+		alice = vf.createBNode();
+		alexander = vf.createBNode();
+
+		nameAlice = vf.createLiteral("Alice");
+		nameBob = vf.createLiteral("Bob");
+
+		mboxAlice = vf.createLiteral("alice@example.org");
+		mboxBob = vf.createLiteral("bob@example.org");
+
+		context1 = vf.createIRI("urn:x-local:graph1");
+		context2 = vf.createIRI("urn:x-local:graph2");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		try {
+			testCon.close();
+		} finally {
+			testRepository.shutDown();
+		}
+	}
+
+	@Test
+	public void testAddRDFStarSubject() throws Exception {
+		Triple rdfStarTriple = vf.createTriple(bob, FOAF.NAME, nameBob);
+
+		testCon.add(rdfStarTriple, RDF.TYPE, RDF.ALT);
+
+		assertThat(testCon.hasStatement(rdfStarTriple, RDF.TYPE, RDF.ALT, false)).isTrue();
+	}
+
+	@Test
+	public void testAddRDFStarObject() throws Exception {
+		Triple rdfStarTriple = vf.createTriple(bob, FOAF.NAME, nameBob);
+
+		testCon.add(RDF.ALT, RDF.TYPE, rdfStarTriple);
+
+		assertThat(testCon.hasStatement(RDF.ALT, RDF.TYPE, rdfStarTriple, false)).isTrue();
+	}
+
+	@Test
+	public void testAddRDFStarContext() throws Exception {
+		Triple rdfStarTriple = vf.createTriple(bob, FOAF.NAME, nameBob);
+
+		try {
+			testCon.add(RDF.ALT, RDF.TYPE, RDF.ALT, rdfStarTriple);
+			fail("RDF* triple value should not be allowed by store as context identifier");
+		} catch (UnsupportedOperationException e) {
+			// fall through, expected behavior
+		}
+
+	}
+
+	protected abstract Repository createRepository();
+}


### PR DESCRIPTION
GitHub issue resolved: #2024 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* adding and retrieving of Triple objects in the memory store added
* modified SimpleTriple.equals method to allow equality with other implementations of the Triple interface (cf. other simple model object implementations, e.g. SimpleIRI.equals)
* added basic unit and integration tests 
