### PR TITLE
Gh 399 invalid update query detection

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositorySparqlUpdateTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositorySparqlUpdateTest.java
@@ -5,6 +5,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql;
 
+import junit.framework.TestCase;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Assert;
+import org.junit.Test;
+import junit.runner.Version;
+
 /**
  * @author Jeen Broekstra
  */
@@ -52,3 +64,34 @@ package org.eclipse.rdf4j.repository.sparql;
 //		System.err.println("temporarily disabled testAutoCommitHandling() for HTTPRepository");
 //	}
 //}
+
+public class SPARQLRepositorySparqlUpdateTest extends TestCase {
+
+    private Repository m_repository;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        m_repository = new SailRepository(new MemoryStore());
+        m_repository.initialize();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        m_repository.shutDown();
+    }
+
+//    @Test (expected = org.eclipse.rdf4j.rio.RDFParseException.class)
+    @Test
+    public void testInvalidUpdate() {
+        RepositoryConnection connection = m_repository.getConnection();
+        try {
+            Update update = connection.prepareUpdate(QueryLanguage.SPARQL, "insert data { ?s ?p ?o }");
+        } catch (RDFParseException rdfpe) {
+            Assert.assertEquals(7, rdfpe.getLineNumber());
+        }
+
+    }
+}
+

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositorySparqlUpdateTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositorySparqlUpdateTest.java
@@ -67,31 +67,39 @@ import junit.runner.Version;
 
 public class SPARQLRepositorySparqlUpdateTest extends TestCase {
 
-    private Repository m_repository;
+	private Repository m_repository;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        m_repository = new SailRepository(new MemoryStore());
-        m_repository.initialize();
-    }
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		m_repository = new SailRepository(new MemoryStore());
+		m_repository.initialize();
+	}
 
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-        m_repository.shutDown();
-    }
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		m_repository.shutDown();
+	}
 
 //    @Test (expected = org.eclipse.rdf4j.rio.RDFParseException.class)
-    @Test
-    public void testInvalidUpdate() {
-        RepositoryConnection connection = m_repository.getConnection();
-        try {
-            Update update = connection.prepareUpdate(QueryLanguage.SPARQL, "insert data { ?s ?p ?o }");
-        } catch (RDFParseException rdfpe) {
-            Assert.assertEquals(7, rdfpe.getLineNumber());
-        }
+	@Test
+	public void testInvalidInsertUpdate() {
+		RepositoryConnection connection = m_repository.getConnection();
+		try {
+			Update update = connection.prepareUpdate(QueryLanguage.SPARQL, "insert data { ?s ?p ?o }");
+		} catch (RDFParseException rdfpe) {
+			Assert.assertEquals(7, rdfpe.getLineNumber());
+		}
+	}
 
-    }
+	@Test
+	public void testInvalidDeleteUpdate() {
+		RepositoryConnection connection = m_repository.getConnection();
+		try {
+			Update update = connection.prepareUpdate(QueryLanguage.SPARQL, "delete data { ?s ?p ?o }");
+		} catch (RDFParseException rdfpe) {
+			Assert.assertEquals(7, rdfpe.getLineNumber());
+		}
+	}
 }
-

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.Query;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
+import org.eclipse.rdf4j.query.algebra.DeleteData;
 import org.eclipse.rdf4j.query.algebra.InsertData;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.UpdateExpr;
@@ -271,18 +272,19 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 		List<UpdateExpr> updateExprs = parsedUpdate.getUpdateExprs();
 		SPARQLUpdateDataBlockParser parser = new SPARQLUpdateDataBlockParser(this.getValueFactory());
 		for (UpdateExpr expr:updateExprs) {
-			System.out.println(expr);
+			String datablock = "";
 			if (expr instanceof InsertData) {
-				System.out.println("the operation is insert");
-				String datablock = ((InsertData) expr).getDataBlock();
-				System.out.println("Datablock when parsing the query");
-				System.out.println(datablock);
-				try {
-					parser.parse(new StringReader(datablock),"");
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
+				datablock = ((InsertData) expr).getDataBlock();
 			}
+			else if(expr instanceof DeleteData) {
+				datablock = ((DeleteData) expr).getDataBlock();
+			}
+			try {
+				parser.parse(new StringReader(datablock),"");
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+
 		}
 
 		return new SailUpdate(parsedUpdate, this);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -271,16 +271,15 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 		ParsedUpdate parsedUpdate = QueryParserUtil.parseUpdate(ql, update, baseURI);
 		List<UpdateExpr> updateExprs = parsedUpdate.getUpdateExprs();
 		SPARQLUpdateDataBlockParser parser = new SPARQLUpdateDataBlockParser(this.getValueFactory());
-		for (UpdateExpr expr:updateExprs) {
+		for (UpdateExpr expr : updateExprs) {
 			String datablock = "";
 			if (expr instanceof InsertData) {
 				datablock = ((InsertData) expr).getDataBlock();
-			}
-			else if(expr instanceof DeleteData) {
+			} else if (expr instanceof DeleteData) {
 				datablock = ((DeleteData) expr).getDataBlock();
 			}
 			try {
-				parser.parse(new StringReader(datablock),"");
+				parser.parse(new StringReader(datablock), "");
 			} catch (IOException e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
GitHub issue resolved: #399 

Briefly describe the changes proposed in this PR: 

Added code for detecting invalid queries for both the insert and delete data expressions in prepareUpdate function. Also added test cases to check that RDFParseException is thrown in both cases.

---- 
PR Author Checklist: 

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] every commit message starts with the issue number (GH-399) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

