### PR TITLE
GH-2121 group adds/removes together in sparql update sequence

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
@@ -91,71 +91,51 @@ public class SPARQLStoreConnectionTest extends RepositoryConnectionTest {
 	}
 
 	@Override
-	@Ignore
+	@Ignore("relies on SPARQL update operation handled as part of txn")
 	public void testAddDelete() throws RDF4JException {
 		System.err.println("temporarily disabled testAddDelete() for SPARQLRepository");
 	}
 
 	@Override
-	@Ignore
+	@Ignore("relies on SPARQL update operation handled as part of txn")
 	public void testAddRemoveInsert() throws RDF4JException {
 		System.err.println("temporarily disabled testAddRemoveInsert() for SPARQLRepository");
 	}
 
 	@Override
-	@Ignore
+	@Ignore("relies on pending updates being visible in own connection")
 	public void testSizeRollback() throws Exception {
 		System.err.println("temporarily disabled testSizeRollback() for SPARQLRepository");
 	}
 
-	@Test
-	@Ignore
 	@Override
-	public void testURISerialization() throws Exception {
-		System.err.println("temporarily disabled testURISerialization() for SPARQLRepository");
-	}
-
-	@Test
-	@Ignore
-	@Override
-	public void testStatementSerialization() throws Exception {
-		System.err.println("temporarily disabled testStatementSerialization() for SPARQLRepository");
-	}
-
-	@Override
-	@Ignore
+	@Ignore("relies on pending updates being visible in own connection")
 	public void testAutoCommit() throws Exception {
 		System.err.println("temporarily disabled testAutoCommit() for SPARQLRepository");
 	}
 
 	@Override
-	@Ignore
+	@Ignore("relies on pending updates being visible in own connection")
 	public void testRollback() throws Exception {
 		System.err.println("temporarily disabled testRollback() for SPARQLRepository");
 	}
 
 	@Override
-	@Ignore
+	@Ignore("relies on pending updates being visible in own connection")
 	public void testEmptyRollback() throws Exception {
 		System.err.println("temporarily disabled testEmptyRollback() for SPARQLRepository");
 	}
 
 	@Override
-	@Ignore
+	@Ignore("relies on pending updates being visible in own connection")
 	public void testEmptyCommit() throws Exception {
 		System.err.println("temporarily disabled testEmptyCommit() for SPARQLRepository");
 	}
 
 	@Override
-	@Ignore
+	@Ignore("SeRQL language not supported on SPARQL endpoints")
 	public void testPrepareSeRQLQuery() throws Exception {
 		System.err.println("disabled testPrepareSeRQLQuery() for SPARQLRepository");
-	}
-
-	@Override
-	@Ignore
-	public void testLiteralSerialization() throws Exception {
-		System.err.println("temporarily disabled testLiteralSerialization() for SPARQLRepository");
 	}
 
 	@Override

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -89,18 +89,16 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 
 	private final SPARQLProtocolSession client;
 
+	private ModelFactory modelFactory = new DynamicModelFactory();
+
 	private StringBuilder sparqlTransaction;
 
 	private Object transactionLock = new Object();
 
-	private Model pendingAdds = this.getModelFactory().createEmptyModel();
-	private Model pendingRemoves = this.getModelFactory().createEmptyModel();
+	private final Model pendingAdds;
+	private final Model pendingRemoves;
 
 	private final boolean quadMode;
-
-	private ModelFactory getModelFactory() {
-		return new DynamicModelFactory();
-	}
 
 	public SPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession client) {
 		this(repository, client, false); // in triple mode by default
@@ -110,6 +108,8 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 		super(repository);
 		this.client = client;
 		this.quadMode = quadMode;
+		this.pendingAdds = getModelFactory().createEmptyModel();
+		this.pendingRemoves = getModelFactory().createEmptyModel();
 	}
 
 	@Override
@@ -179,9 +179,7 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 			});
 			allGood = true;
 			return result;
-		} catch (MalformedQueryException |
-
-				QueryEvaluationException e) {
+		} catch (MalformedQueryException | QueryEvaluationException e) {
 			throw new RepositoryException(e);
 		} finally {
 			if (!allGood) {
@@ -996,6 +994,10 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 			}
 
 		};
+	}
+
+	private ModelFactory getModelFactory() {
+		return modelFactory;
 	}
 
 }

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -16,9 +17,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class SPARQLConnectionTest {
 
@@ -47,5 +52,53 @@ public class SPARQLConnectionTest {
 		// verify both method signatures for sendUpdate never get called.
 		verify(client, never()).sendUpdate(any(), any(), any(), any(), anyBoolean(), anyInt(), any());
 		verify(client, never()).sendUpdate(any(), any(), any(), any(), anyBoolean(), any());
+	}
+
+	@Test
+	public void testGroupingAddsInInsert() throws Exception {
+		ArgumentCaptor<String> sparqlUpdateCaptor = ArgumentCaptor.forClass(String.class);
+
+		subject.begin();
+		subject.add(FOAF.PERSON, RDF.TYPE, RDFS.CLASS);
+		subject.add(FOAF.AGENT, RDF.TYPE, RDFS.CLASS);
+		subject.commit();
+
+		verify(client).sendUpdate(any(), sparqlUpdateCaptor.capture(), any(), any(), anyBoolean(), anyInt(), any());
+
+		String sparqlUpdate = sparqlUpdateCaptor.getValue();
+		String expectedTriple1 = "<" + FOAF.PERSON + "> <" + RDF.TYPE + "> <" + RDFS.CLASS + ">";
+		String expectedTriple2 = "<" + FOAF.AGENT + "> <" + RDF.TYPE + "> <" + RDFS.CLASS + ">";
+
+		assertThat(sparqlUpdate).containsOnlyOnce("INSERT DATA").contains(expectedTriple1).contains(expectedTriple2);
+	}
+
+	@Test
+	public void testHandlingAddsRemoves() throws Exception {
+		ArgumentCaptor<String> sparqlUpdateCaptor = ArgumentCaptor.forClass(String.class);
+
+		subject.begin();
+		subject.add(FOAF.PERSON, RDF.TYPE, RDFS.CLASS);
+		subject.add(FOAF.AGENT, RDF.TYPE, RDFS.CLASS);
+		subject.remove(FOAF.BIRTHDAY, RDF.TYPE, RDF.PROPERTY);
+		subject.add(FOAF.AGE, RDF.TYPE, RDF.PROPERTY);
+		subject.commit();
+
+		verify(client).sendUpdate(any(), sparqlUpdateCaptor.capture(), any(), any(), anyBoolean(), anyInt(), any());
+
+		String sparqlUpdate = sparqlUpdateCaptor.getValue();
+
+		String expectedAddedTriple1 = "<" + FOAF.PERSON + "> <" + RDF.TYPE + "> <" + RDFS.CLASS + "> .";
+		String expectedAddedTriple2 = "<" + FOAF.AGENT + "> <" + RDF.TYPE + "> <" + RDFS.CLASS + "> .";
+		String expectedAddedTriple3 = "<" + FOAF.AGE + "> <" + RDF.TYPE + "> <" + RDF.PROPERTY + "> ";
+		String expectedRemovedTriple1 = "<" + FOAF.BIRTHDAY + "> <" + RDF.TYPE + "> <" + RDF.PROPERTY + "> .";
+
+		String expectedSequence = "INSERT DATA[^{]*\\{[^}]*\\}[^D]+DELETE DATA[^{]*\\{[^}]*\\}[^I]+INSERT DATA.*";
+
+		assertThat(sparqlUpdate).containsPattern(expectedSequence);
+		assertThat(sparqlUpdate).contains(expectedAddedTriple1)
+				.contains(expectedAddedTriple2)
+				.contains(expectedAddedTriple3)
+				.contains(expectedRemovedTriple1);
+
 	}
 }

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnectionTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnectionTest.java
@@ -1072,6 +1072,21 @@ public abstract class RepositoryConnectionTest {
 	}
 
 	@Test
+	public void testRemoveStatementWithContext() throws Exception {
+		Statement statement = vf.createStatement(alice, name, nameAlice, context1);
+		testCon.add(statement);
+
+		assertThat(testCon.hasStatement(alice, name, nameAlice, false)).isTrue();
+		assertThat(testCon.hasStatement(alice, name, nameAlice, false, context1)).isTrue();
+
+		testCon.remove(alice, name, nameAlice, context1);
+
+		assertThat(testCon.hasStatement(alice, name, nameAlice, false)).isFalse();
+		assertThat(testCon.hasStatement(alice, name, nameAlice, false, context1)).isFalse();
+
+	}
+
+	@Test
 	public void testRemoveStatementCollection() throws Exception {
 		testCon.begin();
 		testCon.add(alice, name, nameAlice);


### PR DESCRIPTION
GitHub issue resolved: #2121 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- SPARQLConnection internally keeps tracks of pending adds / removals. When either commit is called or an add is interleaved with remove (vice versa) the pendings adds/removals get flushed into a single INSERT/DELETE DATA operation
- added one or two unit tests to check content and sequence of update operations in the produced SPARQL string.

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

