### PR TITLE
GH-2469 fix assembly plugin config and minor typo in release script

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -74,6 +74,9 @@
 						<goals>
 							<goal>single</goal>
 						</goals>
+						<configuration>
+							<tarLongFileMode>posix</tarLongFileMode>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/release.sh
+++ b/release.sh
@@ -244,5 +244,4 @@ echo " - Post to Google Groups: https://groups.google.com/forum/#!forum/rdf4j-us
 echo "     - Good example: https://groups.google.com/forum/#!topic/rdf4j-users/isrC7qdhplY"
 echo " - Upload the javadocs by adding them to site/static/javadoc/${MVN_VERSION_RELEASE}"
 echo "     - Aggregated javadoc can be found in target/site/apidocs or in the SDK zip file"
-echo "     - Make sure to also replace the site/static/javadoc/latest directory with a copy (don't use a symlink)"
-
+echo "     - Make sure to also replace the site/static/javadoc/latest directory with a copy. Do not use a symlink."


### PR DESCRIPTION
GitHub issue resolved: #2469 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- fixes assembly plugin config to handle long file names 
- minor typo in release script

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

