### PR TITLE
Gh 2018-2019 shacl validation reporting

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/SHACL.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/SHACL.java
@@ -359,6 +359,12 @@ public class SHACL {
 	public static final IRI XONE_CONSTRAINT_COMPONENT_XONE;
 
 	// Properties
+	/** sh:actual */
+	public static final IRI ACTUAL;
+
+	/** sh:actualformat */
+	public static final IRI ACTUALFORMAT;
+
 	/** sh:alternativePath */
 	public static final IRI ALTERNATIVE_PATH;
 
@@ -415,6 +421,9 @@ public class SHACL {
 
 	/** sh:equals */
 	public static final IRI EQUALS;
+
+	/** sh:expected */
+	public static final IRI EXPECTED;
 
 	/** sh:flags */
 	public static final IRI FLAGS;
@@ -744,6 +753,8 @@ public class SHACL {
 		XONE_CONSTRAINT_COMPONENT = factory.createIRI(NAMESPACE, "XoneConstraintComponent");
 		XONE_CONSTRAINT_COMPONENT_XONE = factory.createIRI(NAMESPACE, "XoneConstraintComponent-xone");
 
+		ACTUAL = factory.createIRI(NAMESPACE, "actual");
+		ACTUALFORMAT = factory.createIRI(NAMESPACE, "actualformat");
 		ALTERNATIVE_PATH = factory.createIRI(NAMESPACE, "alternativePath");
 		AND = factory.createIRI(NAMESPACE, "and");
 		ANNOTATION_PROPERTY = factory.createIRI(NAMESPACE, "annotationProperty");
@@ -762,6 +773,7 @@ public class SHACL {
 		DESCRIPTION = factory.createIRI(NAMESPACE, "description");
 		DETAIL = factory.createIRI(NAMESPACE, "detail");
 		DISJOINT = factory.createIRI(NAMESPACE, "disjoint");
+		EXPECTED = factory.createIRI(NAMESPACE, "expected");
 		EQUALS = factory.createIRI(NAMESPACE, "equals");
 		FLAGS = factory.createIRI(NAMESPACE, "flags");
 		FOCUS_NODE = factory.createIRI(NAMESPACE, "focusNode");

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
@@ -34,6 +34,7 @@ public class DatatypePropertyShape extends AbstractSimplePropertyShape {
 		super(id, connection, nodeShape, deactivated, parent, path);
 
 		this.datatype = datatype;
+		this.Expected = datatype;
 
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
@@ -8,12 +8,14 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -38,6 +40,13 @@ public class LanguageInPropertyShape extends AbstractSimplePropertyShape {
 		super(id, connection, nodeShape, deactivated, parent, path);
 
 		this.languageIn = toList(connection, languageIn).stream().map(Value::stringValue).collect(Collectors.toSet());
+		Iterator value = this.languageIn.iterator();
+		String x = "( ";
+		while (value.hasNext()) {
+			x += "'" + value.next() + "' ";
+		}
+		x += ")";
+		this.Expected = SimpleValueFactory.getInstance().createLiteral(x);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
@@ -48,6 +48,7 @@ public class MaxCountPropertyShape extends PathPropertyShape {
 		super(id, connection, nodeShape, deactivated, parent, path);
 
 		this.maxCount = maxCount;
+		this.Expected = SimpleValueFactory.getInstance().createLiteral(maxCount);
 
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.shacl.AST;
 import java.util.Objects;
 
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -34,6 +35,7 @@ public class MaxLengthPropertyShape extends AbstractSimplePropertyShape {
 		super(id, connection, nodeShape, deactivated, parent, path);
 
 		this.maxLength = maxLength;
+		this.Expected = SimpleValueFactory.getInstance().createLiteral(maxLength);
 
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
@@ -50,6 +50,7 @@ public class MinCountPropertyShape extends PathPropertyShape {
 		super(id, connection, nodeShape, deactivated, parent, path);
 
 		this.minCount = minCount;
+		this.Expected = SimpleValueFactory.getInstance().createLiteral(minCount);
 
 	}
 
@@ -71,7 +72,7 @@ public class MinCountPropertyShape extends PathPropertyShape {
 			PlanNode groupBy = new GroupByCount(allStatements);
 
 			PlanNode filteredStatements = new MinCountFilter(groupBy, minCount).getFalseNode(UnBufferedPlanNode.class);
-
+			
 			if (printPlans) {
 				String planAsGraphvizDot = getPlanAsGraphvizDot(filteredStatements, connectionsGroup);
 				logger.info(planAsGraphvizDot);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
@@ -34,6 +34,7 @@ public class MinExclusivePropertyShape extends AbstractSimplePropertyShape {
 		super(id, connection, nodeShape, deactivated, parent, path);
 
 		this.minExclusive = minExclusive;
+		this.Expected = minExclusive;
 
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.shacl.AST;
 import java.util.Objects;
 
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -34,6 +35,7 @@ public class MinLengthPropertyShape extends AbstractSimplePropertyShape {
 		super(id, connection, nodeShape, deactivated, parent, path);
 
 		this.minLength = minLength;
+		this.Expected = SimpleValueFactory.getInstance().createLiteral(minLength);
 
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
@@ -36,7 +36,7 @@ public class NodeKindPropertyShape extends AbstractSimplePropertyShape {
 		super(id, connection, nodeShape, deactivated, parent, path);
 
 		this.nodeKind = NodeKind.from(nodeKind);
-
+		this.Expected = nodeKind;
 	}
 
 	public enum NodeKind {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.shacl.AST;
 import java.util.Objects;
 
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -36,6 +37,7 @@ public class PatternPropertyShape extends AbstractSimplePropertyShape {
 
 		this.pattern = pattern;
 		this.flags = flags;
+		this.Expected = SimpleValueFactory.getInstance().createLiteral("Flags: "+flags+" : Pattern: "+pattern);
 
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
@@ -16,10 +16,12 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.query.GraphQuery;
@@ -50,12 +52,16 @@ public abstract class PropertyShape implements PlanGenerator, RequiresEvalutatio
 
 	NodeShape nodeShape;
 	PathPropertyShape parent;
+	Value Expected = SimpleValueFactory.getInstance().createLiteral("null");
 
 	PropertyShape(Resource id, NodeShape nodeShape, boolean deactivated, PathPropertyShape parent) {
 		this.id = id;
 		this.nodeShape = nodeShape;
 		this.deactivated = deactivated;
 		this.parent = parent;
+	}
+	public Value getEXP() {
+		return this.Expected;
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailValidationException.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailValidationException.java
@@ -61,6 +61,7 @@ public class ShaclSailValidationException extends SailException implements Valid
 			while (!propertyShapes.isEmpty()) {
 				ValidationResult validationResult = new ValidationResult(propertyShapes.pop(),
 						invalidTuple.line.get(0));
+				validationResult.SetAct(invalidTuple.line.get(1));
 				if (parent == null) {
 					validationReport.addValidationResult(validationResult);
 				} else {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
@@ -10,18 +10,20 @@ package org.eclipse.rdf4j.sail.shacl.results;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
+import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.AST.Path;
 import org.eclipse.rdf4j.sail.shacl.AST.PathPropertyShape;
 import org.eclipse.rdf4j.sail.shacl.AST.PropertyShape;
 import org.eclipse.rdf4j.sail.shacl.AST.SimplePath;
-import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 
 /**
  * The ValidationResult represents the results from a SHACL validation in an easy-to-use Java API.
@@ -39,11 +41,15 @@ public class ValidationResult {
 	private Path path;
 	private ValidationResult detail;
 	private Value focusNode;
+	private Value Expected;
+	private Value Actual = SimpleValueFactory.getInstance().createLiteral("null");
+	private Value ActualFormat = SimpleValueFactory.getInstance().createLiteral("null");
 
 	public ValidationResult(PropertyShape sourceShape, Value focusNode) {
 		this.sourceShape = sourceShape;
 		this.focusNode = focusNode;
 		this.sourceConstraintComponent = sourceShape.getSourceConstraintComponent();
+		this.Expected = sourceShape.getEXP();
 		if (sourceShape instanceof PathPropertyShape) {
 			this.path = ((PathPropertyShape) sourceShape).getPath();
 		}
@@ -85,6 +91,9 @@ public class ValidationResult {
 		model.add(getId(), SHACL.FOCUS_NODE, getFocusNode());
 		model.add(getId(), SHACL.SOURCE_CONSTRAINT_COMPONENT, getSourceConstraintComponent().getIri());
 		model.add(getId(), SHACL.SOURCE_SHAPE, getSourceShapeResource());
+		model.add(getId(), SHACL.ACTUAL, getAct());
+		model.add(getId(), SHACL.ACTUALFORMAT, getActFor());
+		model.add(getId(), SHACL.EXPECTED, getExp());
 
 		if (getPath() != null) {
 			model.add(getId(), SHACL.RESULT_PATH, ((SimplePath) getPath()).getPath());
@@ -121,6 +130,58 @@ public class ValidationResult {
 
 	public Resource getId() {
 		return id;
+	}
+
+	private Value getAct() {
+		return Actual;
+	}
+
+	private Value getActFor() {
+		return ActualFormat;
+	}
+
+	public void SetAct(Value Ac) {
+		if (!(Ac instanceof Literal)) {
+			return;
+		}
+		this.Actual = Ac;
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.MinCountConstraintComponent)) {
+			this.ActualFormat = Ac;
+		}
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.DatatypeConstraintComponent)) {
+			this.ActualFormat = ((Literal) Ac).getDatatype();
+		}
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.LanguageInConstraintComponent)) {
+			Optional<String> x = ((Literal) Ac).getLanguage();
+			if (x.isPresent()) {
+				this.ActualFormat = SimpleValueFactory.getInstance().createLiteral(x.get());
+			}
+		}
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.MaxCountConstraintComponent)) {
+			this.ActualFormat = Ac;
+		}
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.MaxLengthConstraintComponent)) {
+			this.ActualFormat = SimpleValueFactory.getInstance()
+					.createLiteral((long) ((Literal) Ac).stringValue().length());
+		}
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.MinLengthConstraintComponent)) {
+			this.ActualFormat = SimpleValueFactory.getInstance()
+					.createLiteral((long) ((Literal) Ac).stringValue().length());
+		}
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.NodeKindConstraintComponent)) {
+			this.ActualFormat = SimpleValueFactory.getInstance().createLiteral(Ac.getClass().getSimpleName());
+		}
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.PatternConstraintComponent)) {
+			this.ActualFormat = Ac;
+		}
+		if (this.sourceConstraintComponent.equals(SourceConstraintComponent.MinExclusiveConstraintComponent)) {
+			this.ActualFormat = Ac;
+		}
+
+	}
+
+	private Value getExp() {
+		return Expected;
 	}
 
 	/**


### PR DESCRIPTION
GitHub issue resolved: #2018 #2019  <!-- add a Github issue number here, e.g #123. -->

SHACL validation reporting improvements - sh:actual and sh:expected is included in Validation report.

<!-- short description of your change goes here -->

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

