### PR TITLE
GH-2441 fix UpdateExprBuilder to support SPARQLStar expressions in WHERE

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
@@ -397,8 +397,9 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 
 	@Override
 	public TupleExpr visit(ASTTripleRef node, Object data) throws VisitorException {
-		if (where == null)
+		if (where == null) {
 			return super.visit(node, data);
+		}
 		TripleRef ret = new TripleRef();
 		ret.setSubjectVar(mapValueExprToVar(node.getSubj().jjtAccept(this, ret)));
 		ret.setPredicateVar(mapValueExprToVar(node.getPred().jjtAccept(this, ret)));

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
@@ -397,6 +397,8 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 
 	@Override
 	public TupleExpr visit(ASTTripleRef node, Object data) throws VisitorException {
+		if (where == null)
+			return super.visit(node, data);
 		TripleRef ret = new TripleRef();
 		ret.setSubjectVar(mapValueExprToVar(node.getSubj().jjtAccept(this, ret)));
 		ret.setPredicateVar(mapValueExprToVar(node.getPred().jjtAccept(this, ret)));

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestSparqlStarParser.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestSparqlStarParser.java
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.query.algebra.Modify;
 import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.ProjectionElem;
 import org.eclipse.rdf4j.query.algebra.Reduced;
+import org.eclipse.rdf4j.query.algebra.SingletonSet;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.Str;
 import org.eclipse.rdf4j.query.algebra.TripleRef;
@@ -859,5 +860,135 @@ public class TestSparqlStarParser {
 		assertEquals("subject var value", "urn:a", ref.getSubjectVar().getValue().toString());
 		assertEquals("predicate var name", "urn:b", ref.getPredicateVar().getValue().toString());
 		assertEquals("object var name", "urn:c", ref.getObjectVar().getValue().toString());
+	}
+
+	/*-
+	 * Expected UpdateExpr:
+	 * Modify
+	   SingletonSet
+	   Join
+	      TripleRef
+	         Var (name=_const_6a63498_uri, value=urn:a, anonymous)
+	         Var (name=_const_6a63499_uri, value=urn:b, anonymous)
+	         Var (name=_const_6a6349a_uri, value=urn:c, anonymous)
+	         Var (name=_anon_ec2f43ed_6a93_44ff_ad7d_e1f403b4a5e9, anonymous)
+	      StatementPattern
+	         Var (name=_anon_ec2f43ed_6a93_44ff_ad7d_e1f403b4a5e9, anonymous)
+	         Var (name=_const_6a634a7_uri, value=urn:p, anonymous)
+	         Var (name=_const_31_lit_5fc8fb17_0, value="1"^^<http://www.w3.org/2001/XMLSchema#integer>, anonymous)
+	 * @throws Exception
+	 */
+	@Test
+	public void testUpdateWithTripleRefEmptyHead() throws Exception {
+		String simpleSparqlUpdate = "insert {} where {<<<urn:a> <urn:b> <urn:c>>> <urn:p> 1}";
+
+		ParsedUpdate q = parser.parseUpdate(simpleSparqlUpdate, null);
+
+		assertNotNull(q);
+		List<UpdateExpr> list = q.getUpdateExprs();
+		assertNotNull(list);
+		assertEquals("expect single update expr", 1, list.size());
+		assertTrue("expect modify op", list.get(0) instanceof Modify);
+		Modify op = (Modify) list.get(0);
+		assertTrue("do not expect delete", null == op.getDeleteExpr());
+		assertNotNull(op.getInsertExpr());
+		assertTrue("expect singleton", op.getInsertExpr() instanceof SingletonSet);
+
+		assertNotNull(op.getWhereExpr());
+		assertTrue("expect join in where", op.getWhereExpr() instanceof Join);
+		Join join = (Join) op.getWhereExpr();
+		assertTrue("expect left is TripleRef", join.getLeftArg() instanceof TripleRef);
+		TripleRef ref = (TripleRef) join.getLeftArg();
+		assertTrue("expect right is StatementPattern", join.getRightArg() instanceof StatementPattern);
+		StatementPattern st = (StatementPattern) join.getRightArg();
+		assertEquals("expect same Var", ref.getExprVar().getName(), st.getSubjectVar().getName());
+	}
+
+	/*-
+	 * Expected UpdateExpr:
+		Modify
+		   StatementPattern
+		      Var (name=_anon_24e6f014_3e16_49f9_ad0f_ef6d8045bbe9, anonymous)
+		      Var (name=_const_6a634a7_uri, value=urn:p, anonymous)
+		      Var (name=_const_31_lit_5fc8fb17_0, value="1"^^<http://www.w3.org/2001/XMLSchema#integer>, anonymous)
+	 
+		   Extension
+		      ExtensionElem (_anon_24e6f014_3e16_49f9_ad0f_ef6d8045bbe9)
+		         ValueExprTripleRef
+		            Var (name=_const_6a63498_uri, value=urn:a, anonymous)
+		            Var (name=_const_6a63499_uri, value=urn:b, anonymous)
+		            Var (name=_const_6a6349a_uri, value=urn:c, anonymous)
+		      Join
+		         TripleRef
+		            Var (name=_const_6a63498_uri, value=urn:a, anonymous)
+		            Var (name=_const_6a63499_uri, value=urn:b, anonymous)
+		            Var (name=_const_6a6349a_uri, value=urn:c, anonymous)
+		            Var (name=_anon_9e07cd00_0c02_4754_89ad_0ce4a5264d6e, anonymous)
+		         StatementPattern
+		            Var (name=_anon_9e07cd00_0c02_4754_89ad_0ce4a5264d6e, anonymous)
+		            Var (name=_const_6a634a7_uri, value=urn:p, anonymous)
+		            Var (name=_const_31_lit_5fc8fb17_0, value="1"^^<http://www.w3.org/2001/XMLSchema#integer>, anonymous)	 
+	 * @throws Exception
+	 */
+	@Test
+	public void testUpdateWithTripleRefNonEmptyHead() throws Exception {
+		String simpleSparqlUpdate = "insert {<<<urn:a> <urn:b> <urn:c>>> <urn:p> 1} where {<<<urn:a> <urn:b> <urn:c>>> <urn:p> 1}";
+
+		ParsedUpdate q = parser.parseUpdate(simpleSparqlUpdate, null);
+		assertNotNull(q);
+		List<UpdateExpr> list = q.getUpdateExprs();
+		assertNotNull(list);
+		assertEquals("expect single update expr", 1, list.size());
+		assertTrue("expect modify op", list.get(0) instanceof Modify);
+		Modify op = (Modify) list.get(0);
+		assertTrue("do not expect delete", null == op.getDeleteExpr());
+		assertNotNull(op.getInsertExpr());
+		assertTrue("expect statement pattern", op.getInsertExpr() instanceof StatementPattern);
+		StatementPattern insetPattern = (StatementPattern) op.getInsertExpr();
+
+		assertNotNull(op.getWhereExpr());
+		assertTrue("expect extension in where", op.getWhereExpr() instanceof Extension);
+		Extension ext = (Extension) op.getWhereExpr();
+		ExtensionElem el = ext.getElements().get(0);
+		assertTrue("expect valueExprTripleRef", el.getExpr() instanceof ValueExprTripleRef);
+		assertEquals("expect same var", el.getName(), insetPattern.getSubjectVar().getName());
+		assertTrue("expect Join", ext.getArg() instanceof Join);
+		Join join = (Join) ext.getArg();
+		assertTrue("expect left is TripleRef", join.getLeftArg() instanceof TripleRef);
+		TripleRef ref = (TripleRef) join.getLeftArg();
+		assertTrue("expect right is StatementPattern", join.getRightArg() instanceof StatementPattern);
+		StatementPattern st = (StatementPattern) join.getRightArg();
+		assertEquals("expect same Var", ref.getExprVar().getName(), st.getSubjectVar().getName());
+
+	}
+
+	/*-
+	 * Expected UpdateExpr:
+		Modify
+	 * @throws Exception
+	 */
+	@Test
+	public void testUpdateExample() {
+		String update = "INSERT {?s ?p ?o} \r\n" +
+				"WHERE { <<?s ?p ?o>> <p:1> 0.9 }";
+		ParsedUpdate q = parser.parseUpdate(update, null);
+		assertNotNull(q);
+		List<UpdateExpr> list = q.getUpdateExprs();
+		assertNotNull(list);
+		assertEquals("expect single update expr", 1, list.size());
+		assertTrue("expect modify op", list.get(0) instanceof Modify);
+		Modify op = (Modify) list.get(0);
+		assertTrue("do not expect delete", null == op.getDeleteExpr());
+		assertNotNull(op.getInsertExpr());
+		assertTrue("expect statement pattern", op.getInsertExpr() instanceof StatementPattern);
+		assertNotNull(op.getWhereExpr());
+
+		assertTrue("expect join in where", op.getWhereExpr() instanceof Join);
+		Join join = (Join) op.getWhereExpr();
+		assertTrue("expect left is TripleRef", join.getLeftArg() instanceof TripleRef);
+		TripleRef ref = (TripleRef) join.getLeftArg();
+		assertTrue("expect right is StatementPattern", join.getRightArg() instanceof StatementPattern);
+		StatementPattern st = (StatementPattern) join.getRightArg();
+		assertEquals("expect same Var", ref.getExprVar().getName(), st.getSubjectVar().getName());
 	}
 }

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
@@ -150,5 +150,18 @@ public abstract class RDFStarSupportTest {
 
 	}
 
+	@Test
+	public void testSparqlStarUpdate() {
+		Triple rdfStarTriple = vf.createTriple(bob, FOAF.NAME, nameBob);
+		testCon.add(rdfStarTriple, RDF.TYPE, RDF.ALT);
+
+		String update = "PREFIX foaf: <" + FOAF.NAMESPACE
+				+ ">\n INSERT { ?s foaf:age 23 } WHERE { <<?s foaf:name ?o>> ?b ?c .}";
+
+		testCon.prepareUpdate(update).execute();
+
+		assertThat(testCon.hasStatement(bob, FOAF.AGE, vf.createLiteral(23), false));
+	}
+
 	protected abstract Repository createRepository();
 }


### PR DESCRIPTION
Fix in UpdateExprBuilder to process TripleRefs in WHERE clause
 - added simple test cases

Signed-off-by: damyan.ognyanov <damyan.ognyanov@ontotext.com>


GitHub issue resolved: #2441 

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

