### PR TITLE
GH-2443 fix processing of sesame:nil in GRAPH clause

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -516,9 +516,13 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 					// Search zero contexts
 					return new EmptyIteration<>();
 				} else if (graphs == null || graphs.isEmpty()) {
-					// store default behaivour
+					// store default behaviour
 					if (contextValue != null) {
-						contexts = new Resource[] { (Resource) contextValue };
+						if (SESAME.NIL.equals(contextValue)) {
+							contexts = new Resource[] { (Resource) null };
+						} else {
+							contexts = new Resource[] { (Resource) contextValue };
+						}
 					}
 					/*
 					 * TODO activate this to have an exclusive (rather than inclusive) interpretation of the default

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -48,6 +48,7 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.impl.SimpleBinding;
 import org.eclipse.rdf4j.query.impl.SimpleDataset;
+import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQL11ManifestTest;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -271,6 +272,36 @@ public abstract class ComplexSPARQLQueryTest {
 				assertFalse(alice.equals(s)); // should not be present in
 				// default
 				// graph
+			}
+		} catch (QueryEvaluationException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSesameNilAsGraph() throws Exception {
+		loadTestData("/testdata-query/dataset-query.trig");
+		StringBuilder query = new StringBuilder();
+		query.append(getNamespaceDeclarations());
+		query.append(" SELECT * ");
+		query.append(" WHERE { GRAPH sesame:nil { ?s ?p ?o } } ");
+//		query.append(" WHERE { ?s ?p ?o } ");
+
+		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, query.toString());
+
+		try {
+			List<BindingSet> result = QueryResults.asList(tq.evaluate());
+
+			// nil graph should not be empty
+			assertThat(result.size()).isGreaterThan(1);
+
+			for (BindingSet bs : result) {
+				Resource s = (Resource) bs.getValue("s");
+
+				assertNotNull(s);
+				assertThat(s).withFailMessage("%s should not be present in nil graph", bob).isNotEqualTo(bob);
+				assertThat(s).withFailMessage("%s should not be present in nil graph", alice).isNotEqualTo(alice);
 			}
 		} catch (QueryEvaluationException e) {
 			e.printStackTrace();


### PR DESCRIPTION
GitHub issue resolved: #2443 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added regression test and fix for handling of sesame:nil in a GRAPH clause in SPARQL queries

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

