### PR TITLE
GH-2267 fix hardcoded TupleQueryResultFormat in SPARQLRepository

### DIFF
--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/package-info.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/package-info.java
@@ -1,8 +1,8 @@
 /**
- * A repository that serves as a proxy client for a remote repository on an Rdf4j Server.
+ * A repository that serves as a proxy client for a remote repository on an RDF4J Server.
  *
- * Note that this proxy implements a <b>rdf4j-specific extension</b> of the basic SPARQL protocol, and therefore should
- * not be used to communicate with non-Sesame SPARQL endpoints. For such endpoints, use
+ * Note that this proxy implements a <b>RDF4J-specific extension</b> of the basic SPARQL protocol, and therefore should
+ * not be used to communicate with non-RDF4J SPARQL endpoints. For such endpoints, use
  * {@link org.eclipse.rdf4j.repository.sparql.SPARQLRepository} instead.
  */
 package org.eclipse.rdf4j.repository.http;

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepository.java
@@ -19,13 +19,12 @@ import org.eclipse.rdf4j.http.client.SessionManagerDependent;
 import org.eclipse.rdf4j.http.client.SharedHttpClientSessionManager;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.base.AbstractRepository;
 
 /**
- * A proxy class to access any SPARQL endpoint. The instance must be initialized prior to using it.
+ * A proxy class to access any SPARQL 1.1 endpoint.
  *
  * @author James Leigh
  */
@@ -128,16 +127,15 @@ public class SPARQLRepository extends AbstractRepository implements HttpClientDe
 	}
 
 	/**
-	 * Creates a new HTTPClient object. Subclasses may override to return a more specific HTTPClient subtype.
+	 * Creates a new {@link SPARQLProtocolSession} object.
 	 *
-	 * @return a HTTPClient object.
+	 * @return a SPARQLProtocolSession object.
 	 */
 	protected SPARQLProtocolSession createHTTPClient() {
 		// initialize HTTP client
 		SPARQLProtocolSession httpClient = getHttpClientSessionManager().createSPARQLProtocolSession(queryEndpointUrl,
 				updateEndpointUrl);
-		httpClient.setValueFactory(SimpleValueFactory.getInstance());
-		httpClient.setPreferredTupleQueryResultFormat(TupleQueryResultFormat.SPARQL);
+		httpClient.setValueFactory(getValueFactory());
 		httpClient.setAdditionalHttpHeaders(additionalHttpHeaders);
 		if (username != null) {
 			httpClient.setUsernameAndPassword(username, password);

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/package-info.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/package-info.java
@@ -5,9 +5,9 @@
  * Protocol</a> - a means of conveying SPARQL queries and updates to SPARQL processors.
  * </p>
  * <p>
- * Since every rdf4j repository running on a Rdf4j Server is also a SPARQL endpoint, it is possible to use the
+ * Since every RDF4J repository running on a RDf4J Server is also a SPARQL endpoint, it is possible to use the
  * SPARQLRepository to access such a repository. However, it is recommended to instead use
- * {@link org.eclipse.rdf4j.repository.http.HTTPRepository}, which has a number of rdf4j-specific optimizations that
+ * {@link org.eclipse.rdf4j.repository.http.HTTPRepository}, which has a number of RDF4J-specific optimizations that
  * make client-server communication more scalable, and transaction-safe.
  * </p>
  */

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositoryTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositoryTest.java
@@ -1,0 +1,59 @@
+package org.eclipse.rdf4j.repository.sparql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.Executors;
+
+import org.apache.http.client.HttpClient;
+import org.eclipse.rdf4j.http.client.HttpClientSessionManager;
+import org.eclipse.rdf4j.http.client.RDF4JProtocolSession;
+import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SPARQLRepositoryTest {
+
+	String endpointUrl = "http://example.org/sparql";
+	TupleQueryResultFormat customPreferred = TupleQueryResultFormat.CSV;
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testCustomPreferredTupleQueryResultFormat() {
+		SPARQLRepository rep = new SPARQLRepository(endpointUrl);
+		rep.setHttpClientSessionManager(new HttpClientSessionManager() {
+
+			@Override
+			public void shutDown() {
+				// TODO Auto-generated method stub
+
+			}
+
+			@Override
+			public HttpClient getHttpClient() {
+				// TODO Auto-generated method stub
+				return null;
+			}
+
+			@Override
+			public SPARQLProtocolSession createSPARQLProtocolSession(String queryEndpointUrl,
+					String updateEndpointUrl) {
+				SPARQLProtocolSession session = new SPARQLProtocolSession(getHttpClient(),
+						Executors.newSingleThreadExecutor());
+				session.setPreferredTupleQueryResultFormat(customPreferred);
+				return session;
+			}
+
+			@Override
+			public RDF4JProtocolSession createRDF4JProtocolSession(String serverURL) {
+				// TODO Auto-generated method stub
+				return null;
+			}
+		});
+
+		assertThat(rep.createHTTPClient().getPreferredTupleQueryResultFormat()).isEqualTo(customPreferred);
+	}
+}


### PR DESCRIPTION

GitHub issue resolved: #2267 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- fix hardcoded TupleQueryResultFormat in SPARQLRepository
- added regression test
- did some javadoc cleanup while I was at it


---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

