### PR TITLE
GH-2415 allow parsing RDF* using standard sparql json result parser

### DIFF
--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONParser.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONParser.java
@@ -10,6 +10,10 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.query.TupleQueryResultHandler;
@@ -19,13 +23,22 @@ import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
 /**
- * Parser for SPARQL-1.1 JSON Results Format documents
+ * Parser for SPARQL-1.1 JSON Results Format documents.
  *
  * @see <a href="http://www.w3.org/TR/sparql11-results-json/">SPARQL 1.1 Query Results JSON Format</a>
  * @author Peter Ansell
  */
 public class SPARQLResultsJSONParser extends AbstractSPARQLJSONParser implements TupleQueryResultParser {
+
+	final static String TRIPLE_TYPE_STARDOG = "statement";
+
+	final static String SUBJECT_JENA = "subject";
+	final static String PREDICATE_JENA = "predicate";
+	final static String OBJECT_JENA = "object";
 
 	/**
 	 * Default constructor.
@@ -71,4 +84,47 @@ public class SPARQLResultsJSONParser extends AbstractSPARQLJSONParser implements
 		}
 	}
 
+	@Override
+	protected Triple parseTripleValue(JsonParser jp, String fieldName) throws IOException {
+		Value subject = null, predicate = null, object = null;
+
+		while (jp.nextToken() != JsonToken.END_OBJECT) {
+			if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
+				throw new QueryResultParseException("Did not find triple attribute in triple value",
+						jp.getCurrentLocation().getLineNr(),
+						jp.getCurrentLocation().getColumnNr());
+			}
+			String posName = jp.getCurrentName();
+			if (SPARQLStarResultsJSONConstants.SUBJECT.equals(posName) || SUBJECT_JENA.equals(posName)) {
+				subject = parseValue(jp, fieldName + ":" + posName);
+			} else if (SPARQLStarResultsJSONConstants.PREDICATE.equals(posName) || PREDICATE_JENA.equals(posName)) {
+				predicate = parseValue(jp, fieldName + ":" + posName);
+			} else if (SPARQLStarResultsJSONConstants.OBJECT.equals(posName) || OBJECT_JENA.equals(posName)) {
+				object = parseValue(jp, fieldName + ":" + posName);
+			} else {
+				throw new QueryResultParseException("Unexpected field name in triple value: " + posName,
+						jp.getCurrentLocation().getLineNr(),
+						jp.getCurrentLocation().getColumnNr());
+			}
+		}
+
+		if (subject instanceof Resource && predicate instanceof IRI && object != null) {
+			return valueFactory.createTriple((Resource) subject, (IRI) predicate, object);
+		} else {
+			throw new QueryResultParseException("Incomplete or invalid triple value",
+					jp.getCurrentLocation().getLineNr(),
+					jp.getCurrentLocation().getColumnNr());
+		}
+	}
+
+	@Override
+	protected boolean checkTripleType(JsonParser jp, String type) {
+		if (!SPARQLStarResultsJSONConstants.TRIPLE.equals(type) && !TRIPLE_TYPE_STARDOG.equals(type)) {
+			throw new QueryResultParseException("Found a triple value but unexpected type: " + type,
+					jp.getCurrentLocation().getLineNr(),
+					jp.getCurrentLocation().getColumnNr());
+		}
+
+		return true;
+	}
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONConstants.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONConstants.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
+package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONParser.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONParser.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqljson;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+
+/**
+ * Parser for SPARQL* JSON results. This is equivalent to the SPARQL JSON parser with the addition of support for RDF*
+ * triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF* extension.
+ *
+ * @author Pavel Mihaylov
+ */
+public class SPARQLStarResultsJSONParser extends SPARQLResultsJSONParser {
+	/**
+	 * Default constructor.
+	 */
+	public SPARQLStarResultsJSONParser() {
+		super();
+	}
+
+	/**
+	 * Constructs a parser with the supplied {@link ValueFactory}.
+	 *
+	 * @param valueFactory The factory to use to create values.
+	 */
+	public SPARQLStarResultsJSONParser(ValueFactory valueFactory) {
+		super(valueFactory);
+	}
+
+	@Override
+	public TupleQueryResultFormat getTupleQueryResultFormat() {
+		return SPARQLStarResultsJSONConstants.QUERY_RESULT_FORMAT;
+	}
+}

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONParserFactory.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONParserFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqljson;
+
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+
+/**
+ * {@link TupleQueryResultParserFactory} for creating instances of {@link SPARQLStarResultsJSONParser}.
+ *
+ * @author Pavel Mihaylov
+ */
+public class SPARQLStarResultsJSONParserFactory implements TupleQueryResultParserFactory {
+	/**
+	 * Returns {@link TupleQueryResultFormat#JSON_STAR}.
+	 */
+	@Override
+	public TupleQueryResultFormat getTupleQueryResultFormat() {
+		return SPARQLStarResultsJSONConstants.QUERY_RESULT_FORMAT;
+	}
+
+	/**
+	 * Returns a new instance of {@link SPARQLStarResultsJSONParser}.
+	 */
+	@Override
+	public TupleQueryResultParser getParser() {
+		return new SPARQLResultsJSONParser();
+	}
+}

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriter.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqljson;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.QueryResultHandlerException;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+
+/**
+ * Writer for SPARQL* JSON results. This is equivalent to the SPARQL JSON writer with the addition of support for RDF*
+ * triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF* extension.
+ *
+ * @author Pavel Mihaylov
+ */
+public class SPARQLStarResultsJSONWriter extends SPARQLResultsJSONWriter implements TupleQueryResultWriter {
+	public SPARQLStarResultsJSONWriter(OutputStream out) {
+		super(out);
+	}
+
+	@Override
+	public TupleQueryResultFormat getTupleQueryResultFormat() {
+		return SPARQLStarResultsJSONConstants.QUERY_RESULT_FORMAT;
+	}
+
+	@Override
+	public TupleQueryResultFormat getQueryResultFormat() {
+		return getTupleQueryResultFormat();
+	}
+
+	@Override
+	protected void writeValue(Value value) throws IOException, QueryResultHandlerException {
+		if (value instanceof Triple) {
+			jg.writeStartObject();
+
+			jg.writeStringField(AbstractSPARQLJSONParser.TYPE, SPARQLStarResultsJSONConstants.TRIPLE);
+
+			jg.writeObjectFieldStart(AbstractSPARQLJSONParser.VALUE);
+
+			jg.writeFieldName(SPARQLStarResultsJSONConstants.SUBJECT);
+			writeValue(((Triple) value).getSubject());
+
+			jg.writeFieldName(SPARQLStarResultsJSONConstants.PREDICATE);
+			writeValue(((Triple) value).getPredicate());
+
+			jg.writeFieldName(SPARQLStarResultsJSONConstants.OBJECT);
+			writeValue(((Triple) value).getObject());
+
+			jg.writeEndObject();
+
+			jg.writeEndObject();
+		} else {
+			super.writeValue(value);
+		}
+	}
+}

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriterFactory.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriterFactory.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqljson;
+
+import java.io.OutputStream;
+
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+
+/**
+ * {@link TupleQueryResultWriterFactory} for creating instances of {@link SPARQLStarResultsJSONWriter}.
+ *
+ * @author Pavel Mihaylov
+ */
+public class SPARQLStarResultsJSONWriterFactory implements TupleQueryResultWriterFactory {
+	/**
+	 * Returns {@link TupleQueryResultFormat#JSON_STAR}.
+	 */
+	@Override
+	public TupleQueryResultFormat getTupleQueryResultFormat() {
+		return SPARQLStarResultsJSONConstants.QUERY_RESULT_FORMAT;
+	}
+
+	/**
+	 * Returns a new instance of {@link SPARQLStarResultsJSONWriter}.
+	 */
+	@Override
+	public TupleQueryResultWriter getWriter(OutputStream out) {
+		return new SPARQLStarResultsJSONWriter(out);
+	}
+}

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONParser.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONParser.java
@@ -7,95 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
 
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.OBJECT;
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.PREDICATE;
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.QUERY_RESULT_FORMAT;
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.SUBJECT;
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.TRIPLE;
-
-import java.io.IOException;
-
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Triple;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONParser;
-
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-
 /**
- * Parser for SPARQL* JSON results. This is equivalent to the SPARQL JSON parser with the addition of support for RDF*
- * triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF* extension.
- *
- * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - moved to {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParser}
  */
-public class SPARQLStarResultsJSONParser extends SPARQLResultsJSONParser {
-	/**
-	 * Default constructor.
-	 */
-	public SPARQLStarResultsJSONParser() {
-		super();
-	}
+@Deprecated
+public class SPARQLStarResultsJSONParser
+		extends org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParser {
 
-	/**
-	 * Constructs a parser with the supplied {@link ValueFactory}.
-	 *
-	 * @param valueFactory The factory to use to create values.
-	 */
-	public SPARQLStarResultsJSONParser(ValueFactory valueFactory) {
-		super(valueFactory);
-	}
-
-	@Override
-	public TupleQueryResultFormat getTupleQueryResultFormat() {
-		return QUERY_RESULT_FORMAT;
-	}
-
-	@Override
-	protected Triple parseTripleValue(JsonParser jp, String fieldName) throws IOException {
-		Value subject = null, predicate = null, object = null;
-
-		while (jp.nextToken() != JsonToken.END_OBJECT) {
-			if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
-				throw new QueryResultParseException("Did not find triple attribute in triple value",
-						jp.getCurrentLocation().getLineNr(),
-						jp.getCurrentLocation().getColumnNr());
-			}
-			String posName = jp.getCurrentName();
-			if (SUBJECT.equals(posName)) {
-				subject = parseValue(jp, fieldName + ":" + posName);
-			} else if (PREDICATE.equals(posName)) {
-				predicate = parseValue(jp, fieldName + ":" + posName);
-			} else if (OBJECT.equals(posName)) {
-				object = parseValue(jp, fieldName + ":" + posName);
-			} else {
-				throw new QueryResultParseException("Unexpected field name in triple value: " + posName,
-						jp.getCurrentLocation().getLineNr(),
-						jp.getCurrentLocation().getColumnNr());
-			}
-		}
-
-		if (subject instanceof Resource && predicate instanceof IRI && object != null) {
-			return valueFactory.createTriple((Resource) subject, (IRI) predicate, object);
-		} else {
-			throw new QueryResultParseException("Incomplete or invalid triple value",
-					jp.getCurrentLocation().getLineNr(),
-					jp.getCurrentLocation().getColumnNr());
-		}
-	}
-
-	@Override
-	protected boolean checkTripleType(JsonParser jp, String type) {
-		if (!TRIPLE.equals(type)) {
-			throw new QueryResultParseException("Found a triple value but unexpected type: " + type,
-					jp.getCurrentLocation().getLineNr(),
-					jp.getCurrentLocation().getColumnNr());
-		}
-
-		return true;
-	}
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONParserFactory.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONParserFactory.java
@@ -7,29 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
 
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
-
 /**
- * {@link TupleQueryResultParserFactory} for creating instances of {@link SPARQLStarResultsJSONParser}.
  *
- * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - moved to
+ *             {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParserFactory}
  */
-public class SPARQLStarResultsJSONParserFactory implements TupleQueryResultParserFactory {
-	/**
-	 * Returns {@link TupleQueryResultFormat#JSON_STAR}.
-	 */
-	@Override
-	public TupleQueryResultFormat getTupleQueryResultFormat() {
-		return SPARQLStarResultsJSONConstants.QUERY_RESULT_FORMAT;
-	}
-
-	/**
-	 * Returns a new instance of {@link SPARQLStarResultsJSONParser}.
-	 */
-	@Override
-	public TupleQueryResultParser getParser() {
-		return new SPARQLStarResultsJSONParser();
-	}
+@Deprecated
+public class SPARQLStarResultsJSONParserFactory
+		extends org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParserFactory {
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONWriter.java
@@ -7,67 +7,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
 
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.OBJECT;
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.PREDICATE;
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.QUERY_RESULT_FORMAT;
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.SUBJECT;
-import static org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONConstants.TRIPLE;
-
-import java.io.IOException;
 import java.io.OutputStream;
 
-import org.eclipse.rdf4j.model.Triple;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.query.QueryResultHandlerException;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
-import org.eclipse.rdf4j.query.resultio.sparqljson.AbstractSPARQLJSONParser;
-import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONWriter;
-
 /**
- * Writer for SPARQL* JSON results. This is equivalent to the SPARQL JSON writer with the addition of support for RDF*
- * triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF* extension.
- *
- * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - moved to {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriter}
  */
-public class SPARQLStarResultsJSONWriter extends SPARQLResultsJSONWriter implements TupleQueryResultWriter {
+@Deprecated
+public class SPARQLStarResultsJSONWriter
+		extends org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriter {
+
 	public SPARQLStarResultsJSONWriter(OutputStream out) {
 		super(out);
 	}
 
-	@Override
-	public TupleQueryResultFormat getTupleQueryResultFormat() {
-		return QUERY_RESULT_FORMAT;
-	}
-
-	@Override
-	public TupleQueryResultFormat getQueryResultFormat() {
-		return getTupleQueryResultFormat();
-	}
-
-	@Override
-	protected void writeValue(Value value) throws IOException, QueryResultHandlerException {
-		if (value instanceof Triple) {
-			jg.writeStartObject();
-
-			jg.writeStringField(AbstractSPARQLJSONParser.TYPE, TRIPLE);
-
-			jg.writeObjectFieldStart(AbstractSPARQLJSONParser.VALUE);
-
-			jg.writeFieldName(SUBJECT);
-			writeValue(((Triple) value).getSubject());
-
-			jg.writeFieldName(PREDICATE);
-			writeValue(((Triple) value).getPredicate());
-
-			jg.writeFieldName(OBJECT);
-			writeValue(((Triple) value).getObject());
-
-			jg.writeEndObject();
-
-			jg.writeEndObject();
-		} else {
-			super.writeValue(value);
-		}
-	}
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONWriterFactory.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONWriterFactory.java
@@ -7,31 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
 
-import java.io.OutputStream;
-
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
-
 /**
- * {@link TupleQueryResultWriterFactory} for creating instances of {@link SPARQLStarResultsJSONWriter}.
  *
- * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - moved to
+ *             {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriterFactory}
  */
-public class SPARQLStarResultsJSONWriterFactory implements TupleQueryResultWriterFactory {
-	/**
-	 * Returns {@link TupleQueryResultFormat#JSON_STAR}.
-	 */
-	@Override
-	public TupleQueryResultFormat getTupleQueryResultFormat() {
-		return SPARQLStarResultsJSONConstants.QUERY_RESULT_FORMAT;
-	}
-
-	/**
-	 * Returns a new instance of {@link SPARQLStarResultsJSONWriter}.
-	 */
-	@Override
-	public TupleQueryResultWriter getWriter(OutputStream out) {
-		return new SPARQLStarResultsJSONWriter(out);
-	}
+@Deprecated
+public class SPARQLStarResultsJSONWriterFactory
+		extends org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriterFactory {
 }

--- a/core/queryresultio/sparqljson/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory
+++ b/core/queryresultio/sparqljson/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory
@@ -1,2 +1,2 @@
 org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONParserFactory
-org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONParserFactory
+org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParserFactory

--- a/core/queryresultio/sparqljson/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory
+++ b/core/queryresultio/sparqljson/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory
@@ -1,2 +1,2 @@
 org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONWriterFactory
-org.eclipse.rdf4j.query.resultio.sparqlstarjson.SPARQLStarResultsJSONWriterFactory
+org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriterFactory

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -19,6 +20,7 @@ import java.io.InputStream;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -281,5 +283,59 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 			assertTrue(b.getValue("title") instanceof Literal);
 		}
 
+	}
+
+	@Test
+	public void testRDFStar_extendedFormatRDF4J() throws Exception {
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/rdfstar-extendedformat-rdf4j.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		assertThat(handler.getBindingNames().size()).isEqualTo(3);
+		assertThat(handler.getBindingSets()).hasSize(1).allMatch(bs -> bs.getValue("a") instanceof Triple);
+		Triple a = (Triple) handler.getBindingSets().get(0).getValue("a");
+		assertThat(a.getSubject().stringValue()).isEqualTo("http://example.org/bob");
+		assertThat(a.getPredicate().stringValue()).isEqualTo("http://xmlns.com/foaf/0.1/age");
+		assertThat(a.getObject().stringValue()).isEqualTo("23");
+	}
+
+	@Test
+	public void testRDFStar_extendedFormatStardog() throws Exception {
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/rdfstar-extendedformat-stardog.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		assertThat(handler.getBindingNames().size()).isEqualTo(3);
+		assertThat(handler.getBindingSets()).hasSize(1).allMatch(bs -> bs.getValue("a") instanceof Triple);
+		Triple a = (Triple) handler.getBindingSets().get(0).getValue("a");
+		assertThat(a.getSubject().stringValue()).isEqualTo("http://example.org/bob");
+		assertThat(a.getPredicate().stringValue()).isEqualTo("http://xmlns.com/foaf/0.1/age");
+		assertThat(a.getObject().stringValue()).isEqualTo("23");
+	}
+
+	@Test
+	public void testRDFStar_extendedFormatJena() throws Exception {
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/rdfstar-extendedformat-jena.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		assertThat(handler.getBindingNames().size()).isEqualTo(3);
+		assertThat(handler.getBindingSets()).hasSize(1).allMatch(bs -> bs.getValue("a") instanceof Triple);
+		Triple a = (Triple) handler.getBindingSets().get(0).getValue("a");
+		assertThat(a.getSubject().stringValue()).isEqualTo("http://example.org/bob");
+		assertThat(a.getPredicate().stringValue()).isEqualTo("http://xmlns.com/foaf/0.1/age");
+		assertThat(a.getObject().stringValue()).isEqualTo("23");
 	}
 }

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarJSONTupleBackgroundTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarJSONTupleBackgroundTest.java
@@ -5,16 +5,24 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
+package org.eclipse.rdf4j.query.resultio.sparqljson;
 
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
 import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.UnsupportedQueryResultFormatException;
 
 /**
  * @author Pavel Mihaylov
  */
-public class SPARQLStarJSONTupleTest extends AbstractQueryResultIOTupleTest {
+public class SPARQLStarJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTest {
 	@Override
 	protected String getFileName() {
 		return "test.srjs";
@@ -28,5 +36,11 @@ public class SPARQLStarJSONTupleTest extends AbstractQueryResultIOTupleTest {
 	@Override
 	protected BooleanQueryResultFormat getMatchingBooleanFormatOrNull() {
 		return BooleanQueryResultFormat.JSON;
+	}
+
+	@Override
+	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
+			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
+		return QueryResultIO.parseTupleBackground(in, format);
 	}
 }

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarJSONTupleTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarJSONTupleTest.java
@@ -5,24 +5,16 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
+package org.eclipse.rdf4j.query.resultio.sparqljson;
 
-import java.io.IOException;
-import java.io.InputStream;
-
-import org.eclipse.rdf4j.query.TupleQueryResult;
-import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
 import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.QueryResultIO;
-import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.UnsupportedQueryResultFormatException;
 
 /**
  * @author Pavel Mihaylov
  */
-public class SPARQLStarJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTest {
+public class SPARQLStarJSONTupleTest extends AbstractQueryResultIOTupleTest {
 	@Override
 	protected String getFileName() {
 		return "test.srjs";
@@ -38,9 +30,4 @@ public class SPARQLStarJSONTupleBackgroundTest extends AbstractQueryResultIOTupl
 		return BooleanQueryResultFormat.JSON;
 	}
 
-	@Override
-	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
-			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTupleBackground(in, format);
-	}
 }

--- a/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-jena.srj
+++ b/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-jena.srj
@@ -1,0 +1,41 @@
+{
+  "head" : {
+    "vars" : [
+      "a",
+      "b",
+      "c"
+    ]
+  },
+  "results" : {
+    "bindings": [
+      { "a" : {
+          "type" : "triple",
+          "value" : {
+            "subject" : {
+              "type" : "uri",
+              "value" : "http://example.org/bob"
+            },
+            "predicate" : {
+              "type" : "uri",
+              "value" : "http://xmlns.com/foaf/0.1/age"
+            },
+            "object" : {
+              "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+              "type" : "literal",
+              "value" : "23"
+            }
+          }
+        },
+        "b": { 
+          "type": "uri",
+          "value": "http://example.org/certainty"
+        },
+        "c" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+          "type" : "literal",
+          "value" : "0.9"
+        }
+      }
+    ]
+  }
+}

--- a/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-rdf4j.srj
+++ b/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-rdf4j.srj
@@ -1,0 +1,41 @@
+{
+  "head" : {
+    "vars" : [
+      "a",
+      "b",
+      "c"
+    ]
+  },
+  "results" : {
+    "bindings": [
+      { "a" : {
+          "type" : "triple",
+          "value" : {
+            "s" : {
+              "type" : "uri",
+              "value" : "http://example.org/bob"
+            },
+            "p" : {
+              "type" : "uri",
+              "value" : "http://xmlns.com/foaf/0.1/age"
+            },
+            "o" : {
+              "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+              "type" : "literal",
+              "value" : "23"
+            }
+          }
+        },
+        "b": { 
+          "type": "uri",
+          "value": "http://example.org/certainty"
+        },
+        "c" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+          "type" : "literal",
+          "value" : "0.9"
+        }
+      }
+    ]
+  }
+}

--- a/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-stardog.srj
+++ b/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-stardog.srj
@@ -1,0 +1,41 @@
+{
+  "head" : {
+    "vars" : [
+      "a",
+      "b",
+      "c"
+    ]
+  },
+  "results" : {
+    "bindings": [
+      { "a" : {
+          "type" : "statement",
+          "value" : {
+            "s" : {
+              "type" : "uri",
+              "value" : "http://example.org/bob"
+            },
+            "p" : {
+              "type" : "uri",
+              "value" : "http://xmlns.com/foaf/0.1/age"
+            },
+            "o" : {
+              "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+              "type" : "literal",
+              "value" : "23"
+            }
+          }
+        },
+        "b": { 
+          "type": "uri",
+          "value": "http://example.org/certainty"
+        },
+        "c" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+          "type" : "literal",
+          "value" : "0.9"
+        }
+      }
+    ]
+  }
+}

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOTupleTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOTupleTest.java
@@ -221,7 +221,6 @@ public abstract class AbstractQueryResultIOTupleTest extends AbstractQueryResult
 
 		try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
 			QueryResultIO.writeTuple(new IteratingTupleQueryResult(bindingNames, bindings), getTupleFormat(), bos);
-			System.out.println(bos.toString());
 			try (ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray())) {
 				TupleQueryResult parsedBindings = QueryResultIO.parseTuple(bis, getTupleFormat());
 				assertEquals(bindingNames, parsedBindings.getBindingNames());


### PR DESCRIPTION
GitHub issue resolved: #2415 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- allow parsing of RDF* extended syntax when receiving "normal" sparql json results mime type
- support Stardog syntax variant
- support Jena syntax variant

Note that RDF4J still uses the base-64 encoding approach when writing / sending RDF* triples in `application/sparql-results+json` format, a client would have to explicitly ask for `application/x-sparqlstar-results+json` to receive the extended format from an RDF4J-based endpoint. Depending on which way community opinions go with respect to this, we may change that behavior in a followup.

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

