### PR TITLE
GH-2224 handle q flag in SPARQL REGEX filters

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -1385,6 +1385,9 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 				case 'u':
 					f |= Pattern.UNICODE_CASE;
 					break;
+				case 'q':
+					f |= Pattern.LITERAL;
+					break;
 				default:
 					throw new ValueExprEvaluationException(flags);
 				}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -15,6 +16,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -22,11 +25,12 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
 import org.junit.Before;
@@ -83,4 +87,51 @@ public class StrictEvaluationStrategyTest {
 		verify(optimizer1, times(1)).optimize(expr, null, bindings);
 		verify(optimizer2, times(1)).optimize(expr, null, bindings);
 	}
+
+	@Test
+	public void testEvaluateRegexFlags() throws Exception {
+
+		String query = "SELECT ?a WHERE { "
+				+ "VALUES ?a { \"foo.bar\" \"foo bar\" } \n"
+				+ "FILTER REGEX(str(?a), \"foo.bar\")}";
+
+		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, query, null);
+
+		CloseableIteration<BindingSet, QueryEvaluationException> result = strategy.evaluate(pq.getTupleExpr(),
+				new EmptyBindingSet());
+
+		List<BindingSet> bindingSets = QueryResults.asList(result);
+		assertThat(bindingSets).hasSize(2);
+
+		// match with q flag
+		query = "SELECT ?a WHERE { "
+				+ "VALUES ?a { \"foo.bar\" \"foo bar\" } \n"
+				+ "FILTER REGEX(str(?a), \"foo.bar\", \"q\")}";
+
+		pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, query, null);
+
+		result = strategy.evaluate(pq.getTupleExpr(),
+				new EmptyBindingSet());
+
+		bindingSets = QueryResults.asList(result);
+		assertThat(bindingSets).hasSize(1);
+		assertThat(bindingSets.get(0).getValue("a").stringValue()).isEqualTo("foo.bar");
+
+		// match with i and q flag
+		query = "SELECT ?a WHERE { "
+				+ "VALUES ?a { \"foo.bar\" \"FOO.BAR\" \"foo bar\" } \n"
+				+ "FILTER REGEX(str(?a), \"foo.bar\", \"iq\")}";
+
+		pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, query, null);
+
+		result = strategy.evaluate(pq.getTupleExpr(),
+				new EmptyBindingSet());
+
+		bindingSets = QueryResults.asList(result);
+		assertThat(bindingSets).hasSize(2);
+
+		List<String> values = bindingSets.stream().map(v -> v.getValue("a").stringValue()).collect(Collectors.toList());
+		assertThat(values).containsExactlyInAnyOrder("foo.bar", "FOO.BAR");
+	}
+
 }


### PR DESCRIPTION
GitHub issue resolved: #2224 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- recognize 'q' as a legal flag on a regex pattern, conform spec, and handle by setting `Pattern.LITERAL`.
- added regression tests.

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

