### PR TITLE
GH-2419 make executor and httpcontext accessible for subclasses

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
@@ -121,11 +121,11 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 		super(client, executor);
 		this.executor = executor;
 
-		// we want to preserve bnode ids to allow Sesame API methods to match
+		// we want to preserve bnode ids to allow RDF4J API methods to match
 		// blank nodes.
 		getParserConfig().set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
 
-		// Sesame client has preference for binary response formats, as these are
+		// RDF4J Protocol has a preference for binary response formats, as these are
 		// most performant
 		setPreferredTupleQueryResultFormat(TupleQueryResultFormat.BINARY);
 		setPreferredRDFFormat(RDFFormat.BINARY);

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -55,6 +55,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 import org.eclipse.rdf4j.RDF4JConfigException;
 import org.eclipse.rdf4j.RDF4JException;
@@ -127,10 +128,6 @@ import org.slf4j.LoggerFactory;
  */
 public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable {
 
-	/*-----------*
-	 * Constants *
-	 *-----------*/
-
 	protected static final Charset UTF8 = StandardCharsets.UTF_8;
 
 	/**
@@ -159,10 +156,6 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 
 	final static Logger logger = LoggerFactory.getLogger(SPARQLProtocolSession.class);
 
-	/*-----------*
-	 * Variables *
-	 *-----------*/
-
 	private ValueFactory valueFactory;
 
 	private String queryURL;
@@ -187,10 +180,6 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 
 	private Map<String, String> additionalHttpHeaders = Collections.emptyMap();
 
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
-
 	public SPARQLProtocolSession(HttpClient client, ExecutorService executor) {
 		this.httpClient = client;
 		this.httpContext = new HttpClientContext();
@@ -214,10 +203,6 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 		}
 		this.maximumUrlLength = maximumUrlLength;
 	}
-
-	/*-----------------*
-	 * Get/set methods *
-	 *-----------------*/
 
 	@Override
 	public final HttpClient getHttpClient() {
@@ -252,8 +237,7 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	}
 
 	/**
-	 * Sets the preferred format for encoding tuple query results. The {@link TupleQueryResultFormat#BINARY binary}
-	 * format is preferred by default.
+	 * Sets the preferred format for encoding tuple query results.
 	 *
 	 * @param format The preferred {@link TupleQueryResultFormat}, or <tt>null</tt> to indicate no specific format is
 	 *               preferred.
@@ -263,7 +247,8 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	}
 
 	/**
-	 * Gets the preferred {@link TupleQueryResultFormat} for encoding tuple query results.
+	 * Gets the preferred {@link TupleQueryResultFormat} for encoding tuple query results. The
+	 * {@link TupleQueryResultFormat#SPARQL SPARQL/XML} format is preferred by default.
 	 *
 	 * @return The preferred format, of <tt>null</tt> if no specific format is preferred.
 	 */
@@ -272,8 +257,7 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	}
 
 	/**
-	 * Sets the preferred format for encoding RDF documents. The {@link RDFFormat#TURTLE Turtle} format is preferred by
-	 * default.
+	 * Sets the preferred format for encoding RDF documents.
 	 *
 	 * @param format The preferred {@link RDFFormat}, or <tt>null</tt> to indicate no specific format is preferred.
 	 */
@@ -282,7 +266,8 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	}
 
 	/**
-	 * Gets the preferred {@link RDFFormat} for encoding RDF documents.
+	 * Gets the preferred {@link RDFFormat} for encoding RDF documents. The {@link RDFFormat#TURTLE Turtle} format is
+	 * preferred by default.
 	 *
 	 * @return The preferred format, of <tt>null</tt> if no specific format is preferred.
 	 */
@@ -291,8 +276,7 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	}
 
 	/**
-	 * Sets the preferred format for encoding boolean query results. The {@link BooleanQueryResultFormat#TEXT binary}
-	 * format is preferred by default.
+	 * Sets the preferred format for encoding boolean query results.
 	 *
 	 * @param format The preferred {@link BooleanQueryResultFormat}, or <tt>null</tt> to indicate no specific format is
 	 *               preferred.
@@ -302,7 +286,8 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	}
 
 	/**
-	 * Gets the preferred {@link BooleanQueryResultFormat} for encoding boolean query results.
+	 * Gets the preferred {@link BooleanQueryResultFormat} for encoding boolean query results. The
+	 * {@link BooleanQueryResultFormat#TEXT binary} format is preferred by default.
 	 *
 	 * @return The preferred format, of <tt>null</tt> if no specific format is preferred.
 	 */
@@ -1201,5 +1186,14 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 			params = new BasicHttpParams();
 		}
 		params.setIntParameter(CoreConnectionPNames.SO_TIMEOUT, (int) timeout);
+	}
+
+	/**
+	 * Get the {@link HttpContext} used for sending HTTP requests.
+	 *
+	 * @return the {@link HttpContext} instance used for all protocol session requests.
+	 */
+	protected HttpContext getHttpContext() {
+		return this.httpContext;
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #2419 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- SharedHttpClientSessionManager's internal ScheduledExecutorService made accessible (protected) for subclasses
- SPARQLProtocolSession's internal HttpContext made accessible (protected) for subclasses
- some minor updates to javadoc, comments and code organization. 

This allows custom extensions that want to things like hooking into external credential providers, custom handling of authentication over HTTP, etc. This was already possible by providing a fully separate HttpClientSessionManager implementation, but often these customizations are minor adjustments of the basics provided in the SharedHttpClientSessionManager, so it makes sense to subclass and tweak, instead of writing a full implementation from scratch. 

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

