### PR TITLE
GH-2259 changes to PR template, guidelines, and activation of formatting plugins

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -69,7 +69,12 @@ Eclipse RDF4J follows the [Eclipse Coding Conventions for Java](https://wiki.ecl
  *******************************************************************************/
  ```
 
-**NB** for older existing source code, RDF4J uses a slightly different
+...of course, replace `${year}` with the actual current year (if you use
+Eclipse IDE, this will happen automatically). All RDF4J copyright headers
+record only the year a file was _first_ contributed, so there is no need
+to update the year of existing files if you modify those files.
+
+**NB** for older existing source code, RDF4J sometimes uses a slightly different
 copyright header, mentioning 'Aduna' as additional copyright holder . Please
 make sure you do not use that different header for any new contributions. 
 
@@ -80,6 +85,8 @@ For import statements, the following conventions hold:
 - we apply a fixed ordering for import statements, following Eclipse conventions. Import statements are ordered in groups separated by a single empty line, in the following order: static imports, java.\*, javax.\*, org.\*, com.\*, everything else.
 
 There are various ways to apply these conventions to your code, depending on which editor/IDE you use.
+
+We use a single tab as the indentation in all XML files (including the `pom.xml` files). 
 
 ### Eclipse IDE users
 
@@ -102,39 +109,45 @@ For import organization, the Eclipse defaults should be fine, but you can make s
 
 You can apply import organization by hitting Ctrl+Shift+O, or you can configure Eclipse to automtaically organize imports on save. This can be activated by going to 'Preferences' -> 'Java' -> 'Editor' -> 'Save Actions' and making sure the 'Organize imports' option checkbox is ticked.
 
+Finally, for XML formatting, the Eclipse defaults should be fine, but you can make sure as follows:
+
+1. go to 'Preferences' -> 'XML' -> 'XML Files' -> 'Editor'. 
+2. Make sure line width is set to 120, 'Indent using tabs' is active, and indentation size is set to 1. 
+
 ### Other IDEs / using the Maven formatter and import sorting plugins
 
 If you do not use Eclipse IDE, we still welcome your contributions of course. There are several ways in which you can configure your IDE to format according to our conventions. Some tools will have the Eclipse code conventions built in, or will have options to import Eclipse formatter and import sorting settings. 
 
-In addition, the RDF4J project is configured to use the [formatter maven plugin](https://code.revelc.net/formatter-maven-plugin/) and [import sorting maven plugin](https://code.revelc.net/impsort-maven-plugin/index.html) for validation of all code changes against the coding conventions, and compiling the project will automatically fix formatting/import issues.
+In addition, the RDF4J project is configured to use the [formatter maven plugin](https://code.revelc.net/formatter-maven-plugin/), the [import sorting maven plugin](https://code.revelc.net/impsort-maven-plugin/index.html) and [XML Format plugin](https://acegi.github.io/xml-format-maven-plugin/) for validation of all code changes against the coding conventions, and compiling the project using Apache Maven will automatically activate these plugins and fix most formatting/import issues.
+
+The formatters are automatically run by maven during the `process-resources` phase, which means they will activate whenever you compile, verify, package or install the project using maven (see the [maven default lifecycle](https://maven.apache.org/ref/3.6.3/maven-core/lifecycles.html#default_Lifecycle) for more details).
 
 To validate your changes manually, run the following command:
 
 ```
-mvn formatter:validate
+mvn formatter:validate impsort:check xml-format:xml-check
 ```
 
-To reformat your code before committing, run:
+To reformat your code manually before committing, run:
 
 ```
-mvn formatter:format
+mvn formatter:format impsort:sort xml-format:xml-format
 ```
 
-To manually fix import statement organization using maven, run the following command:
+or alternatively:
 
 ```
-mvn impsort:sort
+mvn process-resources
 ```
 
-### XML indentation
+Please note: these maven plugins are meant as a tool to help you and 
+us to quickly check the most common formatting problems. They are _not_,
+however, intended to completely relieve you of responsibility for correct
+formatting, and won't necessarily cover all code conventions we follow. For
+example, the guideline that we don't allow wildcard import statements is not
+checked by these plugins. 
 
-We use a single tab as the indentation in all XML files (including the `pom.xml` files). This is not enforced by the build process, but we ask you to adjust your editors accordingly. If you wish, you can use the following command to check your xml files:
-
-     mvn xml-format:xml-check
-     
-To reformat xml files in bulk, run:
-
-     mvn xml-format:xml-format
+Having said all that, we appreciate your best effort, but if occassionally something slips through, that's no big deal: code conventions are there to help us as developers, not to make your life miserable :) 
      
 ## Workflow 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,10 +6,11 @@ Briefly describe the changes proposed in this PR:
 <!-- short description of your change goes here -->
 
 ---- 
-PR Author Checklist: 
+PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):
 
  - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
  - [ ] I've added tests for the changes I made
+ - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting)
  - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
  - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse
 
  - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
  - [ ] I've added tests for the changes I made
- - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting)
+ - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
  - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
  - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)
 

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -23,7 +23,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Verify formatting
-      run: mvn -B formatter:validate impsort:check
+      run: mvn -B formatter:validate impsort:check xml-format:xml-check
     - name: Build
       run: mvn -B clean install -Pquick,\!formatting
     - name: Run tests

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,18 @@
 							</execution>
 						</executions>
 					</plugin>
+					<plugin>
+						<groupId>au.com.acegi</groupId>
+						<artifactId>xml-format-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>xml-format</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -647,6 +659,7 @@
 					<version>3.1.2</version>
 					<configuration>
 						<tabIndent>true</tabIndent>
+						<excludes>**/target/**</excludes>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
GitHub issue resolved: #2259 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- xml formatting check part of automatic validation by CI
- xml formatting format part of automatic formatting as part of local build
- updated PR template to add links to guidelines and point out formatting conventions
- made it a bit clearer which maven goals you can run to make this easier


---- 
PR Author Checklist: 

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

