### PR TITLE
GH-2171 group pattern as direct child of where clause is not a scope change

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -51,7 +51,6 @@ import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.ExtensionElem;
 import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.FunctionCall;
-import org.eclipse.rdf4j.query.algebra.GraphPatternGroupable;
 import org.eclipse.rdf4j.query.algebra.Group;
 import org.eclipse.rdf4j.query.algebra.GroupConcat;
 import org.eclipse.rdf4j.query.algebra.GroupElem;
@@ -1139,7 +1138,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		TupleExpr rightArg = graphPattern.buildTupleExpr();
 
 		Union union = new Union(leftArg, rightArg);
-		((GraphPatternGroupable) union).setGraphPatternGroup(true);
+		union.setVariableScopeChange(true);
 		parentGP.addRequiredTE(union);
 		graphPattern = parentGP;
 
@@ -1212,7 +1211,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			}
 
 			// when using union to execute path expressions, the scope does not not change
-			union.setGraphPatternGroup(false);
+			union.setVariableScopeChange(false);
 			parentGP.addRequiredTE(union);
 			graphPattern = parentGP;
 		} else {

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -425,8 +425,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 				aliasesInProjection.add(alias);
 
 				ValueExpr valueExpr = castToValueExpr(child.jjtAccept(this, null));
-				if (valueExpr == null)
+				if (valueExpr == null) {
 					throw new VisitorException("Either TripleRef or Expression expected in projection.");
+				}
 
 				String targetName = alias;
 				String sourceName = alias;
@@ -933,8 +934,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 	}
 
 	protected ValueExpr castToValueExpr(Object node) {
-		if (node instanceof ValueExpr)
+		if (node instanceof ValueExpr) {
 			return (ValueExpr) node;
+		}
 		if (node instanceof TripleRef) {
 			TripleRef t = (TripleRef) node;
 			return new ValueExprTripleRef(t.getExprVar().getName(), t.getSubjectVar(), t.getPredicateVar(),
@@ -1056,7 +1058,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 		TupleExpr te = graphPattern.buildTupleExpr();
 		if (node.isScopeChange()) {
-			((GraphPatternGroupable) te).setGraphPatternGroup(true);
+			((VariableScopeChange) te).setVariableScopeChange(true);
 		}
 		parentGP.addRequiredTE(te);
 
@@ -1790,10 +1792,10 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 		for (int i = 0; i < childCount; i++) {
 			Object obj = node.jjtGetChild(i).jjtAccept(this, null);
-			if (obj instanceof ValueExpr)
+			if (obj instanceof ValueExpr) {
 				result.add((ValueExpr) obj);
-			else if (obj instanceof TripleRef) {
-				result.add((ValueExpr) ((TripleRef) obj).getExprVar());
+			} else if (obj instanceof TripleRef) {
+				result.add(((TripleRef) obj).getExprVar());
 			}
 		}
 

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTGraphPatternGroup.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/ASTGraphPatternGroup.java
@@ -28,7 +28,8 @@ public class ASTGraphPatternGroup extends SimpleNode {
 	public boolean isScopeChange() {
 		if (!(this.parent instanceof ASTExistsFunc
 				|| this.parent instanceof ASTNotExistsFunc
-				|| this.parent instanceof ASTGraphGraphPattern)) {
+				|| this.parent instanceof ASTGraphGraphPattern
+				|| this.parent instanceof ASTWhereClause)) {
 			return true;
 		}
 		return super.isScopeChange();

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -18,7 +18,6 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.IsolationLevels;
-import org.eclipse.rdf4j.common.concurrent.locks.Properties;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
@@ -217,16 +216,16 @@ public class QueryPlanRetrievalTest {
 					"            Compare (!=)\n" +
 					"               Var (name=c)\n" +
 					"               Var (name=d)\n" +
-					"            Join (JoinIterator) (resultSizeActual=6)\n" +
+					"            Join (HashJoinIteration) (resultSizeActual=6)\n" +
 					"               StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n" +
 					"                  Var (name=a)\n" +
 					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
 					"                  Var (name=c)\n" +
-					"               LeftJoin (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=6)\n"
+					"               LeftJoin (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
 					+
-					"                  SingletonSet (resultSizeActual=6)\n" +
-					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=72)\n" +
+					"                  SingletonSet (resultSizeActual=4)\n" +
+					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
 					"                     Var (name=d)\n" +
 					"                     Var (name=e)\n" +
 					"                     Var (name=f)\n" +
@@ -264,16 +263,16 @@ public class QueryPlanRetrievalTest {
 					"            Compare (!=)\n" +
 					"               Var (name=c)\n" +
 					"               Var (name=d)\n" +
-					"            Join (JoinIterator) (resultSizeActual=6)\n" +
+					"            Join (HashJoinIteration) (resultSizeActual=6)\n" +
 					"               StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n" +
 					"                  Var (name=a)\n" +
 					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
 					"                  Var (name=c)\n" +
-					"               LeftJoin (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=6)\n"
+					"               LeftJoin (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
 					+
-					"                  SingletonSet (resultSizeActual=6)\n" +
-					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=72)\n" +
+					"                  SingletonSet (resultSizeActual=4)\n" +
+					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
 					"                     Var (name=d)\n" +
 					"                     Var (name=e)\n" +
 					"                     Var (name=f)\n" +
@@ -334,7 +333,7 @@ public class QueryPlanRetrievalTest {
 					"            \"type\" : \"Var (name=d)\"\n" +
 					"          } ]\n" +
 					"        }, {\n" +
-					"          \"type\" : \"Join (JoinIterator)\",\n" +
+					"          \"type\" : \"Join (HashJoinIteration)\",\n" +
 					"          \"resultSizeActual\" : 6,\n" +
 					"          \"plans\" : [ {\n" +
 					"            \"type\" : \"StatementPattern\",\n" +
@@ -353,14 +352,14 @@ public class QueryPlanRetrievalTest {
 					"            \"type\" : \"LeftJoin (BadlyDesignedLeftJoinIterator)\",\n" +
 					"            \"costEstimate\" : 5.241482788417793,\n" +
 					"            \"resultSizeEstimate\" : 12.0,\n" +
-					"            \"resultSizeActual\" : 6,\n" +
+					"            \"resultSizeActual\" : 4,\n" +
 					"            \"plans\" : [ {\n" +
 					"              \"type\" : \"SingletonSet\",\n" +
-					"              \"resultSizeActual\" : 6\n" +
+					"              \"resultSizeActual\" : 4\n" +
 					"            }, {\n" +
 					"              \"type\" : \"StatementPattern\",\n" +
 					"              \"resultSizeEstimate\" : 12.0,\n" +
-					"              \"resultSizeActual\" : 72,\n" +
+					"              \"resultSizeActual\" : 48,\n" +
 					"              \"plans\" : [ {\n" +
 					"                \"type\" : \"Var (name=d)\"\n" +
 					"              }, {\n" +
@@ -414,16 +413,16 @@ public class QueryPlanRetrievalTest {
 					"            Compare (!=)\n" +
 					"               Var (name=c)\n" +
 					"               Var (name=d)\n" +
-					"            Join (JoinIterator) (resultSizeActual=4)\n" +
+					"            Join (HashJoinIteration) (resultSizeActual=4)\n" +
 					"               StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n" +
 					"                  Var (name=a)\n" +
 					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
 					"                  Var (name=c)\n" +
-					"               LeftJoin (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
+					"               LeftJoin (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=3)\n"
 					+
-					"                  SingletonSet (resultSizeActual=4)\n" +
-					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=38)\n" +
+					"                  SingletonSet (resultSizeActual=3)\n" +
+					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=36)\n" +
 					"                     Var (name=d)\n" +
 					"                     Var (name=e)\n" +
 					"                     Var (name=f)\n" +
@@ -471,17 +470,17 @@ public class QueryPlanRetrievalTest {
 					"                  Compare (!=)\n" +
 					"                     Var (name=c)\n" +
 					"                     Var (name=d)\n" +
-					"                  Join (JoinIterator) (resultSizeActual=6)\n" +
+					"                  Join (HashJoinIteration) (resultSizeActual=6)\n" +
 					"                     StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n"
 					+
 					"                        Var (name=a)\n" +
 					"                        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
 					"                        Var (name=c)\n" +
-					"                     LeftJoin (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=6)\n"
+					"                     LeftJoin (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
 					+
-					"                        SingletonSet (resultSizeActual=6)\n" +
-					"                        StatementPattern (resultSizeEstimate=12, resultSizeActual=72)\n" +
+					"                        SingletonSet (resultSizeActual=4)\n" +
+					"                        StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
 					"                           Var (name=d)\n" +
 					"                           Var (name=e)\n" +
 					"                           Var (name=f)\n" +


### PR DESCRIPTION
GitHub issue resolved: #2171 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

This covers the case where the group graph pattern has the where clause as its direct parent - in this case we shouldn't count it as a scope change.

There are still several failing tests in QueryPlanRetrievalTest but I'm not immediately sure if these are problems in the new approach or simply a consequence of slight brittleness. 

---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

