### PR TITLE
GH-1105 regex escaping special chars sparql query

### DIFF
--- a/core/queryparser/sparql/pom.xml
+++ b/core/queryparser/sparql/pom.xml
@@ -52,5 +52,11 @@
 			<version>${jmhVersion}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-rio-turtle</artifactId>
+			<version>3.2.2-SNAPSHOT</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SyntaxTreeBuilderTokenManager.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SyntaxTreeBuilderTokenManager.java
@@ -3340,14 +3340,22 @@ public class SyntaxTreeBuilderTokenManager implements SyntaxTreeBuilderConstants
 		}
 	}
 
-	public String backSlashCorrection(String image){
-		String newImage = "";
-		if (image.equals("\"\\.\"")){
-			newImage = "\"\\\\.\"";
+	public String backSlashCorrection(String image) {
+		StringBuilder newimg = new StringBuilder();
+		int imglen = image.length(), cnt = 0;
+		for (int i = 0; i < imglen; i++) {
+			if (image.charAt(i) == '\\') {
+				cnt++;
+			} else if (cnt % 2 == 1) {
+				newimg.append('\\');
+				cnt = 0;
+			}
+			newimg.append(image.charAt(i));
 		}
-		else{
-			newImage = image;
+		if (cnt % 2 == 1) {
+			newimg.append('\\');
 		}
+		String newImage = new String(newimg);
 		return newImage;
 	}
 
@@ -3366,7 +3374,6 @@ public class SyntaxTreeBuilderTokenManager implements SyntaxTreeBuilderConstants
 		endColumn = input_stream.getEndColumn();
 		String newImage = backSlashCorrection(curTokenImage);
 		t = Token.newToken(jjmatchedKind, newImage);
-		System.out.println("kind: "+jjmatchedKind + "string: " + newImage);
 
 		t.beginLine = beginLine;
 		t.endLine = endLine;

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SyntaxTreeBuilderTokenManager.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/SyntaxTreeBuilderTokenManager.java
@@ -3340,6 +3340,17 @@ public class SyntaxTreeBuilderTokenManager implements SyntaxTreeBuilderConstants
 		}
 	}
 
+	public String backSlashCorrection(String image){
+		String newImage = "";
+		if (image.equals("\"\\.\"")){
+			newImage = "\"\\\\.\"";
+		}
+		else{
+			newImage = image;
+		}
+		return newImage;
+	}
+
 	protected Token jjFillToken() {
 		final Token t;
 		final String curTokenImage;
@@ -3353,7 +3364,9 @@ public class SyntaxTreeBuilderTokenManager implements SyntaxTreeBuilderConstants
 		beginColumn = input_stream.getBeginColumn();
 		endLine = input_stream.getEndLine();
 		endColumn = input_stream.getEndColumn();
-		t = Token.newToken(jjmatchedKind, curTokenImage);
+		String newImage = backSlashCorrection(curTokenImage);
+		t = Token.newToken(jjmatchedKind, newImage);
+		System.out.println("kind: "+jjmatchedKind + "string: " + newImage);
 
 		t.beginLine = beginLine;
 		t.endLine = endLine;

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/UnicodeEscapeStream.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/UnicodeEscapeStream.java
@@ -58,7 +58,7 @@ public class UnicodeEscapeStream extends JavaCharStream implements CharStream {
 							break;
 						}
 
-						if (backSlashCnt % 2 == 1) {
+						if (backSlashCnt % 2 == 1 && buffer[0] == '"') {
 							backup(backSlashCnt + 1);
 						} else {
 							backup(backSlashCnt);

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/UnicodeEscapeStream.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/UnicodeEscapeStream.java
@@ -58,10 +58,9 @@ public class UnicodeEscapeStream extends JavaCharStream implements CharStream {
 							break;
 						}
 
-						if(backSlashCnt%2==1){
-							backup(backSlashCnt+1);
-						}
-						else {
+						if (backSlashCnt % 2 == 1) {
+							backup(backSlashCnt + 1);
+						} else {
 							backup(backSlashCnt);
 						}
 						return '\\';

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/UnicodeEscapeStream.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ast/UnicodeEscapeStream.java
@@ -58,7 +58,12 @@ public class UnicodeEscapeStream extends JavaCharStream implements CharStream {
 							break;
 						}
 
-						backup(backSlashCnt);
+						if(backSlashCnt%2==1){
+							backup(backSlashCnt+1);
+						}
+						else {
+							backup(backSlashCnt);
+						}
 						return '\\';
 					}
 				} catch (java.io.IOException e) {

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -73,307 +73,339 @@ public class SPARQLParserTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.query.parser.sparql.SPARQLParser#parseQuery(java.lang.String, java.lang.String)} .
 	 */
-//	@Test
-//	public void testSourceStringAssignment() throws Exception {
-//		String simpleSparqlQuery = "SELECT * WHERE {?X ?P ?Y }";
-//
-//		ParsedQuery q = parser.parseQuery(simpleSparqlQuery, null);
-//
-//		assertNotNull(q);
-//		assertEquals(simpleSparqlQuery, q.getSourceString());
-//	}
-//
-//	@Test
-//	public void testInsertDataLineNumberReporting() throws Exception {
-//		String insertDataString = "INSERT DATA {\n incorrect reference }";
-//
-//		try {
-//			ParsedUpdate u = parser.parseUpdate(insertDataString, null);
-//			fail("should have resulted in parse exception");
-//		} catch (MalformedQueryException e) {
-//			assertTrue(e.getMessage().contains("line 2,"));
-//		}
-//
-//	}
-//
-//	@Test
-//	public void testDeleteDataLineNumberReporting() throws Exception {
-//		String deleteDataString = "DELETE DATA {\n incorrect reference }";
-//
-//		try {
-//			ParsedUpdate u = parser.parseUpdate(deleteDataString, null);
-//			fail("should have resulted in parse exception");
-//		} catch (MalformedQueryException e) {
-//			assertTrue(e.getMessage().contains("line 2,"));
-//		}
-//	}
-//
-//	@Test
-//	public void testSES1922PathSequenceWithValueConstant() throws Exception {
-//
-//		StringBuilder qb = new StringBuilder();
-//		qb.append("ASK {?A (<foo:bar>)/<foo:foo> <foo:objValue>} ");
-//
-//		ParsedQuery q = parser.parseQuery(qb.toString(), null);
-//		TupleExpr te = q.getTupleExpr();
-//
-//		assertNotNull(te);
-//
-//		assertTrue(te instanceof Slice);
-//		Slice s = (Slice) te;
-//		assertTrue(s.getArg() instanceof Join);
-//		Join j = (Join) s.getArg();
-//
-//		assertTrue(j.getLeftArg() instanceof StatementPattern);
-//		assertTrue(j.getRightArg() instanceof StatementPattern);
-//		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
-//		StatementPattern rightArg = (StatementPattern) j.getRightArg();
-//
-//		assertTrue(leftArg.getObjectVar().equals(rightArg.getSubjectVar()));
-//		assertEquals(leftArg.getObjectVar().getName(), rightArg.getSubjectVar().getName());
-//	}
-//
-//	@Test
-//	public void testParsedBooleanQueryRootNode() throws Exception {
-//		StringBuilder qb = new StringBuilder();
-//		qb.append("ASK {?a <foo:bar> \"test\"}");
-//
-//		ParsedBooleanQuery q = (ParsedBooleanQuery) parser.parseQuery(qb.toString(), null);
-//		TupleExpr te = q.getTupleExpr();
-//
-//		assertNotNull(te);
-//		assertTrue(te instanceof Slice);
-//		assertNull(te.getParentNode());
-//	}
-//
-//	/**
-//	 * Verify that an INSERT with a subselect using a wildcard correctly adds vars to projection
-//	 *
-//	 * @see <a href="https://github.com/eclipse/rdf4j/issues/686">#686</a>
-//	 */
-//	@Test
-//	public void testParseWildcardSubselectInUpdate() throws Exception {
-//		StringBuilder update = new StringBuilder();
-//		update.append("INSERT { <urn:a> <urn:b> <urn:c> . } WHERE { SELECT * {?s ?p ?o } }");
-//
-//		ParsedUpdate parsedUpdate = parser.parseUpdate(update.toString(), null);
-//		List<UpdateExpr> exprs = parsedUpdate.getUpdateExprs();
-//		assertEquals(1, exprs.size());
-//
-//		UpdateExpr expr = exprs.get(0);
-//		assertTrue(expr instanceof Modify);
-//		Modify m = (Modify) expr;
-//		TupleExpr whereClause = m.getWhereExpr();
-//		assertTrue(whereClause instanceof Projection);
-//		ProjectionElemList projectionElemList = ((Projection) whereClause).getProjectionElemList();
-//		assertNotNull(projectionElemList);
-//		List<ProjectionElem> elements = projectionElemList.getElements();
-//		assertNotNull(elements);
-//
-//		assertEquals("projection should contain all three variables", 3, elements.size());
-//	}
-//
-//	@Test
-//	public void testParseIntegerObjectValue() throws Exception {
-//		// test that the parser correctly parses the object value as an integer, instead of as a decimal.
-//		String query = "select ?Concept where { ?Concept a 1. ?Concept2 a 1. } ";
-//		ParsedTupleQuery q = (ParsedTupleQuery) parser.parseQuery(query, null);
-//
-//		// all we're verifying is that the query is parsed without error. If it doesn't parse as integer but as a
-//		// decimal, the
-//		// parser will fail, because the statement pattern doesn't end with a full-stop.
-//		assertNotNull(q);
-//	}
-//
-//	@Test
-//	public void testParsedTupleQueryRootNode() throws Exception {
-//		StringBuilder qb = new StringBuilder();
-//		qb.append("SELECT *  {?a <foo:bar> \"test\"}");
-//
-//		ParsedTupleQuery q = (ParsedTupleQuery) parser.parseQuery(qb.toString(), null);
-//		TupleExpr te = q.getTupleExpr();
-//
-//		assertNotNull(te);
-//		assertTrue(te instanceof Projection);
-//		assertNull(te.getParentNode());
-//	}
-//
-//	@Test
-//	public void testParsedGraphQueryRootNode() throws Exception {
-//		StringBuilder qb = new StringBuilder();
-//		qb.append("CONSTRUCT WHERE {?a <foo:bar> \"test\"}");
-//
-//		ParsedGraphQuery q = (ParsedGraphQuery) parser.parseQuery(qb.toString(), null);
-//		TupleExpr te = q.getTupleExpr();
-//
-//		assertNotNull(te);
-//		assertTrue(te instanceof Projection);
-//		assertNull(te.getParentNode());
-//	}
-//
-//	@Test
-//	public void testOrderByWithAliases1() throws Exception {
-//		String queryString = " SELECT ?x (SUM(?v1)/COUNT(?v1) as ?r) WHERE { ?x <urn:foo> ?v1 } GROUP BY ?x ORDER BY ?r";
-//
-//		ParsedQuery query = parser.parseQuery(queryString, null);
-//
-//		assertNotNull(query);
-//		TupleExpr te = query.getTupleExpr();
-//
-//		assertTrue(te instanceof Projection);
-//
-//		te = ((Projection) te).getArg();
-//
-//		assertTrue(te instanceof Order);
-//
-//		te = ((Order) te).getArg();
-//
-//		assertTrue(te instanceof Extension);
-//	}
-//
-//	@Test
-//	public void testSES1927UnequalLiteralValueConstants1() throws Exception {
-//
-//		StringBuilder qb = new StringBuilder();
-//		qb.append("ASK {?a <foo:bar> \"test\". ?a <foo:foo> \"test\"@en .} ");
-//
-//		ParsedQuery q = parser.parseQuery(qb.toString(), null);
-//		TupleExpr te = q.getTupleExpr();
-//
-//		assertNotNull(te);
-//
-//		assertTrue(te instanceof Slice);
-//		Slice s = (Slice) te;
-//		assertTrue(s.getArg() instanceof Join);
-//		Join j = (Join) s.getArg();
-//
-//		assertTrue(j.getLeftArg() instanceof StatementPattern);
-//		assertTrue(j.getRightArg() instanceof StatementPattern);
-//		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
-//		StatementPattern rightArg = (StatementPattern) j.getRightArg();
-//
-//		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
-//		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
-//	}
-//
-//	@Test
-//	public void testSES1927UnequalLiteralValueConstants2() throws Exception {
-//
-//		StringBuilder qb = new StringBuilder();
-//		qb.append("ASK {?a <foo:bar> \"test\". ?a <foo:foo> \"test\"^^<foo:bar> .} ");
-//
-//		ParsedQuery q = parser.parseQuery(qb.toString(), null);
-//		TupleExpr te = q.getTupleExpr();
-//
-//		assertNotNull(te);
-//
-//		assertTrue(te instanceof Slice);
-//		Slice s = (Slice) te;
-//		assertTrue(s.getArg() instanceof Join);
-//		Join j = (Join) s.getArg();
-//
-//		assertTrue(j.getLeftArg() instanceof StatementPattern);
-//		assertTrue(j.getRightArg() instanceof StatementPattern);
-//		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
-//		StatementPattern rightArg = (StatementPattern) j.getRightArg();
-//
-//		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
-//		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
-//	}
-//
-//	@Test
-//	public void testLongUnicode() throws Exception {
-//		ParsedUpdate ru = parser.parseUpdate("insert data {<urn:test:foo> <urn:test:bar> \"\\U0001F61F\" .}",
-//				"urn:test");
-//		InsertData insertData = (InsertData) ru.getUpdateExprs().get(0);
-//		String[] lines = insertData.getDataBlock().split("\n");
-//		assertEquals("\uD83D\uDE1F", lines[lines.length - 1].replaceAll(".*\"(.*)\".*", "$1"));
-//	}
-//
-//	@Test
-//	public void testWildCardPathFixedEnd() {
-//
-//		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ((:|!:)|(^:|!^:))* :Jane.} ";
-//
-//		ParsedQuery parsedQuery = parser.parseQuery(query, null);
-//
-//		// parsing should not throw exception
-//		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
-//
-//	}
-//
-//	@Test
-//	public void testWildCardPathPushNegation() {
-//
-//		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ^(:|!:) ?jane.} ";
-//
-//		ParsedQuery parsedQuery = parser.parseQuery(query, null);
-//		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
-//
-//		Slice slice = (Slice) tupleExpr;
-//		Union union = (Union) slice.getArg();
-//
-//		Var leftSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
-//		Var rightSubjectVar = ((StatementPattern) ((Filter) union.getRightArg()).getArg()).getSubjectVar();
-//
-//		assertEquals(leftSubjectVar, rightSubjectVar);
-//
-//	}
-//
-//	@Test
-//	public void testWildCardPathPushNegation2() {
-//
-//		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ^(:|!:) :Jane.} ";
-//
-//		ParsedQuery parsedQuery = parser.parseQuery(query, null);
-//		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
-//
-//		Slice slice = (Slice) tupleExpr;
-//		Union union = (Union) slice.getArg();
-//
-//		Var leftSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
-//		Var rightSubjectVar = ((StatementPattern) ((Filter) union.getRightArg()).getArg()).getSubjectVar();
-//
-//		assertEquals(leftSubjectVar, rightSubjectVar);
-//
-//	}
-//
-//	@Test
-//	public void testWildCardPathComplexSubjectHandling() {
-//
-//		String query = "PREFIX : <http://example.org/>\n ASK { ?a (:comment/^(:subClassOf|(:type/:label))/:type)* ?b } ";
-//
-//		ParsedQuery parsedQuery = parser.parseQuery(query, null);
-//		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
-//
-//		Slice slice = (Slice) tupleExpr;
-//
-//		ArbitraryLengthPath path = (ArbitraryLengthPath) slice.getArg();
-//		Var pathStart = path.getSubjectVar();
-//		Var pathEnd = path.getObjectVar();
-//
-//		assertThat(pathStart.getName()).isEqualTo("a");
-//		assertThat(pathEnd.getName()).isEqualTo("b");
-//
-//		Join pathSequence = (Join) path.getPathExpression();
-//		Join innerJoin = (Join) pathSequence.getLeftArg();
-//		Var commentObjectVar = ((StatementPattern) innerJoin.getLeftArg()).getObjectVar();
-//
-//		Union union = (Union) innerJoin.getRightArg();
-//		Var subClassOfSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
-//		assertThat(subClassOfSubjectVar).isNotEqualTo(commentObjectVar);
-//
-//		Var subClassOfObjectVar = ((StatementPattern) union.getLeftArg()).getObjectVar();
-//
-//		assertThat(subClassOfObjectVar).isEqualTo(commentObjectVar);
-//	}
+	@Test
+	public void testSourceStringAssignment() throws Exception {
+		String simpleSparqlQuery = "SELECT * WHERE {?X ?P ?Y }";
+
+		ParsedQuery q = parser.parseQuery(simpleSparqlQuery, null);
+
+		assertNotNull(q);
+		assertEquals(simpleSparqlQuery, q.getSourceString());
+	}
 
 	@Test
-	public void testEscape() {
+	public void testInsertDataLineNumberReporting() throws Exception {
+		String insertDataString = "INSERT DATA {\n incorrect reference }";
+
+		try {
+			ParsedUpdate u = parser.parseUpdate(insertDataString, null);
+			fail("should have resulted in parse exception");
+		} catch (MalformedQueryException e) {
+			assertTrue(e.getMessage().contains("line 2,"));
+		}
+
+	}
+
+	@Test
+	public void testDeleteDataLineNumberReporting() throws Exception {
+		String deleteDataString = "DELETE DATA {\n incorrect reference }";
+
+		try {
+			ParsedUpdate u = parser.parseUpdate(deleteDataString, null);
+			fail("should have resulted in parse exception");
+		} catch (MalformedQueryException e) {
+			assertTrue(e.getMessage().contains("line 2,"));
+		}
+	}
+
+	@Test
+	public void testSES1922PathSequenceWithValueConstant() throws Exception {
+
+		StringBuilder qb = new StringBuilder();
+		qb.append("ASK {?A (<foo:bar>)/<foo:foo> <foo:objValue>} ");
+
+		ParsedQuery q = parser.parseQuery(qb.toString(), null);
+		TupleExpr te = q.getTupleExpr();
+
+		assertNotNull(te);
+
+		assertTrue(te instanceof Slice);
+		Slice s = (Slice) te;
+		assertTrue(s.getArg() instanceof Join);
+		Join j = (Join) s.getArg();
+
+		assertTrue(j.getLeftArg() instanceof StatementPattern);
+		assertTrue(j.getRightArg() instanceof StatementPattern);
+		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
+		StatementPattern rightArg = (StatementPattern) j.getRightArg();
+
+		assertTrue(leftArg.getObjectVar().equals(rightArg.getSubjectVar()));
+		assertEquals(leftArg.getObjectVar().getName(), rightArg.getSubjectVar().getName());
+	}
+
+	@Test
+	public void testParsedBooleanQueryRootNode() throws Exception {
+		StringBuilder qb = new StringBuilder();
+		qb.append("ASK {?a <foo:bar> \"test\"}");
+
+		ParsedBooleanQuery q = (ParsedBooleanQuery) parser.parseQuery(qb.toString(), null);
+		TupleExpr te = q.getTupleExpr();
+
+		assertNotNull(te);
+		assertTrue(te instanceof Slice);
+		assertNull(te.getParentNode());
+	}
+
+	/**
+	 * Verify that an INSERT with a subselect using a wildcard correctly adds vars to projection
+	 *
+	 * @see <a href="https://github.com/eclipse/rdf4j/issues/686">#686</a>
+	 */
+	@Test
+	public void testParseWildcardSubselectInUpdate() throws Exception {
+		StringBuilder update = new StringBuilder();
+		update.append("INSERT { <urn:a> <urn:b> <urn:c> . } WHERE { SELECT * {?s ?p ?o } }");
+
+		ParsedUpdate parsedUpdate = parser.parseUpdate(update.toString(), null);
+		List<UpdateExpr> exprs = parsedUpdate.getUpdateExprs();
+		assertEquals(1, exprs.size());
+
+		UpdateExpr expr = exprs.get(0);
+		assertTrue(expr instanceof Modify);
+		Modify m = (Modify) expr;
+		TupleExpr whereClause = m.getWhereExpr();
+		assertTrue(whereClause instanceof Projection);
+		ProjectionElemList projectionElemList = ((Projection) whereClause).getProjectionElemList();
+		assertNotNull(projectionElemList);
+		List<ProjectionElem> elements = projectionElemList.getElements();
+		assertNotNull(elements);
+
+		assertEquals("projection should contain all three variables", 3, elements.size());
+	}
+
+	@Test
+	public void testParseIntegerObjectValue() throws Exception {
+		// test that the parser correctly parses the object value as an integer, instead of as a decimal.
+		String query = "select ?Concept where { ?Concept a 1. ?Concept2 a 1. } ";
+		ParsedTupleQuery q = (ParsedTupleQuery) parser.parseQuery(query, null);
+
+		// all we're verifying is that the query is parsed without error. If it doesn't parse as integer but as a
+		// decimal, the
+		// parser will fail, because the statement pattern doesn't end with a full-stop.
+		assertNotNull(q);
+	}
+
+	@Test
+	public void testParsedTupleQueryRootNode() throws Exception {
+		StringBuilder qb = new StringBuilder();
+		qb.append("SELECT *  {?a <foo:bar> \"test\"}");
+
+		ParsedTupleQuery q = (ParsedTupleQuery) parser.parseQuery(qb.toString(), null);
+		TupleExpr te = q.getTupleExpr();
+
+		assertNotNull(te);
+		assertTrue(te instanceof Projection);
+		assertNull(te.getParentNode());
+	}
+
+	@Test
+	public void testParsedGraphQueryRootNode() throws Exception {
+		StringBuilder qb = new StringBuilder();
+		qb.append("CONSTRUCT WHERE {?a <foo:bar> \"test\"}");
+
+		ParsedGraphQuery q = (ParsedGraphQuery) parser.parseQuery(qb.toString(), null);
+		TupleExpr te = q.getTupleExpr();
+
+		assertNotNull(te);
+		assertTrue(te instanceof Projection);
+		assertNull(te.getParentNode());
+	}
+
+	@Test
+	public void testOrderByWithAliases1() throws Exception {
+		String queryString = " SELECT ?x (SUM(?v1)/COUNT(?v1) as ?r) WHERE { ?x <urn:foo> ?v1 } GROUP BY ?x ORDER BY ?r";
+
+		ParsedQuery query = parser.parseQuery(queryString, null);
+
+		assertNotNull(query);
+		TupleExpr te = query.getTupleExpr();
+
+		assertTrue(te instanceof Projection);
+
+		te = ((Projection) te).getArg();
+
+		assertTrue(te instanceof Order);
+
+		te = ((Order) te).getArg();
+
+		assertTrue(te instanceof Extension);
+	}
+
+	@Test
+	public void testSES1927UnequalLiteralValueConstants1() throws Exception {
+
+		StringBuilder qb = new StringBuilder();
+		qb.append("ASK {?a <foo:bar> \"test\". ?a <foo:foo> \"test\"@en .} ");
+
+		ParsedQuery q = parser.parseQuery(qb.toString(), null);
+		TupleExpr te = q.getTupleExpr();
+
+		assertNotNull(te);
+
+		assertTrue(te instanceof Slice);
+		Slice s = (Slice) te;
+		assertTrue(s.getArg() instanceof Join);
+		Join j = (Join) s.getArg();
+
+		assertTrue(j.getLeftArg() instanceof StatementPattern);
+		assertTrue(j.getRightArg() instanceof StatementPattern);
+		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
+		StatementPattern rightArg = (StatementPattern) j.getRightArg();
+
+		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
+		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
+	}
+
+	@Test
+	public void testSES1927UnequalLiteralValueConstants2() throws Exception {
+
+		StringBuilder qb = new StringBuilder();
+		qb.append("ASK {?a <foo:bar> \"test\". ?a <foo:foo> \"test\"^^<foo:bar> .} ");
+
+		ParsedQuery q = parser.parseQuery(qb.toString(), null);
+		TupleExpr te = q.getTupleExpr();
+
+		assertNotNull(te);
+
+		assertTrue(te instanceof Slice);
+		Slice s = (Slice) te;
+		assertTrue(s.getArg() instanceof Join);
+		Join j = (Join) s.getArg();
+
+		assertTrue(j.getLeftArg() instanceof StatementPattern);
+		assertTrue(j.getRightArg() instanceof StatementPattern);
+		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
+		StatementPattern rightArg = (StatementPattern) j.getRightArg();
+
+		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
+		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
+	}
+
+	@Test
+	public void testLongUnicode() throws Exception {
+		ParsedUpdate ru = parser.parseUpdate("insert data {<urn:test:foo> <urn:test:bar> \"\\U0001F61F\" .}",
+				"urn:test");
+		InsertData insertData = (InsertData) ru.getUpdateExprs().get(0);
+		String[] lines = insertData.getDataBlock().split("\n");
+		assertEquals("\uD83D\uDE1F", lines[lines.length - 1].replaceAll(".*\"(.*)\".*", "$1"));
+	}
+
+	@Test
+	public void testWildCardPathFixedEnd() {
+
+		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ((:|!:)|(^:|!^:))* :Jane.} ";
+
+		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+
+		// parsing should not throw exception
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+	}
+
+	@Test
+	public void testWildCardPathPushNegation() {
+
+		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ^(:|!:) ?jane.} ";
+
+		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		Slice slice = (Slice) tupleExpr;
+		Union union = (Union) slice.getArg();
+
+		Var leftSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
+		Var rightSubjectVar = ((StatementPattern) ((Filter) union.getRightArg()).getArg()).getSubjectVar();
+
+		assertEquals(leftSubjectVar, rightSubjectVar);
+
+	}
+
+	@Test
+	public void testWildCardPathPushNegation2() {
+
+		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ^(:|!:) :Jane.} ";
+
+		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		Slice slice = (Slice) tupleExpr;
+		Union union = (Union) slice.getArg();
+
+		Var leftSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
+		Var rightSubjectVar = ((StatementPattern) ((Filter) union.getRightArg()).getArg()).getSubjectVar();
+
+		assertEquals(leftSubjectVar, rightSubjectVar);
+
+	}
+
+	@Test
+	public void testWildCardPathComplexSubjectHandling() {
+
+		String query = "PREFIX : <http://example.org/>\n ASK { ?a (:comment/^(:subClassOf|(:type/:label))/:type)* ?b } ";
+
+		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		Slice slice = (Slice) tupleExpr;
+
+		ArbitraryLengthPath path = (ArbitraryLengthPath) slice.getArg();
+		Var pathStart = path.getSubjectVar();
+		Var pathEnd = path.getObjectVar();
+
+		assertThat(pathStart.getName()).isEqualTo("a");
+		assertThat(pathEnd.getName()).isEqualTo("b");
+
+		Join pathSequence = (Join) path.getPathExpression();
+		Join innerJoin = (Join) pathSequence.getLeftArg();
+		Var commentObjectVar = ((StatementPattern) innerJoin.getLeftArg()).getObjectVar();
+
+		Union union = (Union) innerJoin.getRightArg();
+		Var subClassOfSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
+		assertThat(subClassOfSubjectVar).isNotEqualTo(commentObjectVar);
+
+		Var subClassOfObjectVar = ((StatementPattern) union.getLeftArg()).getObjectVar();
+
+		assertThat(subClassOfObjectVar).isEqualTo(commentObjectVar);
+	}
+
+	@Test
+	public void testEscape_odd_slashes() {
 		String query = "SELECT ?d ?r "
 				+ " WHERE { "
 				+ " ?s <http://example.org/prop> ?d . "
 				+ " BIND(REPLACE(?d, \"\\.\", \"FOO\") AS ?r) }";
+		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+
+		assertNotNull(parsedQuery);
+
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		System.out.println(tupleExpr.toString());
+
+	}
+
+	@Test
+	public void testEscape_even_slashes() {
+		String query = "SELECT ?d ?r "
+				+ " WHERE { "
+				+ " ?s <http://example.org/prop> ?d . "
+				+ " BIND(REPLACE(?d, \"\\\\.\", \"FOO\") AS ?r) }";
+		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+
+		assertNotNull(parsedQuery);
+
+		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+
+		System.out.println(tupleExpr.toString());
+
+	}
+
+	@Test
+	public void testEscape_different_char() {
+		String query = "SELECT ?d ?r "
+				+ " WHERE { "
+				+ " ?s <http://example.org/prop> ?d . "
+				+ " BIND(REPLACE(?d, \"\\*\", \"FOO\") AS ?r) }";
 		ParsedQuery parsedQuery = parser.parseQuery(query, null);
 
 		assertNotNull(parsedQuery);

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -71,298 +71,316 @@ public class SPARQLParserTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.query.parser.sparql.SPARQLParser#parseQuery(java.lang.String, java.lang.String)} .
 	 */
+//	@Test
+//	public void testSourceStringAssignment() throws Exception {
+//		String simpleSparqlQuery = "SELECT * WHERE {?X ?P ?Y }";
+//
+//		ParsedQuery q = parser.parseQuery(simpleSparqlQuery, null);
+//
+//		assertNotNull(q);
+//		assertEquals(simpleSparqlQuery, q.getSourceString());
+//	}
+//
+//	@Test
+//	public void testInsertDataLineNumberReporting() throws Exception {
+//		String insertDataString = "INSERT DATA {\n incorrect reference }";
+//
+//		try {
+//			ParsedUpdate u = parser.parseUpdate(insertDataString, null);
+//			fail("should have resulted in parse exception");
+//		} catch (MalformedQueryException e) {
+//			assertTrue(e.getMessage().contains("line 2,"));
+//		}
+//
+//	}
+//
+//	@Test
+//	public void testDeleteDataLineNumberReporting() throws Exception {
+//		String deleteDataString = "DELETE DATA {\n incorrect reference }";
+//
+//		try {
+//			ParsedUpdate u = parser.parseUpdate(deleteDataString, null);
+//			fail("should have resulted in parse exception");
+//		} catch (MalformedQueryException e) {
+//			assertTrue(e.getMessage().contains("line 2,"));
+//		}
+//	}
+//
+//	@Test
+//	public void testSES1922PathSequenceWithValueConstant() throws Exception {
+//
+//		StringBuilder qb = new StringBuilder();
+//		qb.append("ASK {?A (<foo:bar>)/<foo:foo> <foo:objValue>} ");
+//
+//		ParsedQuery q = parser.parseQuery(qb.toString(), null);
+//		TupleExpr te = q.getTupleExpr();
+//
+//		assertNotNull(te);
+//
+//		assertTrue(te instanceof Slice);
+//		Slice s = (Slice) te;
+//		assertTrue(s.getArg() instanceof Join);
+//		Join j = (Join) s.getArg();
+//
+//		assertTrue(j.getLeftArg() instanceof StatementPattern);
+//		assertTrue(j.getRightArg() instanceof StatementPattern);
+//		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
+//		StatementPattern rightArg = (StatementPattern) j.getRightArg();
+//
+//		assertTrue(leftArg.getObjectVar().equals(rightArg.getSubjectVar()));
+//		assertEquals(leftArg.getObjectVar().getName(), rightArg.getSubjectVar().getName());
+//	}
+//
+//	@Test
+//	public void testParsedBooleanQueryRootNode() throws Exception {
+//		StringBuilder qb = new StringBuilder();
+//		qb.append("ASK {?a <foo:bar> \"test\"}");
+//
+//		ParsedBooleanQuery q = (ParsedBooleanQuery) parser.parseQuery(qb.toString(), null);
+//		TupleExpr te = q.getTupleExpr();
+//
+//		assertNotNull(te);
+//		assertTrue(te instanceof Slice);
+//		assertNull(te.getParentNode());
+//	}
+//
+//	/**
+//	 * Verify that an INSERT with a subselect using a wildcard correctly adds vars to projection
+//	 *
+//	 * @see <a href="https://github.com/eclipse/rdf4j/issues/686">#686</a>
+//	 */
+//	@Test
+//	public void testParseWildcardSubselectInUpdate() throws Exception {
+//		StringBuilder update = new StringBuilder();
+//		update.append("INSERT { <urn:a> <urn:b> <urn:c> . } WHERE { SELECT * {?s ?p ?o } }");
+//
+//		ParsedUpdate parsedUpdate = parser.parseUpdate(update.toString(), null);
+//		List<UpdateExpr> exprs = parsedUpdate.getUpdateExprs();
+//		assertEquals(1, exprs.size());
+//
+//		UpdateExpr expr = exprs.get(0);
+//		assertTrue(expr instanceof Modify);
+//		Modify m = (Modify) expr;
+//		TupleExpr whereClause = m.getWhereExpr();
+//		assertTrue(whereClause instanceof Projection);
+//		ProjectionElemList projectionElemList = ((Projection) whereClause).getProjectionElemList();
+//		assertNotNull(projectionElemList);
+//		List<ProjectionElem> elements = projectionElemList.getElements();
+//		assertNotNull(elements);
+//
+//		assertEquals("projection should contain all three variables", 3, elements.size());
+//	}
+//
+//	@Test
+//	public void testParseIntegerObjectValue() throws Exception {
+//		// test that the parser correctly parses the object value as an integer, instead of as a decimal.
+//		String query = "select ?Concept where { ?Concept a 1. ?Concept2 a 1. } ";
+//		ParsedTupleQuery q = (ParsedTupleQuery) parser.parseQuery(query, null);
+//
+//		// all we're verifying is that the query is parsed without error. If it doesn't parse as integer but as a
+//		// decimal, the
+//		// parser will fail, because the statement pattern doesn't end with a full-stop.
+//		assertNotNull(q);
+//	}
+//
+//	@Test
+//	public void testParsedTupleQueryRootNode() throws Exception {
+//		StringBuilder qb = new StringBuilder();
+//		qb.append("SELECT *  {?a <foo:bar> \"test\"}");
+//
+//		ParsedTupleQuery q = (ParsedTupleQuery) parser.parseQuery(qb.toString(), null);
+//		TupleExpr te = q.getTupleExpr();
+//
+//		assertNotNull(te);
+//		assertTrue(te instanceof Projection);
+//		assertNull(te.getParentNode());
+//	}
+//
+//	@Test
+//	public void testParsedGraphQueryRootNode() throws Exception {
+//		StringBuilder qb = new StringBuilder();
+//		qb.append("CONSTRUCT WHERE {?a <foo:bar> \"test\"}");
+//
+//		ParsedGraphQuery q = (ParsedGraphQuery) parser.parseQuery(qb.toString(), null);
+//		TupleExpr te = q.getTupleExpr();
+//
+//		assertNotNull(te);
+//		assertTrue(te instanceof Projection);
+//		assertNull(te.getParentNode());
+//	}
+//
+//	@Test
+//	public void testOrderByWithAliases1() throws Exception {
+//		String queryString = " SELECT ?x (SUM(?v1)/COUNT(?v1) as ?r) WHERE { ?x <urn:foo> ?v1 } GROUP BY ?x ORDER BY ?r";
+//
+//		ParsedQuery query = parser.parseQuery(queryString, null);
+//
+//		assertNotNull(query);
+//		TupleExpr te = query.getTupleExpr();
+//
+//		assertTrue(te instanceof Projection);
+//
+//		te = ((Projection) te).getArg();
+//
+//		assertTrue(te instanceof Order);
+//
+//		te = ((Order) te).getArg();
+//
+//		assertTrue(te instanceof Extension);
+//	}
+//
+//	@Test
+//	public void testSES1927UnequalLiteralValueConstants1() throws Exception {
+//
+//		StringBuilder qb = new StringBuilder();
+//		qb.append("ASK {?a <foo:bar> \"test\". ?a <foo:foo> \"test\"@en .} ");
+//
+//		ParsedQuery q = parser.parseQuery(qb.toString(), null);
+//		TupleExpr te = q.getTupleExpr();
+//
+//		assertNotNull(te);
+//
+//		assertTrue(te instanceof Slice);
+//		Slice s = (Slice) te;
+//		assertTrue(s.getArg() instanceof Join);
+//		Join j = (Join) s.getArg();
+//
+//		assertTrue(j.getLeftArg() instanceof StatementPattern);
+//		assertTrue(j.getRightArg() instanceof StatementPattern);
+//		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
+//		StatementPattern rightArg = (StatementPattern) j.getRightArg();
+//
+//		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
+//		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
+//	}
+//
+//	@Test
+//	public void testSES1927UnequalLiteralValueConstants2() throws Exception {
+//
+//		StringBuilder qb = new StringBuilder();
+//		qb.append("ASK {?a <foo:bar> \"test\". ?a <foo:foo> \"test\"^^<foo:bar> .} ");
+//
+//		ParsedQuery q = parser.parseQuery(qb.toString(), null);
+//		TupleExpr te = q.getTupleExpr();
+//
+//		assertNotNull(te);
+//
+//		assertTrue(te instanceof Slice);
+//		Slice s = (Slice) te;
+//		assertTrue(s.getArg() instanceof Join);
+//		Join j = (Join) s.getArg();
+//
+//		assertTrue(j.getLeftArg() instanceof StatementPattern);
+//		assertTrue(j.getRightArg() instanceof StatementPattern);
+//		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
+//		StatementPattern rightArg = (StatementPattern) j.getRightArg();
+//
+//		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
+//		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
+//	}
+//
+//	@Test
+//	public void testLongUnicode() throws Exception {
+//		ParsedUpdate ru = parser.parseUpdate("insert data {<urn:test:foo> <urn:test:bar> \"\\U0001F61F\" .}",
+//				"urn:test");
+//		InsertData insertData = (InsertData) ru.getUpdateExprs().get(0);
+//		String[] lines = insertData.getDataBlock().split("\n");
+//		assertEquals("\uD83D\uDE1F", lines[lines.length - 1].replaceAll(".*\"(.*)\".*", "$1"));
+//	}
+//
+//	@Test
+//	public void testWildCardPathFixedEnd() {
+//
+//		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ((:|!:)|(^:|!^:))* :Jane.} ";
+//
+//		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+//
+//		// parsing should not throw exception
+//		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+//
+//	}
+//
+//	@Test
+//	public void testWildCardPathPushNegation() {
+//
+//		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ^(:|!:) ?jane.} ";
+//
+//		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+//		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+//
+//		Slice slice = (Slice) tupleExpr;
+//		Union union = (Union) slice.getArg();
+//
+//		Var leftSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
+//		Var rightSubjectVar = ((StatementPattern) ((Filter) union.getRightArg()).getArg()).getSubjectVar();
+//
+//		assertEquals(leftSubjectVar, rightSubjectVar);
+//
+//	}
+//
+//	@Test
+//	public void testWildCardPathPushNegation2() {
+//
+//		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ^(:|!:) :Jane.} ";
+//
+//		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+//		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+//
+//		Slice slice = (Slice) tupleExpr;
+//		Union union = (Union) slice.getArg();
+//
+//		Var leftSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
+//		Var rightSubjectVar = ((StatementPattern) ((Filter) union.getRightArg()).getArg()).getSubjectVar();
+//
+//		assertEquals(leftSubjectVar, rightSubjectVar);
+//
+//	}
+//
+//	@Test
+//	public void testWildCardPathComplexSubjectHandling() {
+//
+//		String query = "PREFIX : <http://example.org/>\n ASK { ?a (:comment/^(:subClassOf|(:type/:label))/:type)* ?b } ";
+//
+//		ParsedQuery parsedQuery = parser.parseQuery(query, null);
+//		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
+//
+//		Slice slice = (Slice) tupleExpr;
+//
+//		ArbitraryLengthPath path = (ArbitraryLengthPath) slice.getArg();
+//		Var pathStart = path.getSubjectVar();
+//		Var pathEnd = path.getObjectVar();
+//
+//		assertThat(pathStart.getName()).isEqualTo("a");
+//		assertThat(pathEnd.getName()).isEqualTo("b");
+//
+//		Join pathSequence = (Join) path.getPathExpression();
+//		Join innerJoin = (Join) pathSequence.getLeftArg();
+//		Var commentObjectVar = ((StatementPattern) innerJoin.getLeftArg()).getObjectVar();
+//
+//		Union union = (Union) innerJoin.getRightArg();
+//		Var subClassOfSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
+//		assertThat(subClassOfSubjectVar).isNotEqualTo(commentObjectVar);
+//
+//		Var subClassOfObjectVar = ((StatementPattern) union.getLeftArg()).getObjectVar();
+//
+//		assertThat(subClassOfObjectVar).isEqualTo(commentObjectVar);
+//	}
+
 	@Test
-	public void testSourceStringAssignment() throws Exception {
-		String simpleSparqlQuery = "SELECT * WHERE {?X ?P ?Y }";
-
-		ParsedQuery q = parser.parseQuery(simpleSparqlQuery, null);
-
-		assertNotNull(q);
-		assertEquals(simpleSparqlQuery, q.getSourceString());
-	}
-
-	@Test
-	public void testInsertDataLineNumberReporting() throws Exception {
-		String insertDataString = "INSERT DATA {\n incorrect reference }";
-
-		try {
-			ParsedUpdate u = parser.parseUpdate(insertDataString, null);
-			fail("should have resulted in parse exception");
-		} catch (MalformedQueryException e) {
-			assertTrue(e.getMessage().contains("line 2,"));
-		}
-
-	}
-
-	@Test
-	public void testDeleteDataLineNumberReporting() throws Exception {
-		String deleteDataString = "DELETE DATA {\n incorrect reference }";
-
-		try {
-			ParsedUpdate u = parser.parseUpdate(deleteDataString, null);
-			fail("should have resulted in parse exception");
-		} catch (MalformedQueryException e) {
-			assertTrue(e.getMessage().contains("line 2,"));
-		}
-	}
-
-	@Test
-	public void testSES1922PathSequenceWithValueConstant() throws Exception {
-
-		StringBuilder qb = new StringBuilder();
-		qb.append("ASK {?A (<foo:bar>)/<foo:foo> <foo:objValue>} ");
-
-		ParsedQuery q = parser.parseQuery(qb.toString(), null);
-		TupleExpr te = q.getTupleExpr();
-
-		assertNotNull(te);
-
-		assertTrue(te instanceof Slice);
-		Slice s = (Slice) te;
-		assertTrue(s.getArg() instanceof Join);
-		Join j = (Join) s.getArg();
-
-		assertTrue(j.getLeftArg() instanceof StatementPattern);
-		assertTrue(j.getRightArg() instanceof StatementPattern);
-		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
-		StatementPattern rightArg = (StatementPattern) j.getRightArg();
-
-		assertTrue(leftArg.getObjectVar().equals(rightArg.getSubjectVar()));
-		assertEquals(leftArg.getObjectVar().getName(), rightArg.getSubjectVar().getName());
-	}
-
-	@Test
-	public void testParsedBooleanQueryRootNode() throws Exception {
-		StringBuilder qb = new StringBuilder();
-		qb.append("ASK {?a <foo:bar> \"test\"}");
-
-		ParsedBooleanQuery q = (ParsedBooleanQuery) parser.parseQuery(qb.toString(), null);
-		TupleExpr te = q.getTupleExpr();
-
-		assertNotNull(te);
-		assertTrue(te instanceof Slice);
-		assertNull(te.getParentNode());
-	}
-
-	/**
-	 * Verify that an INSERT with a subselect using a wildcard correctly adds vars to projection
-	 *
-	 * @see <a href="https://github.com/eclipse/rdf4j/issues/686">#686</a>
-	 */
-	@Test
-	public void testParseWildcardSubselectInUpdate() throws Exception {
-		StringBuilder update = new StringBuilder();
-		update.append("INSERT { <urn:a> <urn:b> <urn:c> . } WHERE { SELECT * {?s ?p ?o } }");
-
-		ParsedUpdate parsedUpdate = parser.parseUpdate(update.toString(), null);
-		List<UpdateExpr> exprs = parsedUpdate.getUpdateExprs();
-		assertEquals(1, exprs.size());
-
-		UpdateExpr expr = exprs.get(0);
-		assertTrue(expr instanceof Modify);
-		Modify m = (Modify) expr;
-		TupleExpr whereClause = m.getWhereExpr();
-		assertTrue(whereClause instanceof Projection);
-		ProjectionElemList projectionElemList = ((Projection) whereClause).getProjectionElemList();
-		assertNotNull(projectionElemList);
-		List<ProjectionElem> elements = projectionElemList.getElements();
-		assertNotNull(elements);
-
-		assertEquals("projection should contain all three variables", 3, elements.size());
-	}
-
-	@Test
-	public void testParseIntegerObjectValue() throws Exception {
-		// test that the parser correctly parses the object value as an integer, instead of as a decimal.
-		String query = "select ?Concept where { ?Concept a 1. ?Concept2 a 1. } ";
-		ParsedTupleQuery q = (ParsedTupleQuery) parser.parseQuery(query, null);
-
-		// all we're verifying is that the query is parsed without error. If it doesn't parse as integer but as a
-		// decimal, the
-		// parser will fail, because the statement pattern doesn't end with a full-stop.
-		assertNotNull(q);
-	}
-
-	@Test
-	public void testParsedTupleQueryRootNode() throws Exception {
-		StringBuilder qb = new StringBuilder();
-		qb.append("SELECT *  {?a <foo:bar> \"test\"}");
-
-		ParsedTupleQuery q = (ParsedTupleQuery) parser.parseQuery(qb.toString(), null);
-		TupleExpr te = q.getTupleExpr();
-
-		assertNotNull(te);
-		assertTrue(te instanceof Projection);
-		assertNull(te.getParentNode());
-	}
-
-	@Test
-	public void testParsedGraphQueryRootNode() throws Exception {
-		StringBuilder qb = new StringBuilder();
-		qb.append("CONSTRUCT WHERE {?a <foo:bar> \"test\"}");
-
-		ParsedGraphQuery q = (ParsedGraphQuery) parser.parseQuery(qb.toString(), null);
-		TupleExpr te = q.getTupleExpr();
-
-		assertNotNull(te);
-		assertTrue(te instanceof Projection);
-		assertNull(te.getParentNode());
-	}
-
-	@Test
-	public void testOrderByWithAliases1() throws Exception {
-		String queryString = " SELECT ?x (SUM(?v1)/COUNT(?v1) as ?r) WHERE { ?x <urn:foo> ?v1 } GROUP BY ?x ORDER BY ?r";
-
-		ParsedQuery query = parser.parseQuery(queryString, null);
-
-		assertNotNull(query);
-		TupleExpr te = query.getTupleExpr();
-
-		assertTrue(te instanceof Projection);
-
-		te = ((Projection) te).getArg();
-
-		assertTrue(te instanceof Order);
-
-		te = ((Order) te).getArg();
-
-		assertTrue(te instanceof Extension);
-	}
-
-	@Test
-	public void testSES1927UnequalLiteralValueConstants1() throws Exception {
-
-		StringBuilder qb = new StringBuilder();
-		qb.append("ASK {?a <foo:bar> \"test\". ?a <foo:foo> \"test\"@en .} ");
-
-		ParsedQuery q = parser.parseQuery(qb.toString(), null);
-		TupleExpr te = q.getTupleExpr();
-
-		assertNotNull(te);
-
-		assertTrue(te instanceof Slice);
-		Slice s = (Slice) te;
-		assertTrue(s.getArg() instanceof Join);
-		Join j = (Join) s.getArg();
-
-		assertTrue(j.getLeftArg() instanceof StatementPattern);
-		assertTrue(j.getRightArg() instanceof StatementPattern);
-		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
-		StatementPattern rightArg = (StatementPattern) j.getRightArg();
-
-		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
-		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
-	}
-
-	@Test
-	public void testSES1927UnequalLiteralValueConstants2() throws Exception {
-
-		StringBuilder qb = new StringBuilder();
-		qb.append("ASK {?a <foo:bar> \"test\". ?a <foo:foo> \"test\"^^<foo:bar> .} ");
-
-		ParsedQuery q = parser.parseQuery(qb.toString(), null);
-		TupleExpr te = q.getTupleExpr();
-
-		assertNotNull(te);
-
-		assertTrue(te instanceof Slice);
-		Slice s = (Slice) te;
-		assertTrue(s.getArg() instanceof Join);
-		Join j = (Join) s.getArg();
-
-		assertTrue(j.getLeftArg() instanceof StatementPattern);
-		assertTrue(j.getRightArg() instanceof StatementPattern);
-		StatementPattern leftArg = (StatementPattern) j.getLeftArg();
-		StatementPattern rightArg = (StatementPattern) j.getRightArg();
-
-		assertFalse(leftArg.getObjectVar().equals(rightArg.getObjectVar()));
-		assertNotEquals(leftArg.getObjectVar().getName(), rightArg.getObjectVar().getName());
-	}
-
-	@Test
-	public void testLongUnicode() throws Exception {
-		ParsedUpdate ru = parser.parseUpdate("insert data {<urn:test:foo> <urn:test:bar> \"\\U0001F61F\" .}",
-				"urn:test");
-		InsertData insertData = (InsertData) ru.getUpdateExprs().get(0);
-		String[] lines = insertData.getDataBlock().split("\n");
-		assertEquals("\uD83D\uDE1F", lines[lines.length - 1].replaceAll(".*\"(.*)\".*", "$1"));
-	}
-
-	@Test
-	public void testWildCardPathFixedEnd() {
-
-		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ((:|!:)|(^:|!^:))* :Jane.} ";
-
+	public void testEscape() {
+		String query = "SELECT ?d ?r "
+				+ " WHERE { "
+				+ " ?s <http://example.org/prop> ?d . "
+				+ " BIND(REPLACE(?d, \"\\.\", \"FOO\") AS ?r) }";
 		ParsedQuery parsedQuery = parser.parseQuery(query, null);
 
-		// parsing should not throw exception
+		assertNotNull(parsedQuery);
+
 		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
 
-	}
+		System.out.println(tupleExpr.toString());
 
-	@Test
-	public void testWildCardPathPushNegation() {
+		assertTrue(tupleExpr instanceof Projection);
 
-		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ^(:|!:) ?jane.} ";
-
-		ParsedQuery parsedQuery = parser.parseQuery(query, null);
-		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
-
-		Slice slice = (Slice) tupleExpr;
-		Union union = (Union) slice.getArg();
-
-		Var leftSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
-		Var rightSubjectVar = ((StatementPattern) ((Filter) union.getRightArg()).getArg()).getSubjectVar();
-
-		assertEquals(leftSubjectVar, rightSubjectVar);
-
-	}
-
-	@Test
-	public void testWildCardPathPushNegation2() {
-
-		String query = "PREFIX : <http://example.org/>\n ASK {:IBM ^(:|!:) :Jane.} ";
-
-		ParsedQuery parsedQuery = parser.parseQuery(query, null);
-		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
-
-		Slice slice = (Slice) tupleExpr;
-		Union union = (Union) slice.getArg();
-
-		Var leftSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
-		Var rightSubjectVar = ((StatementPattern) ((Filter) union.getRightArg()).getArg()).getSubjectVar();
-
-		assertEquals(leftSubjectVar, rightSubjectVar);
-
-	}
-
-	@Test
-	public void testWildCardPathComplexSubjectHandling() {
-
-		String query = "PREFIX : <http://example.org/>\n ASK { ?a (:comment/^(:subClassOf|(:type/:label))/:type)* ?b } ";
-
-		ParsedQuery parsedQuery = parser.parseQuery(query, null);
-		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
-
-		Slice slice = (Slice) tupleExpr;
-
-		ArbitraryLengthPath path = (ArbitraryLengthPath) slice.getArg();
-		Var pathStart = path.getSubjectVar();
-		Var pathEnd = path.getObjectVar();
-
-		assertThat(pathStart.getName()).isEqualTo("a");
-		assertThat(pathEnd.getName()).isEqualTo("b");
-
-		Join pathSequence = (Join) path.getPathExpression();
-		Join innerJoin = (Join) pathSequence.getLeftArg();
-		Var commentObjectVar = ((StatementPattern) innerJoin.getLeftArg()).getObjectVar();
-
-		Union union = (Union) innerJoin.getRightArg();
-		Var subClassOfSubjectVar = ((StatementPattern) union.getLeftArg()).getSubjectVar();
-		assertThat(subClassOfSubjectVar).isNotEqualTo(commentObjectVar);
-
-		Var subClassOfObjectVar = ((StatementPattern) union.getLeftArg()).getObjectVar();
-
-		assertThat(subClassOfObjectVar).isEqualTo(commentObjectVar);
 	}
 }

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.fail;
 import java.util.List;
 
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.Filter;
@@ -379,8 +381,6 @@ public class SPARQLParserTest {
 		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
 
 		System.out.println(tupleExpr.toString());
-
-		assertTrue(tupleExpr instanceof Projection);
 
 	}
 }

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -380,8 +380,24 @@ public class SPARQLParserTest {
 
 		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
 
-		System.out.println(tupleExpr.toString());
-
+		String expectedResult = "Projection\n" +
+				"   ProjectionElemList\n" +
+				"      ProjectionElem \"d\"\n" +
+				"      ProjectionElem \"r\"\n" +
+				"   Extension\n" +
+				"      ExtensionElem (r)\n" +
+				"         Var (name=r)\n" +
+				"      Extension\n" +
+				"         ExtensionElem (r)\n" +
+				"            FunctionCall (http://www.w3.org/2005/xpath-functions#replace)\n" +
+				"               Var (name=d)\n" +
+				"               ValueConstant (value=\"\\.\")\n" +
+				"               ValueConstant (value=\"FOO\")\n" +
+				"         StatementPattern\n" +
+				"            Var (name=s)\n" +
+				"            Var (name=_const_62d811c4_uri, value=http://example.org/prop, anonymous)\n" +
+				"            Var (name=d)\n";
+		assertEquals(tupleExpr.toString(), expectedResult);
 	}
 
 	@Test
@@ -396,8 +412,24 @@ public class SPARQLParserTest {
 
 		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
 
-		System.out.println(tupleExpr.toString());
-
+		String expectedResult = "Projection\n" +
+				"   ProjectionElemList\n" +
+				"      ProjectionElem \"d\"\n" +
+				"      ProjectionElem \"r\"\n" +
+				"   Extension\n" +
+				"      ExtensionElem (r)\n" +
+				"         Var (name=r)\n" +
+				"      Extension\n" +
+				"         ExtensionElem (r)\n" +
+				"            FunctionCall (http://www.w3.org/2005/xpath-functions#replace)\n" +
+				"               Var (name=d)\n" +
+				"               ValueConstant (value=\"\\.\")\n" +
+				"               ValueConstant (value=\"FOO\")\n" +
+				"         StatementPattern\n" +
+				"            Var (name=s)\n" +
+				"            Var (name=_const_62d811c4_uri, value=http://example.org/prop, anonymous)\n" +
+				"            Var (name=d)\n";
+		assertEquals(tupleExpr.toString(), expectedResult);
 	}
 
 	@Test
@@ -412,7 +444,24 @@ public class SPARQLParserTest {
 
 		TupleExpr tupleExpr = parsedQuery.getTupleExpr();
 
-		System.out.println(tupleExpr.toString());
+		String expectedResult = "Projection\n" +
+				"   ProjectionElemList\n" +
+				"      ProjectionElem \"d\"\n" +
+				"      ProjectionElem \"r\"\n" +
+				"   Extension\n" +
+				"      ExtensionElem (r)\n" +
+				"         Var (name=r)\n" +
+				"      Extension\n" +
+				"         ExtensionElem (r)\n" +
+				"            FunctionCall (http://www.w3.org/2005/xpath-functions#replace)\n" +
+				"               Var (name=d)\n" +
+				"               ValueConstant (value=\"\\*\")\n" +
+				"               ValueConstant (value=\"FOO\")\n" +
+				"         StatementPattern\n" +
+				"            Var (name=s)\n" +
+				"            Var (name=_const_62d811c4_uri, value=http://example.org/prop, anonymous)\n" +
+				"            Var (name=d)\n";
+		assertEquals(tupleExpr.toString(), expectedResult);
 
 	}
 }

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
@@ -553,7 +553,6 @@ class SAXFilter implements ContentHandler {
 			// Create a String with all needed context prefixes
 			StringBuilder contextPrefixes = new StringBuilder(1024);
 			ElementInfo topElement = peekStack();
-			System.out.println(topElement.localName);
 
 			for (int i = 0; i < unknownPrefixesCount; i++) {
 				String prefix = unknownPrefixesInXMLLiteral.get(i);
@@ -562,9 +561,6 @@ class SAXFilter implements ContentHandler {
 					appendNamespaceDecl(contextPrefixes, prefix, namespace);
 				}
 			}
-
-			System.out.println(contextPrefixes);
-			System.out.println(charBuf);
 
 			// Insert this String before the first '>' character
 			int endOfFirstStartTag = charBuf.indexOf(">");

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
@@ -553,6 +553,7 @@ class SAXFilter implements ContentHandler {
 			// Create a String with all needed context prefixes
 			StringBuilder contextPrefixes = new StringBuilder(1024);
 			ElementInfo topElement = peekStack();
+			System.out.println(topElement.localName);
 
 			for (int i = 0; i < unknownPrefixesCount; i++) {
 				String prefix = unknownPrefixesInXMLLiteral.get(i);
@@ -561,6 +562,9 @@ class SAXFilter implements ContentHandler {
 					appendNamespaceDecl(contextPrefixes, prefix, namespace);
 				}
 			}
+
+			System.out.println(contextPrefixes);
+			System.out.println(charBuf);
 
 			// Insert this String before the first '>' character
 			int endOfFirstStartTag = charBuf.indexOf(">");


### PR DESCRIPTION
GitHub issue resolved: #1105 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->
We have added a code to handle an odd number of backslashes. The functions meant for reading the regex expect a backslash ('\\') before the backslash meant to treat the regex as a normal character. Thus the odd number of backslashes were leading to the "Malformed query" error.
---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

