### PR TITLE
GH-2304: Disables stack trace collection for ValueExprEvaluationException

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/ValueExprEvaluationException.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/ValueExprEvaluationException.java
@@ -35,4 +35,10 @@ public class ValueExprEvaluationException extends QueryEvaluationException {
 	public ValueExprEvaluationException(Throwable t) {
 		super(t);
 	}
+
+	@Override
+	public Throwable fillInStackTrace() {
+		// Exception used for excessive flow control. Collecting the stack trace is a slow operation, so skip it.
+		return this;
+	}
 }


### PR DESCRIPTION
GitHub issue resolved: #2304

Briefly describe the changes proposed in this PR:

Disable stack trace collection for ValueExprEvaluationException.
---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

