### PR TITLE
GH-2158: Added getAllValues function to QueryResults

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.query;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -85,6 +87,22 @@ public class QueryResults extends Iterations {
 		Model model = modelFactory.createEmptyModel();
 		addAll(iteration, model);
 		return model;
+	}
+
+	/**
+	 * Returns a list of values of a particular variable out of the QueryResult.
+	 *
+	 * @param result
+	 * @param var    variable for which list of values needs to be returned
+	 * @return a list of Values of var
+	 * @throws QueryEvaluationException
+	 */
+	public static List<Value> getAllValues(TupleQueryResult result, String var) throws QueryEvaluationException {
+		try (Stream<BindingSet> stream = result.stream()) {
+			return result.getBindingNames().contains(var)
+					? stream.map(bs -> bs.getValue(var)).collect(Collectors.toList())
+					: Collections.emptyList();
+		}
 	}
 
 	/**

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/QueryResultsTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/QueryResultsTest.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -351,5 +352,38 @@ public class QueryResultsTest {
 		tqr1.append(new ListBindingSet(twoBindingNames, foo, bnode2));
 
 		assertFalse(QueryResults.equals(tqr1, tqr3));
+	}
+
+	@Test
+	public void testStreamTupleAllValuesOfResult1() {
+		BindingSet a = new ListBindingSet(twoBindingNames, foo, lit1);
+		BindingSet b = new ListBindingSet(twoBindingNames, bar, lit2);
+		tqr1.append(a);
+		tqr1.append(b);
+		tqr1.append(a);
+		tqr1.append(b);
+		tqr1.append(b);
+
+		List<Value> list = QueryResults.getAllValues(tqr1, "a");
+
+		assertNotNull(list);
+		assertFalse(list.isEmpty());
+		assertTrue(list.equals(Arrays.asList(foo, bar, foo, bar, bar)));
+	}
+
+	@Test
+	public void testStreamTupleAllValuesOfResult2() {
+		BindingSet a = new ListBindingSet(twoBindingNames, foo, lit1);
+		BindingSet b = new ListBindingSet(twoBindingNames, bar, lit2);
+		tqr1.append(a);
+		tqr1.append(b);
+		tqr1.append(a);
+		tqr1.append(b);
+		tqr1.append(b);
+
+		List<Value> list = QueryResults.getAllValues(tqr1, "c");
+
+		assertNotNull(list);
+		assertTrue(list.isEmpty());
 	}
 }


### PR DESCRIPTION
Signed-off-by: shubhi0108 <shubhi16267@iiitd.ac.in>

GH-2158: Formatted getAllValues function

Signed-off-by: navdhaagarwal <navdha16250@iiitd.ac.in>

GH-2158: Added a test

Signed-off-by: navdhaagarwal <navdha16250@iiitd.ac.in>

GH-2158: changed function name

Signed-off-by: navdhaagarwal <navdha16250@iiitd.ac.in>

GH2158: Final check with one more test

Signed-off-by: navdhaagarwal <navdha16250@iiitd.ac.in>


GitHub issue resolved: #2158 

Added a new utility function `getAllValues()` to QueryResults for fetching all the values of a binding variable from the `TupleQueryResult`

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

