### PR TITLE
GH-2101 set fedx:writable property for explicit writable member endpoint

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
@@ -157,7 +157,11 @@ public class FedXFactory {
 	}
 
 	public FedXFactory withResolvableEndpoint(String repositoryId) {
-		members.add(EndpointFactory.loadResolvableRepository(repositoryId));
+		return withResolvableEndpoint(repositoryId, false);
+	}
+
+	public FedXFactory withResolvableEndpoint(String repositoryId, boolean writable) {
+		members.add(EndpointFactory.loadResolvableRepository(repositoryId, writable));
 		return this;
 	}
 
@@ -183,7 +187,6 @@ public class FedXFactory {
 	 * @return the configured {@link FedXRepository}
 	 */
 	public FedXRepository create() {
-
 		if (members.isEmpty()) {
 			log.info("Initializing federation without any pre-configured members");
 		}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointBase.java
@@ -51,6 +51,7 @@ public abstract class EndpointBase implements Endpoint {
 		super();
 		this.repoInfo = repoInfo;
 		this.endpoint = endpoint;
+		this.writable = repoInfo.isWritable();
 		this.endpointClassification = endpointClassification;
 	}
 
@@ -107,8 +108,9 @@ public abstract class EndpointBase implements Endpoint {
 
 	@Override
 	public RepositoryConnection getConnection() {
-		if (!initialized)
+		if (!initialized) {
 			throw new FedXRuntimeException("Repository for endpoint " + getId() + " not initialized");
+		}
 		if (dependentConn != null) {
 			return this.dependentConn;
 		}
@@ -147,8 +149,9 @@ public abstract class EndpointBase implements Endpoint {
 
 	@Override
 	public void init(FederationContext federationContext) throws RepositoryException {
-		if (isInitialized())
+		if (isInitialized()) {
 			return;
+		}
 		Repository repo = getRepository();
 		tripleSource = TripleSourceFactory.tripleSourceFor(this, getType(), federationContext);
 		if (useSingleConnection()) {
@@ -172,8 +175,9 @@ public abstract class EndpointBase implements Endpoint {
 
 	@Override
 	public void shutDown() throws RepositoryException {
-		if (!isInitialized())
+		if (!isInitialized()) {
 			return;
+		}
 		if (dependentConn != null) {
 			dependentConn.closeManagedConnection();
 			dependentConn = null;
@@ -192,23 +196,30 @@ public abstract class EndpointBase implements Endpoint {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (obj == null) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
+		}
 		EndpointBase other = (EndpointBase) obj;
 		if (getId() == null) {
-			if (other.getId() != null)
+			if (other.getId() != null) {
 				return false;
-		} else if (!getId().equals(other.getId()))
+			}
+		} else if (!getId().equals(other.getId())) {
 			return false;
+		}
 		if (getType() == null) {
-			if (other.getType() != null)
+			if (other.getType() != null) {
 				return false;
-		} else if (!getType().equals(other.getType()))
+			}
+		} else if (!getType().equals(other.getType())) {
 			return false;
+		}
 		return true;
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
@@ -85,17 +85,27 @@ public class EndpointFactory {
 	public static Endpoint loadSPARQLEndpoint(String endpoint) throws FedXException {
 		try {
 			String id = new URL(endpoint).getHost();
-			if (id.equals("localhost"))
+			if (id.equals("localhost")) {
 				id = id + "_" + new URL(endpoint).getPort();
+			}
 			return loadSPARQLEndpoint("http://" + id, endpoint);
 		} catch (MalformedURLException e) {
 			throw new FedXException("Malformed URL: " + endpoint);
 		}
 	}
 
+
 	public static Endpoint loadRemoteRepository(String repositoryServer, String repositoryName) throws FedXException {
+		return loadRemoteRepository(repositoryServer, repositoryName, false);
+	}
+
+	public static Endpoint loadRemoteRepository(String repositoryServer, String repositoryName, boolean writable)
+			throws FedXException {
 		RemoteRepositoryProvider repProvider = new RemoteRepositoryProvider();
-		return repProvider.loadEndpoint(new RemoteRepositoryRepositoryInformation(repositoryServer, repositoryName));
+		RemoteRepositoryRepositoryInformation info = new RemoteRepositoryRepositoryInformation(repositoryServer,
+				repositoryName);
+		info.setWritable(writable);
+		return repProvider.loadEndpoint(info);
 
 	}
 
@@ -123,7 +133,7 @@ public class EndpointFactory {
 	}
 
 	/**
-	 * Load an {@link EndpointBase} for a given (configured) Repository.
+	 * Load an {@link Endpoint} for a given (configured) Repository.
 	 * <p>
 	 * Note that {@link EndpointType} is set to {@link EndpointType#Other}
 	 * </p>
@@ -212,8 +222,9 @@ public class EndpointFactory {
 	 */
 	public static List<Endpoint> loadFederationMembers(File dataConfig, File fedXBaseDir) throws FedXException {
 
-		if (!dataConfig.exists())
+		if (!dataConfig.exists()) {
 			throw new FedXRuntimeException("File does not exist: " + dataConfig.getAbsolutePath());
+		}
 
 		Model graph = new TreeModel();
 		RDFParser parser = Rio.createParser(RDFFormat.TURTLE);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
@@ -94,7 +94,6 @@ public class EndpointFactory {
 		}
 	}
 
-
 	public static Endpoint loadRemoteRepository(String repositoryServer, String repositoryName) throws FedXException {
 		return loadRemoteRepository(repositoryServer, repositoryName, false);
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactory.java
@@ -128,8 +128,33 @@ public class EndpointFactory {
 	 * @see ResolvableRepositoryInformation
 	 */
 	public static Endpoint loadResolvableRepository(String repositoryId) {
+		return loadResolvableRepository(repositoryId, false);
+	}
+
+	/**
+	 * Load a {@link ResolvableEndpoint}
+	 * 
+	 * <p>
+	 * The federation must be initialized with a {@link RepositoryResolver} ( see
+	 * {@link FedXFactory#withRepositoryResolver(RepositoryResolver)}) and this resolver must offer a Repository with
+	 * the id provided by {@link Endpoint#getId()}
+	 * </p>
+	 * 
+	 * <p>
+	 * Note that the name is set to "http://" + repositoryId
+	 * </p>
+	 * 
+	 * @param repositoryId the repository identifier
+	 * @param writable     whether to configure the endpoint as writable.
+	 * @return the configured {@link Endpoint}
+	 * @see ResolvableRepositoryProvider
+	 * @see ResolvableRepositoryInformation
+	 */
+	public static Endpoint loadResolvableRepository(String repositoryId, boolean writable) {
 		ResolvableRepositoryProvider repProvider = new ResolvableRepositoryProvider();
-		return repProvider.loadEndpoint(new ResolvableRepositoryInformation(repositoryId));
+		ResolvableRepositoryInformation info = new ResolvableRepositoryInformation(repositoryId);
+		info.setWritable(writable);
+		return repProvider.loadEndpoint(info);
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/NativeRepositoryInformation.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/NativeRepositoryInformation.java
@@ -7,11 +7,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.endpoint.provider;
 
+import static org.eclipse.rdf4j.model.util.Models.getPropertyLiteral;
+import static org.eclipse.rdf4j.model.util.Models.getPropertyString;
+
 import java.io.File;
 
 import org.eclipse.rdf4j.federated.endpoint.EndpointType;
 import org.eclipse.rdf4j.federated.repository.FedXRepository;
 import org.eclipse.rdf4j.federated.util.Vocabulary;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
@@ -65,12 +69,15 @@ public class NativeRepositoryInformation extends RepositoryInformation {
 		// name: the node's value
 		setProperty("name", repNode.stringValue());
 
+		setWritable(getPropertyLiteral(graph, repNode, Vocabulary.FEDX.WRITABLE)
+				.map(Literal::booleanValue)
+				.orElse(false));
+
 		// location
-		Model location = graph.filter(repNode, Vocabulary.FEDX.REPOSITORY_LOCATION, null);
-		String repoLocation = location.iterator().next().getObject().stringValue();
-		setProperty("location", repoLocation);
+		String location = getPropertyString(graph, repNode, Vocabulary.FEDX.REPOSITORY_LOCATION).orElse(null);
+		setProperty("location", location);
 
 		// id: the name of the location
-		setProperty("id", new File(repoLocation).getName());
+		setProperty("id", new File(location).getName());
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/RepositoryInformation.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/RepositoryInformation.java
@@ -43,7 +43,6 @@ public class RepositoryInformation {
 		return props.getProperty("location");
 	}
 
-
 	public EndpointType getType() {
 		return type;
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/RepositoryInformation.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/RepositoryInformation.java
@@ -18,6 +18,8 @@ public class RepositoryInformation {
 	private EndpointType type = EndpointType.Other; // the endpoint type, default Other
 	private EndpointConfiguration endpointConfiguration; // optional configuration settings for the endpoint
 
+	private boolean writable;
+
 	public RepositoryInformation(String id, String name, String location, EndpointType type) {
 		props.setProperty("id", id);
 		props.setProperty("name", name);
@@ -40,6 +42,7 @@ public class RepositoryInformation {
 	public String getLocation() {
 		return props.getProperty("location");
 	}
+
 
 	public EndpointType getType() {
 		return type;
@@ -70,5 +73,19 @@ public class RepositoryInformation {
 
 	public void setType(EndpointType type) {
 		this.type = type;
+	}
+
+	/**
+	 * @return the writable
+	 */
+	public boolean isWritable() {
+		return writable;
+	}
+
+	/**
+	 * @param writable the writable to set
+	 */
+	public void setWritable(boolean writable) {
+		this.writable = writable;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/Vocabulary.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/Vocabulary.java
@@ -44,6 +44,8 @@ public class Vocabulary {
 		public static final IRI REPOSITORY_SERVER = vf.createIRI(NAMESPACE, "repositoryServer");
 
 		public static final IRI REPOSITORY_NAME = vf.createIRI(NAMESPACE, "repositoryName");
+
+		public static final IRI WRITABLE = vf.createIRI(NAMESPACE, "writable");
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
@@ -54,16 +54,13 @@ public class ReadOnlyWriteStrategy implements WriteStrategy {
 	}
 
 	@Override
-	public void initialize() throws RepositoryException {
+	public void clear(Resource... contexts) throws RepositoryException {
+		throw new UnsupportedOperationException("Writing not supported to a federation: the federation is readonly.");
 	}
+
 
 	@Override
 	public void close() throws RepositoryException {
-	}
-
-	@Override
-	public boolean isInitialized() {
-		return true;
 	}
 
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
@@ -58,7 +58,6 @@ public class ReadOnlyWriteStrategy implements WriteStrategy {
 		throw new UnsupportedOperationException("Writing not supported to a federation: the federation is readonly.");
 	}
 
-
 	@Override
 	public void close() throws RepositoryException {
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategy.java
@@ -37,45 +37,53 @@ public class RepositoryWriteStrategy implements WriteStrategy {
 	}
 
 	@Override
-	public void initialize() throws RepositoryException {
-		connection = writeRepository.getConnection();
-	}
-
-	@Override
-	public boolean isInitialized() {
-		return connection != null;
-	}
-
-	@Override
 	public void close() throws RepositoryException {
-		connection.close();
+		if (connection != null) {
+			connection.close();
+		}
 	}
 
 	@Override
 	public void begin() throws RepositoryException {
+		createConnection();
 		connection.begin();
 	}
 
 	@Override
 	public void commit() throws RepositoryException {
+		createConnection();
 		connection.commit();
 	}
 
 	@Override
 	public void rollback() throws RepositoryException {
+		createConnection();
 		connection.rollback();
 	}
 
 	@Override
 	public void addStatement(Resource subj, IRI pred, Value obj,
 			Resource... contexts) throws RepositoryException {
+		createConnection();
 		connection.add(subj, pred, obj, contexts);
-
 	}
 
 	@Override
 	public void removeStatement(Resource subj, IRI pred, Value obj,
 			Resource... contexts) throws RepositoryException {
+		createConnection();
 		connection.remove(subj, pred, obj, contexts);
+	}
+
+	@Override
+	public void clear(Resource... contexts) throws RepositoryException {
+		createConnection();
+		connection.clear(contexts);
+	}
+
+	private void createConnection() throws RepositoryException {
+		if (connection == null || !connection.isOpen()) {
+			connection = writeRepository.getConnection();
+		}
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/WriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/WriteStrategy.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.federated.write;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 
 /**
@@ -25,49 +24,35 @@ import org.eclipse.rdf4j.repository.RepositoryException;
  * @see RepositoryWriteStrategy
  * @see ReadOnlyWriteStrategy
  */
-public interface WriteStrategy {
-
-	/**
-	 * Initialize the write strategy (e.g. open a shared {@link RepositoryConnection}.
-	 * 
-	 * @throws RepositoryException
-	 */
-	public void initialize() throws RepositoryException;
-
-	/**
-	 * Returns true if this instance is initialized
-	 * 
-	 * @return flag indicating the initialization resources
-	 */
-	public boolean isInitialized();
-
+public interface WriteStrategy extends AutoCloseable {
 	/**
 	 * Close this write strategy (e.g. close a shared {@link RepositoryException}).
 	 * 
 	 * @throws RepositoryException
 	 */
-	public void close() throws RepositoryException;
+	@Override
+	void close() throws RepositoryException;
 
 	/**
 	 * Begin a transaction.
 	 * 
 	 * @throws RepositoryException
 	 */
-	public void begin() throws RepositoryException;
+	void begin() throws RepositoryException;
 
 	/**
 	 * Commit a transaction.
 	 * 
 	 * @throws RepositoryException
 	 */
-	public void commit() throws RepositoryException;
+	void commit() throws RepositoryException;
 
 	/**
 	 * Rollback a transaction.
 	 * 
 	 * @throws RepositoryException
 	 */
-	public void rollback() throws RepositoryException;
+	void rollback() throws RepositoryException;
 
 	/**
 	 * Add a statement
@@ -78,7 +63,7 @@ public interface WriteStrategy {
 	 * @param contexts
 	 * @throws RepositoryException
 	 */
-	public void addStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws RepositoryException;
+	void addStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws RepositoryException;
 
 	/**
 	 * Remove a statement
@@ -89,5 +74,8 @@ public interface WriteStrategy {
 	 * @param contexts
 	 * @throws RepositoryException
 	 */
-	public void removeStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws RepositoryException;
+	void removeStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws RepositoryException;
+
+	void clear(Resource... contexts) throws RepositoryException;
+
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXFactoryTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXFactoryTest.java
@@ -53,6 +53,35 @@ public class FedXFactoryTest extends SPARQLServerBaseTest {
 	}
 
 	@Test
+	public void testFederationWithResolver_writable() throws Exception {
+
+		assumeSparqlEndpoint();
+
+		// load some data into endpoint2
+		loadDataSet(server.getRepository(2), "/tests/medium/data2.ttl");
+
+		RepositoryResolver repositoryResolver = ((SPARQLEmbeddedServer) server).getRepositoryResolver();
+
+		FedXRepository repo = FedXFactory.newFederation()
+				.withRepositoryResolver(repositoryResolver)
+				.withResolvableEndpoint("endpoint1", true)
+				.withResolvableEndpoint("endpoint2")
+				.create();
+
+		repo.init();
+
+		// load data into the endpoint1 via the federation
+		loadDataSet(repo, "/tests/medium/data1.ttl");
+
+		federationContext = repo.getFederationContext();
+		try (RepositoryConnection conn = repo.getConnection()) {
+			execute(conn, "/tests/medium/query01.rq", "/tests/medium/query01.srx", false);
+		}
+
+		repo.shutDown();
+	}
+
+	@Test
 	public void testFederationWithResolver_DataConfig() throws Exception {
 
 		assumeSparqlEndpoint();

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactoryTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/endpoint/EndpointFactoryTest.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.endpoint;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
@@ -79,6 +81,27 @@ public class EndpointFactoryTest extends SPARQLBaseTest {
 		Assertions.assertEquals(new File("target/tmp/fedxTest", "repositories/dbmodel"),
 				((ManagedRepositoryEndpoint) nativeStore).repository.getDataDir());
 
+	}
+
+	@Test
+	public void testDataConfig_writableEndpoint() throws Exception {
+
+		File baseDir = new File("target/tmp/fedxTest");
+
+		File dataConfig = new File(
+				EndpointFactoryTest.class.getResource("/tests/dataconfig/endpointfactoryTest_writable.ttl").toURI());
+
+		List<Endpoint> endpoints = EndpointFactory.loadFederationMembers(dataConfig, baseDir);
+
+		endpoints.sort((e1, e2) -> e1.getName().compareTo(e2.getName()));
+
+		assertThat(endpoints.size()).isEqualTo(3);
+
+		Endpoint nativeStore = endpoints.get(2);
+		assertThat(nativeStore.getName()).isEqualTo("http://dbpedia.native");
+		assertThat(nativeStore.getId()).isEqualTo("dbmodel");
+		assertThat(nativeStore.getEndpoint()).isEqualTo("dbmodel");
+		assertThat(nativeStore.isWritable()).isTrue();
 	}
 
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigTest.java
@@ -36,7 +36,7 @@ public class FedXRepositoryConfigTest {
 
 		Model members = config.getMembers();
 		assertThat(members.filter(null, FEDX.STORE, null).size()).isEqualTo(2);
-		
+
 		assertThat(members.filter(null, FEDX.REPOSITORY_NAME, null).objects().stream().map(Value::stringValue))
 				.containsExactly("endpoint1", "endpoint2");
 	}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfigTest.java
@@ -7,27 +7,26 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.util.Models.subject;
+
 import java.io.InputStream;
-import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.federated.util.Vocabulary.FEDX;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.TreeModel;
-import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.github.jsonldjava.shaded.com.google.common.collect.Sets;
-
 public class FedXRepositoryConfigTest {
 
 	@Test
 	public void testParseConfig() throws Exception {
-
 		Model model = readConfig("/tests/rdf4jserver/config.ttl");
 
 		FedXRepositoryConfig config = new FedXRepositoryConfig();
@@ -36,19 +35,14 @@ public class FedXRepositoryConfigTest {
 		Assertions.assertNull(config.getDataConfig());
 
 		Model members = config.getMembers();
-		Assertions.assertEquals(2, members.filter(null, FEDX.STORE, null).size()); // 2 members
-		Assertions.assertEquals(Sets.newHashSet("endpoint1", "endpoint2"),
-				members.filter(null, FEDX.REPOSITORY_NAME, null)
-						.objects()
-						.stream()
-						.map(v -> v.stringValue())
-						.collect(Collectors.toSet()));
-
+		assertThat(members.filter(null, FEDX.STORE, null).size()).isEqualTo(2);
+		
+		assertThat(members.filter(null, FEDX.REPOSITORY_NAME, null).objects().stream().map(Value::stringValue))
+				.containsExactly("endpoint1", "endpoint2");
 	}
 
 	@Test
 	public void testParseConfig_DataConfig() throws Exception {
-
 		Model model = readConfig("/tests/rdf4jserver/config-withDataConfig.ttl");
 
 		FedXRepositoryConfig config = new FedXRepositoryConfig();
@@ -62,7 +56,6 @@ public class FedXRepositoryConfigTest {
 
 	@Test
 	public void testExport() throws Exception {
-
 		Model model = readConfig("/tests/rdf4jserver/config.ttl");
 
 		FedXRepositoryConfig config = new FedXRepositoryConfig();
@@ -72,13 +65,10 @@ public class FedXRepositoryConfigTest {
 		Model export = new TreeModel();
 		Resource implNode = config.export(export);
 
-		Assertions.assertEquals(2, export.filter(implNode, FedXRepositoryConfig.MEMBER, null).size()); // 2 members
-		Assertions.assertEquals(Sets.newHashSet("endpoint1", "endpoint2"),
-				export.filter(null, FEDX.REPOSITORY_NAME, null)
-						.objects()
-						.stream()
-						.map(v -> v.stringValue())
-						.collect(Collectors.toSet()));
+		assertThat(export.filter(implNode, FedXRepositoryConfig.MEMBER, null).size()).isEqualTo(2);
+
+		assertThat(export.filter(null, FEDX.REPOSITORY_NAME, null).objects().stream().map(Value::stringValue))
+				.containsExactly("endpoint1", "endpoint2");
 	}
 
 	protected Model readConfig(String configResource) throws Exception {
@@ -88,7 +78,7 @@ public class FedXRepositoryConfigTest {
 	}
 
 	protected Resource implNode(Model model) {
-		return Models.subject(model.filter(null, RepositoryConfigSchema.REPOSITORYTYPE, null)).get();
+		return subject(model.filter(null, RepositoryConfigSchema.REPOSITORYTYPE, null)).get();
 	}
 
 }

--- a/tools/federation/src/test/resources/tests/dataconfig/endpointfactoryTest_writable.ttl
+++ b/tools/federation/src/test/resources/tests/dataconfig/endpointfactoryTest_writable.ttl
@@ -1,0 +1,17 @@
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix fedx: <http://rdf4j.org/config/federation#>.
+
+<http://dbpedia> a sd:Service ;
+	fedx:store "SPARQLEndpoint";
+	sd:endpoint "http://dbpedia.org/sparql".
+
+<http://dbpedia.local> a sd:Service ;
+	fedx:store "RemoteRepository";
+	fedx:repositoryServer "http://10.212.10.29:8088/rdf4j-server";
+	fedx:repositoryName "dbpedia".
+
+<http://dbpedia.native> a sd:Service ;
+	fedx:store "NativeStore" ;
+	fedx:repositoryLocation "dbmodel" ;
+        fedx:writable true .
+

--- a/tools/federation/src/test/resources/tests/rdf4jserver/config.ttl
+++ b/tools/federation/src/test/resources/tests/rdf4jserver/config.ttl
@@ -10,7 +10,8 @@
       rep:repositoryType "fedx:FedXRepository" ;
       fedx:member [
          fedx:store "ResolvableRepository" ;
-         fedx:repositoryName "endpoint1" 
+         fedx:repositoryName "endpoint1" ;
+         fedx:writable true 
       ] ,
       [
          fedx:store "ResolvableRepository" ;

--- a/tools/federation/src/test/resources/tests/rdf4jserver/dataConfig.ttl
+++ b/tools/federation/src/test/resources/tests/rdf4jserver/dataConfig.ttl
@@ -3,7 +3,8 @@
 
 <http://endpoint1> a sd:Service ;
 	fedx:store "ResolvableRepository" ;
-	fedx:repositoryName "endpoint1" .
+	fedx:repositoryName "endpoint1" ;
+        fedx:writable true.
 	
 <http://endpoint2> a sd:Service ;
 	fedx:store "ResolvableRepository" ;


### PR DESCRIPTION
GitHub issue resolved: #2101  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Added `fedx:writable` property which can optionally be set to true for a member endpoint service (or a member repository when using "classic config").

Added simple unit tests to verify property is communicated. 


---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

