### PR TITLE
GH-2401 introduce rdf4j:nil and deprecate sesame:nil

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/RDF4J.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/RDF4J.java
@@ -42,6 +42,13 @@ public class RDF4J {
 	public final static IRI SHACL_SHAPE_GRAPH = create("SHACLShapeGraph");
 	public final static IRI TRUNCATED = create("truncated");
 
+	/**
+	 * The SPARQL default context identifier ( <tt>http://rdf4j.org/schema/rdf4j#nil</tt>)
+	 *
+	 * @since 3.3.2
+	 */
+	public final static IRI NIL = create("nil");
+
 	private static IRI create(String localName) {
 		return SimpleValueFactory.getInstance().createIRI(NAMESPACE, localName);
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/SESAME.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/vocabulary/SESAME.java
@@ -44,7 +44,10 @@ public class SESAME {
 
 	/**
 	 * The SPARQL null context identifier ( <tt>http://www.openrdf.org/schema/sesame#nil</tt>)
+	 *
+	 * @deprecated since 3.3.2 - use {@link RDF4J#NIL} instead
 	 */
+	@Deprecated
 	public final static IRI NIL;
 
 	/**

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -43,6 +43,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.Binding;
@@ -518,7 +519,7 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 				} else if (graphs == null || graphs.isEmpty()) {
 					// store default behaviour
 					if (contextValue != null) {
-						if (SESAME.NIL.equals(contextValue)) {
+						if (RDF4J.NIL.equals(contextValue) || SESAME.NIL.equals(contextValue)) {
 							contexts = new Resource[] { (Resource) null };
 						} else {
 							contexts = new Resource[] { (Resource) contextValue };
@@ -545,7 +546,7 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 					int i = 0;
 					for (IRI graph : graphs) {
 						IRI context = null;
-						if (!SESAME.NIL.equals(graph)) {
+						if (!(RDF4J.NIL.equals(graph) || SESAME.NIL.equals(graph))) {
 							context = graph;
 						}
 						contexts[i++] = context;

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/DatasetDeclProcessor.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/DatasetDeclProcessor.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.SESAME;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.impl.SimpleDataset;
@@ -55,7 +55,7 @@ public class DatasetDeclProcessor {
 					ASTIRI astIri = dc.jjtGetChild(ASTIRI.class);
 
 					try {
-						IRI uri = SESAME.NIL;
+						IRI uri = RDF4J.NIL;
 
 						if (astIri != null) {
 							uri = SimpleValueFactory.getInstance().createIRI(astIri.getValue());

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/PrefixDeclProcessor.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/PrefixDeclProcessor.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.model.vocabulary.FN;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -74,6 +75,7 @@ public class PrefixDeclProcessor {
 		// insert some default prefixes (if not explicitly defined in the query)
 		final int defaultPrefixesAdded = insertDefaultPrefix(prefixMap, "rdf", RDF.NAMESPACE)
 				+ insertDefaultPrefix(prefixMap, "rdfs", RDFS.NAMESPACE)
+				+ insertDefaultPrefix(prefixMap, "rdf4j", RDF4J.NAMESPACE)
 				+ insertDefaultPrefix(prefixMap, "sesame", SESAME.NAMESPACE)
 				+ insertDefaultPrefix(prefixMap, "owl", OWL.NAMESPACE)
 				+ insertDefaultPrefix(prefixMap, "xsd", XSD.NAMESPACE)

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -461,7 +462,8 @@ public class SailUpdateExecutor {
 		if (set.isEmpty()) {
 			return new IRI[0];
 		}
-		if (set.remove(SESAME.NIL)) {
+
+		if (set.remove(SESAME.NIL) | set.remove(RDF4J.NIL)) {
 			set.add(null);
 		}
 
@@ -584,7 +586,7 @@ public class SailUpdateExecutor {
 				}
 
 				if (context != null) {
-					if (SESAME.NIL.equals(context)) {
+					if (RDF4J.NIL.equals(context) || SESAME.NIL.equals(context)) {
 						con.removeStatement(uc, subject, predicate, object, (Resource) null);
 					} else {
 						con.removeStatement(uc, subject, predicate, object, context);

--- a/core/spin/src/main/java/org/eclipse/rdf4j/spin/SpinParser.java
+++ b/core/spin/src/main/java/org/eclipse/rdf4j/spin/SpinParser.java
@@ -40,6 +40,7 @@ import org.eclipse.rdf4j.model.vocabulary.AFN;
 import org.eclipse.rdf4j.model.vocabulary.FN;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.model.vocabulary.SP;
@@ -1828,6 +1829,7 @@ public class SpinParser {
 		DataVisitor() {
 			appendPrefix(RDF.PREFIX, RDF.NAMESPACE);
 			appendPrefix(RDFS.PREFIX, RDFS.NAMESPACE);
+			appendPrefix(RDF4J.PREFIX, RDF4J.NAMESPACE);
 			appendPrefix(SESAME.PREFIX, SESAME.NAMESPACE);
 			appendPrefix(OWL.PREFIX, OWL.NAMESPACE);
 			appendPrefix(XSD.PREFIX, XSD.NAMESPACE);

--- a/core/spin/src/test/java/org/eclipse/rdf4j/spin/SpinParserTest.java
+++ b/core/spin/src/test/java/org/eclipse/rdf4j/spin/SpinParserTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.spin;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -23,6 +24,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.evaluation.ModelTripleSource;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.SP;
+import org.eclipse.rdf4j.query.algebra.UpdateExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.parser.ParsedOperation;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
@@ -90,7 +92,10 @@ public class SpinParserTest {
 		if (textParsedOp instanceof ParsedQuery) {
 			assertEquals(((ParsedQuery) textParsedOp).getTupleExpr(), ((ParsedQuery) rdfParsedOp).getTupleExpr());
 		} else {
-			assertEquals(((ParsedUpdate) textParsedOp).getUpdateExprs(), ((ParsedUpdate) rdfParsedOp).getUpdateExprs());
+			List<UpdateExpr> textUpdates = ((ParsedUpdate) textParsedOp).getUpdateExprs();
+			List<UpdateExpr> rdfUpdates = ((ParsedUpdate) rdfParsedOp).getUpdateExprs();
+
+			assertThat(textUpdates).isEqualTo(rdfUpdates);
 		}
 	}
 }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -252,7 +252,7 @@ public abstract class ComplexSPARQLQueryTest {
 		StringBuilder query = new StringBuilder();
 		query.append(getNamespaceDeclarations());
 		query.append(" SELECT * ");
-		query.append(" FROM sesame:nil ");
+		query.append(" FROM rdf4j:nil ");
 		query.append(" WHERE { ?s ?p ?o } ");
 
 		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, query.toString());
@@ -285,7 +285,7 @@ public abstract class ComplexSPARQLQueryTest {
 		StringBuilder query = new StringBuilder();
 		query.append(getNamespaceDeclarations());
 		query.append(" SELECT * ");
-		query.append(" WHERE { GRAPH sesame:nil { ?s ?p ?o } } ");
+		query.append(" WHERE { GRAPH rdf4j:nil { ?s ?p ?o } } ");
 //		query.append(" WHERE { ?s ?p ?o } ");
 
 		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, query.toString());

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateTest.java
@@ -26,8 +26,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -128,7 +128,7 @@ public abstract class SPARQLUpdateTest {
 
 		assertTrue(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF.ALT));
 		assertTrue(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF.BAG));
-		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, SESAME.NIL));
+		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF4J.NIL));
 		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, (Resource) null));
 	}
 
@@ -148,7 +148,7 @@ public abstract class SPARQLUpdateTest {
 
 		assertTrue(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF.ALT));
 		assertTrue(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF.BAG));
-		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, SESAME.NIL));
+		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, RDF4J.NIL));
 		assertFalse(con.hasStatement(RDF.FIRST, RDF.FIRST, RDF.FIRST, true, (Resource) null));
 	}
 

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestInfoServlet.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestInfoServlet.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
-import org.eclipse.rdf4j.model.vocabulary.SESAME;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.repository.manager.RepositoryInfo;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
@@ -52,7 +52,7 @@ public class TestInfoServlet {
 	public final void testSES1770regression() throws Exception {
 		when(manager.hasRepositoryConfig(null)).thenThrow(new NullPointerException());
 		WorkbenchRequest req = mock(WorkbenchRequest.class);
-		when(req.getParameter(anyString())).thenReturn(SESAME.NIL.toString());
+		when(req.getParameter(anyString())).thenReturn(RDF4J.NIL.toString());
 		HttpServletResponse resp = mock(HttpServletResponse.class);
 		when(resp.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
 		servlet.service(req, resp, "");


### PR DESCRIPTION
GitHub issue resolved: #2401  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- introduce new constant `RDF4J.NIL` and marked `SESAME.NIL` deprecated
- updated relevant usage and tests

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

