### PR TITLE
GH-99 allow SailConnection to bypass Query Parser

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/Query.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/Query.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query;
 
+import org.eclipse.rdf4j.model.Statement;
+
 /**
  * A query on a repository that can be formulated in one of the supported query languages (for example SeRQL or SPARQL).
  * It allows one to predefine bindings in the query to be able to reuse the same query with different bindings.
@@ -21,9 +23,21 @@ public interface Query extends Operation {
 	 * 
 	 * @since 3.2.0
 	 */
-	public enum Type {
+	public enum QueryType {
+		/**
+		 * Boolean queries (such as the SPARQL ASK query form) return either {@code true} or {@code false} as the
+		 * result.
+		 */
 		BOOLEAN,
+		/**
+		 * Graph queries (such as the SPARQL CONSTRUCT and DESCRIBE query form) return a sequence of RDF
+		 * {@link Statement statements} as the result.
+		 */
 		GRAPH,
+		/**
+		 * Tuple queries (such as the SPARQL SELECT query form) return a sequence of {@link BindingSet sets of variable
+		 * bindings} as the result.
+		 */
 		TUPLE
 	}
 

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/Query.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/Query.java
@@ -17,6 +17,17 @@ package org.eclipse.rdf4j.query;
 public interface Query extends Operation {
 
 	/**
+	 * The different types of queries that RDF4J recognizes: boolean queries, graph queries, and tuple queries.
+	 * 
+	 * @since 3.2.0
+	 */
+	public enum Type {
+		BOOLEAN,
+		GRAPH,
+		TUPLE
+	}
+
+	/**
 	 * Specifies the maximum time that a query is allowed to run. The query will be interrupted when it exceeds the time
 	 * limit. Any consecutive requests to fetch query results will result in {@link QueryInterruptedException}s.
 	 * 

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -144,6 +144,9 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * Prepares a SPARQL query for evaluation on this repository (optional operation). In case the query contains
 	 * relative URIs that need to be resolved against an external base URI, one should use
 	 * {@link #prepareQuery(QueryLanguage, String, String)} instead.
+	 * <p>
+	 * If you already know the type of query, using the more specific {@link #prepareTupleQuery},
+	 * {@link #prepareGraphQuery} or {@link #prepareBooleanQuery} is likely to be more efficient.
 	 * 
 	 * @param query The query string, in SPARQL syntax.
 	 * @return A query ready to be evaluated on this repository.
@@ -159,6 +162,9 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * Prepares a query for evaluation on this repository (optional operation). In case the query contains relative URIs
 	 * that need to be resolved against an external base URI, one should use
 	 * {@link #prepareQuery(QueryLanguage, String, String)} instead.
+	 * <p>
+	 * If you already know the type of query, using the more specific {@link #prepareTupleQuery},
+	 * {@link #prepareGraphQuery} or {@link #prepareBooleanQuery} is likely to be more efficient.
 	 * 
 	 * @param ql    The {@link QueryLanguage query language} in which the query is formulated.
 	 * @param query The query string.
@@ -172,6 +178,9 @@ public interface RepositoryConnection extends AutoCloseable {
 
 	/**
 	 * Prepares a query for evaluation on this repository (optional operation).
+	 * <p>
+	 * If you already know the type of query, using the more specific {@link #prepareTupleQuery},
+	 * {@link #prepareGraphQuery} or {@link #prepareBooleanQuery} is likely to be more efficient.
 	 * 
 	 * @param ql      The {@link QueryLanguage query language} in which the query is formulated.
 	 * @param query   The query string.

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -226,9 +226,10 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	public SailTupleQuery prepareTupleQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
 		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.TUPLE, queryString, baseURI);
-		ParsedTupleQuery parsedQuery = sailTupleExpr.isPresent()
-				? new ParsedTupleQuery(queryString, sailTupleExpr.get())
-				: QueryParserUtil.parseTupleQuery(ql, queryString, baseURI);
+		
+		ParsedTupleQuery parsedQuery = sailTupleExpr
+				.map(expr -> new ParsedTupleQuery(queryString, expr))
+				.orElse(QueryParserUtil.parseTupleQuery(ql, queryString, baseURI));
 		return new SailTupleQuery(parsedQuery, this);
 	}
 
@@ -236,9 +237,9 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	public SailGraphQuery prepareGraphQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
 		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.GRAPH, queryString, baseURI);
-		ParsedGraphQuery parsedQuery = sailTupleExpr.isPresent()
-				? new ParsedGraphQuery(queryString, sailTupleExpr.get())
-				: QueryParserUtil.parseGraphQuery(ql, queryString, baseURI);
+		ParsedGraphQuery parsedQuery = sailTupleExpr
+				.map(expr -> new ParsedGraphQuery(queryString, expr))
+				.orElse(QueryParserUtil.parseGraphQuery(ql, queryString, baseURI));
 		return new SailGraphQuery(parsedQuery, this);
 	}
 
@@ -246,9 +247,9 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	public SailBooleanQuery prepareBooleanQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
 		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.BOOLEAN, queryString, baseURI);
-		ParsedBooleanQuery parsedQuery = sailTupleExpr.isPresent()
-				? new ParsedBooleanQuery(queryString, sailTupleExpr.get())
-				: QueryParserUtil.parseBooleanQuery(ql, queryString, baseURI);
+		ParsedBooleanQuery parsedQuery = sailTupleExpr
+				.map(expr -> new ParsedBooleanQuery(queryString, expr))
+				.orElse(QueryParserUtil.parseBooleanQuery(ql, queryString, baseURI));
 		return new SailBooleanQuery(parsedQuery, this);
 	}
 

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -199,19 +199,21 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 		ParsedQuery parsedQuery = QueryParserUtil.parseQuery(ql, queryString, baseURI);
 
 		if (parsedQuery instanceof ParsedTupleQuery) {
-			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.TUPLE, queryString, baseURI);
+			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.QueryType.TUPLE, queryString,
+					baseURI);
 			if (sailTupleExpr.isPresent()) {
 				parsedQuery = new ParsedTupleQuery(queryString, sailTupleExpr.get());
 			}
 			return new SailTupleQuery((ParsedTupleQuery) parsedQuery, this);
 		} else if (parsedQuery instanceof ParsedGraphQuery) {
-			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.GRAPH, queryString, baseURI);
+			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.QueryType.GRAPH, queryString,
+					baseURI);
 			if (sailTupleExpr.isPresent()) {
 				parsedQuery = new ParsedGraphQuery(queryString, sailTupleExpr.get());
 			}
 			return new SailGraphQuery((ParsedGraphQuery) parsedQuery, this);
 		} else if (parsedQuery instanceof ParsedBooleanQuery) {
-			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.BOOLEAN, queryString,
+			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.QueryType.BOOLEAN, queryString,
 					baseURI);
 			if (sailTupleExpr.isPresent()) {
 				parsedQuery = new ParsedBooleanQuery(queryString, sailTupleExpr.get());
@@ -225,8 +227,9 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	@Override
 	public SailTupleQuery prepareTupleQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
-		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.TUPLE, queryString, baseURI);
-		
+		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.QueryType.TUPLE, queryString,
+				baseURI);
+
 		ParsedTupleQuery parsedQuery = sailTupleExpr
 				.map(expr -> new ParsedTupleQuery(queryString, expr))
 				.orElse(QueryParserUtil.parseTupleQuery(ql, queryString, baseURI));
@@ -236,7 +239,8 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	@Override
 	public SailGraphQuery prepareGraphQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
-		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.GRAPH, queryString, baseURI);
+		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.QueryType.GRAPH, queryString,
+				baseURI);
 		ParsedGraphQuery parsedQuery = sailTupleExpr
 				.map(expr -> new ParsedGraphQuery(queryString, expr))
 				.orElse(QueryParserUtil.parseGraphQuery(ql, queryString, baseURI));
@@ -246,7 +250,8 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	@Override
 	public SailBooleanQuery prepareBooleanQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
-		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.BOOLEAN, queryString, baseURI);
+		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.QueryType.BOOLEAN, queryString,
+				baseURI);
 		ParsedBooleanQuery parsedQuery = sailTupleExpr
 				.map(expr -> new ParsedBooleanQuery(queryString, expr))
 				.orElse(QueryParserUtil.parseBooleanQuery(ql, queryString, baseURI));

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.Query;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
@@ -195,14 +196,26 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 
 	@Override
 	public SailQuery prepareQuery(QueryLanguage ql, String queryString, String baseURI) throws MalformedQueryException {
-
 		ParsedQuery parsedQuery = QueryParserUtil.parseQuery(ql, queryString, baseURI);
 
 		if (parsedQuery instanceof ParsedTupleQuery) {
+			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.TUPLE, queryString, baseURI);
+			if (sailTupleExpr.isPresent()) {
+				parsedQuery = new ParsedTupleQuery(queryString, sailTupleExpr.get());
+			}
 			return new SailTupleQuery((ParsedTupleQuery) parsedQuery, this);
 		} else if (parsedQuery instanceof ParsedGraphQuery) {
+			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.GRAPH, queryString, baseURI);
+			if (sailTupleExpr.isPresent()) {
+				parsedQuery = new ParsedGraphQuery(queryString, sailTupleExpr.get());
+			}
 			return new SailGraphQuery((ParsedGraphQuery) parsedQuery, this);
 		} else if (parsedQuery instanceof ParsedBooleanQuery) {
+			Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.BOOLEAN, queryString,
+					baseURI);
+			if (sailTupleExpr.isPresent()) {
+				parsedQuery = new ParsedBooleanQuery(queryString, sailTupleExpr.get());
+			}
 			return new SailBooleanQuery((ParsedBooleanQuery) parsedQuery, this);
 		} else {
 			throw new RuntimeException("Unexpected query type: " + parsedQuery.getClass());
@@ -212,7 +225,7 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	@Override
 	public SailTupleQuery prepareTupleQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
-		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, queryString, baseURI);
+		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.TUPLE, queryString, baseURI);
 		ParsedTupleQuery parsedQuery = sailTupleExpr.isPresent()
 				? new ParsedTupleQuery(queryString, sailTupleExpr.get())
 				: QueryParserUtil.parseTupleQuery(ql, queryString, baseURI);
@@ -222,7 +235,7 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	@Override
 	public SailGraphQuery prepareGraphQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
-		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, queryString, baseURI);
+		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.GRAPH, queryString, baseURI);
 		ParsedGraphQuery parsedQuery = sailTupleExpr.isPresent()
 				? new ParsedGraphQuery(queryString, sailTupleExpr.get())
 				: QueryParserUtil.parseGraphQuery(ql, queryString, baseURI);
@@ -232,7 +245,7 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	@Override
 	public SailBooleanQuery prepareBooleanQuery(QueryLanguage ql, String queryString, String baseURI)
 			throws MalformedQueryException {
-		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, queryString, baseURI);
+		Optional<TupleExpr> sailTupleExpr = sailConnection.prepareQuery(ql, Query.Type.BOOLEAN, queryString, baseURI);
 		ParsedBooleanQuery parsedQuery = sailTupleExpr.isPresent()
 				? new ParsedBooleanQuery(queryString, sailTupleExpr.get())
 				: QueryParserUtil.parseBooleanQuery(ql, queryString, baseURI);

--- a/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
+++ b/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sail;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.eclipse.rdf4j.common.iteration.EmptyIteration;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SailRepositoryConnection}
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class SailRepositoryConnectionTest {
+
+	private SailRepositoryConnection subject;
+	private SailConnection sailConnection;
+	private SailRepository sailRepository;
+
+	@Before
+	public void setUp() throws Exception {
+		sailConnection = mock(SailConnection.class);
+		sailRepository = mock(SailRepository.class);
+
+		subject = new SailRepositoryConnection(sailRepository, sailConnection);
+	}
+
+	@Test
+	public void testPrepareTupleQuery_not_bypassed() throws Exception {
+		Optional<TupleExpr> response = Optional.empty();
+		when(sailConnection.prepareQuery(any(), any(), any())).thenReturn(response);
+		when(sailConnection.evaluate(any(), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
+
+		TupleQuery query = subject.prepareTupleQuery("SELECT * WHERE { ?s ?p ?o }");
+		query.evaluate();
+		// check that evaluation is still called, and not with an empty TupleExpr
+		verify(sailConnection).evaluate(any(TupleExpr.class), any(), any(), anyBoolean());
+	}
+
+	@Test
+	public void testPrepareTupleQuery_bypassed() throws Exception {
+		TupleExpr expr = mock(TupleExpr.class);
+		Optional<TupleExpr> response = Optional.of(expr);
+		when(sailConnection.prepareQuery(any(), any(), any())).thenReturn(response);
+		when(sailConnection.evaluate(eq(expr), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
+
+		TupleQuery query = subject.prepareTupleQuery("SELECT * WHERE { ?s ?p ?o }");
+		query.evaluate();
+		// check that the TupleExpr implementation created by the underlying sail was passed to the evaluation
+		verify(sailConnection).evaluate(eq(expr), any(), any(), anyBoolean());
+	}
+
+	@Test
+	public void testPrepareGraphQuery_not_bypassed() throws Exception {
+		Optional<TupleExpr> response = Optional.empty();
+		when(sailConnection.prepareQuery(any(), any(), any())).thenReturn(response);
+		when(sailConnection.evaluate(any(), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
+
+		GraphQuery query = subject.prepareGraphQuery("CONSTRUCT WHERE { ?s ?p ?o }");
+		query.evaluate();
+		// check that evaluation is still called, and not with an empty TupleExpr
+		verify(sailConnection).evaluate(any(TupleExpr.class), any(), any(), anyBoolean());
+	}
+
+	@Test
+	public void testPrepareGraphQuery_bypassed() throws Exception {
+		TupleExpr expr = mock(TupleExpr.class);
+		Optional<TupleExpr> response = Optional.of(expr);
+		when(sailConnection.prepareQuery(any(), any(), any())).thenReturn(response);
+		when(sailConnection.evaluate(eq(expr), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
+
+		GraphQuery query = subject.prepareGraphQuery("CONSTRUCT WHERE { ?s ?p ?o }");
+		query.evaluate();
+		// check that the TupleExpr implementation created by the underlying sail was passed to the evaluation
+		verify(sailConnection).evaluate(eq(expr), any(), any(), anyBoolean());
+	}
+
+	@Test
+	public void testPrepareBooleanQuery_not_bypassed() throws Exception {
+		Optional<TupleExpr> response = Optional.empty();
+		when(sailConnection.prepareQuery(any(), any(), any())).thenReturn(response);
+		when(sailConnection.evaluate(any(), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
+
+		BooleanQuery query = subject.prepareBooleanQuery("ASK WHERE { ?s ?p ?o }");
+		query.evaluate();
+		// check that evaluation is still called, and not with an empty TupleExpr
+		verify(sailConnection).evaluate(any(TupleExpr.class), any(), any(), anyBoolean());
+	}
+
+	@Test
+	public void testPrepareBooleanQuery_bypassed() throws Exception {
+		TupleExpr expr = mock(TupleExpr.class);
+		Optional<TupleExpr> response = Optional.of(expr);
+		when(sailConnection.prepareQuery(any(), any(), any())).thenReturn(response);
+		when(sailConnection.evaluate(eq(expr), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
+
+		BooleanQuery query = subject.prepareBooleanQuery("ASK WHERE { ?s ?p ?o }");
+		query.evaluate();
+		// check that the TupleExpr implementation created by the underlying sail was passed to the evaluation
+		verify(sailConnection).evaluate(eq(expr), any(), any(), anyBoolean());
+	}
+
+}

--- a/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
+++ b/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
@@ -49,7 +49,7 @@ public class SailRepositoryConnectionTest {
 	@Test
 	public void testPrepareQuery_not_bypassed() throws Exception {
 		Optional<TupleExpr> response = Optional.empty();
-		when(sailConnection.prepareQuery(any(), eq(Query.Type.TUPLE), any(), any())).thenReturn(response);
+		when(sailConnection.prepareQuery(any(), eq(Query.QueryType.TUPLE), any(), any())).thenReturn(response);
 		when(sailConnection.evaluate(any(), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
 
 		TupleQuery query = (TupleQuery) subject.prepareQuery("SELECT * WHERE { ?s ?p ?o }");
@@ -62,7 +62,7 @@ public class SailRepositoryConnectionTest {
 	public void testPrepareQuery_bypassed() throws Exception {
 		TupleExpr expr = mock(TupleExpr.class);
 		Optional<TupleExpr> response = Optional.of(expr);
-		when(sailConnection.prepareQuery(any(), eq(Query.Type.GRAPH), any(), any())).thenReturn(response);
+		when(sailConnection.prepareQuery(any(), eq(Query.QueryType.GRAPH), any(), any())).thenReturn(response);
 		when(sailConnection.evaluate(eq(expr), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
 
 		GraphQuery query = (GraphQuery) subject.prepareQuery("CONSTRUCT WHERE { ?s ?p ?o }");
@@ -74,7 +74,7 @@ public class SailRepositoryConnectionTest {
 	@Test
 	public void testPrepareTupleQuery_not_bypassed() throws Exception {
 		Optional<TupleExpr> response = Optional.empty();
-		when(sailConnection.prepareQuery(any(), eq(Query.Type.TUPLE), any(), any())).thenReturn(response);
+		when(sailConnection.prepareQuery(any(), eq(Query.QueryType.TUPLE), any(), any())).thenReturn(response);
 		when(sailConnection.evaluate(any(), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
 
 		TupleQuery query = subject.prepareTupleQuery("SELECT * WHERE { ?s ?p ?o }");
@@ -87,7 +87,7 @@ public class SailRepositoryConnectionTest {
 	public void testPrepareTupleQuery_bypassed() throws Exception {
 		TupleExpr expr = mock(TupleExpr.class);
 		Optional<TupleExpr> response = Optional.of(expr);
-		when(sailConnection.prepareQuery(any(), eq(Query.Type.TUPLE), any(), any())).thenReturn(response);
+		when(sailConnection.prepareQuery(any(), eq(Query.QueryType.TUPLE), any(), any())).thenReturn(response);
 		when(sailConnection.evaluate(eq(expr), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
 
 		TupleQuery query = subject.prepareTupleQuery("SELECT * WHERE { ?s ?p ?o }");
@@ -99,7 +99,7 @@ public class SailRepositoryConnectionTest {
 	@Test
 	public void testPrepareGraphQuery_not_bypassed() throws Exception {
 		Optional<TupleExpr> response = Optional.empty();
-		when(sailConnection.prepareQuery(any(), eq(Query.Type.GRAPH), any(), any())).thenReturn(response);
+		when(sailConnection.prepareQuery(any(), eq(Query.QueryType.GRAPH), any(), any())).thenReturn(response);
 		when(sailConnection.evaluate(any(), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
 
 		GraphQuery query = subject.prepareGraphQuery("CONSTRUCT WHERE { ?s ?p ?o }");
@@ -112,7 +112,7 @@ public class SailRepositoryConnectionTest {
 	public void testPrepareGraphQuery_bypassed() throws Exception {
 		TupleExpr expr = mock(TupleExpr.class);
 		Optional<TupleExpr> response = Optional.of(expr);
-		when(sailConnection.prepareQuery(any(), eq(Query.Type.GRAPH), any(), any())).thenReturn(response);
+		when(sailConnection.prepareQuery(any(), eq(Query.QueryType.GRAPH), any(), any())).thenReturn(response);
 		when(sailConnection.evaluate(eq(expr), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
 
 		GraphQuery query = subject.prepareGraphQuery("CONSTRUCT WHERE { ?s ?p ?o }");
@@ -124,7 +124,7 @@ public class SailRepositoryConnectionTest {
 	@Test
 	public void testPrepareBooleanQuery_not_bypassed() throws Exception {
 		Optional<TupleExpr> response = Optional.empty();
-		when(sailConnection.prepareQuery(any(), eq(Query.Type.BOOLEAN), any(), any())).thenReturn(response);
+		when(sailConnection.prepareQuery(any(), eq(Query.QueryType.BOOLEAN), any(), any())).thenReturn(response);
 		when(sailConnection.evaluate(any(), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
 
 		BooleanQuery query = subject.prepareBooleanQuery("ASK WHERE { ?s ?p ?o }");
@@ -137,7 +137,7 @@ public class SailRepositoryConnectionTest {
 	public void testPrepareBooleanQuery_bypassed() throws Exception {
 		TupleExpr expr = mock(TupleExpr.class);
 		Optional<TupleExpr> response = Optional.of(expr);
-		when(sailConnection.prepareQuery(any(), eq(Query.Type.BOOLEAN), any(), any())).thenReturn(response);
+		when(sailConnection.prepareQuery(any(), eq(Query.QueryType.BOOLEAN), any(), any())).thenReturn(response);
 		when(sailConnection.evaluate(eq(expr), any(), any(), anyBoolean())).thenReturn(new EmptyIteration<>());
 
 		BooleanQuery query = subject.prepareBooleanQuery("ASK WHERE { ?s ?p ?o }");

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.Query;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
@@ -55,13 +56,14 @@ public interface SailConnection extends AutoCloseable {
 	 * parser.
 	 * 
 	 * @param ql      the query language.
+	 * @param type    indicates if the supplied query is a graph, tuple, or boolean query
 	 * @param query   the unparsed query string
 	 * @param baseURI the provided base URI. May be null or empty.
 	 * @return an optional TupleExpr that represents a sail-specific version of the query, which {@link #evaluate} can
 	 *         process. Returns {@link Optional#empty()} if the Sail does not provide its own query processing.
 	 * @since 3.2.0
 	 */
-	public default Optional<TupleExpr> prepareQuery(QueryLanguage ql, String query, String baseURI) {
+	public default Optional<TupleExpr> prepareQuery(QueryLanguage ql, Query.Type type, String query, String baseURI) {
 		return Optional.empty();
 	}
 

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
@@ -63,7 +63,8 @@ public interface SailConnection extends AutoCloseable {
 	 *         process. Returns {@link Optional#empty()} if the Sail does not provide its own query processing.
 	 * @since 3.2.0
 	 */
-	public default Optional<TupleExpr> prepareQuery(QueryLanguage ql, Query.Type type, String query, String baseURI) {
+	public default Optional<TupleExpr> prepareQuery(QueryLanguage ql, Query.QueryType type, String query,
+			String baseURI) {
 		return Optional.empty();
 	}
 

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail;
 
+import java.util.Optional;
+
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
@@ -18,6 +20,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.UpdateExpr;
 
@@ -45,6 +48,22 @@ public interface SailConnection extends AutoCloseable {
 	 */
 	@Override
 	public void close() throws SailException;
+
+	/**
+	 * Allows the SailConnection to bypass the standard query parser and provide its own internal {@link TupleExpr}
+	 * implementation. By default this method returns an empty result, signaling that it will rely on the RDF4J query
+	 * parser.
+	 * 
+	 * @param ql      the query language.
+	 * @param query   the unparsed query string
+	 * @param baseURI the provided base URI. May be null or empty.
+	 * @return an optional TupleExpr that represents a sail-specific version of the query, which {@link #evaluate} can
+	 *         process. Returns {@link Optional#empty()} if the Sail does not provide its own query processing.
+	 * @since 3.2.0
+	 */
+	public default Optional<TupleExpr> prepareQuery(QueryLanguage ql, String query, String baseURI) {
+		return Optional.empty();
+	}
 
 	/**
 	 * Evaluates the supplied TupleExpr on the data contained in this Sail object, using the (optional) dataset and
@@ -270,6 +289,7 @@ public interface SailConnection extends AutoCloseable {
 	/**
 	 * @deprecated since 4.0. Use {@link #removeStatements(Resource, IRI, Value, Resource...)} instead.
 	 */
+	@Deprecated
 	default void removeStatements(Resource subj, URI pred, Value obj, Resource... contexts) throws SailException {
 		removeStatements(subj, (IRI) pred, obj, contexts);
 	}

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.Query;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
@@ -87,8 +88,8 @@ public class SailConnectionWrapper implements SailConnection, FederatedServiceRe
 	}
 
 	@Override
-	public Optional<TupleExpr> prepareQuery(QueryLanguage ql, String query, String baseURI) {
-		return wrappedCon.prepareQuery(ql, query, baseURI);
+	public Optional<TupleExpr> prepareQuery(QueryLanguage ql, Query.Type type, String query, String baseURI) {
+		return wrappedCon.prepareQuery(ql, type, query, baseURI);
 	}
 
 	@Override

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.helpers;
 
+import java.util.Optional;
+
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
@@ -17,6 +19,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
@@ -81,6 +84,11 @@ public class SailConnectionWrapper implements SailConnection, FederatedServiceRe
 	@Override
 	public void close() throws SailException {
 		wrappedCon.close();
+	}
+
+	@Override
+	public Optional<TupleExpr> prepareQuery(QueryLanguage ql, String query, String baseURI) {
+		return wrappedCon.prepareQuery(ql, query, baseURI);
 	}
 
 	@Override

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
@@ -88,7 +88,7 @@ public class SailConnectionWrapper implements SailConnection, FederatedServiceRe
 	}
 
 	@Override
-	public Optional<TupleExpr> prepareQuery(QueryLanguage ql, Query.Type type, String query, String baseURI) {
+	public Optional<TupleExpr> prepareQuery(QueryLanguage ql, Query.QueryType type, String query, String baseURI) {
 		return wrappedCon.prepareQuery(ql, type, query, baseURI);
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #99 <!-- add a Github issue number here, e.g #123. This line 
                              automatically closes the issue when the PR is merged --> 

Briefly describe the changes proposed in this PR:

- adds new method 'prepareQuery' to SailConnection that gets the raw
  query string
- SailConnection can optionally pass back a custom implementation of
  TupleExpr. If this happens the SailRepository skips parsing the query
  and will just pass back in the custom TuplExpr when
  SailConnection.evaluate is called.
- by default the method does nothing (returns empty optional)
