### PR TITLE
GH-1270 sparqlbuilder should reuse iri validation code

### DIFF
--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQueryTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQueryTest.java
@@ -1,0 +1,45 @@
+package org.eclipse.rdf4j.sparqlbuilder.core.query;
+
+import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.junit.Assert.*;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.*;
+import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+import org.junit.Test;
+
+public class ModifyQueryTest extends BaseExamples {
+
+	/**
+	 * DELETE { GRAPH ?g1 { ?subject <http://my-example.com/anyIRI/> ?object . ?subject ?predicate
+	 * <http://my-example.com/anyIRI/> . } } WHERE { GRAPH ?g1 { OPTIONAL { ?subject ?predicate
+	 * <http://my-example.com/anyIRI/> . } OPTIONAL { ?subject <http://my-example.com/anyIRI/> ?object . } } }
+	 */
+	@Test
+	public void example_issue_1481() {
+		ModifyQuery modify = Queries.MODIFY();
+		Iri g1 = () -> "<g1>";
+
+		Variable subject = SparqlBuilder.var("subject");
+		Variable obj = SparqlBuilder.var("object");
+		Variable predicate = SparqlBuilder.var("predicate");
+
+		TriplePattern delTriple1 = subject.has(iri("http://my-example.com/anyIRI/"), obj);
+		TriplePattern delTriple2 = subject.has(predicate, iri("http://my-example.com/anyIRI/"));
+		TriplePattern whereTriple1 = subject.has(predicate, iri("http://my-example.com/anyIRI/"));
+		TriplePattern whereTriple2 = subject.has(iri("http://my-example.com/anyIRI/"), obj);
+
+		modify.with(g1)
+				.delete(delTriple1, delTriple2)
+				.where(and(GraphPatterns.optional(whereTriple1), GraphPatterns.optional(whereTriple2)));
+
+		assertEquals(modify.getQueryString(), "WITH <g1>\n" +
+				"DELETE { ?subject <http://my-example.com/anyIRI/> ?object .\n" +
+				"?subject ?predicate <http://my-example.com/anyIRI/> . }\n" +
+				"WHERE { OPTIONAL { ?subject ?predicate <http://my-example.com/anyIRI/> . }\n" +
+				"OPTIONAL { ?subject <http://my-example.com/anyIRI/> ?object . } }");
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
@@ -342,4 +342,30 @@ public class Section3Test extends BaseExamples {
 	public void example_15() {
 		p(Queries.ADD().fromDefault().to(iri("http://example.org/named")));
 	}
+
+	/**
+	 * DELETE { GRAPH ?g1 { ?subject <http://my-example.com/anyIRI/> ?object . ?subject ?predicate
+	 * <http://my-example.com/anyIRI/> . } } WHERE { GRAPH ?g1 { OPTIONAL { ?subject ?predicate
+	 * <http://my-example.com/anyIRI/> . } OPTIONAL { ?subject <http://my-example.com/anyIRI/> ?object . } } }
+	 */
+	@Test
+	public void example_issue_1481() {
+		ModifyQuery modify = Queries.MODIFY();
+		Iri g1 = () -> "<g1>";
+
+		Variable subject = SparqlBuilder.var("subject");
+		Variable obj = SparqlBuilder.var("object");
+		Prefix pre = SparqlBuilder.prefix(iri("http://my-example.com/anyIRI/"));
+		Variable predicate = SparqlBuilder.var("predicate");
+
+		TriplePattern delTriple1 = subject.has(pre.iri(""), obj);
+		TriplePattern delTriple2 = subject.has(predicate, pre.iri(""));
+		TriplePattern whereTriple1 = subject.has(predicate, pre.iri(""));
+		TriplePattern whereTriple2 = subject.has(pre.iri(""), obj);
+
+		modify.with(g1)
+				.delete(delTriple1, delTriple2)
+				.where(and(GraphPatterns.optional(whereTriple1), GraphPatterns.optional(whereTriple2)));
+	}
+
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
@@ -343,29 +343,4 @@ public class Section3Test extends BaseExamples {
 		p(Queries.ADD().fromDefault().to(iri("http://example.org/named")));
 	}
 
-	/**
-	 * DELETE { GRAPH ?g1 { ?subject <http://my-example.com/anyIRI/> ?object . ?subject ?predicate
-	 * <http://my-example.com/anyIRI/> . } } WHERE { GRAPH ?g1 { OPTIONAL { ?subject ?predicate
-	 * <http://my-example.com/anyIRI/> . } OPTIONAL { ?subject <http://my-example.com/anyIRI/> ?object . } } }
-	 */
-	@Test
-	public void example_issue_1481() {
-		ModifyQuery modify = Queries.MODIFY();
-		Iri g1 = () -> "<g1>";
-
-		Variable subject = SparqlBuilder.var("subject");
-		Variable obj = SparqlBuilder.var("object");
-		Prefix pre = SparqlBuilder.prefix(iri("http://my-example.com/anyIRI/"));
-		Variable predicate = SparqlBuilder.var("predicate");
-
-		TriplePattern delTriple1 = subject.has(pre.iri(""), obj);
-		TriplePattern delTriple2 = subject.has(predicate, pre.iri(""));
-		TriplePattern whereTriple1 = subject.has(predicate, pre.iri(""));
-		TriplePattern whereTriple2 = subject.has(pre.iri(""), obj);
-
-		modify.with(g1)
-				.delete(delTriple1, delTriple2)
-				.where(and(GraphPatterns.optional(whereTriple1), GraphPatterns.optional(whereTriple2)));
-	}
-
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/IriValidationTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/IriValidationTest.java
@@ -1,0 +1,36 @@
+package org.eclipse.rdf4j.sparqlbuilder.rdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URISyntaxException;
+
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.junit.Test;
+
+public class IriValidationTest {
+
+	@Test
+	public void testURN() throws URISyntaxException {
+		assertEquals("urn:test:foobar", new ParsedIRI("urn:test:foobar").toString());
+		assertEquals("urn", new ParsedIRI("urn:test:foobar").getScheme());
+		assertEquals("test:foobar", new ParsedIRI("urn:test:foobar").getPath());
+		assertTrue(new ParsedIRI("urn:test:foobar").isOpaque());
+	}
+
+	@Test
+	public void testUnknownSchemeHostProcessing() throws URISyntaxException {
+		ParsedIRI uri = new ParsedIRI("bundleresource://385.fwk19480900/test.ttl");
+		assertThat(uri.isAbsolute());
+		assertThat(uri.getScheme()).isEqualTo("bundleresource");
+		assertThat(uri.isOpaque());
+		assertThat(uri.getHost()).isEqualTo("385.fwk19480900");
+	}
+
+	@Test
+	public void validateIRI() throws URISyntaxException {
+		ParsedIRI iri = new ParsedIRI("urn://example.org/ros&#xE9");
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #1270 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR: 

I have added tests to see if ParsedIRI class correctly parses IRIs that may start with anything except HTTP etc. (For example- IRIs starting with URN get parsed correctly). 

<!-- short description of your change goes here -->

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

