### PR TITLE
GH-2091 deprecate old shacl compliance tests

### DIFF
--- a/compliance/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SHACLComplianceTest.java
+++ b/compliance/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SHACLComplianceTest.java
@@ -20,8 +20,12 @@ import junit.framework.TestSuite;
 /**
  * Tests the SHACL implementation against the w3c test suite
  *
+ * @deprecated This test suite is not maintained. Use {@see org.eclipse.rdf4j.sail.shacl.W3cComplianceTest} instead. We
+ *             may un-deprecate this suite in the future.
+ *
  * @author James Leigh
  */
+@Deprecated
 public class SHACLComplianceTest extends AbstractSHACLTest {
 
 	// set this to true to run all tests!

--- a/testsuites/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/AbstractSHACLTest.java
+++ b/testsuites/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/AbstractSHACLTest.java
@@ -22,9 +22,13 @@ import junit.framework.TestCase;
 
 /**
  * A SHACL constraint test suite, created by reading in a W3C working-group style manifest.
- * 
+ *
+ * @deprecated This test suite is not maintained. Use {@see org.eclipse.rdf4j.sail.shacl.W3cComplianceTest} instead. We
+ *             may un-deprecate this suite in the future.
+ *
  * @author James Leigh
  */
+@Deprecated
 public abstract class AbstractSHACLTest extends TestCase {
 
 	/*-----------*
@@ -89,7 +93,7 @@ public abstract class AbstractSHACLTest extends TestCase {
 
 	/**
 	 * Creates a new un-initialized Sail stack
-	 * 
+	 *
 	 * @return a new un-initialized Sail stack
 	 */
 	protected abstract Sail newSail();


### PR DESCRIPTION
GitHub issue resolved: #2091 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

