### PR TITLE
GH-2142 property path intermediate vars

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -1258,6 +1258,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	@Override
 	public Object visit(ASTPathSequence pathSeqNode, Object data) throws VisitorException {
+		// FIXME the entire path sequence processing needs to be separated out and more cleanly implemented, as it is
+		// currently a very messy operation involving way too many if...else conditions and strange edge case handling.
+
 		Var subjVar = mapValueExprToVar(data);
 
 		// check if we should invert subject and object.
@@ -1420,7 +1423,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 						if (invertSequence) {
 							endVar = subjVar;
 							// only swap startVar if it is not an intermediate var for a path sequence of length > 1
-							if (!(startVar.isAnonymous() && startVar.getName().startsWith("_anon_"))) {
+							// or otherwise we'd create a reflexive path (possible in nested expressions)
+							if (subjVar.equals(startVar)
+									|| !(startVar.isAnonymous() && startVar.getName().startsWith("_anon_"))) {
 								startVar = objVar;
 							}
 						}

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser.sparql;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -335,4 +336,28 @@ public class SPARQLParserTest {
 
 	}
 
+	@Test
+	public void testWildCardPathComplexSubjectHandling() {
+
+		String query = "PREFIX : <http://example.org/>\n ASK { ?a (:comment/^(:subClassOf|(:type/:label))/:type)* ?b } ";
+
+		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		Slice slice = (Slice) tupleExpr;
+
+		ArbitraryLengthPath path = (ArbitraryLengthPath) slice.getArg();
+		Join pathExpression = (Join) path.getPathExpression();
+		Join innerJoin = (Join) pathExpression.getLeftArg();
+		Var commentObjectVar = ((StatementPattern) innerJoin.getLeftArg()).getObjectVar();
+
+		Union union = (Union) innerJoin.getRightArg();
+		Var subClassOfSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
+
+		assertThat(subClassOfSubjectVar).isEqualTo(commentObjectVar);
+
+		Var subClassOfObjectVar = ((StatementPattern) union.getLeftArg()).getObjectVar();
+
+		assertThat(subClassOfSubjectVar).isNotEqualTo(subClassOfObjectVar);
+	}
 }

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -347,17 +347,22 @@ public class SPARQLParserTest {
 		Slice slice = (Slice) tupleExpr;
 
 		ArbitraryLengthPath path = (ArbitraryLengthPath) slice.getArg();
-		Join pathExpression = (Join) path.getPathExpression();
-		Join innerJoin = (Join) pathExpression.getLeftArg();
+		Var pathStart = path.getSubjectVar();
+		Var pathEnd = path.getObjectVar();
+
+		assertThat(pathStart.getName()).isEqualTo("a");
+		assertThat(pathEnd.getName()).isEqualTo("b");
+
+		Join pathSequence = (Join) path.getPathExpression();
+		Join innerJoin = (Join) pathSequence.getLeftArg();
 		Var commentObjectVar = ((StatementPattern) innerJoin.getLeftArg()).getObjectVar();
 
 		Union union = (Union) innerJoin.getRightArg();
 		Var subClassOfSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
-
-		assertThat(subClassOfSubjectVar).isEqualTo(commentObjectVar);
+		assertThat(subClassOfSubjectVar).isNotEqualTo(commentObjectVar);
 
 		Var subClassOfObjectVar = ((StatementPattern) union.getLeftArg()).getObjectVar();
 
-		assertThat(subClassOfSubjectVar).isNotEqualTo(subClassOfObjectVar);
+		assertThat(subClassOfObjectVar).isEqualTo(commentObjectVar);
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #2142 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- regression test for complex nested property path parsing involving inversions
- simple fix for the immediate case which avoids creating reflexive paths (subject and object same var), which can happen in nested expressions.
- added FIXME header to indicate a more robust refactoring of the path expression processing is long overdue. 
---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

