### PR TITLE
GH-2511 allow regular Turtle parser to process RDF*

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
@@ -28,4 +28,18 @@ public class TurtleParserSettings {
 			"org.eclipse.rdf4j.rio.turtle.case_insensitive_directives",
 			"Allows case-insensitive directives to be recognised", Boolean.FALSE);
 
+	/**
+	 * Allows the regular Turtle parser to accept data using the non-standard Turtle* extension.
+	 * <p>
+	 * Defaults to true.
+	 * <p>
+	 * This setting has no effect on the behavior of the TurtleStarParser.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.turtle.accept_turtlestar}.
+	 */
+	public static final RioSetting<Boolean> ACCEPT_TURTLESTAR = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.turtle.accept_turtlestar",
+			"Allow processing of Turtle* data by the standard Turtle parser",
+			Boolean.TRUE);
+
 }

--- a/core/rio/trig/pom.xml
+++ b/core/rio/trig/pom.xml
@@ -56,5 +56,10 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trig;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -194,7 +195,7 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		assertEquals(13, Rio.createParser(RDFFormat.TRIG).getSupportedSettings().size());
+		assertThat(Rio.createParser(RDFFormat.TRIG).getSupportedSettings()).hasSize(14);
 	}
 
 	@Test

--- a/core/rio/turtle/pom.xml
+++ b/core/rio/turtle/pom.xml
@@ -61,5 +61,10 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -104,6 +104,7 @@ public class TurtleParser extends AbstractRDFParser {
 	public Collection<RioSetting<?>> getSupportedSettings() {
 		Set<RioSetting<?>> result = new HashSet<>(super.getSupportedSettings());
 		result.add(TurtleParserSettings.CASE_INSENSITIVE_DIRECTIVES);
+		result.add(TurtleParserSettings.ACCEPT_TURTLESTAR);
 		return result;
 	}
 
@@ -568,6 +569,10 @@ public class TurtleParser extends AbstractRDFParser {
 	 * Parses an RDF value. This method parses uriref, qname, node ID, quoted literal, integer, double and boolean.
 	 */
 	protected Value parseValue() throws IOException, RDFParseException, RDFHandlerException {
+		if (getParserConfig().get(TurtleParserSettings.ACCEPT_TURTLESTAR) && peekIsTripleValue()) {
+			return parseTripleValue();
+		}
+
 		int c = peekCodePoint();
 
 		if (c == '<') {

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParser.java
@@ -49,7 +49,6 @@ public class TurtleStarParser extends TurtleParser {
 		if (peekIsTripleValue()) {
 			return parseTripleValue();
 		}
-
 		return super.parseValue();
 	}
 }

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -22,9 +23,8 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.model.impl.NamespaceImpl;
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.impl.ValueFactoryImpl;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
@@ -41,6 +41,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Custom tests for Turtle Parser
@@ -62,12 +64,14 @@ public class CustomTurtleParserTest {
 
 	private StatementCollector statementCollector;
 
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+
 	/**
 	 * @throws java.lang.Exception
 	 */
 	@Before
 	public void setUp() throws Exception {
-		vf = ValueFactoryImpl.getInstance();
+		vf = SimpleValueFactory.getInstance();
 		settingsNoVerifyLangTag = new ParserConfig();
 		settingsNoVerifyLangTag.set(BasicParserSettings.VERIFY_LANGUAGE_TAGS, false);
 		errors = new ParseErrorCollector();
@@ -175,15 +179,13 @@ public class CustomTurtleParserTest {
 
 		String str = out.toString();
 
-		System.err.println(str);
-
 		assertTrue("okLiteralString not found", str.contains(okLiteralString));
 		assertTrue("errLiteralString not found", str.contains(errLiteralString));
 	}
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		assertEquals(13, parser.getSupportedSettings().size());
+		assertThat(parser.getSupportedSettings()).hasSize(14);
 	}
 
 	@Test
@@ -242,7 +244,7 @@ public class CustomTurtleParserTest {
 		Model model = Rio.parse(new StringReader("<urn:a> a _:c2; a <urn:b> ."), "", RDFFormat.TURTLE);
 
 		assertEquals(2, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), RDF.TYPE, vf.createURI("urn:b")));
+		assertTrue(model.contains(vf.createIRI("urn:a"), RDF.TYPE, vf.createIRI("urn:b")));
 	}
 
 	@Test
@@ -250,7 +252,7 @@ public class CustomTurtleParserTest {
 		Model model = Rio.parse(new StringReader("<urn:a> a _:c2;a <urn:b> ."), "", RDFFormat.TURTLE);
 
 		assertEquals(2, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), RDF.TYPE, vf.createURI("urn:b")));
+		assertTrue(model.contains(vf.createIRI("urn:a"), RDF.TYPE, vf.createIRI("urn:b")));
 	}
 
 	@Test
@@ -294,7 +296,7 @@ public class CustomTurtleParserTest {
 					"", RDFFormat.TURTLE);
 			fail("Did not receive an exception");
 		} catch (RDFParseException e) {
-			System.out.println(e.getMessage());
+			logger.debug(e.getMessage(), e);
 			assertTrue(e.getMessage().contains("Object for statement missing"));
 		}
 	}
@@ -307,7 +309,7 @@ public class CustomTurtleParserTest {
 					"", RDFFormat.TURTLE);
 			fail("Did not receive an exception");
 		} catch (RDFParseException e) {
-			System.out.println(e.getMessage());
+			logger.debug(e.getMessage(), e);
 			assertTrue(e.getMessage()
 					.contains("Illegal predicate value: \"\"^^<http://www.w3.org/2001/XMLSchema#integer>"));
 		}
@@ -321,7 +323,7 @@ public class CustomTurtleParserTest {
 					"", RDFFormat.TURTLE);
 			fail("Did not receive an exception");
 		} catch (RDFParseException e) {
-			System.out.println(e.getMessage());
+			logger.debug(e.getMessage(), e);
 			assertTrue(e.getMessage().contains("Expected an RDF value here, found ';'"));
 		}
 	}
@@ -334,7 +336,7 @@ public class CustomTurtleParserTest {
 					"", RDFFormat.TURTLE);
 			fail("Did not receive an exception");
 		} catch (RDFParseException e) {
-			System.out.println(e.getMessage());
+			logger.debug(e.getMessage(), e);
 			assertTrue(e.getMessage().contains("Expected an RDF value here, found ';'"));
 		}
 	}
@@ -394,7 +396,7 @@ public class CustomTurtleParserTest {
 		Model model = Rio.parse(new StringReader("<urn:a> skos:broader <urn:b>."), "", RDFFormat.TURTLE);
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), SKOS.BROADER, vf.createURI("urn:b")));
+		assertTrue(model.contains(vf.createIRI("urn:a"), SKOS.BROADER, vf.createIRI("urn:b")));
 	}
 
 	@Test
@@ -402,13 +404,13 @@ public class CustomTurtleParserTest {
 		ParserConfig aConfig = new ParserConfig();
 
 		aConfig.set(BasicParserSettings.NAMESPACES,
-				Collections.<Namespace>singleton(new NamespaceImpl("foo", SKOS.NAMESPACE)));
+				Collections.<Namespace>singleton(new SimpleNamespace("foo", SKOS.NAMESPACE)));
 
 		Model model = Rio.parse(new StringReader("<urn:a> foo:broader <urn:b>."), "", RDFFormat.TURTLE, aConfig, vf,
 				new ParseErrorLogger());
 
 		assertEquals(1, model.size());
-		assertTrue(model.contains(vf.createURI("urn:a"), SKOS.BROADER, vf.createURI("urn:b")));
+		assertTrue(model.contains(vf.createIRI("urn:a"), SKOS.BROADER, vf.createIRI("urn:b")));
 	}
 
 	@Test
@@ -416,7 +418,7 @@ public class CustomTurtleParserTest {
 		ParserConfig aConfig = new ParserConfig();
 
 		aConfig.set(BasicParserSettings.NAMESPACES,
-				Collections.<Namespace>singleton(new NamespaceImpl("foo", SKOS.NAMESPACE)));
+				Collections.<Namespace>singleton(new SimpleNamespace("foo", SKOS.NAMESPACE)));
 
 		Model model = Rio.parse(new StringReader("@prefix skos : <urn:not_skos:> ." + "<urn:a> skos:broader <urn:b>."),
 				"", RDFFormat.TURTLE, aConfig, vf, new ParseErrorLogger());

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.eclipse.rdf4j.rio.helpers.TurtleParserSettings;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -102,6 +103,17 @@ public class TurtleStarParserTest {
 			assertTrue(stmts.contains(vf.createStatement(bookTitleEn, DCTERMS.SOURCE, bobshomepage)));
 			assertTrue(stmts.contains(vf.createStatement(bookTitleDe, DCTERMS.SOURCE, bobshomepage)));
 			assertTrue(stmts.contains(vf.createStatement(bookTitleEnUs, DCTERMS.SOURCE, bobshomepage)));
+		}
+	}
+
+	@Test
+	public void testParseRDFStar_TurtleStarDisabled() throws IOException {
+		parser.getParserConfig().set(TurtleParserSettings.ACCEPT_TURTLESTAR, false);
+
+		try (InputStream in = this.getClass().getResourceAsStream("/test-rdfstar.ttls")) {
+			parser.parse(in, baseURI);
+		} catch (RDFParseException e) {
+			fail("parser setting should have no influence on TurtleStarParser handling of RDF* data");
 		}
 	}
 


### PR DESCRIPTION


GitHub issue resolved: #2511 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- regular turtle parser accepts Turtle* (to handle cases where endpoints send it on the normal Turtle MIME-type)
- can be configured to _not_ accept RDF* data when needed (e.g. for validation)


---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

