### PR TITLE
Gh 2125 native store force sync benchmarks and transaction status improvements

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
@@ -17,8 +17,6 @@ import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.concurrent.locks.Lock;
 import org.eclipse.rdf4j.common.concurrent.locks.LockManager;
 import org.eclipse.rdf4j.common.io.MavenUtil;
-import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.model.ModelFactory;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
@@ -42,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * The NativeStore is designed for datasets between 100,000 and 100 million triples. On most operating systems, if there
  * is sufficient physical memory, the NativeStore will act like the MemoryStore, because the read/write commands will be
  * cached by the OS. This technique allows the NativeStore to operate quite well for millions of triples.
- * 
+ *
  * @author Arjohn Kampman
  * @author jeen
  */
@@ -76,6 +74,9 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 	private volatile int namespaceIDCacheSize = ValueStore.NAMESPACE_ID_CACHE_SIZE;
 
 	private SailStore store;
+
+	// used to decide if store is writable, is true if the store was writable during initialization
+	private boolean isWritable;
 
 	/**
 	 * Data directory lock.
@@ -135,7 +136,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 
 	/**
 	 * Sets the triple indexes for the native store, must be called before initialization.
-	 * 
+	 *
 	 * @param tripleIndexes An index strings, e.g. <tt>spoc,posc</tt>.
 	 */
 	public void setTripleIndexes(String tripleIndexes) {
@@ -213,7 +214,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 	/**
 	 * Overrides the {@link FederatedServiceResolver} used by this instance, but the given resolver is not shutDown when
 	 * this instance is.
-	 * 
+	 *
 	 * @param resolver The SERVICE resolver to set.
 	 */
 	@Override
@@ -226,7 +227,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 
 	/**
 	 * Initializes this NativeStore.
-	 * 
+	 *
 	 * @exception SailException If this NativeStore could not be initialized using the parameters that have been set.
 	 */
 	@Override
@@ -298,6 +299,8 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 			throw new SailException(e);
 		}
 
+		isWritable = getDataDir().canWrite();
+
 		logger.debug("NativeStore initialized");
 	}
 
@@ -320,7 +323,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 
 	@Override
 	public boolean isWritable() {
-		return getDataDir().canWrite();
+		return isWritable;
 	}
 
 	@Override
@@ -343,7 +346,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 	 * {@link IsolationLevels#NONE} isolation. Store is either exclusively in {@link IsolationLevels#NONE} isolation
 	 * with potentially zero or more transactions, or exclusively in higher isolation mode with potentially zero or more
 	 * transactions.
-	 * 
+	 *
 	 * @param level indicating desired mode {@link IsolationLevels#NONE} or higher
 	 * @return Lock used to prevent Store from switching isolation modes
 	 * @throws SailException
@@ -372,7 +375,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 
 	/**
 	 * Checks if any {@link IsolationLevels#NONE} isolation transactions are active.
-	 * 
+	 *
 	 * @return <code>true</code> if at least one transaction has direct access to the indexes
 	 */
 	boolean isIsolationDisabled() {

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TxnStatusFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TxnStatusFile.java
@@ -23,7 +23,7 @@ class TxnStatusFile {
 
 		/**
 		 * No active transaction. This occurs if no transaction has been started yet, or if all transactions have been
-		 * committed or rolled back.
+		 * committed or rolled back. An empty TxnStatus file also represents the NONE status.
 		 */
 		NONE(TxnStatus.NONE_BYTE),
 
@@ -58,7 +58,9 @@ class TxnStatusFile {
 			return onDisk;
 		}
 
-		private static final byte NONE_BYTE = (byte) 0b00000001;
+		private static final byte NONE_BYTE = (byte) 0b00000000;
+		private static final byte OLD_NONE_BYTE = (byte) 0b00000001;
+
 		private static final byte ACTIVE_BYTE = (byte) 0b00000010;
 		private static final byte COMMITTING_BYTE = (byte) 0b00000100;
 		private static final byte ROLLING_BACK_BYTE = (byte) 0b00001000;
@@ -82,10 +84,6 @@ class TxnStatusFile {
 	public TxnStatusFile(File dataDir) throws IOException {
 		File statusFile = new File(dataDir, FILE_NAME);
 		nioFile = new NioFile(statusFile, "rwd");
-
-		if (nioFile.size() == 0) {
-			setTxnStatus(TxnStatus.NONE);
-		}
 	}
 
 	public void close() throws IOException {
@@ -99,9 +97,11 @@ class TxnStatusFile {
 	 * @throws IOException If the transaction status could not be written to file.
 	 */
 	public void setTxnStatus(TxnStatus txnStatus) throws IOException {
-		byte[] bytes = txnStatus.onDisk;
-		nioFile.truncate(bytes.length);
-		nioFile.writeBytes(bytes, 0);
+		if (txnStatus == TxnStatus.NONE) {
+			nioFile.truncate(0);
+		} else {
+			nioFile.writeBytes(txnStatus.onDisk, 0);
+		}
 	}
 
 	/**
@@ -118,6 +118,9 @@ class TxnStatusFile {
 
 		switch (bytes[0]) {
 		case TxnStatus.NONE_BYTE:
+			status = TxnStatus.NONE;
+			break;
+		case TxnStatus.OLD_NONE_BYTE:
 			status = TxnStatus.NONE;
 			break;
 		case TxnStatus.ACTIVE_BYTE:

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFile.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.common.io.NioFile;
 
 /**
  * Class supplying access to a hash file.
- * 
+ *
  * @author Arjohn Kampman
  */
 public class HashFile implements Closeable {
@@ -71,7 +71,7 @@ public class HashFile implements Closeable {
 	private volatile int itemCount;
 
 	// Load factor (fixed, for now)
-	private final float loadFactor = 0.75f;
+	private final float loadFactor;
 
 	// recordSize = ITEM_SIZE * bucketSize + 4
 	private final int recordSize;
@@ -93,6 +93,7 @@ public class HashFile implements Closeable {
 	public HashFile(File file, boolean forceSync) throws IOException {
 		this.nioFile = new NioFile(file);
 		this.forceSync = forceSync;
+		loadFactor = 0.75f;
 
 		try {
 			if (nioFile.size() == 0L) {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
@@ -36,11 +36,11 @@ import org.openjdk.jmh.annotations.Warmup;
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 5)
+@Warmup(iterations = 20)
 @BenchmarkMode({ Mode.Throughput })
 @Fork(value = 1, jvmArgs = { "-Xms8G", "-Xmx8G", "-XX:+UseG1GC" })
 //@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G", "-XX:+UseG1GC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
-@Measurement(iterations = 5)
+@Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.SECONDS)
 public class TransactionsPerSecondBenchmark {
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
@@ -94,6 +94,15 @@ public class TransactionsPerSecondBenchmark {
 	}
 
 	@Benchmark
+	public void mediumTransactionsLevelNone() {
+		connection.begin(IsolationLevels.NONE);
+		for (int k = 0; k < 10; k++) {
+			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral(i++ + "_" + k));
+		}
+		connection.commit();
+	}
+
+	@Benchmark
 	public void largerTransaction() {
 		connection.begin();
 		for (int k = 0; k < 10000; k++) {
@@ -106,6 +115,15 @@ public class TransactionsPerSecondBenchmark {
 	public void largerTransactionLevelNone() {
 		connection.begin(IsolationLevels.NONE);
 		for (int k = 0; k < 10000; k++) {
+			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral(i++ + "_" + k));
+		}
+		connection.commit();
+	}
+
+	@Benchmark
+	public void veryLargerTransactionLevelNone() {
+		connection.begin(IsolationLevels.NONE);
+		for (int k = 0; k < 1000000; k++) {
 			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral(i++ + "_" + k));
 		}
 		connection.commit();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
@@ -42,7 +42,7 @@ import org.openjdk.jmh.annotations.Warmup;
 //@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G", "-XX:+UseG1GC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
 @Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.SECONDS)
-public class TransactionsPerSecondBenchmark {
+public class TransactionsPerSecondForceSyncBenchmark {
 
 	private SailRepository repository;
 	private File file;
@@ -60,7 +60,7 @@ public class TransactionsPerSecondBenchmark {
 		file = Files.newTemporaryFolder();
 
 		NativeStore sail = new NativeStore(file, "spoc,ospc,psoc");
-		sail.setForceSync(false);
+		sail.setForceSync(true);
 		repository = new SailRepository(sail);
 		connection = repository.getConnection();
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
@@ -36,11 +36,11 @@ import org.openjdk.jmh.annotations.Warmup;
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 5)
+@Warmup(iterations = 20)
 @BenchmarkMode({ Mode.Throughput })
 @Fork(value = 1, jvmArgs = { "-Xms8G", "-Xmx8G", "-XX:+UseG1GC" })
 //@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G", "-XX:+UseG1GC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
-@Measurement(iterations = 5)
+@Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.SECONDS)
 public class TransactionsPerSecondForceSyncBenchmark {
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
@@ -94,6 +94,15 @@ public class TransactionsPerSecondForceSyncBenchmark {
 	}
 
 	@Benchmark
+	public void mediumTransactionsLevelNone() {
+		connection.begin(IsolationLevels.NONE);
+		for (int k = 0; k < 10; k++) {
+			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral(i++ + "_" + k));
+		}
+		connection.commit();
+	}
+
+	@Benchmark
 	public void largerTransaction() {
 		connection.begin();
 		for (int k = 0; k < 10000; k++) {
@@ -106,6 +115,15 @@ public class TransactionsPerSecondForceSyncBenchmark {
 	public void largerTransactionLevelNone() {
 		connection.begin(IsolationLevels.NONE);
 		for (int k = 0; k < 10000; k++) {
+			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral(i++ + "_" + k));
+		}
+		connection.commit();
+	}
+
+	@Benchmark
+	public void veryLargerTransactionLevelNone() {
+		connection.begin(IsolationLevels.NONE);
+		for (int k = 0; k < 1000000; k++) {
 			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral(i++ + "_" + k));
 		}
 		connection.commit();


### PR DESCRIPTION
GitHub issue resolved: #2125 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - Benchmarks for NativeStore fsync feature.

- Small changes to improve transaction throughput for small transactions.
    - cache "isWritable()" in NativeStore
    - transaction status NONE is represented by the empty file (truncating is about as slow as overwriting, but truncating means that one txn status write can be done with append instead of overwrite making it faster)

<!-- short description of your change goes here -->

---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

