### PR TITLE
GH-2489 Indexing and searching over geospatial data using lucene

### DIFF
--- a/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -679,8 +679,15 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 	}
 
 	@Override
-	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty, Shape shape,
+	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty, String wkt,
 			Var contextVar) throws MalformedQueryException, IOException {
+
+		Shape shape = null;
+		try {
+			shape = super.parseQueryShape(SearchFields.getPropertyField(geoProperty), wkt);
+		} catch (ParseException e) {
+			logger.error("error while parsing wkt geometry", e);
+		}
 		ShapeRelation spatialOp = toSpatialOp(relation);
 		if (spatialOp == null) {
 			return null;

--- a/core/sail/lucene-api/pom.xml
+++ b/core/sail/lucene-api/pom.xml
@@ -43,5 +43,10 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-queryparser</artifactId>
+			<version>${lucene.version}</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -82,5 +82,9 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.locationtech.jts</groupId>
+			<artifactId>jts-core</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
+++ b/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
@@ -838,7 +838,7 @@ public class LuceneIndex extends AbstractLuceneIndex {
 		LatLonShape.QueryRelation relation = getRelation(op);
 		if (shape instanceof double[]) {
 			double[] point = (double[]) shape;
-			q = LatLonShape.newBoxQuery(geoField, relation, point[1], point[0], point[1], point[0]);
+			q = LatLonShape.newBoxQuery(geoField, relation, point[1], point[1], point[0], point[0]);
 		} else if (shape instanceof Polygon) {
 			q = LatLonShape.newPolygonQuery(geoField, relation, (Polygon) shape);
 		} else if (shape instanceof Polygon[]) {

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/examples/LuceneSailExample.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/examples/LuceneSailExample.java
@@ -7,9 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene.examples;
 
-import java.io.File;
-import java.io.FileInputStream;
-
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -59,9 +56,6 @@ public class LuceneSailExample {
 		// set this parameter to let the lucene index store its data in ram
 		lucenesail.setParameter(LuceneSail.LUCENE_RAMDIR_KEY, "true");
 		// set this parameter to store the lucene index on disk
-		lucenesail.setParameter(LuceneSail.WKT_FIELDS,
-				"http://nuts.de/geometry https://linkedopendata.eu/prop/direct/P127");
-
 		// lucenesail.setParameter(LuceneSail.LUCENE_DIR_KEY,
 		// "./data/mydirectory");
 
@@ -73,37 +67,47 @@ public class LuceneSailExample {
 		repository.initialize();
 
 		try ( // add some test data, the FOAF ont
-				SailRepositoryConnection connection = repository.getConnection()) {
+			  SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin();
-			connection.add(new FileInputStream(new File("some_dir")),
-					"", RDFFormat.NTRIPLES);
+			connection.add(LuceneSailExample.class.getResourceAsStream("/org/openrdf/sail/lucene/examples/foaf.rdfs"),
+					"", RDFFormat.RDFXML);
 			connection.commit();
 
 			// search for resources that mention "person"
-			// String queryString = "PREFIX geof: <http://www.opengis.net/def/function/geosparql/> PREFIX geo:
-			// <http://www.opengis.net/ont/geosparql#> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX
-			// rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?id WHERE { ?s <http://nuts.de/geometry> ?o . FILTER
-			// (geof:sfWithin(\"Point(-2.7633 47.826)\"^^geo:wktLiteral,?o)) }";
-			// String queryString = "PREFIX geof: <http://www.opengis.net/def/function/geosparql/> PREFIX geo:
-			// <http://www.opengis.net/ont/geosparql#> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX
-			// rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?id WHERE { ?s <http://nuts.de/geometry> ?o . FILTER
-			// (geof:sfContains(?o,\"POINT(33.30260 38.675310)\"^^geo:wktLiteral)) ?s <http://example.com/id> ?id . }";
-			// String queryString = "PREFIX geof: <http://www.opengis.net/def/function/geosparql/> PREFIX geo:
-			// <http://www.opengis.net/ont/geosparql#> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX
-			// rdfs: <http://www.w3.org/2000/01/rdf-schema#> SELECT ?id WHERE { ?s <http://nuts.de/geometry> ?o . FILTER
-			// (geof:sfWithin(\"Point(7.98 45.363)\"^^geo:wktLiteral,?o)) ?s <http://nuts.de/id> ?id . }";
-			String queryString = "SELECT ?s0 where { ?s0 <https://linkedopendata.eu/prop/direct/P127> ?coordinates . FILTER ( <http://www.opengis.net/def/function/geosparql/distance>(\"Point(12.2018 44.4161)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>,?coordinates,<http://www.opengis.net/def/uom/OGC/1.0/metre>)< 100000) .    ?s0 <https://linkedopendata.eu/prop/direct/P35> <https://linkedopendata.eu/entity/Q9934> .}";
-			/*
-			 * String queryString = "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n" +
-			 * "PREFIX geof: <http://www.opengis.net/def/function/geosparql/>\n" +
-			 * "PREFIX uom: <http://www.opengis.net/def/uom/OGC/1.0/>\n" + "PREFIX ex: <http://example.org/>\n" +
-			 * "SELECT *\n" + "WHERE {\n" + "  ?lmA a ex:Landmark ;\n" +
-			 * "       geo:hasGeometry [ geo:asWKT ?coord1 ].\n" + "  ?lmB a ex:Landmark ;\n" +
-			 * "       geo:hasGeometry [ geo:asWKT ?coord2 ].\n" +
-			 * "  BIND((geof:distance(?coord1, ?coord2, uom:metre)/1000) as ?dist) .\n" +
-			 * "  FILTER (str(?lmA) < str(?lmB))\n" + "}";
-			 */
+			String queryString = "PREFIX search:   <" + LuceneSailSchema.NAMESPACE + "> \n"
+					+ "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n" + "SELECT * WHERE { \n"
+					+ "?subject search:matches ?match . \n" + "?match search:query \"person\" ; \n"
+					+ "       search:property ?property ; \n" + "       search:score ?score ; \n"
+					+ "       search:snippet ?snippet . \n" + "?subject rdf:type ?type . \n" + "} LIMIT 3 \n"
+					+ "BINDINGS ?type { \n" + " (<http://www.w3.org/2002/07/owl#Class>) \n" + "}";
 			tupleQuery(queryString, connection);
+
+			// search for property "name" with domain "person"
+			queryString = "PREFIX search: <" + LuceneSailSchema.NAMESPACE + "> \n"
+					+ "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n" + "SELECT * WHERE { \n"
+					+ "?subject rdfs:domain ?domain . \n" + "?subject search:matches ?match . \n"
+					+ "?match search:query \"chat\" ; \n" + "       search:score ?score . \n"
+					+ "?domain search:matches ?match2 . \n" + "?match2 search:query \"person\" ; \n"
+					+ "        search:score ?score2 . \n" + "} LIMIT 5";
+			tupleQuery(queryString, connection);
+
+			// search in subquery and filter results
+			queryString = "PREFIX search:   <" + LuceneSailSchema.NAMESPACE + "> \n" + "SELECT * WHERE { \n"
+					+ "{ SELECT * WHERE { \n" + "  ?subject search:matches ?match . \n"
+					+ "  ?match search:query \"person\" ; \n" + "         search:property ?property ; \n"
+					+ "         search:score ?score ; \n" + "         search:snippet ?snippet . \n" + "} } \n"
+					+ "FILTER(CONTAINS(STR(?subject), \"Person\")) \n" + "} \n" + "";
+			tupleQuery(queryString, connection);
+
+			// search for property "homepage" with domain foaf:Person
+			queryString = "PREFIX search: <" + LuceneSailSchema.NAMESPACE + "> \n"
+					+ "PREFIX foaf: <http://xmlns.com/foaf/0.1/> \n"
+					+ "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n"
+					+ "CONSTRUCT { ?x rdfs:domain foaf:Person } \n" + "WHERE { \n" + "?x rdfs:domain foaf:Person . \n"
+					+ "?x search:matches ?match . \n" + "?match search:query \"homepage\" ; \n"
+					+ "       search:property ?property ; \n" + "       search:score ?score ; \n"
+					+ "       search:snippet ?snippet . \n" + "} LIMIT 3 \n";
+			graphQuery(queryString, connection);
 		} finally {
 			repository.shutDown();
 		}

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/examples/LuceneSailExample.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/examples/LuceneSailExample.java
@@ -67,7 +67,7 @@ public class LuceneSailExample {
 		repository.initialize();
 
 		try ( // add some test data, the FOAF ont
-			  SailRepositoryConnection connection = repository.getConnection()) {
+				SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin();
 			connection.add(LuceneSailExample.class.getResourceAsStream("/org/openrdf/sail/lucene/examples/foaf.rdfs"),
 					"", RDFFormat.RDFXML);

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
@@ -427,13 +427,12 @@ public class SolrIndex extends AbstractSearchIndex {
 	}
 
 	@Override
-	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty, Shape shape,
+	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty, String wkt,
 			Var contextVar) throws MalformedQueryException, IOException {
 		String spatialOp = toSpatialOp(relation);
 		if (spatialOp == null) {
 			return null;
 		}
-		String wkt = toWkt(shape);
 		String qstr = "\"" + spatialOp + "(" + wkt + ")\"";
 		if (contextVar != null) {
 			Resource ctx = (Resource) contextVar.getValue();

--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
 			<dependency>
 				<groupId>org.locationtech.jts</groupId>
 				<artifactId>jts-core</artifactId>
-				<version>1.15.1</version>
+				<version>1.17.1</version>
 			</dependency>
 			<!-- Java Enterprise Edition -->
 			<dependency>


### PR DESCRIPTION
GitHub issue resolved: #2489 

With the current implementation in rdf4j, the lucene index have had some troubles in indexing and searching over geospatial data. After trying some modifications as presented in the issue #2489, no good results came out. So in this pull request the new way to index data introduced by Lucene is integrated and has been tested on very huge geo-shapes, the indexing works much much faster and it doesn't fail at all, adding to that the very fast search capability over such data is attained.


---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

