### PR TITLE
GH-2171 AST nodes now determine if node is scope change

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizer.java
@@ -68,7 +68,7 @@ public class QueryModelNormalizer extends AbstractQueryModelVisitor<RuntimeExcep
 			Join leftJoin = new Join(union.getLeftArg(), rightArg.clone());
 			Join rightJoin = new Join(union.getRightArg(), rightArg.clone());
 			Union newUnion = new Union(leftJoin, rightJoin);
-			newUnion.setGraphPatternGroup(union.isGraphPatternGroup());
+			newUnion.setVariableScopeChange(union.isVariableScopeChange());
 			join.replaceWith(newUnion);
 			newUnion.visit(this);
 		} else if (rightArg instanceof Union) {
@@ -77,7 +77,7 @@ public class QueryModelNormalizer extends AbstractQueryModelVisitor<RuntimeExcep
 			Join leftJoin = new Join(leftArg.clone(), union.getLeftArg());
 			Join rightJoin = new Join(leftArg.clone(), union.getRightArg());
 			Union newUnion = new Union(leftJoin, rightJoin);
-			newUnion.setGraphPatternGroup(union.isGraphPatternGroup());
+			newUnion.setVariableScopeChange(union.isVariableScopeChange());
 			join.replaceWith(newUnion);
 			newUnion.visit(this);
 		} else if (leftArg instanceof LeftJoin && isWellDesigned(((LeftJoin) leftArg))) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -849,7 +849,7 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 	}
 
 	private boolean isOutOfScopeForLeftArgBindings(TupleExpr expr) {
-		return (TupleExprs.isGraphPatternGroup(expr) || TupleExprs.containsSubquery(expr));
+		return (TupleExprs.isVariableScopeChange(expr) || TupleExprs.containsSubquery(expr));
 	}
 
 	public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(LeftJoin leftJoin,

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.query.algebra.helpers.QueryModelTreePrinter;
 /**
  * Base implementation of {@link QueryModelNode}.
  */
-public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPatternGroupable {
+public abstract class AbstractQueryModelNode implements QueryModelNode, VariableScopeChange, GraphPatternGroupable {
 
 	/*-----------*
 	 * Variables *
@@ -25,7 +25,7 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 
 	private QueryModelNode parent;
 
-	private boolean isGraphPatternGroup;
+	private boolean isVariableScopeChange;
 
 	/*---------*
 	 * Methods *
@@ -41,24 +41,26 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 		this.parent = parent;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.eclipse.rdf4j.query.algebra.GraphPatternGroupable#isGraphPatternGroup()
-	 */
 	@Override
-	public boolean isGraphPatternGroup() {
-		return isGraphPatternGroup;
+	public boolean isVariableScopeChange() {
+		return isVariableScopeChange;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.eclipse.rdf4j.query.algebra.GraphPatternGroupable#setGraphPatternGroup(boolean)
-	 */
 	@Override
+	public void setVariableScopeChange(boolean isVariableScopeChange) {
+		this.isVariableScopeChange = isVariableScopeChange;
+	}
+
+	@Override
+	@Deprecated
+	public boolean isGraphPatternGroup() {
+		return isVariableScopeChange();
+	}
+
+	@Override
+	@Deprecated
 	public void setGraphPatternGroup(boolean isGraphPatternGroup) {
-		this.isGraphPatternGroup = isGraphPatternGroup;
+		setVariableScopeChange(isGraphPatternGroup);
 	}
 
 	/**
@@ -110,7 +112,7 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, GraphPat
 	public AbstractQueryModelNode clone() {
 		try {
 			AbstractQueryModelNode clone = (AbstractQueryModelNode) super.clone();
-			clone.setGraphPatternGroup(this.isGraphPatternGroup());
+			clone.setVariableScopeChange(this.isVariableScopeChange());
 			return clone;
 		} catch (CloneNotSupportedException e) {
 			throw new RuntimeException("Query model nodes are required to be cloneable", e);

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Projection.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Projection.java
@@ -132,5 +132,4 @@ public class Projection extends UnaryTupleOperator {
 	public void setSubquery(boolean subquery) {
 		this.subquery = subquery;
 	}
-
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/VariableScopeChange.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/VariableScopeChange.java
@@ -8,27 +8,23 @@
 package org.eclipse.rdf4j.query.algebra;
 
 /**
+ * {@link QueryModelNode}s that can constitute a variable scope change (such as group graph patterns, subselects, etc).
  * 
- * @author jeen
- *
- * @deprecated since 3.2. Use {@link VariableScopeChange} instead.
+ * @author Jeen Broekstra
  */
-@Deprecated
-public interface GraphPatternGroupable {
+public interface VariableScopeChange {
 
 	/**
-	 * indicates if the node represents the root of a graph pattern group.
+	 * indicates if the node represents a variable scope change.
 	 * 
-	 * @return true iff the node represents the node of a graph pattern group.
+	 * @return true iff the node represents a variable scope change.
 	 *
 	 */
-	@Deprecated
-	boolean isGraphPatternGroup();
+	public boolean isVariableScopeChange();
 
 	/**
-	 * Set the value of {@link #isGraphPatternGroup()} to true or false.
+	 * Set the value of {@link #isVariableScopeChange()} to true or false.
 	 */
-	@Deprecated
-	void setGraphPatternGroup(boolean isGraphPatternGroup);
+	public void setVariableScopeChange(boolean isVariableScopeChange);
 
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprs.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprs.java
@@ -24,6 +24,7 @@ import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.VariableScopeChange;
 
 /**
  * Utility methods for {@link TupleExpr} objects.
@@ -60,12 +61,29 @@ public class TupleExprs {
 	}
 
 	/**
+	 * Verifies if the supplied {@link TupleExpr} represents a variable scope change.
+	 * 
+	 * @param expr a {@link TupleExpr}
+	 * @return <code>true</code> if the {@link TupleExpr} implements {@link VariableScopeChange} and has its scope
+	 *         change flag set to <code>true</code>, <code>false</code> otherwise.
+	 */
+	public static boolean isVariableScopeChange(TupleExpr expr) {
+		if (expr instanceof VariableScopeChange) {
+			return ((VariableScopeChange) expr).isVariableScopeChange();
+		}
+		return false;
+	}
+
+	/**
 	 * Verifies if the supplied {@link TupleExpr} represents a group graph pattern.
 	 * 
 	 * @param expr a {@link TupleExpr}
 	 * @return <code>true</code> if the {@link TupleExpr} is {@link GraphPatternGroupable} and has its graph pattern
 	 *         group flag set to <code>true</code>, <code>false</code> otherwise.
+	 * 
+	 * @deprecated since 3.2. Use {@link #isVariableScopeChange(TupleExpr)} instead.
 	 */
+	@Deprecated
 	public static boolean isGraphPatternGroup(TupleExpr expr) {
 		if (expr instanceof GraphPatternGroupable) {
 			return ((GraphPatternGroupable) expr).isGraphPatternGroup();

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -91,6 +91,7 @@ import org.eclipse.rdf4j.query.algebra.Union;
 import org.eclipse.rdf4j.query.algebra.ValueConstant;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.VariableScopeChange;
 import org.eclipse.rdf4j.query.algebra.ZeroLengthPath;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.algebra.helpers.StatementPatternCollector;
@@ -246,7 +247,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		final ASTBindingsClause bindingsClause = node.getBindingsClause();
 		if (bindingsClause != null) {
 			// values clause should be treated as scoped to the where clause
-			((GraphPatternGroupable) tupleExpr).setGraphPatternGroup(false);
+			((VariableScopeChange) tupleExpr).setVariableScopeChange(false);
 			tupleExpr = new Join((BindingSetAssignment) bindingsClause.jjtAccept(this, null), tupleExpr);
 		}
 

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTGraphPatternGroup.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTGraphPatternGroup.java
@@ -23,4 +23,14 @@ public class ASTGraphPatternGroup extends SimpleNode {
 	public Object jjtAccept(SyntaxTreeBuilderVisitor visitor, Object data) throws VisitorException {
 		return visitor.visit(this, data);
 	}
+
+	@Override
+	public boolean isScopeChange() {
+		if (!(this.parent instanceof ASTExistsFunc
+				|| this.parent instanceof ASTNotExistsFunc
+				|| this.parent instanceof ASTGraphGraphPattern)) {
+			return true;
+		}
+		return super.isScopeChange();
+	}
 }

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SimpleNode.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SimpleNode.java
@@ -24,6 +24,8 @@ public class SimpleNode implements Node {
 
 	protected SyntaxTreeBuilder parser;
 
+	private boolean isScopeChange = false;
+
 	public SimpleNode(int id) {
 		this.id = id;
 		children = new ArrayList<>();
@@ -195,5 +197,21 @@ public class SimpleNode implements Node {
 		} catch (IOException e) {
 			throw new RuntimeException("Unexpected I/O error while writing to StringWriter", e);
 		}
+	}
+
+	/**
+	 * Check if this AST node constitutes a variable scope change.
+	 * 
+	 * @return the isScopeChange
+	 */
+	public boolean isScopeChange() {
+		return isScopeChange;
+	}
+
+	/**
+	 * @param isScopeChange the isScopeChange to set
+	 */
+	public void setScopeChange(boolean isScopeChange) {
+		this.isScopeChange = isScopeChange;
 	}
 }

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/optimizers/PrepareOwnedTupleExpr.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/optimizers/PrepareOwnedTupleExpr.java
@@ -260,11 +260,11 @@ public class PrepareOwnedTupleExpr extends AbstractQueryModelVisitor<RepositoryE
 				// no owner
 				builder = null; // NOPMD
 			} else if (builder != null) {
-				if (TupleExprs.isGraphPatternGroup(arg)) {
+				if (TupleExprs.isVariableScopeChange(arg)) {
 					builder.append("{");
 				}
 				builder.append(pattern);
-				if (TupleExprs.isGraphPatternGroup(arg)) {
+				if (TupleExprs.isVariableScopeChange(arg)) {
 					builder.append("}");
 				}
 				builder.append("\n");
@@ -288,11 +288,11 @@ public class PrepareOwnedTupleExpr extends AbstractQueryModelVisitor<RepositoryE
 
 		leftArg.visit(this);
 		if (patternNode != null) {
-			if (TupleExprs.isGraphPatternGroup(leftArg)) {
+			if (TupleExprs.isVariableScopeChange(leftArg)) {
 				builder.append("{");
 			}
 			builder.append(pattern);
-			if (TupleExprs.isGraphPatternGroup(leftArg)) {
+			if (TupleExprs.isVariableScopeChange(leftArg)) {
 				builder.append("}");
 			}
 			builder.append("\n");
@@ -300,11 +300,11 @@ public class PrepareOwnedTupleExpr extends AbstractQueryModelVisitor<RepositoryE
 			vars.putAll(variables);
 			rightArg.visit(this);
 			if (patternNode != null) {
-				if (TupleExprs.isGraphPatternGroup(rightArg)) {
+				if (TupleExprs.isVariableScopeChange(rightArg)) {
 					builder.append("{");
 				}
 				builder.append(pattern);
-				if (TupleExprs.isGraphPatternGroup(rightArg)) {
+				if (TupleExprs.isVariableScopeChange(rightArg)) {
 					builder.append("}");
 				}
 				builder.append("\n");

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -2424,6 +2424,33 @@ public abstract class ComplexSPARQLQueryTest {
 		assertEquals("http://subj1", result.get(0).getValue("s").stringValue());
 	}
 
+	@Test
+	public void testValuesClauseNamedGraph() throws Exception {
+		String ex = "http://example.org/";
+		String data = "@prefix foaf: <" + FOAF.NAMESPACE + "> .\n"
+				+ "@prefix ex: <" + ex + "> .\n"
+				+ "ex:graph1 {\n" +
+				"	ex:Person1 rdf:type foaf:Person ;\n" +
+				"		foaf:name \"Person 1\" .	ex:Person2 rdf:type foaf:Person ;\n" +
+				"		foaf:name \"Person 2\" .	ex:Person3 rdf:type foaf:Person ;\n" +
+				"		foaf:name \"Person 3\" .\n" +
+				"}";
+
+		conn.add(new StringReader(data), "", RDFFormat.TRIG);
+
+		String query = "SELECT  ?person ?name ?__index \n"
+				+ "WHERE { "
+				+ "        VALUES (?person ?name  ?__index) { \n"
+				+ "                  (<http://example.org/Person1> UNDEF \"0\") \n"
+				+ "                  (<http://example.org/Person3> UNDEF \"2\")  } \n"
+				+ "        GRAPH <http://example.org/graph1> { ?person <http://xmlns.com/foaf/0.1/name> ?name .   } }";
+
+		TupleQuery q = conn.prepareTupleQuery(query);
+
+		List<BindingSet> result = QueryResults.asList(q.evaluate());
+		assertThat(result).hasSize(2);
+	}
+
 	/**
 	 * See https://github.com/eclipse/rdf4j/issues/1267
 	 */


### PR DESCRIPTION


GitHub issue resolved: #2171 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- TupleExprBuilder uses this to build algebra tree with correct settings
- GraphPatternGroupable renamed to VariableScopeChange
- easier to distinguish corner cases at correct abstraction level
- added regression test for handling of values clause and named graphs

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

