### PR TITLE
GH-2520 replace all usage of old domain name

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/package-info.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/package-info.java
@@ -24,6 +24,6 @@
  * by means of a {@link org.eclipse.rdf4j.model.ValueFactory ValueFactory}.
  * </p>
  *
- * @see <a href="https://rdf4j.eclipse.org/documentation/programming/model/">rdf4j model documentation</a>
+ * @see <a href="https://rdf4j.org/documentation/programming/model/">RDF4J model documentation</a>
  */
 package org.eclipse.rdf4j.model;

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/package-info.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/package-info.java
@@ -8,6 +8,6 @@
  * An important notion in a rdf4j repository is that of <strong>context</strong> . Within one repository, subsets of
  * statements can be identified by their context.
  *
- * @see <a href="https://rdf4j.eclipse.org/documentation/programming/repository/">rdf4j repository API documentation</a>
+ * @see <a href="https://rdf4j.org/documentation/programming/repository/">rdf4j repository API documentation</a>
  */
 package org.eclipse.rdf4j.repository;

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/package-info.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/package-info.java
@@ -1,9 +1,9 @@
 /**
- * Rio: The rdf4j parser/writer API.
+ * Rio: The RDF4J parser/writer API.
  *
  * The Rio parser/writer toolkit provides support for all major RDF syntax formats, including RDF/XML, Turtle,
  * N-Triples, N-Quads, TriG, and TriX.
  *
- * @see <a href="https://rdf4j.eclipse.org/documentation/programming/rio/">the Rio documentation</a>
+ * @see <a href="https://rdf4j.org/documentation/programming/rio/">the Rio documentation</a>
  */
 package org.eclipse.rdf4j.rio;

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/package-info.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Parser/writer for the <a href="https://rdf4j.eclipse.org/documentation/rdf4j-binary/">rdf4j binary RDF format</a>.
+ * Parser/writer for the <a href="https://rdf4j.org/documentation/reference/rdf4j-binary/">RDF4J binary RDF format</a>.
  */
 package org.eclipse.rdf4j.rio.binary;

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/package-info.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/package-info.java
@@ -1,5 +1,4 @@
 /**
- * Core classes and interfaces for the
- * <a href="https://rdf4j.eclipse.org/documentation/sparqlbuilder/">SPARQLBuilder</a>.
+ * Core classes and interfaces for the <a href="https://rdf4j.org/documentation/sparqlbuilder/">SPARQLBuilder</a>.
  */
 package org.eclipse.rdf4j.sparqlbuilder.core;

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>pom</packaging>
 	<name>Eclipse RDF4J</name>
 	<description>An extensible Java framework for RDF and SPARQL</description>
-	<url>https://rdf4j.eclipse.org/</url>
+	<url>https://rdf4j.org/</url>
 	<inceptionYear>2015</inceptionYear>
 	<organization>
 		<name>Eclipse Foundation</name>
@@ -17,7 +17,7 @@
 		<developer>
 			<id>jeenbroekstra</id>
 			<name>Jeen Broekstra</name>
-			<email>jeen.broekstra@gmail.com</email>
+			<email>jeen@fastmail.com</email>
 			<timezone>GMT+10</timezone>
 		</developer>
 		<developer>


### PR DESCRIPTION
GitHub issue resolved: #2520 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- obsolete rdf4j.eclipse.org project url replaced with rdf4j.org

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

