### PR TITLE
GH-2206 prettier plans by using box-drawing characters to group joins

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/explanation/GenericPlanNode.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/explanation/GenericPlanNode.java
@@ -217,6 +217,8 @@ public class GenericPlanNode {
 		this.algorithm = algorithm;
 	}
 
+	private static int prettyBoxDrawingType = 0;
+
 	/**
 	 * Human readable string. Do not attempt to parse this.
 	 *
@@ -224,7 +226,16 @@ public class GenericPlanNode {
 	 */
 	@Override
 	public String toString() {
+		return getHumanReadable(0);
+	}
 
+	/**
+	 *
+	 * @param prettyBoxDrawingType for deciding if we should use single or double walled character for drawing the
+	 *                             connectors between nodes in the query plan. Eg. ├ or ╠ and ─ o
+	 * @return
+	 */
+	private String getHumanReadable(int prettyBoxDrawingType) {
 		StringBuilder sb = new StringBuilder();
 
 		String newLine = System.getProperty("line.separator");
@@ -246,10 +257,54 @@ public class GenericPlanNode {
 		}
 		appendCostAnnotation(sb);
 		sb.append(newLine);
-		plans.forEach(child -> sb.append(Arrays.stream(child.toString().split(newLine))
-				.map(c -> "   " + c)
-				.reduce((a, b) -> a + newLine + b)
-				.orElse("") + newLine));
+
+		// we use box-drawing characters to "group" nodes in the plan visually when there are exactly two child plans
+		// and
+		// the child plans contain child plans
+		if (plans.size() == 2 && plans.stream().anyMatch(p -> !p.plans.isEmpty())) {
+
+			String start;
+			String horizontal;
+			String vertical;
+			String end;
+
+			if (prettyBoxDrawingType % 2 == 0) {
+				start = "╠";
+				horizontal = "══";
+				vertical = "║";
+				end = "╚";
+			} else {
+				start = "├";
+				horizontal = "──";
+				vertical = "│";
+				end = "└";
+			}
+
+			String left = plans.get(0).getHumanReadable(prettyBoxDrawingType + 1);
+			String right = plans.get(1).getHumanReadable(prettyBoxDrawingType + 1);
+			{
+				String[] split = left.split(newLine);
+				sb.append(start).append(horizontal).append(split[0]).append(newLine);
+				for (int i = 1; i < split.length; i++) {
+					sb.append(vertical).append("  ").append(split[i]).append(newLine);
+				}
+			}
+
+			{
+				String[] split = right.split(newLine);
+				sb.append(end).append(horizontal).append(split[0]).append(newLine);
+				for (int i = 1; i < split.length; i++) {
+					sb.append("   ").append(split[i]).append(newLine);
+				}
+			}
+
+		} else {
+			plans.forEach(
+					child -> sb.append(Arrays.stream(child.getHumanReadable(prettyBoxDrawingType + 1).split(newLine))
+							.map(c -> "   " + c)
+							.reduce((a, b) -> a + newLine + b)
+							.orElse("") + newLine));
+		}
 
 		return sb.toString();
 	}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -87,32 +87,32 @@ public class QueryPlanRetrievalTest {
 			String actual = query.explain(Explanation.Level.Unoptimized).toString();
 
 			String expected = "Projection\n" +
-					"   ProjectionElemList\n" +
-					"      ProjectionElem \"a\"\n" +
-					"   Filter\n" +
-					"      Compare (!=)\n" +
-					"         Var (name=c)\n" +
-					"         Var (name=d)\n" +
-					"      LeftJoin\n" +
-					"         Join\n" +
-					"            Join\n" +
-					"               LeftJoin (new scope)\n" +
-					"                  SingletonSet\n" +
-					"                  StatementPattern\n" +
-					"                     Var (name=d)\n" +
-					"                     Var (name=e)\n" +
-					"                     Var (name=f)\n" +
-					"               StatementPattern\n" +
-					"                  Var (name=a)\n" +
-					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"╠══ProjectionElemList\n" +
+					"║     ProjectionElem \"a\"\n" +
+					"╚══Filter\n" +
+					"   ├──Compare (!=)\n" +
+					"   │     Var (name=c)\n" +
+					"   │     Var (name=d)\n" +
+					"   └──LeftJoin\n" +
+					"      ╠══Join\n" +
+					"      ║  ├──Join\n" +
+					"      ║  │  ╠══LeftJoin (new scope)\n" +
+					"      ║  │  ║  ├──SingletonSet\n" +
+					"      ║  │  ║  └──StatementPattern\n" +
+					"      ║  │  ║        Var (name=d)\n" +
+					"      ║  │  ║        Var (name=e)\n" +
+					"      ║  │  ║        Var (name=f)\n" +
+					"      ║  │  ╚══StatementPattern\n" +
+					"      ║  │        Var (name=a)\n" +
+					"      ║  │        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                  Var (name=c)\n" +
-					"            StatementPattern\n" +
-					"               Var (name=a)\n" +
-					"               Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"      ║  │        Var (name=c)\n" +
+					"      ║  └──StatementPattern\n" +
+					"      ║        Var (name=a)\n" +
+					"      ║        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"               Var (name=d)\n" +
-					"         StatementPattern\n" +
+					"      ║        Var (name=d)\n" +
+					"      ╚══StatementPattern\n" +
 					"            Var (name=d)\n" +
 					"            Var (name=e)\n" +
 					"            Var (name=f)\n";
@@ -132,32 +132,32 @@ public class QueryPlanRetrievalTest {
 			TupleQuery query = connection.prepareTupleQuery(TUPLE_QUERY);
 			String actual = query.explain(Explanation.Level.Optimized).toString();
 			String expected = "Projection\n" +
-					"   ProjectionElemList\n" +
-					"      ProjectionElem \"a\"\n" +
-					"   LeftJoin (LeftJoinIterator)\n" +
-					"      Join (JoinIterator)\n" +
-					"         StatementPattern (costEstimate=1, resultSizeEstimate=4)\n" +
-					"            Var (name=a)\n" +
-					"            Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"╠══ProjectionElemList\n" +
+					"║     ProjectionElem \"a\"\n" +
+					"╚══LeftJoin (LeftJoinIterator)\n" +
+					"   ├──Join (JoinIterator)\n" +
+					"   │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4)\n" +
+					"   │  ║     Var (name=a)\n" +
+					"   │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"            Var (name=d)\n" +
-					"         Filter\n" +
-					"            Compare (!=)\n" +
-					"               Var (name=c)\n" +
-					"               Var (name=d)\n" +
-					"            Join\n" +
-					"               StatementPattern (costEstimate=2, resultSizeEstimate=4)\n" +
-					"                  Var (name=a)\n" +
-					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"   │  ║     Var (name=d)\n" +
+					"   │  ╚══Filter\n" +
+					"   │     ├──Compare (!=)\n" +
+					"   │     │     Var (name=c)\n" +
+					"   │     │     Var (name=d)\n" +
+					"   │     └──Join\n" +
+					"   │        ╠══StatementPattern (costEstimate=2, resultSizeEstimate=4)\n" +
+					"   │        ║     Var (name=a)\n" +
+					"   │        ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                  Var (name=c)\n" +
-					"               LeftJoin (new scope) (costEstimate=5, resultSizeEstimate=12)\n" +
-					"                  SingletonSet\n" +
-					"                  StatementPattern (resultSizeEstimate=12)\n" +
-					"                     Var (name=d)\n" +
-					"                     Var (name=e)\n" +
-					"                     Var (name=f)\n" +
-					"      StatementPattern (resultSizeEstimate=12)\n" +
+					"   │        ║     Var (name=c)\n" +
+					"   │        ╚══LeftJoin (new scope) (costEstimate=5, resultSizeEstimate=12)\n" +
+					"   │           ├──SingletonSet\n" +
+					"   │           └──StatementPattern (resultSizeEstimate=12)\n" +
+					"   │                 Var (name=d)\n" +
+					"   │                 Var (name=e)\n" +
+					"   │                 Var (name=f)\n" +
+					"   └──StatementPattern (resultSizeEstimate=12)\n" +
 					"         Var (name=d)\n" +
 					"         Var (name=e)\n" +
 					"         Var (name=f)\n";
@@ -205,33 +205,33 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
 			String expected = "Projection (resultSizeActual=2)\n" +
-					"   ProjectionElemList\n" +
-					"      ProjectionElem \"a\"\n" +
-					"   LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
-					"      Join (JoinIterator) (resultSizeActual=2)\n" +
-					"         StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"            Var (name=a)\n" +
-					"            Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"╠══ProjectionElemList\n" +
+					"║     ProjectionElem \"a\"\n" +
+					"╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
+					"   ├──Join (JoinIterator) (resultSizeActual=2)\n" +
+					"   │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
+					"   │  ║     Var (name=a)\n" +
+					"   │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"            Var (name=d)\n" +
-					"         Filter (resultSizeActual=2)\n" +
-					"            Compare (!=)\n" +
-					"               Var (name=c)\n" +
-					"               Var (name=d)\n" +
-					"            Join (HashJoinIteration) (resultSizeActual=6)\n" +
-					"               StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n" +
-					"                  Var (name=a)\n" +
-					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"   │  ║     Var (name=d)\n" +
+					"   │  ╚══Filter (resultSizeActual=2)\n" +
+					"   │     ├──Compare (!=)\n" +
+					"   │     │     Var (name=c)\n" +
+					"   │     │     Var (name=d)\n" +
+					"   │     └──Join (HashJoinIteration) (resultSizeActual=6)\n" +
+					"   │        ╠══StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n" +
+					"   │        ║     Var (name=a)\n" +
+					"   │        ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                  Var (name=c)\n" +
-					"               LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
+					"   │        ║     Var (name=c)\n" +
+					"   │        ╚══LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
 					+
-					"                  SingletonSet (resultSizeActual=4)\n" +
-					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
-					"                     Var (name=d)\n" +
-					"                     Var (name=e)\n" +
-					"                     Var (name=f)\n" +
-					"      StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n" +
+					"   │           ├──SingletonSet (resultSizeActual=4)\n" +
+					"   │           └──StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
+					"   │                 Var (name=d)\n" +
+					"   │                 Var (name=e)\n" +
+					"   │                 Var (name=f)\n" +
+					"   └──StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n" +
 					"         Var (name=d)\n" +
 					"         Var (name=e)\n" +
 					"         Var (name=f)\n";
@@ -252,33 +252,33 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Executed).toGenericPlanNode().toString();
 			String expected = "Projection (resultSizeActual=2)\n" +
-					"   ProjectionElemList\n" +
-					"      ProjectionElem \"a\"\n" +
-					"   LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
-					"      Join (JoinIterator) (resultSizeActual=2)\n" +
-					"         StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"            Var (name=a)\n" +
-					"            Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"╠══ProjectionElemList\n" +
+					"║     ProjectionElem \"a\"\n" +
+					"╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
+					"   ├──Join (JoinIterator) (resultSizeActual=2)\n" +
+					"   │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
+					"   │  ║     Var (name=a)\n" +
+					"   │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"            Var (name=d)\n" +
-					"         Filter (resultSizeActual=2)\n" +
-					"            Compare (!=)\n" +
-					"               Var (name=c)\n" +
-					"               Var (name=d)\n" +
-					"            Join (HashJoinIteration) (resultSizeActual=6)\n" +
-					"               StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n" +
-					"                  Var (name=a)\n" +
-					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"   │  ║     Var (name=d)\n" +
+					"   │  ╚══Filter (resultSizeActual=2)\n" +
+					"   │     ├──Compare (!=)\n" +
+					"   │     │     Var (name=c)\n" +
+					"   │     │     Var (name=d)\n" +
+					"   │     └──Join (HashJoinIteration) (resultSizeActual=6)\n" +
+					"   │        ╠══StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n" +
+					"   │        ║     Var (name=a)\n" +
+					"   │        ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                  Var (name=c)\n" +
-					"               LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
+					"   │        ║     Var (name=c)\n" +
+					"   │        ╚══LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
 					+
-					"                  SingletonSet (resultSizeActual=4)\n" +
-					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
-					"                     Var (name=d)\n" +
-					"                     Var (name=e)\n" +
-					"                     Var (name=f)\n" +
-					"      StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n" +
+					"   │           ├──SingletonSet (resultSizeActual=4)\n" +
+					"   │           └──StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
+					"   │                 Var (name=d)\n" +
+					"   │                 Var (name=e)\n" +
+					"   │                 Var (name=f)\n" +
+					"   └──StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n" +
 					"         Var (name=d)\n" +
 					"         Var (name=e)\n" +
 					"         Var (name=f)\n";
@@ -410,30 +410,30 @@ public class QueryPlanRetrievalTest {
 			String actual = query.explain(Explanation.Level.Executed).toString();
 			String expected = "Slice (limit=1) (resultSizeActual=1)\n" +
 					"   LeftJoin (LeftJoinIterator) (resultSizeActual=1)\n" +
-					"      Join (JoinIterator) (resultSizeActual=1)\n" +
-					"         StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=3)\n" +
-					"            Var (name=a)\n" +
-					"            Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"   ├──Join (JoinIterator) (resultSizeActual=1)\n" +
+					"   │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=3)\n" +
+					"   │  ║     Var (name=a)\n" +
+					"   │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"            Var (name=d)\n" +
-					"         Filter (resultSizeActual=1)\n" +
-					"            Compare (!=)\n" +
-					"               Var (name=c)\n" +
-					"               Var (name=d)\n" +
-					"            Join (HashJoinIteration) (resultSizeActual=4)\n" +
-					"               StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"                  Var (name=a)\n" +
-					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"   │  ║     Var (name=d)\n" +
+					"   │  ╚══Filter (resultSizeActual=1)\n" +
+					"   │     ├──Compare (!=)\n" +
+					"   │     │     Var (name=c)\n" +
+					"   │     │     Var (name=d)\n" +
+					"   │     └──Join (HashJoinIteration) (resultSizeActual=4)\n" +
+					"   │        ╠══StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n" +
+					"   │        ║     Var (name=a)\n" +
+					"   │        ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                  Var (name=c)\n" +
-					"               LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=3)\n"
+					"   │        ║     Var (name=c)\n" +
+					"   │        ╚══LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=3)\n"
 					+
-					"                  SingletonSet (resultSizeActual=3)\n" +
-					"                  StatementPattern (resultSizeEstimate=12, resultSizeActual=36)\n" +
-					"                     Var (name=d)\n" +
-					"                     Var (name=e)\n" +
-					"                     Var (name=f)\n" +
-					"      StatementPattern (resultSizeEstimate=12, resultSizeActual=1)\n" +
+					"   │           ├──SingletonSet (resultSizeActual=3)\n" +
+					"   │           └──StatementPattern (resultSizeEstimate=12, resultSizeActual=36)\n" +
+					"   │                 Var (name=d)\n" +
+					"   │                 Var (name=e)\n" +
+					"   │                 Var (name=f)\n" +
+					"   └──StatementPattern (resultSizeEstimate=12, resultSizeActual=1)\n" +
 					"         Var (name=d)\n" +
 					"         Var (name=e)\n" +
 					"         Var (name=f)\n";
@@ -464,34 +464,34 @@ public class QueryPlanRetrievalTest {
 					"         ProjectionElem \"_const_f5e5585a_uri\" AS \"predicate\"\n" +
 					"         ProjectionElem \"d\" AS \"object\"\n" +
 					"      Extension (resultSizeActual=2)\n" +
-					"         ExtensionElem (_const_f5e5585a_uri)\n" +
-					"            ValueConstant (value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type)\n" +
-					"         LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
-					"            Join (JoinIterator) (resultSizeActual=2)\n" +
-					"               StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"                  Var (name=a)\n" +
-					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"      ╠══ExtensionElem (_const_f5e5585a_uri)\n" +
+					"      ║     ValueConstant (value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type)\n" +
+					"      ╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
+					"         ├──Join (JoinIterator) (resultSizeActual=2)\n" +
+					"         │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
+					"         │  ║     Var (name=a)\n" +
+					"         │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                  Var (name=d)\n" +
-					"               Filter (resultSizeActual=2)\n" +
-					"                  Compare (!=)\n" +
-					"                     Var (name=c)\n" +
-					"                     Var (name=d)\n" +
-					"                  Join (HashJoinIteration) (resultSizeActual=6)\n" +
-					"                     StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n"
+					"         │  ║     Var (name=d)\n" +
+					"         │  ╚══Filter (resultSizeActual=2)\n" +
+					"         │     ├──Compare (!=)\n" +
+					"         │     │     Var (name=c)\n" +
+					"         │     │     Var (name=d)\n" +
+					"         │     └──Join (HashJoinIteration) (resultSizeActual=6)\n" +
+					"         │        ╠══StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n"
 					+
-					"                        Var (name=a)\n" +
-					"                        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"         │        ║     Var (name=a)\n" +
+					"         │        ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                        Var (name=c)\n" +
-					"                     LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
+					"         │        ║     Var (name=c)\n" +
+					"         │        ╚══LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
 					+
-					"                        SingletonSet (resultSizeActual=4)\n" +
-					"                        StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
-					"                           Var (name=d)\n" +
-					"                           Var (name=e)\n" +
-					"                           Var (name=f)\n" +
-					"            StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n" +
+					"         │           ├──SingletonSet (resultSizeActual=4)\n" +
+					"         │           └──StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
+					"         │                 Var (name=d)\n" +
+					"         │                 Var (name=e)\n" +
+					"         │                 Var (name=f)\n" +
+					"         └──StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n" +
 					"               Var (name=d)\n" +
 					"               Var (name=e)\n" +
 					"               Var (name=f)\n";
@@ -537,44 +537,44 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
 			String expected = "Projection (resultSizeActual=4)\n" +
-					"   ProjectionElemList\n" +
-					"      ProjectionElem \"a\"\n" +
-					"   Join (HashJoinIteration) (resultSizeActual=4)\n" +
-					"      Projection (new scope) (resultSizeActual=4)\n" +
-					"         ProjectionElemList\n" +
-					"            ProjectionElem \"a\"\n" +
-					"         StatementPattern (resultSizeActual=4)\n" +
-					"            Var (name=a)\n" +
-					"            Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"╠══ProjectionElemList\n" +
+					"║     ProjectionElem \"a\"\n" +
+					"╚══Join (HashJoinIteration) (resultSizeActual=4)\n" +
+					"   ├──Projection (new scope) (resultSizeActual=4)\n" +
+					"   │  ╠══ProjectionElemList\n" +
+					"   │  ║     ProjectionElem \"a\"\n" +
+					"   │  ╚══StatementPattern (resultSizeActual=4)\n" +
+					"   │        Var (name=a)\n" +
+					"   │        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"            Var (name=type)\n" +
-					"      Projection (new scope) (resultSizeActual=2)\n" +
-					"         ProjectionElemList\n" +
-					"            ProjectionElem \"a\"\n" +
-					"         LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
-					"            Join (JoinIterator) (resultSizeActual=2)\n" +
-					"               Filter (resultSizeActual=44)\n" +
-					"                  Compare (!=)\n" +
-					"                     Var (name=c)\n" +
-					"                     Var (name=d)\n" +
-					"                  Join (JoinIterator) (resultSizeActual=48)\n" +
-					"                     LeftJoin (new scope) (LeftJoinIterator) (resultSizeActual=12)\n" +
-					"                        SingletonSet (resultSizeActual=1)\n" +
-					"                        StatementPattern (resultSizeActual=12)\n" +
-					"                           Var (name=d)\n" +
-					"                           Var (name=e)\n" +
-					"                           Var (name=f)\n" +
-					"                     StatementPattern (resultSizeActual=48)\n" +
-					"                        Var (name=a)\n" +
-					"                        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"   │        Var (name=type)\n" +
+					"   └──Projection (new scope) (resultSizeActual=2)\n" +
+					"      ╠══ProjectionElemList\n" +
+					"      ║     ProjectionElem \"a\"\n" +
+					"      ╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
+					"         ├──Join (JoinIterator) (resultSizeActual=2)\n" +
+					"         │  ╠══Filter (resultSizeActual=44)\n" +
+					"         │  ║  ├──Compare (!=)\n" +
+					"         │  ║  │     Var (name=c)\n" +
+					"         │  ║  │     Var (name=d)\n" +
+					"         │  ║  └──Join (JoinIterator) (resultSizeActual=48)\n" +
+					"         │  ║     ╠══LeftJoin (new scope) (LeftJoinIterator) (resultSizeActual=12)\n" +
+					"         │  ║     ║  ├──SingletonSet (resultSizeActual=1)\n" +
+					"         │  ║     ║  └──StatementPattern (resultSizeActual=12)\n" +
+					"         │  ║     ║        Var (name=d)\n" +
+					"         │  ║     ║        Var (name=e)\n" +
+					"         │  ║     ║        Var (name=f)\n" +
+					"         │  ║     ╚══StatementPattern (resultSizeActual=48)\n" +
+					"         │  ║           Var (name=a)\n" +
+					"         │  ║           Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                        Var (name=c)\n" +
-					"               StatementPattern (resultSizeActual=2)\n" +
-					"                  Var (name=a)\n" +
-					"                  Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"         │  ║           Var (name=c)\n" +
+					"         │  ╚══StatementPattern (resultSizeActual=2)\n" +
+					"         │        Var (name=a)\n" +
+					"         │        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                  Var (name=d)\n" +
-					"            StatementPattern (resultSizeActual=2)\n" +
+					"         │        Var (name=d)\n" +
+					"         └──StatementPattern (resultSizeActual=2)\n" +
 					"               Var (name=d)\n" +
 					"               Var (name=e)\n" +
 					"               Var (name=f)\n";
@@ -596,46 +596,46 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
 			String expected = "Projection (resultSizeActual=0)\n" +
-					"   ProjectionElemList\n" +
-					"      ProjectionElem \"a\"\n" +
-					"   Join (HashJoinIteration) (resultSizeActual=0)\n" +
-					"      StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"         Var (name=a)\n" +
-					"         Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"╠══ProjectionElemList\n" +
+					"║     ProjectionElem \"a\"\n" +
+					"╚══Join (HashJoinIteration) (resultSizeActual=0)\n" +
+					"   ├──StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
+					"   │     Var (name=a)\n" +
+					"   │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"         Var (name=type)\n" +
-					"      Union (new scope) (resultSizeActual=24)\n" +
-					"         Join (HashJoinIteration) (resultSizeActual=12)\n" +
-					"            StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=12)\n" +
-					"               Var (name=a)\n" +
-					"               Var (name=b)\n" +
-					"               Var (name=c2)\n" +
-					"            Union (new scope) (resultSizeActual=96)\n" +
-					"               Join (JoinIterator) (resultSizeActual=48)\n" +
-					"                  StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n"
+					"   │     Var (name=type)\n" +
+					"   └──Union (new scope) (resultSizeActual=24)\n" +
+					"      ╠══Join (HashJoinIteration) (resultSizeActual=12)\n" +
+					"      ║  ├──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=12)\n" +
+					"      ║  │     Var (name=a)\n" +
+					"      ║  │     Var (name=b)\n" +
+					"      ║  │     Var (name=c2)\n" +
+					"      ║  └──Union (new scope) (resultSizeActual=96)\n" +
+					"      ║     ╠══Join (JoinIterator) (resultSizeActual=48)\n" +
+					"      ║     ║  ├──StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n"
 					+
-					"                     Var (name=c2)\n" +
-					"                     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"      ║     ║  │     Var (name=c2)\n" +
+					"      ║     ║  │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                     Var (name=type1)\n" +
-					"                  StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=48)\n"
+					"      ║     ║  │     Var (name=type1)\n" +
+					"      ║     ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=48)\n"
 					+
-					"                     Var (name=a)\n" +
-					"                     Var (name=b)\n" +
-					"                     Var (name=c)\n" +
-					"               Join (JoinIterator) (resultSizeActual=48)\n" +
-					"                  StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n"
+					"      ║     ║        Var (name=a)\n" +
+					"      ║     ║        Var (name=b)\n" +
+					"      ║     ║        Var (name=c)\n" +
+					"      ║     ╚══Join (JoinIterator) (resultSizeActual=48)\n" +
+					"      ║        ├──StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n"
 					+
-					"                     Var (name=c2)\n" +
-					"                     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"      ║        │     Var (name=c2)\n" +
+					"      ║        │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"                     Var (name=type2)\n" +
-					"                  StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=48)\n"
+					"      ║        │     Var (name=type2)\n" +
+					"      ║        └──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=48)\n"
 					+
-					"                     Var (name=a)\n" +
-					"                     Var (name=b)\n" +
-					"                     Var (name=c)\n" +
-					"         StatementPattern (new scope) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=12)\n"
+					"      ║              Var (name=a)\n" +
+					"      ║              Var (name=b)\n" +
+					"      ║              Var (name=c)\n" +
+					"      ╚══StatementPattern (new scope) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=12)\n"
 					+
 					"            Var (name=type)\n" +
 					"            Var (name=d)\n" +


### PR DESCRIPTION
GitHub issue closing #2206 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Use box-drawing characters (https://en.wikipedia.org/wiki/Box-drawing_character) for making query plans easier to read.

---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

