### PR TITLE
GH-2238: fix join order optimization for bound variables through BIND

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryAlgebraUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryAlgebraUtil.java
@@ -586,8 +586,8 @@ public class QueryAlgebraUtil {
 		}
 
 		if (tupleExpr instanceof Extension) {
-			// for a BIND extension in our cost model we work with 0 free vars
-			return new ArrayList<String>();
+			// for a BIND extension in our cost model we use the binding names
+			return new ArrayList<String>(tupleExpr.getBindingNames());
 		}
 
 		if (tupleExpr instanceof ArbitraryLengthPath) {

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/QueryPlanTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/QueryPlanTest.java
@@ -19,4 +19,12 @@ public class QueryPlanTest extends SPARQLBaseTest {
 				"/tests/medium/data4.ttl"));
 		evaluateQueryPlan("/tests/medium/query03.rq", "/tests/medium/query03.qp");
 	}
+
+	@Test
+	public void testQueryPlan_joinOrderBind() throws Exception {
+		prepareTest(Arrays.asList("/tests/medium/data1.ttl", "/tests/medium/data2.ttl", "/tests/medium/data3.ttl",
+				"/tests/medium/data4.ttl"));
+		evaluateQueryPlan("/tests/optimizer/queryPlan_bind.rq", "/tests/optimizer/queryPlan_bind.qp");
+	}
+
 }

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_bind.qp
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_bind.qp
@@ -1,0 +1,23 @@
+QueryRoot
+   Projection
+      ProjectionElemList
+         ProjectionElem "project"
+         ProjectionElem "label"
+      NJoin
+         Extension
+            ExtensionElem (type)
+               ValueConstant (value=http://namespace3.org/Project)
+            SingletonSet
+         StatementSourcePattern
+            Var (name=project)
+            Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
+            Var (name=type)
+            StatementSource (id=endpoint1, type=REMOTE)
+            StatementSource (id=endpoint2, type=REMOTE)
+            StatementSource (id=endpoint3, type=REMOTE)
+            StatementSource (id=endpoint4, type=REMOTE)
+         ExclusiveStatement
+            Var (name=project)
+            Var (name=_const_9285ccfc_uri, value=http://www.w3.org/2000/01/rdf-schema#label, anonymous)
+            Var (name=label)
+            StatementSource (id=endpoint3, type=REMOTE)

--- a/tools/federation/src/test/resources/tests/optimizer/queryPlan_bind.rq
+++ b/tools/federation/src/test/resources/tests/optimizer/queryPlan_bind.rq
@@ -1,0 +1,13 @@
+# test for join order optimizer to re-order bound type
+
+PREFIX ns3: <http://namespace3.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> 
+PREFIX owl:  <http://www.w3.org/2002/07/owl#>
+
+SELECT ?project ?label WHERE {
+ BIND(ns3:Project AS ?type)
+ ?project rdfs:label ?label .
+ ?project rdf:type ?type .
+}


### PR DESCRIPTION
We now explicitly consider the binding names of the BIND clause (i.e. an
Extension) as variable for the join. In this way, statements where such
bindings occur obtain a lower cost.

Toy example for illustration:

```
SELECT ?project ?label WHERE {
 BIND(:SomeThing AS ?type)
 ?project rdfs:label ?label .
 ?project rdf:type ?type .
}
```

With this change the type BGP gets evaluated before the label BGP.
Change is covered with a unit test.


GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

