### PR TITLE
GH-2175: Introduced new system property to configure SharedHttpClient…

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -33,13 +33,10 @@ import org.slf4j.LoggerFactory;
  */
 public class SharedHttpClientSessionManager implements HttpClientSessionManager, HttpClientDependent {
 	/**
-	 * FIXME: issue #1271, workaround for OpenJDK 8 bug. ScheduledThreadPoolExecutor with 0 core threads may cause 100%
-	 * CPU usage. Using 1 core thread instead of 0 (default) fixes the problem but wastes some resources.
-	 * 
-	 * @see <a href="https://bugs.openjdk.java.net/browse/JDK-8129861">JDK-8129861</a>
+	 * Configurable system property {@code org.eclipse.rdf4j.client.executors.corePoolSize} for specifying the
+	 * background executor core thread pool size.
 	 */
-	private static final int cores = (System.getProperty("org.eclipse.rdf4j.client.executors.jdkbug") != null) ? 1 : 0;
-	/**/
+	public static final String CORE_POOL_SIZE_PROPERTY = "org.eclipse.rdf4j.client.executors.corePoolSize";
 
 	private static final AtomicLong threadCount = new AtomicLong();
 
@@ -66,7 +63,8 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 
 	public SharedHttpClientSessionManager() {
 		final ThreadFactory backingThreadFactory = Executors.defaultThreadFactory();
-		this.executor = Executors.newScheduledThreadPool(cores, (Runnable runnable) -> {
+		final int corePoolSize = Integer.getInteger(CORE_POOL_SIZE_PROPERTY, 1);
+		this.executor = Executors.newScheduledThreadPool(corePoolSize, (Runnable runnable) -> {
 			Thread thread = backingThreadFactory.newThread(runnable);
 			thread.setName(String.format("rdf4j-sesameclientimpl-%d", threadCount.getAndIncrement()));
 			thread.setDaemon(true);


### PR DESCRIPTION
GitHub issue resolved: #2175

Briefly describe the changes proposed in this PR:

- Introduces a new system property (`org.eclipse.rdf4j.client.executors.corePoolSize`) to configure the core thread pool size of `SharedHttpClientSessionManager#executor`.

- Changes the default value of the `SharedHttpClientSessionManager#executor` core thread pool size from 0 to 1.

- This new system property **replaces** the hotfix system property (`org.eclipse.rdf4j.client.executors.jdkbug`) introduced in https://github.com/eclipse/rdf4j/pull/1272.

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

