### PR TITLE
Gh 2151 nativestore datastore benchmarks

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataFile.java
@@ -191,6 +191,10 @@ public class DataFile implements Closeable {
 		}
 	}
 
+	public void sync(boolean force) throws IOException {
+		nioFile.force(force);
+	}
+
 	/**
 	 * Closes the data file, releasing any file locks that it might have.
 	 *

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFile.java
@@ -190,10 +190,9 @@ public class HashFile implements Closeable {
 	}
 
 	private void storeID(long bucketOffset, int hash, int id) throws IOException {
-		boolean idStored = false;
 		ByteBuffer bucket = ByteBuffer.allocate(recordSize);
 
-		while (!idStored) {
+		while (true) {
 			nioFile.read(bucket, bucketOffset);
 
 			// Find first empty slot in bucket
@@ -205,7 +204,7 @@ public class HashFile implements Closeable {
 				bucket.putInt(ITEM_SIZE * slotID + 4, id);
 				bucket.rewind();
 				nioFile.write(bucket, bucketOffset);
-				idStored = true;
+				break;
 			} else {
 				// No empty slot found, check if bucket has an overflow bucket
 				int overflowID = bucket.getInt(ITEM_SIZE * bucketSize);

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/IDFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/IDFile.java
@@ -237,7 +237,7 @@ public class IDFile implements Closeable {
 	public void clear() throws IOException {
 		nioFile.truncate(HEADER_LENGTH);
 		nioFileSize = nioFile.size();
-		cache.clear();
+		clearCache();
 	}
 
 	/**
@@ -247,6 +247,10 @@ public class IDFile implements Closeable {
 		if (forceSync) {
 			nioFile.force(false);
 		}
+	}
+
+	public void sync(boolean force) throws IOException {
+		nioFile.force(false);
 	}
 
 	/**
@@ -284,4 +288,11 @@ public class IDFile implements Closeable {
 		}
 		return cacheLine;
 	}
+
+	synchronized public void clearCache() {
+		cache.clear();
+		gcReducingCacheIndex = -1;
+		gcReducingCache = null;
+	}
+
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/HashFileBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/HashFileBenchmark.java
@@ -37,10 +37,10 @@ import org.openjdk.jmh.annotations.Warmup;
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 10)
+@Warmup(iterations = 20)
 @BenchmarkMode({ Mode.AverageTime })
 @Fork(value = 1, jvmArgs = { "-Xms256M", "-Xmx256M", "-XX:+UseG1GC" })
-//@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G",  "-XX:+UseG1GC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+//@Fork(value = 1, jvmArgs = {"-Xms256M", "-Xmx256M", "-XX:+UseG1GC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
 @Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class HashFileBenchmark {
@@ -52,10 +52,6 @@ public class HashFileBenchmark {
 	private static List<Integer> hashes;
 	private File tempFolder;
 	private HashFile hashFile;
-
-	private static InputStream getResourceAsStream(String name) {
-		return HashFileBenchmark.class.getClassLoader().getResourceAsStream(name);
-	}
 
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/HashFileBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/HashFileBenchmark.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.nativerdf.benchmark;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.util.Files;
+import org.eclipse.rdf4j.sail.nativerdf.datastore.HashFile;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 10)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms256M", "-Xmx256M", "-XX:+UseG1GC" })
+//@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G",  "-XX:+UseG1GC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class HashFileBenchmark {
+
+	// May be interesting to test without OS disk cache. For OSX use: watch --interval=0.1 sudo purge
+
+	public static final int RANDOM_SEED = 524826405;
+	private static final int COUNT = 1_000_000;
+	private static List<Integer> hashes;
+	private File tempFolder;
+	private HashFile hashFile;
+
+	private static InputStream getResourceAsStream(String name) {
+		return HashFileBenchmark.class.getClassLoader().getResourceAsStream(name);
+	}
+
+	@Setup(Level.Trial)
+	public void beforeClass() throws IOException {
+
+		tempFolder = Files.newTemporaryFolder();
+
+		File file = File.createTempFile("hashfile", "hash", tempFolder);
+
+		hashFile = new HashFile(file, false, (int) (COUNT / .75f) + 1);
+		Random random = new Random(RANDOM_SEED);
+
+		hashes = new ArrayList<>();
+
+		for (int i = 0; i < COUNT; i++) {
+			int hash = random.nextInt();
+			hashes.add(hash);
+			hashFile.storeID(hash, i);
+		}
+
+		hashFile.sync(true);
+
+		System.gc();
+
+	}
+
+	@TearDown(Level.Trial)
+	public void afterClass() throws IOException {
+
+		try {
+			hashFile.close();
+		} finally {
+			FileUtils.deleteDirectory(tempFolder);
+		}
+
+	}
+
+	@Benchmark
+	public long readNoMissesReadOneTenth() throws IOException {
+		long count = 0;
+
+		ArrayList<Integer> integers = new ArrayList<>(hashes);
+
+		Collections.shuffle(integers, new Random(RANDOM_SEED));
+
+		for (int i = 0; i < integers.size(); i += 10) {
+
+			HashFile.IDIterator idIterator = hashFile.getIDIterator(integers.get(i));
+
+			while (true) {
+				int next = idIterator.next();
+				if (next >= 0) {
+					count++;
+				} else {
+					break;
+				}
+			}
+
+			idIterator.close();
+
+		}
+
+		return count;
+	}
+
+	@Benchmark
+	public long readNoMisses() throws IOException {
+		long count = 0;
+
+		ArrayList<Integer> shuffledHashes = new ArrayList<>(hashes);
+
+		Collections.shuffle(shuffledHashes, new Random(RANDOM_SEED));
+
+		for (Integer integer : shuffledHashes) {
+
+			HashFile.IDIterator idIterator = hashFile.getIDIterator(integer);
+
+			while (true) {
+				int next = idIterator.next();
+				if (next >= 0) {
+					count++;
+				} else {
+					break;
+				}
+			}
+
+			idIterator.close();
+
+		}
+
+		return count;
+	}
+
+	@Benchmark
+	public long readHighMissCount() throws IOException {
+
+		Random random = new Random(RANDOM_SEED + 21483);
+
+		long count = 0;
+		for (int i = 0; i < COUNT; i++) {
+			HashFile.IDIterator idIterator = hashFile.getIDIterator(random.nextInt());
+
+			while (true) {
+				int next = idIterator.next();
+				if (next >= 0) {
+					count++;
+				} else {
+					break;
+				}
+			}
+
+			idIterator.close();
+
+		}
+
+		return count;
+
+	}
+
+	@Benchmark()
+	public int fillHashfileKnownSize() throws IOException {
+		int testSize = COUNT / 10;
+
+		File file = File.createTempFile("hashfile", "hash", tempFolder);
+
+		try (HashFile hashFile = new HashFile(file, false, (int) (testSize / .75f) + 1)) {
+
+			Random random = new Random(RANDOM_SEED);
+
+			for (int i = 0; i < testSize; i++) {
+				int hash = random.nextInt();
+				hashFile.storeID(hash, i);
+			}
+
+			return hashFile.getItemCount();
+		} finally {
+			file.delete();
+		}
+
+	}
+
+	@Benchmark()
+	public int fillHashfileUnknownSize() throws IOException {
+		int testSize = COUNT / 10;
+
+		File file = File.createTempFile("hashfile", "hash", tempFolder);
+
+		try (HashFile hashFile = new HashFile(file, false)) {
+			Random random = new Random(RANDOM_SEED);
+
+			for (int i = 0; i < testSize; i++) {
+				int hash = random.nextInt();
+				hashFile.storeID(hash, i);
+			}
+
+			return hashFile.getItemCount();
+		} finally {
+			file.delete();
+		}
+
+	}
+
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/IDFileBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/IDFileBenchmark.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.nativerdf.benchmark;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.util.Files;
+import org.eclipse.rdf4j.sail.nativerdf.datastore.IDFile;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 20)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms256M", "-Xmx256M", "-XX:+UseG1GC" })
+//@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G",  "-XX:+UseG1GC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class IDFileBenchmark {
+
+	// May be interesting to test without OS disk cache. For OSX use: watch --interval=0.1 sudo purge
+
+	public static final int RANDOM_SEED = 524826405;
+	private static final int COUNT = 1_000_000;
+	private File tempFolder;
+	private IDFile idFile;
+
+	private static InputStream getResourceAsStream(String name) {
+		return IDFileBenchmark.class.getClassLoader().getResourceAsStream(name);
+	}
+
+	@Setup(Level.Trial)
+	public void beforeClass() throws IOException {
+
+		tempFolder = Files.newTemporaryFolder();
+
+		File file = File.createTempFile("idfile", "id", tempFolder);
+
+		idFile = new IDFile(file);
+
+		for (int i = 0; i < COUNT * 8; i++) {
+			idFile.storeOffset(i);
+		}
+
+		idFile.sync(true);
+
+		System.gc();
+
+	}
+
+	@TearDown(Level.Trial)
+	public void afterClass() throws IOException {
+
+		try {
+			idFile.close();
+		} finally {
+			FileUtils.deleteDirectory(tempFolder);
+		}
+
+	}
+
+	@Benchmark
+	public long addAndRead() throws IOException {
+
+		File file = File.createTempFile("idfile", "id", tempFolder);
+
+		int writeCount = COUNT / 10;
+
+		IDFile idFile = new IDFile(file);
+
+		for (int i = 0; i < writeCount * 8; i++) {
+			idFile.storeOffset(i);
+		}
+
+		idFile.clearCache();
+
+		Random random = new Random(RANDOM_SEED);
+
+		long sum = 0;
+		for (int i = 0; i < writeCount; i++) {
+			sum += idFile.getOffset(random.nextInt(writeCount));
+		}
+
+		idFile.close();
+
+		boolean delete = file.delete();
+
+		return sum;
+
+	}
+
+	@Benchmark
+	public long read() throws IOException {
+
+		idFile.clearCache();
+
+		Random random = new Random(RANDOM_SEED);
+
+		long sum = 0;
+		for (int i = 0; i < COUNT; i++) {
+			sum += idFile.getOffset(random.nextInt(COUNT));
+		}
+
+		return sum;
+
+	}
+
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/Main.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/Main.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.nativerdf.benchmark;
+
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * @author Håvard Ottestad
+ */
+
+public class Main {
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("")
+//				.include("HashFileBenchmark.fillHashfileKnownSize$").forks(0)
+				.build();
+
+		new Runner(opt).run();
+	}
+
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/Main.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/Main.java
@@ -22,7 +22,8 @@ public class Main {
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
 				.include("")
-//				.include("HashFileBenchmark.fillHashfileKnownSize$").forks(0)
+//				.include("DataFileBenchmark.write$")
+//				.forks(0)
 				.build();
 
 		new Runner(opt).run();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
@@ -50,7 +50,7 @@ public class TransactionsPerSecondBenchmark {
 	SailRepositoryConnection connection;
 	int i;
 
-	@Setup(Level.Invocation)
+	@Setup(Level.Iteration)
 	public void beforeClass() {
 		if (connection != null) {
 			connection.close();
@@ -68,7 +68,7 @@ public class TransactionsPerSecondBenchmark {
 
 	}
 
-	@TearDown(Level.Invocation)
+	@TearDown(Level.Iteration)
 	public void afterClass() throws IOException {
 		if (connection != null) {
 			connection.close();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
@@ -50,7 +50,7 @@ public class TransactionsPerSecondForceSyncBenchmark {
 	SailRepositoryConnection connection;
 	int i;
 
-	@Setup(Level.Invocation)
+	@Setup(Level.Iteration)
 	public void beforeClass() {
 		if (connection != null) {
 			connection.close();
@@ -68,7 +68,7 @@ public class TransactionsPerSecondForceSyncBenchmark {
 
 	}
 
-	@TearDown(Level.Invocation)
+	@TearDown(Level.Iteration)
 	public void afterClass() throws IOException {
 		if (connection != null) {
 			connection.close();


### PR DESCRIPTION
GitHub issue resolved: #2151 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Some benchmarks for the lower level file operations in NativeStore and a couple of tweaks to control caching and syncing better as well as support for specifying the initial size of the HashFile.

---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

