### PR TITLE
Fixes GH-2343 using cloned vars while constructing ALP. VarReplacer a…

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -1754,7 +1754,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 				} else {
 					// upperbound is abitrary-length
 
-					result = new ArbitraryLengthPath(scope, subjVar, te, endVar, contextVar, lowerBound);
+					result = new ArbitraryLengthPath(scope, subjVar.clone(), te, endVar.clone(), contextVar,
+							lowerBound);
 				}
 			} else {
 				// create single path of fixed length.
@@ -1873,8 +1874,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		public void meet(Var var) {
 			if (toBeReplaced.equals(var)) {
 				QueryModelNode parent = var.getParentNode();
-				parent.replaceChildNode(var, replacement);
-				replacement.setParentNode(parent);
+				Var replacementVar = replacement.clone();
+				parent.replaceChildNode(var, replacementVar);
+				replacementVar.setParentNode(parent);
 			}
 		}
 	}

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestPropPathMisbehaviour.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestPropPathMisbehaviour.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.parser.sparql;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
+import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.Projection;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestPropPathMisbehaviour {
+	private SPARQLParser parser;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		parser = new SPARQLParser();
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+		parser = null;
+	}
+
+	/**
+	 * reproduces GH-2343: the obj var of the nested statement pattern should be equal to the objVar of the ALP path
+	 * that is using the PE
+	 */
+	@Test
+	public void testGH2343() {
+		String query1 = "select ?iri ?value where { \n" +
+				"    ?iri (<urn:p>+) / <urn:q> ?value .\n" +
+				"}";
+		ParsedQuery q = parser.parseQuery(query1, "http://base.org/");
+
+		assertNotNull(q);
+		assertTrue("expect projection", q.getTupleExpr() instanceof Projection);
+		Projection proj = (Projection) q.getTupleExpr();
+
+		assertTrue("expect join", proj.getArg() instanceof Join);
+		assertTrue("expect left arg to be ALP", ((Join) proj.getArg()).getLeftArg() instanceof ArbitraryLengthPath);
+		ArbitraryLengthPath alp = (ArbitraryLengthPath) ((Join) proj.getArg()).getLeftArg();
+
+		assertTrue("expect single statement pattern in alp PE", alp.getPathExpression() instanceof StatementPattern);
+		StatementPattern sp = (StatementPattern) alp.getPathExpression();
+		assertNotNull(sp.getSubjectVar());
+
+		assertTrue("expect subj var to be iri", "iri".equals(sp.getSubjectVar().getName()));
+
+		assertTrue("expect obj var of the pattern to be same as the objVar of ALP",
+				alp.getObjectVar().equals(sp.getObjectVar()));
+	}
+}


### PR DESCRIPTION


GitHub issue resolved: #2343

Briefly describe the changes proposed in this PR:
Use cloned vars as `subj` or `obj` while constructing the ArbitraryLengthPath.
`VarReplacer` also use clones of the replacement var to avoid colissions when same var is replaced multiple times in single expression


---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

