### PR TITLE
Fix protection branch action hook by using 'build' as job name

### DIFF
--- a/.github/workflows/develop-status.yml
+++ b/.github/workflows/develop-status.yml
@@ -6,7 +6,7 @@ on:
       - develop
 
 jobs:
-  verify:
+  build:
 
     runs-on: ubuntu-latest    
     strategy:

--- a/.github/workflows/master-status.yml
+++ b/.github/workflows/master-status.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  verify:
+  build:
 
     runs-on: ubuntu-latest    
     strategy:


### PR DESCRIPTION
This is an attempt to fix current master-to-develop being stuck by the expedient of just renaming the status check jobs, so that they're aligned with the name of the required check as configured in the branch protection. 

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

