### PR TITLE
GH-1135 replaced deprecated URI with IRI

### DIFF
--- a/core/spin/src/main/java/org/eclipse/rdf4j/spin/function/EvalFunction.java
+++ b/core/spin/src/main/java/org/eclipse/rdf4j/spin/function/EvalFunction.java
@@ -11,8 +11,8 @@ import java.util.Set;
 
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
@@ -117,11 +117,11 @@ public class EvalFunction extends AbstractSpinFunction implements Function {
 	}
 
 	private boolean isQuery(Resource r, TripleSource store) throws RDF4JException {
-		try (CloseableIteration<? extends URI, QueryEvaluationException> typeIter = TripleSources.getObjectURIs(r,
+		try (CloseableIteration<? extends IRI, QueryEvaluationException> typeIter = TripleSources.getObjectURIs(r,
 				RDF.TYPE,
 				store)) {
 			while (typeIter.hasNext()) {
-				URI type = typeIter.next();
+				IRI type = typeIter.next();
 				if (SP.SELECT_CLASS.equals(type) || SP.ASK_CLASS.equals(type) || SPIN.TEMPLATES_CLASS.equals(type)) {
 					return true;
 				}
@@ -133,10 +133,10 @@ public class EvalFunction extends AbstractSpinFunction implements Function {
 
 	protected static void addArguments(Query query, Value... args) throws ValueExprEvaluationException {
 		for (int i = 1; i < args.length; i += 2) {
-			if (!(args[i] instanceof URI)) {
-				throw new ValueExprEvaluationException("Argument " + i + " must be a URI");
+			if (!(args[i] instanceof IRI)) {
+				throw new ValueExprEvaluationException("Argument " + i + " must be a IRI");
 			}
-			query.setBinding(((URI) args[i]).getLocalName(), args[i + 1]);
+			query.setBinding(((IRI) args[i]).getLocalName(), args[i + 1]);
 		}
 	}
 }


### PR DESCRIPTION

GitHub issue resolved: #1135 

Briefly describe the changes proposed in this PR:

Replaced deprecated URI with IRI

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

