### PR TITLE
GH-2306 more robust check for external bindings in FedXConnection

### DIFF
--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
@@ -198,7 +198,7 @@ public class SailUpdateExecutor {
 
 		// clear destination
 		final long start = System.currentTimeMillis();
-		con.clear(destination);
+		con.clear((Resource) destination);
 		final long clearTime = (System.currentTimeMillis() - start) / 1000;
 
 		if (maxExecutionTime > 0) {
@@ -210,7 +210,7 @@ public class SailUpdateExecutor {
 		// get all statements from source and add them to destination
 		CloseableIteration<? extends Statement, SailException> statements = null;
 		try {
-			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), source);
+			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), (Resource) source);
 
 			if (maxExecutionTime > 0) {
 				statements = new TimeLimitIteration<Statement, SailException>(statements,
@@ -225,7 +225,7 @@ public class SailUpdateExecutor {
 
 			while (statements.hasNext()) {
 				Statement st = statements.next();
-				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), destination);
+				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), (Resource) destination);
 			}
 		} finally {
 			if (statements != null) {
@@ -254,7 +254,7 @@ public class SailUpdateExecutor {
 		// get all statements from source and add them to destination
 		CloseableIteration<? extends Statement, SailException> statements = null;
 		try {
-			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), source);
+			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), (Resource) source);
 
 			if (maxExecTime > 0) {
 				statements = new TimeLimitIteration<Statement, SailException>(statements, 1000L * maxExecTime) {
@@ -268,7 +268,7 @@ public class SailUpdateExecutor {
 
 			while (statements.hasNext()) {
 				Statement st = statements.next();
-				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), destination);
+				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), (Resource) destination);
 			}
 		} finally {
 			if (statements != null) {
@@ -296,7 +296,7 @@ public class SailUpdateExecutor {
 
 		// clear destination
 		final long start = System.currentTimeMillis();
-		con.clear(destination);
+		con.clear((Resource) destination);
 		final long clearTime = (System.currentTimeMillis() - start) / 1000;
 
 		if (maxExecutionTime > 0 && clearTime > maxExecutionTime) {
@@ -307,7 +307,7 @@ public class SailUpdateExecutor {
 		CloseableIteration<? extends Statement, SailException> statements = null;
 
 		try {
-			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), source);
+			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), (Resource) source);
 			if (maxExecutionTime > 0) {
 				statements = new TimeLimitIteration<Statement, SailException>(statements,
 						1000L * (maxExecutionTime - clearTime)) {
@@ -321,8 +321,8 @@ public class SailUpdateExecutor {
 
 			while (statements.hasNext()) {
 				Statement st = statements.next();
-				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), destination);
-				con.removeStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), source);
+				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), (Resource) destination);
+				con.removeStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), (Resource) source);
 			}
 		} finally {
 			if (statements != null) {
@@ -696,7 +696,7 @@ public class SailUpdateExecutor {
 				if (mappedObject != null) {
 					patternValue = mappedObject.getValue();
 					if (patternValue instanceof Resource) {
-						object = patternValue;
+						object = (Resource) patternValue;
 					}
 				} else {
 					object = vf.createBNode();

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
@@ -198,7 +198,7 @@ public class SailUpdateExecutor {
 
 		// clear destination
 		final long start = System.currentTimeMillis();
-		con.clear((Resource) destination);
+		con.clear(destination);
 		final long clearTime = (System.currentTimeMillis() - start) / 1000;
 
 		if (maxExecutionTime > 0) {
@@ -210,7 +210,7 @@ public class SailUpdateExecutor {
 		// get all statements from source and add them to destination
 		CloseableIteration<? extends Statement, SailException> statements = null;
 		try {
-			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), (Resource) source);
+			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), source);
 
 			if (maxExecutionTime > 0) {
 				statements = new TimeLimitIteration<Statement, SailException>(statements,
@@ -225,7 +225,7 @@ public class SailUpdateExecutor {
 
 			while (statements.hasNext()) {
 				Statement st = statements.next();
-				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), (Resource) destination);
+				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), destination);
 			}
 		} finally {
 			if (statements != null) {
@@ -254,7 +254,7 @@ public class SailUpdateExecutor {
 		// get all statements from source and add them to destination
 		CloseableIteration<? extends Statement, SailException> statements = null;
 		try {
-			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), (Resource) source);
+			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), source);
 
 			if (maxExecTime > 0) {
 				statements = new TimeLimitIteration<Statement, SailException>(statements, 1000L * maxExecTime) {
@@ -268,7 +268,7 @@ public class SailUpdateExecutor {
 
 			while (statements.hasNext()) {
 				Statement st = statements.next();
-				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), (Resource) destination);
+				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), destination);
 			}
 		} finally {
 			if (statements != null) {
@@ -296,7 +296,7 @@ public class SailUpdateExecutor {
 
 		// clear destination
 		final long start = System.currentTimeMillis();
-		con.clear((Resource) destination);
+		con.clear(destination);
 		final long clearTime = (System.currentTimeMillis() - start) / 1000;
 
 		if (maxExecutionTime > 0 && clearTime > maxExecutionTime) {
@@ -307,7 +307,7 @@ public class SailUpdateExecutor {
 		CloseableIteration<? extends Statement, SailException> statements = null;
 
 		try {
-			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), (Resource) source);
+			statements = con.getStatements(null, null, null, uc.isIncludeInferred(), source);
 			if (maxExecutionTime > 0) {
 				statements = new TimeLimitIteration<Statement, SailException>(statements,
 						1000L * (maxExecutionTime - clearTime)) {
@@ -321,8 +321,8 @@ public class SailUpdateExecutor {
 
 			while (statements.hasNext()) {
 				Statement st = statements.next();
-				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), (Resource) destination);
-				con.removeStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), (Resource) source);
+				con.addStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), destination);
+				con.removeStatement(uc, st.getSubject(), st.getPredicate(), st.getObject(), source);
 			}
 		} finally {
 			if (statements != null) {
@@ -497,23 +497,27 @@ public class SailUpdateExecutor {
 				protected BindingSet convert(BindingSet sourceBinding) throws QueryEvaluationException {
 					if (whereClause instanceof SingletonSet && sourceBinding instanceof EmptyBindingSet
 							&& uc.getBindingSet() != null) {
-						// in the case of an empty WHERE clause, we use the
-						// supplied
-						// bindings to produce triples to DELETE/INSERT
+						// in the case of an empty WHERE clause, we use the supplied bindings to produce triples to
+						// DELETE/INSERT
 						return uc.getBindingSet();
 					} else {
-						// check if any supplied bindings do not occur in the
-						// bindingset
-						// produced by the WHERE clause. If so, merge.
+						// check if any supplied bindings do not occur in the bindingset produced by the WHERE clause.
+						// If so, merge.
 						Set<String> uniqueBindings = new HashSet<>(uc.getBindingSet().getBindingNames());
 						uniqueBindings.removeAll(sourceBinding.getBindingNames());
 						if (uniqueBindings.size() > 0) {
 							MapBindingSet mergedSet = new MapBindingSet();
 							for (String bindingName : sourceBinding.getBindingNames()) {
-								mergedSet.addBinding(sourceBinding.getBinding(bindingName));
+								final Binding binding = sourceBinding.getBinding(bindingName);
+								if (binding != null) {
+									mergedSet.addBinding(binding);
+								}
 							}
 							for (String bindingName : uniqueBindings) {
-								mergedSet.addBinding(uc.getBindingSet().getBinding(bindingName));
+								final Binding binding = uc.getBindingSet().getBinding(bindingName);
+								if (binding != null) {
+									mergedSet.addBinding(binding);
+								}
 							}
 							return mergedSet;
 						}
@@ -692,7 +696,7 @@ public class SailUpdateExecutor {
 				if (mappedObject != null) {
 					patternValue = mappedObject.getValue();
 					if (patternValue instanceof Resource) {
-						object = (Resource) patternValue;
+						object = patternValue;
 					}
 				} else {
 					object = vf.createBNode();

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -138,10 +138,8 @@ public class FedXConnection extends AbstractSailConnection {
 
 		try {
 			// make sure to apply any external bindings
-			// Note: we use a conditional check for performance reasons.
-			// Further note that we subtract -1 from the size as the baseUri is optional
 			BindingSet queryBindings = EmptyBindingSet.getInstance();
-			if (bindings.size() > FedXRepositoryConnection.FEDX_BINDINGS.size() - 1) {
+			if (!FedXRepositoryConnection.FEDX_BINDINGS.containsAll(bindings.getBindingNames())) {
 				MapBindingSet actualQueryBindings = new MapBindingSet();
 				bindings.forEach(binding -> {
 					if (!FedXRepositoryConnection.FEDX_BINDINGS.contains(binding.getName())) {


### PR DESCRIPTION
GitHub issue resolved: #2306  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- in FedXConnection, when checking if supplied bindings contain anything other than the "special" FedX bindings, do not assume we know the exact number of supplied FedX bindings, as it can vary.
- in SailUpdateExecutor, when merging result bindings with preset bindings, ensure a binding is not null before merging.

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

