### PR TITLE
GH-688: Added getLabel OptionalMethod for Optional

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -9,7 +9,11 @@ package org.eclipse.rdf4j.model.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.Date;
+import java.util.IllformedLocaleException;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
 
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -50,7 +54,7 @@ public class Literals {
 
 	public static String getLabel(Optional v, String fallback) {
 
-		return v instanceof Optional ? getLabel((Value) v.orElseGet(null), fallback) : fallback;
+		return v != null ? getLabel((Value) v.orElseGet(null), fallback) : fallback;
 	}
 
 	/**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -9,10 +9,7 @@ package org.eclipse.rdf4j.model.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Date;
-import java.util.IllformedLocaleException;
-import java.util.Locale;
-import java.util.Objects;
+import java.util.*;
 
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -49,6 +46,11 @@ public class Literals {
 	 */
 	public static String getLabel(Value v, String fallback) {
 		return v instanceof Literal ? getLabel((Literal) v, fallback) : fallback;
+	}
+
+	public static String getLabel(Optional v, String fallback) {
+
+		return v instanceof Optional ? getLabel((Value) v.orElseGet(null), fallback) : fallback;
 	}
 
 	/**

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -15,13 +15,15 @@ import static org.junit.Assert.fail;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Optional;
 
+import javax.swing.text.html.Option;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.junit.Ignore;
@@ -818,5 +820,25 @@ public class LiteralsTest {
 		assertEquals("fr-FR", Literals.normalizeLanguageTag("fr-fr"));
 		assertEquals("fr-FR", Literals.normalizeLanguageTag("FR-FR"));
 		assertEquals("fr-FR", Literals.normalizeLanguageTag("FR-fr"));
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getLabel(Optional, String)}} .
+	 */
+	@Test
+	public void testGetLabelForOptinal() throws Exception {
+		ValueFactory VF = SimpleValueFactory.getInstance();
+		Model model = new LinkedHashModel();
+
+		IRI foo = VF.createIRI("http://example.org/foo");
+		IRI bar = VF.createIRI("http://example.org/bar");
+
+		Literal lit = VF.createLiteral(1.0);
+		model.add(foo, bar, lit);
+
+		Optional result = Models.object(model);
+		String label = Literals.getLabel(result, null);
+		assertNotNull(label);
+		assertTrue(label.equals("1.0"));
 	}
 }

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -17,12 +17,14 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Optional;
 
-import javax.swing.text.html.Option;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
 
-import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
@@ -37,6 +39,9 @@ import org.junit.Test;
 public class LiteralsTest {
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();
+	private static final Model model = new LinkedHashModel();
+	private static final IRI foo = vf.createIRI("http://example.org/foo");
+	private static final IRI bar = vf.createIRI("http://example.org/bar");
 
 	/**
 	 * Test method for
@@ -826,19 +831,29 @@ public class LiteralsTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getLabel(Optional, String)}} .
 	 */
 	@Test
-	public void testGetLabelForOptinal() throws Exception {
-		ValueFactory VF = SimpleValueFactory.getInstance();
-		Model model = new LinkedHashModel();
+	public void testGetLabelForOptional() throws Exception {
 
-		IRI foo = VF.createIRI("http://example.org/foo");
-		IRI bar = VF.createIRI("http://example.org/bar");
-
-		Literal lit = VF.createLiteral(1.0);
+		Literal lit = vf.createLiteral(1.0);
 		model.add(foo, bar, lit);
 
 		Optional result = Models.object(model);
-		String label = Literals.getLabel(result, null);
+		String label = Literals.getLabel(result, "fallback");
 		assertNotNull(label);
 		assertTrue(label.equals("1.0"));
+	}
+
+	/**
+	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getLabel(Optional, String)}} .
+	 */
+	@Test
+	public void testGetLabelForOptionalInFallback() throws Exception {
+
+		Literal lit = vf.createLiteral(1.0);
+		model.add(foo, bar, lit);
+
+		Optional result = Models.object(model);
+		String label = Literals.getLabel((Optional) null, "fallback");
+		assertNotNull(label);
+		assertTrue(label.equals("fallback"));
 	}
 }


### PR DESCRIPTION
Signed-off-by: SakshiSaini17092 <sakshi17092@iiitd.ac.in>


GitHub issue resolved: #688 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
Added getLabel function for Optional.
<!-- short description of your change goes here -->

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

