### PR TITLE
GH-2186, GH-2185: variable named graphs + fixed graph handling for SAIL

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveStatement.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveStatement.java
@@ -62,7 +62,7 @@ public class ExclusiveStatement extends FedXStatementPattern implements Exclusiv
 			 */
 
 			CloseableIteration<BindingSet, QueryEvaluationException> res = null;
-			if (t.usePreparedQuery()) {
+			if (t.usePreparedQuery(this, queryInfo)) {
 
 				AtomicBoolean isEvaluated = new AtomicBoolean(false); // is filter evaluated
 				String preparedQuery;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
@@ -75,7 +75,7 @@ public class StatementSourcePattern extends FedXStatementPattern {
 				 * efficient to use getStatements(subj, pred, obj) instead of evaluating a prepared query.
 				 */
 
-				if (t.usePreparedQuery()) {
+				if (t.usePreparedQuery(this, queryInfo)) {
 
 					// queryString needs to be constructed only once for a given bindingset
 					if (preparedQuery == null) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
@@ -15,7 +15,6 @@ import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
 import org.eclipse.rdf4j.federated.algebra.PrecompiledQueryNode;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
-import org.eclipse.rdf4j.federated.evaluation.iterator.FilteringInsertBindingsIteration;
 import org.eclipse.rdf4j.federated.evaluation.iterator.FilteringIteration;
 import org.eclipse.rdf4j.federated.evaluation.iterator.InsertBindingsIteration;
 import org.eclipse.rdf4j.federated.evaluation.iterator.StatementConversionIteration;
@@ -30,8 +29,6 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
-import org.eclipse.rdf4j.query.QueryLanguage;
-import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
@@ -55,42 +52,6 @@ public class SailTripleSource extends TripleSourceBase implements TripleSource {
 
 	SailTripleSource(Endpoint endpoint, FederationContext federationContext) {
 		super(federationContext, endpoint);
-	}
-
-	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> getStatements(
-			String preparedQuery, final BindingSet bindings, final FilterValueExpr filterExpr, QueryInfo queryInfo)
-			throws RepositoryException, MalformedQueryException,
-			QueryEvaluationException {
-
-		return withConnection((conn, resultHolder) -> {
-
-			TupleQuery query = conn.prepareTupleQuery(QueryLanguage.SPARQL, preparedQuery, null);
-			configureInference(query, queryInfo);
-			applyMaxExecutionTimeUpperBound(query);
-
-			// evaluate the query
-			CloseableIteration<BindingSet, QueryEvaluationException> res = query.evaluate();
-			resultHolder.set(res);
-
-			// apply filter and/or insert original bindings
-			if (filterExpr != null) {
-				if (bindings.size() > 0)
-					res = new FilteringInsertBindingsIteration(filterExpr, bindings, res,
-							SailTripleSource.this.strategy);
-				else
-					res = new FilteringIteration(filterExpr, res, SailTripleSource.this.strategy);
-				if (!res.hasNext()) {
-					Iterations.closeCloseable(res);
-					resultHolder.set(new EmptyIteration<>());
-					return;
-				}
-			} else if (bindings.size() > 0) {
-				res = new InsertBindingsIteration(res, bindings);
-			}
-
-			resultHolder.set(res);
-		});
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
@@ -137,7 +137,22 @@ public class SailTripleSource extends TripleSourceBase implements TripleSource {
 	}
 
 	@Override
-	public boolean usePreparedQuery() {
+	public boolean usePreparedQuery(StatementPattern stmt, QueryInfo queryInfo) {
+		// we use a prepared query for variable GRAPH patterns (=> cannot be done
+		// using the Repository API).
+		if (stmt.getContextVar() != null && !stmt.getContextVar().hasValue()) {
+			return true;
+		}
+		Dataset ds = queryInfo.getDataset();
+		if (ds != null) {
+
+			// if FROM NAMED is used we rely on a prepared query
+			if (!ds.getNamedGraphs().isEmpty()) {
+				return true;
+			}
+		}
+
+		// in all other cases: try to use the Repository API
 		return false;
 	}
 
@@ -184,5 +199,4 @@ public class SailTripleSource extends TripleSourceBase implements TripleSource {
 			resultHolder.set(res);
 		});
 	}
-
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlTripleSource.java
@@ -64,8 +64,6 @@ public class SparqlTripleSource extends TripleSourceBase implements TripleSource
 		}
 	}
 
-
-
 	@Override
 	public CloseableIteration<BindingSet, QueryEvaluationException> getStatements(
 			StatementPattern stmt, BindingSet bindings, FilterValueExpr filterExpr, QueryInfo queryInfo)
@@ -170,7 +168,7 @@ public class SparqlTripleSource extends TripleSourceBase implements TripleSource
 	}
 
 	@Override
-	public boolean usePreparedQuery() {
+	public boolean usePreparedQuery(StatementPattern stmt, QueryInfo queryInfo) {
 		return true;
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
@@ -189,7 +189,19 @@ public interface TripleSource {
 	/**
 	 * 
 	 * @return true if a prepared query is to be used preferably, false otherwise
+	 * @deprecated replaced with {@link #usePreparedQuery(StatementPattern, QueryInfo)}, to be removed in 4.0
 	 */
-	public boolean usePreparedQuery();
+	@Deprecated
+	public default boolean usePreparedQuery() {
+		return true;
+	}
+
+	/**
+	 * 
+	 * @param stmt
+	 * @param queryInfo
+	 * @return true if a prepared query is to be used preferably, false otherwise
+	 */
+	public boolean usePreparedQuery(StatementPattern stmt, QueryInfo queryInfo);
 
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
@@ -167,7 +167,7 @@ public class QueryStringUtil {
 	 * @return the SELECT query
 	 * @throws IllegalQueryException if the query does not have any free variables
 	 */
-	public static String selectQueryString(FedXStatementPattern stmt, BindingSet bindings, FilterValueExpr filterExpr,
+	public static String selectQueryString(StatementPattern stmt, BindingSet bindings, FilterValueExpr filterExpr,
 			AtomicBoolean evaluated, Dataset dataset) throws IllegalQueryException {
 
 		Set<String> varNames = new HashSet<>();
@@ -202,10 +202,13 @@ public class QueryStringUtil {
 
 		res.append(" }");
 
-		long upperLimit = stmt.getUpperLimit();
-		if (upperLimit > 0) {
-			res.append(" LIMIT ").append(upperLimit);
+		if (stmt instanceof FedXStatementPattern) {
+			long upperLimit = ((FedXStatementPattern) stmt).getUpperLimit();
+			if (upperLimit > 0) {
+				res.append(" LIMIT ").append(upperLimit);
+			}
 		}
+
 		return res.toString();
 	}
 

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/NamedGraphTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/NamedGraphTests.java
@@ -168,6 +168,10 @@ public class NamedGraphTests extends SPARQLBaseTest {
 		assertThat(values(res, "person"))
 				.containsExactlyInAnyOrder(NS_1.iri("Person_1"), NS_1.iri("Person_2"));
 
+		res = runQuery("SELECT ?person FROM NAMED <http://namespace1.org/graph1> "
+				+ "WHERE { ?person a foaf:Person }");
+		assertThat(values(res, "person")).isEmpty();
+
 		// 3. graph is available in multiple endpoints
 		res = runQuery("SELECT ?person FROM NAMED <http://namespace3.org/sharedGraph> "
 				+ " WHERE { GRAPH <http://namespace3.org/sharedGraph> { ?person a foaf:Person } }");
@@ -288,6 +292,35 @@ public class NamedGraphTests extends SPARQLBaseTest {
 		assertThat(values(res, "name"))
 				.containsExactlyInAnyOrder(l("Person 1"), l("Person 2"), l("Person 3"), l("Person 4"),
 						l("Person 11"), l("Person 12"), l("Person 13"), l("Person 14"));
+	}
+
+	@Test
+	public void testVariableGraph() throws Exception {
+
+		prepareTest(Arrays.asList("/tests/named-graphs/data1.trig", "/tests/named-graphs/data2.trig",
+				"/tests/named-graphs/data3.trig", "/tests/named-graphs/data4.trig"));
+
+		List<BindingSet> res;
+
+		res = runQuery(
+				"SELECT DISTINCT ?g WHERE { GRAPH ?g { ?person a foaf:Person } }");
+
+		assertThat(values(res, "g"))
+				.containsExactlyInAnyOrder(NS_1.GRAPH_1, NS_1.GRAPH_2, NS_2.GRAPH_1, NS_2.GRAPH_2, NS_3.SHARED_GRAPH);
+
+		res = runQuery(
+				"SELECT DISTINCT ?g WHERE { GRAPH ?g { ?person a foaf:Person . ?person foaf:age ?age } }");
+
+		System.out.println(res);
+
+		assertThat(values(res, "g"))
+				.containsExactlyInAnyOrder(NS_1.GRAPH_1, NS_1.GRAPH_2, NS_2.GRAPH_1);
+
+		res = runQuery(
+				"SELECT ?person WHERE { BIND (<http://namespace1.org/graph1> AS ?g) . GRAPH ?g { ?person a foaf:Person } }");
+
+		assertThat(values(res, "person"))
+				.containsExactlyInAnyOrder(NS_1.iri("Person_1"), NS_1.iri("Person_2"));
 	}
 
 	private List<Value> values(List<BindingSet> result, String bindingName) {

--- a/tools/federation/src/test/resources/tests/named-graphs/data2.trig
+++ b/tools/federation/src/test/resources/tests/named-graphs/data2.trig
@@ -10,7 +10,7 @@
 	:Person_6 rdf:type foaf:Person .
 	:Person_6 rdf:type :Person .
 	:Person_6 foaf:name "Person6" .
-	:Person_1 foaf:age "25"^^xsd:integer .
+	:Person_6 foaf:age "25"^^xsd:integer .
 
 	:Person_7 rdf:type foaf:Person .
 	:Person_7 rdf:type :Person .


### PR DESCRIPTION
GitHub issue resolved: #2186 #2185 

GH-2186, GH-2185: variable named graphs + fixed graph handling for SAIL

* add unit tests covering variable named graphs
* fix handling of graphs (especially FROM NAMED) in Sail Strategy

Note that we now always use prepared SELECT queries if the query is
targeted against a variable graph or against a FROM NAMED graph.

GH-2186: move getStatements for prepared query to TripleSourceBase

There was actually no real difference in the implementation provided by
SparqlTripleSource and SailTripleSource. Thus we move the implementation
of SparqlTripleSource unmodified (except for adding brackets) to the
abstract base class to avoid code duplication.


---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

