### PR TITLE
GH-2439 sh:value produced correctly for all constraint components

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/SourceConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/SourceConstraintComponent.java
@@ -13,40 +13,42 @@ import org.eclipse.rdf4j.model.vocabulary.DASH;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 
 public enum SourceConstraintComponent {
-	MaxCountConstraintComponent(SHACL.MAX_COUNT_CONSTRAINT_COMPONENT, ConstraintType.Cardinality),
-	MinCountConstraintComponent(SHACL.MIN_COUNT_CONSTRAINT_COMPONENT, ConstraintType.Cardinality),
+	MaxCountConstraintComponent(SHACL.MAX_COUNT_CONSTRAINT_COMPONENT, ConstraintType.Cardinality, false),
+	MinCountConstraintComponent(SHACL.MIN_COUNT_CONSTRAINT_COMPONENT, ConstraintType.Cardinality, false),
 
-	DatatypeConstraintComponent(SHACL.DATATYPE_CONSTRAINT_COMPONENT, ConstraintType.ValueType),
-	LanguageInConstraintComponent(SHACL.LANGUAGE_IN_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+	DatatypeConstraintComponent(SHACL.DATATYPE_CONSTRAINT_COMPONENT, ConstraintType.ValueType, true),
+	LanguageInConstraintComponent(SHACL.LANGUAGE_IN_CONSTRAINT_COMPONENT, ConstraintType.StringBased, true),
 
-	NodeKindConstraintComponent(SHACL.NODE_KIND_CONSTRAINT_COMPONENT, ConstraintType.ValueType),
-	PatternConstraintComponent(SHACL.PATTERN_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+	NodeKindConstraintComponent(SHACL.NODE_KIND_CONSTRAINT_COMPONENT, ConstraintType.ValueType, true),
+	PatternConstraintComponent(SHACL.PATTERN_CONSTRAINT_COMPONENT, ConstraintType.StringBased, true),
 
-	ClassConstraintComponent(SHACL.CLASS_CONSTRAINT_COMPONENT, ConstraintType.ValueType),
+	ClassConstraintComponent(SHACL.CLASS_CONSTRAINT_COMPONENT, ConstraintType.ValueType, true),
 
-	InConstraintComponent(SHACL.IN_CONSTRAINT_COMPONENT, ConstraintType.Other),
-	HasValueConstraintComponent(SHACL.HAS_VALUE_CONSTRAINT_COMPONENT, ConstraintType.Other),
-	HasValueInConstraintComponent(DASH.HasValueInConstraintComponent, ConstraintType.Other),
-	UniqueLangConstraintComponent(SHACL.UNIQUE_LANG_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+	InConstraintComponent(SHACL.IN_CONSTRAINT_COMPONENT, ConstraintType.Other, true),
+	HasValueConstraintComponent(SHACL.HAS_VALUE_CONSTRAINT_COMPONENT, ConstraintType.Other, false),
+	HasValueInConstraintComponent(DASH.HasValueInConstraintComponent, ConstraintType.Other, false),
+	UniqueLangConstraintComponent(SHACL.UNIQUE_LANG_CONSTRAINT_COMPONENT, ConstraintType.StringBased, false),
 
-	MinExclusiveConstraintComponent(SHACL.MIN_EXCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange),
-	MaxExclusiveConstraintComponent(SHACL.MAX_EXCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange),
-	MaxInclusiveConstraintComponent(SHACL.MAX_INCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange),
-	MinInclusiveConstraintComponent(SHACL.MIN_INCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange),
+	MinExclusiveConstraintComponent(SHACL.MIN_EXCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange, true),
+	MaxExclusiveConstraintComponent(SHACL.MAX_EXCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange, true),
+	MaxInclusiveConstraintComponent(SHACL.MAX_INCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange, true),
+	MinInclusiveConstraintComponent(SHACL.MIN_INCLUSIVE_CONSTRAINT_COMPONENT, ConstraintType.ValueRange, true),
 
-	MaxLengthConstraintComponent(SHACL.MAX_LENGTH_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
-	MinLengthConstraintComponent(SHACL.MIN_LENGTH_CONSTRAINT_COMPONENT, ConstraintType.StringBased),
+	MaxLengthConstraintComponent(SHACL.MAX_LENGTH_CONSTRAINT_COMPONENT, ConstraintType.StringBased, true),
+	MinLengthConstraintComponent(SHACL.MIN_LENGTH_CONSTRAINT_COMPONENT, ConstraintType.StringBased, true),
 
-	AndConstraintComponent(SHACL.AND_CONSTRAINT_COMPONENT, ConstraintType.Logical),
-	OrConstraintComponent(SHACL.OR_CONSTRAINT_COMPONENT, ConstraintType.Logical),
-	NotConstraintComponent(SHACL.NOT_CONSTRAINT_COMPONENT, ConstraintType.Logical);
+	AndConstraintComponent(SHACL.AND_CONSTRAINT_COMPONENT, ConstraintType.Logical, true),
+	OrConstraintComponent(SHACL.OR_CONSTRAINT_COMPONENT, ConstraintType.Logical, true),
+	NotConstraintComponent(SHACL.NOT_CONSTRAINT_COMPONENT, ConstraintType.Logical, true);
 
 	private final IRI iri;
 	private final ConstraintType constraintType;
+	private final boolean producesValidationResultValue;
 
-	SourceConstraintComponent(IRI iri, ConstraintType constraintType) {
+	SourceConstraintComponent(IRI iri, ConstraintType constraintType, boolean producesValidationResultValue) {
 		this.iri = iri;
 		this.constraintType = constraintType;
+		this.producesValidationResultValue = producesValidationResultValue;
 	}
 
 	public IRI getIri() {
@@ -65,7 +67,11 @@ public enum SourceConstraintComponent {
 		PropertyPair,
 		Logical,
 		ShapeBased,
-		Other
+		Other;
 
+	}
+
+	public boolean producesValidationResultValue() {
+		return producesValidationResultValue;
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
@@ -46,12 +46,6 @@ public class ValidationResult {
 	private final Value focusNode;
 	private final Optional<Value> value;
 
-	static Set<SourceConstraintComponent.ConstraintType> constraintTypesThatSupportValue = Arrays
-			.stream(SourceConstraintComponent.ConstraintType.values())
-			.filter(t -> t != SourceConstraintComponent.ConstraintType.Cardinality)
-			.filter(t -> t != SourceConstraintComponent.ConstraintType.Logical)
-			.collect(Collectors.toSet());
-
 	public ValidationResult(PropertyShape sourceShape, Value focusNode, Value value) {
 		this.sourceShape = sourceShape;
 		this.focusNode = focusNode;
@@ -60,7 +54,9 @@ public class ValidationResult {
 			this.path = ((PathPropertyShape) sourceShape).getPath();
 		}
 
-		if (constraintTypesThatSupportValue.contains(sourceConstraintComponent.getConstraintType())) {
+		if (sourceConstraintComponent.producesValidationResultValue() &&
+		// WE DON'T SUPPORT sh:value FOR LOGICAL OPERATORS YET
+				sourceConstraintComponent.getConstraintType() != SourceConstraintComponent.ConstraintType.Logical) {
 			this.value = Optional.of(value);
 		} else {
 			this.value = Optional.empty();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UnknownShapesTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UnknownShapesTest.java
@@ -30,7 +30,7 @@ import ch.qos.logback.core.AppenderBase;
 public class UnknownShapesTest {
 
 	@Test
-	public void testPropertyShapes() throws IOException {
+	public void testPropertyShapes() throws IOException, InterruptedException {
 		ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory
 				.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
 
@@ -45,6 +45,8 @@ public class UnknownShapesTest {
 			connection.commit();
 		}
 
+		Thread.sleep(100);
+
 		Set<String> relevantLog = newAppender.logged.stream()
 				.filter(m -> m.startsWith("Unsupported SHACL feature"))
 				.collect(Collectors.toSet());
@@ -58,7 +60,7 @@ public class UnknownShapesTest {
 	}
 
 	@Test
-	public void testComplexPath() throws IOException {
+	public void testComplexPath() throws IOException, InterruptedException {
 		ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory
 				.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
 
@@ -72,6 +74,8 @@ public class UnknownShapesTest {
 			connection.add(RDF.TYPE, RDF.TYPE, RDFS.RESOURCE);
 			connection.commit();
 		}
+
+		Thread.sleep(100);
 
 		Set<String> relevantLog = newAppender.logged.stream()
 				.filter(m -> m.startsWith("Unsupported SHACL feature"))

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.sail.Sail;
 import org.junit.Test;
 
 public class ValidationReportTest {
@@ -188,6 +189,114 @@ public class ValidationReportTest {
 					"      sh:resultPath ex:age;\n" +
 					"      sh:sourceConstraintComponent sh:OrConstraintComponent;\n" +
 					"      sh:sourceShape ex:personShapeOr\n" +
+					"    ] ." + ""), "", RDFFormat.TURTLE);
+
+			assertTrue(Models.isomorphic(expected, actual));
+
+		}
+	}
+
+	@Test
+	public void testHasValueIn() throws IOException {
+
+		SailRepository shaclSail = Utils.getInitializedShaclRepository("test-cases/hasValueIn/simple/shacl.ttl", false);
+
+		ShaclSail sail = (ShaclSail) shaclSail.getSail();
+		sail.setDashDataShapes(true);
+
+		try (SailRepositoryConnection connection = shaclSail.getConnection()) {
+
+			connection.begin();
+			connection.prepareUpdate(IOUtils.toString(ValidationReportTest.class.getClassLoader()
+					.getResourceAsStream("test-cases/hasValueIn/simple/invalid/case1/query1.rq"),
+					StandardCharsets.UTF_8))
+					.execute();
+			connection.commit();
+			fail();
+
+		} catch (RepositoryException e) {
+			ShaclSailValidationException cause = (ShaclSailValidationException) e.getCause();
+			Model actual = cause.validationReportAsModel();
+
+			actual.setNamespace(RDF.PREFIX, RDF.NAMESPACE);
+			actual.setNamespace(RDFS.PREFIX, RDFS.NAMESPACE);
+			actual.setNamespace("ex", "http://example.com/ns#");
+
+			WriterConfig writerConfig = new WriterConfig();
+			writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
+			writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
+
+			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
+
+			Model expected = Rio.parse(new StringReader(""
+					+ "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+					"@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
+					"@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n" +
+					"@prefix ex: <http://example.com/ns#> .\n" +
+					"\n" +
+					"[] a sh:ValidationReport;\n" +
+					"  sh:conforms false;\n" +
+					"  <http://rdf4j.org/schema/rdf4j#truncated> false;\n" +
+					"  sh:result [ a sh:ValidationResult;\n" +
+					"      sh:focusNode ex:validPerson1;\n" +
+					"      sh:sourceConstraintComponent <http://datashapes.org/dash#HasValueInConstraintComponent>;\n" +
+					"      sh:sourceShape [];\n" +
+					"      sh:resultPath ex:knows;\n" +
+					"      sh:value \"1234567\"\n" +
+					"    ] ." + ""), "", RDFFormat.TURTLE);
+
+			assertTrue(Models.isomorphic(expected, actual));
+
+		}
+	}
+
+	@Test
+	public void testHasValue() throws IOException {
+
+		SailRepository shaclSail = Utils.getInitializedShaclRepository("test-cases/hasValue/simple/shacl.ttl", false);
+
+		ShaclSail sail = (ShaclSail) shaclSail.getSail();
+		sail.setDashDataShapes(true);
+
+		try (SailRepositoryConnection connection = shaclSail.getConnection()) {
+
+			connection.begin();
+			connection.prepareUpdate(IOUtils.toString(ValidationReportTest.class.getClassLoader()
+					.getResourceAsStream("test-cases/hasValue/simple/invalid/case1/query1.rq"),
+					StandardCharsets.UTF_8))
+					.execute();
+			connection.commit();
+			fail();
+
+		} catch (RepositoryException e) {
+			ShaclSailValidationException cause = (ShaclSailValidationException) e.getCause();
+			Model actual = cause.validationReportAsModel();
+
+			actual.setNamespace(RDF.PREFIX, RDF.NAMESPACE);
+			actual.setNamespace(RDFS.PREFIX, RDFS.NAMESPACE);
+			actual.setNamespace("ex", "http://example.com/ns#");
+
+			WriterConfig writerConfig = new WriterConfig();
+			writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
+			writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
+
+			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
+
+			Model expected = Rio.parse(new StringReader(""
+					+ "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+					"@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
+					"@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n" +
+					"@prefix ex: <http://example.com/ns#> .\n" +
+					"\n" +
+					"[] a sh:ValidationReport;\n" +
+					"  sh:conforms false;\n" +
+					"  <http://rdf4j.org/schema/rdf4j#truncated> false;\n" +
+					"  sh:result [ a sh:ValidationResult;\n" +
+					"      sh:focusNode ex:validPerson1;\n" +
+					"      sh:sourceConstraintComponent <http://datashapes.org/dash#HasValueInConstraintComponent>;\n" +
+					"      sh:sourceShape [];\n" +
+					"      sh:resultPath ex:knows;\n" +
+					"      sh:value \"1234567\"\n" +
 					"    ] ." + ""), "", RDFFormat.TURTLE);
 
 			assertTrue(Models.isomorphic(expected, actual));

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
@@ -58,7 +58,7 @@ public class ValidationReportTest {
 			actual.setNamespace(RDFS.PREFIX, RDFS.NAMESPACE);
 			actual.setNamespace("ex", "http://example.com/ns#");
 
-			Rio.write(actual, System.out, RDFFormat.TURTLE);
+//			Rio.write(actual, System.out, RDFFormat.TURTLE);
 
 			Model expected = Rio.parse(new StringReader("" + "@prefix ex: <http://example.com/ns#> .\n" +
 					"@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
@@ -110,7 +110,7 @@ public class ValidationReportTest {
 			actual.setNamespace(RDFS.PREFIX, RDFS.NAMESPACE);
 			actual.setNamespace("ex", "http://example.com/ns#");
 
-			Rio.write(actual, System.out, RDFFormat.TURTLE);
+//			Rio.write(actual, System.out, RDFFormat.TURTLE);
 
 			Model expected = Rio.parse(new StringReader("" +
 					"@prefix ex: <http://example.com/ns#> .\n" +
@@ -160,7 +160,7 @@ public class ValidationReportTest {
 			writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
 			writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
 
-			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
+//			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
 
 			Model expected = Rio.parse(new StringReader(""
 					+ "@prefix ex: <http://example.com/ns#> .\n" +
@@ -168,27 +168,27 @@ public class ValidationReportTest {
 					"@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
 					"\n" +
 					"[] a sh:ValidationReport;\n" +
-					"  <http://rdf4j.org/schema/rdf4j#truncated> false;\n" +
 					"  sh:conforms false;\n" +
+					"  <http://rdf4j.org/schema/rdf4j#truncated> false;\n" +
 					"  sh:result [ a sh:ValidationResult;\n" +
+					"      sh:focusNode ex:validPerson1;\n" +
+					"      sh:sourceConstraintComponent sh:OrConstraintComponent;\n" +
+					"      sh:sourceShape ex:personShapeOr;\n" +
+					"      sh:resultPath ex:age;\n" +
 					"      sh:detail [ a sh:ValidationResult;\n" +
-					"          sh:detail [ a sh:ValidationResult;\n" +
-					"              sh:focusNode ex:validPerson1;\n" +
-					"              sh:resultPath ex:age;\n" +
-					"              sh:sourceConstraintComponent sh:DatatypeConstraintComponent;\n" +
-					"              sh:sourceShape ex:personShapeAgeLong;\n" +
-					"              sh:value \"abc\"\n" +
-					"            ];\n" +
 					"          sh:focusNode ex:validPerson1;\n" +
-					"          sh:resultPath ex:age;\n" +
 					"          sh:sourceConstraintComponent sh:DatatypeConstraintComponent;\n" +
 					"          sh:sourceShape ex:personShapeAgeInteger;\n" +
-					"          sh:value \"abc\"\n" +
-					"        ];\n" +
-					"      sh:focusNode ex:validPerson1;\n" +
-					"      sh:resultPath ex:age;\n" +
-					"      sh:sourceConstraintComponent sh:OrConstraintComponent;\n" +
-					"      sh:sourceShape ex:personShapeOr\n" +
+					"          sh:resultPath ex:age;\n" +
+					"          sh:value \"abc\";\n" +
+					"          sh:detail [ a sh:ValidationResult;\n" +
+					"              sh:focusNode ex:validPerson1;\n" +
+					"              sh:sourceConstraintComponent sh:DatatypeConstraintComponent;\n" +
+					"              sh:sourceShape ex:personShapeAgeLong;\n" +
+					"              sh:resultPath ex:age;\n" +
+					"              sh:value \"abc\"\n" +
+					"            ]\n" +
+					"        ]\n" +
 					"    ] ." + ""), "", RDFFormat.TURTLE);
 
 			assertTrue(Models.isomorphic(expected, actual));
@@ -226,7 +226,7 @@ public class ValidationReportTest {
 			writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
 			writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
 
-			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
+//			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
 
 			Model expected = Rio.parse(new StringReader(""
 					+ "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
@@ -242,7 +242,6 @@ public class ValidationReportTest {
 					"      sh:sourceConstraintComponent <http://datashapes.org/dash#HasValueInConstraintComponent>;\n" +
 					"      sh:sourceShape [];\n" +
 					"      sh:resultPath ex:knows;\n" +
-					"      sh:value \"1234567\"\n" +
 					"    ] ." + ""), "", RDFFormat.TURTLE);
 
 			assertTrue(Models.isomorphic(expected, actual));
@@ -280,7 +279,7 @@ public class ValidationReportTest {
 			writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
 			writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
 
-			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
+//			Rio.write(actual, System.out, RDFFormat.TURTLE, writerConfig);
 
 			Model expected = Rio.parse(new StringReader(""
 					+ "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
@@ -293,11 +292,10 @@ public class ValidationReportTest {
 					"  <http://rdf4j.org/schema/rdf4j#truncated> false;\n" +
 					"  sh:result [ a sh:ValidationResult;\n" +
 					"      sh:focusNode ex:validPerson1;\n" +
-					"      sh:sourceConstraintComponent <http://datashapes.org/dash#HasValueInConstraintComponent>;\n" +
+					"      sh:sourceConstraintComponent sh:HasValueConstraintComponent;\n" +
 					"      sh:sourceShape [];\n" +
-					"      sh:resultPath ex:knows;\n" +
-					"      sh:value \"1234567\"\n" +
-					"    ] ." + ""), "", RDFFormat.TURTLE);
+					"      sh:resultPath ex:knows\n" +
+					"    ] .\n" + ""), "", RDFFormat.TURTLE);
 
 			assertTrue(Models.isomorphic(expected, actual));
 


### PR DESCRIPTION
GitHub issue resolved: #2439 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

We now produce sh:value correctly for all constraint components with an exception for logical components where we need to wait for the new AST to support sh:value correctly.

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

