### PR TITLE
GH-2143 ensure project is binary compatible with 3.1 releases

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -267,6 +267,11 @@ public interface ValueFactory {
 	 * @param predicate The statement's predicate.
 	 * @param object    The statement's object.
 	 * @return The created triple.
+	 * @implNote This temporary default method is only supplied as a stop-gap for backward compatibility, but throws an
+	 *           {@link UnsupportedOperationException}. Concrete implementations are expected to override.
+	 * @since 3.2.0
 	 */
-	Triple createTriple(Resource subject, IRI predicate, Value object);
+	default Triple createTriple(Resource subject, IRI predicate, Value object) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Models.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Models.java
@@ -58,29 +58,76 @@ public class Models {
 	}
 
 	/**
+	 * Retrieves an object {@link Value} from the supplied statements. If more than one possible object value exists,
+	 * any one value is picked and returned.
+	 *
+	 * @param statements the {@link Statement } {@link Iterable} from which to retrieve an object value.
+	 * @return an object value from the given statement collection, or {@link Optional#empty()} if no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #object(Model)}.
+	 */
+	public static Optional<Value> object(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false).map(st -> st.getObject()).findAny();
+	}
+
+	/**
 	 * Retrieves an object {@link Value} from the statements in the given model. If more than one possible object value
 	 * exists, any one value is picked and returned.
 	 *
 	 * @param m the model from which to retrieve an object value.
 	 * @return an object value from the given model, or {@link Optional#empty()} if no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #object(Iterable)}. This method signature kept for binary
+	 *          compatibility.
+	 * 
 	 */
-	public static Optional<Value> object(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false).map(st -> st.getObject()).findAny();
+	public static Optional<Value> object(Model m) {
+		return object((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves an object {@link Literal} value from the supplied statements. If more than one possible Literal value
+	 * exists, any one Literal value is picked and returned.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve an object Literal value.
+	 * @return an object Literal value from the given model, or {@link Optional#empty()} if no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #objectLiteral(Model)}.
+	 */
+	public static Optional<Literal> objectLiteral(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
+				.map(st -> st.getObject())
+				.filter(o -> o instanceof Literal)
+				.map(l -> (Literal) l)
+				.findAny();
 	}
 
 	/**
 	 * Retrieves an object {@link Literal} value from the statements in the given model. If more than one possible
 	 * Literal value exists, any one Literal value is picked and returned.
 	 *
-	 * @param m the model from which to retrieve an object Literal value.
+	 * @param m the {@link Model} from which to retrieve an object Literal value.
 	 * @return an object Literal value from the given model, or {@link Optional#empty()} if no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #objectLiteral(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 */
-	public static Optional<Literal> objectLiteral(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
+	public static Optional<Literal> objectLiteral(Model m) {
+		return objectLiteral((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves all object {@link Literal} values from the supplied statements.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve all object {@link Literal}
+	 *                   values.
+	 * @return a {@link Set} containing object {@link Literal} values from the given model, which will be empty if no
+	 *         such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #objectLiterals(Model)}.
+	 * @see Model#objects()
+	 */
+	public static Set<Literal> objectLiterals(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
 				.map(st -> st.getObject())
 				.filter(o -> o instanceof Literal)
 				.map(l -> (Literal) l)
-				.findAny();
+				.collect(Collectors.toSet());
 	}
 
 	/**
@@ -89,14 +136,30 @@ public class Models {
 	 * @param m the model from which to retrieve all object {@link Literal} values.
 	 * @return a {@link Set} containing object {@link Literal} values from the given model, which will be empty if no
 	 *         such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #objectLiterals(Iterable)}. This method signature kept
+	 *          for binary compatibility.
+	 * 
 	 * @see Model#objects()
 	 */
-	public static Set<Literal> objectLiterals(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
+	public static Set<Literal> objectLiterals(Model m) {
+		return objectLiterals((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves an object {@link Resource} value from the supplied statements. If more than one possible Resource value
+	 * exists, any one Resource value is picked and returned.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve an object Resource value.
+	 * @return an {@link Optional} object Resource value from the given model, which will be {@link Optional#empty()
+	 *         empty} if no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #objectResource(Model)}.
+	 */
+	public static Optional<Resource> objectResource(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
 				.map(st -> st.getObject())
-				.filter(o -> o instanceof Literal)
-				.map(l -> (Literal) l)
-				.collect(Collectors.toSet());
+				.filter(o -> o instanceof Resource)
+				.map(r -> (Resource) r)
+				.findAny();
 	}
 
 	/**
@@ -106,25 +169,25 @@ public class Models {
 	 * @param m the model from which to retrieve an object Resource value.
 	 * @return an {@link Optional} object Resource value from the given model, which will be {@link Optional#empty()
 	 *         empty} if no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #objectResource(Iterable)}. This method signature kept
+	 *          for binary compatibility.
 	 */
-	public static Optional<Resource> objectResource(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
-				.map(st -> st.getObject())
-				.filter(o -> o instanceof Resource)
-				.map(r -> (Resource) r)
-				.findAny();
+	public static Optional<Resource> objectResource(Model m) {
+		return objectResource((Iterable<Statement>) m);
 	}
 
 	/**
-	 * Retrieves all object {@link Resource} values from the statements in the given model.
+	 * Retrieves all object {@link Resource} values from the supplied statements.
 	 *
-	 * @param m the model from which to retrieve all object {@link Resource} values.
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve all object {@link Resource}
+	 *                   values.
 	 * @return a {@link Set} containing object {@link Resource} values from the given model, which will be empty if no
 	 *         such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #objectResources(Model)}.
 	 * @see Model#objects()
 	 */
-	public static Set<Resource> objectResources(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
+	public static Set<Resource> objectResources(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
 				.map(st -> st.getObject())
 				.filter(o -> o instanceof Resource)
 				.map(r -> (Resource) r)
@@ -132,35 +195,92 @@ public class Models {
 	}
 
 	/**
-	 * Retrieves an object {@link IRI} value from the statements in the given model. If more than one possible IRI value
-	 * exists, any one value is picked and returned.
+	 * Retrieves all object {@link Resource} values from the supplied model.
 	 *
-	 * @param m the model from which to retrieve an object IRI value.
+	 * @param m the {@link Model} from which to retrieve all object {@link Resource} values.
+	 * @return a {@link Set} containing object {@link Resource} values from the given model, which will be empty if no
+	 *         such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #objectResources(Iterable)}. This method signature kept
+	 *          for binary compatibility.
+	 * @see Model#objects()
+	 */
+	public static Set<Resource> objectResources(Model m) {
+		return objectResources((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves an object {@link IRI} value from the supplied statements. If more than one possible IRI value exists,
+	 * any one value is picked and returned.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve an object IRI value.
 	 * @return an {@link Optional} object IRI value from the given model, which will be {@link Optional#empty() empty}
 	 *         if no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #objectIRI(Model)}.
 	 */
-	public static Optional<IRI> objectIRI(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
+	public static Optional<IRI> objectIRI(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
 				.map(st -> st.getObject())
 				.filter(o -> o instanceof IRI)
 				.map(r -> (IRI) r)
 				.findAny();
+	}
+
+	/**
+	 * Retrieves an object {@link IRI} value from the supplied statements in the given model. If more than one possible
+	 * IRI value exists, any one value is picked and returned.
+	 *
+	 * @param m the model from which to retrieve an object IRI value.
+	 * @return an {@link Optional} object IRI value from the given model, which will be {@link Optional#empty() empty}
+	 *         if no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #objectIRI(Iterable)}. This method signature kept for
+	 *          binary compatibility.
+	 */
+	public static Optional<IRI> objectIRI(Model m) {
+		return objectIRI((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves all object {@link IRI} values from the supplied statements.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve all object IRI values.
+	 * @return a {@link Set} containing object IRI values from the given model, which will be empty if no such value
+	 *         exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #objectIRIs(Model)}.
+	 * @see Model#objects()
+	 */
+	public static Set<IRI> objectIRIs(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
+				.map(st -> st.getObject())
+				.filter(o -> o instanceof IRI)
+				.map(r -> (IRI) r)
+				.collect(Collectors.toSet());
 	}
 
 	/**
 	 * Retrieves all object {@link IRI} values from the statements in the given model.
 	 *
-	 * @param m the model from which to retrieve all object IRI values.
+	 * @param m the {@link Model} from which to retrieve all object IRI values.
 	 * @return a {@link Set} containing object IRI values from the given model, which will be empty if no such value
 	 *         exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #objectIRIs(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 * @see Model#objects()
 	 */
-	public static Set<IRI> objectIRIs(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
-				.map(st -> st.getObject())
-				.filter(o -> o instanceof IRI)
-				.map(r -> (IRI) r)
-				.collect(Collectors.toSet());
+	public static Set<IRI> objectIRIs(Model m) {
+		return objectIRIs((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves an object value as a String from the supplied statements. If more than one possible object value
+	 * exists, any one value is picked and returned.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve an object String value.
+	 * @return an {@link Optional} object String value from the given model, which will be {@link Optional#empty()
+	 *         empty} if no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #objectString(Model)}.
+	 */
+	public static Optional<String> objectString(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false).map(st -> st.getObject().stringValue()).findAny();
 	}
 
 	/**
@@ -170,9 +290,26 @@ public class Models {
 	 * @param m the model from which to retrieve an object String value.
 	 * @return an {@link Optional} object String value from the given model, which will be {@link Optional#empty()
 	 *         empty} if no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #objectString(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 */
-	public static Optional<String> objectString(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false).map(st -> st.getObject().stringValue()).findAny();
+	public static Optional<String> objectString(Model m) {
+		return objectString((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves all object String values from the supplied statements.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve all object String values.
+	 * @return a {@link Set} containing object String values from the given model, which will be empty if no such value
+	 *         exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #objectStrings(Model)}.
+	 * @see Model#objects()
+	 */
+	public static Set<String> objectStrings(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
+				.map(st -> st.getObject().stringValue())
+				.collect(Collectors.toSet());
 	}
 
 	/**
@@ -181,12 +318,25 @@ public class Models {
 	 * @param m the model from which to retrieve all object String values.
 	 * @return a {@link Set} containing object String values from the given model, which will be empty if no such value
 	 *         exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #objectStrings(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 * @see Model#objects()
 	 */
-	public static Set<String> objectStrings(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
-				.map(st -> st.getObject().stringValue())
-				.collect(Collectors.toSet());
+	public static Set<String> objectStrings(Model m) {
+		return objectStrings((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves a subject {@link Resource} from the supplied statements. If more than one possible resource value
+	 * exists, any one resource value is picked and returned.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve a subject Resource.
+	 * @return an {@link Optional} subject resource from the given model, which will be {@link Optional#empty() empty}
+	 *         if no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #subject(Model)}.
+	 */
+	public static Optional<Resource> subject(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false).map(st -> st.getSubject()).findAny();
 	}
 
 	/**
@@ -196,9 +346,28 @@ public class Models {
 	 * @param m the model from which to retrieve a subject Resource.
 	 * @return an {@link Optional} subject resource from the given model, which will be {@link Optional#empty() empty}
 	 *         if no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #subject(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 */
-	public static Optional<Resource> subject(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false).map(st -> st.getSubject()).findAny();
+	public static Optional<Resource> subject(Model m) {
+		return subject((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves a subject {@link IRI} from the supplied statements. If more than one possible IRI value exists, any one
+	 * IRI value is picked and returned.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve a subject IRI value.
+	 * @return an {@link Optional} subject IRI value from the given model, which will be {@link Optional#empty() empty}
+	 *         if no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #subjectIRI(Model)}.
+	 */
+	public static Optional<IRI> subjectIRI(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
+				.map(st -> st.getSubject())
+				.filter(s -> s instanceof IRI)
+				.map(s -> (IRI) s)
+				.findAny();
 	}
 
 	/**
@@ -208,13 +377,26 @@ public class Models {
 	 * @param m the model from which to retrieve a subject IRI value.
 	 * @return an {@link Optional} subject IRI value from the given model, which will be {@link Optional#empty() empty}
 	 *         if no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #subjectIRI(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 */
-	public static Optional<IRI> subjectIRI(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
+	public static Optional<IRI> subjectIRI(Model m) {
+		return subjectIRI((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves all subject {@link IRI}s from the supplied statements.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve a subject IRI value.
+	 * @return a {@link Set} of subject IRI values from the given model. The returned Set may be empty.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #subjectIRIs(Model)}.
+	 */
+	public static Set<IRI> subjectIRIs(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
 				.map(st -> st.getSubject())
-				.filter(s -> s instanceof IRI)
-				.map(s -> (IRI) s)
-				.findAny();
+				.filter(o -> o instanceof IRI)
+				.map(r -> (IRI) r)
+				.collect(Collectors.toSet());
 	}
 
 	/**
@@ -222,9 +404,28 @@ public class Models {
 	 *
 	 * @param m the model from which to retrieve a subject IRI value.
 	 * @return a {@link Set} of subject IRI values from the given model. The returned Set may be empty.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #subjectIRIs(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 */
 	public static Set<IRI> subjectIRIs(Model m) {
-		return m.subjects().stream().filter(s -> s instanceof IRI).map(s -> (IRI) s).collect(Collectors.toSet());
+		return subjectIRIs((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves a subject {@link BNode} from the supplied statements. If more than one possible blank node value
+	 * exists, any one blank node value is picked and returned.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve a subject BNode value.
+	 * @return an {@link Optional} subject BNode value from the given model, which will be {@link Optional#empty()
+	 *         empty} if no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #subjectBNode(Model)}.
+	 */
+	public static Optional<BNode> subjectBNode(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
+				.map(st -> st.getSubject())
+				.filter(s -> s instanceof BNode)
+				.map(s -> (BNode) s)
+				.findAny();
 	}
 
 	/**
@@ -234,13 +435,26 @@ public class Models {
 	 * @param m the model from which to retrieve a subject BNode value.
 	 * @return an {@link Optional} subject BNode value from the given model, which will be {@link Optional#empty()
 	 *         empty} if no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #subjectBNode(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 */
-	public static Optional<BNode> subjectBNode(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false)
+	public static Optional<BNode> subjectBNode(Model m) {
+		return subjectBNode((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves all subject {@link BNode}s from the supplied statements.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve a subject IRI value.
+	 * @return a {@link Set} of subject {@link BNode} values from the given model. The returned Set may be empty.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #subjectBNodes(Model)}.
+	 */
+	public static Set<BNode> subjectBNodes(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false)
 				.map(st -> st.getSubject())
-				.filter(s -> s instanceof BNode)
-				.map(s -> (BNode) s)
-				.findAny();
+				.filter(o -> o instanceof BNode)
+				.map(r -> (BNode) r)
+				.collect(Collectors.toSet());
 	}
 
 	/**
@@ -248,9 +462,24 @@ public class Models {
 	 *
 	 * @param m the model from which to retrieve a subject IRI value.
 	 * @return a {@link Set} of subject {@link BNode} values from the given model. The returned Set may be empty.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #subjectBNodes(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 */
 	public static Set<BNode> subjectBNodes(Model m) {
-		return m.subjects().stream().filter(s -> s instanceof BNode).map(s -> (BNode) s).collect(Collectors.toSet());
+		return subjectBNodes((Iterable<Statement>) m);
+	}
+
+	/**
+	 * Retrieves a predicate from the supplied statements. If more than one possible predicate value exists, any one
+	 * value is picked and returned.
+	 *
+	 * @param statements the {@link Statement} {@link Iterable} from which to retrieve a predicate value.
+	 * @return an {@link Optional} predicate value from the given model, which will be {@link Optional#empty() empty} if
+	 *         no such value exists.
+	 * @apiNote this method signature is new in 3.2.0, and is a generalization of {@link #predicate(Model)}.
+	 */
+	public static Optional<IRI> predicate(Iterable<Statement> statements) {
+		return StreamSupport.stream(statements.spliterator(), false).map(st -> st.getPredicate()).findAny();
 	}
 
 	/**
@@ -260,9 +489,11 @@ public class Models {
 	 * @param m the model from which to retrieve a predicate value.
 	 * @return an {@link Optional} predicate value from the given model, which will be {@link Optional#empty() empty} if
 	 *         no such value exists.
+	 * @apiNote replaced in 3.2.0 with the more generic {@link #predicate(Iterable)}. This method signature kept for
+	 *          binary compatibility.
 	 */
-	public static Optional<IRI> predicate(Iterable<Statement> m) {
-		return StreamSupport.stream(m.spliterator(), false).map(st -> st.getPredicate()).findAny();
+	public static Optional<IRI> predicate(Model m) {
+		return predicate((Iterable<Statement>) m);
 	}
 
 	/**

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -56,6 +56,12 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 		tupleExpr.visit(new JoinVisitor());
 	}
 
+	/**
+	 * 
+	 * @deprecated This class is protected for historic reasons only, and will be made private in a future major
+	 *             release.
+	 */
+	@Deprecated
 	protected class JoinVisitor extends AbstractQueryModelVisitor<RuntimeException> {
 
 		Set<String> boundVars = new HashSet<>();

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -393,6 +393,12 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 			return result;
 		}
 
+		@Deprecated
+		protected double getTupleExprCardinality(TupleExpr tupleExpr, Map<TupleExpr, Double> cardinalityMap,
+				Map<TupleExpr, List<Var>> varsMap, Map<Var, Integer> varFreqMap, Set<String> boundVars) {
+			return getTupleExprCost(tupleExpr, cardinalityMap, varsMap, varFreqMap, boundVars);
+		}
+
 		protected double getTupleExprCost(TupleExpr tupleExpr, Map<TupleExpr, Double> cardinalityMap,
 				Map<TupleExpr, List<Var>> varsMap, Map<Var, Integer> varFreqMap, Set<String> boundVars) {
 			double cost = cardinalityMap.get(tupleExpr);

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelVisitor.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelVisitor.java
@@ -170,9 +170,23 @@ public interface QueryModelVisitor<X extends Exception> {
 
 	public void meet(ZeroLengthPath node) throws X;
 
-	public void meet(TripleRef node) throws X;
+	/**
+	 * @implNote This temporary default method is only supplied as a stop-gap for backward compatibility. Concrete
+	 *           implementations are expected to override.
+	 * @since 3.2.0
+	 */
+	public default void meet(TripleRef node) throws X {
+		// no-op
+	}
 
-	public void meet(ValueExprTripleRef node) throws X;
+	/**
+	 * @implNote This temporary default method is only supplied as a stop-gap for backward compatibility. Concrete
+	 *           implementations are expected to override.
+	 * @since 3.2.0
+	 */
+	public default void meet(ValueExprTripleRef node) throws X {
+		// no-op
+	}
 
 	public void meetOther(QueryModelNode node) throws X;
 }

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
@@ -34,6 +34,7 @@ public abstract class AbstractQueryResultWriter implements QueryResultWriter {
 
 	/**
 	 * Default constructor.
+	 * 
 	 */
 	protected AbstractQueryResultWriter() {
 		this(null);
@@ -43,6 +44,7 @@ public abstract class AbstractQueryResultWriter implements QueryResultWriter {
 		this.outputStream = out;
 	}
 
+	@Override
 	public Optional<OutputStream> getOutputStream() {
 		return Optional.ofNullable(outputStream);
 	}
@@ -85,8 +87,14 @@ public abstract class AbstractQueryResultWriter implements QueryResultWriter {
 	 *
 	 * @param bindings the solution to handle
 	 * @throws TupleQueryResultHandlerException
+	 * 
+	 * @implNote this temporary implementation throws an {@link UnsupportedOperationException} and is only provided for
+	 *           backward compatility.
+	 * @since 3.2.0
 	 */
-	protected abstract void handleSolutionImpl(BindingSet bindings) throws TupleQueryResultHandlerException;
+	protected void handleSolutionImpl(BindingSet bindings) throws TupleQueryResultHandlerException {
+		throw new UnsupportedOperationException();
+	}
 
 	protected boolean xsdStringToPlainLiteral() {
 		return getWriterConfig().get(BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL);

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultWriter.java
@@ -32,8 +32,13 @@ public interface QueryResultWriter extends QueryResultHandler {
 	 * Gets the {@link OutputStream} this writer writes to, if it uses one.
 	 * 
 	 * @return an optional OutputStream
+	 * @implNote This temporary default method is only supplied as a stop-gap for backward compatibility. Concrete
+	 *           implementations are expected to override.
+	 * @since 3.2.0
 	 */
-	Optional<OutputStream> getOutputStream();
+	default Optional<OutputStream> getOutputStream() {
+		return Optional.empty();
+	}
 
 	/**
 	 * Handles a namespace prefix declaration. If this is called, it should be called before {@link #startDocument()} to

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormat.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormat.java
@@ -100,15 +100,41 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	/**
 	 * Creates a new TupleQueryResultFormat object.
 	 *
+	 * @param name     The name of the format, e.g. "SPARQL/XML".
+	 * @param mimeType The MIME type of the format, e.g. <tt>application/sparql-results+xml</tt> for the SPARQL/XML
+	 *                 format.
+	 * @param fileExt  The (default) file extension for the format, e.g. <tt>srx</tt> for SPARQL/XML.
+	 */
+	public TupleQueryResultFormat(String name, String mimeType, String fileExt) {
+		this(name, mimeType, null, fileExt, NO_RDF_STAR);
+	}
+
+	/**
+	 * Creates a new TupleQueryResultFormat object.
+	 *
 	 * @param name            The name of the format, e.g. "SPARQL/XML".
 	 * @param mimeType        The MIME type of the format, e.g. <tt>application/sparql-results+xml</tt> for the
 	 *                        SPARQL/XML format.
 	 * @param fileExt         The (default) file extension for the format, e.g. <tt>srx</tt> for SPARQL/XML.
 	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively
 	 *                        and <tt>false</tt> otherwise.
+	 * @since 3.2.0
 	 */
 	public TupleQueryResultFormat(String name, String mimeType, String fileExt, boolean supportsRDFStar) {
 		this(name, mimeType, null, fileExt, supportsRDFStar);
+	}
+
+	/**
+	 * Creates a new TupleQueryResultFormat object.
+	 *
+	 * @param name     The name of the format, e.g. "SPARQL/XML".
+	 * @param mimeType The MIME type of the format, e.g. <tt>application/sparql-results+xml</tt> for the SPARQL/XML
+	 *                 format.
+	 * @param charset  The default character encoding of the format. Specify <tt>null</tt> if not applicable.
+	 * @param fileExt  The (default) file extension for the format, e.g. <tt>srx</tt> for SPARQL/XML.
+	 */
+	public TupleQueryResultFormat(String name, String mimeType, Charset charset, String fileExt) {
+		this(name, mimeType, charset, fileExt, NO_RDF_STAR);
 	}
 
 	/**
@@ -121,11 +147,28 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 * @param fileExt         The (default) file extension for the format, e.g. <tt>srx</tt> for SPARQL/XML.
 	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively
 	 *                        and <tt>false</tt> otherwise.
+	 * @since 3.2.0
 	 */
 	public TupleQueryResultFormat(String name, String mimeType, Charset charset, String fileExt,
 			boolean supportsRDFStar) {
 		super(name, mimeType, charset, fileExt);
 		this.supportsRDFStar = supportsRDFStar;
+	}
+
+	/**
+	 * Creates a new TupleQueryResultFormat object.
+	 *
+	 * @param name           The name of the format, e.g. "SPARQL/XML".
+	 * @param mimeTypes      The MIME types of the format, e.g. <tt>application/sparql-results+xml</tt> for the
+	 *                       SPARQL/XML format. The first item in the list is interpreted as the default MIME type for
+	 *                       the format.
+	 * @param charset        The default character encoding of the format. Specify <tt>null</tt> if not applicable.
+	 * @param fileExtensions The format's file extensions, e.g. <tt>srx</tt> for SPARQL/XML files. The first item in the
+	 *                       list is interpreted as the default file extension for the format.
+	 */
+	public TupleQueryResultFormat(String name, Collection<String> mimeTypes, Charset charset,
+			Collection<String> fileExtensions) {
+		this(name, mimeTypes, charset, fileExtensions, NO_RDF_STAR);
 	}
 
 	/**
@@ -140,11 +183,31 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 *                        the list is interpreted as the default file extension for the format.
 	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively
 	 *                        and <tt>false</tt> otherwise.
+	 * @since 3.2.0
 	 */
 	public TupleQueryResultFormat(String name, Collection<String> mimeTypes, Charset charset,
 			Collection<String> fileExtensions, boolean supportsRDFStar) {
 		super(name, mimeTypes, charset, fileExtensions);
 		this.supportsRDFStar = supportsRDFStar;
+	}
+
+	/**
+	 * Creates a new TupleQueryResultFormat object.
+	 *
+	 * @param name           The name of the format, e.g. "SPARQL/XML".
+	 * @param mimeTypes      The MIME types of the format, e.g. <tt>application/sparql-results+xml</tt> for the
+	 *                       SPARQL/XML format. The first item in the list is interpreted as the default MIME type for
+	 *                       the format.
+	 * @param charset        The default character encoding of the format. Specify <tt>null</tt> if not applicable.
+	 * @param fileExtensions The format's file extensions, e.g. <tt>srx</tt> for SPARQL/XML files. The first item in the
+	 *                       list is interpreted as the default file extension for the format.
+	 * @param standardURI    The standard URI that has been assigned to this format by a standards organisation or null
+	 *                       if it does not currently have a standard URI.
+	 * @since 3.2.0
+	 */
+	public TupleQueryResultFormat(String name, Collection<String> mimeTypes, Charset charset,
+			Collection<String> fileExtensions, IRI standardURI) {
+		this(name, mimeTypes, charset, fileExtensions, standardURI, NO_RDF_STAR);
 	}
 
 	/**
@@ -161,6 +224,7 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 *                        if it does not currently have a standard URI.
 	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively
 	 *                        and <tt>false</tt> otherwise.
+	 * @since 3.2.0
 	 */
 	public TupleQueryResultFormat(String name, Collection<String> mimeTypes, Charset charset,
 			Collection<String> fileExtensions, IRI standardURI, boolean supportsRDFStar) {
@@ -174,6 +238,8 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 
 	/**
 	 * Return <tt>true</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively.
+	 * 
+	 * @since 3.2.0
 	 */
 	public boolean supportsRDFStar() {
 		return supportsRDFStar;

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFWriter.java
@@ -28,8 +28,13 @@ public interface RDFWriter extends RDFHandler {
 	 * Gets the {@link OutputStream} this writer writes to, if it uses one.
 	 * 
 	 * @return an optional OutputStream
+	 * @implNote This temporary default method is only supplied as a stop-gap for backward compatibility. Concrete
+	 *           implementations are expected to override.
+	 * @since 3.2.0
 	 */
-	public Optional<OutputStream> getOutputStream();
+	public default Optional<OutputStream> getOutputStream() {
+		return Optional.empty();
+	}
 
 	/**
 	 * Sets all supplied writer configuration options.

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
 		<httpcore.version>4.4.12</httpcore.version>
 		<jackson.version>2.9.9</jackson.version>
 		<jsonldjava.version>0.12.5</jsonldjava.version>
-		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
+		<last.japicmp.compare.version>3.1.4</last.japicmp.compare.version>
 		<jaxb.version>2.3.1</jaxb.version>
 		<solr.version>7.5.0</solr.version>
 		<elasticsearch.version>6.5.4</elasticsearch.version>
@@ -805,7 +805,7 @@
 				<plugin>
 					<groupId>com.github.siom79.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.14.0</version>
+					<version>0.14.3</version>
 					<configuration>
 						<oldVersion>
 							<dependency>
@@ -821,9 +821,25 @@
 							</file>
 						</newVersion>
 						<parameter>
-							<ignoreMissingClasses>true</ignoreMissingClasses>
-							<!-- necessary to allow removal of deprecated code -->
 							<onlyModified>true</onlyModified>
+							<breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+							<breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+							<excludes>
+								<exclude>@org.eclipse.rdf4j.common.annotation.InternalUseOnly</exclude>
+								<exclude>@org.eclipse.rdf4j.common.annotation.Experimental</exclude>
+							</excludes>
+							<overrideCompatibilityChangeParameters>
+								<overrideCompatibilityChangeParameter>
+									<compatibilityChange>METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE</compatibilityChange>
+									<binaryCompatible>true</binaryCompatible>
+									<sourceCompatible>true</sourceCompatible>
+								</overrideCompatibilityChangeParameter>
+								<overrideCompatibilityChangeParameter>
+									<compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
+									<binaryCompatible>true</binaryCompatible>
+									<sourceCompatible>true</sourceCompatible>
+								</overrideCompatibilityChangeParameter>
+							</overrideCompatibilityChangeParameters>
 						</parameter>
 					</configuration>
 					<executions>


### PR DESCRIPTION
GitHub issue resolved: #2143  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- modified several RDF* related changes to ensure reasonable defaults are in place
- modified several recent public and protected method changes to ensure binary compatibility
- configured [japicmp](https://siom79.github.io/japicmp/MavenPlugin.html) to check (and fail!) build on both source and binary compatibility with previous minor release. It ignore items annotated with InternalUseOnly or Experimental.  

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

