### PR TITLE
GH-1097 bump guava to version 29.0

### DIFF
--- a/compliance/solr/pom.xml
+++ b/compliance/solr/pom.xml
@@ -67,6 +67,14 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<!-- override managed dependency for backward compatibility with solr test rig -->
+			<version>18.0</version>
+			<!--$NO-MVN-MAN-VER$-->
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<profiles>
 		<profile>

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
 		<servlet.version>3.1.0</servlet.version>
 		<jetty.version>9.4.24.v20191120</jetty.version>
 		<spring.version>5.2.4.RELEASE</spring.version>
-		<guava.version>18.0</guava.version>
+		<guava.version>29.0-jre</guava.version>
 		<jmhVersion>1.21</jmhVersion>
 	</properties>
 	<dependencyManagement>


### PR DESCRIPTION


GitHub issue resolved: #1097 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- update to guava version 29.0
- override managed dependency to allow for solr testing rig

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

