### PR TITLE
GH-2561 fix ordering of tuples that have different lengths

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Tuple.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Tuple.java
@@ -147,7 +147,7 @@ public class Tuple implements Comparable<Tuple> {
 
 		}
 
-		return 0;
+		return line.size() - o.line.size();
 	}
 
 	public String getCause() {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/OrderingTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/OrderingTest.java
@@ -9,10 +9,12 @@
 package org.eclipse.rdf4j.sail.shacl;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -28,6 +30,7 @@ import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.sail.shacl.AST.ShaclProperties;
 import org.eclipse.rdf4j.sail.shacl.mock.MockConsumePlanNode;
+import org.eclipse.rdf4j.sail.shacl.mock.MockInputPlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.InnerJoin;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
@@ -151,6 +154,11 @@ public class OrderingTest {
 					Arrays.asList(target5.toString(), target5.toString()));
 
 		}
+	}
+
+	@Test
+	public void testComparableTuplesDifferentLength() {
+		assertThat(new Tuple(RDF.FIRST)).isLessThan(new Tuple(RDF.FIRST, RDF.REST));
 	}
 
 	public void verify(List<Tuple> actual, List<String>... expect) {


### PR DESCRIPTION

GitHub issue resolved: #2561 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

Short tuples are smaller than longer tuples if otherwise equal.

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

