### PR TITLE
GH-2011 added warning to use merge commit to merge the branch sync

### DIFF
--- a/.github/workflows/merge_master_to_develop.yml
+++ b/.github/workflows/merge_master_to_develop.yml
@@ -17,5 +17,5 @@ jobs:
         #source_branch: "master"               # If blank, default: triggered branch
         destination_branch: "develop"         # If blank, default: master
         pr_title: "Merge master into develop"
-        pr_body: "Automatically generated PR to keep develop in sync with master. See .github/workflows/merge_master_to_develop.yml"  # Full markdown support, requires pr_title to be set
+        pr_body: "Automatically generated PR to keep develop in sync with master.\n\n **USE MERGE COMMIT TO MERGE THIS PR**.\n\nSee [merge_master_to_develop.yml](/eclipse/rdf4j/.github/workflows/merge_master_to_develop.yml)."  # Full markdown support, requires pr_title to be set
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


GitHub issue resolved: #2011 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Tweaked the github action that creates the master->develop branch sync to output a warning to use merge commit, and made the link to the action script clickable.

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

