### PR TITLE
GH-2211 Fix DynamicModel upgrade flaky test failure

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
@@ -49,7 +49,7 @@ public class DynamicModel implements Model {
 
 	private static final Resource[] NULL_CTX = new Resource[] { null };
 
-	private Map<Statement, Statement> statements = new LinkedHashMap<>();
+	private volatile Map<Statement, Statement> statements = new LinkedHashMap<>();
 	final Set<Namespace> namespaces = new LinkedHashSet<>();
 
 	volatile private Model model = null;

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
@@ -142,7 +142,6 @@ public class DynamicModelConcurrentModificationAndUpgradeTest {
 			} catch (Exception e) {
 				exception[0] = e;
 			}
-
 		};
 
 		Runnable upgrade = () -> {

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/DynamicModelConcurrentModificationAndUpgradeTest.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -159,8 +159,7 @@ public class DynamicModelConcurrentModificationAndUpgradeTest {
 		addAllThread.join();
 		upgradeThread.join();
 
-		assertEquals(UnsupportedOperationException.class, exception[0].getClass());
-
+		assertThat(exception[0]).isInstanceOf(UnsupportedOperationException.class);
 	}
 
 }


### PR DESCRIPTION
GitHub issue resolved: #2211 <!-- add a Github issue number here, e.g #123. -->

This is a draft branch to address test failure in `org.eclipse.rdf4j.model.DynamicModelConcurrentModificationAndUpgradeTest`  on Github CI. The test succeeds when ran on my local machine so it's flaky (which is not unusual with multithreaded stuff). 

I am not immediately spotting a problem with either the test or the implementation, so opening this draft PR to see the problem (hoping the CI build at least consistently fails) and cooperate on a fix. 


---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

