### PR TITLE
GH-2187 keep parent reference in querymodelnode consistent

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
@@ -113,7 +113,7 @@ public class EvaluationStatistics {
 			// statement pattern.
 			cardinality = 2.0 * getCardinality(
 					new StatementPattern(node.getSubjectVar().clone(), pathVar, node.getObjectVar().clone(),
-							node.getContextVar() != null ? node.getContextVar() : null));
+							node.getContextVar() != null ? node.getContextVar().clone() : null));
 		}
 
 		@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
@@ -112,7 +112,8 @@ public class EvaluationStatistics {
 			// the length of the path is unknown but expected to be _at least_ twice that of a normal
 			// statement pattern.
 			cardinality = 2.0 * getCardinality(
-					new StatementPattern(node.getSubjectVar(), pathVar, node.getObjectVar(), node.getContextVar()));
+					new StatementPattern(node.getSubjectVar().clone(), pathVar, node.getObjectVar().clone(),
+							node.getContextVar() != null ? node.getContextVar() : null));
 		}
 
 		@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ParentReferenceCleaner.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ParentReferenceCleaner.java
@@ -1,0 +1,54 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import java.util.ArrayDeque;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cleans up {@link QueryModelNode#getParentNode()} references that have become inconsistent with the actual algebra
+ * tree structure due to optimization operations. Typically used at the very end of the optimization pipeline.
+ * 
+ * @author Jeen Broekstra
+ */
+public class ParentReferenceCleaner implements QueryOptimizer {
+
+	private static final Logger logger = LoggerFactory.getLogger(ParentReferenceCleaner.class);
+
+	@Override
+	public void optimize(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings) {
+		tupleExpr.visit(new ParentFixingVisitor());
+	}
+
+	private class ParentFixingVisitor extends AbstractQueryModelVisitor<RuntimeException> {
+
+		private final ArrayDeque<QueryModelNode> ancestors = new ArrayDeque<>();
+
+		@Override
+		protected void meetNode(QueryModelNode node) throws RuntimeException {
+			QueryModelNode expectedParent = ancestors.peekLast();
+			if (node.getParentNode() != expectedParent) {
+				logger.debug("unexpected parent for node {}: {} (expected {})", node, node.getParentNode(),
+						expectedParent);
+				node.setParentNode(expectedParent);
+			}
+
+			ancestors.addLast(node);
+			super.meetNode(node);
+			ancestors.pollLast();
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
@@ -56,7 +56,8 @@ public class StandardQueryOptimizerPipeline implements QueryOptimizerPipeline {
 				new QueryJoinOptimizer(evaluationStatistics),
 				new IterativeEvaluationOptimizer(),
 				new FilterOptimizer(),
-				new OrderLimitOptimizer());
+				new OrderLimitOptimizer(),
+				new ParentReferenceCleaner());
 	}
 
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
@@ -260,7 +260,8 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 			// the variable must remain unbound for this solution see https://www.w3.org/TR/sparql11-query/#assignment
 			currentIter = new EmptyIteration<>();
 		} else if (currentLength == 0L) {
-			ZeroLengthPath zlp = new ZeroLengthPath(scope, startVar, endVar, contextVar);
+			ZeroLengthPath zlp = new ZeroLengthPath(scope, startVar.clone(), endVar.clone(),
+					contextVar != null ? contextVar.clone() : null);
 			currentIter = this.evaluationStrategyImpl.evaluate(zlp, bindings);
 			currentLength++;
 		} else if (currentLength == 1) {

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizerTest.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.junit.jupiter.api.Test;
+
+public abstract class QueryOptimizerTest {
+
+	@Test
+	public void testParentReferencesConsistent_pathExpressions() {
+		ParsedTupleQuery query = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL,
+				"select * where {?a ?b ?c. ?c <http://a>* ?d}", null);
+
+		TupleExpr expr = query.getTupleExpr();
+
+		getOptimizer().optimize(expr, null, EmptyBindingSet.getInstance());
+
+		ParentCheckingVisitor checker = new ParentCheckingVisitor();
+		expr.visit(checker);
+
+		assertThat(checker.getInconsistentNodes()).isEmpty();
+	}
+
+	@Test
+	public void testParentReferencesConsistent_filter() {
+		ParsedTupleQuery query = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL,
+				"select * where {?a ?b ?c. FILTER(?c = <urn:foo>) }", null);
+
+		TupleExpr expr = query.getTupleExpr();
+
+		getOptimizer().optimize(expr, null, EmptyBindingSet.getInstance());
+
+		ParentCheckingVisitor checker = new ParentCheckingVisitor();
+		expr.visit(checker);
+
+		assertThat(checker.getInconsistentNodes()).isEmpty();
+	}
+
+	@Test
+	public void testParentReferencesConsistent_subselect() {
+		ParsedTupleQuery query = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL,
+				"select * where {?a ?b ?c. { select ?a ?z where { ?a a ?z } }}", null);
+
+		TupleExpr expr = query.getTupleExpr();
+
+		getOptimizer().optimize(expr, null, EmptyBindingSet.getInstance());
+
+		ParentCheckingVisitor checker = new ParentCheckingVisitor();
+		expr.visit(checker);
+
+		assertThat(checker.getInconsistentNodes()).isEmpty();
+	}
+
+	public abstract QueryOptimizer getOptimizer();
+
+	private class ParentCheckingVisitor extends AbstractQueryModelVisitor<RuntimeException> {
+		private final ArrayDeque<QueryModelNode> ancestors = new ArrayDeque<>();
+		private List<QueryModelNode> inconsistentNodes = new ArrayList<>();
+
+		@Override
+		protected void meetNode(QueryModelNode node) throws RuntimeException {
+			QueryModelNode expectedParent = ancestors.peekLast();
+			if (node.getParentNode() != expectedParent) {
+				inconsistentNodes.add(node);
+			}
+
+			ancestors.addLast(node);
+			super.meetNode(node);
+			ancestors.pollLast();
+		}
+
+		public List<QueryModelNode> getInconsistentNodes() {
+			return inconsistentNodes;
+		}
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingAssignerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingAssignerTest.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+public class BindingAssignerTest extends QueryOptimizerTest {
+
+	@Override
+	public BindingAssigner getOptimizer() {
+		return new BindingAssigner();
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/CompareOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/CompareOptimizerTest.java
@@ -1,0 +1,23 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+/**
+ * @author jeen
+ *
+ */
+public class CompareOptimizerTest extends QueryOptimizerTest {
+
+	@Override
+	public CompareOptimizer getOptimizer() {
+		return new CompareOptimizer();
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ConjunctiveConstraintSplitterTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ConjunctiveConstraintSplitterTest.java
@@ -1,0 +1,23 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+/**
+ * @author jeen
+ *
+ */
+public class ConjunctiveConstraintSplitterTest extends QueryOptimizerTest {
+
+	@Override
+	public ConjunctiveConstraintSplitter getOptimizer() {
+		return new ConjunctiveConstraintSplitter();
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ConstantOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ConstantOptimizerTest.java
@@ -7,9 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -24,15 +25,16 @@ import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
 import org.eclipse.rdf4j.query.algebra.helpers.QueryModelVisitorBase;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  */
-public class ConstantOptimizerTest {
+public class ConstantOptimizerTest extends QueryOptimizerTest {
 
 	@Test
 	public void testAndOptimization() throws RDF4JException {
@@ -57,7 +59,7 @@ public class ConstantOptimizerTest {
 		TupleExpr optimized = optimize(pq.getTupleExpr().clone(), constants, strategy);
 
 		optimized.visit(finder);
-		assertFalse("optimized query should no longer contain && operator", finder.logicalAndfound);
+		assertThat(finder.logicalAndfound).isFalse();
 
 		CloseableIteration<BindingSet, QueryEvaluationException> result = strategy.evaluate(optimized,
 				new EmptyBindingSet());
@@ -92,7 +94,7 @@ public class ConstantOptimizerTest {
 		TupleExpr optimized = optimize(pq.getTupleExpr().clone(), constants, strategy);
 
 		optimized.visit(finder);
-		assertFalse("optimized query should no longer contain function call", finder.functionCallFound);
+		assertThat(finder.functionCallFound).isFalse();
 
 		CloseableIteration<BindingSet, QueryEvaluationException> result = strategy.evaluate(optimized,
 				new EmptyBindingSet());
@@ -135,5 +137,10 @@ public class ConstantOptimizerTest {
 		new BindingAssigner().optimize(optRoot, null, bs);
 		new ConstantOptimizer(strategy).optimize(optRoot, null, bs);
 		return optRoot;
+	}
+
+	@Override
+	public ConstantOptimizer getOptimizer() {
+		return new ConstantOptimizer(mock(StrictEvaluationStrategy.class));
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DisjunctiveConstraintOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DisjunctiveConstraintOptimizerTest.java
@@ -1,0 +1,23 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+/**
+ * @author jeen
+ *
+ */
+public class DisjunctiveConstraintOptimizerTest extends QueryOptimizerTest {
+
+	@Override
+	public DisjunctiveConstraintOptimizer getOptimizer() {
+		return new DisjunctiveConstraintOptimizer();
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatisticsTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatisticsTest.java
@@ -1,14 +1,6 @@
-/******************************************************************************* 
- * Copyright (c) 2021 Eclipse RDF4J contributors. 
- * All rights reserved. This program and the accompanying materials 
- * are made available under the terms of the Eclipse Distribution License v1.0 
- * which accompanies this distribution, and is available at 
- * http://www.eclipse.org/org/documents/edl-v10.php. 
- *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -17,38 +9,30 @@ import java.util.List;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
-import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
-import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
-import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
-import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class ParentReferenceCleanerTest {
+public class EvaluationStatisticsTest {
 
 	@Test
-	public void testStandardOptimizerPipeline() {
+	public void testGetCardinality_ParentReferences() throws Exception {
 		ParsedTupleQuery query = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL,
 				"select * where {?a ?b ?c. ?c <http://a>* ?d}", null);
 
 		TupleExpr expr = query.getTupleExpr();
 
-		// We are indirectly relying on the ParentReferenceCleaner being part of the standard pipeline. Not the cleanest
-		// way to test, but it's a quick way to make sure that our standard pipeline at least results in a consistent
-		// tree.
-		StandardQueryOptimizerPipeline pipeline = new StandardQueryOptimizerPipeline(mock(EvaluationStrategy.class),
-				mock(TripleSource.class), new EvaluationStatistics());
+		TupleExpr clone = expr.clone();
 
-		for (QueryOptimizer optimizer : pipeline.getOptimizers()) {
-			optimizer.optimize(expr, null, EmptyBindingSet.getInstance());
-		}
+		new EvaluationStatistics().getCardinality(clone);
 
 		ParentCheckingVisitor checker = new ParentCheckingVisitor();
-		expr.visit(checker);
+		clone.visit(checker);
+		assertThat(checker.getInconsistentNodes()).isEmpty();
 
+		checker.reset();
+		expr.visit(checker);
 		assertThat(checker.getInconsistentNodes()).isEmpty();
 	}
 
@@ -57,6 +41,11 @@ public class ParentReferenceCleanerTest {
 		private final ArrayDeque<QueryModelNode> ancestors = new ArrayDeque<>();
 
 		private List<QueryModelNode> inconsistentNodes = new ArrayList<>();
+
+		public void reset() {
+			inconsistentNodes.clear();
+			ancestors.clear();
+		}
 
 		@Override
 		protected void meetNode(QueryModelNode node) throws RuntimeException {

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+public class FilterOptimizerTest extends QueryOptimizerTest {
+
+	@Override
+	public FilterOptimizer getOptimizer() {
+		return new FilterOptimizer();
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/IterativeEvaluationOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/IterativeEvaluationOptimizerTest.java
@@ -1,0 +1,23 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+/**
+ * @author jeen
+ *
+ */
+public class IterativeEvaluationOptimizerTest extends QueryOptimizerTest {
+
+	@Override
+	public IterativeEvaluationOptimizer getOptimizer() {
+		return new IterativeEvaluationOptimizer();
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/OrderLimitOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/OrderLimitOptimizerTest.java
@@ -1,0 +1,16 @@
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+public class OrderLimitOptimizerTest extends QueryOptimizerTest {
+
+	@Override
+	public QueryOptimizer getOptimizer() {
+		return new OrderLimitOptimizer();
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ParentReferenceCleanerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ParentReferenceCleanerTest.java
@@ -1,0 +1,104 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.junit.jupiter.api.Test;
+
+public class ParentReferenceCleanerTest {
+
+	@Test
+	public void testStandardOptimizerPipeline() {
+		ParsedTupleQuery query = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL,
+				"select * where {?a ?b ?c. ?c <http://a>* ?d}", null);
+
+		TupleExpr expr = query.getTupleExpr();
+
+		// We are indirectly relying on the ParentReferenceCleaner being part of the standard pipeline. Not the cleanest
+		// way to test, but it's a quick way to make sure that our standard pipeline at least results in a consistent
+		// tree.
+		StandardQueryOptimizerPipeline pipeline = new StandardQueryOptimizerPipeline(mock(EvaluationStrategy.class),
+				mock(TripleSource.class), new EvaluationStatistics());
+
+		for (QueryOptimizer optimizer : pipeline.getOptimizers()) {
+			optimizer.optimize(expr, null, EmptyBindingSet.getInstance());
+		}
+
+		ParentCheckingVisitor checker = new ParentCheckingVisitor();
+		expr.visit(checker);
+
+		assertThat(checker.getInconsistentNodes()).isEmpty();
+	}
+
+	private class ParentCheckingVisitor extends AbstractQueryModelVisitor<RuntimeException> {
+
+		private final ArrayDeque<QueryModelNode> ancestors = new ArrayDeque<>();
+
+		private List<QueryModelNode> inconsistentNodes = new ArrayList<>();
+
+		@Override
+		protected void meetNode(QueryModelNode node) throws RuntimeException {
+			QueryModelNode expectedParent = ancestors.peekLast();
+			if (node.getParentNode() != expectedParent) {
+				inconsistentNodes.add(node);
+			}
+
+			ancestors.addLast(node);
+			super.meetNode(node);
+			ancestors.pollLast();
+		}
+
+		public List<QueryModelNode> getInconsistentNodes() {
+			return inconsistentNodes;
+		}
+	}
+
+	private static class StatementPatternFinder extends AbstractQueryModelVisitor<RuntimeException> {
+
+		private StatementPattern pattern;
+
+		@Override
+		public void meet(StatementPattern node) throws RuntimeException {
+			if (pattern != null) {
+				return;
+			}
+			pattern = node;
+		}
+
+		public StatementPattern getStatementPattern() {
+			return pattern;
+		}
+	}
+
+	private static class SloppyReplacer extends AbstractQueryModelVisitor<RuntimeException> {
+
+		@Override
+		public void meet(StatementPattern node) throws RuntimeException {
+			super.meet(node);
+			node.replaceWith(new StatementPattern(node.getObjectVar(), node.getPredicateVar(), node.getSubjectVar(),
+					node.getContextVar()));
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizerTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.UnsupportedQueryLanguageException;
@@ -22,6 +24,8 @@ import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.UnaryTupleOperator;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
@@ -34,7 +38,7 @@ import org.junit.Test;
  *
  * @author Mark
  */
-public class QueryJoinOptimizerTest {
+public class QueryJoinOptimizerTest extends QueryOptimizerTest {
 
 	@Test
 	public void testBindingSetAssignmentOptimization() throws RDF4JException {
@@ -121,6 +125,11 @@ public class QueryJoinOptimizerTest {
 				.isInstanceOf(Extension.class);
 	}
 
+	@Override
+	public QueryJoinOptimizer getOptimizer() {
+		return new QueryJoinOptimizer();
+	}
+
 	private TupleExpr findLeaf(TupleExpr expr) {
 		if (expr instanceof UnaryTupleOperator) {
 			return findLeaf(((UnaryTupleOperator) expr).getArg());
@@ -134,7 +143,7 @@ public class QueryJoinOptimizerTest {
 	private void testOptimizer(String expectedQuery, String actualQuery)
 			throws MalformedQueryException, UnsupportedQueryLanguageException {
 		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, actualQuery, null);
-		QueryJoinOptimizer opt = new QueryJoinOptimizer();
+		QueryJoinOptimizer opt = getOptimizer();
 		QueryRoot optRoot = new QueryRoot(pq.getTupleExpr());
 		opt.optimize(optRoot, null, null);
 
@@ -160,4 +169,5 @@ public class QueryJoinOptimizerTest {
 			return join;
 		}
 	}
+
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizerTest.java
@@ -13,16 +13,17 @@ import org.eclipse.rdf4j.query.algebra.EmptySet;
 import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.SingletonSet;
 import org.eclipse.rdf4j.query.algebra.Union;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class QueryModelNormalizerTest {
+public class QueryModelNormalizerTest extends QueryOptimizerTest {
 
-	private static QueryModelNormalizer subject;
+	private QueryModelNormalizer subject;
 
-	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
-		subject = new QueryModelNormalizer();
+	@BeforeEach
+	public void setup() throws Exception {
+		subject = getOptimizer();
 	}
 
 	@Test
@@ -67,6 +68,11 @@ public class QueryModelNormalizerTest {
 		subject.meet(union);
 
 		assertThat(p.getArg()).isEqualTo(union);
+	}
+
+	@Override
+	public QueryModelNormalizer getOptimizer() {
+		return new QueryModelNormalizer();
 	}
 
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizerTest.java
@@ -1,0 +1,20 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+public class RegexAsStringFunctionOptimizerTest extends QueryOptimizerTest {
+
+	@Override
+	public RegexAsStringFunctionOptimizer getOptimizer() {
+		return new RegexAsStringFunctionOptimizer(SimpleValueFactory.getInstance());
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SameTermFilterOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SameTermFilterOptimizerTest.java
@@ -1,0 +1,23 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+
+/**
+ * @author jeen
+ *
+ */
+public class SameTermFilterOptimizerTest extends QueryOptimizerTest {
+
+	@Override
+	public SameTermFilterOptimizer getOptimizer() {
+		return new SameTermFilterOptimizer();
+	}
+
+}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -43,6 +43,10 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, Variable
 
 	@Override
 	public void setParentNode(QueryModelNode parent) {
+		if (this.parent != null && this.parent != parent) {
+			// debug here
+			System.out.println();
+		}
 		this.parent = parent;
 	}
 

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -43,10 +43,6 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, Variable
 
 	@Override
 	public void setParentNode(QueryModelNode parent) {
-		if (this.parent != null && this.parent != parent) {
-			// debug here
-			System.out.println();
-		}
 		this.parent = parent;
 	}
 

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/GroupElem.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/GroupElem.java
@@ -76,6 +76,11 @@ public class GroupElem extends AbstractQueryModelNode {
 	}
 
 	@Override
+	public String getSignature() {
+		return super.getSignature() + " (" + name + ")";
+	}
+
+	@Override
 	public boolean equals(Object other) {
 		if (other instanceof GroupElem) {
 			GroupElem o = (GroupElem) other;

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreeToGenericPlanNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreeToGenericPlanNode.java
@@ -8,7 +8,6 @@
 package org.eclipse.rdf4j.query.algebra.helpers;
 
 import java.util.ArrayDeque;
-import java.util.IdentityHashMap;
 
 import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
@@ -26,9 +25,7 @@ public class QueryModelTreeToGenericPlanNode extends AbstractQueryModelVisitor<R
 
 	GenericPlanNode top = null;
 	QueryModelNode topTupleExpr;
-	ArrayDeque<GenericPlanNode> deque = new ArrayDeque<>();
-	ArrayDeque<QueryModelNode> deque2 = new ArrayDeque<>();
-	IdentityHashMap<QueryModelNode, QueryModelNode> visited = new IdentityHashMap<>();
+	ArrayDeque<GenericPlanNode> planNodes = new ArrayDeque<>();
 
 	public QueryModelTreeToGenericPlanNode(QueryModelNode topTupleExpr) {
 		this.topTupleExpr = topTupleExpr;
@@ -38,13 +35,8 @@ public class QueryModelTreeToGenericPlanNode extends AbstractQueryModelVisitor<R
 		return top;
 	}
 
-	// node.getParentNode() is not reliable because nodes are reused and parent is not maintained! This is why we use a
-	// queue to maintain the effective parent stack.
 	@Override
 	protected void meetNode(QueryModelNode node) {
-		assert !visited.containsKey(node);
-		visited.put(node, node);
-
 		GenericPlanNode genericPlanNode = new GenericPlanNode(node.getSignature());
 		genericPlanNode.setCostEstimate(node.getCostEstimate());
 		genericPlanNode.setResultSizeEstimate(node.getResultSizeEstimate());
@@ -66,18 +58,14 @@ public class QueryModelTreeToGenericPlanNode extends AbstractQueryModelVisitor<R
 			top = genericPlanNode;
 		}
 
-		if (!deque.isEmpty()) {
-			GenericPlanNode genericParentNode = deque.getLast();
+		if (!planNodes.isEmpty()) {
+			GenericPlanNode genericParentNode = planNodes.getLast();
 			genericParentNode.addPlans(genericPlanNode);
-			assert node.getParentNode() == deque2.getLast();
 		}
 
-		deque.addLast(genericPlanNode);
-		deque2.addLast(node);
+		planNodes.addLast(genericPlanNode);
 		super.meetNode(node);
-		deque.removeLast();
-		deque2.removeLast();
-
+		planNodes.removeLast();
 	}
 
 }

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -874,7 +874,26 @@ public class QueryPlanRetrievalTest {
 	}
 
 	@Test
-	public void temp() {
+	public void testArbitraryLengthPath() {
+
+		String expected = "Projection\n"
+				+ "╠══ProjectionElemList\n"
+				+ "║     ProjectionElem \"a\"\n"
+				+ "║     ProjectionElem \"b\"\n"
+				+ "║     ProjectionElem \"c\"\n"
+				+ "║     ProjectionElem \"d\"\n"
+				+ "╚══Join (JoinIterator)\n"
+				+ "   ├──StatementPattern (costEstimate=6, resultSizeEstimate=12)\n"
+				+ "   │     Var (name=a)\n"
+				+ "   │     Var (name=b)\n"
+				+ "   │     Var (name=c)\n"
+				+ "   └──ArbitraryLengthPath (costEstimate=5, resultSizeEstimate=24)\n"
+				+ "         Var (name=c)\n"
+				+ "         StatementPattern (resultSizeEstimate=0)\n"
+				+ "            Var (name=c)\n"
+				+ "            Var (name=_const_f804988f_uri, value=http://a, anonymous)\n"
+				+ "            Var (name=d)\n"
+				+ "         Var (name=d)\n";
 		SailRepository sailRepository = new SailRepository(new MemoryStore());
 		addData(sailRepository);
 
@@ -882,6 +901,7 @@ public class QueryPlanRetrievalTest {
 			TupleQuery query = connection.prepareTupleQuery("select * where {?a ?b ?c. ?c <http://a>* ?d}");
 			String actual = query.explain(Explanation.Level.Optimized).toString();
 
+			assertThat(actual).isEqualTo(expected);
 		}
 		sailRepository.shutDown();
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -873,4 +873,18 @@ public class QueryPlanRetrievalTest {
 
 	}
 
+	@Test
+	public void temp() {
+		SailRepository sailRepository = new SailRepository(new MemoryStore());
+		addData(sailRepository);
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+			TupleQuery query = connection.prepareTupleQuery("select * where {?a ?b ?c. ?c <http://a>* ?d}");
+			String actual = query.explain(Explanation.Level.Optimized).toString();
+
+		}
+		sailRepository.shutDown();
+
+	}
+
 }


### PR DESCRIPTION
GitHub issue resolved: #2187 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- ensure optimizers and other components that manipulate the algebra tree keep the parent node references consistent
- added "cleanup" at end of optimizer pipeline to catch any wrongdoers
- added regression tests for all optimizer implementations

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

