### PR TITLE
GH-2011 merge strategy and checklist added to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,15 @@ GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. This lin
 
 Briefly describe the changes proposed in this PR:
 
-* 
-* 
-* 
+<!-- short description of your change goes here -->
+
+---- 
+PR Author Checklist: 
+
+ - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
+ - [ ] I've added tests for the changes I made
+ - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
+ - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)
+
+Note: we merge all feature pull requests using [Squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
 
-GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. This line 
-                              automatically closes the issue when the PR is merged --> 
+GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->
 
 Briefly describe the changes proposed in this PR:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,5 @@ PR Author Checklist:
  - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
  - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)
 
-Note: we merge all feature pull requests using [Squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.
+Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.
 


### PR DESCRIPTION
GitHub issue resolved: #2011 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

* added PR author checklist (not required for people to check things off, more a reminder)
* added a note about our default merge strategy being squash and merge
* added a link to the developer documentation that goes into more detail about our merge strategy. 
