### PR TITLE
GH-2085 naive implementation of RDFStarTripleSource for memory store

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -7,6 +7,26 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
+import static org.eclipse.rdf4j.http.protocol.Protocol.ACCEPT_PARAM_NAME;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HeaderElement;
@@ -85,26 +105,6 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.StringReader;
-import java.net.HttpURLConnection;
-import java.net.URISyntaxException;
-import java.nio.charset.Charset;
-import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-
-import static org.eclipse.rdf4j.http.protocol.Protocol.ACCEPT_PARAM_NAME;
 
 /**
  * The SPARQLProtocolSession provides low level HTTP methods for communication with SPARQL endpoints. All methods are
@@ -1187,7 +1187,7 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 		if (params == null) {
 			return 0;
 		}
-		return (long) params.getIntParameter(CoreConnectionPNames.SO_TIMEOUT, 0);
+		return params.getIntParameter(CoreConnectionPNames.SO_TIMEOUT, 0);
 	}
 
 	/**

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.Service;
 import org.eclipse.rdf4j.query.algebra.SingletonSet;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TripleRef;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.UnaryTupleOperator;
 import org.eclipse.rdf4j.query.algebra.Var;
@@ -144,6 +145,13 @@ public class EvaluationStatistics {
 		@Override
 		public void meet(StatementPattern sp) {
 			cardinality = getCardinality(sp);
+		}
+
+		@Override
+		public void meet(TripleRef tripleRef) {
+			cardinality = getSubjectCardinality(tripleRef.getSubjectVar())
+					* getPredicateCardinality(tripleRef.getPredicateVar())
+					* getObjectCardinality(tripleRef.getObjectVar());
 		}
 
 		protected double getCardinality(StatementPattern sp) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -1870,8 +1870,6 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 			CloseableIteration<? extends Triple, QueryEvaluationException> sourceIter = ((RDFStarTripleSource) tripleSource)
 					.getRdfStarTriples((Resource) subjValue, (IRI) predValue, objValue);
 
-			// FIXME this filter is put in as an additional safeguard - it should strictly speaking not be necessary if
-			// the triple source is correctly implemented.
 			FilterIteration<Triple, QueryEvaluationException> filterIter = new FilterIteration<Triple, QueryEvaluationException>(
 					sourceIter) {
 				@Override
@@ -1885,9 +1883,11 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 					if (objValue != null && !objValue.equals(triple.getObject())) {
 						return false;
 					}
+					if (extValue != null && !extValue.equals(triple)) {
+						return false;
+					}
 					return true;
 				}
-
 			};
 
 			return new ConvertingIteration<Triple, BindingSet, QueryEvaluationException>(filterIter) {

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStrategyWithRDFStarTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStrategyWithRDFStarTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -329,8 +330,9 @@ public class EvaluationStrategyWithRDFStarTest {
 			while (iter.hasNext()) {
 				received.add(iter.next());
 			}
-			assertTrue("all expected must be received", received.containsAll(expected));
-			assertTrue("all received must be expected", expected.containsAll(received));
+
+			assertThat(received).containsAll(expected);
+			assertThat(expected).containsAll(received);
 		}
 	}
 

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/DelegatingSailDataset.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/DelegatingSailDataset.java
@@ -12,6 +12,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.SailException;
 
@@ -62,5 +63,11 @@ abstract class DelegatingSailDataset implements SailDataset {
 	public CloseableIteration<? extends Statement, SailException> getStatements(Resource subj, IRI pred, Value obj,
 			Resource... contexts) throws SailException {
 		return delegate.getStatements(subj, pred, obj, contexts);
+	}
+
+	@Override
+	public CloseableIteration<? extends Triple, SailException> getTriples(Resource subj, IRI pred,
+			Value obj) throws SailException {
+		return delegate.getTriples(subj, pred, obj);
 	}
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDataset.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDataset.java
@@ -86,7 +86,9 @@ public interface SailDataset extends SailClosable {
 	 * @return An iterator over the relevant triples.
 	 * @throws SailException If the triple source failed to get the RDF* triples.
 	 */
-	CloseableIteration<? extends Triple, SailException> getTriples(Resource subj, IRI pred, Value obj)
-			throws SailException;
+	default CloseableIteration<? extends Triple, SailException> getTriples(Resource subj, IRI pred, Value obj)
+			throws SailException {
+		throw new SailException("RDF* triple retrieval not supported by this store");
+	}
 
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDataset.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDataset.java
@@ -13,6 +13,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.SailException;
 
@@ -74,5 +75,18 @@ public interface SailDataset extends SailClosable {
 	 */
 	CloseableIteration<? extends Statement, SailException> getStatements(Resource subj, IRI pred, Value obj,
 			Resource... contexts) throws SailException;
+
+	/**
+	 * Gets all RDF* triples that have a specific subject, predicate and/or object. All three parameters may be null to
+	 * indicate wildcards.
+	 * 
+	 * @param subj A Resource specifying the subject, or <tt>null</tt> for a wildcard.
+	 * @param pred A IRI specifying the predicate, or <tt>null</tt> for a wildcard.
+	 * @param obj  A Value specifying the object, or <tt>null</tt> for a wildcard.
+	 * @return An iterator over the relevant triples.
+	 * @throws SailException If the triple source failed to get the RDF* triples.
+	 */
+	CloseableIteration<? extends Triple, SailException> getTriples(Resource subj, IRI pred, Value obj)
+			throws SailException;
 
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
@@ -333,5 +333,4 @@ class SailDatasetImpl implements SailDataset {
 		};
 	}
 
-
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.sail.SailException;
@@ -285,6 +286,39 @@ class SailDatasetImpl implements SailDataset {
 		}
 	}
 
+	@Override
+	public CloseableIteration<? extends Triple, SailException> getTriples(Resource subj, IRI pred, Value obj)
+			throws SailException {
+		CloseableIteration<? extends Triple, SailException> iter;
+		if (changes.isStatementCleared()) {
+			iter = null;
+		} else {
+			iter = derivedFrom.getTriples(subj, pred, obj);
+		}
+
+		if (iter == null) {
+			return new EmptyIteration<>();
+		}
+		return iter; // TODO we will need to figure out a way to handle transaction isolation with deprecated and
+						// approved data
+//		Model deprecated = changes.getDeprecated();
+//		if (deprecated != null && iter != null) {
+//			iter = difference(iter, deprecated.));
+//		}
+//		Model approved = changes.getApproved();
+//		if (approved != null && iter != null) {
+//			return new DistinctModelReducingUnionIteration(iter, approved, (m) -> m.filter(subj, pred, obj, contexts));
+//
+//		} else if (approved != null) {
+//			Iterator<Statement> i = approved.filter(subj, pred, obj, contexts).iterator();
+//			return new CloseableIteratorIteration<>(i);
+//		} else if (iter != null) {
+//			return iter;
+//		} else {
+//			return new EmptyIteration<>();
+//		}
+	}
+
 	private CloseableIteration<? extends Statement, SailException> difference(
 			CloseableIteration<? extends Statement, SailException> result, final Model excluded) {
 		if (excluded.isEmpty()) {
@@ -298,5 +332,6 @@ class SailDatasetImpl implements SailDataset {
 			}
 		};
 	}
+
 
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetTripleSource.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetTripleSource.java
@@ -80,6 +80,7 @@ class SailDatasetTripleSource implements TripleSource, RDFStarTripleSource {
 		}
 
 	}
+
 	@Override
 	public CloseableIteration<? extends Triple, QueryEvaluationException> getRdfStarTriples(Resource subj, IRI pred,
 			Value obj) throws QueryEvaluationException {

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetTripleSource.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetTripleSource.java
@@ -13,16 +13,18 @@ import org.eclipse.rdf4j.common.iteration.Iteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.RDFStarTripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.sail.SailException;
 
 /**
  * Implementation of the TripleSource interface using {@link SailDataset}
  */
-class SailDatasetTripleSource implements TripleSource {
+class SailDatasetTripleSource implements TripleSource, RDFStarTripleSource {
 
 	private final ValueFactory vf;
 
@@ -64,5 +66,27 @@ class SailDatasetTripleSource implements TripleSource {
 			return new QueryEvaluationException(e);
 		}
 
+	}
+
+	static class TriplesIteration extends ExceptionConvertingIteration<Triple, QueryEvaluationException> {
+
+		public TriplesIteration(Iteration<? extends Triple, ? extends Exception> iter) {
+			super(iter);
+		}
+
+		@Override
+		protected QueryEvaluationException convert(Exception e) {
+			return new QueryEvaluationException(e);
+		}
+
+	}
+	@Override
+	public CloseableIteration<? extends Triple, QueryEvaluationException> getRdfStarTriples(Resource subj, IRI pred,
+			Value obj) throws QueryEvaluationException {
+		try {
+			return new TriplesIteration(dataset.getTriples(subj, pred, obj));
+		} catch (SailException e) { // TODO is this necessary?
+			throw new QueryEvaluationException(e);
+		}
 	}
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/UnionSailDataset.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/UnionSailDataset.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.SailException;
 
@@ -89,6 +90,17 @@ class UnionSailDataset implements SailDataset {
 		result = new CloseableIteration[datasets.length];
 		for (int i = 0; i < datasets.length; i++) {
 			result[i] = datasets[i].getStatements(subj, pred, obj, contexts);
+		}
+		return union(result);
+	}
+
+	@Override
+	public CloseableIteration<? extends Triple, SailException> getTriples(Resource subj, IRI pred, Value obj)
+			throws SailException {
+		CloseableIteration<? extends Triple, SailException>[] result;
+		result = new CloseableIteration[datasets.length];
+		for (int i = 0; i < datasets.length; i++) {
+			result[i] = datasets[i].getTriples(subj, pred, obj);
 		}
 		return union(result);
 	}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemTripleIterator.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemTripleIterator.java
@@ -1,20 +1,27 @@
 /*******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.sail.memory.model;
+package org.eclipse.rdf4j.sail.memory;
 
 import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.sail.memory.model.MemIRI;
+import org.eclipse.rdf4j.sail.memory.model.MemResource;
+import org.eclipse.rdf4j.sail.memory.model.MemStatement;
+import org.eclipse.rdf4j.sail.memory.model.MemStatementList;
+import org.eclipse.rdf4j.sail.memory.model.MemTriple;
+import org.eclipse.rdf4j.sail.memory.model.MemValue;
 
 /**
- * A StatementIterator that can iterate over a list of Statement objects. This iterator compares Resource and Literal
- * objects using the '==' operator, which is possible thanks to the extensive sharing of these objects in the
- * MemoryStore.
+ * An Iteration that can iterate over a list of {@link Triple} objects.
+ * 
+ * @author Jeen Broekstra
  */
-public class MemTripleIterator<X extends Exception> extends LookAheadIteration<MemTriple, X> {
+class MemTripleIterator<X extends Exception> extends LookAheadIteration<MemTriple, X> {
 
 	/*-----------*
 	 * Variables *
@@ -55,9 +62,9 @@ public class MemTripleIterator<X extends Exception> extends LookAheadIteration<M
 	 *--------------*/
 
 	/**
-	 * Creates a new MemStatementIterator that will iterate over the statements contained in the supplied
-	 * MemStatementList searching for statements that match the specified pattern of subject, predicate, object and
-	 * context(s).
+	 * Creates a new MemTripleIterator that will iterate over the triples contained in the supplied MemStatementList
+	 * searching for triples that occur as either subject or object in those statements, and which match the specified
+	 * pattern of subject, predicate, object.
 	 * 
 	 * @param statementList the statements over which to iterate.
 	 * @param subject       subject of pattern.
@@ -80,10 +87,8 @@ public class MemTripleIterator<X extends Exception> extends LookAheadIteration<M
 	 *---------*/
 
 	/**
-	 * Searches through statementList, starting from index <tt>_nextStatementIdx + 1</tt>, for statements that match the
-	 * constraints that have been set for this iterator. If a matching statement has been found it will be stored in
-	 * <tt>_nextStatement</tt> and <tt>_nextStatementIdx</tt> points to the index of this statement in
-	 * <tt>_statementList</tt>. Otherwise, <tt>_nextStatement</tt> will set to <tt>null</tt>.
+	 * Searches through statementList, starting from index <tt>_nextStatementIdx + 1</tt>, for triples that match the
+	 * constraints that have been set for this iterator.
 	 */
 	@Override
 	protected MemTriple getNextElement() {
@@ -97,8 +102,7 @@ public class MemTripleIterator<X extends Exception> extends LookAheadIteration<M
 					if (matchesPattern(triple)) {
 						return triple;
 					}
-				}
-				else if (st.getObject() instanceof MemTriple) {
+				} else if (st.getObject() instanceof MemTriple) {
 					MemTriple triple = (MemTriple) st.getObject();
 					if (matchesPattern(triple)) {
 						return triple;

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -46,7 +46,6 @@ import org.eclipse.rdf4j.sail.memory.model.MemStatement;
 import org.eclipse.rdf4j.sail.memory.model.MemStatementIterator;
 import org.eclipse.rdf4j.sail.memory.model.MemStatementList;
 import org.eclipse.rdf4j.sail.memory.model.MemTriple;
-import org.eclipse.rdf4j.sail.memory.model.MemTripleIterator;
 import org.eclipse.rdf4j.sail.memory.model.MemValue;
 import org.eclipse.rdf4j.sail.memory.model.MemValueFactory;
 import org.slf4j.Logger;

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemTripleIterator.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemTripleIterator.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.model;
+
+import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
+
+/**
+ * A StatementIterator that can iterate over a list of Statement objects. This iterator compares Resource and Literal
+ * objects using the '==' operator, which is possible thanks to the extensive sharing of these objects in the
+ * MemoryStore.
+ */
+public class MemTripleIterator<X extends Exception> extends LookAheadIteration<MemTriple, X> {
+
+	/*-----------*
+	 * Variables *
+	 *-----------*/
+
+	/**
+	 * The lists of statements over which to iterate.
+	 */
+	private final MemStatementList statementList;
+
+	/**
+	 * The subject of statements to return, or null if any subject is OK.
+	 */
+	private final MemResource subject;
+
+	/**
+	 * The predicate of statements to return, or null if any predicate is OK.
+	 */
+	private final MemIRI predicate;
+
+	/**
+	 * The object of statements to return, or null if any object is OK.
+	 */
+	private final MemValue object;
+
+	/**
+	 * Indicates which snapshot should be iterated over.
+	 */
+	private final int snapshot;
+
+	/**
+	 * The index of the last statement that has been returned.
+	 */
+	private volatile int statementIdx;
+
+	/*--------------*
+	 * Constructors *
+	 *--------------*/
+
+	/**
+	 * Creates a new MemStatementIterator that will iterate over the statements contained in the supplied
+	 * MemStatementList searching for statements that match the specified pattern of subject, predicate, object and
+	 * context(s).
+	 * 
+	 * @param statementList the statements over which to iterate.
+	 * @param subject       subject of pattern.
+	 * @param predicate     predicate of pattern.
+	 * @param object        object of pattern.
+	 */
+	public MemTripleIterator(MemStatementList statementList, MemResource subject, MemIRI predicate, MemValue object,
+			int snapshot) {
+		this.statementList = statementList;
+		this.subject = subject;
+		this.predicate = predicate;
+		this.object = object;
+		this.snapshot = snapshot;
+
+		this.statementIdx = -1;
+	}
+
+	/*---------*
+	 * Methods *
+	 *---------*/
+
+	/**
+	 * Searches through statementList, starting from index <tt>_nextStatementIdx + 1</tt>, for statements that match the
+	 * constraints that have been set for this iterator. If a matching statement has been found it will be stored in
+	 * <tt>_nextStatement</tt> and <tt>_nextStatementIdx</tt> points to the index of this statement in
+	 * <tt>_statementList</tt>. Otherwise, <tt>_nextStatement</tt> will set to <tt>null</tt>.
+	 */
+	@Override
+	protected MemTriple getNextElement() {
+		statementIdx++;
+
+		for (; statementIdx < statementList.size(); statementIdx++) {
+			MemStatement st = statementList.get(statementIdx);
+			if (isInSnapshot(st)) {
+				if (st.getSubject() instanceof MemTriple) {
+					MemTriple triple = (MemTriple) st.getSubject();
+					if (matchesPattern(triple)) {
+						return triple;
+					}
+				}
+				else if (st.getObject() instanceof MemTriple) {
+					MemTriple triple = (MemTriple) st.getObject();
+					if (matchesPattern(triple)) {
+						return triple;
+					}
+				}
+			}
+		}
+
+		// No more matching statements.
+		return null;
+	}
+
+	private boolean matchesPattern(MemTriple triple) {
+		if (!(subject == null || subject.equals(triple.getSubject()))) {
+			return false;
+		}
+		if (!(predicate == null || predicate.equals(triple.getPredicate()))) {
+			return false;
+		}
+		if (!(object == null || object.equals(triple.getObject()))) {
+			return false;
+		}
+		return true;
+	}
+
+	private boolean isInSnapshot(MemStatement st) {
+		return snapshot < 0 || st.isInSnapshot(snapshot);
+	}
+}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.rdf4j.model.BNode;
@@ -20,7 +21,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.BindingSet;
-import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.QueryResults;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -125,6 +126,7 @@ public abstract class RDFStarSupportTest {
 			fail("RDF* triple value should not be allowed by store as context identifier");
 		} catch (UnsupportedOperationException e) {
 			// fall through, expected behavior
+			testCon.rollback();
 		}
 
 	}
@@ -135,12 +137,17 @@ public abstract class RDFStarSupportTest {
 
 		testCon.add(rdfStarTriple, RDF.TYPE, RDF.ALT);
 
-		String query = "PREFIX foaf: <" + FOAF.NAMESPACE + ">\nSELECT * WHERE { <<?s foaf:name ?o>> ?b ?c. }";
+		String query = "PREFIX foaf: <" + FOAF.NAMESPACE + ">\nSELECT DISTINCT * WHERE { <<?s foaf:name ?o>> ?b ?c. }";
 
-		TupleQuery q = testCon.prepareTupleQuery(query);
-		for (BindingSet bs : q.evaluate()) {
-			System.out.println(bs);
-		}
+		List<BindingSet> result = QueryResults.asList(testCon.prepareTupleQuery(query).evaluate());
+		assertThat(result).hasSize(1);
+
+		BindingSet bs = result.get(0);
+		assertThat(bs.getValue("s")).isEqualTo(bob);
+		assertThat(bs.getValue("o")).isEqualTo(nameBob);
+		assertThat(bs.getValue("b")).isEqualTo(RDF.TYPE);
+		assertThat(bs.getValue("c")).isEqualTo(RDF.ALT);
+
 	}
 
 	protected abstract Repository createRepository();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQuery;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -125,6 +127,20 @@ public abstract class RDFStarSupportTest {
 			// fall through, expected behavior
 		}
 
+	}
+
+	@Test
+	public void testSparqlStar() {
+		Triple rdfStarTriple = vf.createTriple(bob, FOAF.NAME, nameBob);
+
+		testCon.add(rdfStarTriple, RDF.TYPE, RDF.ALT);
+
+		String query = "PREFIX foaf: <" + FOAF.NAMESPACE + ">\nSELECT * WHERE { <<?s foaf:name ?o>> ?b ?c. }";
+
+		TupleQuery q = testCon.prepareTupleQuery(query);
+		for (BindingSet bs : q.evaluate()) {
+			System.out.println(bs);
+		}
 	}
 
 	protected abstract Repository createRepository();


### PR DESCRIPTION
GitHub issue resolved: #2085 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

This enables SPARQL* querying on in-memory stores.

- added `getTriples` to SailDataset and related classes
- added implementation to SailDatasetTripleSource (which is used by memory store and native store)
- added memory store specific triple iterator


---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

