### PR TITLE
GH-2169: support to propagate SERVICE clauses to SingleSourceQuery

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -80,6 +80,7 @@ import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.eclipse.rdf4j.query.algebra.Service;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
@@ -188,7 +189,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 		info.optimize(query);
 
 		// if the federation has a single member only, evaluate the entire query there
-		if (members.size() == 1 && queryInfo.getQuery() != null && !info.hasService()
+		if (members.size() == 1 && queryInfo.getQuery() != null && propagateServices(info.getServices())
 				&& queryInfo.getQueryType() != QueryType.UPDATE)
 			return new SingleSourceQuery(expr, members.get(0), queryInfo);
 
@@ -196,7 +197,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 			log.trace("Query before Optimization: " + query);
 		}
 
-		/* original sesame optimizers */
+		/* original RDF4J optimizers */
 		new ConstantOptimizer(this).optimize(query, dataset, bindings); // maybe remove this optimizer later
 
 		new DisjunctiveConstraintOptimizer().optimize(query, dataset, bindings);
@@ -208,11 +209,12 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 
 		/* custom optimizers, execute only when needed */
 
-		// if the query has a single relevant source (and if it is no a SERVICE query), evaluate at this source only
+		// if the query has a single relevant source (and if it is not a SERVICE query), evaluate at this source only
 		// Note: UPDATE queries are always handled in the federation engine to adhere to the configured
 		// write strategy
 		Set<Endpoint> relevantSources = performSourceSelection(members, cache, queryInfo, info);
-		if (relevantSources.size() == 1 && !info.hasService() && queryInfo.getQueryType() != QueryType.UPDATE)
+		if (relevantSources.size() == 1 && propagateServices(info.getServices())
+				&& queryInfo.getQueryType() != QueryType.UPDATE)
 			return new SingleSourceQuery(query, relevantSources.iterator().next(), queryInfo);
 
 		if (info.hasService())
@@ -269,6 +271,25 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 	protected void optimizeJoinOrder(TupleExpr query, QueryInfo queryInfo, GenericInfoOptimizer info) {
 		// optimize statement groups and join order
 		new StatementGroupAndJoinOptimizer(queryInfo, DefaultFedXCostModel.INSTANCE).optimize(query);
+	}
+
+	/**
+	 * Whether to propagate a {@link SingleSourceQuery} containing SERVICE clauses. By default, the query is always
+	 * evaluated within the FedX engine if it contains a SERVICE clause.
+	 * <p>
+	 * Customized implementation may propagate a {@link SingleSourceQuery} including the SERVICE clause (e.g. for
+	 * Wikidata the Label service can only be accessed in the wikidata endpoint.
+	 * </p>
+	 * 
+	 * @param serviceNodes
+	 * @return if <code>true</code>, a {@link SingleSourceQuery} containing SERVICE clauses is propagated as-is
+	 */
+	protected boolean propagateServices(List<Service> serviceNodes) {
+		boolean hasServices = serviceNodes != null && !serviceNodes.isEmpty();
+		if (hasServices) {
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.federated.optimizer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.rdf4j.federated.algebra.FedXLeftJoin;
@@ -38,7 +39,7 @@ public class GenericInfoOptimizer extends AbstractQueryModelVisitor<Optimization
 
 	protected boolean hasFilter = false;
 	protected boolean hasUnion = false;
-	protected boolean hasService = false;
+	protected List<Service> services = null;
 	protected long limit = -1; // set to a positive number if the main query has a limit
 	protected List<StatementPattern> stmts = new ArrayList<>();
 
@@ -99,7 +100,10 @@ public class GenericInfoOptimizer extends AbstractQueryModelVisitor<Optimization
 
 	@Override
 	public void meet(Service service) {
-		hasService = true;
+		if (services == null) {
+			services = new ArrayList<Service>();
+		}
+		services.add(service);
 	}
 
 	@Override
@@ -149,6 +153,10 @@ public class GenericInfoOptimizer extends AbstractQueryModelVisitor<Optimization
 	}
 
 	public boolean hasService() {
-		return hasService;
+		return services != null && services.size() > 0;
+	}
+
+	public List<Service> getServices() {
+		return services == null ? Collections.emptyList() : services;
 	}
 }


### PR DESCRIPTION
This change supports extensibility of the evaluation strategy to
potentially propagate SERVICE clauses as part of SingleSourceQueries.

Existing functionality is remaining as-is.

Note that existing functionality is already covered with unit tests.



GitHub issue resolved: #2169 

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

