### PR TITLE
GH-387 really uses contexts instead of only creating an empty array

### DIFF
--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/RDFSailRemover.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/RDFSailRemover.java
@@ -111,7 +111,8 @@ class RDFSailRemover extends AbstractRDFHandler {
 				if (ctxt == null) {
 					final Set<IRI> removeGraphs = uc.getDataset().getDefaultRemoveGraphs();
 					if (!removeGraphs.isEmpty()) {
-						con.removeStatement(uc, subj, pred, obj, new IRI[removeGraphs.size()]);
+						IRI[] ctxts = removeGraphs.toArray(new IRI[removeGraphs.size()]);
+						con.removeStatement(uc, subj, pred, obj, ctxts);
 					} else {
 						con.removeStatement(uc, subj, pred, obj);
 					}


### PR DESCRIPTION
GitHub issue resolved: #387 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

* a suitable sized - but empty - array of contexts was created based on the size of a set

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

