### PR TITLE
GH-1913: Added N3Parser to handle '=' sign 

### DIFF
--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
@@ -8,7 +8,7 @@
 package org.eclipse.rdf4j.rio.n3;
 
 import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.n3.N3Parser;
+import org.eclipse.rdf4j.rio.turtle.TurtleParser;
 import org.junit.Ignore;
 
 import junit.framework.Test;
@@ -26,6 +26,6 @@ public class N3ParserTest extends N3ParserTestCase {
 
 	@Override
 	protected RDFParser createRDFParser() {
-		return new N3Parser();
+		return new TurtleParser();
 	}
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
@@ -8,7 +8,7 @@
 package org.eclipse.rdf4j.rio.n3;
 
 import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.turtle.TurtleParser;
+import org.eclipse.rdf4j.rio.n3.N3Parser;
 import org.junit.Ignore;
 
 import junit.framework.Test;
@@ -26,6 +26,6 @@ public class N3ParserTest extends N3ParserTestCase {
 
 	@Override
 	protected RDFParser createRDFParser() {
-		return new TurtleParser();
+		return new N3Parser();
 	}
 }

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Parser.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Parser.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.n3;
+
+import java.io.IOException;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.turtle.TurtleParser;
+import org.eclipse.rdf4j.rio.turtle.TurtleUtil;
+
+public class N3Parser extends TurtleParser {
+
+	/*--------------*
+	 * Constructors *
+	 *--------------*/
+
+	/**
+	 * Creates a new N3Parser that will use a {@link SimpleValueFactory} to create RDF model objects.
+	 */
+	public N3Parser() {
+		super();
+	}
+
+	/**
+	 * Creates a new N3Parser that will use the supplied ValueFactory to create RDF model objects.
+	 *
+	 * @param valueFactory A ValueFactory.
+	 */
+	public N3Parser(ValueFactory valueFactory) {
+		super(valueFactory);
+	}
+
+	@Override
+	protected IRI parsePredicate() throws IOException, RDFParseException, RDFHandlerException {
+		// Check if the short-cut 'a' or '=' is used
+		int c1 = readCodePoint();
+
+		if (c1 == 'a') {
+			int c2 = readCodePoint();
+
+			if (TurtleUtil.isWhitespace(c2)) {
+				// Short-cut is used, return the rdf:type URI
+				return RDF.TYPE;
+			}
+
+			// Short-cut is not used, unread all characters
+			unread(c2);
+		}
+		if (c1 == '=') {
+			int c2 = readCodePoint();
+
+			if (TurtleUtil.isWhitespace(c2)) {
+				// Short-cut is used, return the owl:sameAs URI
+				return OWL.SAMEAS;
+			}
+
+			// Short-cut is not used, unread all characters
+			unread(c2);
+		}
+		unread(c1);
+
+		// Predicate is a normal resource
+		Value predicate = parseValue();
+		if (predicate instanceof IRI) {
+			return (IRI) predicate;
+		} else {
+			reportFatalError("Illegal predicate value: " + predicate);
+			return null;
+		}
+	}
+
+}

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Parser.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Parser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3ParserFactory.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3ParserFactory.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.rio.n3;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFParserFactory;
-import org.eclipse.rdf4j.rio.turtle.TurtleParser;
+import org.eclipse.rdf4j.rio.n3.N3Parser;
 
 /**
  * An {@link RDFParserFactory} for N3 parsers.
@@ -28,10 +28,10 @@ public class N3ParserFactory implements RDFParserFactory {
 	}
 
 	/**
-	 * Returns a new instance of {@link TurtleParser}.
+	 * Returns a new instance of {@link N3Parser}.
 	 */
 	@Override
 	public RDFParser getParser() {
-		return new TurtleParser();
+		return new N3Parser();
 	}
 }

--- a/core/rio/n3/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
+++ b/core/rio/n3/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.n3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
+import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author tanisha
+ */
+public class N3ParserTest {
+
+	private N3Parser parser;
+
+	private ValueFactory vf = SimpleValueFactory.getInstance();
+
+	private final ParseErrorCollector errorCollector = new ParseErrorCollector();
+
+	private final StatementCollector statementCollector = new StatementCollector();
+
+	private final String prefixes = "@prefix ex: <http://example.org/ex/> . \n@prefix : <http://example.org/> . \n";
+
+	private final String baseURI = "http://example.org/";
+
+	private SimpleParseLocationListener locationListener = new SimpleParseLocationListener();
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() {
+		parser = new N3Parser();
+		parser.setParseErrorListener(errorCollector);
+		parser.setRDFHandler(statementCollector);
+		parser.setParseLocationListener(locationListener);
+	}
+
+	@Test
+	public void testParseEquals() throws IOException {
+		String data = prefixes + " ex:foo = ex:bar. ";
+
+		parser.parse(new StringReader(data), baseURI);
+
+		assertTrue(errorCollector.getWarnings().isEmpty());
+		assertTrue(errorCollector.getErrors().isEmpty());
+		assertTrue(errorCollector.getFatalErrors().isEmpty());
+
+		assertFalse(statementCollector.getStatements().isEmpty());
+		assertEquals(1, statementCollector.getStatements().size());
+
+		for (Statement st : statementCollector.getStatements()) {
+			System.out.println(st);
+		}
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: tanishapandey tanishapandey99@gmail.com

GitHub issue resolved: #1913 

Briefly describe the changes proposed in this PR:

- Handled '=' sign in N3 format by creating a new parser which extends TurtleParser and overwrites the parsePredicate function to handle the '=' sign.
- Made corresponding changes in the N3ParserFactory file to return N3Parser object
- Added unit test in the new N3ParserTest file.