### PR TITLE
GH-2179 relax host validation on non-standard IRI schemes

### DIFF
--- a/core/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/net/ParsedIRI.java
@@ -702,8 +702,9 @@ public class ParsedIRI implements Cloneable, Serializable {
 	public ParsedIRI relativize(ParsedIRI absolute) {
 		// identity URI reference
 		String _frag = absolute.getFragment();
-		if (iri.equals(absolute.iri) && _frag == null)
+		if (iri.equals(absolute.iri) && _frag == null) {
 			return new ParsedIRI(null, null, null, -1, "", null, null);
+		}
 		// different scheme or authority
 		if (absolute.getScheme() != null && !absolute.getScheme().equalsIgnoreCase(this.getScheme())) {
 			return absolute;
@@ -732,8 +733,9 @@ public class ParsedIRI implements Cloneable, Serializable {
 			}
 		}
 		// opaque IRI
-		if (this.isOpaque() || absolute.isOpaque())
+		if (this.isOpaque() || absolute.isOpaque()) {
 			return absolute;
+		}
 		// query string URI reference
 		String _query = absolute.getQuery();
 		if (_query != null) {
@@ -913,11 +915,13 @@ public class ParsedIRI implements Cloneable, Serializable {
 				pos = startPos;
 				String host = parsePctEncoded(hchar, ':', '/');
 
-				if (isTLDValid(start) || scheme.equalsIgnoreCase("bundle")) {
-					return host;
-				} else {
-					throw parsingException;
+				// http(s) scheme requires a valid top-level domain
+				if (isScheme("http") || isScheme("https")) {
+					if (!isTLDValid(start)) {
+						throw parsingException;
+					}
 				}
+				return host;
 			}
 		} else {
 			return parsePctEncoded(hchar, ':', '/');
@@ -1292,8 +1296,9 @@ public class ParsedIRI implements Cloneable, Serializable {
 		while (same < paths.length && same < seg.length - 1 && paths[same].equals(seg[same])) {
 			same++;
 		}
-		if (same < 2) // no path segments in common
+		if (same < 2) {
 			return absolute;
+		}
 		StringBuilder sb = new StringBuilder();
 		// last segment is empty or file name
 		for (int i = same; i < paths.length - 1; i++) {

--- a/core/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java
+++ b/core/util/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.net;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -57,6 +58,20 @@ public class ParsedIRITest {
 	@Test(expected = URISyntaxException.class)
 	public void testIncorrectIPv4() throws URISyntaxException {
 		ParsedIRI iri = new ParsedIRI("http://127.0.0.256/");
+	}
+
+	@Test
+	public void testUnknownSchemeHostProcessing() throws URISyntaxException {
+		ParsedIRI uri = new ParsedIRI("bundleresource://385.fwk19480900/test.ttl");
+		assertThat(uri.isAbsolute());
+		assertThat(uri.getScheme()).isEqualTo("bundleresource");
+		assertThat(uri.isOpaque());
+		assertThat(uri.getHost()).isEqualTo("385.fwk19480900");
+	}
+
+	@Test(expected = URISyntaxException.class)
+	public void testHttpSchemeHostProcessing() throws URISyntaxException {
+		ParsedIRI uri = new ParsedIRI("http://385.fwk19480900/test.ttl");
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #2179 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- on non-standard uri schemes, do not validate that the host describes a valid TLD
- added tests

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

