### PR TITLE
GH-2357 Add NTripletsParser comment lines handling

### DIFF
--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -145,8 +145,8 @@ public class NTriplesParser extends AbstractRDFParser {
 
 			while (c != -1) {
 				if (c == '#') {
-					// Comment, ignore
-					c = skipLine(c);
+					// Comment
+					c = parseComment(c);
 				} else if (c == '\r' || c == '\n') {
 					// Empty line, ignore
 					c = skipLine(c);
@@ -211,9 +211,16 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * Reads characters from reader until the first EOL has been read. The first character after the EOL is returned. In
 	 * case the end of the character stream has been reached, -1 is returned.
 	 */
-	protected int skipLine(int c) throws IOException {
+	protected int skipLine(int c, StringBuilder sb) throws IOException {
 		while (c != -1 && c != '\r' && c != '\n') {
 			c = readCodePoint();
+			if (sb != null) {
+				sb.append(Character.toChars(c));
+			}
+		}
+		// delete last appended char as it is the line break
+		if (sb != null) {
+			sb.deleteCharAt(sb.length() - 1);
 		}
 
 		// c is equal to -1, \r or \n. In case of a \r, we should
@@ -238,6 +245,17 @@ public class NTriplesParser extends AbstractRDFParser {
 		}
 
 		return c;
+	}
+
+	protected int skipLine(int c) throws IOException {
+		return skipLine(c, null);
+	}
+
+	private int parseComment(int c) throws IOException {
+		StringBuilder sb = new StringBuilder(100);
+		int res = skipLine(c, sb);
+		rdfHandler.handleComment(sb.toString());
+		return res;
 	}
 
 	private int parseTriple(int c) throws IOException, RDFParseException, RDFHandlerException {

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -214,12 +214,13 @@ public class NTriplesParser extends AbstractRDFParser {
 	protected int skipLine(int c, StringBuilder sb) throws IOException {
 		while (c != -1 && c != '\r' && c != '\n') {
 			c = readCodePoint();
-			if (sb != null) {
+			// make sure c is not EOF
+			if (sb != null && c != -1) {
 				sb.append(Character.toChars(c));
 			}
 		}
-		// delete last appended char as it is the line break
-		if (sb != null) {
+		// delete last appended char as it is the line break, unless `c` is EOF and then we did not append it
+		if (sb != null && c != -1) {
 			sb.deleteCharAt(sb.length() - 1);
 		}
 
@@ -254,7 +255,9 @@ public class NTriplesParser extends AbstractRDFParser {
 	private int parseComment(int c) throws IOException {
 		StringBuilder sb = new StringBuilder(100);
 		int res = skipLine(c, sb);
-		rdfHandler.handleComment(sb.toString());
+		if (rdfHandler != null) {
+			rdfHandler.handleComment(sb.toString());
+		}
 		return res;
 	}
 

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -12,15 +12,15 @@ import static org.junit.Assert.fail;
 
 import java.io.InputStream;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.junit.Test;
@@ -460,6 +460,34 @@ public abstract class AbstractNTriplesParserUnitTest {
 			fail("Should have failed to parse invalid N-Triples bnode with '" + character
 					+ "' at the begining of the bnode label");
 		}
+	}
+
+	private static class CommentCollector extends StatementCollector {
+		final List<String> comments = new LinkedList<>();
+
+		public CommentCollector(Model model) {
+			super(model);
+		}
+
+		@Override
+		public void handleComment(String comment) throws RDFHandlerException {
+			comments.add(comment);
+		}
+	}
+
+	@Test
+	public void testHandleComment() throws Exception {
+		RDFParser ntriplesParser = createRDFParser();
+		Model model = new LinkedHashModel();
+		String commentStr = "some comment in it's own line";
+		CommentCollector cc = new CommentCollector(model);
+		ntriplesParser.setRDFHandler(cc);
+		ntriplesParser.parse(
+				new StringReader("<s:1> <p:1> <o:1> .\n#" + commentStr + "\n<s:2> <p:2> <o:2> ."),
+				"http://example/");
+		assertEquals(2, model.size());
+		assertEquals(new TreeSet<>(Arrays.asList("o:1", "o:2")), Models.objectStrings(model));
+		assertEquals(Arrays.asList(commentStr), cc.comments);
 	}
 
 	protected abstract RDFParser createRDFParser();

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -12,7 +12,12 @@ import static org.junit.Assert.fail;
 
 import java.io.InputStream;
 import java.io.StringReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.TreeSet;
+import java.util.Arrays;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -13,11 +13,11 @@ import static org.junit.Assert.fail;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.LinkedList;
-import java.util.TreeSet;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.TreeSet;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;


### PR DESCRIPTION
Signed-off-by: Elad Shaked <elad.shaked@sparkbeyond.com>


GitHub issue resolved: #2357

In NTriplesParser, lines starting with a hash tag ('#') are send to rdfHander.handleComment rather than being ignored

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

