### PR TITLE
GH-2362 pass TripleSource through to function evaluation

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/CustomFunctionEvaluationTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/CustomFunctionEvaluationTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.parser.sparql.function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringReader;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests for evaluation of custom functions in SPARQL
+ *
+ * @author Jeen Broekstra
+ */
+public class CustomFunctionEvaluationTest {
+
+	private SailRepository rep;
+
+	@Before
+	public void setUp() {
+		rep = new SailRepository(new MemoryStore());
+	}
+
+	@Test
+	public void testTriplesourceRetrieval() throws Exception {
+		String data = "<ex:s1> a <ex:CustomClass> . <ex:s1> <ex:related> <ex:s2>, <ex:s3> .";
+		String query = "SELECT ?s ?result WHERE { ?s a <ex:CustomClass>. BIND(<urn:triplesourceCustomFunction>(?s) as ?result) }";
+
+		try (RepositoryConnection conn = rep.getConnection()) {
+			conn.add(new StringReader(data), "", RDFFormat.TURTLE);
+
+			TupleQueryResult result = conn.prepareTupleQuery(query).evaluate();
+			BindingSet bs = result.next();
+			assertThat(bs.getValue("result").stringValue()).isEqualTo("related to ex:s2, ex:s3");
+		}
+
+	}
+
+}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/TestTripleSourceCustomFunction.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/TestTripleSourceCustomFunction.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.parser.sparql.function;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
+
+/**
+ * A test-only function that evaluates against the supplied triple source. It looks up the 'ex:related' relations for
+ * the given input IRI and outputs a single literal of the form "related to v1, v2, v3".
+ *
+ * @author Jeen Broekstra
+ *
+ */
+public class TestTripleSourceCustomFunction implements Function {
+
+	@Override
+	public String getURI() {
+		return "urn:triplesourceCustomFunction";
+	}
+
+	@Override
+	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
+		throw new UnsupportedOperationException("can only evaluate with triplesource");
+	}
+
+	@Override
+	public Value evaluate(TripleSource tripleSource, Value... args) throws ValueExprEvaluationException {
+		IRI subject = (IRI) args[0];
+		IRI related = tripleSource.getValueFactory().createIRI("ex:related");
+		List<? extends Statement> relatedStatements = QueryResults
+				.asList(tripleSource.getStatements(subject, related, null));
+
+		StringBuilder functionResult = new StringBuilder();
+		functionResult.append("related to ");
+		for (Statement st : relatedStatements) {
+			functionResult.append(st.getObject().stringValue());
+			functionResult.append(", ");
+		}
+		functionResult.setLength(functionResult.length() - 2);
+
+		return tripleSource.getValueFactory().createLiteral(functionResult.toString());
+	}
+
+}

--- a/compliance/sparql/src/test/resources/META-INF/services/org.eclipse.rdf4j.query.algebra.evaluation.function.Function
+++ b/compliance/sparql/src/test/resources/META-INF/services/org.eclipse.rdf4j.query.algebra.evaluation.function.Function
@@ -1,0 +1,1 @@
+org.eclipse.rdf4j.query.parser.sparql.function.TestTripleSourceCustomFunction

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
@@ -38,11 +38,10 @@ public interface Function {
 	Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException;
 
 	/**
-	 * Evaluate the function over the supplied input arguments, using the supplied {@link ValueFactory} to produce the
-	 * result.
+	 * Evaluate the function over the supplied input arguments.
 	 *
-	 * @param tripleSource the {@link TripleSource} used in the query's evaluation plan. This can be used to access the
-	 *                     current state of the store.
+	 * @param tripleSource the {@link TripleSource} used in the query evaluation. This can be used to access the current
+	 *                     state of the store.
 	 * @param args         the function input arguments.
 	 * @return the function result value.
 	 * @throws ValueExprEvaluationException

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
@@ -32,7 +32,8 @@ public interface Function {
 	 * @param args         the function input arguments.
 	 * @return the function result value.
 	 * @throws ValueExprEvaluationException
-	 * @deprecated since 3.3.0. Use {@link #evaluate(TripleSource, Value...)} instead.
+	 * @deprecated since 3.3.0. Use {@link #evaluate(TripleSource, Value...)} instead. A reference to a ValueFactory can
+	 *             be retrieved using {@link TripleSource#getValueFactory()} if needed.
 	 */
 	@Deprecated
 	Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
@@ -9,14 +9,46 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function;
 
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 
 /**
+ * A query function, which can be a built-in function in the query language, or a custom function as documented in the
+ * <a href="https://www.w3.org/TR/sparql11-query/">SPARQL 1.1 Query Language Recommendation</a>.
+ *
  * @author Arjohn Kampman
+ * @author Jeen Broekstra
+ * @see FunctionRegistry
  */
 public interface Function {
 
-	public String getURI();
+	String getURI();
 
-	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException;
+	/**
+	 * Evaluate the function over the supplied input arguments, using the supplied {@link ValueFactory} to produce the
+	 * result.
+	 *
+	 * @param valueFactory a {@link ValueFactory} to use for producing the function result.
+	 * @param args         the function input arguments.
+	 * @return the function result value.
+	 * @throws ValueExprEvaluationException
+	 * @deprecated since 3.3.0. Use {@link #evaluate(TripleSource, Value...)} instead.
+	 */
+	@Deprecated
+	Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException;
+
+	/**
+	 * Evaluate the function over the supplied input arguments, using the supplied {@link ValueFactory} to produce the
+	 * result.
+	 *
+	 * @param tripleSource the {@link TripleSource} used in the query's evaluation plan. This can be used to access the
+	 *                     current state of the store.
+	 * @param args         the function input arguments.
+	 * @return the function result value.
+	 * @throws ValueExprEvaluationException
+	 * @since 3.3.0
+	 */
+	default Value evaluate(TripleSource tripleSource, Value... args) throws ValueExprEvaluationException {
+		return evaluate(tripleSource.getValueFactory(), args);
+	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/FunctionRegistry.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/FunctionRegistry.java
@@ -10,6 +10,9 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function;
 import org.eclipse.rdf4j.common.lang.service.ServiceRegistry;
 
 /**
+ * A ServiceRegistry for implemetnations of the {@link Function} interface. Functions are registered by their
+ * {@link Function#getURI() IRI}.
+ *
  * @author Arjohn Kampman
  */
 public class FunctionRegistry extends ServiceRegistry<String, Function> {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/FunctionRegistry.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/FunctionRegistry.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function;
 import org.eclipse.rdf4j.common.lang.service.ServiceRegistry;
 
 /**
- * A ServiceRegistry for implemetnations of the {@link Function} interface. Functions are registered by their
+ * A ServiceRegistry for implementations of the {@link Function} interface. Functions are registered by their
  * {@link Function#getURI() IRI}.
  *
  * @author Arjohn Kampman

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -1545,7 +1545,7 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 			argValues[i] = evaluate(args.get(i), bindings);
 		}
 
-		return function.evaluate(tripleSource.getValueFactory(), argValues);
+		return function.evaluate(tripleSource, argValues);
 
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #2362  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Allow access to database during function evaluation.

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

