### PR TITLE
GH-2006: fix handling of external bindings in FedX SingleSourceQuery

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -409,7 +409,8 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 		try {
 			Endpoint source = query.getSource();
 			return source.getTripleSource()
-					.getStatements(query.getQueryString(), query.getQueryInfo().getQueryType(), query.getQueryInfo());
+					.getStatements(query.getQueryString(), bindings, query.getQueryInfo().getQueryType(),
+							query.getQueryInfo());
 		} catch (RepositoryException | MalformedQueryException e) {
 			throw new QueryEvaluationException(e);
 		}
@@ -689,7 +690,8 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 				Endpoint ownedEndpoint = federationContext.getEndpointManager()
 						.getEndpoint(statementSources.get(0).getEndpointID());
 				org.eclipse.rdf4j.federated.evaluation.TripleSource t = ownedEndpoint.getTripleSource();
-				result = t.getStatements(preparedQuery, EmptyBindingSet.getInstance(), null, queryInfo);
+				result = t.getStatements(preparedQuery, EmptyBindingSet.getInstance(), (FilterValueExpr) null,
+						queryInfo);
 			}
 
 			else {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
@@ -80,8 +80,30 @@ public interface TripleSource {
 	 * @throws RepositoryException
 	 * @throws MalformedQueryException
 	 * @throws QueryEvaluationException
+	 * @Deprecated will be removed in 4.0. Replaced with
+	 *             {@link #getStatements(String, BindingSet, QueryType, QueryInfo)}
+	 */
+	@Deprecated
+	public default CloseableIteration<BindingSet, QueryEvaluationException> getStatements(String preparedQuery,
+			QueryType queryType, QueryInfo queryInfo)
+			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
+		return getStatements(preparedQuery, EmptyBindingSet.getInstance(), queryType, queryInfo);
+	}
+
+	/**
+	 * Evaluate a given SPARQL query of the provided query type at the given source.
+	 * 
+	 * @param preparedQuery
+	 * @param queryBindings optional query bindings, use {@link EmptyBindingSet} if there are none
+	 * @param queryType
+	 * @param queryInfo
+	 * @return the statements
+	 * @throws RepositoryException
+	 * @throws MalformedQueryException
+	 * @throws QueryEvaluationException
 	 */
 	public CloseableIteration<BindingSet, QueryEvaluationException> getStatements(String preparedQuery,
+			BindingSet queryBindings,
 			QueryType queryType, QueryInfo queryInfo)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 


### PR DESCRIPTION
This change correctly set externally passed binding to single source
queries, i.e. where the query is relevant at a single owner (and thus
the original query string is passed as-is)


GitHub issue resolved: #2006 