### PR TITLE
GH-2211 more thread safe upgrading of the DynamicModel

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
@@ -37,10 +37,9 @@ import org.eclipse.rdf4j.util.iterators.SingletonIterator;
  * predicate).
  *
  * DynamicModel is thread safe to the extent that the underlying LinkedHashMap or Model is. The upgrade path is
- * protected by the actual upgrade method being synchronized and any writes being synchronized too. This means that
- * writes can safely assume that their underlying storage will not change while writing. The LinkedHashMap storage is
- * not removed once upgraded, so concurrent reads that have started reading from the LinkedHashMap can continue to read
- * even during an upgrade. We do make the LinkedHashMap unmodifiable to reduce the chance of there being a bug.
+ * protected by the actual upgrade method being synchronized. The LinkedHashMap storage is not removed once upgraded, so
+ * concurrent reads that have started reading from the LinkedHashMap can continue to read even during an upgrade. We do
+ * make the LinkedHashMap unmodifiable to reduce the chance of there being a bug.
  *
  * @author Håvard Mikkelsen Ottestad
  */

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
@@ -62,7 +62,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public Model unmodifiable() {
+	public Model unmodifiable() {
 		upgrade();
 		return model.unmodifiable();
 	}
@@ -83,7 +83,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public Namespace setNamespace(String prefix, String name) {
+	public Namespace setNamespace(String prefix, String name) {
 		removeNamespace(prefix);
 		Namespace result = new SimpleNamespace(prefix, name);
 		namespaces.add(result);
@@ -91,13 +91,13 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public void setNamespace(Namespace namespace) {
+	public void setNamespace(Namespace namespace) {
 		removeNamespace(namespace.getPrefix());
 		namespaces.add(namespace);
 	}
 
 	@Override
-	synchronized public Optional<Namespace> removeNamespace(String prefix) {
+	public Optional<Namespace> removeNamespace(String prefix) {
 		Optional<Namespace> result = getNamespace(prefix);
 		result.ifPresent(namespaces::remove);
 		return result;
@@ -110,7 +110,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public boolean add(Resource subj, IRI pred, Value obj, Resource... contexts) {
+	public boolean add(Resource subj, IRI pred, Value obj, Resource... contexts) {
 		if (contexts.length == 0) {
 			contexts = NULL_CTX;
 		}
@@ -129,13 +129,13 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public boolean clear(Resource... context) {
+	public boolean clear(Resource... context) {
 		upgrade();
 		return model.clear(context);
 	}
 
 	@Override
-	synchronized public boolean remove(Resource subj, IRI pred, Value obj, Resource... contexts) {
+	public boolean remove(Resource subj, IRI pred, Value obj, Resource... contexts) {
 		if (subj == null || pred == null || obj == null || contexts.length == 0) {
 			upgrade();
 		}
@@ -233,7 +233,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public boolean add(Statement statement) {
+	public boolean add(Statement statement) {
 		Objects.requireNonNull(statement);
 		if (model == null) {
 			return statements.put(statement, statement) == null;
@@ -242,7 +242,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public boolean remove(Object o) {
+	public boolean remove(Object o) {
 		Objects.requireNonNull(o);
 		if (model == null) {
 			return statements.remove(o) != null;
@@ -260,7 +260,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public boolean addAll(Collection<? extends Statement> c) {
+	public boolean addAll(Collection<? extends Statement> c) {
 		Objects.requireNonNull(c);
 		if (model == null) {
 			return c.stream()
@@ -275,7 +275,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public boolean retainAll(Collection<?> c) {
+	public boolean retainAll(Collection<?> c) {
 		if (model == null) {
 			return statements.keySet().retainAll(c);
 		}
@@ -283,7 +283,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public boolean removeAll(Collection<?> c) {
+	public boolean removeAll(Collection<?> c) {
 		if (model == null) {
 			return c
 					.stream()
@@ -296,7 +296,7 @@ public class DynamicModel implements Model {
 	}
 
 	@Override
-	synchronized public void clear() {
+	public void clear() {
 		if (model == null) {
 			statements.clear();
 		} else {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
@@ -331,9 +331,11 @@ public class DynamicModel implements Model {
 
 	synchronized private void synchronizedUpgrade() {
 		if (model == null) {
+			// make statements unmodifiable first, to increase chance of an early failure if the user is doing
+			// concurrent write with reads
+			statements = Collections.unmodifiableMap(statements);
 			Model tempModel = modelFactory.createEmptyModel();
 			tempModel.addAll(statements.values());
-			statements = Collections.unmodifiableMap(statements);
 			model = tempModel;
 		}
 	}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.rdf4j.model.impl.DynamicModel;
+import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.junit.Test;
+
+public class DynamicModelConcurrentModificationAndUpgradeTest {
+
+	@Test
+	public void testConcurrentAddAndUpgrade() throws InterruptedException {
+
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+		List<Statement> statements = Arrays.asList(
+				vf.createStatement(vf.createBNode(), RDF.TYPE, RDFS.RESOURCE),
+				vf.createStatement(vf.createBNode(), RDF.TYPE, RDFS.RESOURCE),
+				vf.createStatement(vf.createBNode(), RDF.TYPE, RDFS.RESOURCE),
+				vf.createStatement(vf.createBNode(), RDF.TYPE, RDFS.RESOURCE),
+				vf.createStatement(vf.createBNode(), RDF.TYPE, RDFS.RESOURCE));
+
+		DynamicModel model = new DynamicModel(new LinkedHashModelFactory());
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		final Exception[] exception = new Exception[1];
+
+		Runnable addAll = () -> {
+			try {
+				model.addAll(new Collection<Statement>() {
+					@Override
+					public int size() {
+						return statements.size();
+					}
+
+					@Override
+					public boolean isEmpty() {
+						return statements.isEmpty();
+					}
+
+					@Override
+					public boolean contains(Object o) {
+						return statements.contains(o);
+					}
+
+					@Override
+					public Iterator<Statement> iterator() {
+						return new Iterator<Statement>() {
+
+							Iterator<Statement> iterator = statements.iterator();
+
+							@Override
+							public boolean hasNext() {
+								try {
+									countDownLatch.await();
+								} catch (InterruptedException e) {
+									e.printStackTrace();
+								}
+								return iterator.hasNext();
+							}
+
+							@Override
+							public Statement next() {
+								try {
+									countDownLatch.await();
+								} catch (InterruptedException e) {
+									e.printStackTrace();
+								}
+								return iterator.next();
+							}
+						};
+					}
+
+					@Override
+					public Object[] toArray() {
+						return statements.toArray();
+					}
+
+					@Override
+					public <T> T[] toArray(T[] a) {
+						return statements.toArray(a);
+					}
+
+					@Override
+					public boolean add(Statement statement) {
+						return false;
+					}
+
+					@Override
+					public boolean remove(Object o) {
+						return false;
+					}
+
+					@Override
+					public boolean containsAll(Collection<?> c) {
+						return statements.containsAll(c);
+					}
+
+					@Override
+					public boolean addAll(Collection<? extends Statement> c) {
+						return false;
+					}
+
+					@Override
+					public boolean removeAll(Collection<?> c) {
+						return false;
+					}
+
+					@Override
+					public boolean retainAll(Collection<?> c) {
+						return false;
+					}
+
+					@Override
+					public void clear() {
+						System.out.println();
+					}
+				});
+			} catch (Exception e) {
+				exception[0] = e;
+			}
+
+		};
+
+		Runnable upgrade = () -> {
+			model.filter(null, RDF.TYPE, null);
+			countDownLatch.countDown();
+		};
+
+		Thread addAllThread = new Thread(addAll);
+		Thread upgradeThread = new Thread(upgrade);
+
+		addAllThread.start();
+		upgradeThread.start();
+
+		addAllThread.join();
+		upgradeThread.join();
+
+		assertEquals(UnsupportedOperationException.class, exception[0].getClass());
+
+	}
+
+}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
@@ -64,7 +64,7 @@ public class DynamicModelConcurrentModificationAndUpgradeTest {
 					public Iterator<Statement> iterator() {
 						return new Iterator<Statement>() {
 
-							Iterator<Statement> iterator = statements.iterator();
+							final Iterator<Statement> iterator = statements.iterator();
 
 							@Override
 							public boolean hasNext() {

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
@@ -25,6 +25,12 @@ import org.junit.Test;
 
 public class DynamicModelConcurrentModificationAndUpgradeTest {
 
+	/**
+	 * Add multiple statements while forcing an upgrade to make sure we then get an exception because the underlying
+	 * storage was upgraded
+	 * 
+	 * @throws InterruptedException
+	 */
 	@Test
 	public void testConcurrentAddAndUpgrade() throws InterruptedException {
 


### PR DESCRIPTION
GitHub issue resolved: #221 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - LinkedHashMap is not removed while upgrading, allowing current users to keep using it
 - Upgrading during a write will now wait for the write to complete, thanks to synchronized writes
 
---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

