### PR TITLE
GH-2502 modified SPARQL/JSON parser to deal with Stardog dialect

### DIFF
--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONConstants.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONConstants.java
@@ -70,4 +70,25 @@ final class SPARQLStarResultsJSONConstants {
 	 * Key name of the JSON object for the triple's object.
 	 */
 	static final String OBJECT = "o";
+
+	/**
+	 * Type string for serialized {@link org.eclipse.rdf4j.model.Triple} value - Stardog dialect
+	 */
+	final static String TRIPLE_STARDOG = "statement";
+
+	/**
+	 * Key name of the JSON object for the triple's subject - Apache Jena dialect
+	 */
+	final static String SUBJECT_JENA = "subject";
+
+	/**
+	 * Key name of the JSON object for the triple's predicate - Apache Jena dialect
+	 */
+	final static String PREDICATE_JENA = "predicate";
+
+	/**
+	 * Key name of the JSON object for the triple's object - Apache Jena dialect
+	 */
+	final static String OBJECT_JENA = "object";
+
 }

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -27,6 +28,7 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultIOTupleTest;
 import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
 import org.junit.Test;
@@ -301,6 +303,32 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		assertThat(a.getSubject().stringValue()).isEqualTo("http://example.org/bob");
 		assertThat(a.getPredicate().stringValue()).isEqualTo("http://xmlns.com/foaf/0.1/age");
 		assertThat(a.getObject().stringValue()).isEqualTo("23");
+	}
+
+	@Test
+	public void testRDFStar_extendedFormatRDF4J_incompleteTriple() throws Exception {
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass()
+				.getResourceAsStream("/sparqljson/rdfstar-extendedformat-rdf4j-incompletetriple.srj");
+		assertNotNull("Could not find test resource", stream);
+		assertThatThrownBy(() -> parser.parseQueryResult(stream)).isInstanceOf(QueryResultParseException.class)
+				.hasMessageContaining("Did not find triple attribute in triple value");
+	}
+
+	@Test
+	public void testRDFStar_extendedFormatRDF4J_doubleSubject() throws Exception {
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass()
+				.getResourceAsStream("/sparqljson/rdfstar-extendedformat-rdf4j-doublesubject.srj");
+		assertNotNull("Could not find test resource", stream);
+		assertThatThrownBy(() -> parser.parseQueryResult(stream)).isInstanceOf(QueryResultParseException.class)
+				.hasMessageContaining("s field encountered twice in triple value:");
 	}
 
 	@Test

--- a/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-rdf4j-doublesubject.srj
+++ b/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-rdf4j-doublesubject.srj
@@ -1,0 +1,45 @@
+{
+  "head" : {
+    "vars" : [
+      "a",
+      "b",
+      "c"
+    ]
+  },
+  "results" : {
+    "bindings": [
+      { "a" : {
+          "type" : "triple",
+          "value" : {
+            "s" : {
+              "type" : "uri",
+              "value" : "http://example.org/bob"
+            },
+			"p" : {
+              "type" : "uri",
+              "value" : "http://xmlns.com/foaf/0.1/age"
+            },
+            "s" : {
+              "type" : "uri",
+              "value" : "http://example.org/bob"
+            }
+            "o" : {
+              "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+              "type" : "literal",
+              "value" : "23"
+            } 
+          }
+        },
+        "b": { 
+          "type": "uri",
+          "value": "http://example.org/certainty"
+        },
+        "c" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+          "type" : "literal",
+          "value" : "0.9"
+        }
+      }
+    ]
+  }
+}

--- a/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-rdf4j-incompletetriple.srj
+++ b/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-rdf4j-incompletetriple.srj
@@ -9,19 +9,17 @@
   "results" : {
     "bindings": [
       { "a" : {
-          "type" : "statement",
-          "s" : {
-            "type" : "uri",
-            "value" : "http://example.org/bob"
-          },
-          "p" : {
-            "type" : "uri",
-            "value" : "http://xmlns.com/foaf/0.1/age"
-          },
-          "o" : {
-            "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
-            "type" : "literal",
-            "value" : "23"
+          "type" : "triple",
+          "value" : {
+            "s" : {
+              "type" : "uri",
+              "value" : "http://example.org/bob"
+            },
+            "o" : {
+              "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+              "type" : "literal",
+              "value" : "23"
+            }
           }
         },
         "b": { 


### PR DESCRIPTION
GitHub issue resolved: #2502  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- stardog dialect departs from common pattern by not wrapping subject,  predicate and object of an RDF* triple into a "value" json object.
- parser treats stardog as a separate case.
- added updated test data; all tests now greenline.

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

