### PR TITLE
GH-2495 add Stardog dialect of SPARQL*/XML results

### DIFF
--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsSAXParser.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsSAXParser.java
@@ -15,10 +15,14 @@ import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstan
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.LITERAL_LANG_ATT;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.LITERAL_TAG;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.OBJECT_TAG;
+import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.O_TAG;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.PREDICATE_TAG;
+import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.P_TAG;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.RESULT_SET_TAG;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.RESULT_TAG;
+import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.STATEMENT_TAG;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.SUBJECT_TAG;
+import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.S_TAG;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.TRIPLE_TAG;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.URI_TAG;
 import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstants.VAR_NAME_ATT;
@@ -110,7 +114,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 			if (currentBindingName == null) {
 				throw new SAXException(BINDING_NAME_ATT + " attribute missing for " + BINDING_TAG + " element");
 			}
-		} else if (TRIPLE_TAG.equals(tagName)) {
+		} else if (TRIPLE_TAG.equals(tagName) || STATEMENT_TAG.equals(tagName)) {
 			tripleStack.push(new TripleContainer());
 		} else if (URI_TAG.equals(tagName)) {
 			try {
@@ -175,6 +179,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 			currentValue = null;
 			break;
 		case SUBJECT_TAG:
+		case S_TAG:
 			currentTriple = tripleStack.peek();
 			if (currentTriple.getSubject() != null) {
 				throw new SAXException("RDF* triple subject defined twice");
@@ -186,6 +191,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 			}
 			break;
 		case PREDICATE_TAG:
+		case P_TAG:
 			currentTriple = tripleStack.peek();
 			if (currentTriple.getPredicate() != null) {
 				throw new SAXException("RDF* triple predicate defined twice");
@@ -197,6 +203,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 			}
 			break;
 		case OBJECT_TAG:
+		case O_TAG:
 			currentTriple = tripleStack.peek();
 			if (currentTriple.getObject() != null) {
 				throw new SAXException("RDF* triple object defined twice");
@@ -204,6 +211,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 			currentTriple.setObject(currentValue);
 			break;
 		case TRIPLE_TAG:
+		case STATEMENT_TAG:
 			currentTriple = tripleStack.pop();
 			currentValue = valueFactory.createTriple(currentTriple.getSubject(), currentTriple.getPredicate(),
 					currentTriple.getObject());

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsXMLConstants.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsXMLConstants.java
@@ -58,8 +58,22 @@ interface SPARQLResultsXMLConstants {
 
 	public static final String QNAME = "q:qname";
 
+	/* tag constants for serialization of RDF* values in results */
+
 	public static final String TRIPLE_TAG = "triple";
+
+	/* Stardog variant */
+	public static final String STATEMENT_TAG = "statement";
+
 	public static final String SUBJECT_TAG = "subject";
+	/* Stardog variant */
+	public static final String S_TAG = "s";
+
 	public static final String PREDICATE_TAG = "predicate";
+	/* Stardog variant */
+	public static final String P_TAG = "p";
+
 	public static final String OBJECT_TAG = "object";
+	/* Stardog variant */
+	public static final String O_TAG = "o";
 }

--- a/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleTest.java
+++ b/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleTest.java
@@ -7,9 +7,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqlxml;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
 import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
+import org.junit.Test;
 
 /**
  * @author Peter Ansell
@@ -29,5 +38,41 @@ public class SPARQLXMLTupleTest extends AbstractQueryResultIOTupleTest {
 	@Override
 	protected BooleanQueryResultFormat getMatchingBooleanFormatOrNull() {
 		return BooleanQueryResultFormat.SPARQL;
+	}
+
+	@Test
+	public void testRDFStar_extendedFormatRDF4J() throws Exception {
+		SPARQLResultsXMLParser parser = new SPARQLResultsXMLParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqlxml/rdfstar-extendedformat-rdf4j.srx");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		assertThat(handler.getBindingNames().size()).isEqualTo(3);
+		assertThat(handler.getBindingSets()).hasSize(1).allMatch(bs -> bs.getValue("a") instanceof Triple);
+		Triple a = (Triple) handler.getBindingSets().get(0).getValue("a");
+		assertThat(a.getSubject().stringValue()).isEqualTo("http://example.org/bob");
+		assertThat(a.getPredicate().stringValue()).isEqualTo("http://xmlns.com/foaf/0.1/age");
+		assertThat(a.getObject().stringValue()).isEqualTo("23");
+	}
+
+	@Test
+	public void testRDFStar_extendedFormatStardog() throws Exception {
+		SPARQLResultsXMLParser parser = new SPARQLResultsXMLParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass().getResourceAsStream("/sparqlxml/rdfstar-extendedformat-stardog.srx");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		assertThat(handler.getBindingNames().size()).isEqualTo(3);
+		assertThat(handler.getBindingSets()).hasSize(1).allMatch(bs -> bs.getValue("a") instanceof Triple);
+		Triple a = (Triple) handler.getBindingSets().get(0).getValue("a");
+		assertThat(a.getSubject().stringValue()).isEqualTo("http://example.org/bob");
+		assertThat(a.getPredicate().stringValue()).isEqualTo("http://xmlns.com/foaf/0.1/age");
+		assertThat(a.getObject().stringValue()).isEqualTo("23");
 	}
 }

--- a/core/queryresultio/sparqlxml/src/test/resources/sparqlxml/rdfstar-extendedformat-rdf4j.srx
+++ b/core/queryresultio/sparqlxml/src/test/resources/sparqlxml/rdfstar-extendedformat-rdf4j.srx
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sparql xmlns='http://www.w3.org/2005/sparql-results#'>
+	<head>
+		<variable name='a'/>
+		<variable name='b'/>
+		<variable name='c'/>
+	</head>
+	<results>
+		<result>
+			<binding name='a'>
+				<triple>
+					<subject>
+						<uri>http://example.org/bob</uri>
+					</subject>
+					<predicate>
+						<uri>http://xmlns.com/foaf/0.1/age</uri>
+					</predicate>
+					<object>
+						<literal datatype='http://www.w3.org/2001/XMLSchema#integer'>23</literal>
+					</object>
+				</triple>
+			</binding>
+			<binding name='b'>
+				<uri>http://example.org/certainty</uri>
+			</binding>
+			<binding name='c'>
+				<literal datatype='http://www.w3.org/2001/XMLSchema#decimal'>0.9</literal>
+			</binding>
+		</result>
+	</results>
+</sparql>

--- a/core/queryresultio/sparqlxml/src/test/resources/sparqlxml/rdfstar-extendedformat-stardog.srx
+++ b/core/queryresultio/sparqlxml/src/test/resources/sparqlxml/rdfstar-extendedformat-stardog.srx
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<sparql xmlns='http://www.w3.org/2005/sparql-results#'>
+	<head>
+		<variable name='a'/>
+		<variable name='b'/>
+		<variable name='c'/>
+	</head>
+	<results>
+		<result>
+			<binding name='a'>
+				<statement>
+					<s>
+						<uri>http://example.org/bob</uri>
+					</s>
+					<p>
+						<uri>http://xmlns.com/foaf/0.1/age</uri>
+					</p>
+					<o>
+						<literal datatype='http://www.w3.org/2001/XMLSchema#integer'>23</literal>
+					</o>
+				</statement>
+			</binding>
+			<binding name='b'>
+				<uri>http://example.org/certainty</uri>
+			</binding>
+			<binding name='c'>
+				<literal datatype='http://www.w3.org/2001/XMLSchema#decimal'>0.9</literal>
+			</binding>
+		</result>
+	</results>
+</sparql>


### PR DESCRIPTION
GitHub issue resolved: #2495 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- SPARQL results xml parser can now deal with Stardog variant of extended format
- added test cases

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

