### PR TITLE
Gh-2018 support for sh:value

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailValidationException.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailValidationException.java
@@ -59,8 +59,9 @@ public class ShaclSailValidationException extends SailException implements Valid
 			ArrayDeque<PropertyShape> propertyShapes = new ArrayDeque<>(invalidTuple.getCausedByPropertyShapes());
 
 			while (!propertyShapes.isEmpty()) {
+
 				ValidationResult validationResult = new ValidationResult(propertyShapes.pop(),
-						invalidTuple.getLine().get(0));
+						invalidTuple.getLine().get(0), invalidTuple.getLine().get(invalidTuple.getLine().size() - 1));
 				if (parent == null) {
 					validationReport.addValidationResult(validationResult);
 				} else {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/SourceConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/SourceConstraintComponent.java
@@ -13,35 +13,59 @@ import org.eclipse.rdf4j.model.vocabulary.DASH;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 
 public enum SourceConstraintComponent {
-	MaxCountConstraintComponent(SHACL.MAX_COUNT_CONSTRAINT_COMPONENT),
-	DatatypeConstraintComponent(SHACL.DATATYPE_CONSTRAINT_COMPONENT),
-	OrConstraintComponent(SHACL.OR_CONSTRAINT_COMPONENT),
-	MinCountConstraintComponent(SHACL.MIN_COUNT_CONSTRAINT_COMPONENT),
-	LanguageInConstraintComponent(SHACL.LANGUAGE_IN_CONSTRAINT_COMPONENT),
-	MaxLengthConstraintComponent(SHACL.MAX_LENGTH_CONSTRAINT_COMPONENT),
-	MinLengthConstraintComponent(SHACL.MIN_LENGTH_CONSTRAINT_COMPONENT),
-	NodeKindConstraintComponent(SHACL.NODE_KIND_CONSTRAINT_COMPONENT),
-	PatternConstraintComponent(SHACL.PATTERN_CONSTRAINT_COMPONENT),
-	MinExclusiveConstraintComponent(SHACL.MIN_EXCLUSIVE_CONSTRAINT_COMPONENT),
-	MaxExclusiveConstraintComponent(SHACL.MAX_EXCLUSIVE_CONSTRAINT_COMPONENT),
-	MaxInclusiveConstraintComponent(SHACL.MAX_INCLUSIVE_CONSTRAINT_COMPONENT),
-	MinInclusiveConstraintComponent(SHACL.MIN_INCLUSIVE_CONSTRAINT_COMPONENT),
-	ClassConstraintComponent(SHACL.CLASS_CONSTRAINT_COMPONENT),
-	InConstraintComponent(SHACL.IN_CONSTRAINT_COMPONENT),
-	HasValueConstraintComponent(SHACL.HAS_VALUE_CONSTRAINT_COMPONENT),
-	ValueInConstraintComponent(DASH.ValueInConstraintComponent),
-	UniqueLangConstraintComponent(SHACL.UNIQUE_LANG_CONSTRAINT_COMPONENT),
-	AndConstraintComponent(SHACL.AND_CONSTRAINT_COMPONENT),
-	NotConstraintComponent(SHACL.NOT_CONSTRAINT_COMPONENT);
+	MaxCountConstraintComponent(SHACL.MAX_COUNT_CONSTRAINT_COMPONENT, ConstraintType.Cardinality),
+	MinCountConstraintComponent(SHACL.MIN_COUNT_CONSTRAINT_COMPONENT, ConstraintType.Cardinality),
+
+	DatatypeConstraintComponent(SHACL.DATATYPE_CONSTRAINT_COMPONENT, ConstraintType.ValueType),
+	LanguageInConstraintComponent(SHACL.LANGUAGE_IN_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+
+	NodeKindConstraintComponent(SHACL.NODE_KIND_CONSTRAINT_COMPONENT, ConstraintType.ValueType),
+	PatternConstraintComponent(SHACL.PATTERN_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+
+	ClassConstraintComponent(SHACL.CLASS_CONSTRAINT_COMPONENT, ConstraintType.ValueType),
+
+	InConstraintComponent(SHACL.IN_CONSTRAINT_COMPONENT, ConstraintType.Other),
+	HasValueConstraintComponent(SHACL.HAS_VALUE_CONSTRAINT_COMPONENT, ConstraintType.Other),
+	ValueInConstraintComponent(DASH.ValueInConstraintComponent, ConstraintType.Other),
+	UniqueLangConstraintComponent(SHACL.UNIQUE_LANG_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+
+	MinExclusiveConstraintComponent(SHACL.MIN_EXCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange),
+	MaxExclusiveConstraintComponent(SHACL.MAX_EXCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange),
+	MaxInclusiveConstraintComponent(SHACL.MAX_INCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange),
+	MinInclusiveConstraintComponent(SHACL.MIN_INCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange),
+
+	MaxLengthConstraintComponent(SHACL.MAX_LENGTH_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+	MinLengthConstraintComponent(SHACL.MIN_LENGTH_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+
+	AndConstraintComponent(SHACL.AND_CONSTRAINT_COMPONENT, ConstraintType.Logical),
+	OrConstraintComponent(SHACL.OR_CONSTRAINT_COMPONENT, ConstraintType.Logical),
+	NotConstraintComponent(SHACL.NOT_CONSTRAINT_COMPONENT, ConstraintType.Logical);
 
 	private final IRI iri;
+	private final ConstraintType constraintType;
 
-	SourceConstraintComponent(IRI iri) {
+	SourceConstraintComponent(IRI iri, ConstraintType constraintType) {
 		this.iri = iri;
+		this.constraintType = constraintType;
 	}
 
 	public IRI getIri() {
 		return iri;
 	}
 
+	public ConstraintType getConstraintType() {
+		return constraintType;
+	}
+
+	public enum ConstraintType {
+		ValueType,
+		Cardinality,
+		ValueRange,
+		StringBased,
+		PropertyPair,
+		Logical,
+		ShapeBased,
+		Other
+
+	}
 }

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
@@ -107,14 +107,15 @@ public class ValidationReportTest {
 					"@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
 					"@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
 					"\n" +
-					"_:node1e4dsta0ax19 a sh:ValidationReport;\n" +
+					"_:node1ebu5r1fdx77 a sh:ValidationReport;\n" +
 					"  sh:conforms false;\n" +
-					"  sh:result _:node1e4dsta0ax20 .\n" +
+					"  sh:result _:node1ebu5r1fdx78 .\n" +
 					"\n" +
-					"_:node1e4dsta0ax20 a sh:ValidationResult;\n" +
+					"_:node1ebu5r1fdx78 a sh:ValidationResult;\n" +
 					"  sh:focusNode ex:node1;\n" +
 					"  sh:sourceConstraintComponent sh:ClassConstraintComponent;\n" +
-					"  sh:sourceShape ex:PersonShape ."
+					"  sh:sourceShape ex:PersonShape;\n" +
+					"  sh:value ex:node1 .\n"
 					+ ""), "", RDFFormat.TURTLE);
 
 			assertTrue(Models.isomorphic(expected, actual));
@@ -151,10 +152,11 @@ public class ValidationReportTest {
 			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
 
 			Model expected = Rio.parse(new StringReader(""
-					+ "@prefix ex: <http://example.com/ns#> .\n"
-					+ "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n"
-					+ "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" + "\n"
-					+ "[] a sh:ValidationReport;\n" +
+					+ "@prefix ex: <http://example.com/ns#> .\n" +
+					"@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
+					"@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+					"\n" +
+					"[] a sh:ValidationReport;\n" +
 					"  sh:conforms false;\n" +
 					"  sh:result [ a sh:ValidationResult;\n" +
 					"      sh:detail [ a sh:ValidationResult;\n" +
@@ -162,12 +164,14 @@ public class ValidationReportTest {
 					"              sh:focusNode ex:validPerson1;\n" +
 					"              sh:resultPath ex:age;\n" +
 					"              sh:sourceConstraintComponent sh:DatatypeConstraintComponent;\n" +
-					"              sh:sourceShape ex:personShapeAgeLong\n" +
+					"              sh:sourceShape ex:personShapeAgeLong;\n" +
+					"              sh:value \"abc\"\n" +
 					"            ];\n" +
 					"          sh:focusNode ex:validPerson1;\n" +
 					"          sh:resultPath ex:age;\n" +
 					"          sh:sourceConstraintComponent sh:DatatypeConstraintComponent;\n" +
-					"          sh:sourceShape ex:personShapeAgeInteger\n" +
+					"          sh:sourceShape ex:personShapeAgeInteger;\n" +
+					"          sh:value \"abc\"\n" +
 					"        ];\n" +
 					"      sh:focusNode ex:validPerson1;\n" +
 					"      sh:resultPath ex:age;\n" +


### PR DESCRIPTION
GitHub issue resolved: #2018  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Support for `sh:value` for all constraints except for cardinality constraints and logical constraints. 

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

