### PR TITLE
GH-2504 added info on performance impact when using transactions

### DIFF
--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -40,10 +40,12 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 
 /**
- * Main interface for updating data in and performing queries on an RDF4J {@link Repository}. By default, a
- * RepositoryConnection is in auto-commit mode, meaning that each operation corresponds to a single transaction on the
- * underlying store. Multiple operations can be bundled in a single transaction by using {@link #begin()} and
- * {@link #commit() commit}/ {@link #rollback() rollback}. Care should be taking to always properly close a
+ * Main interface for updating data in and performing queries on an RDF4J {@link Repository}.
+ * <p>
+ * By default, a RepositoryConnection is in auto-commit mode, meaning that each operation corresponds to a single
+ * transaction on the underlying store. Multiple operations can be bundled in a single transaction by using
+ * {@link #begin()} and {@link #commit() commit}/ {@link #rollback() rollback}, which may improve performance
+ * considerably when dealing with many thousands of statements. Care should be taking to always properly close a
  * RepositoryConnection after one is finished with it, to free up resources and avoid unnecessary locks.
  * <p>
  * RepositoryConnection is not guaranteed to be thread-safe. The recommended access pattern in a multithreaded

--- a/site/content/documentation/programming/repository.md
+++ b/site/content/documentation/programming/repository.md
@@ -1359,7 +1359,9 @@ try(RepositoryConnection conn = repo.getConnection()) {
 
 So far, we have shown individual operations on repositories: adding statements, removing them, etc. By default, each operation on a `RepositoryConnection` is immediately sent to the store and committed.
 
-The `RepositoryConnection` interface supports a full transactional mechanism that allows one to group modification operations together and treat them as a single update: before the transaction is committed, none of the operations in the transaction has taken effect, and after, they all take effect. If something goes wrong at any point during a transaction, it can be rolled back so that the state of the repository is the same as before the transaction started. Bundling update operations in a single transaction often also improves update performance compared to multiple smaller transactions.
+The `RepositoryConnection` interface supports a full transactional mechanism that allows one to group modification operations together and treat them as a single update: before the transaction is committed, none of the operations in the transaction has taken effect, and after, they all take effect. If something goes wrong at any point during a transaction, it can be rolled back so that the state of the repository is the same as before the transaction started.
+
+Bundling update operations in a single transaction often also improves update performance compared to multiple smaller transactions. This may not be noticeable when adding a few thousand statements, but it can make a big difference when loading millions of statements into a repository.
 
 We can indicate that we want to begin a transaction by using the `RepositoryConnection.begin()` method. In the following example, we use a connection to bundle two file addition operations in a single transaction:
 


### PR DESCRIPTION
GitHub issue resolved: #2504 
Briefly describe the changes proposed in this PR:

Documentation changes only: made it somewhat more explicit that using transactions can improve performance

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

