### PR TITLE
GH-2145: named graph support in federation engine

### DIFF
--- a/compliance/sparql/pom.xml
+++ b/compliance/sparql/pom.xml
@@ -120,6 +120,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-tools-federation</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/W3CApprovedSPARQL11QueryTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/W3CApprovedSPARQL11QueryTest.java
@@ -14,9 +14,11 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.dataset.DatasetRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Ignore;
 
 import junit.framework.Test;
 
+@Ignore("replaced by org.eclipse.rdf4j.sail.memory.MemorySPARQL11QueryComplianceTest")
 public class W3CApprovedSPARQL11QueryTest extends SPARQLQueryTest {
 
 	public static Test suite() throws Exception {

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FedXSPARQL11QueryComplianceTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FedXSPARQL11QueryComplianceTest.java
@@ -1,0 +1,81 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.federation;
+
+import java.io.IOException;
+
+import org.eclipse.rdf4j.federated.FedXFactory;
+import org.eclipse.rdf4j.federated.repository.FedXRepository;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQL11QueryComplianceTest;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
+import org.eclipse.rdf4j.repository.dataset.DatasetRepository;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
+import org.eclipse.rdf4j.repository.manager.RepositoryProvider;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
+import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author jeen
+ *
+ */
+public class FedXSPARQL11QueryComplianceTest extends SPARQL11QueryComplianceTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	private static final String dirName = "testmanager";
+
+	private RepositoryManager manager;
+
+	public FedXSPARQL11QueryComplianceTest(String displayName, String testURI, String name, String queryFileURL,
+			String resultFileURL, Dataset dataset, boolean ordered) {
+		super(displayName, testURI, name, queryFileURL, resultFileURL, dataset, ordered);
+
+		// FIXME see https://github.com/eclipse/rdf4j/issues/2173
+		addIgnoredTest("sq04 - Subquery within graph pattern, default graph does not apply");
+	}
+
+	private void initManager() {
+		if (manager == null) {
+			try {
+				manager = RepositoryProvider.getRepositoryManager(tempFolder.newFolder(dirName));
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	@Override
+	protected Repository newRepository() throws Exception {
+		initManager();
+
+		addMemoryStore("repo1");
+		addMemoryStore("repo2");
+		FedXRepository repo = FedXFactory.newFederation()
+				.withResolvableEndpoint("repo1", true)
+				.withResolvableEndpoint("repo2")
+				.withRepositoryResolver(manager)
+				.create();
+
+		// Use DatasetRepository to handle on-the-fly loading of local datasets, as specified in the test manifest
+		return new DatasetRepository(repo);
+	}
+
+	private void addMemoryStore(String repoId) throws RepositoryConfigException, RepositoryException, IOException {
+		RepositoryImplConfig implConfig = new SailRepositoryConfig(new MemoryStoreConfig());
+		RepositoryConfig config = new RepositoryConfig(repoId, implConfig);
+		manager.addRepositoryConfig(config);
+	}
+}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/memory/MemorySPARQL11QueryComplianceTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/memory/MemorySPARQL11QueryComplianceTest.java
@@ -1,0 +1,32 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQL11QueryComplianceTest;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.dataset.DatasetRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+
+/**
+ * Run {@link SPARQL11QueryComplianceTest} on an in-memory store
+ * 
+ * @author Jeen Broekstra
+ */
+public class MemorySPARQL11QueryComplianceTest extends SPARQL11QueryComplianceTest {
+
+	public MemorySPARQL11QueryComplianceTest(String displayName, String testURI, String name, String queryFileURL,
+			String resultFileURL, Dataset dataset, boolean ordered) {
+		super(displayName, testURI, name, queryFileURL, resultFileURL, dataset, ordered);
+	}
+
+	@Override
+	protected Repository newRepository() throws Exception {
+		return new DatasetRepository(new SailRepository(new MemoryStore()));
+	}
+}

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL11QueryComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL11QueryComplianceTest.java
@@ -1,0 +1,664 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.parser.sparql.manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.io.IOUtil;
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.common.text.StringUtil;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.Query;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.dawg.DAWGTestResultSetUtil;
+import org.eclipse.rdf4j.query.impl.MutableTupleQueryResult;
+import org.eclipse.rdf4j.query.impl.SimpleDataset;
+import org.eclipse.rdf4j.query.impl.TupleQueryResultBuilder;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultParserRegistry;
+import org.eclipse.rdf4j.query.resultio.QueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.repository.util.RDFInserter;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A test suite that runs the W3C Approved SPARQL 1.1 query tests.
+ * 
+ * @author Jeen Broekstra
+ * 
+ * @see https://www.w3.org/2009/sparql/docs/tests/
+ */
+@RunWith(Parameterized.class)
+public abstract class SPARQL11QueryComplianceTest {
+
+	private static final Logger logger = LoggerFactory.getLogger(SPARQL11QueryComplianceTest.class);
+
+	private static final String[] defaultIgnoredTests = {
+			// test case incompatible with RDF 1.1 - see
+			// http://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0006.html
+			"STRDT() TypeErrors",
+			// test case incompatible with RDF 1.1 - see
+			// http://lists.w3.org/Archives/Public/public-sparql-dev/2013AprJun/0006.html
+			"STRLANG() TypeErrors",
+			// known issue: SES-937
+			"sq03 - Subquery within graph pattern, graph variable is not bound"
+	};
+
+	private List<String> ignoredTests = new ArrayList<>(Arrays.asList(defaultIgnoredTests));
+
+	private static final String[] excludedSubdirs = { "service" };
+
+	private String testURI;
+	private String name;
+	private String queryFileURL;
+	private String resultFileURL;
+	private Dataset dataset;
+	private boolean ordered;
+	private Repository dataRep;
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(getTestData());
+	}
+
+	public SPARQL11QueryComplianceTest(String displayName, String testURI, String name, String queryFileURL,
+			String resultFileURL, Dataset dataset, boolean ordered) {
+		this.testURI = testURI;
+		this.name = name;
+		this.queryFileURL = queryFileURL;
+		this.resultFileURL = resultFileURL;
+		this.dataset = dataset;
+		this.ordered = ordered;
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		dataRep = createRepository();
+		if (dataset != null) {
+			try {
+				uploadDataset(dataset);
+			} catch (Exception exc) {
+				try {
+					dataRep.shutDown();
+					dataRep = null;
+				} catch (Exception e2) {
+					logger.error(e2.toString(), e2);
+				}
+				throw exc;
+			}
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (dataRep != null) {
+			dataRep.shutDown();
+			dataRep = null;
+		}
+	}
+
+	private final Repository createRepository() throws Exception {
+		Repository repo = newRepository();
+		try (RepositoryConnection con = repo.getConnection()) {
+			con.clear();
+			con.clearNamespaces();
+		}
+		return repo;
+	}
+
+	protected abstract Repository newRepository() throws Exception;
+
+	@Test
+	public void test() throws Exception {
+		runTest();
+	}
+
+	private static Object[][] getTestData() {
+
+		List<Object[]> tests = new ArrayList<>();
+
+		Deque<String> manifests = new ArrayDeque<>();
+		manifests.add(
+				SPARQL11QueryComplianceTest.class.getClassLoader()
+						.getResource("testcases-sparql-1.1-w3c/manifest-all.ttl")
+						.toExternalForm());
+		while (!manifests.isEmpty()) {
+			String pop = manifests.pop();
+			Manifest manifest = new Manifest(pop);
+			tests.addAll(manifest.tests);
+			manifests.addAll(manifest.subManifests);
+		}
+
+		Object[][] result = new Object[tests.size()][6];
+		tests.toArray(result);
+
+		return result;
+	}
+
+	static class Manifest {
+		List<Object[]> tests = new ArrayList<>();
+		List<String> subManifests = new ArrayList<>();
+
+		public Manifest(String filename) {
+			SailRepository sailRepository = new SailRepository(new MemoryStore());
+			try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+				connection.add(new URL(filename), filename, RDFFormat.TURTLE);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+
+			try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+				String manifestQuery = " PREFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> "
+						+ "PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> "
+						+ "SELECT DISTINCT ?manifestFile "
+						+ "WHERE { [] mf:include [ rdf:rest*/rdf:first ?manifestFile ] . }   ";
+
+				try (TupleQueryResult manifestResults = connection
+						.prepareTupleQuery(QueryLanguage.SPARQL, manifestQuery, filename)
+						.evaluate()) {
+					for (BindingSet bindingSet : manifestResults) {
+						String subManifestFile = bindingSet.getValue("manifestFile").stringValue();
+						if (includeSubManifest(subManifestFile, excludedSubdirs)) {
+							subManifests.add(subManifestFile);
+						}
+					}
+				}
+
+				StringBuilder query = new StringBuilder(512);
+				query.append(" PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> \n");
+				query.append(" PREFIX dawgt: <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> \n");
+				query.append(" PREFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> \n");
+				query.append(" PREFIX sd: <http://www.w3.org/ns/sparql-service-description#> \n");
+				query.append(" PREFIX ent: <http://www.w3.org/ns/entailment/> \n");
+				query.append(
+						" SELECT DISTINCT ?testURI ?testName ?resultFile ?action ?queryFile ?defaultGraph ?ordered \n");
+				query.append(" WHERE { [] rdf:first ?testURI . \n");
+//				if (approvedOnly) {
+				query.append(" ?testURI dawgt:approval dawgt:Approved . \n");
+//				}
+				query.append(" ?testURI mf:name ?testName; \n");
+				query.append("          mf:result ?resultFile . \n");
+				query.append(" OPTIONAL { ?testURI mf:checkOrder ?ordered } \n");
+				query.append(" OPTIONAL { ?testURI  mf:requires ?requirement } \n");
+				query.append(" ?testURI mf:action ?action. \n");
+				query.append(" ?action qt:query ?queryFile . \n");
+				query.append(" OPTIONAL { ?action qt:data ?defaultGraph } \n");
+				query.append(" OPTIONAL { ?action sd:entailmentRegime ?regime } \n");
+				// skip tests involving CSV result files, these are not query tests
+				query.append(" FILTER(!STRENDS(STR(?resultFile), \"csv\")) \n");
+				// skip tests involving entailment regimes
+				query.append(" FILTER(!BOUND(?regime)) \n");
+				// skip test involving basic federation, these are tested separately.
+				query.append(" FILTER (!BOUND(?requirement) || (?requirement != mf:BasicFederation)) \n");
+				query.append(" }\n");
+
+				try (TupleQueryResult result = connection.prepareTupleQuery(query.toString()).evaluate()) {
+
+					query.setLength(0);
+					query.append(" PREFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> \n");
+					query.append(" SELECT ?graph \n");
+					query.append(" WHERE { ?action qt:graphData ?graph } \n");
+					TupleQuery namedGraphsQuery = connection.prepareTupleQuery(query.toString());
+
+					for (BindingSet bs : result) {
+						// FIXME I'm sure there's a neater way to do this
+						String testName = bs.getValue("testName").stringValue();
+						String displayName = filename.substring(
+								filename.lastIndexOf("testcases-sparql-1.1-w3c/")
+										+ "testcases-sparql-1.1-w3c/".length(),
+								filename.lastIndexOf("/"))
+								+ ": " + testName;
+
+						IRI defaultGraphURI = (IRI) bs.getValue("defaultGraph");
+						Value action = bs.getValue("action");
+						Value ordered = bs.getValue("ordered");
+
+						SimpleDataset dataset = null;
+
+						// Query named graphs
+						namedGraphsQuery.setBinding("action", action);
+						try (TupleQueryResult namedGraphs = namedGraphsQuery.evaluate()) {
+							if (defaultGraphURI != null || namedGraphs.hasNext()) {
+								dataset = new SimpleDataset();
+								if (defaultGraphURI != null) {
+									dataset.addDefaultGraph(defaultGraphURI);
+								}
+								while (namedGraphs.hasNext()) {
+									BindingSet graphBindings = namedGraphs.next();
+									IRI namedGraphURI = (IRI) graphBindings.getValue("graph");
+									dataset.addNamedGraph(namedGraphURI);
+								}
+							}
+						}
+
+						tests.add(new Object[] {
+								displayName,
+								bs.getValue("testURI").stringValue(),
+								testName,
+								bs.getValue("queryFile").stringValue(),
+								bs.getValue("resultFile").stringValue(),
+								dataset,
+								Literals.getBooleanValue(ordered, false) });
+					}
+				}
+
+			}
+
+		}
+
+	}
+
+	private void runTest() throws Exception {
+		assumeThat(getIgnoredTests().contains(name)).withFailMessage("test case '%s' is ignored", name).isFalse();
+
+		logger.debug("running {}", name);
+
+		try (RepositoryConnection conn = dataRep.getConnection()) {
+			// Some SPARQL Tests have non-XSD datatypes that must pass for the test
+			// suite to complete successfully
+			conn.getParserConfig().set(BasicParserSettings.VERIFY_DATATYPE_VALUES, Boolean.FALSE);
+			conn.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, Boolean.FALSE);
+
+			String queryString = readQueryString();
+			Query query = conn.prepareQuery(QueryLanguage.SPARQL, queryString, queryFileURL);
+			if (dataset != null) {
+				query.setDataset(dataset);
+			}
+
+			if (query instanceof TupleQuery) {
+				TupleQueryResult actualResult = ((TupleQuery) query).evaluate();
+				TupleQueryResult expectedResult = readExpectedTupleQueryResult();
+				compareTupleQueryResults(actualResult, expectedResult);
+			} else if (query instanceof GraphQuery) {
+				GraphQueryResult gqr = ((GraphQuery) query).evaluate();
+				Set<Statement> actualResult = Iterations.asSet(gqr);
+				Set<Statement> expectedResult = readExpectedGraphQueryResult();
+
+				compareGraphs(actualResult, expectedResult);
+			} else if (query instanceof BooleanQuery) {
+				boolean actualResult = ((BooleanQuery) query).evaluate();
+				boolean expectedResult = readExpectedBooleanQueryResult();
+				assertThat(actualResult).isEqualTo(expectedResult);
+			} else {
+				throw new RuntimeException("Unexpected query type: " + query.getClass());
+			}
+		}
+	}
+
+	private final void uploadDataset(Dataset dataset) throws Exception {
+		try (RepositoryConnection con = dataRep.getConnection()) {
+			// Merge default and named graphs to filter duplicates
+			Set<IRI> graphURIs = new HashSet<>();
+			graphURIs.addAll(dataset.getDefaultGraphs());
+			graphURIs.addAll(dataset.getNamedGraphs());
+
+			for (Resource graphURI : graphURIs) {
+				upload(((IRI) graphURI), graphURI);
+			}
+		}
+	}
+
+	private void upload(IRI graphURI, Resource context) throws Exception {
+		RepositoryConnection con = dataRep.getConnection();
+
+		try {
+			con.begin();
+			RDFFormat rdfFormat = Rio.getParserFormatForFileName(graphURI.toString()).orElse(RDFFormat.TURTLE);
+			RDFParser rdfParser = Rio.createParser(rdfFormat, dataRep.getValueFactory());
+			rdfParser.setVerifyData(false);
+			rdfParser.setDatatypeHandling(DatatypeHandling.IGNORE);
+			// rdfParser.setPreserveBNodeIDs(true);
+
+			RDFInserter rdfInserter = new RDFInserter(con);
+			rdfInserter.enforceContext(context);
+			rdfParser.setRDFHandler(rdfInserter);
+
+			URL graphURL = new URL(graphURI.toString());
+			InputStream in = graphURL.openStream();
+			try {
+				rdfParser.parse(in, graphURI.toString());
+			} finally {
+				in.close();
+			}
+
+			con.commit();
+		} catch (Exception e) {
+			if (con.isActive()) {
+				con.rollback();
+			}
+			throw e;
+		} finally {
+			con.close();
+		}
+	}
+
+	private final String readQueryString() throws IOException {
+		try (InputStream stream = new URL(queryFileURL).openStream()) {
+			return IOUtil.readString(new InputStreamReader(stream, StandardCharsets.UTF_8));
+		}
+	}
+
+	private final TupleQueryResult readExpectedTupleQueryResult() throws Exception {
+		Optional<QueryResultFormat> tqrFormat = QueryResultIO.getParserFormatForFileName(resultFileURL);
+
+		if (tqrFormat.isPresent()) {
+			InputStream in = new URL(resultFileURL).openStream();
+			try {
+				TupleQueryResultParser parser = QueryResultIO.createTupleParser(tqrFormat.get());
+				parser.setValueFactory(dataRep.getValueFactory());
+
+				TupleQueryResultBuilder qrBuilder = new TupleQueryResultBuilder();
+				parser.setQueryResultHandler(qrBuilder);
+
+				parser.parseQueryResult(in);
+				return qrBuilder.getQueryResult();
+			} finally {
+				in.close();
+			}
+		} else {
+			Set<Statement> resultGraph = readExpectedGraphQueryResult();
+			return DAWGTestResultSetUtil.toTupleQueryResult(resultGraph);
+		}
+	}
+
+	private final boolean readExpectedBooleanQueryResult() throws Exception {
+		Optional<QueryResultFormat> bqrFormat = BooleanQueryResultParserRegistry.getInstance()
+				.getFileFormatForFileName(resultFileURL);
+
+		if (bqrFormat.isPresent()) {
+			InputStream in = new URL(resultFileURL).openStream();
+			try {
+				return QueryResultIO.parseBoolean(in, bqrFormat.get());
+			} finally {
+				in.close();
+			}
+		} else {
+			Set<Statement> resultGraph = readExpectedGraphQueryResult();
+			return DAWGTestResultSetUtil.toBooleanQueryResult(resultGraph);
+		}
+	}
+
+	private final Set<Statement> readExpectedGraphQueryResult() throws Exception {
+		RDFFormat rdfFormat = Rio.getParserFormatForFileName(resultFileURL)
+				.orElseThrow(Rio.unsupportedFormat(resultFileURL));
+
+		RDFParser parser = Rio.createParser(rdfFormat);
+		parser.setDatatypeHandling(DatatypeHandling.IGNORE);
+		parser.setPreserveBNodeIDs(true);
+		parser.setValueFactory(dataRep.getValueFactory());
+
+		Set<Statement> result = new LinkedHashSet<>();
+		parser.setRDFHandler(new StatementCollector(result));
+
+		InputStream in = new URL(resultFileURL).openStream();
+		try {
+			parser.parse(in, resultFileURL);
+		} finally {
+			in.close();
+		}
+
+		return result;
+	}
+
+	private final void compareGraphs(Set<Statement> queryResult, Set<Statement> expectedResult) throws Exception {
+		if (!Models.isomorphic(expectedResult, queryResult)) {
+			StringBuilder message = new StringBuilder(128);
+			message.append("\n============ ");
+			message.append(name);
+			message.append(" =======================\n");
+			message.append("Expected result: \n");
+			for (Statement st : expectedResult) {
+				message.append(st.toString());
+				message.append("\n");
+			}
+			message.append("=============");
+			StringUtil.appendN('=', name.length(), message);
+			message.append("========================\n");
+
+			message.append("Query result: \n");
+			for (Statement st : queryResult) {
+				message.append(st.toString());
+				message.append("\n");
+			}
+			message.append("=============");
+			StringUtil.appendN('=', name.length(), message);
+			message.append("========================\n");
+
+			logger.error(message.toString());
+			fail(message.toString());
+		}
+	}
+
+	private final void compareTupleQueryResults(TupleQueryResult queryResult, TupleQueryResult expectedResult)
+			throws Exception {
+		// Create MutableTupleQueryResult to be able to re-iterate over the
+		// results
+		MutableTupleQueryResult queryResultTable = new MutableTupleQueryResult(queryResult);
+		MutableTupleQueryResult expectedResultTable = new MutableTupleQueryResult(expectedResult);
+
+		boolean resultsEqual;
+		boolean laxCardinality = false; // TODO determine if we still need this
+		if (laxCardinality) {
+			resultsEqual = QueryResults.isSubset(queryResultTable, expectedResultTable);
+		} else {
+			resultsEqual = QueryResults.equals(queryResultTable, expectedResultTable);
+
+			if (ordered) {
+				// also check the order in which solutions occur.
+				queryResultTable.beforeFirst();
+				expectedResultTable.beforeFirst();
+
+				while (queryResultTable.hasNext()) {
+					BindingSet bs = queryResultTable.next();
+					BindingSet expectedBs = expectedResultTable.next();
+
+					if (!bs.equals(expectedBs)) {
+						resultsEqual = false;
+						break;
+					}
+				}
+			}
+		}
+
+		if (!resultsEqual) {
+			queryResultTable.beforeFirst();
+			expectedResultTable.beforeFirst();
+
+			/*
+			 * StringBuilder message = new StringBuilder(128); message.append("\n============ ");
+			 * message.append(getName()); message.append(" =======================\n"); message.append(
+			 * "Expected result: \n"); while (expectedResultTable.hasNext()) {
+			 * message.append(expectedResultTable.next()); message.append("\n"); } message.append("=============");
+			 * StringUtil.appendN('=', getName().length(), message); message.append("========================\n");
+			 * message.append("Query result: \n"); while (queryResultTable.hasNext()) {
+			 * message.append(queryResultTable.next()); message.append("\n"); } message.append("=============");
+			 * StringUtil.appendN('=', getName().length(), message); message.append("========================\n");
+			 */
+
+			List<BindingSet> queryBindings = Iterations.asList(queryResultTable);
+
+			List<BindingSet> expectedBindings = Iterations.asList(expectedResultTable);
+
+			List<BindingSet> missingBindings = new ArrayList<>(expectedBindings);
+			missingBindings.removeAll(queryBindings);
+
+			List<BindingSet> unexpectedBindings = new ArrayList<>(queryBindings);
+			unexpectedBindings.removeAll(expectedBindings);
+
+			StringBuilder message = new StringBuilder(128);
+			message.append("\n============ ");
+			message.append(name);
+			message.append(" =======================\n");
+
+			if (!missingBindings.isEmpty()) {
+
+				message.append("Missing bindings: \n");
+				for (BindingSet bs : missingBindings) {
+					printBindingSet(bs, message);
+				}
+
+				message.append("=============");
+				StringUtil.appendN('=', name.length(), message);
+				message.append("========================\n");
+			}
+
+			if (!unexpectedBindings.isEmpty()) {
+				message.append("Unexpected bindings: \n");
+				for (BindingSet bs : unexpectedBindings) {
+					printBindingSet(bs, message);
+				}
+
+				message.append("=============");
+				StringUtil.appendN('=', name.length(), message);
+				message.append("========================\n");
+			}
+
+			if (ordered && missingBindings.isEmpty() && unexpectedBindings.isEmpty()) {
+				message.append("Results are not in expected order.\n");
+				message.append(" =======================\n");
+				message.append("query result: \n");
+				for (BindingSet bs : queryBindings) {
+					printBindingSet(bs, message);
+				}
+				message.append(" =======================\n");
+				message.append("expected result: \n");
+				for (BindingSet bs : expectedBindings) {
+					printBindingSet(bs, message);
+				}
+				message.append(" =======================\n");
+
+				System.out.print(message.toString());
+			} else if (missingBindings.isEmpty() && unexpectedBindings.isEmpty()) {
+				message.append("unexpected duplicate in result.\n");
+				message.append(" =======================\n");
+				message.append("query result: \n");
+				for (BindingSet bs : queryBindings) {
+					printBindingSet(bs, message);
+				}
+				message.append(" =======================\n");
+				message.append("expected result: \n");
+				for (BindingSet bs : expectedBindings) {
+					printBindingSet(bs, message);
+				}
+				message.append(" =======================\n");
+
+				System.out.print(message.toString());
+			}
+
+			logger.error(message.toString());
+			fail(message.toString());
+		}
+	}
+
+	private final void printBindingSet(BindingSet bs, StringBuilder appendable) {
+		List<String> names = new ArrayList<>(bs.getBindingNames());
+		Collections.sort(names);
+
+		for (String name : names) {
+			if (bs.hasBinding(name)) {
+				appendable.append(bs.getBinding(name));
+				appendable.append(' ');
+			}
+		}
+		appendable.append("\n");
+	}
+
+	/**
+	 * Verifies if the selected subManifest occurs in the supplied list of excluded subdirs.
+	 * 
+	 * @param subManifestFile the url of a sub-manifest
+	 * @param excludedSubdirs an array of directory names. May be null.
+	 * @return <code>false</code> if the supplied list of excluded subdirs is not empty and contains a match for the
+	 *         supplied sub-manifest, <code>true</code> otherwise.
+	 */
+	private static boolean includeSubManifest(String subManifestFile, String[] excludedSubdirs) {
+		boolean result = true;
+
+		if (excludedSubdirs != null && excludedSubdirs.length > 0) {
+			int index = subManifestFile.lastIndexOf('/');
+			String path = subManifestFile.substring(0, index);
+			String sd = path.substring(path.lastIndexOf('/') + 1);
+
+			for (String subdir : excludedSubdirs) {
+				if (sd.equals(subdir)) {
+					result = false;
+					break;
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * @return the ignoredTests
+	 */
+	protected List<String> getIgnoredTests() {
+		return ignoredTests;
+	}
+
+	protected void addIgnoredTest(String ignoredTest) {
+		this.ignoredTests.add(ignoredTest);
+	}
+
+	/**
+	 * @param ignoredTests the ignoredTests to set
+	 */
+	protected void setIgnoredTests(List<String> ignoredTests) {
+		this.ignoredTests = ignoredTests;
+	}
+}

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -148,5 +148,10 @@
 			<version>1.4.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -125,6 +125,12 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sparql-testsuite</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<version>5.4.2</version>

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/QueryManager.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/QueryManager.java
@@ -296,7 +296,8 @@ public class QueryManager {
 			throw new MalformedQueryException("Not a ParsedQuery: " + query.getClass());
 		// we use a dummy query info object here
 		QueryInfo qInfo = new QueryInfo(queryString, QueryType.SELECT,
-				federationContext.getConfig().getIncludeInferredDefault(), federationContext);
+				federationContext.getConfig().getIncludeInferredDefault(), federationContext,
+				((ParsedQuery) query).getDataset());
 		TupleExpr tupleExpr = ((ParsedQuery) query).getTupleExpr();
 		try {
 			FederationEvaluationStatistics evaluationStatistics = new FederationEvaluationStatistics(qInfo,

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/CheckStatementPattern.java
@@ -188,7 +188,7 @@ public class CheckStatementPattern implements StatementTupleExpr, BoundJoinTuple
 						.getEndpointManager()
 						.getEndpoint(source.getEndpointID());
 				TripleSource t = ownedEndpoint.getTripleSource();
-				if (t.hasStatements(st, bindings, queryInfo)) {
+				if (t.hasStatements(st, bindings, queryInfo, queryInfo.getDataset())) {
 					return new SingleBindingSetIteration(bindings);
 				}
 			}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveStatement.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveStatement.java
@@ -67,11 +67,12 @@ public class ExclusiveStatement extends FedXStatementPattern implements Exclusiv
 				AtomicBoolean isEvaluated = new AtomicBoolean(false); // is filter evaluated
 				String preparedQuery;
 				try {
-					preparedQuery = QueryStringUtil.selectQueryString(this, bindings, filterExpr, isEvaluated);
+					preparedQuery = QueryStringUtil.selectQueryString(this, bindings, filterExpr, isEvaluated,
+							queryInfo.getDataset());
 				} catch (IllegalQueryException e1) {
 					// TODO there might be an issue with filters being evaluated => investigate
 					/* all vars are bound, this must be handled as a check query, can occur in joins */
-					if (t.hasStatements(this, bindings, queryInfo)) {
+					if (t.hasStatements(this, bindings, queryInfo, queryInfo.getDataset())) {
 						res = new SingleBindingSetIteration(bindings);
 						if (boundFilters != null) {
 							// make sure to insert any values from FILTER expressions that are directly

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXStatementPattern.java
@@ -46,6 +46,7 @@ public abstract class FedXStatementPattern extends StatementPattern
 
 	public FedXStatementPattern(StatementPattern node, QueryInfo queryInfo) {
 		super(node.getSubjectVar(), node.getPredicateVar(), node.getObjectVar(), node.getContextVar());
+		setScope(node.getScope());
 		this.id = NodeFactory.getNextId();
 		this.queryInfo = queryInfo;
 		initFreeVars();

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
@@ -80,7 +80,8 @@ public class StatementSourcePattern extends FedXStatementPattern {
 					// queryString needs to be constructed only once for a given bindingset
 					if (preparedQuery == null) {
 						try {
-							preparedQuery = QueryStringUtil.selectQueryString(this, bindings, filterExpr, isEvaluated);
+							preparedQuery = QueryStringUtil.selectQueryString(this, bindings, filterExpr, isEvaluated,
+									queryInfo.getDataset());
 						} catch (IllegalQueryException e1) {
 							/* all vars are bound, this must be handled as a check query, can occur in joins */
 							CloseableIteration<BindingSet, QueryEvaluationException> res = handleStatementSourcePatternCheck(
@@ -127,7 +128,7 @@ public class StatementSourcePattern extends FedXStatementPattern {
 					.getEndpointManager()
 					.getEndpoint(source.getEndpointID());
 			TripleSource t = ownedEndpoint.getTripleSource();
-			if (t.hasStatements(this, bindings, queryInfo))
+			if (t.hasStatements(this, bindings, queryInfo, queryInfo.getDataset()))
 				return new SingleBindingSetIteration(bindings);
 		}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/CacheUtils.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/CacheUtils.java
@@ -30,18 +30,22 @@ public class CacheUtils {
 	 * 
 	 * @param cache
 	 * @param endpoint
-	 * @param stmt
+	 * @param subj
+	 * @param pred
+	 * @param obj
+	 * @param queryInfo
+	 * @param contexts
 	 * @return
 	 * @throws OptimizationException
 	 */
 	private static boolean checkEndpointForResults(SourceSelectionCache cache, Endpoint endpoint, Resource subj,
-			IRI pred, Value obj, QueryInfo queryInfo)
+			IRI pred, Value obj, QueryInfo queryInfo, Resource... contexts)
 			throws OptimizationException {
 		try {
 			TripleSource t = endpoint.getTripleSource();
-			boolean hasResults = t.hasStatements(subj, pred, obj, queryInfo);
+			boolean hasResults = t.hasStatements(subj, pred, obj, queryInfo, contexts);
 
-			cache.updateInformation(new SubQuery(subj, pred, obj), endpoint, hasResults);
+			cache.updateInformation(new SubQuery(subj, pred, obj, contexts), endpoint, hasResults);
 
 			return hasResults;
 		} catch (Exception e) {
@@ -59,20 +63,22 @@ public class CacheUtils {
 	 * @param subj
 	 * @param pred
 	 * @param obj
+	 * @param queryInfo
+	 * @param contexts
 	 * @return whether some endpoint can provide results
 	 */
 	public static boolean checkCacheUpdateCache(SourceSelectionCache cache, List<Endpoint> endpoints, Resource subj,
 			IRI pred,
-			Value obj, QueryInfo queryInfo) {
+			Value obj, QueryInfo queryInfo, Resource... contexts) {
 
-		SubQuery q = new SubQuery(subj, pred, obj);
+		SubQuery q = new SubQuery(subj, pred, obj, contexts);
 
 		for (Endpoint e : endpoints) {
 			StatementSourceAssurance a = cache.getAssurance(q, e);
 			if (a == StatementSourceAssurance.HAS_REMOTE_STATEMENTS)
 				return true;
 			if (a == StatementSourceAssurance.POSSIBLY_HAS_STATEMENTS
-					&& checkEndpointForResults(cache, e, subj, pred, obj, queryInfo))
+					&& checkEndpointForResults(cache, e, subj, pred, obj, queryInfo, contexts))
 				return true;
 		}
 		return false;
@@ -87,14 +93,16 @@ public class CacheUtils {
 	 * @param subj
 	 * @param pred
 	 * @param obj
+	 * @param queryInfo
+	 * @param contexts
 	 * 
 	 * @return the list of relevant statement sources
 	 */
 	public static List<StatementSource> checkCacheForStatementSourcesUpdateCache(SourceSelectionCache cache,
 			List<Endpoint> endpoints,
-			Resource subj, IRI pred, Value obj, QueryInfo queryInfo) {
+			Resource subj, IRI pred, Value obj, QueryInfo queryInfo, Resource... contexts) {
 
-		SubQuery q = new SubQuery(subj, pred, obj);
+		SubQuery q = new SubQuery(subj, pred, obj, contexts);
 		List<StatementSource> sources = new ArrayList<>(endpoints.size());
 
 		for (Endpoint e : endpoints) {
@@ -105,7 +113,7 @@ public class CacheUtils {
 			} else if (a == StatementSourceAssurance.POSSIBLY_HAS_STATEMENTS) {
 
 				// check if the endpoint has results (statistics + ask request)
-				if (CacheUtils.checkEndpointForResults(cache, e, subj, pred, obj, queryInfo))
+				if (CacheUtils.checkEndpointForResults(cache, e, subj, pred, obj, queryInfo, contexts))
 					sources.add(new StatementSource(e.getId(), StatementSourceType.REMOTE));
 			}
 		}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionMemoryCache.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/cache/SourceSelectionMemoryCache.java
@@ -62,8 +62,9 @@ public class SourceSelectionMemoryCache implements SourceSelectionCache {
 		// check if we can infer something from other cached entries
 		// if endpoint does not have data for {?s foaf:name ?o}, it does also not have data for {?s foaf:name "Alan" }
 		if (subQuery.object() != null) {
-			if (getAssurance(new SubQuery(subQuery.subject(), subQuery.predicate(), null), endpoint)
-					.equals(StatementSourceAssurance.NONE)) {
+			if (getAssurance(new SubQuery(subQuery.subject(), subQuery.predicate(), null, subQuery.contexts()),
+					endpoint)
+							.equals(StatementSourceAssurance.NONE)) {
 				return StatementSourceAssurance.NONE;
 			}
 		}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -371,15 +371,12 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 			IRI pred, Value obj, Resource... contexts)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 
-		if (contexts.length != 0)
-			log.warn("Context queries are not yet supported by FedX.");
-
 		List<Endpoint> members = federationContext.getFederation().getMembers();
 
 		// a bound query: if at least one fed member provides results
 		// return the statement, otherwise empty result
 		if (subj != null && pred != null && obj != null) {
-			if (CacheUtils.checkCacheUpdateCache(cache, members, subj, pred, obj, queryInfo)) {
+			if (CacheUtils.checkCacheUpdateCache(cache, members, subj, pred, obj, queryInfo, contexts)) {
 				return new SingletonIteration<>(
 						FedXUtil.valueFactory().createStatement(subj, pred, obj));
 			}
@@ -388,7 +385,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 
 		// form the union of results from relevant endpoints
 		List<StatementSource> sources = CacheUtils.checkCacheForStatementSourcesUpdateCache(cache, members, subj, pred,
-				obj, queryInfo);
+				obj, queryInfo, contexts);
 
 		if (sources.isEmpty())
 			return new EmptyIteration<>();
@@ -582,7 +579,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 			FilterValueExpr filterValueExpr = null; // TODO consider optimization using FilterTuple
 			String preparedQuery = QueryStringUtil.selectQueryString((ExclusiveTupleExprRenderer) expr, bindings,
 					filterValueExpr,
-					isEvaluated);
+					isEvaluated, expr.getQueryInfo().getDataset());
 			return t.getStatements(preparedQuery, bindings,
 					(isEvaluated.get() ? null : filterValueExpr), expr.getQueryInfo());
 		} catch (IllegalQueryException e) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
@@ -20,12 +20,14 @@ import org.eclipse.rdf4j.federated.evaluation.iterator.FilteringIteration;
 import org.eclipse.rdf4j.federated.evaluation.iterator.InsertBindingsIteration;
 import org.eclipse.rdf4j.federated.evaluation.iterator.StatementConversionIteration;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.util.FedXUtil;
 import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
@@ -104,8 +106,11 @@ public class SailTripleSource extends TripleSourceBase implements TripleSource {
 
 		return withConnection((conn, resultHolder) -> {
 
+			// TODO we need to fix this here: if the dataset contains FROM NAMED, we cannot use
+			// the API and require to write as query
+
 			RepositoryResult<Statement> repoResult = conn.getStatements((Resource) subjValue, (IRI) predValue, objValue,
-					queryInfo.getIncludeInferred(), new Resource[0]);
+					queryInfo.getIncludeInferred(), FedXUtil.toContexts(stmt, queryInfo.getDataset()));
 
 			// XXX implementation remark and TODO taken from Sesame
 			// The same variable might have been used multiple times in this
@@ -134,11 +139,10 @@ public class SailTripleSource extends TripleSourceBase implements TripleSource {
 			throws RepositoryException,
 			MalformedQueryException, QueryEvaluationException {
 
-		// TODO add handling for contexts
 		return withConnection((conn, resultHolder) -> {
 
 			RepositoryResult<Statement> repoResult = conn.getStatements(subj, pred, obj,
-					queryInfo.getIncludeInferred());
+					queryInfo.getIncludeInferred(), contexts);
 
 			// XXX implementation remark and TODO taken from Sesame
 			// The same variable might have been used multiple times in this
@@ -155,7 +159,7 @@ public class SailTripleSource extends TripleSourceBase implements TripleSource {
 
 	@Override
 	public boolean hasStatements(StatementPattern stmt,
-			BindingSet bindings, QueryInfo queryInfo)
+			BindingSet bindings, QueryInfo queryInfo, Dataset dataset)
 			throws RepositoryException, MalformedQueryException,
 			QueryEvaluationException {
 
@@ -163,9 +167,11 @@ public class SailTripleSource extends TripleSourceBase implements TripleSource {
 		Value predValue = QueryAlgebraUtil.getVarValue(stmt.getPredicateVar(), bindings);
 		Value objValue = QueryAlgebraUtil.getVarValue(stmt.getObjectVar(), bindings);
 
+		Resource[] contexts = FedXUtil.toContexts(dataset);
+
 		try (RepositoryConnection conn = endpoint.getConnection()) {
 			return conn.hasStatement((Resource) subjValue, (IRI) predValue, objValue, queryInfo.getIncludeInferred(),
-					new Resource[0]);
+					contexts);
 		}
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
@@ -74,7 +74,7 @@ public class SparqlFederationEvalStrategy extends FederationEvalStrategy {
 
 		AtomicBoolean isEvaluated = new AtomicBoolean(false);
 		String preparedQuery = QueryStringUtil.selectQueryStringBoundJoinVALUES((StatementPattern) stmt, bindings,
-				filterExpr, isEvaluated);
+				filterExpr, isEvaluated, stmt.getQueryInfo().getDataset());
 
 		CloseableIteration<BindingSet, QueryEvaluationException> result = null;
 		try {
@@ -116,7 +116,7 @@ public class SparqlFederationEvalStrategy extends FederationEvalStrategy {
 
 		Boolean isEvaluated = false;
 		String preparedQuery = QueryStringUtil.selectQueryStringBoundUnion((StatementPattern) stmt, bindings,
-				filterExpr, isEvaluated);
+				filterExpr, isEvaluated, stmt.getQueryInfo().getDataset());
 
 		CloseableIteration<BindingSet, QueryEvaluationException> result = evaluateAtStatementSources(preparedQuery,
 				stmt.getStatementSources(), stmt.getQueryInfo());
@@ -142,7 +142,8 @@ public class SparqlFederationEvalStrategy extends FederationEvalStrategy {
 		if (bindings.size() == 1)
 			return stmt.evaluate(bindings.get(0));
 
-		String preparedQuery = QueryStringUtil.selectQueryStringBoundCheck(stmt.getStatementPattern(), bindings);
+		String preparedQuery = QueryStringUtil.selectQueryStringBoundCheck(stmt.getStatementPattern(), bindings,
+				stmt.getQueryInfo().getDataset());
 
 		CloseableIteration<BindingSet, QueryEvaluationException> result = evaluateAtStatementSources(preparedQuery,
 				stmt.getStatementSources(), stmt.getQueryInfo());
@@ -174,7 +175,7 @@ public class SparqlFederationEvalStrategy extends FederationEvalStrategy {
 
 		try {
 			String preparedQuery = QueryStringUtil.selectQueryString(group, bindings, group.getFilterExpr(),
-					isEvaluated);
+					isEvaluated, group.getQueryInfo().getDataset());
 			return tripleSource.getStatements(preparedQuery, bindings,
 					(isEvaluated.get() ? null : group.getFilterExpr()), group.getQueryInfo());
 		} catch (IllegalQueryException e) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
@@ -146,15 +147,17 @@ public interface TripleSource {
 	 * Check if the provided statement can return results.
 	 * 
 	 * @param stmt
-	 * @param bindings a binding set. in case no bindings are present, an {@link EmptyBindingSet} can be used (i.e.
-	 *                 never null)
+	 * @param bindings  a binding set. in case no bindings are present, an {@link EmptyBindingSet} can be used (i.e.
+	 *                  never null)
+	 * @param queryInfo
+	 * @param dataset
 	 * 
 	 * @return whether the source can return results
 	 * @throws RepositoryException
 	 * @throws MalformedQueryException
 	 * @throws QueryEvaluationException
 	 */
-	public boolean hasStatements(StatementPattern stmt, BindingSet bindings, QueryInfo queryInfo)
+	public boolean hasStatements(StatementPattern stmt, BindingSet bindings, QueryInfo queryInfo, Dataset dataset)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException;
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
@@ -91,7 +91,7 @@ public class SourceSelection {
 
 			stmtToSources.put(stmt, new ArrayList<>());
 
-			SubQuery q = new SubQuery(stmt);
+			SubQuery q = new SubQuery(stmt, queryInfo.getDataset());
 
 			// check for each current federation member (cache or remote ASK)
 			for (Endpoint e : endpoints) {
@@ -312,10 +312,11 @@ public class SourceSelection {
 			try {
 				TripleSource t = endpoint.getTripleSource();
 				boolean hasResults = false;
-				hasResults = t.hasStatements(stmt, EmptyBindingSet.getInstance(), queryInfo);
+				hasResults = t.hasStatements(stmt, EmptyBindingSet.getInstance(), queryInfo, queryInfo.getDataset());
 
 				SourceSelection sourceSelection = control.sourceSelection;
-				sourceSelection.cache.updateInformation(new SubQuery(stmt), endpoint, hasResults);
+				sourceSelection.cache.updateInformation(new SubQuery(stmt, queryInfo.getDataset()), endpoint,
+						hasResults);
 
 				if (hasResults)
 					sourceSelection.addSource(stmt, new StatementSource(endpoint.getId(), StatementSourceType.REMOTE));

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/FedXDataset.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/FedXDataset.java
@@ -61,21 +61,33 @@ public class FedXDataset implements Dataset {
 
 	@Override
 	public Set<IRI> getDefaultGraphs() {
+		if (delegate == null) {
+			return Collections.emptySet();
+		}
 		return delegate.getDefaultGraphs();
 	}
 
 	@Override
 	public IRI getDefaultInsertGraph() {
+		if (delegate == null) {
+			return null;
+		}
 		return delegate.getDefaultInsertGraph();
 	}
 
 	@Override
 	public Set<IRI> getDefaultRemoveGraphs() {
+		if (delegate == null) {
+			return Collections.emptySet();
+		}
 		return delegate.getDefaultRemoveGraphs();
 	}
 
 	@Override
 	public Set<IRI> getNamedGraphs() {
+		if (delegate == null) {
+			return Collections.emptySet();
+		}
 		return delegate.getNamedGraphs();
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +40,13 @@ public class QueryInfo {
 
 	private final BigInteger queryID;
 	private final String query;
+	private final String baseURI;
+
 	private final QueryType queryType;
 	private final long maxExecutionTimeMs;
 	private final long start;
 	private final boolean includeInferred;
+	private final Dataset dataset;
 
 	private final FederationContext federationContext;
 
@@ -51,8 +55,8 @@ public class QueryInfo {
 	protected Set<ParallelTask<?>> scheduledSubtasks = ConcurrentHashMap.newKeySet();
 
 	public QueryInfo(String query, QueryType queryType, boolean incluedInferred,
-			FederationContext federationContext) {
-		this(query, queryType, 0, incluedInferred, federationContext);
+			FederationContext federationContext, Dataset dataset) {
+		this(query, null, queryType, 0, incluedInferred, federationContext, dataset);
 	}
 
 	/**
@@ -63,16 +67,19 @@ public class QueryInfo {
 	 *                          {@link org.eclipse.rdf4j.federated.FedXConfig#getEnforceMaxQueryTime()}
 	 * @param includeInferred   whether to include inferred statements
 	 * @param federationContext the {@link FederationContext}
+	 * @param dataset           the {@link Dataset}
 	 */
-	public QueryInfo(String query, QueryType queryType, int maxExecutionTime, boolean includeInferred,
-			FederationContext federationContext) {
+	public QueryInfo(String query, String baseURI, QueryType queryType, int maxExecutionTime, boolean includeInferred,
+			FederationContext federationContext, Dataset dataset) {
 		super();
 		this.queryID = federationContext.getQueryManager().getNextQueryId();
 
 		this.federationContext = federationContext;
 
 		this.query = query;
+		this.baseURI = baseURI;
 		this.queryType = queryType;
+		this.dataset = dataset;
 
 		int _maxExecutionTime = maxExecutionTime <= 0 ? federationContext.getConfig().getEnforceMaxQueryTime()
 				: maxExecutionTime;
@@ -82,9 +89,9 @@ public class QueryInfo {
 	}
 
 	public QueryInfo(Resource subj, IRI pred, Value obj, boolean includeInferred,
-			FederationContext federationContext) {
-		this(QueryStringUtil.toString(subj, (IRI) pred, obj), QueryType.GET_STATEMENTS, includeInferred,
-				federationContext);
+			FederationContext federationContext, Dataset dataset) {
+		this(QueryStringUtil.toString(subj, pred, obj), QueryType.GET_STATEMENTS, includeInferred,
+				federationContext, dataset);
 	}
 
 	public BigInteger getQueryID() {
@@ -101,6 +108,17 @@ public class QueryInfo {
 
 	public boolean getIncludeInferred() {
 		return includeInferred;
+	}
+
+	public Dataset getDataset() {
+		return dataset;
+	}
+
+	/**
+	 * @return the baseURI
+	 */
+	public String getBaseURI() {
+		return baseURI;
 	}
 
 	/**
@@ -194,18 +212,23 @@ public class QueryInfo {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (obj == null) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
+		}
 		QueryInfo other = (QueryInfo) obj;
 		if (queryID == null) {
-			if (other.queryID != null)
+			if (other.queryID != null) {
 				return false;
-		} else if (!queryID.equals(other.queryID))
+			}
+		} else if (!queryID.equals(other.queryID)) {
 			return false;
+		}
 		return true;
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/SubQuery.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/SubQuery.java
@@ -8,10 +8,13 @@
 package org.eclipse.rdf4j.federated.structures;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
+import org.eclipse.rdf4j.federated.util.FedXUtil;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 
 public class SubQuery implements Serializable {
@@ -21,17 +24,22 @@ public class SubQuery implements Serializable {
 	protected final Resource subj;
 	protected final IRI pred;
 	protected final Value obj;
+	/**
+	 * the contexts, length zero array for triple mode query
+	 */
+	protected final Resource[] contexts;
 
-	public SubQuery(Resource subj, IRI pred, Value obj) {
+	public SubQuery(Resource subj, IRI pred, Value obj, Resource... contexts) {
 		super();
 		this.subj = subj;
 		this.pred = pred;
 		this.obj = obj;
+		this.contexts = contexts;
 	}
 
-	public SubQuery(StatementPattern stmt) {
+	public SubQuery(StatementPattern stmt, Dataset dataset) {
 		this((Resource) stmt.getSubjectVar().getValue(), (IRI) stmt.getPredicateVar().getValue(),
-				stmt.getObjectVar().getValue());
+				stmt.getObjectVar().getValue(), FedXUtil.toContexts(stmt, dataset));
 	}
 
 	/**
@@ -54,10 +62,15 @@ public class SubQuery implements Serializable {
 		return this.obj;
 	}
 
+	public Resource[] contexts() {
+		return this.contexts;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + Arrays.hashCode(contexts);
 		result = prime * result + ((obj == null) ? 0 : obj.hashCode());
 		result = prime * result + ((pred == null) ? 0 : pred.hashCode());
 		result = prime * result + ((subj == null) ? 0 : subj.hashCode());
@@ -73,6 +86,8 @@ public class SubQuery implements Serializable {
 		if (getClass() != obj.getClass())
 			return false;
 		SubQuery other = (SubQuery) obj;
+		if (!Arrays.equals(contexts, other.contexts))
+			return false;
 		if (this.obj == null) {
 			if (other.obj != null)
 				return false;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/FedXUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/FedXUtil.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.util;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.rdf4j.federated.FedXConfig;
@@ -14,10 +15,20 @@ import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.repository.FedXRepositoryConnection;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.Operation;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.StatementPattern.Scope;
+import org.eclipse.rdf4j.query.impl.SimpleDataset;
 import org.eclipse.rdf4j.repository.sail.SailQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
 
 /**
  * General utility functions
@@ -26,6 +37,8 @@ import org.eclipse.rdf4j.repository.sail.SailQuery;
  * @since 5.0
  */
 public class FedXUtil {
+
+	private static final Logger log = LoggerFactory.getLogger(FedXUtil.class);
 
 	private static final AtomicLong count = new AtomicLong(0L);
 
@@ -90,5 +103,99 @@ public class FedXUtil {
 			return;
 		}
 		operation.setMaxExecutionTime(maxExecutionTime);
+	}
+
+	/**
+	 * Convert the given contexts to a {@link Dataset} representation.
+	 * 
+	 * @param contexts
+	 * @return
+	 */
+	public static Dataset toDataset(Resource[] contexts) {
+		SimpleDataset dataset = new SimpleDataset();
+		for (Resource context : contexts) {
+			if (!(context instanceof IRI)) {
+				log.warn("FedX does not support to use non-IRIs as context identifier. Ignoring {}", context);
+				continue;
+			}
+			dataset.addDefaultGraph((IRI) context);
+		}
+		return dataset;
+	}
+
+	/**
+	 * Convert the given {@link Dataset} to an array of contexts
+	 * 
+	 * @param ds
+	 * @return
+	 */
+	public static Resource[] toContexts(Dataset ds) {
+		if (ds == null) {
+			return new Resource[0];
+		}
+		return ds.getDefaultGraphs().toArray(new Resource[0]);
+	}
+
+	/**
+	 * Retrieve the contexts from the {@link StatementPattern} and {@link Dataset}.
+	 * 
+	 * @param stmt
+	 * @param dataset
+	 * @return
+	 */
+	public static Resource[] toContexts(StatementPattern stmt, Dataset dataset) {
+		if (dataset == null && (stmt.getContextVar() == null || !stmt.getContextVar().hasValue())) {
+			return new Resource[0];
+		}
+
+		Set<Resource> contexts = Sets.newHashSet();
+
+		if (dataset != null) {
+			contexts.addAll(dataset.getDefaultGraphs());
+		}
+
+		if (stmt.getScope().equals(Scope.NAMED_CONTEXTS)) {
+			if (stmt.getContextVar().hasValue()) {
+				contexts.add((Resource) stmt.getContextVar().getValue());
+			}
+		}
+
+		return contexts.toArray(new Resource[contexts.size()]);
+	}
+
+	/**
+	 * Returns a {@link Dataset} representation of the given {@link StatementPattern} and {@link Dataset}.
+	 * <p>
+	 * If the {@link StatementPattern} does not have a context value, the {@link Dataset} is returned as-is, which may
+	 * also be <code>null</code>.
+	 * </p>
+	 * 
+	 * <p>
+	 * Otherwise the newly constructed {@link Dataset} contains all information from the original one plus the context
+	 * from the statement.
+	 * </p>
+	 * 
+	 * @param stmt
+	 * @param dataset
+	 * @return
+	 */
+	public static Dataset toDataset(StatementPattern stmt, Dataset dataset) {
+		if (stmt.getContextVar() == null || !stmt.getContextVar().hasValue()) {
+			return dataset;
+		}
+		SimpleDataset res = new SimpleDataset();
+		if (dataset != null) {
+			dataset.getDefaultGraphs().forEach(iri -> res.addDefaultGraph(iri));
+			dataset.getNamedGraphs().forEach(iri -> res.addNamedGraph(iri));
+			dataset.getDefaultRemoveGraphs().forEach(iri -> res.addDefaultRemoveGraph(iri));
+			res.setDefaultInsertGraph(dataset.getDefaultInsertGraph());
+		}
+		Value stmtContext = stmt.getContextVar().getValue();
+		if (stmtContext instanceof IRI) {
+			res.addDefaultGraph((IRI) stmtContext);
+		} else {
+			log.warn("FedX named graph handling does not support non-IRIs: " + stmtContext);
+		}
+		return res;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
@@ -33,9 +33,11 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.StatementPattern.Scope;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.slf4j.Logger;
@@ -67,8 +69,9 @@ public class QueryStringUtil {
 	 */
 	public static boolean hasFreeVars(StatementPattern stmt, BindingSet bindings) {
 		for (Var var : stmt.getVarList()) {
-			if (!var.hasValue() && !bindings.hasBinding(var.getName()))
+			if (!var.hasValue() && !bindings.hasBinding(var.getName())) {
 				return true; // there is at least one free var
+			}
 		}
 		return false;
 	}
@@ -131,8 +134,9 @@ public class QueryStringUtil {
 	}
 
 	public static String toString(Var var) {
-		if (!var.hasValue())
+		if (!var.hasValue()) {
 			return "?" + var.getName();
+		}
 		return getValueString(var.getValue());
 	}
 
@@ -164,7 +168,7 @@ public class QueryStringUtil {
 	 * @throws IllegalQueryException if the query does not have any free variables
 	 */
 	public static String selectQueryString(FedXStatementPattern stmt, BindingSet bindings, FilterValueExpr filterExpr,
-			AtomicBoolean evaluated) throws IllegalQueryException {
+			AtomicBoolean evaluated, Dataset dataset) throws IllegalQueryException {
 
 		Set<String> varNames = new HashSet<>();
 		String s = constructStatement(stmt, varNames, bindings);
@@ -173,13 +177,17 @@ public class QueryStringUtil {
 
 		res.append("SELECT ");
 
-		if (varNames.isEmpty())
+		if (varNames.isEmpty()) {
 			throw new IllegalQueryException("SELECT query needs at least one projection!");
+		}
 
-		for (String var : varNames)
+		for (String var : varNames) {
 			res.append(" ?").append(var);
+		}
 
-		res.append(" WHERE { ").append(s);
+		res.append(" ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE { ").append(s);
 
 		if (filterExpr != null) {
 			try {
@@ -215,7 +223,7 @@ public class QueryStringUtil {
 	 */
 	public static String selectQueryString(ExclusiveTupleExprRenderer expr, BindingSet bindings,
 			FilterValueExpr filterExpr,
-			AtomicBoolean evaluated) throws IllegalQueryException {
+			AtomicBoolean evaluated, Dataset dataset) throws IllegalQueryException {
 
 		Set<String> varNames = new HashSet<>();
 		String s = constructJoinArg(expr, varNames, bindings);
@@ -224,13 +232,17 @@ public class QueryStringUtil {
 
 		res.append("SELECT ");
 
-		if (varNames.isEmpty())
+		if (varNames.isEmpty()) {
 			throw new IllegalQueryException("SELECT query needs at least one projection!");
+		}
 
-		for (String var : varNames)
+		for (String var : varNames) {
 			res.append(" ?").append(var);
+		}
 
-		res.append(" WHERE { ").append(s);
+		res.append(" ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE { ").append(s);
 
 		if (filterExpr != null) {
 			try {
@@ -268,24 +280,29 @@ public class QueryStringUtil {
 	 * 
 	 */
 	public static String selectQueryString(ExclusiveGroup group, BindingSet bindings, FilterValueExpr filterExpr,
-			AtomicBoolean evaluated) throws IllegalQueryException {
+			AtomicBoolean evaluated, Dataset dataset) throws IllegalQueryException {
 
 		StringBuilder sb = new StringBuilder();
 		Set<String> varNames = new HashSet<>();
 
-		for (ExclusiveTupleExpr s : group.getExclusiveExpressions())
+		for (ExclusiveTupleExpr s : group.getExclusiveExpressions()) {
 			sb.append(constructJoinArg(s, varNames, bindings));
+		}
 
-		if (varNames.isEmpty())
+		if (varNames.isEmpty()) {
 			throw new IllegalQueryException("SELECT query needs at least one projection!");
+		}
 
 		StringBuilder res = new StringBuilder();
 		res.append("SELECT  ");
 
-		for (String var : varNames)
+		for (String var : varNames) {
 			res.append(" ?").append(var);
+		}
 
-		res.append(" WHERE { ").append(sb);
+		res.append(" ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE { ").append(sb);
 
 		if (filterExpr != null) {
 			try {
@@ -311,12 +328,14 @@ public class QueryStringUtil {
 	 * @return the ASK query string
 	 * @throws IllegalQueryException
 	 */
-	public static String askQueryString(ExclusiveTupleExpr expr, BindingSet bindings) {
+	public static String askQueryString(ExclusiveTupleExpr expr, BindingSet bindings, Dataset dataset) {
 
 		Set<String> varNames = new HashSet<>();
 
 		StringBuilder res = new StringBuilder();
-		res.append("ASK { ").append(constructJoinArg(expr, varNames, bindings)).append(" }");
+		res.append("ASK ");
+		appendDatasetClause(res, dataset);
+		res.append("{ ").append(constructJoinArg(expr, varNames, bindings)).append(" }");
 		return res.toString();
 	}
 
@@ -341,15 +360,15 @@ public class QueryStringUtil {
 	 */
 	@Deprecated
 	public static String selectQueryStringBoundUnion(StatementPattern stmt, List<BindingSet> unionBindings,
-			FilterValueExpr filterExpr, Boolean evaluated) {
+			FilterValueExpr filterExpr, Boolean evaluated, Dataset dataset) {
 
 		Set<String> varNames = new HashSet<>();
-
 		StringBuilder unions = new StringBuilder();
 		for (int i = 0; i < unionBindings.size(); i++) {
 			String s = constructStatementId(stmt, Integer.toString(i), varNames, unionBindings.get(i));
-			if (i > 0)
+			if (i > 0) {
 				unions.append(" UNION");
+			}
 			unions.append(" { ").append(s).append(" }");
 		}
 
@@ -357,10 +376,13 @@ public class QueryStringUtil {
 
 		res.append("SELECT ");
 
-		for (String var : varNames)
+		for (String var : varNames) {
 			res.append(" ?").append(var);
+		}
 
-		res.append(" WHERE {");
+		res.append(" ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE { ");
 
 		res.append(unions);
 
@@ -403,7 +425,7 @@ public class QueryStringUtil {
 	 * @since 3.0
 	 */
 	public static String selectQueryStringBoundJoinVALUES(StatementPattern stmt, List<BindingSet> unionBindings,
-			FilterValueExpr filterExpr, AtomicBoolean evaluated) {
+			FilterValueExpr filterExpr, AtomicBoolean evaluated, Dataset dataset) {
 
 		Set<String> varNames = new LinkedHashSet<>();
 		StringBuilder res = new StringBuilder();
@@ -411,10 +433,15 @@ public class QueryStringUtil {
 		String stmtPattern = constructStatement(stmt, varNames, new EmptyBindingSet());
 		res.append("SELECT ");
 
-		for (String var : varNames)
+		for (String var : varNames) {
 			res.append(" ?").append(var);
+		}
 
-		res.append(" ?").append(BoundJoinVALUESConversionIteration.INDEX_BINDING_NAME).append(" WHERE {");
+		res.append(" ?").append(BoundJoinVALUESConversionIteration.INDEX_BINDING_NAME);
+
+		res.append(" ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE {");
 
 		// TODO evaluate filter expression remote
 //		if (filterExpr!=null) {
@@ -425,18 +452,20 @@ public class QueryStringUtil {
 		res.append(" VALUES (");
 
 		// find relevant bindings
-		for (String var : varNames)
+		for (String var : varNames) {
 			res.append("?").append(var).append(" ");
+		}
 		res.append(" ?__index) { ");
 
 		int index = 0;
 		for (BindingSet b : unionBindings) {
 			res.append("(");
 			for (String var : varNames) {
-				if (b.hasBinding(var))
+				if (b.hasBinding(var)) {
 					appendValue(res, b.getValue(var)).append(" ");
-				else
+				} else {
 					res.append("UNDEF ");
+				}
 			}
 			res.append("\"").append(index).append("\") ");
 			index++;
@@ -462,15 +491,17 @@ public class QueryStringUtil {
 	 * @param unionBindings
 	 * @return the SELECT query string
 	 */
-	public static String selectQueryStringBoundCheck(StatementPattern stmt, List<BindingSet> unionBindings) {
+	public static String selectQueryStringBoundCheck(StatementPattern stmt, List<BindingSet> unionBindings,
+			Dataset dataset) {
 
 		Set<String> varNames = new HashSet<>();
 
 		StringBuilder unions = new StringBuilder();
 		for (int i = 0; i < unionBindings.size(); i++) {
 			String s = constructStatementCheckId(stmt, i, varNames, unionBindings.get(i));
-			if (i > 0)
+			if (i > 0) {
 				unions.append(" UNION");
+			}
 			unions.append(" { ").append(s).append(" }");
 		}
 
@@ -478,10 +509,15 @@ public class QueryStringUtil {
 
 		res.append("SELECT ");
 
-		for (String var : varNames)
+		for (String var : varNames) {
 			res.append(" ?").append(var);
+		}
 
-		res.append(" WHERE {").append(unions).append(" }");
+		res.append(" ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE {");
+
+		res.append(unions).append(" }");
 
 		return res.toString();
 	}
@@ -492,8 +528,9 @@ public class QueryStringUtil {
 		StringBuilder innerUnion = new StringBuilder();
 
 		for (int idx = 0; idx < bindings.size(); idx++) {
-			if (idx > 0)
+			if (idx > 0) {
 				innerUnion.append("UNION ");
+			}
 			innerUnion.append("{")
 					.append(constructStatementId(stmt, outerID + "_" + idx, varNames, bindings.get(idx)))
 					.append("} ");
@@ -545,14 +582,16 @@ public class QueryStringUtil {
 	 * @param bindings
 	 * @return the ASK query string
 	 */
-	public static String askQueryString(StatementPattern stmt, BindingSet bindings) {
+	public static String askQueryString(StatementPattern stmt, BindingSet bindings, Dataset dataset) {
 
 		Set<String> varNames = new HashSet<>();
 		String s = constructStatement(stmt, varNames, bindings);
 
 		StringBuilder res = new StringBuilder();
 
-		res.append("ASK {");
+		res.append("ASK ");
+		appendDatasetClause(res, dataset);
+		res.append(" { ");
 		res.append(s).append(" }");
 
 		return res.toString();
@@ -566,14 +605,16 @@ public class QueryStringUtil {
 	 * @param bindings
 	 * @return the SELECT query string
 	 */
-	public static String selectQueryStringLimit1(StatementPattern stmt, BindingSet bindings) {
+	public static String selectQueryStringLimit1(StatementPattern stmt, BindingSet bindings, Dataset dataset) {
 
 		Set<String> varNames = new HashSet<>();
 		String s = constructStatement(stmt, varNames, bindings);
 
 		StringBuilder res = new StringBuilder();
 
-		res.append("SELECT * WHERE {");
+		res.append("SELECT * ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE { ");
 		res.append(s).append(" } LIMIT 1");
 
 		return res.toString();
@@ -587,10 +628,10 @@ public class QueryStringUtil {
 	 * @param bindings
 	 * @return the SELECT query string
 	 */
-	public static String selectQueryStringLimit1(ExclusiveTupleExpr expr, BindingSet bindings) {
+	public static String selectQueryStringLimit1(ExclusiveTupleExpr expr, BindingSet bindings, Dataset dataset) {
 
 		if (expr instanceof ExclusiveGroup) {
-			return selectQueryStringLimit1((ExclusiveGroup) expr, bindings);
+			return selectQueryStringLimit1((ExclusiveGroup) expr, bindings, dataset);
 		}
 
 		Set<String> varNames = new HashSet<>();
@@ -598,7 +639,9 @@ public class QueryStringUtil {
 
 		StringBuilder res = new StringBuilder();
 
-		res.append("SELECT * WHERE {");
+		res.append("SELECT * ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE {");
 		res.append(s).append(" } LIMIT 1");
 
 		return res.toString();
@@ -612,15 +655,18 @@ public class QueryStringUtil {
 	 * @param bindings
 	 * @return the SELECT query string
 	 */
-	public static String selectQueryStringLimit1(ExclusiveGroup group, BindingSet bindings) {
+	public static String selectQueryStringLimit1(ExclusiveGroup group, BindingSet bindings, Dataset dataset) {
 
 		Set<String> varNames = new HashSet<>();
 		StringBuilder res = new StringBuilder();
 
-		res.append("SELECT * WHERE { ");
+		res.append("SELECT * ");
+		appendDatasetClause(res, dataset);
+		res.append("WHERE {");
 
-		for (ExclusiveTupleExpr s : group.getExclusiveExpressions())
+		for (ExclusiveTupleExpr s : group.getExclusiveExpressions()) {
 			res.append(constructJoinArg(s, varNames, bindings));
+		}
 
 		res.append(" } LIMIT 1");
 
@@ -640,9 +686,18 @@ public class QueryStringUtil {
 	protected static String constructStatement(StatementPattern stmt, Set<String> varNames, BindingSet bindings) {
 		StringBuilder sb = new StringBuilder();
 
+		if (stmt.getScope().equals(Scope.NAMED_CONTEXTS)) {
+			sb.append("GRAPH ");
+			appendVar(sb, stmt.getContextVar(), varNames, bindings);
+			sb.append(" { ");
+		}
 		sb = appendVar(sb, stmt.getSubjectVar(), varNames, bindings).append(" ");
 		sb = appendVar(sb, stmt.getPredicateVar(), varNames, bindings).append(" ");
 		sb = appendVar(sb, stmt.getObjectVar(), varNames, bindings).append(" . ");
+
+		if (stmt.getScope().equals(Scope.NAMED_CONTEXTS)) {
+			sb.append("} ");
+		}
 
 		return sb.toString();
 	}
@@ -720,12 +775,14 @@ public class QueryStringUtil {
 	 */
 	protected static StringBuilder appendVar(StringBuilder sb, Var var, Set<String> varNames, BindingSet bindings) {
 		if (!var.hasValue()) {
-			if (bindings.hasBinding(var.getName()))
+			if (bindings.hasBinding(var.getName())) {
 				return appendValue(sb, bindings.getValue(var.getName()));
+			}
 			varNames.add(var.getName());
 			return sb.append("?").append(var.getName());
-		} else
+		} else {
 			return appendValue(sb, var.getValue());
+		}
 	}
 
 	/**
@@ -744,13 +801,15 @@ public class QueryStringUtil {
 	protected static StringBuilder appendVarId(StringBuilder sb, Var var, String varID, Set<String> varNames,
 			BindingSet bindings) {
 		if (!var.hasValue()) {
-			if (bindings.hasBinding(var.getName()))
+			if (bindings.hasBinding(var.getName())) {
 				return appendValue(sb, bindings.getValue(var.getName()));
+			}
 			String newName = var.getName() + "_" + varID;
 			varNames.add(newName);
 			return sb.append("?").append(newName);
-		} else
+		} else {
 			return appendValue(sb, var.getValue());
+		}
 	}
 
 	/**
@@ -777,12 +836,15 @@ public class QueryStringUtil {
 	 */
 	protected static StringBuilder appendValue(StringBuilder sb, Value value) {
 
-		if (value instanceof IRI)
+		if (value instanceof IRI) {
 			return appendURI(sb, (IRI) value);
-		if (value instanceof Literal)
+		}
+		if (value instanceof Literal) {
 			return appendLiteral(sb, (Literal) value);
-		if (value instanceof BNode)
+		}
+		if (value instanceof BNode) {
 			return appendBNode(sb, (BNode) value);
+		}
 		throw new RuntimeException("Type not supported: " + value.getClass().getCanonicalName());
 	}
 
@@ -865,17 +927,32 @@ public class QueryStringUtil {
 			String tmpQuery = "";
 			while ((tmp = in.readLine()) != null) {
 				if (tmp.isEmpty()) {
-					if (!tmpQuery.isEmpty())
+					if (!tmpQuery.isEmpty()) {
 						res.add(tmpQuery);
+					}
 					tmpQuery = "";
 				} else {
 					tmpQuery = tmpQuery + tmp;
 				}
 			}
-			if (!tmpQuery.isEmpty())
+			if (!tmpQuery.isEmpty()) {
 				res.add(tmpQuery);
+			}
 			return res;
 		}
 
+	}
+
+	private static StringBuilder appendDatasetClause(StringBuilder sb, Dataset dataset) {
+		if (dataset == null) {
+			return sb;
+		}
+		for (IRI context : dataset.getDefaultGraphs()) {
+			sb.append("FROM <").append(context.stringValue()).append("> ");
+		}
+		for (IRI namedContext : dataset.getNamedGraphs()) {
+			sb.append("FROM NAMED <").append(namedContext.stringValue()).append("> ");
+		}
+		return sb;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
@@ -62,4 +62,9 @@ public class ReadOnlyWriteStrategy implements WriteStrategy {
 	public void close() throws RepositoryException {
 	}
 
+	@Override
+	public void clearNamespaces() throws RepositoryException {
+		throw new UnsupportedOperationException("Writing not supported to a federation: the federation is readonly.");
+	}
+
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategy.java
@@ -86,4 +86,10 @@ public class RepositoryWriteStrategy implements WriteStrategy {
 			connection = writeRepository.getConnection();
 		}
 	}
+
+	@Override
+	public void clearNamespaces() throws RepositoryException {
+		createConnection();
+		connection.clearNamespaces();
+	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/WriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/WriteStrategy.java
@@ -78,4 +78,5 @@ public interface WriteStrategy extends AutoCloseable {
 
 	void clear(Resource... contexts) throws RepositoryException;
 
+	void clearNamespaces() throws RepositoryException;
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BindTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BindTests.java
@@ -2,17 +2,10 @@ package org.eclipse.rdf4j.federated;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.repository.util.Repositories;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -68,16 +61,4 @@ public class BindTests extends SPARQLBaseTest {
 		return Repositories.tupleQueryNoTransaction(this.fedxRule.repository, query, it -> QueryResults.asList(it));
 	}
 
-	protected void assertContainsAll(List<BindingSet> res, String bindingName, Set<Value> expected) {
-		Assertions.assertEquals(expected,
-				res.stream().map(bs -> bs.getValue(bindingName)).collect(Collectors.toSet()));
-	}
-
-	protected IRI fullIri(String iri) {
-		return SimpleValueFactory.getInstance().createIRI(iri);
-	}
-
-	protected Literal l(String literal) {
-		return SimpleValueFactory.getInstance().createLiteral(literal);
-	}
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXBaseTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FedXBaseTest.java
@@ -61,8 +61,9 @@ public abstract class FedXBaseTest {
 	@BeforeAll
 	public static void initLogging() throws Exception {
 
-		if (System.getProperty("log4j.configurationFile") == null)
+		if (System.getProperty("log4j.configurationFile") == null) {
 			System.setProperty("log4j.configurationFile", "file:build/test/log4j-debug.properties");
+		}
 
 		log = LoggerFactory.getLogger(FedXBaseTest.class);
 	}
@@ -164,8 +165,12 @@ public abstract class FedXBaseTest {
 		return iri(defaultNamespace, localName);
 	}
 
-	protected IRI iri(String namespace, String localName) {
+	protected static IRI iri(String namespace, String localName) {
 		return vf.createIRI(namespace, localName);
+	}
+
+	protected static IRI fullIri(String fullIri) {
+		return vf.createIRI(fullIri);
 	}
 
 	/**
@@ -209,8 +214,9 @@ public abstract class FedXBaseTest {
 
 		if (tqrFormat != null) {
 			InputStream in = SPARQLBaseTest.class.getResourceAsStream(resultFile);
-			if (in == null)
+			if (in == null) {
 				throw new IOException("File could not be opened: " + resultFile);
+			}
 
 			try {
 				TupleQueryResultParser parser = QueryResultIO.createTupleParser(tqrFormat);
@@ -443,10 +449,11 @@ public abstract class FedXBaseTest {
 		public SimpleTupleQueryResultBuilder add(BindingSet b) throws IllegalArgumentException {
 
 			// check if the binding names are a subset of defined binding names
-			if (!bindingNames.containsAll(b.getBindingNames()))
+			if (!bindingNames.containsAll(b.getBindingNames())) {
 				throw new IllegalArgumentException(
 						"Provided binding set does must be a subset of defined binding names: " + bindingNames
 								+ ". Was: " + b.getBindingNames());
+			}
 			this.bindings.add(b);
 			return this;
 		}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/NamedGraphTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/NamedGraphTests.java
@@ -1,0 +1,304 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class NamedGraphTests extends SPARQLBaseTest {
+
+	private static class TestVocabulary {
+		public final String NAMESPACE;
+
+		public final IRI GRAPH_1;
+		public final IRI GRAPH_2;
+		public final IRI SHARED_GRAPH;
+
+		public TestVocabulary(String namespace) {
+			this.NAMESPACE = namespace;
+			this.GRAPH_1 = iri("graph1");
+			this.GRAPH_2 = iri("graph2");
+			this.SHARED_GRAPH = iri("sharedGraph");
+		}
+
+		public IRI iri(String localName) {
+			return SimpleValueFactory.getInstance().createIRI(NAMESPACE, localName);
+		}
+	}
+
+	private static TestVocabulary NS_1 = new TestVocabulary("http://namespace1.org/");
+	private static TestVocabulary NS_2 = new TestVocabulary("http://namespace2.org/");
+	private static TestVocabulary NS_3 = new TestVocabulary("http://namespace3.org/");
+	private static TestVocabulary NS_4 = new TestVocabulary("http://namespace4.org/");
+	private static TestVocabulary EX = new TestVocabulary("http://example.org/");
+
+	@BeforeEach
+	public void registerPrefixes() {
+		QueryManager qm = federationContext().getQueryManager();
+		qm.addPrefixDeclaration("foaf", FOAF.NAMESPACE);
+		qm.addPrefixDeclaration("owl", OWL.NAMESPACE);
+		qm.addPrefixDeclaration("ns1", NS_1.NAMESPACE);
+		qm.addPrefixDeclaration("ns4", NS_4.NAMESPACE);
+	}
+
+	@Test
+	public void testGetContextIDs() throws Exception {
+		prepareTest(Arrays.asList("/tests/named-graphs/data1.trig", "/tests/named-graphs/data2.trig",
+				"/tests/named-graphs/data3.trig", "/tests/named-graphs/data4.trig"));
+
+		try (RepositoryConnection conn = fedxRule.getRepository().getConnection()) {
+			List<Resource> graphs = Iterations.asList(conn.getContextIDs());
+
+			assertThat(graphs).containsExactlyInAnyOrder(NS_1.GRAPH_1, NS_1.GRAPH_2, NS_3.SHARED_GRAPH, NS_2.GRAPH_1,
+					NS_2.GRAPH_2);
+		}
+	}
+
+	@Test
+	public void testGetStatements() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/named-graphs/data1.trig", "/tests/named-graphs/data2.trig",
+				"/tests/named-graphs/data3.trig", "/tests/named-graphs/data4.trig"));
+
+		try (RepositoryConnection conn = fedxRule.getRepository().getConnection()) {
+
+			// 1. named graph only present in single endpoint
+			assertThat(Models.subjectIRIs(conn.getStatements(null, RDF.TYPE, FOAF.PERSON, NS_1.GRAPH_1)))
+					.containsExactlyInAnyOrder(NS_1.iri("Person_1"), NS_1.iri("Person_2"));
+
+			// 2. multiple graphs
+			assertThat(Models.subjectIRIs(conn.getStatements(null, RDF.TYPE, FOAF.PERSON, NS_1.GRAPH_1, NS_2.GRAPH_1)))
+					.containsExactlyInAnyOrder(
+							NS_1.iri("Person_1"), NS_1.iri("Person_2"), NS_2.iri("Person_6"), NS_2.iri("Person_7"));
+
+			// 3. graph is available in multiple endpoints
+			assertThat(Models.subjectIRIs(conn.getStatements(null, RDF.TYPE, FOAF.PERSON, NS_3.SHARED_GRAPH)))
+					.containsExactlyInAnyOrder(NS_1.iri("Person_5"), NS_2.iri("Person_10"));
+		}
+	}
+
+	@Test
+	public void testSimpleSelect_FromClause() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/named-graphs/data1.trig", "/tests/named-graphs/data2.trig",
+				"/tests/named-graphs/data3.trig", "/tests/named-graphs/data4.trig"));
+
+		List<BindingSet> res;
+
+		// 1. named graph only present in single endpoint
+		res = runQuery("SELECT ?person FROM <http://namespace1.org/graph1> WHERE { ?person a foaf:Person }");
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_1"), NS_1.iri("Person_2"));
+
+		// 2. multiple graphs
+		res = runQuery(
+				"SELECT ?person FROM <http://namespace1.org/graph1> "
+						+ "FROM <http://namespace2.org/graph1> "
+						+ "WHERE { ?person a foaf:Person }");
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_1"), NS_1.iri("Person_2"), NS_2.iri("Person_6"),
+						NS_2.iri("Person_7"));
+
+		// 3. graph is available in multiple endpoints
+		res = runQuery(
+				"SELECT ?person FROM <http://namespace3.org/sharedGraph> WHERE { ?person a foaf:Person }");
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_5"), NS_2.iri("Person_10"));
+	}
+
+	@Test
+	public void testSimpleSelect_GraphClause() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/named-graphs/data1.trig", "/tests/named-graphs/data2.trig",
+				"/tests/named-graphs/data3.trig", "/tests/named-graphs/data4.trig"));
+
+		List<BindingSet> res;
+
+		// 1. named graph only present in single endpoint
+		res = runQuery(
+				"SELECT ?person WHERE { GRAPH <http://namespace1.org/graph1> { ?person a foaf:Person } }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_1"), NS_1.iri("Person_2"));
+
+		// 3. graph is available in multiple endpoints
+		res = runQuery(
+				"SELECT ?person WHERE { GRAPH <http://namespace3.org/sharedGraph> { ?person a foaf:Person } }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_5"), NS_2.iri("Person_10"));
+
+	}
+
+	@Test
+	public void testSimpleSelect_FromNamedClause() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/named-graphs/data1.trig", "/tests/named-graphs/data2.trig",
+				"/tests/named-graphs/data3.trig", "/tests/named-graphs/data4.trig"));
+
+		List<BindingSet> res;
+
+		res = runQuery("SELECT ?person FROM NAMED <http://namespace1.org/graph1> "
+				+ "WHERE { GRAPH <http://namespace1.org/graph1> { ?person a foaf:Person } }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_1"), NS_1.iri("Person_2"));
+
+		// 3. graph is available in multiple endpoints
+		res = runQuery("SELECT ?person FROM NAMED <http://namespace3.org/sharedGraph> "
+				+ " WHERE { GRAPH <http://namespace3.org/sharedGraph> { ?person a foaf:Person } }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_5"), NS_2.iri("Person_10"));
+
+	}
+
+	@Test
+	public void testSimpleSelect_ExclusiveGroup_GraphClause() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/named-graphs/data1.trig", "/tests/named-graphs/data2.trig",
+				"/tests/named-graphs/data3.trig", "/tests/named-graphs/data4.trig"));
+
+		List<BindingSet> res;
+
+		// 1. named graph only present in single endpoint
+		// => single source query
+		res = runQuery(
+				"SELECT ?person ?name WHERE { GRAPH <http://namespace1.org/graph1> { ?person a foaf:Person . ?person foaf:name ?name } }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_1"), NS_1.iri("Person_2"));
+		assertThat(values(res, "name"))
+				.containsExactlyInAnyOrder(l("Person1"), l("Person2"));
+
+		// 2. graph is available in multiple endpoints
+		res = runQuery(
+				"SELECT ?person ?name WHERE { GRAPH <http://namespace3.org/sharedGraph> { ?person a foaf:Person . ?person foaf:name ?name } }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_5"), NS_2.iri("Person_10"));
+		assertThat(values(res, "name"))
+				.containsExactlyInAnyOrder(l("Person5"), l("Person10"));
+
+		// 3. graph is available in multiple endpoints, data is exclusive to ep1
+		// join argument is present in other endpoint
+		res = runQuery(
+				"SELECT ?person ?name WHERE { "
+						+ "GRAPH <http://namespace3.org/sharedGraph> { ns1:Person_5 a foaf:Person . ns1:Person_5 foaf:name ?name }  "
+						+ "?author owl:sameAs ns1:Person_5 "
+						+ "}");
+
+		assertThat(values(res, "name"))
+				.containsExactlyInAnyOrder(l("Person5"));
+	}
+
+	@Test
+	public void testSelect_JoinOfGraphs() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/named-graphs/data1.trig", "/tests/named-graphs/data2.trig",
+				"/tests/named-graphs/data3.trig", "/tests/named-graphs/data4.trig"));
+
+		List<BindingSet> res;
+
+		res = runQuery(
+				"SELECT ?person ?author WHERE { "
+						+ "GRAPH <http://namespace1.org/graph1> { ?person a foaf:Person  } "
+						+ "GRAPH <http://namespace3.org/sharedGraph> { ?author owl:sameAs ?person } "
+						+ "}");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_2"));
+		assertThat(values(res, "author"))
+				.containsExactlyInAnyOrder(NS_4.iri("Author_2"));
+
+		// 2. more complex join groups
+		res = runQuery(
+				"SELECT ?person ?author ?name ?authorId WHERE { "
+						+ "GRAPH <http://namespace1.org/graph1> { ?person a foaf:Person . ?person foaf:name ?name } "
+						+ "GRAPH <http://namespace3.org/sharedGraph> { ?author owl:sameAs ?person . ?author ns4:authorId ?authorId } "
+						+ "}");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_2"));
+		assertThat(values(res, "author"))
+				.containsExactlyInAnyOrder(NS_4.iri("Author_2"));
+		assertThat(values(res, "name"))
+				.containsExactlyInAnyOrder(l("Person2"));
+		assertThat(values(res, "authorId"))
+				.containsExactlyInAnyOrder(l("Author2"));
+	}
+
+	@Test
+	public void testBoundJoin() throws Exception {
+
+		prepareTest(
+				Arrays.asList("/tests/named-graphs/data-boundjoin1.trig", "/tests/named-graphs/data-boundjoin2.trig"));
+
+		List<BindingSet> res;
+		res = runQuery(
+				"SELECT ?person ?name WHERE { GRAPH <http://example.org/graph1> { ?person a foaf:Person . ?person foaf:name ?name } }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(EX.iri("Person1"), EX.iri("Person2"), EX.iri("Person3"),
+						EX.iri("Person4"), EX.iri("Person11"), EX.iri("Person12"),
+						EX.iri("Person13"), EX.iri("Person14"));
+		assertThat(values(res, "name"))
+				.containsExactlyInAnyOrder(l("Person 1"), l("Person 2"), l("Person 3"), l("Person 4"),
+						l("Person 11"), l("Person 12"), l("Person 13"), l("Person 14"));
+	}
+
+	@Test
+	public void testBoundJoin_FROM_CLAUSE() throws Exception {
+
+		prepareTest(
+				Arrays.asList("/tests/named-graphs/data-boundjoin1.trig", "/tests/named-graphs/data-boundjoin2.trig"));
+
+		List<BindingSet> res;
+		res = runQuery(
+				"SELECT ?person ?name FROM <http://example.org/graph1> WHERE {  ?person a foaf:Person . ?person foaf:name ?name }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(EX.iri("Person1"), EX.iri("Person2"), EX.iri("Person3"),
+						EX.iri("Person4"), EX.iri("Person11"), EX.iri("Person12"),
+						EX.iri("Person13"), EX.iri("Person14"));
+		assertThat(values(res, "name"))
+				.containsExactlyInAnyOrder(l("Person 1"), l("Person 2"), l("Person 3"), l("Person 4"),
+						l("Person 11"), l("Person 12"), l("Person 13"), l("Person 14"));
+	}
+
+	private List<Value> values(List<BindingSet> result, String bindingName) {
+		return result.stream().map(bs -> bs.getValue(bindingName)).collect(Collectors.toList());
+	}
+
+	protected List<BindingSet> runQuery(String query) {
+		TupleQuery tq = federationContext().getQueryManager().prepareTupleQuery(query);
+		try (TupleQueryResult tqr = tq.evaluate()) {
+			return Iterations.asList(tqr);
+		}
+
+	}
+}

--- a/tools/federation/src/test/resources/tests/named-graphs/data-boundjoin1.trig
+++ b/tools/federation/src/test/resources/tests/named-graphs/data-boundjoin1.trig
@@ -1,0 +1,41 @@
+@prefix ex: <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+
+ex:graph1 {
+	ex:Person1 rdf:type foaf:Person ;
+		foaf:name "Person 1" .
+	
+	ex:Person2 rdf:type foaf:Person ;
+		foaf:name "Person 2" .
+	
+	ex:Person3 rdf:type foaf:Person ;
+		foaf:name "Person 3" .
+		
+	ex:Person4 rdf:type foaf:Person ;
+		foaf:name "Person 4" .
+	
+	ex:Person5 rdf:type foaf:Person .
+}
+
+ex:graph2 {
+	ex:Person6 rdf:type foaf:Person ;
+		foaf:name "Person 6" .
+	
+	ex:Person7 rdf:type foaf:Person ;
+		foaf:name "Person 7" .
+	
+	ex:Person8 rdf:type foaf:Person ;
+		foaf:name "Person 8" .
+		
+	ex:Person9 rdf:type foaf:Person ;
+		foaf:name "Person 9" .
+	
+	ex:Person10 rdf:type foaf:Person ;
+		foaf:name "Person 10" .
+} 
+
+ex:graph3 {
+	ex:Person5 foaf:name "Person 5" .
+}

--- a/tools/federation/src/test/resources/tests/named-graphs/data-boundjoin2.trig
+++ b/tools/federation/src/test/resources/tests/named-graphs/data-boundjoin2.trig
@@ -1,0 +1,41 @@
+@prefix ex: <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+
+ex:graph1 {
+	ex:Person11 rdf:type foaf:Person ;
+		foaf:name "Person 11" .
+	
+	ex:Person12 rdf:type foaf:Person ;
+		foaf:name "Person 12" .
+	
+	ex:Person13 rdf:type foaf:Person ;
+		foaf:name "Person 13" .
+		
+	ex:Person14 rdf:type foaf:Person ;
+		foaf:name "Person 14" .
+	
+	ex:Person15 rdf:type foaf:Person .
+}
+
+ex:graph2 {
+	ex:Person16 rdf:type foaf:Person ;
+		foaf:name "Person 16" .
+	
+	ex:Person17 rdf:type foaf:Person ;
+		foaf:name "Person 17" .
+	
+	ex:Person18 rdf:type foaf:Person ;
+		foaf:name "Person 18" .
+		
+	ex:Person19 rdf:type foaf:Person ;
+		foaf:name "Person 19" .
+	
+	ex:Person20 rdf:type foaf:Person ;
+		foaf:name "Person 20" .
+}
+
+ex:graph3 {
+	ex:Person15 foaf:name "Person 15" .
+}

--- a/tools/federation/src/test/resources/tests/named-graphs/data1.trig
+++ b/tools/federation/src/test/resources/tests/named-graphs/data1.trig
@@ -1,0 +1,37 @@
+@prefix : <http://namespace1.org/> .
+@prefix ns3: <http://namespace3.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . 
+@prefix owl:  <http://www.w3.org/2002/07/owl#> . 
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+:graph1 {
+	:Person_1 rdf:type foaf:Person .
+	:Person_1 rdf:type :Person .
+	:Person_1 foaf:name "Person1" .
+	:Person_1 foaf:age "20"^^xsd:integer .
+
+	:Person_2 rdf:type foaf:Person .
+	:Person_2 rdf:type :Person .
+	:Person_2 foaf:name "Person2" .
+	:Person_2 foaf:age "27"^^xsd:integer .
+}
+
+:graph2 {
+	:Person_3 rdf:type foaf:Person .
+	:Person_3 rdf:type :Person .
+	:Person_3 foaf:name "Person3" .
+	:Person_3 foaf:age "30"^^xsd:integer .
+	
+	:Person_4 rdf:type foaf:Person .
+	:Person_4 rdf:type :Person .
+	:Person_4 foaf:name "Person4" .
+}
+
+ns3:sharedGraph {
+	:Person_5 rdf:type foaf:Person .
+	:Person_5 rdf:type :Person .
+	:Person_5 foaf:name "Person5" .
+}
+

--- a/tools/federation/src/test/resources/tests/named-graphs/data2.trig
+++ b/tools/federation/src/test/resources/tests/named-graphs/data2.trig
@@ -1,0 +1,35 @@
+@prefix : <http://namespace2.org/> .
+@prefix ns3: <http://namespace3.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . 
+@prefix owl:  <http://www.w3.org/2002/07/owl#> . 
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+:graph1 {
+	:Person_6 rdf:type foaf:Person .
+	:Person_6 rdf:type :Person .
+	:Person_6 foaf:name "Person6" .
+	:Person_1 foaf:age "25"^^xsd:integer .
+
+	:Person_7 rdf:type foaf:Person .
+	:Person_7 rdf:type :Person .
+	:Person_7 foaf:name "Person7" .
+}
+
+:graph2 {
+	:Person_8 rdf:type foaf:Person .
+	:Person_8 rdf:type :Person .
+	:Person_8 foaf:name "Person8" .
+	
+	:Person_9 rdf:type foaf:Person .
+	:Person_9 rdf:type :Person .
+	:Person_9 foaf:name "Person9" .
+}
+
+ns3:sharedGraph {
+	:Person_10 rdf:type foaf:Person .
+	:Person_10 rdf:type :Person .
+	:Person_10 foaf:name "Person10" .
+}
+

--- a/tools/federation/src/test/resources/tests/named-graphs/data3.trig
+++ b/tools/federation/src/test/resources/tests/named-graphs/data3.trig
@@ -1,0 +1,20 @@
+@prefix : <http://namespace3.org/> .
+@prefix ns1: <http://namespace1.org/> .
+@prefix ns2: <http://namespace2.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . 
+@prefix owl:  <http://www.w3.org/2002/07/owl#> . 
+
+:sharedGraph {
+	:Project_1 rdf:type :Project .
+	:Project_1 rdfs:label "Project1" .
+	:Project_1 :responsible ns2:Person_7 .
+	
+	:Project_2 rdf:type :Project .
+	:Project_2 rdfs:label "Project2" .
+	
+	:Project_3 rdf:type :Project .
+	:Project_3 rdfs:label "Project3" .
+}
+

--- a/tools/federation/src/test/resources/tests/named-graphs/data4.trig
+++ b/tools/federation/src/test/resources/tests/named-graphs/data4.trig
@@ -1,0 +1,132 @@
+@prefix : <http://namespace4.org/> .
+@prefix ns1: <http://namespace1.org/> .
+@prefix ns2: <http://namespace2.org/> .
+@prefix ns3: <http://namespace3.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . 
+@prefix owl:  <http://www.w3.org/2002/07/owl#> . 
+
+ns3:sharedGraph {
+	
+	:Author_1 rdf:type :Author .
+	:Author_1 :authorId "Author1" .
+	
+	:Author_2 rdf:type :Author .
+	:Author_2 :authorId "Author2" .
+	:Author_2 owl:sameAs ns1:Person_2 .
+	
+	:Author_3 rdf:type :Author .
+	:Author_3 :authorId "Author3" .
+	
+	:Author_4 rdf:type :Author .
+	:Author_4 :authorId "Author4" .
+	
+	:Author_5 rdf:type :Author .
+	:Author_5 :authorId "Author5" .
+	:Author_5 owl:sameAs ns1:Person_5 .
+	
+	:Author_6 rdf:type :Author .
+	:Author_6 :authorId "Author6" .
+	
+	:Author_7 rdf:type :Author .
+	:Author_7 :authorId "Author7" .
+	:Author_7 owl:sameAs ns2:Person_7 .
+	
+	:Author_8 rdf:type :Author .
+	:Author_8 :authorId "Author8" .
+	:Author_8 owl:sameAs ns2:Person_8 .
+	
+	:Author_9 rdf:type :Author .
+	:Author_9 :authorId "Author9" .
+	
+	:Author_10 rdf:type :Author .
+	:Author_10 :authorId "Author10" .
+	
+	:Author_11 rdf:type :Author .
+	:Author_11 :authorId "Author11" .
+	
+	:Author_12 rdf:type :Author .
+	:Author_12 :authorId "Author12" .
+	
+	:Author_13 rdf:type :Author .
+	:Author_13 :authorId "Author13" .
+	
+	:Author_14 rdf:type :Author .
+	:Author_14 :authorId "Author14" .
+	
+	:Author_15 rdf:type :Author .
+	:Author_15 :authorId "Author15" .
+	
+	:Author_16 rdf:type :Author .
+	:Author_16 :authorId "Author16" .
+	
+	:Author_17 rdf:type :Author .
+	:Author_17 :authorId "Author17" .
+	
+	:Author_18 rdf:type :Author .
+	:Author_18 :authorId "Author18" .
+	
+	:Author_19 rdf:type :Author .
+	:Author_19 :authorId "Author19" .
+	
+	:Author_20 rdf:type :Author .
+	:Author_20 :authorId "Author20" .
+	
+	:Publication_1 rdf:type :Publication .
+	:Publication_1 :title "Publication1" .
+	:Publication_1 :hasAuthor :Author_14 .
+	:Publication_1 :hasAuthor :Author_1 .
+	
+	:Publication_2 rdf:type :Publication .
+	:Publication_2 :title "Publication2" .
+	:Publication_2 :hasAuthor :Author_11 .
+	:Publication_2 :hasAuthor :Author_3 .
+	:Publication_2 :hasAuthor :Author_12 .
+	:Publication_2 :hasAuthor :Author_18 .
+	
+	:Publication_3 rdf:type :Publication .
+	:Publication_3 :title "Publication3" .
+	:Publication_3 :hasAuthor :Author_18 .
+	
+	:Publication_4 rdf:type :Publication .
+	:Publication_4 :title "Publication4" .
+	:Publication_4 :hasAuthor :Author_18 .
+	:Publication_4 :hasAuthor :Author_11 .
+	:Publication_4 :hasAuthor :Author_10 .
+	
+	:Publication_5 rdf:type :Publication .
+	:Publication_5 :title "Publication5" .
+	:Publication_5 :hasAuthor :Author_7 .
+	:Publication_5 :hasAuthor :Author_3 .
+	
+	:Publication_6 rdf:type :Publication .
+	:Publication_6 :title "Publication6" .
+	:Publication_6 :hasAuthor :Author_1 .
+	:Publication_6 :hasAuthor :Author_19 .
+	:Publication_6 :hasAuthor :Author_18 .
+	:Publication_6 :hasAuthor :Author_8 .
+	
+	:Publication_7 rdf:type :Publication .
+	:Publication_7 :title "Publication7" .
+	:Publication_7 :hasAuthor :Author_19 .
+	:Publication_7 :hasAuthor :Author_2 .
+	:Publication_7 :hasAuthor :Author_1 .
+	
+	:Publication_8 rdf:type :Publication .
+	:Publication_8 :title "Publication8" .
+	:Publication_8 :hasAuthor :Author_20 .
+	:Publication_8 :hasAuthor :Author_11 .
+	:Publication_8 :hasAuthor :Author_14 .
+	:Publication_8 :hasAuthor :Author_12 .
+	
+	:Publication_9 rdf:type :Publication .
+	:Publication_9 :title "Publication9" .
+	:Publication_9 :hasAuthor :Author_19 .
+	
+	:Publication_10 rdf:type :Publication .
+	:Publication_10 :title "Publication10" .
+	:Publication_10 :hasAuthor :Author_20 .
+	:Publication_10 :hasAuthor :Author_9 .
+	:Publication_10 :hasAuthor :Author_1 .
+}


### PR DESCRIPTION
GH-2145: fix context retrieval in federation engine

* context IDs retrieved from the endpoints have to be materialized as
they are only available while the connection is open
* add unit test infrastructure for named graph tests and define some
test data


GH-2145: add named graph handling for #getStatements API

Add named graph support to the RepositoryConnection API using the
getStatements method. Also covered with various unit tests.

Note that this change provides already the infrastructure to further add
support for named graph queries.


GH-2145: add named graph handling for simple federated SELECT patterns

* support GRAPH clause around single basic graph pattern
* support FROM clause in queries


* add named graph handling for simple federated SELECT patterns
** support GRAPH clause around single basic graph pattern
** support FROM clause in queries

* fix handling of base URIs for query parsing in FedX

* add named graph support for bound joins

GH-2149 GH-2145 use new compliance test suite for testing of FedX

GitHub issue resolved: #2145


---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

