### PR TITLE
GH-2167: make FedX WriteStrategy configurable

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.endpoint.ResolvableEndpoint;
 import org.eclipse.rdf4j.federated.exception.ExceptionUtil;
 import org.eclipse.rdf4j.federated.exception.FedXException;
+import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
 import org.eclipse.rdf4j.federated.util.FedXUtil;
 import org.eclipse.rdf4j.federated.write.ReadOnlyWriteStrategy;
 import org.eclipse.rdf4j.federated.write.RepositoryWriteStrategy;
@@ -98,14 +99,17 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 	 * {@link Endpoint}. In none is found, the {@link ReadOnlyWriteStrategy} is used.
 	 * 
 	 * @return the {@link WriteStrategy}
+	 * @throws FedXRuntimeException if the {@link WriteStrategy} could not be created
 	 */
 	public WriteStrategy getWriteStrategy() {
-		for (Endpoint e : members) {
-			if (e.isWritable()) {
-				return new RepositoryWriteStrategy(e.getRepository());
-			}
+		try {
+			return federationContext.getConfig()
+					.getWriteStrategyFactory()
+					.newInstance()
+					.create(members, federationContext);
+		} catch (Exception e) {
+			throw new FedXRuntimeException("Failed to instantiate write strategy: " + e.getMessage(), e);
 		}
-		return ReadOnlyWriteStrategy.INSTANCE;
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -15,6 +15,8 @@ import org.eclipse.rdf4j.federated.evaluation.SparqlFederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
 import org.eclipse.rdf4j.federated.monitoring.QueryLog;
 import org.eclipse.rdf4j.federated.monitoring.QueryPlanLog;
+import org.eclipse.rdf4j.federated.write.DefaultWriteStrategyFactory;
+import org.eclipse.rdf4j.federated.write.WriteStrategyFactory;
 import org.eclipse.rdf4j.query.Operation;
 import org.eclipse.rdf4j.query.Query;
 
@@ -56,6 +58,8 @@ public class FedXConfig {
 	private Class<? extends FederationEvalStrategy> sailEvaluationStrategy = SailFederationEvalStrategy.class;
 
 	private Class<? extends FederationEvalStrategy> sparqlEvaluationStrategy = SparqlFederationEvalStrategy.class;
+
+	private Class<? extends WriteStrategyFactory> writeStrategyFactory = DefaultWriteStrategyFactory.class;
 
 	private String prefixDeclarations = null;
 
@@ -118,6 +122,17 @@ public class FedXConfig {
 	 */
 	public FedXConfig withSailEvaluationStrategy(Class<? extends FederationEvalStrategy> sailEvaluationStrategy) {
 		this.sailEvaluationStrategy = sailEvaluationStrategy;
+		return this;
+	}
+
+	/**
+	 * Set the {@link WriteStrategyFactory} to be used.
+	 * 
+	 * @param writeStrategyFactory
+	 * @return the current config
+	 */
+	public FedXConfig withWriteStrategyFactory(Class<? extends WriteStrategyFactory> writeStrategyFactory) {
+		this.writeStrategyFactory = writeStrategyFactory;
 		return this;
 	}
 
@@ -441,6 +456,19 @@ public class FedXConfig {
 	 */
 	public Class<? extends FederationEvalStrategy> getSPARQLEvaluationStrategy() {
 		return sparqlEvaluationStrategy;
+	}
+
+	/**
+	 * Returns the class of the {@link WriteStrategyFactory} implementation.
+	 * 
+	 * <p>
+	 * Default: {@link DefaultWriteStrategyFactory}
+	 * </p>
+	 * 
+	 * @return the {@link WriteStrategyFactory} class
+	 */
+	public Class<? extends WriteStrategyFactory> getWriteStrategyFactory() {
+		return writeStrategyFactory;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/DefaultWriteStrategyFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/DefaultWriteStrategyFactory.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.write;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.federated.endpoint.Endpoint;
+
+/**
+ * Default implementation of {@link WriteStrategyFactory}.
+ * 
+ * <p>
+ * The default implementation uses the {@link RepositoryWriteStrategy} with the first discovered writable
+ * {@link Endpoint}. In none is found, the {@link ReadOnlyWriteStrategy} is used.
+ * </p>
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public class DefaultWriteStrategyFactory implements WriteStrategyFactory {
+
+	@Override
+	public WriteStrategy create(List<Endpoint> members, FederationContext federationContext) {
+		for (Endpoint e : members) {
+			if (e.isWritable()) {
+				return new RepositoryWriteStrategy(e.getRepository());
+			}
+		}
+		return ReadOnlyWriteStrategy.INSTANCE;
+	}
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/WriteStrategyFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/WriteStrategyFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.write;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.federated.endpoint.Endpoint;
+
+/**
+ * Factory to create {@link WriteStrategy} instantiations.
+ * 
+ * <p>
+ * Implementations must have a default constructor.
+ * </p>
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public interface WriteStrategyFactory {
+
+	/**
+	 * Create the {@link WriteStrategy} using the provided context
+	 * 
+	 * @param members           the current federation members
+	 * @param federationContext the federation context
+	 * @return the {@link WriteStrategy}
+	 */
+	public WriteStrategy create(List<Endpoint> members, FederationContext federationContext);
+}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/WriteTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/WriteTest.java
@@ -10,20 +10,26 @@ package org.eclipse.rdf4j.federated.write;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.SPARQLBaseTest;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.endpoint.EndpointBase;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -161,9 +167,61 @@ public class WriteTest extends SPARQLBaseTest {
 		}
 	}
 
+	@Test
+	public void testCustomWriteStrategy() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/basic/data_emptyStore.ttl", "/tests/basic/data_emptyStore.ttl"));
+
+		// configure the test write strategy factory
+		fedxRule.getFederationContext().getConfig().withWriteStrategyFactory(TestWriteStrategyFactory.class);
+
+		try (RepositoryConnection conn = fedxRule.getRepository().getConnection()) {
+			Update update = conn.prepareUpdate(QueryLanguage.SPARQL,
+					"PREFIX : <http://example.org/> INSERT { :subject a :Person } WHERE { }");
+			update.execute();
+
+			// test that statement is returned from federation
+			List<Statement> stmts = Iterations.asList(conn.getStatements(null, null, null, true));
+			Assertions.assertEquals(1, stmts.size());
+			Assertions.assertEquals(RDF.TYPE, stmts.get(0).getPredicate());
+
+			Assertions.assertEquals(1, writeOperations.get());
+		}
+	}
+
 	protected Statement simpleStatement() {
 		ValueFactory vf = SimpleValueFactory.getInstance();
 		IRI subject = vf.createIRI("http://example.org/person1");
 		return vf.createStatement(subject, RDF.TYPE, FOAF.PERSON);
+	}
+
+	@BeforeEach
+	public void clearWriteOperations() throws Exception {
+		writeOperations.set(0);
+	}
+
+	// write operations done
+	static final AtomicInteger writeOperations = new AtomicInteger(0);
+
+	public static class TestWriteStrategyFactory implements WriteStrategyFactory {
+
+		@Override
+		public WriteStrategy create(List<Endpoint> members, FederationContext federationContext) {
+			return new TestWriteStrategy(members.get(0).getRepository());
+		}
+	}
+
+	static class TestWriteStrategy extends RepositoryWriteStrategy {
+
+		public TestWriteStrategy(Repository writeRepository) {
+			super(writeRepository);
+		}
+
+		@Override
+		public void addStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws RepositoryException {
+			writeOperations.incrementAndGet();
+			super.addStatement(subj, pred, obj, contexts);
+		}
+
 	}
 }


### PR DESCRIPTION
This change makes the FedX WriteStrategy configurable (e.g. for
application developers who want to define a different implementation).

Default behavior remains as before.

Functionality is covered with a unit test.


GitHub issue resolved: #2167 

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

