### PR TITLE
GH-2437 merge writers for rdf* extended formats with writer for standard form

### DIFF
--- a/core/queryresultio/binary/src/test/java/org/eclipse/rdf4j/query/resultio/binary/BinaryTupleQueryResultWriterTest.java
+++ b/core/queryresultio/binary/src/test/java/org/eclipse/rdf4j/query/resultio/binary/BinaryTupleQueryResultWriterTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.binary;
+
+import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+
+/**
+ * @author jeen
+ *
+ */
+public class BinaryTupleQueryResultWriterTest extends AbstractTupleQueryResultWriterTest {
+
+	@Override
+	protected TupleQueryResultParserFactory getParserFactory() {
+		return new BinaryQueryResultParserFactory();
+	}
+
+	@Override
+	protected TupleQueryResultWriterFactory getWriterFactory() {
+		return new BinaryQueryResultWriterFactory();
+	}
+
+}

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
@@ -343,6 +343,7 @@ abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implem
 		result.add(BasicQueryWriterSettings.JSONP_CALLBACK);
 		result.add(BasicWriterSettings.PRETTY_PRINT);
 		result.add(BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL);
+		result.add(BasicWriterSettings.ENCODE_RDF_STAR);
 
 		return result;
 	}

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONWriter.java
@@ -7,8 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
+import java.io.IOException;
 import java.io.OutputStream;
 
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 
@@ -40,4 +44,29 @@ public class SPARQLResultsJSONWriter extends AbstractSPARQLJSONWriter implements
 		return getTupleQueryResultFormat();
 	}
 
+	@Override
+	protected void writeValue(Value value) throws IOException, QueryResultHandlerException {
+		if (value instanceof Triple) {
+			jg.writeStartObject();
+
+			jg.writeStringField(AbstractSPARQLJSONParser.TYPE, SPARQLStarResultsJSONConstants.TRIPLE);
+
+			jg.writeObjectFieldStart(AbstractSPARQLJSONParser.VALUE);
+
+			jg.writeFieldName(SPARQLStarResultsJSONConstants.SUBJECT);
+			writeValue(((Triple) value).getSubject());
+
+			jg.writeFieldName(SPARQLStarResultsJSONConstants.PREDICATE);
+			writeValue(((Triple) value).getPredicate());
+
+			jg.writeFieldName(SPARQLStarResultsJSONConstants.OBJECT);
+			writeValue(((Triple) value).getObject());
+
+			jg.writeEndObject();
+
+			jg.writeEndObject();
+		} else {
+			super.writeValue(value);
+		}
+	}
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriter.java
@@ -7,12 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
-import org.eclipse.rdf4j.model.Triple;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 
@@ -21,6 +17,9 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
  * triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF* extension.
  *
  * @author Pavel Mihaylov
+ * @implNote the actual {@link SPARQLResultsJSONWriter} itself already supports writing RDF* triples according to the
+ *           extension. This subclass functions as an anchor point for the custom
+ *           {@link TupleQueryResultFormat#JSON_STAR} content type.
  */
 public class SPARQLStarResultsJSONWriter extends SPARQLResultsJSONWriter implements TupleQueryResultWriter {
 	public SPARQLStarResultsJSONWriter(OutputStream out) {
@@ -35,31 +34,5 @@ public class SPARQLStarResultsJSONWriter extends SPARQLResultsJSONWriter impleme
 	@Override
 	public TupleQueryResultFormat getQueryResultFormat() {
 		return getTupleQueryResultFormat();
-	}
-
-	@Override
-	protected void writeValue(Value value) throws IOException, QueryResultHandlerException {
-		if (value instanceof Triple) {
-			jg.writeStartObject();
-
-			jg.writeStringField(AbstractSPARQLJSONParser.TYPE, SPARQLStarResultsJSONConstants.TRIPLE);
-
-			jg.writeObjectFieldStart(AbstractSPARQLJSONParser.VALUE);
-
-			jg.writeFieldName(SPARQLStarResultsJSONConstants.SUBJECT);
-			writeValue(((Triple) value).getSubject());
-
-			jg.writeFieldName(SPARQLStarResultsJSONConstants.PREDICATE);
-			writeValue(((Triple) value).getPredicate());
-
-			jg.writeFieldName(SPARQLStarResultsJSONConstants.OBJECT);
-			writeValue(((Triple) value).getObject());
-
-			jg.writeEndObject();
-
-			jg.writeEndObject();
-		} else {
-			super.writeValue(value);
-		}
 	}
 }

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONWriterTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONWriterTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqljson;
+
+import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+
+public class SPARQLResultsJSONWriterTest extends AbstractTupleQueryResultWriterTest {
+
+	@Override
+	protected TupleQueryResultParserFactory getParserFactory() {
+		return new SPARQLResultsJSONParserFactory();
+	}
+
+	@Override
+	protected TupleQueryResultWriterFactory getWriterFactory() {
+		return new SPARQLResultsJSONWriterFactory();
+	}
+
+}

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriterTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriterTest.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqljson;
+
+import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+
+public class SPARQLStarResultsJSONWriterTest extends AbstractTupleQueryResultWriterTest {
+
+	@Override
+	protected TupleQueryResultParserFactory getParserFactory() {
+		return new SPARQLStarResultsJSONParserFactory();
+	}
+
+	@Override
+	protected TupleQueryResultWriterFactory getWriterFactory() {
+		return new SPARQLStarResultsJSONWriterFactory();
+	}
+}

--- a/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleQueryResultWriterTest.java
+++ b/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleQueryResultWriterTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.sparqlxml;
+
+import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public class SPARQLXMLTupleQueryResultWriterTest extends AbstractTupleQueryResultWriterTest {
+
+	@Override
+	protected TupleQueryResultParserFactory getParserFactory() {
+		return new SPARQLResultsXMLParserFactory();
+	}
+
+	@Override
+	protected TupleQueryResultWriterFactory getWriterFactory() {
+		return new SPARQLResultsXMLWriterFactory();
+	}
+
+	@Override
+	@Test
+	@Ignore("pending implementation of RDF* extensions for the xml format - see https://github.com/eclipse/rdf4j/issues/2054")
+	public void testRDFStarHandling_NoEncoding() throws Exception {
+	}
+}

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVMappingStrategy.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVMappingStrategy.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.resultio.text.SPARQLResultsXSVMappingStrategy;
+import org.eclipse.rdf4j.rio.helpers.NTriplesUtil;
 
 import com.opencsv.CSVReader;
 
@@ -56,7 +57,9 @@ public class SPARQLResultsTSVMappingStrategy extends SPARQLResultsXSVMappingStra
 
 	protected Value parseValue(String valueString) {
 		Value v = null;
-		if (valueString.startsWith("_:")) {
+		if (valueString.startsWith("<<")) {
+			v = NTriplesUtil.parseTriple(valueString, valueFactory);
+		} else if (valueString.startsWith("_:")) {
 			v = valueFactory.createBNode(valueString.substring(2));
 		} else if (valueString.startsWith("<") && valueString.endsWith(">")) {
 			try {

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.util.Literals;
@@ -125,7 +126,15 @@ public class SPARQLResultsTSVWriter extends AbstractQueryResultWriter implements
 	}
 
 	protected void writeValue(Value val) throws IOException {
-		if (val instanceof Resource) {
+		if (val instanceof Triple) {
+			writer.write("<<");
+			writeValue(((Triple) val).getSubject());
+			writer.write(' ');
+			writeValue(((Triple) val).getPredicate());
+			writer.write(' ');
+			writeValue(((Triple) val).getObject());
+			writer.write(">>");
+		} else if (val instanceof Resource) {
 			writeResource((Resource) val);
 		} else {
 			writeLiteral((Literal) val);

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVParser.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVParser.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.tsv;
+
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+
+/**
+ * Parser for SPARQL* TSV results. This is equivalent to the SPARQL TSV parser with the addition of support for RDF*
+ * triples. Serialized triples must be in Turtle* fashion with the notable exception that any embedded literals may not
+ * use the triple quotes notation (as regular literals in SPARQL TSV).
+ *
+ * @author Pavel Mihaylov
+ * @author Jeen Broekstra
+ * @implNote this class is functionally equivalent to the standard {@link SPARQLResultsTSVParser} - its only purpose is
+ *           to provide a hook for the customized content type {@link TupleQueryResultFormat#TSV_STAR}.
+ */
+public class SPARQLStarResultsTSVParser extends SPARQLResultsTSVParser {
+	@Override
+	public TupleQueryResultFormat getTupleQueryResultFormat() {
+		return TupleQueryResultFormat.TSV_STAR;
+	}
+}

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVParserFactory.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVParserFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.tsv;
+
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+
+/**
+ * {@link TupleQueryResultParserFactory} for creating instances of {@link SPARQLStarResultsTSVParser}.
+ *
+ * @author Pavel Mihaylov
+ */
+public class SPARQLStarResultsTSVParserFactory implements TupleQueryResultParserFactory {
+	/**
+	 * Returns {@link TupleQueryResultFormat#TSV_STAR}.
+	 */
+	@Override
+	public TupleQueryResultFormat getTupleQueryResultFormat() {
+		return TupleQueryResultFormat.TSV_STAR;
+	}
+
+	/**
+	 * Returns a new instance of {@link SPARQLStarResultsTSVParser}.
+	 */
+	@Override
+	public TupleQueryResultParser getParser() {
+		return new SPARQLStarResultsTSVParser();
+	}
+}

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVWriter.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.tsv;
+
+import java.io.OutputStream;
+
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+
+/**
+ * Writer for SPARQL* TSV results. This is equivalent to the SPARQL TSV writer with the addition of support for RDF*
+ * triples. Triples will be serialized in Turtle* fashion with the notable exception that any embedded literals will not
+ * use the triple quotes notation (as regular literals in SPARQL TSV).
+ *
+ * @author Pavel Mihaylov
+ */
+public class SPARQLStarResultsTSVWriter extends SPARQLResultsTSVWriter {
+	public SPARQLStarResultsTSVWriter(OutputStream out) {
+		super(out);
+	}
+
+	@Override
+	public TupleQueryResultFormat getTupleQueryResultFormat() {
+		return TupleQueryResultFormat.TSV_STAR;
+	}
+
+}

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVWriterFactory.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVWriterFactory.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.tsv;
+
+import java.io.OutputStream;
+
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+
+/**
+ * {@link TupleQueryResultWriterFactory} for creating instances of {@link SPARQLStarResultsTSVWriter}.
+ *
+ * @author Pavel Mihaylov
+ */
+public class SPARQLStarResultsTSVWriterFactory implements TupleQueryResultWriterFactory {
+	/**
+	 * Returns {@link TupleQueryResultFormat#TSV_STAR}.
+	 */
+	@Override
+	public TupleQueryResultFormat getTupleQueryResultFormat() {
+		return TupleQueryResultFormat.TSV_STAR;
+	}
+
+	/**
+	 * Returns a new instance of {@link SPARQLStarResultsTSVWriter}.
+	 */
+	@Override
+	public TupleQueryResultWriter getWriter(OutputStream out) {
+		return new SPARQLStarResultsTSVWriter(out);
+	}
+}

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVMappingStrategy.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVMappingStrategy.java
@@ -7,27 +7,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.textstar.tsv;
 
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVMappingStrategy;
-import org.eclipse.rdf4j.rio.helpers.NTriplesUtil;
 
 /**
  * Extends {@link SPARQLResultsTSVMappingStrategy} with support for parsing a {@link org.eclipse.rdf4j.model.Triple}.
  *
  * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - functionality has been folded into {@link SPARQLResultsTSVMappingStrategy}
  */
+@Deprecated
 public class SPARQLStarResultsTSVMappingStrategy extends SPARQLResultsTSVMappingStrategy {
 	public SPARQLStarResultsTSVMappingStrategy(ValueFactory valueFactory) {
 		super(valueFactory);
-	}
-
-	@Override
-	protected Value parseValue(String valueString) {
-		if (valueString.startsWith("<<")) {
-			return NTriplesUtil.parseTriple(valueString, valueFactory);
-		} else {
-			return super.parseValue(valueString);
-		}
 	}
 }

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVParser.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVParser.java
@@ -7,25 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.textstar.tsv;
 
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVMappingStrategy;
-import org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVParser;
-
 /**
- * Parser for SPARQL* TSV results. This is equivalent to the SPARQL TSV parser with the addition of support for RDF*
- * triples. Serialized triples must be in Turtle* fashion with the notable exception that any embedded literals may not
- * use the triple quotes notation (as regular literals in SPARQL TSV).
  *
- * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - moved to {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVParser}.
  */
-public class SPARQLStarResultsTSVParser extends SPARQLResultsTSVParser {
-	@Override
-	public TupleQueryResultFormat getTupleQueryResultFormat() {
-		return TupleQueryResultFormat.TSV_STAR;
-	}
-
-	@Override
-	protected SPARQLResultsTSVMappingStrategy createMappingStrategy() {
-		return new SPARQLStarResultsTSVMappingStrategy(valueFactory);
-	}
+@Deprecated
+public class SPARQLStarResultsTSVParser extends org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVParser {
 }

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVParserFactory.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVParserFactory.java
@@ -7,29 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.textstar.tsv;
 
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
-
 /**
- * {@link TupleQueryResultParserFactory} for creating instances of {@link SPARQLStarResultsTSVParser}.
  *
- * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - moved to
+ *             {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVParserFactory}.
  */
-public class SPARQLStarResultsTSVParserFactory implements TupleQueryResultParserFactory {
-	/**
-	 * Returns {@link TupleQueryResultFormat#TSV_STAR}.
-	 */
-	@Override
-	public TupleQueryResultFormat getTupleQueryResultFormat() {
-		return TupleQueryResultFormat.TSV_STAR;
-	}
-
-	/**
-	 * Returns a new instance of {@link SPARQLStarResultsTSVParser}.
-	 */
-	@Override
-	public TupleQueryResultParser getParser() {
-		return new SPARQLStarResultsTSVParser();
-	}
+@Deprecated
+public class SPARQLStarResultsTSVParserFactory
+		extends org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVParserFactory {
 }

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVWriter.java
@@ -7,43 +7,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.textstar.tsv;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
-import org.eclipse.rdf4j.model.Triple;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVWriter;
-
 /**
- * Writer for SPARQL* TSV results. This is equivalent to the SPARQL TSV writer with the addition of support for RDF*
- * triples. Triples will be serialized in Turtle* fashion with the notable exception that any embedded literals will not
- * use the triple quotes notation (as regular literals in SPARQL TSV).
  *
- * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - moved to {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriter}.
  */
-public class SPARQLStarResultsTSVWriter extends SPARQLResultsTSVWriter {
+@Deprecated
+public class SPARQLStarResultsTSVWriter extends org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriter {
+
 	public SPARQLStarResultsTSVWriter(OutputStream out) {
 		super(out);
-	}
-
-	@Override
-	public TupleQueryResultFormat getTupleQueryResultFormat() {
-		return TupleQueryResultFormat.TSV_STAR;
-	}
-
-	@Override
-	protected void writeValue(Value val) throws IOException {
-		if (val instanceof Triple) {
-			writer.write("<<");
-			writeValue(((Triple) val).getSubject());
-			writer.write(' ');
-			writeValue(((Triple) val).getPredicate());
-			writer.write(' ');
-			writeValue(((Triple) val).getObject());
-			writer.write(">>");
-		} else {
-			super.writeValue(val);
-		}
 	}
 }

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVWriterFactory.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVWriterFactory.java
@@ -7,31 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.textstar.tsv;
 
-import java.io.OutputStream;
-
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
-
 /**
- * {@link TupleQueryResultWriterFactory} for creating instances of {@link SPARQLStarResultsTSVWriter}.
  *
- * @author Pavel Mihaylov
+ * @deprecated since 3.4.0 - moved to
+ *             {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriterFactory}.
  */
-public class SPARQLStarResultsTSVWriterFactory implements TupleQueryResultWriterFactory {
-	/**
-	 * Returns {@link TupleQueryResultFormat#TSV_STAR}.
-	 */
-	@Override
-	public TupleQueryResultFormat getTupleQueryResultFormat() {
-		return TupleQueryResultFormat.TSV_STAR;
-	}
-
-	/**
-	 * Returns a new instance of {@link SPARQLStarResultsTSVWriter}.
-	 */
-	@Override
-	public TupleQueryResultWriter getWriter(OutputStream out) {
-		return new SPARQLStarResultsTSVWriter(out);
-	}
+@Deprecated
+public class SPARQLStarResultsTSVWriterFactory
+		extends org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriterFactory {
 }

--- a/core/queryresultio/text/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory
+++ b/core/queryresultio/text/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory
@@ -1,3 +1,3 @@
 org.eclipse.rdf4j.query.resultio.text.csv.SPARQLResultsCSVParserFactory
 org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVParserFactory
-org.eclipse.rdf4j.query.resultio.textstar.tsv.SPARQLStarResultsTSVParserFactory
+org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVParserFactory

--- a/core/queryresultio/text/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory
+++ b/core/queryresultio/text/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory
@@ -1,3 +1,3 @@
 org.eclipse.rdf4j.query.resultio.text.csv.SPARQLResultsCSVWriterFactory
 org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVWriterFactory
-org.eclipse.rdf4j.query.resultio.textstar.tsv.SPARQLStarResultsTSVWriterFactory
+org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriterFactory

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleQueryResultWriterTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleQueryResultWriterTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.csv;
+
+import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public class SPARQLCSVTupleQueryResultWriterTest extends AbstractTupleQueryResultWriterTest {
+
+	@Override
+	protected TupleQueryResultParserFactory getParserFactory() {
+		return new SPARQLResultsCSVParserFactory();
+	}
+
+	@Override
+	protected TupleQueryResultWriterFactory getWriterFactory() {
+		return new SPARQLResultsCSVWriterFactory();
+	}
+
+	@Override
+	@Ignore("pending implementation of RDF* extensions for the csv format")
+	@Test
+	public void testRDFStarHandling_NoEncoding() throws Exception {
+	}
+}

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleBackgroundTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleBackgroundTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.query.resultio.textstar.tsv;
+package org.eclipse.rdf4j.query.resultio.text.tsv;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleQueryResultWriterTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleQueryResultWriterTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.tsv;
+
+import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public class SPARQLStarTSVTupleQueryResultWriterTest extends AbstractTupleQueryResultWriterTest {
+
+	@Override
+	protected TupleQueryResultParserFactory getParserFactory() {
+		return new SPARQLStarResultsTSVParserFactory();
+	}
+
+	@Override
+	protected TupleQueryResultWriterFactory getWriterFactory() {
+		return new SPARQLStarResultsTSVWriterFactory();
+	}
+}

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.query.resultio.textstar.tsv;
+package org.eclipse.rdf4j.query.resultio.text.tsv;
 
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
 import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleQueryResultWriterTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleQueryResultWriterTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio.text.tsv;
+
+import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public class SPARQLTSVTupleQueryResultWriterTest extends AbstractTupleQueryResultWriterTest {
+
+	@Override
+	protected TupleQueryResultParserFactory getParserFactory() {
+		return new SPARQLResultsTSVParserFactory();
+	}
+
+	@Override
+	protected TupleQueryResultWriterFactory getWriterFactory() {
+		return new SPARQLResultsTSVWriterFactory();
+	}
+}

--- a/testsuites/queryresultio/pom.xml
+++ b/testsuites/queryresultio/pom.xml
@@ -20,5 +20,10 @@
 			<artifactId>junit</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractTupleQueryResultWriterTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractTupleQueryResultWriterTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.resultio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.impl.MapBindingSet;
+import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
+import org.junit.Test;
+
+/**
+ * Generic tests for {@link TupleQueryResultWriter} implementations.
+ *
+ * @author Jeen Broekstra
+ */
+public abstract class AbstractTupleQueryResultWriterTest {
+
+	protected final static ValueFactory vf = SimpleValueFactory.getInstance();
+
+	@Test
+	public void testRDFStarHandling_WithEncoding() throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		TupleQueryResultWriter writer = getWriterFactory().getWriter(baos);
+
+		writer.getWriterConfig().set(BasicWriterSettings.ENCODE_RDF_STAR, true);
+
+		Triple t = vf.createTriple(RDF.ALT, RDF.TYPE, RDFS.CLASS);
+		MapBindingSet bs = new MapBindingSet();
+		bs.addBinding("t", t);
+
+		writer.startQueryResult(new ArrayList<>(bs.getBindingNames()));
+		writer.handleSolution(bs);
+		writer.endQueryResult();
+
+		QueryResultCollector collector = new QueryResultCollector();
+		TupleQueryResultParser parser = getParserFactory().getParser();
+		parser.getParserConfig().set(BasicParserSettings.PROCESS_ENCODED_RDF_STAR, false);
+		parser.setQueryResultHandler(collector);
+		parser.parseQueryResult(new ByteArrayInputStream(baos.toByteArray()));
+
+		BindingSet actual = collector.getBindingSets().get(0);
+
+		if (writer.getTupleQueryResultFormat().supportsRDFStar()) {
+			// natively-supporting RDF* writers should ignore the encoding setting and just always use their extended
+			// format
+			assertThat(actual.getValue("t")).isInstanceOf(Triple.class);
+		} else {
+			assertThat(actual.getValue("t")).isInstanceOf(IRI.class);
+			assertThat(actual.getValue("t")).isEqualTo(RDFStarUtil.toRDFEncodedValue((Resource) t));
+
+		}
+	}
+
+	@Test
+	public void testRDFStarHandling_NoEncoding() throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		TupleQueryResultWriter writer = getWriterFactory().getWriter(baos);
+
+		writer.getWriterConfig().set(BasicWriterSettings.ENCODE_RDF_STAR, false);
+
+		Triple t = vf.createTriple(RDF.ALT, RDF.TYPE, RDFS.CLASS);
+		MapBindingSet bs = new MapBindingSet();
+		bs.addBinding("t", t);
+
+		writer.startQueryResult(new ArrayList<>(bs.getBindingNames()));
+		writer.handleSolution(bs);
+		writer.endQueryResult();
+
+		QueryResultCollector collector = new QueryResultCollector();
+		TupleQueryResultParser parser = getParserFactory().getParser();
+
+		parser.getParserConfig().set(BasicParserSettings.PROCESS_ENCODED_RDF_STAR, false);
+		parser.setQueryResultHandler(collector);
+		parser.parseQueryResult(new ByteArrayInputStream(baos.toByteArray()));
+
+		BindingSet actual = collector.getBindingSets().get(0);
+		assertThat(actual.getValue("t")).isInstanceOf(Triple.class);
+	}
+
+	protected abstract TupleQueryResultParserFactory getParserFactory();
+
+	protected abstract TupleQueryResultWriterFactory getWriterFactory();
+}


### PR DESCRIPTION
GitHub issue resolved: #2437 

Briefly describe the changes proposed in this PR:

- SPARQL results JSON writer functionality for RDF* extended  format merged into default parser
- SPARQL results TSV writer functionality for RDF* extended  format merged into default parser
- moved extended TSV parser/writer to package `org.eclipse.rdf4j.query.resultio.text.tsv`and adapted serviceloader entries
- added generic test suite for tuple query results writers to check behavior under different configuration settings

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

