### PR TITLE
GH-1098 removed org.json dep, replaced usage with Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,11 +545,6 @@
 				<artifactId>logback-classic</artifactId>
 				<version>${logback.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>org.json</groupId>
-				<artifactId>json</artifactId>
-				<version>20140107</version>
-			</dependency>
 			<!-- Testing: JUnit -->
 			<dependency>
 				<groupId>junit</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -238,11 +238,6 @@
 				<artifactId>logback-classic</artifactId>
 				<version>${logback.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>org.json</groupId>
-				<artifactId>json</artifactId>
-				<version>20140107</version>
-			</dependency>
 			<!-- Testing: JUnit -->
 			<dependency>
 				<groupId>junit</groupId>

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -74,10 +74,6 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/DeleteServlet.java
+++ b/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/DeleteServlet.java
@@ -20,12 +20,16 @@ import org.eclipse.rdf4j.repository.manager.RepositoryInfo;
 import org.eclipse.rdf4j.workbench.base.TransformationServlet;
 import org.eclipse.rdf4j.workbench.util.TupleResultBuilder;
 import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
-import org.json.JSONObject;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Servlet responsible for presenting the list of repositories, and deleting the chosen one.
  */
 public class DeleteServlet extends TransformationServlet {
+
+	private static final ObjectMapper mapper = new ObjectMapper();
 
 	/**
 	 * Deletes the repository with the given ID, then redirects to the repository selection page. If given a "checkSafe"
@@ -45,8 +49,10 @@ public class DeleteServlet extends TransformationServlet {
 			super.service(req, resp, xslPath);
 		} else {
 			// Respond to 'checkSafe' XmlHttpRequest with JSON.
+			ObjectNode jsonObject = mapper.createObjectNode();
+			jsonObject.put("safe", manager.isSafeToRemove(checkSafe));
 			final PrintWriter writer = new PrintWriter(new BufferedWriter(resp.getWriter()));
-			writer.write(new JSONObject().put("safe", manager.isSafeToRemove(checkSafe)).toString());
+			writer.write(mapper.writeValueAsString(jsonObject));
 			writer.flush();
 		}
 

--- a/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/QueryServlet.java
+++ b/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/QueryServlet.java
@@ -47,10 +47,11 @@ import org.eclipse.rdf4j.workbench.util.QueryEvaluator;
 import org.eclipse.rdf4j.workbench.util.QueryStorage;
 import org.eclipse.rdf4j.workbench.util.TupleResultBuilder;
 import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class QueryServlet extends TransformationServlet {
 
@@ -71,6 +72,8 @@ public class QueryServlet extends TransformationServlet {
 	private static final Logger LOGGER = LoggerFactory.getLogger(QueryServlet.class);
 
 	private static final QueryEvaluator EVAL = QueryEvaluator.INSTANCE;
+
+	private static final ObjectMapper mapper = new ObjectMapper();
 
 	private QueryStorage storage;
 
@@ -157,7 +160,7 @@ public class QueryServlet extends TransformationServlet {
 
 	@Override
 	protected void service(final WorkbenchRequest req, final HttpServletResponse resp, final String xslPath)
-			throws IOException, RDF4JException, BadRequestException, JSONException {
+			throws IOException, RDF4JException, BadRequestException {
 		if (!writeQueryCookie) {
 			// If we suppressed putting the query text into the cookies before.
 			cookies.addCookie(req, resp, REF, "hash");
@@ -167,11 +170,11 @@ public class QueryServlet extends TransformationServlet {
 			cookies.addCookie(req, resp, QUERY, hash);
 		}
 		if ("get".equals(req.getParameter("action"))) {
-			JSONObject json = new JSONObject();
-			json.put("queryText", getQueryText(req));
+			ObjectNode jsonObject = mapper.createObjectNode();
+			jsonObject.put("queryText", getQueryText(req));
 			PrintWriter writer = new PrintWriter(new BufferedWriter(resp.getWriter()));
 			try {
-				writer.write(json.toString());
+				writer.write(mapper.writeValueAsString(jsonObject));
 			} finally {
 				writer.flush();
 			}
@@ -201,7 +204,7 @@ public class QueryServlet extends TransformationServlet {
 
 	@Override
 	protected void doPost(final WorkbenchRequest req, final HttpServletResponse resp, final String xslPath)
-			throws IOException, BadRequestException, RDF4JException, JSONException {
+			throws IOException, BadRequestException, RDF4JException {
 		final String action = req.getParameter("action");
 		if ("save".equals(action)) {
 			saveQuery(req, resp);
@@ -237,17 +240,19 @@ public class QueryServlet extends TransformationServlet {
 	}
 
 	private void saveQuery(final WorkbenchRequest req, final HttpServletResponse resp)
-			throws IOException, BadRequestException, RDF4JException, JSONException {
+			throws IOException, BadRequestException, RDF4JException {
 		resp.setContentType("application/json");
-		final JSONObject json = new JSONObject();
+		ObjectNode jsonObject = mapper.createObjectNode();
+		jsonObject.put("queryText", getQueryText(req));
+
 		final HTTPRepository http = (HTTPRepository) repository;
 		final boolean accessible = storage.checkAccess(http);
-		json.put("accessible", accessible);
+		jsonObject.put("accessible", accessible);
 		if (accessible) {
 			final String queryName = req.getParameter("query-name");
 			String userName = getUserNameFromParameter(req, SERVER_USER);
 			final boolean existed = storage.askExists(http, queryName, userName);
-			json.put("existed", existed);
+			jsonObject.put("existed", existed);
 			final boolean written = Boolean.valueOf(req.getParameter("overwrite")) || !existed;
 			if (written) {
 				final boolean shared = !Boolean.valueOf(req.getParameter("save-private"));
@@ -262,10 +267,10 @@ public class QueryServlet extends TransformationServlet {
 					storage.saveQuery(http, queryName, userName, shared, queryLanguage, queryText, infer, rowsPerPage);
 				}
 			}
-			json.put("written", written);
+			jsonObject.put("written", written);
 		}
 		final PrintWriter writer = new PrintWriter(new BufferedWriter(resp.getWriter()));
-		writer.write(json.toString());
+		writer.write(mapper.writeValueAsString(jsonObject));
 		writer.flush();
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #1098 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Removed all references to org.json package. Replaced its use in the workbench with equivalent Jackson functionality. 

I've not written unit tests because the servlet code is rather tangled, and writing tests for it is a chore I just can't face at the moment. However, I compiled and ran the modified workbench, and verified that executing queries, saving queries, and deleting data still all work as expected.

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

