### PR TITLE
GH-1079 INLINE_BLANK_NODES-lose-bnode

### DIFF
--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -242,6 +242,8 @@ public class ArrangedWriter extends AbstractRDFWriter {
 							+ BasicWriterSettings.INLINE_BLANK_NODES.getKey());
 				}
 			} else {
+				// this function call ensures that statements are displayed for an inline blank node which is repeated.
+				queueBlankStatements(bkey);
 				stack.addLast(bkey);
 			}
 		}

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -7,9 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -242,8 +244,6 @@ public class ArrangedWriter extends AbstractRDFWriter {
 							+ BasicWriterSettings.INLINE_BLANK_NODES.getKey());
 				}
 			} else {
-				// this function call ensures that statements are displayed for an inline blank node which is repeated.
-				queueBlankStatements(bkey);
 				stack.addLast(bkey);
 			}
 		}
@@ -309,9 +309,62 @@ public class ArrangedWriter extends AbstractRDFWriter {
 		if (!stmtBySubject.isEmpty() || !blanks.isEmpty()) {
 			flushNamespaces();
 			Statement st;
+
+			// used to store all the statements
+			ArrayList<Statement> statements = new ArrayList<Statement>();
+
+			// used to store blank nodes along with the number of times they are used as an object in a statement.
+			Map<BNode, Integer> bNodeOccurence = new HashMap<BNode, Integer>();
+
 			while ((st = nextStatement()) != null) {
-				delegate.handleStatement(st);
+				statements.add(st);
+				Value obj = st.getObject();
+
+				// if the object in the statement is a blank node, we will update its number of occurence
+				if (obj instanceof BNode) {
+					BNode bNode = (BNode) obj;
+					if (!bNodeOccurence.containsKey(bNode)) {
+						bNodeOccurence.put(bNode, 0);
+					}
+					bNodeOccurence.put(bNode, bNodeOccurence.get(bNode) + 1);
+				}
 			}
+
+			boolean INLINE_BLANK_NODES = getWriterConfig().get(BasicWriterSettings.INLINE_BLANK_NODES);
+
+			for (int i = 0; i < statements.size(); i++) {
+				st = statements.get(i);
+
+				if (INLINE_BLANK_NODES) {
+					Value obj = st.getObject();
+					Resource subj = st.getSubject();
+					if (obj instanceof BNode) {
+						BNode bNode = (BNode) obj;
+						if (bNodeOccurence.get(bNode) > 1) {
+							/*
+							 * if INLINE_BLANK_NODES is true and the blank node is repeated, we will set
+							 * INLINE_BLANK_NODES as false so as to make sure that the blank node object is not inlined.
+							 */
+							getWriterConfig().set(BasicWriterSettings.INLINE_BLANK_NODES, false);
+						}
+
+					} else if (subj instanceof BNode) {
+						/*
+						 * if the subject of a statement is a blank node that has been repeated, it should not be
+						 * inlined.
+						 */
+						BNode bNode = (BNode) subj;
+						if (bNodeOccurence.containsKey(bNode) && bNodeOccurence.get(bNode) > 1) {
+							getWriterConfig().set(BasicWriterSettings.INLINE_BLANK_NODES, false);
+						}
+					}
+				}
+				delegate.handleStatement(st);
+
+				// resetting the value of INLINE_BLANK_NODES
+				getWriterConfig().set(BasicWriterSettings.INLINE_BLANK_NODES, INLINE_BLANK_NODES);
+			}
+
 			assert queueSize == 0;
 		}
 	}

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -225,6 +225,7 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 		try {
 			Resource subj = st.getSubject();
 			IRI pred = st.getPredicate();
+			inlineBNodes = getWriterConfig().get(BasicWriterSettings.INLINE_BLANK_NODES);
 			if (inlineBNodes && (pred.equals(RDF.FIRST) || pred.equals(RDF.REST))) {
 				handleList(st);
 			} else if (inlineBNodes && !subj.equals(lastWrittenSubject) && stack.contains(subj)) {
@@ -255,7 +256,6 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 		Resource subj = st.getSubject();
 		IRI pred = st.getPredicate();
 		Value obj = st.getObject();
-
 		try {
 			if (subj.equals(lastWrittenSubject)) {
 				if (pred.equals(lastWrittenPredicate)) {

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriterTest.java
@@ -44,12 +44,15 @@ public class ArrangedWriterTest {
 
 	private RDFWriterFactory writerFactory;
 
-	private BNode bnode;
+	private BNode bnode1;
+
+	private BNode bnode2;
 
 	public ArrangedWriterTest() {
 		vf = SimpleValueFactory.getInstance();
 
-		bnode = vf.createBNode("bnode");
+		bnode1 = vf.createBNode("bnode1");
+		bnode2 = vf.createBNode("bnode2");
 
 		exNs = "http://example.org/";
 
@@ -84,10 +87,13 @@ public class ArrangedWriterTest {
 	@Test
 	public void testWriteRepeatedInlineBlankNode() {
 		Model model = new ModelBuilder().subject(exNs + "subject")
-				.add(vf.createIRI(exNs, "rel1"), bnode)
-				.add(vf.createIRI(exNs, "rel2"), bnode)
-				.subject(bnode)
-				.add(RDFS.LABEL, "the bnode")
+				.add(vf.createIRI(exNs, "rel1"), bnode1)
+				.add(vf.createIRI(exNs, "rel2"), bnode1)
+				.add(vf.createIRI(exNs, "rel3"), bnode2)
+				.subject(bnode1)
+				.add(RDFS.LABEL, "the bnode1")
+				.subject(bnode2)
+				.add(RDFS.LABEL, "the bnode2")
 				.build();
 
 		model.setNamespace(RDFS.NS);
@@ -103,11 +109,11 @@ public class ArrangedWriterTest {
 		String expectedResult = "@prefix ex: <http://example.org/> ." + sep +
 				"@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> ." + sep +
 				"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> ." + sep + sep +
-				"ex:subject ex:rel1 [" + sep +
-				"      rdfs:label \"the bnode\"" + sep +
-				"    ];" + sep +
-				"  ex:rel2 [" + sep +
-				"      rdfs:label \"the bnode\"" + sep +
+				"ex:subject ex:rel1 _:bnode1 ." + sep + sep +
+				"_:bnode1 rdfs:label \"the bnode1\" ." + sep + sep +
+				"ex:subject ex:rel2 _:bnode1;" + sep +
+				"  ex:rel3 [" + sep +
+				"      rdfs:label \"the bnode2\"" + sep +
 				"    ] ." + sep;
 
 		assertEquals(expectedResult, stringWriter.toString());


### PR DESCRIPTION
Signed-off-by: Mirr99 <mihir17166@iiitd.ac.in>


GitHub issue resolved: #1079

Briefly describe the changes proposed in this PR:

- Added a function call to `queueBlankStatements(SubjectInContext key)` to ensure that the statements related to a repeated BNode are also written.

Please let me know if a test case is required.
