### PR TITLE
GH-2377: fix LuceneSail#reindex() to create document for last resource

### DIFF
--- a/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
+++ b/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
@@ -8,6 +8,15 @@
 package org.eclipse.rdf4j.sail.lucene;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.util.Repositories;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author jeen
@@ -24,6 +33,40 @@ public class LuceneSailTest extends AbstractLuceneSailTest {
 	protected void configure(LuceneSail sail) throws IOException {
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneIndex.class.getName());
 		sail.setParameter(LuceneSail.LUCENE_RAMDIR_KEY, "true");
+	}
+
+	@Test
+	public void testReindexing_SingleResource() throws Exception {
+
+		// wipe the Lucene index to allow specific test data
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.clear();
+		}
+
+		String query = "PREFIX search: <http://www.openrdf.org/contrib/lucenesail#> \n" +
+				"SELECT ?subj ?text ?prop ?score WHERE { \n" +
+				"  ?subj search:matches [ search:query \"one\" ; search:property ?prop; search:snippet ?text ; search:score ?score] }";
+
+		List<BindingSet> res;
+
+		// expected empty result => no data in the index
+		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
+		Assert.assertEquals(Collections.emptyList(), res);
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.add(SUBJECT_1, PREDICATE_1, vf.createLiteral("one"));
+		}
+
+		// expected single result
+		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
+		Assert.assertEquals(1, res.size());
+
+		// re-index
+		this.sail.reindex();
+
+		// expected single result
+		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
+		Assert.assertEquals(1, res.size());
 	}
 
 }

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -551,6 +551,15 @@ public class LuceneSail extends NotifyingSailWrapper {
 						}
 						statements.add(vf.createStatement(r, p, o, c));
 					}
+
+					// make sure to index statements for last resource
+					if (current != null) {
+						if (logger.isDebugEnabled()) {
+							logger.debug("reindexing resource " + current);
+						}
+						// commit
+						luceneIndex.addDocuments(current, statements);
+					}
 				}
 			} finally {
 				repo.shutDown();

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -553,7 +553,7 @@ public class LuceneSail extends NotifyingSailWrapper {
 					}
 
 					// make sure to index statements for last resource
-					if (current != null) {
+					if (current != null && !statements.isEmpty()) {
 						if (logger.isDebugEnabled()) {
 							logger.debug("reindexing resource " + current);
 						}

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -32,7 +31,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -52,10 +50,8 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.repository.util.Repositories;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -985,40 +981,6 @@ public abstract class AbstractLuceneSailTest {
 	public void testReindexing() throws Exception {
 		sail.reindex();
 		testComplexQueryTwo();
-	}
-
-	@Test
-	public void testReindexing_SingleResource() throws Exception {
-
-		// wipe the Lucene index to allow specific test data
-		try (RepositoryConnection connection = repository.getConnection()) {
-			connection.clear();
-		}
-
-		String query = "PREFIX search: <http://www.openrdf.org/contrib/lucenesail#> \n" +
-				"SELECT ?subj ?text ?prop ?score WHERE { \n" +
-				"  ?subj search:matches [ search:query \"one\" ; search:property ?prop; search:snippet ?text ; search:score ?score] }";
-
-		List<BindingSet> res;
-
-		// expected empty result => no data in the index
-		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
-		Assert.assertEquals(Collections.emptyList(), res);
-
-		try (RepositoryConnection connection = repository.getConnection()) {
-			connection.add(SUBJECT_1, PREDICATE_1, vf.createLiteral("one"));
-		}
-
-		// expected single result
-		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
-		Assert.assertEquals(1, res.size());
-
-		// re-index
-		this.sail.reindex();
-
-		// expected single result
-		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
-		Assert.assertEquals(1, res.size());
 	}
 
 	@Test

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
@@ -121,7 +121,6 @@ public abstract class AbstractLuceneSailTest {
 
 		// create a Repository wrapping the LuceneSail
 		repository = new SailRepository(sail);
-		repository.init();
 
 		// add some statements to it
 		try (RepositoryConnection connection = repository.getConnection()) {

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -31,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -50,8 +52,10 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.util.Repositories;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -121,7 +125,7 @@ public abstract class AbstractLuceneSailTest {
 
 		// create a Repository wrapping the LuceneSail
 		repository = new SailRepository(sail);
-		repository.initialize();
+		repository.init();
 
 		// add some statements to it
 		try (RepositoryConnection connection = repository.getConnection()) {
@@ -981,6 +985,40 @@ public abstract class AbstractLuceneSailTest {
 	public void testReindexing() throws Exception {
 		sail.reindex();
 		testComplexQueryTwo();
+	}
+
+	@Test
+	public void testReindexing_SingleResource() throws Exception {
+
+		// wipe the Lucene index to allow specific test data
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.clear();
+		}
+
+		String query = "PREFIX search: <http://www.openrdf.org/contrib/lucenesail#> \n" +
+				"SELECT ?subj ?text ?prop ?score WHERE { \n" +
+				"  ?subj search:matches [ search:query \"one\" ; search:property ?prop; search:snippet ?text ; search:score ?score] }";
+
+		List<BindingSet> res;
+
+		// expected empty result => no data in the index
+		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
+		Assert.assertEquals(Collections.emptyList(), res);
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.add(SUBJECT_1, PREDICATE_1, vf.createLiteral("one"));
+		}
+
+		// expected single result
+		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
+		Assert.assertEquals(1, res.size());
+
+		// re-index
+		this.sail.reindex();
+
+		// expected single result
+		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
+		Assert.assertEquals(1, res.size());
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #2377  <!-- add a Github issue number here, e.g #123. -->

With the current algorithm the document for the last resource was never
persisted. This is now change to explicitly persist the last document
after loop completion.

Behavior is covered with a unit test

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x ] I've added tests for the changes I made
 - [ x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

