### PR TITLE
GH-956-SilentModeSparqlEndpoint : added silentMode in sparql connection

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -121,6 +121,10 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 		return client.getQueryURL();
 	}
 
+	public void enableSilentMode(boolean flag) {
+		this.silentMode = flag;
+	}
+
 	@Override
 	public void setParserConfig(ParserConfig parserConfig) {
 		client.setParserConfig(parserConfig);

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -103,6 +103,7 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 	private int maxPendingSize = DEFAULT_MAX_PENDING_SIZE;
 
 	private final boolean quadMode;
+	private boolean silentMode;
 
 	public SPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession client) {
 		this(repository, client, false); // in triple mode by default
@@ -112,6 +113,7 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 		super(repository);
 		this.client = client;
 		this.quadMode = quadMode;
+		this.silentMode = false;
 	}
 
 	@Override
@@ -604,16 +606,21 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 		OpenRDFUtil.verifyContextNotNull(contexts);
 		boolean localTransaction = startLocalTransaction();
 
+		String clearMode = "CLEAR";
+		if (this.isSilentMode()) {
+			clearMode = "CLEAR SILENT";
+		}
+
 		if (contexts.length == 0) {
-			sparqlTransaction.append("CLEAR ALL ");
+			sparqlTransaction.append(clearMode + " ALL ");
 			sparqlTransaction.append("; ");
 		} else {
 			for (Resource context : contexts) {
 				if (context == null) {
-					sparqlTransaction.append("CLEAR DEFAULT ");
+					sparqlTransaction.append(clearMode + " DEFAULT ");
 					sparqlTransaction.append("; ");
 				} else if (context instanceof IRI) {
-					sparqlTransaction.append("CLEAR GRAPH <" + context.stringValue() + "> ");
+					sparqlTransaction.append(clearMode + " GRAPH <" + context.stringValue() + "> ");
 					sparqlTransaction.append("; ");
 				} else {
 					throw new RepositoryException("SPARQL does not support named graphs identified by blank nodes.");
@@ -984,6 +991,10 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 	 */
 	protected boolean isQuadMode() {
 		return quadMode;
+	}
+
+	protected boolean isSilentMode() {
+		return silentMode;
 	}
 
 	/**

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
@@ -37,7 +37,6 @@ public class SPARQLRepository extends AbstractRepository implements HttpClientDe
 	 * @see #enableQuadMode(boolean)
 	 */
 	private boolean quadMode = false;
-	private boolean silentMode = false;
 	/**
 	 * The HTTP client that takes care of the client-server communication.
 	 */
@@ -246,9 +245,5 @@ public class SPARQLRepository extends AbstractRepository implements HttpClientDe
 	 */
 	public void enableQuadMode(boolean flag) {
 		this.quadMode = flag;
-	}
-
-	public void enableSilentMode(boolean flag) {
-		this.silentMode = flag;
 	}
 }

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
@@ -37,7 +37,7 @@ public class SPARQLRepository extends AbstractRepository implements HttpClientDe
 	 * @see #enableQuadMode(boolean)
 	 */
 	private boolean quadMode = false;
-
+	private boolean silentMode = false;
 	/**
 	 * The HTTP client that takes care of the client-server communication.
 	 */
@@ -246,5 +246,9 @@ public class SPARQLRepository extends AbstractRepository implements HttpClientDe
 	 */
 	public void enableQuadMode(boolean flag) {
 		this.quadMode = flag;
+	}
+
+	public void enableSilentMode(boolean flag) {
+		this.silentMode = flag;
 	}
 }

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
@@ -11,7 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
 import org.eclipse.rdf4j.model.IRI;
@@ -30,14 +33,12 @@ public class SPARQLConnectionTest {
 
 	private SPARQLConnection subject;
 	private SPARQLProtocolSession client;
-	private SPARQLRepository repository;
 	private final ValueFactory vf = SimpleValueFactory.getInstance();
 
 	@Before
 	public void setUp() throws Exception {
 		client = mock(SPARQLProtocolSession.class);
-		repository = mock(SPARQLRepository.class);
-		subject = new SPARQLConnection(repository, client);
+		subject = new SPARQLConnection(null, client);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: SakshiSaini17092 <sakshi17092@iiitd.ac.in>


GitHub issue resolved: #956  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
I added a boolean indicator for silentMode just like quadMode. Which can be enabled/disabled through SparqlConnection.
<!-- short description of your change goes here -->

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

