### PR TITLE
GH-2140 Unions can have specified new scope

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DisjunctiveConstraintOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DisjunctiveConstraintOptimizer.java
@@ -23,7 +23,7 @@ import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
  * A query optimizer that optimize disjunctive constraints on tuple expressions. Currently, this optimizer {@link Union
  * unions} a clone of the underlying tuple expression with the original expression for each {@link SameTerm} operator,
  * moving the SameTerm to the cloned tuple expression.
- * 
+ *
  * @author Arjohn Kampman
  * @author James Leigh
  */
@@ -53,7 +53,7 @@ public class DisjunctiveConstraintOptimizer implements QueryOptimizer {
 
 				Filter leftFilter = new Filter(node.clone(), leftConstraint);
 				Filter rightFilter = new Filter(node.clone(), rightConstraint);
-				Union union = new Union(leftFilter, rightFilter);
+				Union union = new Union(leftFilter, rightFilter, false);
 				node.replaceWith(union);
 
 				filter.getParentNode().visit(this);

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizer.java
@@ -36,7 +36,7 @@ import org.eclipse.rdf4j.query.algebra.helpers.VarNameCollector;
 /**
  * A query optimizer that (partially) normalizes query models to a canonical form. Note: this implementation does not
  * yet cover all query node types.
- * 
+ *
  * @author Arjohn Kampman
  */
 public class QueryModelNormalizer extends AbstractQueryModelVisitor<RuntimeException> implements QueryOptimizer {
@@ -67,7 +67,7 @@ public class QueryModelNormalizer extends AbstractQueryModelVisitor<RuntimeExcep
 			Union union = (Union) leftArg;
 			Join leftJoin = new Join(union.getLeftArg(), rightArg.clone());
 			Join rightJoin = new Join(union.getRightArg(), rightArg.clone());
-			Union newUnion = new Union(leftJoin, rightJoin);
+			Union newUnion = new Union(leftJoin, rightJoin, union.isNewScope());
 			join.replaceWith(newUnion);
 			newUnion.visit(this);
 		} else if (rightArg instanceof Union) {
@@ -75,7 +75,7 @@ public class QueryModelNormalizer extends AbstractQueryModelVisitor<RuntimeExcep
 			Union union = (Union) rightArg;
 			Join leftJoin = new Join(leftArg.clone(), union.getLeftArg());
 			Join rightJoin = new Join(leftArg.clone(), union.getRightArg());
-			Union newUnion = new Union(leftJoin, rightJoin);
+			Union newUnion = new Union(leftJoin, rightJoin, union.isNewScope());
 			join.replaceWith(newUnion);
 			newUnion.visit(this);
 		} else if (leftArg instanceof LeftJoin && isWellDesigned(((LeftJoin) leftArg))) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/JoinIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/JoinIterator.java
@@ -105,7 +105,7 @@ public class JoinIterator extends LookAheadIteration<BindingSet, QueryEvaluation
 	}
 
 	private boolean isOutOfScopeForLeftArgBindings(TupleExpr expr) {
-		if (expr instanceof Union) {
+		if (expr instanceof Union && ((Union) expr).isNewScope()) {
 			return true;
 		}
 		return TupleExprs.isGraphPatternGroup(expr) && !(expr instanceof Filter);

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Union.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Union.java
@@ -15,21 +15,36 @@ import java.util.Set;
  */
 public class Union extends BinaryTupleOperator {
 
+	// Used to differentiate between Unions introduced by the user that require a new scope and unions introduced for
+	// evaluation or performance purposes that do not introduce a new scope. This means that they can be executed more
+	// efficiently.
+	private boolean newScope;
+
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
 
 	public Union() {
+		this(true);
+	}
+
+	public Union(boolean newScope) {
+		this.newScope = newScope;
 	}
 
 	/**
 	 * Creates a new union operator that operates on the two specified arguments.
-	 * 
+	 *
 	 * @param leftArg  The left argument of the union operator.
 	 * @param rightArg The right argument of the union operator.
 	 */
 	public Union(TupleExpr leftArg, TupleExpr rightArg) {
+		this(leftArg, rightArg, true);
+	}
+
+	public Union(TupleExpr leftArg, TupleExpr rightArg, boolean newScope) {
 		super(leftArg, rightArg);
+		this.newScope = newScope;
 	}
 
 	/*---------*
@@ -69,6 +84,16 @@ public class Union extends BinaryTupleOperator {
 
 	@Override
 	public Union clone() {
-		return (Union) super.clone();
+		Union clone = (Union) super.clone();
+		clone.newScope = this.newScope;
+		return clone;
+	}
+
+	public boolean isNewScope() {
+		return newScope;
+	}
+
+	public void setNewScope(boolean newScope) {
+		this.newScope = newScope;
 	}
 }

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -1187,7 +1187,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 		if (altCount > 1) {
 			GraphPattern parentGP = graphPattern;
-			Union union = new Union();
+			Union union = new Union(false);
 			Union currentUnion = union;
 			for (int i = 0; i < altCount - 1; i++) {
 				graphPattern = new GraphPattern(parentGP);
@@ -1200,7 +1200,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 					arg = graphPattern.buildTupleExpr();
 					currentUnion.setRightArg(arg);
 				} else {
-					Union newUnion = new Union();
+					Union newUnion = new Union(false);
 					currentUnion.setRightArg(newUnion);
 					currentUnion = newUnion;
 				}
@@ -1595,7 +1595,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 					// upperbound is fixed-length
 
 					// create set of unions for all path lengths between lower and upper bound.
-					Union union = new Union();
+					Union union = new Union(false);
 					Union currentUnion = union;
 
 					for (long length = lowerBound; length < upperBound; length++) {
@@ -1607,7 +1607,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 							path = createPath(scope, subjVar, te, endVar, contextVar, length + 1);
 							currentUnion.setRightArg(path);
 						} else {
-							Union nextUnion = new Union();
+							Union nextUnion = new Union(false);
 							currentUnion.setRightArg(nextUnion);
 							currentUnion = nextUnion;
 						}


### PR DESCRIPTION
GitHub issue resolved: #2140 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Unions are introduced when parsing queries with alternate paths. These are again optimized by the QueryModelNormalizer with new Unions. None of these Unions need to introduce a new scope, as they were not introduced by the user.

Added an option for specifying scope to Unions.

<!-- short description of your change goes here -->

---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

