### PR TITLE
GH-2107 predict the size of the data that needs to be read in DataFile

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataFile.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf.datastore;
 
+import org.eclipse.rdf4j.common.io.NioFile;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -14,12 +16,10 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 
-import org.eclipse.rdf4j.common.io.NioFile;
-
 /**
  * Class supplying access to a data file. A data file stores data sequentially. Each entry starts with the entry's
  * length (4 bytes), followed by the data itself. File offsets are used to identify entries.
- * 
+ *
  * @author Arjohn Kampman
  */
 public class DataFile implements Closeable {
@@ -101,7 +101,7 @@ public class DataFile implements Closeable {
 
 	/**
 	 * Stores the specified data and returns the byte-offset at which it has been stored.
-	 * 
+	 *
 	 * @param data The data to store, must not be <tt>null</tt>.
 	 * @return The byte-offset in the file at which the data was stored.
 	 */
@@ -121,9 +121,13 @@ public class DataFile implements Closeable {
 		return offset;
 	}
 
+	// This variable is used for predicting the number of bytes to read in getData(long offset). This helps us to only
+	// need to execute a single IO read instead of first one read to find the length and then one read to read the data.
+	int dataLengthApproximateAverage = 25;
+
 	/**
 	 * Gets the data that is stored at the specified offset.
-	 * 
+	 *
 	 * @param offset An offset in the data file, must be larger than 0.
 	 * @return The data that was found on the specified offset.
 	 * @exception IOException If an I/O error occurred.
@@ -131,19 +135,49 @@ public class DataFile implements Closeable {
 	public byte[] getData(long offset) throws IOException {
 		assert offset > 0 : "offset must be larger than 0, is: " + offset;
 
-		// TODO: maybe get more data in one go is more efficient?
-		int dataLength = nioFile.readInt(offset);
-
-		byte[] data = new byte[dataLength];
+		// Read in twice the average length because multiple small read operations take more time than one single larger
+		// operation even if that larger operation is unnecessarily large (within sensible limits).
+		byte[] data = new byte[(dataLengthApproximateAverage * 2) + 4];
 		ByteBuffer buf = ByteBuffer.wrap(data);
-		nioFile.read(buf, offset + 4L);
+		nioFile.read(buf, offset);
 
-		return data;
+		int dataLength = (data[0] << 24) & 0xff000000 |
+				(data[1] << 16) & 0x00ff0000 |
+				(data[2] << 8) & 0x0000ff00 |
+				(data[3]) & 0x000000ff;
+
+		assert dataLength == nioFile.readInt(offset);
+
+		// We have either managed to read enough data and can return the required subset of the data, or we have read
+		// too little so we need to execute another read to get the correct data.
+		if (dataLength <= data.length - 4) {
+
+			// adjust the approximate average with 1 part actual length and 99 parts previous average up to a sensible
+			// max of 200
+			dataLengthApproximateAverage = (int) (Math.min(200,
+					((dataLengthApproximateAverage / 100.0) * 99) + (dataLength / 100.0)));
+
+			return Arrays.copyOfRange(data, 4, dataLength + 4);
+
+		} else {
+
+			// adjust the approximate average, but favour the actual dataLength since dataLength predictions misses are
+			// costly
+			dataLengthApproximateAverage = Math.min(200, (dataLengthApproximateAverage + dataLength) / 2);
+
+			// we didn't read enough data so we need to execute a new read
+			data = new byte[dataLength];
+			buf = ByteBuffer.wrap(data);
+			nioFile.read(buf, offset + 4L);
+
+			return data;
+		}
+
 	}
 
 	/**
 	 * Discards all stored data.
-	 * 
+	 *
 	 * @throws IOException If an I/O error occurred.
 	 */
 	public void clear() throws IOException {
@@ -161,7 +195,7 @@ public class DataFile implements Closeable {
 
 	/**
 	 * Closes the data file, releasing any file locks that it might have.
-	 * 
+	 *
 	 * @throws IOException
 	 */
 	@Override
@@ -171,7 +205,7 @@ public class DataFile implements Closeable {
 
 	/**
 	 * Gets an iterator that can be used to iterate over all stored data.
-	 * 
+	 *
 	 * @return a DataIterator.
 	 */
 	public DataIterator iterator() {

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataFile.java
@@ -146,8 +146,6 @@ public class DataFile implements Closeable {
 				(data[2] << 8) & 0x0000ff00 |
 				(data[3]) & 0x000000ff;
 
-		assert dataLength == nioFile.readInt(offset);
-
 		// We have either managed to read enough data and can return the required subset of the data, or we have read
 		// too little so we need to execute another read to get the correct data.
 		if (dataLength <= data.length - 4) {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
@@ -16,7 +16,6 @@ import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -59,12 +58,16 @@ public class QueryBenchmark {
 	private static final String query1;
 	private static final String query2;
 	private static final String query3;
+	private static final String query4;
+	private static final String query5;
 
 	static {
 		try {
 			query1 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query1.qr"), StandardCharsets.UTF_8);
 			query2 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query2.qr"), StandardCharsets.UTF_8);
 			query3 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query3.qr"), StandardCharsets.UTF_8);
+			query4 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query4.qr"), StandardCharsets.UTF_8);
+			query5 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query5.qr"), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
@@ -107,12 +110,38 @@ public class QueryBenchmark {
 	}
 
 	@Benchmark
-	public List<BindingSet> groupByQuery() {
+	public long groupByQuery() {
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			return Iterations.asList(connection
+			return connection
 					.prepareTupleQuery(query1)
-					.evaluate());
+					.evaluate()
+					.stream()
+					.count();
+		}
+	}
+
+	@Benchmark
+	public long complexQuery() {
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query4)
+					.evaluate()
+					.stream()
+					.count();
+		}
+	}
+
+	@Benchmark
+	public long distinctPredicatesQuery() {
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query5)
+					.evaluate()
+					.stream()
+					.count();
 		}
 	}
 

--- a/core/sail/nativerdf/src/test/resources/benchmarkFiles/query4.qr
+++ b/core/sail/nativerdf/src/test/resources/benchmarkFiles/query4.qr
@@ -1,0 +1,26 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT ?type1 ?type2 ?language ?mbox where {
+        ?b dcat:dataset ?a.
+        ?b a ?type1.
+
+        ?a a ?type2.
+        ?a dct:identifier ?identifier.
+        ?a dct:language ?language.
+        ?a dct:publisher [foaf:mbox ?mbox] .
+
+        #FILTER (?identifier = "60019b6c-810b-4154-8455-77af1976af93")
+
+
+}
+

--- a/core/sail/nativerdf/src/test/resources/benchmarkFiles/query5.qr
+++ b/core/sail/nativerdf/src/test/resources/benchmarkFiles/query5.qr
@@ -1,0 +1,18 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT DISTINCT ?pred WHERE {
+        ?subj ?pred ?obj.
+
+
+}
+


### PR DESCRIPTION
GitHub issue resolved: #2107 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:


In DataFile try to predict the size of the data that needs to be read so that we can get away with a single read. This improves performance because even though the operating system might be smart, it's still cheaper to get 50 bytes in one read than to get 4+20 in two reads.

---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

