### PR TITLE
GH-2338 Increased TurtleParser pushback reader buffer to 10

### DIFF
--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -165,7 +165,7 @@ public class TurtleParser extends AbstractRDFParser {
 			lineNumber = 1;
 
 			// Allow at most 8 characters to be pushed back:
-			this.reader = new PushbackReader(reader, 8);
+			this.reader = new PushbackReader(reader, 10);
 
 			// Store normalized base URI
 			setBaseURI(baseURI);

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
@@ -495,4 +495,17 @@ public class TurtleParserTest {
 		}
 	}
 
+	@Test
+	public void testOverflowingUnicodeInTripleSubject() throws IOException {
+		String data = "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n<r:\uD800\uDF32\uD800\uDF3F\uD800\uDF44\uD800\uDF39\uD800\uDF43\uD800\uDF3A> a xsd:string .";
+		Reader r = new StringReader(data);
+
+		try {
+			parser.parse(r, baseURI);
+			assertTrue(statementCollector.getStatements().size() == 1);
+		} catch (RDFParseException e) {
+			fail("Complex unicode characters should be parsed correctly (" + e.getMessage() + ")");
+		}
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Elad Shaked <elad.shaked@sparkbeyond.com>


GitHub issue resolved: #2338

Briefly describe the changes proposed in this PR:
TurtleParser pops chars until the StringBuilder has 8 or more chars. It may be the case that Unicode surrogates cause 9 chars to be read (say 7 normal chars followed by a surrogate pair). When trying to pushback those chars into buffer of size 8 causes an overflow.

Increase PushbackReader buffer size to 10 (could have done with 9)
---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

