### PR TITLE
GH-2371 switch to rsx namespace for targetShape

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/RSX.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/RSX.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+
+/**
+ * Constants for the Eclipse RDF4J SHACL Extensions.
+ *
+ */
+public class RSX {
+
+	/** The namespace (<tt>http://rdf4j.org/shacl-extensions#</tt>). */
+	public static final String NAMESPACE = "http://rdf4j.org/shacl-extensions#";
+
+	/**
+	 * Recommended prefix
+	 */
+	public static final String PREFIX = "rsx";
+
+	/**
+	 * An immutable {@link Namespace} constant that represents the namespace.
+	 */
+	public static final Namespace NS = new SimpleNamespace(PREFIX, NAMESPACE);
+
+	/*
+	 * Primitive datatypes
+	 */
+
+	/** <tt>http://rdf4j.org/shacl-extensions#targetShape</tt> */
+	public final static IRI targetShape = create("targetShape");
+
+	private static IRI create(String localName) {
+		return SimpleValueFactory.getInstance().createIRI(RSX.NAMESPACE, localName);
+	}
+}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/SHACL.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/SHACL.java
@@ -596,9 +596,6 @@ public class SHACL {
 	/** sh:targetSubjectsOf */
 	public static final IRI TARGET_SUBJECTS_OF;
 
-	/** sh:targetShape */
-	public static final IRI TARGET_SHAPE;
-
 	/** sh:uniqueLang */
 	public static final IRI UNIQUE_LANG;
 
@@ -833,6 +830,5 @@ public class SHACL {
 		XONE = factory.createIRI(NAMESPACE, "xone");
 		ZERO_OR_MORE_PATH = factory.createIRI(NAMESPACE, "zeroOrMorePath");
 		ZERO_OR_ONE_PATH = factory.createIRI(NAMESPACE, "zeroOrOnePath");
-		TARGET_SHAPE = factory.createIRI(NAMESPACE, "targetShape");
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeShape.java
@@ -251,7 +251,7 @@ public class NodeShape implements PlanGenerator, RequiresEvalutation, QueryGener
 										shaclProperties.getTargetObjectsOf()));
 					}
 
-					if (shaclSail.isShaclAdvancedFeatures()) {
+					if (shaclSail.isEclipseRdf4jShaclExtensions()) {
 						shaclProperties.getTargetShape()
 								.stream()
 								.map(targetShape -> new TargetShape(shapeId, shaclSail, connection,

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ShaclProperties.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ShaclProperties.java
@@ -203,7 +203,7 @@ public class ShaclProperties {
 					}
 					hasValueIn = (Resource) object;
 					break;
-				case "http://www.w3.org/ns/shacl#targetShape":
+				case "http://rdf4j.org/shacl-extensions#targetShape":
 					targetShape.add((Resource) object);
 					break;
 				default:

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetShape.java
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnorderedSelect;
 
 /**
- * sh:targetObjectsOf
+ * rsx:targetShape
  *
  * @author Håvard Mikkelsen Ottestad
  */
@@ -51,7 +51,7 @@ public class TargetShape extends NodeShape {
 
 		if (connection.hasStatement(targetShape, SHACL.PATH, null, false)) {
 			throw new UnsupportedOperationException(
-					"Experimental sh:targetShape support only supports sh:NodeShape and not sh:PropertyShape");
+					"Experimental rsx:targetShape support only supports sh:NodeShape and not sh:PropertyShape");
 		}
 
 		this.targetShape = new NodeShape(targetShape, shaclSail, connection, false);
@@ -149,26 +149,6 @@ public class TargetShape extends NodeShape {
 		return new ExternalFilterByQuery(connectionsGroup.getBaseConnection(), parent, 0,
 				getQuery("?a", null, null), "?a")
 						.getTrueNode(UnBufferedPlanNode.class);
-	}
-
-	private PlanNode getAllSubjectsPlan(SailConnection sailConnection) {
-		// @formatter:off
-		return new Unique(
-			new Sort(
-				new TrimTuple(
-					new UnorderedSelect(
-						sailConnection,
-						null,
-						null,
-						null,
-						UnorderedSelect.OutputPattern.SubjectPredicateObject
-					),
-					0,
-					1)
-			)
-		);
-		// @formatter:on
-
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -32,6 +32,7 @@ import org.eclipse.rdf4j.common.concurrent.locks.Lock;
 import org.eclipse.rdf4j.common.concurrent.locks.ReadPrefReadWriteLockManager;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.DASH;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RSX;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
@@ -245,7 +246,7 @@ public class ShaclSail extends NotifyingSailWrapper {
 	/**
 	 * Lists the predicates that have been implemented in the ShaclSail. All of these, and all combinations,
 	 * <i>should</i> work, please report any bugs. For sh:path, only single predicate paths, or single predicate inverse
-	 * paths are supported. sh:targetShape requires that experimental support is enabled for that feature.
+	 * paths are supported. DASH and RSX features may need to be enabled.
 	 *
 	 * @return List of IRIs (SHACL predicates)
 	 */
@@ -280,6 +281,7 @@ public class ShaclSail extends NotifyingSailWrapper {
 				SHACL.HAS_VALUE,
 				SHACL.TARGET_PROP,
 				SHACL.INVERSE_PATH,
+				DASH.hasValueIn,
 				RSX.targetShape);
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -33,6 +33,7 @@ import org.eclipse.rdf4j.common.concurrent.locks.ReadPrefReadWriteLockManager;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
+import org.eclipse.rdf4j.model.vocabulary.RSX;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryResult;
@@ -187,7 +188,7 @@ public class ShaclSail extends NotifyingSailWrapper {
 	private boolean rdfsSubClassReasoning = ShaclSailConfig.RDFS_SUB_CLASS_REASONING_DEFAULT;
 	private boolean serializableValidation = ShaclSailConfig.SERIALIZABLE_VALIDATION_DEFAULT;
 	private boolean performanceLogging = ShaclSailConfig.PERFORMANCE_LOGGING_DEFAULT;
-	private boolean shaclAdvancedFeatures = ShaclSailConfig.SHACL_ADVANCED_FEATURES_DEFAULT;
+	private boolean eclipseRdf4jShaclExtensions = ShaclSailConfig.ECLIPSE_RDF4J_SHACL_EXTENSIONS_DEFAULT;
 	private boolean dashDataShapes = ShaclSailConfig.DASH_DATA_SHAPES_DEFAULT;
 
 	private long validationResultsLimitTotal = -1;
@@ -279,7 +280,7 @@ public class ShaclSail extends NotifyingSailWrapper {
 				SHACL.HAS_VALUE,
 				SHACL.TARGET_PROP,
 				SHACL.INVERSE_PATH,
-				SHACL.TARGET_SHAPE);
+				RSX.targetShape);
 	}
 
 	private final AtomicBoolean initialized = new AtomicBoolean(false);
@@ -814,30 +815,30 @@ public class ShaclSail extends NotifyingSailWrapper {
 	}
 
 	/**
-	 * Support for SHACL Advanced Features W3C Working Group Note (https://www.w3.org/TR/shacl-af/). Enabling this
-	 * currently enables support for sh:targetShape.
+	 * Support for Eclipse RDF4J SHACL Extensions (http://rdf4j.org/shacl-extensions#). Enabling this currently enables
+	 * support for rsx:targetShape.
 	 *
 	 * EXPERIMENTAL!
 	 *
-	 * @param shaclAdvancedFeatures true to enable (default: false)
+	 * @param eclipseRdf4jShaclExtensions true to enable (default: false)
 	 */
 	@Experimental
-	public void setShaclAdvancedFeatures(boolean shaclAdvancedFeatures) {
-		this.shaclAdvancedFeatures = shaclAdvancedFeatures;
+	public void setEclipseRdf4jShaclExtensions(boolean eclipseRdf4jShaclExtensions) {
+		this.eclipseRdf4jShaclExtensions = eclipseRdf4jShaclExtensions;
 		forceRefreshShapes();
 	}
 
 	/**
-	 * Support for SHACL Advanced Features W3C Working Group Note (https://www.w3.org/TR/shacl-af/). Enabling this
-	 * currently enables support for sh:targetShape.
+	 * Support for Eclipse RDF4J SHACL Extensions (http://rdf4j.org/shacl-extensions#). Enabling this currently enables
+	 * support for rsx:targetShape.
 	 *
 	 * EXPERIMENTAL!
 	 *
 	 * @return true if enabled
 	 */
 	@Experimental
-	public boolean isShaclAdvancedFeatures() {
-		return shaclAdvancedFeatures;
+	public boolean isEclipseRdf4jShaclExtensions() {
+		return eclipseRdf4jShaclExtensions;
 	}
 
 	/**

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
@@ -49,7 +49,7 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	public static final boolean RDFS_SUB_CLASS_REASONING_DEFAULT = true;
 	public static final boolean PERFORMANCE_LOGGING_DEFAULT = false;
 	public static final boolean SERIALIZABLE_VALIDATION_DEFAULT = true;
-	public static final boolean SHACL_ADVANCED_FEATURES_DEFAULT = false;
+	public static final boolean ECLIPSE_RDF4J_SHACL_EXTENSIONS_DEFAULT = false;
 	public static final boolean DASH_DATA_SHAPES_DEFAULT = false;
 	public final static long VALIDATION_RESULTS_LIMIT_TOTAL_DEFAULT = -1;
 	public final static long VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT_DEFAULT = -1;
@@ -65,7 +65,7 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	private boolean rdfsSubClassReasoning = RDFS_SUB_CLASS_REASONING_DEFAULT;
 	private boolean performanceLogging = PERFORMANCE_LOGGING_DEFAULT;
 	private boolean serializableValidation = SERIALIZABLE_VALIDATION_DEFAULT;
-	private boolean shaclAdvancedFeatures = SHACL_ADVANCED_FEATURES_DEFAULT;
+	private boolean eclipseRdf4jShaclExtensions = ECLIPSE_RDF4J_SHACL_EXTENSIONS_DEFAULT;
 	private boolean dashDataShapes = DASH_DATA_SHAPES_DEFAULT;
 	private long validationResultsLimitTotal = VALIDATION_RESULTS_LIMIT_TOTAL_DEFAULT;
 	private long validationResultsLimitPerConstraint = VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT_DEFAULT;
@@ -173,13 +173,13 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	}
 
 	@Experimental
-	public boolean isShaclAdvancedFeatures() {
-		return shaclAdvancedFeatures;
+	public boolean isEclipseRdf4jShaclExtensions() {
+		return eclipseRdf4jShaclExtensions;
 	}
 
 	@Experimental
-	public void setShaclAdvancedFeatures(boolean shaclAdvancedFeatures) {
-		this.shaclAdvancedFeatures = shaclAdvancedFeatures;
+	public void setEclipseRdf4jShaclExtensions(boolean eclipseRdf4jShaclExtensions) {
+		this.eclipseRdf4jShaclExtensions = eclipseRdf4jShaclExtensions;
 	}
 
 	@Experimental
@@ -225,7 +225,8 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 		m.add(implNode, RDFS_SUB_CLASS_REASONING, BooleanLiteral.valueOf(isRdfsSubClassReasoning()));
 		m.add(implNode, PERFORMANCE_LOGGING, BooleanLiteral.valueOf(isPerformanceLogging()));
 		m.add(implNode, SERIALIZABLE_VALIDATION, BooleanLiteral.valueOf(isSerializableValidation()));
-		m.add(implNode, ShaclSailSchema.SHACL_ADVANCED_FEATURES, BooleanLiteral.valueOf(isShaclAdvancedFeatures()));
+		m.add(implNode, ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS,
+				BooleanLiteral.valueOf(isEclipseRdf4jShaclExtensions()));
 		m.add(implNode, ShaclSailSchema.DASH_DATA_SHAPES, BooleanLiteral.valueOf(isDashDataShapes()));
 
 		m.add(implNode, ShaclSailSchema.VALIDATION_RESULTS_LIMIT_TOTAL,
@@ -273,8 +274,8 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 			Models.objectLiteral(m.getStatements(implNode, SERIALIZABLE_VALIDATION, null))
 					.ifPresent(l -> setSerializableValidation(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, ShaclSailSchema.SHACL_ADVANCED_FEATURES, null))
-					.ifPresent(l -> setShaclAdvancedFeatures(l.booleanValue()));
+			Models.objectLiteral(m.getStatements(implNode, ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS, null))
+					.ifPresent(l -> setEclipseRdf4jShaclExtensions(l.booleanValue()));
 
 			Models.objectLiteral(m.getStatements(implNode, ShaclSailSchema.DASH_DATA_SHAPES, null))
 					.ifPresent(l -> setDashDataShapes(l.booleanValue()));

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailFactory.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailFactory.java
@@ -64,7 +64,7 @@ public class ShaclSailFactory implements SailFactory {
 			sail.setPerformanceLogging(shaclSailConfig.isPerformanceLogging());
 			sail.setSerializableValidation(shaclSailConfig.isSerializableValidation());
 			sail.setRdfsSubClassReasoning(shaclSailConfig.isRdfsSubClassReasoning());
-			sail.setShaclAdvancedFeatures(shaclSailConfig.isShaclAdvancedFeatures());
+			sail.setEclipseRdf4jShaclExtensions(shaclSailConfig.isEclipseRdf4jShaclExtensions());
 			sail.setDashDataShapes(shaclSailConfig.isDashDataShapes());
 			sail.setValidationResultsLimitTotal(shaclSailConfig.getValidationResultsLimitTotal());
 			sail.setValidationResultsLimitPerConstraint(shaclSailConfig.getValidationResultsLimitPerConstraint());

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
@@ -55,7 +55,7 @@ public class ShaclSailSchema {
 	/** <code>http://rdf4j.org/config/sail/shacl#serializableValidation</code> */
 	public final static IRI SERIALIZABLE_VALIDATION = create("serializableValidation");
 
-	public final static IRI SHACL_ADVANCED_FEATURES = create("shaclAdvancedFeatures");
+	public final static IRI ECLIPSE_RDF4J_SHACL_EXTENSIONS = create("eclipseRdf4jShaclExtensions");
 
 	public final static IRI DASH_DATA_SHAPES = create("dashDataShapes");
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -632,7 +632,7 @@ abstract public class AbstractShaclTest {
 		shaclSail.setParallelValidation(true);
 		shaclSail.setLogValidationViolations(fullLogging);
 		shaclSail.setGlobalLogValidationExecution(fullLogging);
-		shaclSail.setShaclAdvancedFeatures(true);
+		shaclSail.setEclipseRdf4jShaclExtensions(true);
 		shaclSail.setDashDataShapes(true);
 
 		repository.init();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ExtendedFeaturesetTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ExtendedFeaturesetTest.java
@@ -88,7 +88,7 @@ public class ExtendedFeaturesetTest {
 				.getInitializedShaclRepository("test-cases/class/simpleTargetShape/shacl.ttl", false);
 
 		((ShaclSail) shaclRepository.getSail()).setDashDataShapes(true);
-		((ShaclSail) shaclRepository.getSail()).setShaclAdvancedFeatures(true);
+		((ShaclSail) shaclRepository.getSail()).setEclipseRdf4jShaclExtensions(true);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.begin();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclSailSupportedPredicatesDocumentationTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclSailSupportedPredicatesDocumentationTest.java
@@ -19,6 +19,8 @@ import java.util.stream.Collectors;
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.vocabulary.DASH;
+import org.eclipse.rdf4j.model.vocabulary.RSX;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
@@ -56,7 +58,9 @@ public class ShaclSailSupportedPredicatesDocumentationTest extends AbstractShacl
 
 		Set<IRI> predicatesInUseInTest = parse.predicates()
 				.stream()
-				.filter(p -> p.getNamespace().equals(SHACL.NAMESPACE))
+				.filter(p -> (p.getNamespace().equals(SHACL.NAMESPACE) ||
+						p.getNamespace().equals(RSX.NAMESPACE) ||
+						p.getNamespace().equals(DASH.NAMESPACE)))
 				.collect(Collectors.toSet());
 
 		for (IRI predicate : predicatesInUseInTest) {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexTargetBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexTargetBenchmark.java
@@ -114,7 +114,7 @@ public class ComplexTargetBenchmark {
 		repository = new SailRepository(Utils.getInitializedShaclSail(shape));
 
 		((ShaclSail) repository.getSail()).setDashDataShapes(true);
-		((ShaclSail) repository.getSail()).setShaclAdvancedFeatures(true);
+		((ShaclSail) repository.getSail()).setEclipseRdf4jShaclExtensions(true);
 
 		((ShaclSail) repository.getSail()).disableValidation();
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/TargetBenchmarkInitialData.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/TargetBenchmarkInitialData.java
@@ -109,7 +109,7 @@ public class TargetBenchmarkInitialData {
 		repository = new SailRepository(Utils.getInitializedShaclSail(shape));
 
 		((ShaclSail) repository.getSail()).setDashDataShapes(true);
-		((ShaclSail) repository.getSail()).setShaclAdvancedFeatures(true);
+		((ShaclSail) repository.getSail()).setEclipseRdf4jShaclExtensions(true);
 
 		((ShaclSail) repository.getSail()).disableValidation();
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.shacl.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.CACHE_SELECT_NODES;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.DASH_DATA_SHAPES;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.GLOBAL_LOG_VALIDATION_EXECUTION;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.IGNORE_NO_SHAPES_LOADED_EXCEPTION;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.LOG_VALIDATION_PLANS;
@@ -18,7 +19,6 @@ import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PARALLEL_VALID
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PERFORMANCE_LOGGING;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.RDFS_SUB_CLASS_REASONING;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.SERIALIZABLE_VALIDATION;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.SHACL_ADVANCED_FEATURES;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.UNDEFINED_TARGET_VALIDATES_ALL_SUBJECTS;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_ENABLED;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT;
@@ -50,7 +50,7 @@ public class ShaclSailConfigTest {
 		assertThat(shaclSailConfig.isRdfsSubClassReasoning()).isTrue();
 		assertThat(shaclSailConfig.isPerformanceLogging()).isFalse();
 		assertThat(shaclSailConfig.isSerializableValidation()).isTrue();
-		assertThat(shaclSailConfig.isShaclAdvancedFeatures()).isFalse();
+		assertThat(shaclSailConfig.isEclipseRdf4jShaclExtensions()).isFalse();
 		assertThat(shaclSailConfig.isDashDataShapes()).isFalse();
 		assertThat(shaclSailConfig.getValidationResultsLimitTotal()).isEqualTo(-1);
 		assertThat(shaclSailConfig.getValidationResultsLimitPerConstraint()).isEqualTo(-1);
@@ -74,7 +74,7 @@ public class ShaclSailConfigTest {
 		mb.add(GLOBAL_LOG_VALIDATION_EXECUTION, true);
 		mb.add(RDFS_SUB_CLASS_REASONING, false);
 		mb.add(PERFORMANCE_LOGGING, true);
-		mb.add(SHACL_ADVANCED_FEATURES, true);
+		mb.add(ECLIPSE_RDF4J_SHACL_EXTENSIONS, true);
 		mb.add(DASH_DATA_SHAPES, true);
 		mb.add(SERIALIZABLE_VALIDATION, false);
 
@@ -94,7 +94,7 @@ public class ShaclSailConfigTest {
 		assertThat(shaclSailConfig.isRdfsSubClassReasoning()).isFalse();
 		assertThat(shaclSailConfig.isPerformanceLogging()).isTrue();
 		assertThat(shaclSailConfig.isSerializableValidation()).isFalse();
-		assertThat(shaclSailConfig.isShaclAdvancedFeatures()).isTrue();
+		assertThat(shaclSailConfig.isEclipseRdf4jShaclExtensions()).isTrue();
 		assertThat(shaclSailConfig.isDashDataShapes()).isTrue();
 		assertThat(shaclSailConfig.getValidationResultsLimitTotal()).isEqualTo(100);
 		assertThat(shaclSailConfig.getValidationResultsLimitPerConstraint()).isEqualTo(3);
@@ -144,7 +144,7 @@ public class ShaclSailConfigTest {
 		assertTrue(m.contains(node, RDFS_SUB_CLASS_REASONING, null));
 		assertTrue(m.contains(node, PERFORMANCE_LOGGING, null));
 		assertTrue(m.contains(node, SERIALIZABLE_VALIDATION, null));
-		assertTrue(m.contains(node, SHACL_ADVANCED_FEATURES, null));
+		assertTrue(m.contains(node, ECLIPSE_RDF4J_SHACL_EXTENSIONS, null));
 		assertTrue(m.contains(node, DASH_DATA_SHAPES, null));
 		assertTrue(m.contains(node, VALIDATION_RESULTS_LIMIT_TOTAL, null));
 		assertTrue(m.contains(node, VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT, null));

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailFactoryTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailFactoryTest.java
@@ -58,7 +58,7 @@ public class ShaclSailFactoryTest {
 		config.setPerformanceLogging(!config.isPerformanceLogging());
 		config.setSerializableValidation(!config.isSerializableValidation());
 		config.setRdfsSubClassReasoning(!config.isRdfsSubClassReasoning());
-		config.setShaclAdvancedFeatures(!config.isShaclAdvancedFeatures());
+		config.setEclipseRdf4jShaclExtensions(!config.isEclipseRdf4jShaclExtensions());
 		config.setDashDataShapes(!config.isDashDataShapes());
 
 		config.setValidationResultsLimitTotal(100);
@@ -81,7 +81,7 @@ public class ShaclSailFactoryTest {
 		assertThat(sail.isPerformanceLogging()).isEqualTo(config.isPerformanceLogging());
 		assertThat(sail.isSerializableValidation()).isEqualTo(config.isSerializableValidation());
 		assertThat(sail.isRdfsSubClassReasoning()).isEqualTo(config.isRdfsSubClassReasoning());
-		assertThat(sail.isShaclAdvancedFeatures()).isEqualTo(config.isShaclAdvancedFeatures());
+		assertThat(sail.isEclipseRdf4jShaclExtensions()).isEqualTo(config.isEclipseRdf4jShaclExtensions());
 		assertThat(sail.isDashDataShapes()).isEqualTo(config.isDashDataShapes());
 		assertThat(sail.getValidationResultsLimitTotal()).isEqualTo(config.getValidationResultsLimitTotal());
 		assertThat(sail.getValidationResultsLimitPerConstraint())

--- a/core/sail/shacl/src/test/resources/shaclDatatypeTargetFilter.ttl
+++ b/core/sail/shacl/src/test/resources/shaclDatatypeTargetFilter.ttl
@@ -8,10 +8,11 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix rdf4j-sh: <http://rdf4j.org/schema/rdf4j-shacl#> .
 @prefix dash: <http://datashapes.org/dash#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 ex:PersonShape
 	a sh:NodeShape  ;
-	sh:targetShape [
+	rsx:targetShape [
         	a sh:Shape ;
         	sh:property [
         		sh:path rdf:type ;

--- a/core/sail/shacl/src/test/resources/shaclDatatypeTargetFilterWithUnion.ttl
+++ b/core/sail/shacl/src/test/resources/shaclDatatypeTargetFilterWithUnion.ttl
@@ -8,10 +8,11 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix rdf4j-sh: <http://rdf4j.org/schema/rdf4j-shacl#> .
 @prefix dash: <http://datashapes.org/dash#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 ex:PersonShape
 	a sh:NodeShape  ;
-	sh:targetShape [
+	rsx:targetShape [
         	a sh:Shape ;
         	sh:property [
         		sh:path rdf:type ;

--- a/core/sail/shacl/src/test/resources/test-cases/class/complexTargetShape/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/class/complexTargetShape/shacl.ttl
@@ -6,10 +6,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dash: <http://datashapes.org/dash#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 ex:PersonShape
 	a sh:NodeShape  ;
-	sh:targetShape [
+	rsx:targetShape [
         		a sh:NodeShape ;
         		sh:or (
         		        [ sh:and ([sh:path rdf:type; sh:hasValue ex:Person] [sh:path rdf:type; sh:hasValue ex:Person]) ]

--- a/core/sail/shacl/src/test/resources/test-cases/class/complexTargetShape2/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/class/complexTargetShape2/shacl.ttl
@@ -6,10 +6,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dash: <http://datashapes.org/dash#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 ex:PersonShape
 	a sh:NodeShape  ;
-	sh:targetShape [
+	rsx:targetShape [
         		a sh:NodeShape ;
         		sh:and (
         		        [

--- a/core/sail/shacl/src/test/resources/test-cases/class/simpleTargetShape/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/class/simpleTargetShape/shacl.ttl
@@ -6,10 +6,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dash: <http://datashapes.org/dash#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 ex:PersonShape
 	a sh:NodeShape  ;
-	sh:targetShape [
+	rsx:targetShape [
         		a sh:NodeShape ;
         		sh:property [
         			sh:path rdf:type ;

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/notNodeShapeTargetShape/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/notNodeShapeTargetShape/shacl.ttl
@@ -5,10 +5,11 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 ex:PersonShape
 	a sh:NodeShape  ;
-	sh:targetShape [ sh:property [sh:path rdf:type; sh:hasValue ex:Person ]];
+	rsx:targetShape [ sh:property [sh:path rdf:type; sh:hasValue ex:Person ]];
 	sh:not [
 		sh:path ex:age ;
 		sh:or ([sh:datatype xsd:boolean ] [ sh:datatype xsd:string ] );

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/notTargetShape/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/notTargetShape/shacl.ttl
@@ -5,10 +5,11 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 ex:PersonShape
 	a sh:NodeShape  ;
-	sh:targetShape [ sh:property [sh:path rdf:type; sh:hasValue ex:Person ]];
+	rsx:targetShape [ sh:property [sh:path rdf:type; sh:hasValue ex:Person ]];
 	sh:property [
 		sh:path ex:age ;
 		sh:not [ sh:datatype xsd:boolean ];


### PR DESCRIPTION
GitHub issue resolved: #2371 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
 - switch from sh:targetShape to rsx:targetShape
<!-- short description of your change goes here -->

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

