### PR TITLE
GH-2119 nodes that introduce a new scope get a "new scope" label in the query plan

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/explanation/GenericPlanNode.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/explanation/GenericPlanNode.java
@@ -206,7 +206,7 @@ public class GenericPlanNode {
 
 	/**
 	 * Join nodes can use various algorithms for joining data.
-	 * 
+	 *
 	 * @return the name of the algorithm.
 	 */
 	public String getAlgorithm() {
@@ -246,9 +246,7 @@ public class GenericPlanNode {
 		}
 		appendCostAnnotation(sb);
 		sb.append(newLine);
-		plans.forEach(child -> sb.append(Arrays.stream(
-				child.toString()
-						.split(newLine))
+		plans.forEach(child -> sb.append(Arrays.stream(child.toString().split(newLine))
 				.map(c -> "   " + c)
 				.reduce((a, b) -> a + newLine + b)
 				.orElse("") + newLine));

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryCostEstimatesTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryCostEstimatesTest.java
@@ -52,7 +52,7 @@ public class QueryCostEstimatesTest {
 				"                  Var (name=_const_5c6ba45_uri, value=ex:s1, anonymous)\n" +
 				"                  Var (name=_const_af00e088_uri, value=ex:pred, anonymous)\n" +
 				"                  Var (name=v)\n" +
-				"               LeftJoin (costEstimate=1000, resultSizeEstimate=1000)\n" +
+				"               LeftJoin (new scope) (costEstimate=1000, resultSizeEstimate=1000)\n" +
 				"                  StatementPattern (resultSizeEstimate=1000)\n" +
 				"                     Var (name=s)\n" +
 				"                     Var (name=p)\n" +

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -101,6 +101,9 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 	 */
 	@Override
 	public String getSignature() {
+		if (isGraphPatternGroup) {
+			return this.getClass().getSimpleName() + " (new scope)";
+		}
 		return this.getClass().getSimpleName();
 	}
 

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BinaryTupleOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BinaryTupleOperator.java
@@ -143,6 +143,7 @@ public abstract class BinaryTupleOperator extends AbstractQueryModelNode impleme
 		this.algorithmName = iteration.getClass().getSimpleName();
 	}
 
+	@Experimental
 	public String getAlgorithmName() {
 		return algorithmName;
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreePrinter.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreePrinter.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.algebra.helpers;
 import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
+import org.eclipse.rdf4j.query.algebra.BinaryTupleOperator;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 
 /**
@@ -68,10 +69,20 @@ public class QueryModelTreePrinter extends AbstractQueryModelVisitor<RuntimeExce
 		}
 
 		sb.append(node.getSignature());
+
 		if (node instanceof AbstractQueryModelNode) {
-			if (((AbstractQueryModelNode) node).isVariableScopeChange())
+			if (((AbstractQueryModelNode) node).isVariableScopeChange()) {
 				sb.append(" (new scope)");
+			}
 		}
+
+		if (node instanceof BinaryTupleOperator) {
+			String algorithmName = ((BinaryTupleOperator) node).getAlgorithmName();
+			if (algorithmName != null) {
+				sb.append(" (").append(algorithmName).append(")");
+			}
+		}
+
 		appendCostAnnotation(node, sb);
 		sb.append(LINE_SEPARATOR);
 

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreePrinter.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreePrinter.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
 import org.eclipse.rdf4j.query.algebra.BinaryTupleOperator;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.VariableScopeChange;
 
 /**
  * QueryModelVisitor implementation that "prints" a tree representation of a query model. The tree representations is
@@ -70,8 +71,8 @@ public class QueryModelTreePrinter extends AbstractQueryModelVisitor<RuntimeExce
 
 		sb.append(node.getSignature());
 
-		if (node instanceof AbstractQueryModelNode) {
-			if (((AbstractQueryModelNode) node).isVariableScopeChange()) {
+		if (node instanceof VariableScopeChange) {
+			if (((VariableScopeChange) node).isVariableScopeChange()) {
 				sb.append(" (new scope)");
 			}
 		}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreeToGenericPlanNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreeToGenericPlanNode.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
 import org.eclipse.rdf4j.query.algebra.BinaryTupleOperator;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.VariableScopeChange;
 import org.eclipse.rdf4j.query.explanation.GenericPlanNode;
 
 /**
@@ -43,8 +44,8 @@ public class QueryModelTreeToGenericPlanNode extends AbstractQueryModelVisitor<R
 		genericPlanNode.setCostEstimate(node.getCostEstimate());
 		genericPlanNode.setResultSizeEstimate(node.getResultSizeEstimate());
 		genericPlanNode.setResultSizeActual(node.getResultSizeActual());
-		if (node instanceof AbstractQueryModelNode) {
-			boolean newScope = ((AbstractQueryModelNode) node).isVariableScopeChange();
+		if (node instanceof VariableScopeChange) {
+			boolean newScope = ((VariableScopeChange) node).isVariableScopeChange();
 			genericPlanNode.setNewScope(newScope);
 		}
 

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_1.txt
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_Join_1.txt
@@ -3,7 +3,7 @@ QueryRoot
       ProjectionElemList
          ProjectionElem "person"
       NUnion
-         Extension
+         Extension (new scope)
             ExtensionElem (nameOut)
                Var (name=name)
             EmptyNJoin


### PR DESCRIPTION
GitHub issue resolved: #2119 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - newScope variable in the generic plan node
 - algorithm variable in the generic plan node (should have been there all along)
 - modifications to the old query plan printer

<!-- short description of your change goes here -->

---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

