### PR TITLE
GH-2431 all benchmarks now have a main, and a fat jar

### DIFF
--- a/assembly-descriptors/pom.xml
+++ b/assembly-descriptors/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j</artifactId>
+		<version>3.3.2-SNAPSHOT</version>
+	</parent>
+	<artifactId>rdf4j-assembly-descriptors</artifactId>
+	<name>RDF4J Assembly Descriptors</name>
+	<description/>
+</project>

--- a/assembly-descriptors/src/main/resources/assemblies/benchmark.xml
+++ b/assembly-descriptors/src/main/resources/assemblies/benchmark.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+	<id>benchmarks</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>/</outputDirectory>
+			<useProjectArtifact>true</useProjectArtifact>
+			<unpack>true</unpack>
+			<scope>test</scope>
+		</dependencySet>
+	</dependencySets>
+	<containerDescriptorHandlers>
+		<containerDescriptorHandler>
+			<handlerName>metaInf-services</handlerName>
+		</containerDescriptorHandler>
+		<containerDescriptorHandler>
+			<handlerName>metaInf-spring</handlerName>
+		</containerDescriptorHandler>
+		<containerDescriptorHandler>
+			<handlerName>plexus</handlerName>
+		</containerDescriptorHandler>
+	</containerDescriptorHandlers>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.directory}/test-classes</directory>
+			<outputDirectory>/</outputDirectory>
+			<includes>
+				<include>**/*.class</include>
+				<include>META-INF/BenchmarkList</include>
+				<include>META-INF/CompilerHints</include>
+				<include>logback-test.xml</include>
+				<include>benchmarkFiles/**</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,4 +50,42 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<dependencies>
+						<dependency>
+							<groupId>${project.groupId}</groupId>
+							<artifactId>rdf4j-assembly-descriptors</artifactId>
+							<version>${project.version}</version>
+						</dependency>
+					</dependencies>
+					<configuration>
+						<finalName>jmh</finalName>
+						<descriptorRefs>
+							<descriptorRef>benchmark</descriptorRef>
+						</descriptorRefs>
+					</configuration>
+					<executions>
+						<execution>
+							<id>benchmark-jar</id>
+							<phase>package</phase>
+							<goals>
+								<goal>single</goal>
+							</goals>
+							<configuration>
+								<archive>
+									<manifest>
+										<mainClass>org.openjdk.jmh.Main</mainClass>
+									</manifest>
+								</archive>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 </project>

--- a/core/queryparser/sparql/pom.xml
+++ b/core/queryparser/sparql/pom.xml
@@ -53,4 +53,11 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParseBenchmark.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParseBenchmark.java
@@ -24,6 +24,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @State(Scope.Benchmark)
@@ -34,6 +35,15 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Measurement(iterations = 40)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class SPARQLParseBenchmark {
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("SPARQLParseBenchmark") // adapt to control which benchmark test to run
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Iteration)
 	public void setUp() {
@@ -56,12 +66,6 @@ public class SPARQLParseBenchmark {
 
 		return temp;
 
-	}
-
-	public static void main(String[] args) throws RunnerException {
-		String regexp = SPARQLParseBenchmark.class.getName() + "\\.*";
-
-		new Runner(new OptionsBuilder().include(regexp).build()).run();
 	}
 
 }

--- a/core/sail/extensible-store/pom.xml
+++ b/core/sail/extensible-store/pom.xml
@@ -77,4 +77,11 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestore/benchmark/ExtensibleDynamicEvaluationStatisticsBenchmark.java
+++ b/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestore/benchmark/ExtensibleDynamicEvaluationStatisticsBenchmark.java
@@ -28,6 +28,10 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -42,6 +46,17 @@ import org.openjdk.jmh.annotations.Warmup;
 public class ExtensibleDynamicEvaluationStatisticsBenchmark {
 
 	Model parse;
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("ExtensibleDynamicEvaluationStatisticsBenchmark") // adapt to control which benchmark tests to
+																			// run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Iteration)
 	public void beforeClassIteration() throws IOException, InterruptedException {

--- a/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestore/benchmark/ExtensibleDynamicEvaluationStatisticsLowMemBenchmark.java
+++ b/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestore/benchmark/ExtensibleDynamicEvaluationStatisticsLowMemBenchmark.java
@@ -31,6 +31,10 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -43,6 +47,18 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ExtensibleDynamicEvaluationStatisticsLowMemBenchmark {
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("ExtensibleDynamicEvaluationStatisticsLowMemBenchmark") // adapt to control which benchmark
+																					// tests to
+				// run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Iteration)
 	public void beforeClassIteration() throws IOException, InterruptedException {

--- a/core/sail/memory/pom.xml
+++ b/core/sail/memory/pom.xml
@@ -96,6 +96,9 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/MemoryBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/MemoryBenchmark.java
@@ -30,6 +30,10 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @State(Scope.Benchmark)
 @Warmup(iterations = 20)
@@ -44,6 +48,16 @@ public class MemoryBenchmark {
 	public String isolationLevel;
 
 	private List<Statement> statementList = getStatements();
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("MemoryBenchmark.load") // adapt to run other benchmark tests
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Iteration)
 	public void setUp() {

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
@@ -37,6 +37,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -67,6 +71,16 @@ public class QueryBenchmark {
 	}
 
 	List<Statement> statementList;
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("QueryBenchmark.groupByQuery") // adapt to run other benchmark tests
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Invocation)
 	public void beforeClass() throws IOException, InterruptedException {

--- a/core/sail/nativerdf/pom.xml
+++ b/core/sail/nativerdf/pom.xml
@@ -100,6 +100,9 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/DataFileBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/DataFileBenchmark.java
@@ -33,6 +33,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -56,6 +60,16 @@ public class DataFileBenchmark {
 
 	final static private byte[] BYTES = "fewjf3u28hq98fhref8j2908rhfuhfjnjvfbv2u9r82ufh4908fhuheui2hjdfh9284ru9h34unfre892hf08r48nu2frfh9034"
 			.getBytes(StandardCharsets.UTF_8);
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("DataFileBenchmark.read") // adapt to run other benchmark tests
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/HashFileBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/HashFileBenchmark.java
@@ -31,6 +31,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -51,6 +55,16 @@ public class HashFileBenchmark {
 	private static List<Integer> hashes;
 	private File tempFolder;
 	private HashFile hashFile;
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("HashFileBenchmark") // adapt to run other benchmark tests
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/IDFileBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/IDFileBenchmark.java
@@ -28,6 +28,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -47,6 +51,16 @@ public class IDFileBenchmark {
 	private static final int COUNT = 1_000_000;
 	private File tempFolder;
 	private IDFile idFile;
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("IDFileBenchmark") // adapt to control which benchmark tests to run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
@@ -39,6 +39,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -74,6 +78,16 @@ public class QueryBenchmark {
 	}
 
 	List<Statement> statementList;
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("QueryBenchmark") // adapt to control which benchmark tests to run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondBenchmark.java
@@ -31,6 +31,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -49,6 +53,16 @@ public class TransactionsPerSecondBenchmark {
 
 	SailRepositoryConnection connection;
 	int i;
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("TransactionsPerSecondBenchmark") // adapt to control which benchmark tests to run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Iteration)
 	public void beforeClass() {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/TransactionsPerSecondForceSyncBenchmark.java
@@ -31,6 +31,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -49,6 +53,16 @@ public class TransactionsPerSecondForceSyncBenchmark {
 
 	SailRepositoryConnection connection;
 	int i;
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("TransactionsPerSecondForceSyncBenchmark") // adapt to control which benchmark tests to run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Iteration)
 	public void beforeClass() {

--- a/core/sail/sail-spin/pom.xml
+++ b/core/sail/sail-spin/pom.xml
@@ -79,4 +79,11 @@
 			</build>
 		</profile>
 	</profiles>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/core/sail/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/benchmarks/BasicBenchmarks.java
+++ b/core/sail/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/benchmarks/BasicBenchmarks.java
@@ -43,6 +43,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -68,6 +72,15 @@ public class BasicBenchmarks {
 
 	private static final Value nameAlice = vf.createLiteral("Alice");
 	private static final Value nameBob = vf.createLiteral("Bob");
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("BasicBenchmarks") // adapt to control which benchmark tests to run
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Invocation)
 	public void setUp() {

--- a/core/sail/shacl/pom.xml
+++ b/core/sail/shacl/pom.xml
@@ -74,6 +74,9 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>

--- a/core/util/pom.xml
+++ b/core/util/pom.xml
@@ -30,6 +30,9 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>

--- a/core/util/src/test/java/org/eclipse/rdf4j/common/iteration/benchmark/IterationBenchmarks.java
+++ b/core/util/src/test/java/org/eclipse/rdf4j/common/iteration/benchmark/IterationBenchmarks.java
@@ -29,6 +29,10 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -46,6 +50,16 @@ public class IterationBenchmarks {
 
 	private List<String> strings = new ArrayList<>();
 	private List<String> duplicates = new ArrayList<>();
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("IterationBenchmarks") // adapt to control which benchmark tests to run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
 
 	@Setup(Level.Trial)
 	public void setUp() {

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 		</license>
 	</licenses>
 	<modules>
+		<module>assembly-descriptors</module>
 		<module>core</module>
 		<module>tools</module>
 		<module>testsuites</module>
@@ -619,6 +620,11 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>3.3.0</version>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
GitHub issue resolved: #2431 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- main method makes direct execution from IDE possible
- fat jar (target/jmh-benchmark.jar) makes command line execution
possible

to run benchmarks from command line (example: memory store benchmarks):

1. `cd core/sail/memory`
2. `mvn package -Pquick` 
3. `java -jar target/jmh-benchmarks.jar MemoryBenchmark.load` (to run the specific load benchmark test). 

To run from Eclipse, you can right-click on the benchmark and select "Run as Java application". Occassionally you may need to run a `mvn clean install` beforehand to make this work. Adapt the OptionBuilder in the benchmark's main class to control which exact benchmark tests get run.

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

