### PR TITLE
Gh 2069 store actual result size in query plan node

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategy.java
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.repository.sparql.federation.SPARQLFederatedService;
 
 /**
  * Evaluates {@link TupleExpr}s and {@link ValueExpr}s.
- * 
+ *
  * @author Arjohn Kampman
  * @author James Leigh
  */
@@ -30,7 +30,7 @@ public interface EvaluationStrategy extends FederatedServiceResolver {
 	/**
 	 * Retrieve the {@link FederatedService} registered for serviceUrl. If there is no service registered for
 	 * serviceUrl, a new {@link SPARQLFederatedService} is created and registered.
-	 * 
+	 *
 	 * @param serviceUrl URL of the service.
 	 * @return the {@link FederatedService} registered for the serviceUrl.
 	 * @throws QueryEvaluationException
@@ -41,7 +41,7 @@ public interface EvaluationStrategy extends FederatedServiceResolver {
 
 	/**
 	 * Set the {@link QueryOptimizerPipeline} to use for optimizing any incoming queries.
-	 * 
+	 *
 	 * @param pipeline the {@link QueryOptimizerPipeline}.
 	 * @see #optimize(TupleExpr, EvaluationStatistics, BindingSet)
 	 * @since 3.0
@@ -50,7 +50,7 @@ public interface EvaluationStrategy extends FederatedServiceResolver {
 
 	/**
 	 * Execute the {@link QueryOptimizerPipeline} on the given {@link TupleExpr} to optimize its execution plan.
-	 * 
+	 *
 	 * @param expr                 the {@link TupleExpr} to optimize.
 	 * @param evaluationStatistics the {@link EvaluationStatistics} of the data source, to be used for query planning.
 	 * @param bindings             a-priori bindings supplied for the query, which can potentially be inlined.
@@ -76,7 +76,7 @@ public interface EvaluationStrategy extends FederatedServiceResolver {
 	/**
 	 * Evaluates the tuple expression against the supplied triple source with the specified set of variable bindings as
 	 * input.
-	 * 
+	 *
 	 * @param expr     The Tuple Expression to evaluate
 	 * @param bindings The variables bindings to use for evaluating the expression, if applicable.
 	 * @return A closeable iterator over the variable binding sets that match the tuple expression.
@@ -86,7 +86,7 @@ public interface EvaluationStrategy extends FederatedServiceResolver {
 
 	/**
 	 * Gets the value of this expression.
-	 * 
+	 *
 	 * @param expr
 	 * @param bindings The variables bindings to use for evaluating the expression, if applicable.
 	 * @return The Value that this expression evaluates to, or <tt>null</tt> if the expression could not be evaluated.
@@ -96,7 +96,7 @@ public interface EvaluationStrategy extends FederatedServiceResolver {
 
 	/**
 	 * Evaluates the boolean expression on the supplied TripleSource object.
-	 * 
+	 *
 	 * @param expr
 	 * @param bindings The variables bindings to use for evaluating the expression, if applicable.
 	 * @return The result of the evaluation.

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
@@ -21,7 +21,7 @@ public interface EvaluationStrategyFactory {
 	 * Set the number of query solutions the {@link EvaluationStrategy} will keep in main memory before it attempts to
 	 * sync to a temporary disk cache. If set to 0, no disk caching will occur. EvaluationStrategies that provide no
 	 * disk caching functionality are free to ignore this parameter.
-	 * 
+	 *
 	 * @param threshold the number of query solutions that the EvaluationStrategy can cache in main memory before
 	 *                  attempting disk sync.
 	 */
@@ -36,7 +36,7 @@ public interface EvaluationStrategyFactory {
 
 	/**
 	 * Set a {@link QueryOptimizerPipeline} to be used for query execution planning by the {@link EvaluationStrategy}.
-	 * 
+	 *
 	 * @param pipeline a {@link QueryOptimizerPipeline}
 	 */
 	void setOptimizerPipeline(QueryOptimizerPipeline pipeline);
@@ -44,7 +44,7 @@ public interface EvaluationStrategyFactory {
 	/**
 	 * Get the {@link QueryOptimizerPipeline} that this factory will inject into the {@link EvaluationStrategy}, if any.
 	 * If no {@link QueryOptimizerPipeline} is defined, the {@link EvaluationStrategy} itself determines the pipeline.
-	 * 
+	 *
 	 * @return a {@link QueryOptimizerPipeline}, or {@link Optional#empty()} if no pipeline is set on this factory.
 	 */
 	Optional<QueryOptimizerPipeline> getOptimizerPipeline();
@@ -52,7 +52,7 @@ public interface EvaluationStrategyFactory {
 	/**
 	 * Returns the {@link EvaluationStrategy} to use to evaluate queries for the given {@link Dataset} and
 	 * {@link TripleSource}.
-	 * 
+	 *
 	 * @param dataset              the DataSet to evaluate queries against.
 	 * @param tripleSource         the TripleSource to evaluate queries against.
 	 * @param evaluationStatistics the store evaluation statistics to use for query optimization.
@@ -60,5 +60,25 @@ public interface EvaluationStrategyFactory {
 	 */
 	EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
 			EvaluationStatistics evaluationStatistics);
+
+	/**
+	 * Returns the status of the result size tracking for the query plan. Useful to determine which parts of a query
+	 * plan generated the most data.
+	 *
+	 * @return true if result size tracking is enabled.
+	 */
+	default boolean isTrackResultSize() {
+		return false;
+	}
+
+	/**
+	 * Enable or disable results size tracking for the query plan. Useful to determine which parts of a query plan
+	 * generated the most data.
+	 * 
+	 * @param trackResultSize true to enable tracking.
+	 */
+	default void setTrackResultSize(boolean trackResultSize) {
+		// no-op for backwards compatibility
+	}
 
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
@@ -14,12 +14,15 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
 
 /**
  * Abstract base class for {@link ExtendedEvaluationStrategy}.
- * 
+ *
  * @author Jeen Broekstra
  */
 public abstract class AbstractEvaluationStrategyFactory implements EvaluationStrategyFactory {
 
 	private long querySolutionCacheThreshold;
+
+	// track the results size that each node in the query plan produces during execution
+	private boolean trackResultSize;
 
 	private QueryOptimizerPipeline pipeline;
 
@@ -43,4 +46,13 @@ public abstract class AbstractEvaluationStrategyFactory implements EvaluationStr
 		return Optional.ofNullable(pipeline);
 	}
 
+	@Override
+	public boolean isTrackResultSize() {
+		return trackResultSize;
+	}
+
+	@Override
+	public void setTrackResultSize(boolean trackResultSize) {
+		this.trackResultSize = trackResultSize;
+	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -374,30 +374,28 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 		protected TupleExpr selectNextTupleExpr(List<TupleExpr> expressions, Map<TupleExpr, Double> cardinalityMap,
 				Map<TupleExpr, List<Var>> varsMap, Map<Var, Integer> varFreqMap, Set<String> boundVars) {
 			TupleExpr result = null;
+			double lowestCost = Double.POSITIVE_INFINITY;
 
-			if (expressions.size() > 1) {
-				double lowestCardinality = Double.POSITIVE_INFINITY;
-				for (TupleExpr tupleExpr : expressions) {
-					// Calculate a score for this tuple expression
-					double cardinality = getTupleExprCardinality(tupleExpr, cardinalityMap, varsMap, varFreqMap,
-							boundVars);
+			for (TupleExpr tupleExpr : expressions) {
+				// Calculate a score for this tuple expression
+				double cost = getTupleExprCost(tupleExpr, cardinalityMap, varsMap, varFreqMap,
+						boundVars);
 
-					if (cardinality < lowestCardinality || result == null) {
-						// More specific path expression found
-						lowestCardinality = cardinality;
-						result = tupleExpr;
-					}
+				if (cost < lowestCost || result == null) {
+					// More specific path expression found
+					lowestCost = cost;
+					result = tupleExpr;
 				}
-			} else {
-				result = expressions.get(0);
 			}
+
+			result.setCostEstimate(lowestCost);
 
 			return result;
 		}
 
-		protected double getTupleExprCardinality(TupleExpr tupleExpr, Map<TupleExpr, Double> cardinalityMap,
+		protected double getTupleExprCost(TupleExpr tupleExpr, Map<TupleExpr, Double> cardinalityMap,
 				Map<TupleExpr, List<Var>> varsMap, Map<Var, Integer> varFreqMap, Set<String> boundVars) {
-			double cardinality = cardinalityMap.get(tupleExpr);
+			double cost = cardinalityMap.get(tupleExpr);
 
 			List<Var> vars = varsMap.get(tupleExpr);
 
@@ -407,23 +405,23 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 			int nonConstantVarCount = vars.size() - constantVars.size();
 			if (nonConstantVarCount > 0) {
 				double exp = (double) unboundVars.size() / nonConstantVarCount;
-				cardinality = Math.pow(cardinality, exp);
+				cost = Math.pow(cost, exp);
 			}
 
 			if (unboundVars.isEmpty()) {
 				// Prefer patterns with more bound vars
 				if (nonConstantVarCount > 0) {
-					cardinality /= nonConstantVarCount;
+					cost /= nonConstantVarCount;
 				}
 			} else {
 				// Prefer patterns that bind variables from other tuple expressions
 				int foreignVarFreq = getForeignVarFreq(unboundVars, varFreqMap);
 				if (foreignVarFreq > 0) {
-					cardinality /= 1 + foreignVarFreq;
+					cost /= 1 + foreignVarFreq;
 				}
 			}
 
-			return cardinality;
+			return cost;
 		}
 
 		protected List<Var> getConstantVars(Iterable<Var> vars) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
@@ -16,10 +16,10 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 
 /**
- * 
+ *
  * A standard pipeline with the default {@link QueryOptimizer}s that will be used by {@link StrictEvaluationStrategy}
  * and its subclasses, unless specifically overridden.
- * 
+ *
  * @author Jeen Broekstra
  *
  * @see EvaluationStrategyFactory#setOptimizerPipeline(QueryOptimizerPipeline)
@@ -39,7 +39,7 @@ public class StandardQueryOptimizerPipeline implements QueryOptimizerPipeline {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline#getOptimizers()
 	 */
 	@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
@@ -39,8 +39,9 @@ public class StrictEvaluationStrategyFactory extends AbstractEvaluationStrategyF
 	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
 			EvaluationStatistics evaluationStatistics) {
 		StrictEvaluationStrategy strategy = new StrictEvaluationStrategy(tripleSource, dataset, serviceResolver,
-				getQuerySolutionCacheThreshold(), evaluationStatistics);
-		getOptimizerPipeline().ifPresent(pipeline -> strategy.setOptimizerPipeline(pipeline));
+				getQuerySolutionCacheThreshold(), evaluationStatistics, isTrackResultSize());
+		getOptimizerPipeline().ifPresent(strategy::setOptimizerPipeline);
+
 		return strategy;
 	}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/FilterIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/FilterIterator.java
@@ -85,4 +85,5 @@ public class FilterIterator extends FilterIteration<BindingSet, QueryEvaluationE
 			return false;
 		}
 	}
+
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryCostEstimatesTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryCostEstimatesTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
+import org.junit.Test;
+
+/**
+ * Tests that cost estimates are printed as part of the plan
+ */
+public class QueryCostEstimatesTest {
+
+	@Test
+	public void testBindingSetAssignmentOptimization() throws RDF4JException {
+		String query = "prefix ex: <ex:>" + "select ?s ?p ?o ?x where {" + " ex:s1 ex:pred ?v. "
+				+ " ex:s2 ex:pred 'bah'. {" + "  ?s ?p ?o. " + "  optional {"
+				+ "   values ?x {ex:a ex:b ex:c ex:d ex:e ex:f ex:g}. " + "  }" + " }" + "}";
+
+		SPARQLParser parser = new SPARQLParser();
+		ParsedQuery q = parser.parseQuery(query, null);
+		QueryJoinOptimizer opt = new QueryJoinOptimizer();
+		QueryRoot optRoot = new QueryRoot(q.getTupleExpr());
+		opt.optimize(optRoot, null, null);
+
+		assertEquals("QueryRoot\n" +
+				"   Projection\n" +
+				"      ProjectionElemList\n" +
+				"         ProjectionElem \"s\"\n" +
+				"         ProjectionElem \"p\"\n" +
+				"         ProjectionElem \"o\"\n" +
+				"         ProjectionElem \"x\"\n" +
+				"      Extension\n" +
+				"         ExtensionElem (x)\n" +
+				"            Var (name=x)\n" +
+				"         Join\n" +
+				"            StatementPattern (costEstimate=1, resultSizeEstimate=1)\n" +
+				"               Var (name=_const_5c6ba46_uri, value=ex:s2, anonymous)\n" +
+				"               Var (name=_const_af00e088_uri, value=ex:pred, anonymous)\n" +
+				"               Var (name=_const_17c09_lit_e2eec718_0, value=\"bah\", anonymous)\n" +
+				"            Join\n" +
+				"               StatementPattern (costEstimate=10, resultSizeEstimate=10)\n" +
+				"                  Var (name=_const_5c6ba45_uri, value=ex:s1, anonymous)\n" +
+				"                  Var (name=_const_af00e088_uri, value=ex:pred, anonymous)\n" +
+				"                  Var (name=v)\n" +
+				"               LeftJoin (costEstimate=1000, resultSizeEstimate=1000)\n" +
+				"                  StatementPattern\n" +
+				"                     Var (name=s)\n" +
+				"                     Var (name=p)\n" +
+				"                     Var (name=o)\n" +
+				"                  BindingSetAssignment ([[x=ex:a], [x=ex:b], [x=ex:c], [x=ex:d], [x=ex:e], [x=ex:f], [x=ex:g]])\n",
+				optRoot.toString());
+
+	}
+
+}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ArbitraryLengthPath.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ArbitraryLengthPath.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.query.algebra;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.query.algebra.StatementPattern.Scope;
 
@@ -221,6 +222,8 @@ public class ArbitraryLengthPath extends AbstractQueryModelNode implements Tuple
 		if (scope == Scope.NAMED_CONTEXTS) {
 			sb.append(" FROM NAMED CONTEXT");
 		}
+
+		appendCostAnnotation(sb);
 
 		return sb.toString();
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BinaryTupleOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BinaryTupleOperator.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import java.util.stream.Stream;
+
 /**
  * An abstract superclass for binary tuple operators which, by definition, has two arguments.
  */
@@ -35,7 +37,7 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 
 	/**
 	 * Creates a new binary tuple operator.
-	 * 
+	 *
 	 * @param leftArg  The operator's left argument, must not be <tt>null</tt>.
 	 * @param rightArg The operator's right argument, must not be <tt>null</tt>.
 	 */
@@ -50,7 +52,7 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 
 	/**
 	 * Gets the left argument of this binary tuple operator.
-	 * 
+	 *
 	 * @return The operator's left argument.
 	 */
 	public TupleExpr getLeftArg() {
@@ -59,7 +61,7 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 
 	/**
 	 * Sets the left argument of this binary tuple operator.
-	 * 
+	 *
 	 * @param leftArg The (new) left argument for this operator, must not be <tt>null</tt>.
 	 */
 	public void setLeftArg(TupleExpr leftArg) {
@@ -71,7 +73,7 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 
 	/**
 	 * Gets the right argument of this binary tuple operator.
-	 * 
+	 *
 	 * @return The operator's right argument.
 	 */
 	public TupleExpr getRightArg() {
@@ -80,7 +82,7 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 
 	/**
 	 * Sets the right argument of this binary tuple operator.
-	 * 
+	 *
 	 * @param rightArg The (new) right argument for this operator, must not be <tt>null</tt>.
 	 */
 	public void setRightArg(TupleExpr rightArg) {
@@ -128,5 +130,14 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 		clone.setLeftArg(getLeftArg().clone());
 		clone.setRightArg(getRightArg().clone());
 		return clone;
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BindingSetAssignment.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BindingSetAssignment.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.algebra;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.query.BindingSet;
 
@@ -95,10 +96,12 @@ public class BindingSetAssignment extends AbstractQueryModelNode implements Tupl
 
 	@Override
 	public String getSignature() {
-		String signature = super.getSignature();
+		StringBuilder sb = new StringBuilder(super.getSignature());
 
-		signature += " (" + this.getBindingSets().toString() + ")";
+		sb.append(" (").append(this.getBindingSets().toString()).append(")");
 
-		return signature;
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/DescribeOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/DescribeOperator.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import java.util.stream.Stream;
+
 /**
  * @author Jeen Broekstra
  */
@@ -19,6 +21,15 @@ public class DescribeOperator extends UnaryTupleOperator {
 	@Override
 	public <X extends Exception> void visit(QueryModelVisitor<X> visitor) throws X {
 		visitor.meet(this);
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Distinct.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Distinct.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import java.util.stream.Stream;
+
 public class Distinct extends UnaryTupleOperator {
 
 	/*--------------*
@@ -42,5 +44,14 @@ public class Distinct extends UnaryTupleOperator {
 	@Override
 	public Distinct clone() {
 		return (Distinct) super.clone();
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Extension.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Extension.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * An extension operator that can be used to add bindings to solutions whose values are defined by {@link ValueExpr
@@ -132,5 +133,14 @@ public class Extension extends UnaryTupleOperator {
 		}
 
 		return clone;
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Filter.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Filter.java
@@ -15,7 +15,7 @@ import java.util.stream.Stream;
  * The FILTER operator, as defined in <a href="http://www.w3.org/TR/rdf-sparql-query/#defn_algFilter">SPARQL Query
  * Language for RDF</a>. The FILTER operator filters specific results from the underlying tuple expression based on a
  * configurable condition.
- * 
+ *
  * @author Arjohn Kampman
  */
 public class Filter extends UnaryTupleOperator {
@@ -104,4 +104,15 @@ public class Filter extends UnaryTupleOperator {
 		clone.setCondition(getCondition().clone());
 		return clone;
 	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(128);
+
+		sb.append(super.getSignature());
+
+		appendCostAnnotation(sb);
+		return sb.toString();
+	}
+
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Group.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Group.java
@@ -13,13 +13,14 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.util.iterators.Iterators;
 
 /**
  * A tuple operator that groups tuples that have a specific set of equivalent variable bindings, and that can apply
  * aggregate functions on the grouped results.
- * 
+ *
  * @author David Huynh
  * @author Arjohn Kampman
  */
@@ -167,20 +168,23 @@ public class Group extends UnaryTupleOperator {
 
 	@Override
 	public String getSignature() {
-		StringBuilder b = new StringBuilder();
-		b.append(this.getClass().getSimpleName());
-		b.append(" (");
+		StringBuilder sb = new StringBuilder();
+		sb.append(this.getClass().getSimpleName());
+		sb.append(" (");
 
 		Set<String> bindingNames = getGroupBindingNames();
 		int count = 0;
 		for (String name : bindingNames) {
-			b.append(name);
+			sb.append(name);
 			count++;
 			if (count < bindingNames.size()) {
-				b.append(", ");
+				sb.append(", ");
 			}
 		}
-		b.append(")");
-		return b.toString();
+		sb.append(")");
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/MultiProjection.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/MultiProjection.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * A "multi-projection" that can produce multiple solutions from a single set of bindings.
@@ -142,5 +143,14 @@ public class MultiProjection extends UnaryTupleOperator {
 		}
 
 		return clone;
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Order.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Order.java
@@ -9,10 +9,11 @@ package org.eclipse.rdf4j.query.algebra;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * An order operator that can be used to order bindings as specified by a set of value expressions.
- * 
+ *
  * @author Arjohn Kampman
  */
 public class Order extends UnaryTupleOperator {
@@ -119,5 +120,14 @@ public class Order extends UnaryTupleOperator {
 		}
 
 		return clone;
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Projection.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Projection.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.algebra;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * A generalized projection (allowing the bindings to be renamed) on a tuple expression.
@@ -131,6 +132,15 @@ public class Projection extends UnaryTupleOperator {
 
 	public void setSubquery(boolean subquery) {
 		this.subquery = subquery;
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNode.java
@@ -104,4 +104,12 @@ public interface QueryModelNode extends Cloneable, Serializable {
 	default void setResultSizeEstimate(double rows) {
 		// no-op for backwards compatibility
 	}
+
+	long getResultSizeActual();
+
+	void setResultSizeActual(long resultSizeActual);
+
+	double getCostEstimate();
+
+	void setCostEstimate(double costEstimate);
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Reduced.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Reduced.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import java.util.stream.Stream;
+
 public class Reduced extends UnaryTupleOperator {
 
 	/*--------------*
@@ -42,5 +44,14 @@ public class Reduced extends UnaryTupleOperator {
 	@Override
 	public Reduced clone() {
 		return (Reduced) super.clone();
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Service.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Service.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 
@@ -18,7 +19,7 @@ import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
  * The SERVICE keyword as defined in <a href="http://www.w3.org/TR/sparql11-federated- query/#defn_service" >SERVICE
  * definition</a>. The service expression is evaluated at the specified service URI. If the service reference is a
  * variable, a value for this variable must be available at evaluation time (e.g. from earlier computations).
- * 
+ *
  * @author Andreas Schwarte
  */
 public class Service extends UnaryTupleOperator {
@@ -103,7 +104,7 @@ public class Service extends UnaryTupleOperator {
 
 	/**
 	 * The SERVICE expression, either complete or just the expression e.g. "SERVICE <url> { ... }" becomes " ... "
-	 * 
+	 *
 	 * @param serviceExpressionString the inner expression as SPARQL String representation
 	 */
 	public void setExpressionString(String serviceExpressionString) {
@@ -119,7 +120,7 @@ public class Service extends UnaryTupleOperator {
 
 	/**
 	 * Returns an ASK query string using no projection vars.
-	 * 
+	 *
 	 * @return an ASK query string
 	 */
 	public String getAskQueryString() {
@@ -129,7 +130,7 @@ public class Service extends UnaryTupleOperator {
 	/**
 	 * Returns a SELECT query string using the provided projection vars. The variables are inserted into the
 	 * preparedSelectQueryString in the SELECT clause.
-	 * 
+	 *
 	 * @param projectionVars
 	 * @return SELECT query string, utilizing the given projection variables
 	 */
@@ -193,7 +194,7 @@ public class Service extends UnaryTupleOperator {
 	/**
 	 * Compute the variable names occurring in the service expression using tree traversal, since these are necessary
 	 * for building the SPARQL query.
-	 * 
+	 *
 	 * @return the set of variable names in the given service expression
 	 */
 	private Set<String> computeServiceVars(TupleExpr serviceExpression) {
@@ -255,7 +256,7 @@ public class Service extends UnaryTupleOperator {
 
 	/**
 	 * Compute the prefix string only once to avoid computation overhead during evaluation.
-	 * 
+	 *
 	 * @param prefixDeclarations
 	 * @return a Prefix String or an empty string if there are no prefixes
 	 */
@@ -274,7 +275,7 @@ public class Service extends UnaryTupleOperator {
 	/**
 	 * Parses a service expression to just have the inner expression, e.g. from something like "SERVICE &lt;url&gt; {
 	 * ... }" becomes " ... ", also applies {@link String#trim()} to remove leading/tailing space
-	 * 
+	 *
 	 * @param serviceExpression
 	 * @return the inner expression of the given service expression
 	 */
@@ -299,5 +300,14 @@ public class Service extends UnaryTupleOperator {
 	 */
 	public String getBaseURI() {
 		return baseURI;
+	}
+
+	@Override
+	public String getSignature() {
+		StringBuilder sb = new StringBuilder(super.getSignature());
+
+		appendCostAnnotation(sb);
+
+		return sb.toString();
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Slice.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Slice.java
@@ -7,11 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import java.util.stream.Stream;
+
 /**
  * The SLICE operator, as defined in <a href="http://www.w3.org/TR/rdf-sparql-query/#defn_algSlice">SPARQL Query
  * Language for RDF</a>. The SLICE operator selects specific results from the underlying tuple expression based on an
  * offset and limit value (both optional).
- * 
+ *
  * @author Arjohn Kampman
  */
 public class Slice extends UnaryTupleOperator {
@@ -56,7 +58,7 @@ public class Slice extends UnaryTupleOperator {
 
 	/**
 	 * Checks whether the row selection has a (valid) offset.
-	 * 
+	 *
 	 * @return <tt>true</tt> when <tt>offset &gt; 0</tt>
 	 */
 	public boolean hasOffset() {
@@ -73,7 +75,7 @@ public class Slice extends UnaryTupleOperator {
 
 	/**
 	 * Checks whether the row selection has a (valid) limit.
-	 * 
+	 *
 	 * @return <tt>true</tt> when <tt>offset &gt;= 0</tt>
 	 */
 	public boolean hasLimit() {
@@ -90,7 +92,7 @@ public class Slice extends UnaryTupleOperator {
 		StringBuilder sb = new StringBuilder(256);
 
 		sb.append(super.getSignature());
-		sb.append(" ( ");
+		sb.append(" (");
 
 		if (hasLimit()) {
 			sb.append("limit=").append(getLimit());
@@ -99,7 +101,9 @@ public class Slice extends UnaryTupleOperator {
 			sb.append("offset=").append(getOffset());
 		}
 
-		sb.append(" )");
+		sb.append(")");
+
+		appendCostAnnotation(sb);
 
 		return sb.toString();
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * A tuple expression that matches a statement pattern against an RDF graph. Statement patterns can be targeted at one
@@ -255,7 +256,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 			sb.append(" FROM NAMED CONTEXT");
 		}
 
-		sb.append(" (resultSizeEstimate=").append(toHumanReadbleNumber(getResultSizeEstimate())).append(")");
+		appendCostAnnotation(sb);
 
 		return sb.toString();
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.algebra;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * An abstract superclass for unary tuple operators which, by definition, has one argument.
@@ -32,7 +33,7 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 
 	/**
 	 * Creates a new unary tuple operator.
-	 * 
+	 *
 	 * @param arg The operator's argument, must not be <tt>null</tt>.
 	 */
 	protected UnaryTupleOperator(TupleExpr arg) {
@@ -45,7 +46,7 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 
 	/**
 	 * Gets the argument of this unary tuple operator.
-	 * 
+	 *
 	 * @return The operator's argument.
 	 */
 	public TupleExpr getArg() {
@@ -54,7 +55,7 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 
 	/**
 	 * Sets the argument of this unary tuple operator.
-	 * 
+	 *
 	 * @param arg The (new) argument for this operator, must not be <tt>null</tt>.
 	 */
 	public void setArg(TupleExpr arg) {
@@ -109,4 +110,5 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 		clone.setArg(getArg().clone());
 		return clone;
 	}
+
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 /**
  * An abstract Sail implementation that takes care of common sail tasks, including proper closing of active connections
  * and a grace period for active connections during shutdown of the store.
- * 
+ *
  * @author Herko ter Horst
  * @author jeen
  * @author Arjohn Kampman
@@ -109,6 +109,9 @@ public abstract class AbstractSail implements Sail {
 
 	private long iterationCacheSyncThreshold = DEFAULT_ITERATION_SYNC_THRESHOLD;
 
+	// track the results size that each node in the query plan produces during execution
+	private boolean trackResultSize;
+
 	/**
 	 * Map used to track active connections and where these were acquired. The Throwable value may be null in case
 	 * debugging was disable at the time the connection was acquired.
@@ -131,7 +134,7 @@ public abstract class AbstractSail implements Sail {
 
 	/**
 	 * Set connection timeout on shutdown (in ms).
-	 * 
+	 *
 	 * @param connectionTimeOut timeout (in ms)
 	 */
 	public void setConnectionTimeOut(long connectionTimeOut) {
@@ -164,7 +167,7 @@ public abstract class AbstractSail implements Sail {
 	/**
 	 * Checks whether the Sail has been initialized. Sails are initialized from {@link #initialize() initialization}
 	 * until {@link #shutDown() shutdown}.
-	 * 
+	 *
 	 * @return <tt>true</tt> if the Sail has been initialized, <tt>false</tt> otherwise.
 	 */
 	protected boolean isInitialized() {
@@ -284,7 +287,7 @@ public abstract class AbstractSail implements Sail {
 
 	/**
 	 * Returns a store-specific SailConnection object.
-	 * 
+	 *
 	 * @return A connection to the store.
 	 */
 	protected abstract SailConnection getConnectionInternal() throws SailException;
@@ -292,7 +295,7 @@ public abstract class AbstractSail implements Sail {
 	/**
 	 * Signals to the store that the supplied connection has been closed; called by
 	 * {@link AbstractSailConnection#close()}.
-	 * 
+	 *
 	 * @param connection The connection that has been closed.
 	 */
 	protected void connectionClosed(SailConnection connection) {
@@ -313,7 +316,7 @@ public abstract class AbstractSail implements Sail {
 
 	/**
 	 * Appends the provided {@link IsolationLevels} to the SAIL's list of supported isolation levels.
-	 * 
+	 *
 	 * @param level a supported IsolationLevel.
 	 */
 	protected void addSupportedIsolationLevel(IsolationLevels level) {
@@ -322,7 +325,7 @@ public abstract class AbstractSail implements Sail {
 
 	/**
 	 * Removes all occurrences of the provided {@link IsolationLevels} in the list of supported Isolation levels.
-	 * 
+	 *
 	 * @param level the isolation level to remove.
 	 */
 	protected void removeSupportedIsolationLevel(IsolationLevel level) {
@@ -333,7 +336,7 @@ public abstract class AbstractSail implements Sail {
 	/**
 	 * Sets the list of supported {@link IsolationLevels}s for this SAIL. The list is expected to be ordered in
 	 * increasing complexity.
-	 * 
+	 *
 	 * @param supportedIsolationLevels a list of supported isolation levels.
 	 */
 	protected void setSupportedIsolationLevels(List<IsolationLevel> supportedIsolationLevels) {
@@ -343,7 +346,7 @@ public abstract class AbstractSail implements Sail {
 	/**
 	 * Sets the list of supported {@link IsolationLevels}s for this SAIL. The list is expected to be ordered in
 	 * increasing complexity.
-	 * 
+	 *
 	 * @param supportedIsolationLevels a list of supported isolation levels.
 	 */
 	protected void setSupportedIsolationLevels(IsolationLevel... supportedIsolationLevels) {
@@ -362,7 +365,7 @@ public abstract class AbstractSail implements Sail {
 
 	/**
 	 * Sets the default {@link IsolationLevel} on which transactions in this Sail operate.
-	 * 
+	 *
 	 * @param defaultIsolationLevel The defaultIsolationLevel to set.
 	 */
 	public void setDefaultIsolationLevel(IsolationLevel defaultIsolationLevel) {
@@ -374,7 +377,7 @@ public abstract class AbstractSail implements Sail {
 
 	/**
 	 * Retrieves the currently configured threshold for syncing query evaluation iteration caches to disk.
-	 * 
+	 *
 	 * @return Returns the iterationCacheSyncThreshold.
 	 */
 	public long getIterationCacheSyncThreshold() {
@@ -383,10 +386,30 @@ public abstract class AbstractSail implements Sail {
 
 	/**
 	 * Set the threshold for syncing query evaluation iteration caches to disk.
-	 * 
+	 *
 	 * @param iterationCacheSyncThreshold The iterationCacheSyncThreshold to set.
 	 */
 	public void setIterationCacheSyncThreshold(long iterationCacheSyncThreshold) {
 		this.iterationCacheSyncThreshold = iterationCacheSyncThreshold;
+	}
+
+	/**
+	 * Returns the status of the result size tracking for the query plan. Useful to determine which parts of a query
+	 * plan generated the most data.
+	 *
+	 * @return true if result size tracking is enabled.
+	 */
+	public boolean isTrackResultSize() {
+		return trackResultSize;
+	}
+
+	/**
+	 * Enable or disable results size tracking for the query plan. Useful to determine which parts of a query plan
+	 * generated the most data.
+	 * 
+	 * @param trackResultSize true to enable tracking.
+	 */
+	public void setTrackResultSize(boolean trackResultSize) {
+		this.trackResultSize = trackResultSize;
 	}
 }

--- a/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/ExtensibleStore.java
+++ b/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/ExtensibleStore.java
@@ -108,7 +108,7 @@ public abstract class ExtensibleStore<T extends DataStructureInterface, N extend
 
 	@Override
 	public void setFederatedServiceResolver(FederatedServiceResolver resolver) {
-
+		this.serviceResolver = resolver;
 	}
 
 	@Override
@@ -120,7 +120,8 @@ public abstract class ExtensibleStore<T extends DataStructureInterface, N extend
 		if (evalStratFactory == null) {
 			evalStratFactory = new StrictEvaluationStrategyFactory(getFederatedServiceResolver());
 		}
-		evalStratFactory.setQuerySolutionCacheThreshold(0);
+		evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
+		evalStratFactory.setTrackResultSize(isTrackResultSize());
 		return evalStratFactory;
 	}
 
@@ -136,7 +137,6 @@ public abstract class ExtensibleStore<T extends DataStructureInterface, N extend
 
 	public void setEvaluationStrategyFactory(EvaluationStrategyFactory evalStratFactory) {
 		this.evalStratFactory = evalStratFactory;
-
 	}
 
 	@Override
@@ -154,7 +154,6 @@ public abstract class ExtensibleStore<T extends DataStructureInterface, N extend
 
 	public ExtensibleStatementHelper getExtensibleStatementHelper() {
 		return ExtensibleStatementHelper.getDefaultImpl();
-
 	}
 
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
@@ -202,6 +202,7 @@ public class MemoryStore extends AbstractNotifyingSail implements FederatedServi
 			evalStratFactory = new StrictEvaluationStrategyFactory(getFederatedServiceResolver());
 		}
 		evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
+		evalStratFactory.setTrackResultSize(isTrackResultSize());
 		return evalStratFactory;
 	}
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * The NativeStore is designed for datasets between 100,000 and 100 million triples. On most operating systems, if there
  * is sufficient physical memory, the NativeStore will act like the MemoryStore, because the read/write commands will be
  * cached by the OS. This technique allows the NativeStore to operate quite well for millions of triples.
- * 
+ *
  * @author Arjohn Kampman
  * @author jeen
  */
@@ -135,7 +135,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 
 	/**
 	 * Sets the triple indexes for the native store, must be called before initialization.
-	 * 
+	 *
 	 * @param tripleIndexes An index strings, e.g. <tt>spoc,posc</tt>.
 	 */
 	public void setTripleIndexes(String tripleIndexes) {
@@ -187,6 +187,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 			evalStratFactory = new StrictEvaluationStrategyFactory(getFederatedServiceResolver());
 		}
 		evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
+		evalStratFactory.setTrackResultSize(isTrackResultSize());
 		return evalStratFactory;
 	}
 
@@ -213,7 +214,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 	/**
 	 * Overrides the {@link FederatedServiceResolver} used by this instance, but the given resolver is not shutDown when
 	 * this instance is.
-	 * 
+	 *
 	 * @param resolver The SERVICE resolver to set.
 	 */
 	@Override
@@ -226,7 +227,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 
 	/**
 	 * Initializes this NativeStore.
-	 * 
+	 *
 	 * @exception SailException If this NativeStore could not be initialized using the parameters that have been set.
 	 */
 	@Override
@@ -343,7 +344,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 	 * {@link IsolationLevels#NONE} isolation. Store is either exclusively in {@link IsolationLevels#NONE} isolation
 	 * with potentially zero or more transactions, or exclusively in higher isolation mode with potentially zero or more
 	 * transactions.
-	 * 
+	 *
 	 * @param level indicating desired mode {@link IsolationLevels#NONE} or higher
 	 * @return Lock used to prevent Store from switching isolation modes
 	 * @throws SailException
@@ -372,7 +373,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 
 	/**
 	 * Checks if any {@link IsolationLevels#NONE} isolation transactions are active.
-	 * 
+	 *
 	 * @return <code>true</code> if at least one transaction has direct access to the indexes
 	 */
 	boolean isIsolationDisabled() {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
@@ -42,6 +42,8 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 	protected final QueryInfo queryInfo;
 
 	private double resultSizeEstimate = -1;
+	private double costEstimate = -1;
+	private long resultSizeActual = -1;
 
 	public CheckStatementPattern(StatementTupleExpr stmt, QueryInfo queryInfo) {
 		super();
@@ -143,6 +145,26 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 	}
 
 	@Override
+	public long getResultSizeActual() {
+		return resultSizeActual;
+	}
+
+	@Override
+	public void setResultSizeActual(long resultSizeActual) {
+		this.resultSizeActual = resultSizeActual;
+	}
+
+	@Override
+	public double getCostEstimate() {
+		return costEstimate;
+	}
+
+	@Override
+	public void setCostEstimate(double costEstimate) {
+		this.costEstimate = costEstimate;
+	}
+
+	@Override
 	public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(BindingSet bindings)
 			throws QueryEvaluationException {
 
@@ -155,8 +177,9 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 						.getEndpointManager()
 						.getEndpoint(source.getEndpointID());
 				TripleSource t = ownedEndpoint.getTripleSource();
-				if (t.hasStatements(st, bindings, queryInfo))
+				if (t.hasStatements(st, bindings, queryInfo)) {
 					return new SingleBindingSetIteration(bindings);
+				}
 			}
 		} catch (RepositoryException | MalformedQueryException e) {
 			throw new QueryEvaluationException(e);

--- a/tools/federation/src/test/resources/tests/basic/query_limit01.qp
+++ b/tools/federation/src/test/resources/tests/basic/query_limit01.qp
@@ -1,9 +1,9 @@
 QueryRoot
-   Slice ( limit=1 )
+   Slice (limit=1)
       Projection
          ProjectionElemList
             ProjectionElem "person"
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)

--- a/tools/federation/src/test/resources/tests/filter/query01.qp
+++ b/tools/federation/src/test/resources/tests/filter/query01.qp
@@ -3,7 +3,7 @@ QueryRoot
       ProjectionElemList
          ProjectionElem "s"
          ProjectionElem "name"
-      StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+      StatementSourcePattern
          Var (name=s)
          Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
          Var (name=name, value="Person1")

--- a/tools/federation/src/test/resources/tests/filter/query01a.qp
+++ b/tools/federation/src/test/resources/tests/filter/query01a.qp
@@ -4,13 +4,13 @@ QueryRoot
          ProjectionElem "person"
          ProjectionElem "name"
       NJoin
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person, value=http://namespace1.org/Person_1)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_d7b490e6_uri, value=http://namespace1.org/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
             BoundFilters (person=http://namespace1.org/Person_1)
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=person, value=http://namespace1.org/Person_1)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)

--- a/tools/federation/src/test/resources/tests/medium/query03.qp
+++ b/tools/federation/src/test/resources/tests/medium/query03.qp
@@ -7,28 +7,28 @@ QueryRoot
          ProjectionElem "name"
       NJoin
          ExclusiveGroup
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=project)
                Var (name=_const_e5fa3827_uri, value=http://namespace3.org/responsible, anonymous)
                Var (name=person)
                StatementSource (id=endpoint3, type=REMOTE)
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=project)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_11e414aa_uri, value=http://namespace3.org/Project, anonymous)
                StatementSource (id=endpoint3, type=REMOTE)
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=project)
                Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
                Var (name=label)
                StatementSource (id=endpoint3, type=REMOTE)
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
             StatementSource (id=endpoint2, type=REMOTE)
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=person)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_1.txt
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_1.txt
@@ -7,16 +7,16 @@ QueryRoot
             ExtensionElem (nameOut)
                Var (name=name)
             EmptyNJoin
-               ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+               ExclusiveStatement
                   Var (name=person)
                   Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                   Var (name=name)
                   StatementSource (id=endpoint1, type=REMOTE)
-               EmptyStatementPattern (resultSizeEstimate=UNKNOWN)
+               EmptyStatementPattern
                   Var (name=person)
                   Var (name=_const_4240a169_uri, value=urn:doesNotExistProp, anonymous)
                   Var (name=obj)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_ea9562d5_uri, value=http://xmlns.com/foaf/0.1/interest, anonymous)
             Var (name=o)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_2.txt
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_2.txt
@@ -6,12 +6,12 @@ QueryRoot
          ExtensionElem (person)
             Var (name=person)
          NJoin
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=_const_c0e515a0_uri, value=http://example.org/a, anonymous)
                Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                Var (name=_const_1f2db8_lit_e2eec718_0, value="Alan", anonymous)
                StatementSource (id=endpoint1, type=REMOTE)
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=_const_c0e515a0_uri, value=http://example.org/a, anonymous)
                Var (name=_const_ea9562d5_uri, value=http://xmlns.com/foaf/0.1/interest, anonymous)
                Var (name=_const_5e79d277_lit_e2eec718_0, value="SPARQL 1.1 Basic Federated Query", anonymous)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Optional1
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Optional1
@@ -5,13 +5,13 @@ QueryRoot
          ProjectionElem "o"
          ProjectionElem "o2"
       FedXLeftJoin
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=s)
             Var (name=_const_99282aab_uri, value=http://purl.org/dc/terms/source, anonymous)
             Var (name=o)
             StatementSource (id=endpoint1, type=REMOTE)
             StatementSource (id=endpoint2, type=REMOTE)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=s)
             Var (name=_const_dbb1cdc8_uri, value=http://purl.org/dc/terms/title, anonymous)
             Var (name=o2)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Optional2
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Optional2
@@ -4,13 +4,13 @@ QueryRoot
          ProjectionElem "o"
          ProjectionElem "o2"
       FedXLeftJoin
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=s)
             Var (name=_const_99282aab_uri, value=http://purl.org/dc/terms/source, anonymous)
             Var (name=o)
             StatementSource (id=endpoint1, type=REMOTE)
             StatementSource (id=endpoint2, type=REMOTE)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=s)
             Var (name=_const_dbb1cdc8_uri, value=http://purl.org/dc/terms/title, anonymous)
             Var (name=o2)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_query01
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_query01
@@ -4,7 +4,7 @@ QueryRoot
          ProjectionElem "s"
          ProjectionElem "p"
          ProjectionElem "o"
-      StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+      StatementSourcePattern
          Var (name=s)
          Var (name=p)
          Var (name=o)

--- a/tools/federation/src/test/resources/tests/propertypath/query_path_exclusiveGroup.qp
+++ b/tools/federation/src/test/resources/tests/propertypath/query_path_exclusiveGroup.qp
@@ -5,20 +5,20 @@ QueryRoot
          ProjectionElem "label"
       NJoin
          ExclusiveGroup
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=concept)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_4171603_uri, value=http://www.w3.org/2004/02/skos/core#Concept, anonymous)
                StatementSource (id=endpoint1, type=REMOTE)
             ExclusiveArbitraryLengthPath
                Var (name=concept)
-               ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+               ExclusiveStatement
                   Var (name=concept)
                   Var (name=_const_7123f66a_uri, value=http://www.w3.org/2004/02/skos/core#broader, anonymous)
                   Var (name=_const_da6a40f3_uri, value=http://example.org/mammals, anonymous)
                   StatementSource (id=endpoint1, type=REMOTE)
                Var (name=_const_da6a40f3_uri, value=http://example.org/mammals, anonymous)
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=concept)
             Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
             Var (name=label)

--- a/tools/federation/src/test/resources/tests/propertypath/query_path_exclusivePath.qp
+++ b/tools/federation/src/test/resources/tests/propertypath/query_path_exclusivePath.qp
@@ -6,19 +6,19 @@ QueryRoot
       NJoin
          ExclusiveArbitraryLengthPath
             Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
                Var (name=_const_4592be07_uri, value=http://www.w3.org/2000/01/rdf-schema#subClassOf, anonymous)
                Var (name=_const_50c92f1a_uri, value=http://xmlns.com/foaf/0.1/Agent, anonymous)
                StatementSource (id=endpoint1, type=REMOTE)
             Var (name=_const_50c92f1a_uri, value=http://xmlns.com/foaf/0.1/Agent, anonymous)
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=x)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_anon_5403df55_e1d4_4b0f_87ce_3abce9d396b5, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
             StatementSource (id=endpoint2, type=REMOTE)
-         StatementSourcePattern (resultSizeEstimate=UNKNOWN)
+         StatementSourcePattern
             Var (name=x)
             Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
             Var (name=label)

--- a/tools/federation/src/test/resources/tests/service/query01.qp
+++ b/tools/federation/src/test/resources/tests/service/query01.qp
@@ -4,12 +4,12 @@ QueryRoot
          ProjectionElem "person"
          ProjectionElem "name"
       ExclusiveGroup
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)

--- a/tools/federation/src/test/resources/tests/service/query02.qp
+++ b/tools/federation/src/test/resources/tests/service/query02.qp
@@ -4,17 +4,17 @@ QueryRoot
          ProjectionElem "person"
          ProjectionElem "name"
       ExclusiveGroup
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_d7b490e6_uri, value=http://namespace1.org/Person, anonymous)

--- a/tools/federation/src/test/resources/tests/service/query02a.qp
+++ b/tools/federation/src/test/resources/tests/service/query02a.qp
@@ -4,17 +4,17 @@ QueryRoot
          ProjectionElem "person"
          ProjectionElem "name"
       ExclusiveGroup
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_d7b490e6_uri, value=http://namespace1.org/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
             Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
             StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=person)
             Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
             Var (name=name)

--- a/tools/federation/src/test/resources/tests/service/query04.qp
+++ b/tools/federation/src/test/resources/tests/service/query04.qp
@@ -7,28 +7,28 @@ QueryRoot
          ProjectionElem "name"
       NJoin
          ExclusiveGroup
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=person)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
                StatementSource (id=endpoint2, type=REMOTE)
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=person)
                Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                Var (name=name)
                StatementSource (id=endpoint2, type=REMOTE)
          ExclusiveGroup
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=project)
                Var (name=_const_e5fa3827_uri, value=http://namespace3.org/responsible, anonymous)
                Var (name=person)
                StatementSource (id=endpoint3, type=REMOTE)
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=project)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_11e414aa_uri, value=http://namespace3.org/Project, anonymous)
                StatementSource (id=endpoint3, type=REMOTE)
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=project)
                Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
                Var (name=label)

--- a/tools/federation/src/test/resources/tests/service/query08.qp
+++ b/tools/federation/src/test/resources/tests/service/query08.qp
@@ -6,17 +6,17 @@ QueryRoot
          ProjectionElem "author"
       NJoin
          ExclusiveGroup
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=person)
                Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
                Var (name=_const_e1df31e0_uri, value=http://xmlns.com/foaf/0.1/Person, anonymous)
                StatementSource (id=endpoint1, type=REMOTE)
-            ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+            ExclusiveStatement
                Var (name=person)
                Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
                Var (name=name)
                StatementSource (id=endpoint1, type=REMOTE)
-         ExclusiveStatement (resultSizeEstimate=UNKNOWN)
+         ExclusiveStatement
             Var (name=author)
             Var (name=_const_9f24f144_uri, value=http://www.w3.org/2002/07/owl#sameAs, anonymous)
             Var (name=person)


### PR DESCRIPTION
GitHub issue resolved: #2069 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Proof of concept for how we could track the actual result size generated by a query plan node.

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

