### PR TITLE
GH-2526 handle stardog RDF* optional graph element

### DIFF
--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONParser.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONParser.java
@@ -91,7 +91,7 @@ public class SPARQLResultsJSONParser extends AbstractSPARQLJSONParser implements
 	protected Triple parseTripleValue(JsonParser jp, String fieldName) throws IOException {
 		Value subject = null, predicate = null, object = null;
 
-		while (subject == null || predicate == null || object == null) {
+		while (jp.nextToken() != JsonToken.END_OBJECT) {
 			if (jp.getCurrentToken() != JsonToken.FIELD_NAME) {
 				throw new QueryResultParseException("Did not find triple attribute in triple value",
 						jp.getCurrentLocation().getLineNr(),
@@ -106,9 +106,6 @@ public class SPARQLResultsJSONParser extends AbstractSPARQLJSONParser implements
 							jp.getCurrentLocation().getColumnNr());
 				}
 				subject = parseValue(jp, fieldName + ":" + posName);
-				if (predicate == null || object == null) {
-					jp.nextToken();
-				}
 			} else if (PREDICATE.equals(posName) || PREDICATE_JENA.equals(posName)) {
 				if (predicate != null) {
 					throw new QueryResultParseException(
@@ -117,9 +114,6 @@ public class SPARQLResultsJSONParser extends AbstractSPARQLJSONParser implements
 							jp.getCurrentLocation().getColumnNr());
 				}
 				predicate = parseValue(jp, fieldName + ":" + posName);
-				if (subject == null || object == null) {
-					jp.nextToken();
-				}
 			} else if (OBJECT.equals(posName) || OBJECT_JENA.equals(posName)) {
 				if (object != null) {
 					throw new QueryResultParseException(
@@ -128,9 +122,9 @@ public class SPARQLResultsJSONParser extends AbstractSPARQLJSONParser implements
 							jp.getCurrentLocation().getColumnNr());
 				}
 				object = parseValue(jp, fieldName + ":" + posName);
-				if (predicate == null || subject == null) {
-					jp.nextToken();
-				}
+			} else if ("g".equals(posName)) {
+				// silently ignore named graph field in Stardog dialect
+				parseValue(jp, fieldName + ":" + posName);
 			} else {
 				throw new QueryResultParseException("Unexpected field name in triple value: " + posName,
 						jp.getCurrentLocation().getLineNr(),

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
@@ -315,7 +315,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 				.getResourceAsStream("/sparqljson/rdfstar-extendedformat-rdf4j-incompletetriple.srj");
 		assertNotNull("Could not find test resource", stream);
 		assertThatThrownBy(() -> parser.parseQueryResult(stream)).isInstanceOf(QueryResultParseException.class)
-				.hasMessageContaining("Did not find triple attribute in triple value");
+				.hasMessageContaining("Incomplete or invalid triple value");
 	}
 
 	@Test
@@ -338,6 +338,25 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/rdfstar-extendedformat-stardog.srj");
+		assertNotNull("Could not find test resource", stream);
+		parser.parseQueryResult(stream);
+
+		assertThat(handler.getBindingNames().size()).isEqualTo(3);
+		assertThat(handler.getBindingSets()).hasSize(1).allMatch(bs -> bs.getValue("a") instanceof Triple);
+		Triple a = (Triple) handler.getBindingSets().get(0).getValue("a");
+		assertThat(a.getSubject().stringValue()).isEqualTo("http://example.org/bob");
+		assertThat(a.getPredicate().stringValue()).isEqualTo("http://xmlns.com/foaf/0.1/age");
+		assertThat(a.getObject().stringValue()).isEqualTo("23");
+	}
+
+	@Test
+	public void testRDFStar_extendedFormatStardog_NamedGraph() throws Exception {
+		SPARQLResultsJSONParser parser = new SPARQLResultsJSONParser(SimpleValueFactory.getInstance());
+		QueryResultCollector handler = new QueryResultCollector();
+		parser.setQueryResultHandler(handler);
+
+		InputStream stream = this.getClass()
+				.getResourceAsStream("/sparqljson/rdfstar-extendedformat-stardog-namedgraph.srj");
 		assertNotNull("Could not find test resource", stream);
 		parser.parseQueryResult(stream);
 

--- a/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-stardog-namedgraph.srj
+++ b/core/queryresultio/sparqljson/src/test/resources/sparqljson/rdfstar-extendedformat-stardog-namedgraph.srj
@@ -1,0 +1,43 @@
+{
+  "head" : {
+    "vars" : [
+      "a",
+      "b",
+      "c"
+    ]
+  },
+  "results" : {
+    "bindings": [
+      { "a" : {
+          "type" : "statement",
+          "s" : {
+            "type" : "uri",
+            "value" : "http://example.org/bob"
+          },
+          "p" : {
+            "type" : "uri",
+            "value" : "http://xmlns.com/foaf/0.1/age"
+          },
+          "o" : {
+            "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+            "type" : "literal",
+            "value" : "23"
+          },
+          "g": {
+            "type": "uri",
+            "value": "urn:rdfstar"
+          }
+        },
+        "b": { 
+          "type": "uri",
+          "value": "http://example.org/certainty"
+        },
+        "c" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+          "type" : "literal",
+          "value" : "0.9"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION



GitHub issue resolved: #2526   <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- silently read away optional graph element of embedded triple.
- treating Stardog as a completely separate case for easy of debugging
- hopefully we can just remove this code completely once the format has
  had some standardization

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

