### PR TITLE
GH-2396 remove enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -913,44 +913,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<!-- verify all bytecode (including third party libs) is Java 8 max -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>1.4.1</version>
-				<executions>
-					<execution>
-						<id>enforce-bytecode-version</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<enforceBytecodeVersion>
-									<maxJdkVersion>1.8</maxJdkVersion>
-									<ignoreClasses>
-										<ignoreClass>META-INF/**/module-info</ignoreClass>
-									</ignoreClasses>
-									<excludes>
-										<exclude>org.apache.logging.log4j:log4j-api</exclude>
-										<exclude>org.elasticsearch:elasticsearch</exclude>
-										<exclude>javax.xml.bind:jaxb-api</exclude>
-										<exclude>org.elasticsearch:elasticsearch-core</exclude>
-									</excludes>
-								</enforceBytecodeVersion>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
-				</executions>
-				<dependencies>
-					<dependency>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.0</version>
-					</dependency>
-				</dependencies>
-			</plugin>
-			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
 				<configuration>


### PR DESCRIPTION


GitHub issue resolved: #2396  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Remove enforcer plugin from maven build process

- java 8 compatibility is covered by Github action build job
- speeds up build process
- avoids unnecessary downloads of rdf4j snapshot builds once a day


---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

