### PR TITLE
GH-2577 shacl subclassof in shapes graph

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/RdfsSubClassOfReasoner.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/RdfsSubClassOfReasoner.java
@@ -22,7 +22,9 @@ import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Statements;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,8 +39,8 @@ public class RdfsSubClassOfReasoner {
 
 	private static final Logger logger = LoggerFactory.getLogger(RdfsSubClassOfReasoner.class);
 
-	private final Collection<Statement> subClassOfStatements = new ArrayList<>();
-	private final Collection<Resource> types = new ArrayList<>();
+	private final Collection<Statement> subClassOfStatements = new HashSet<>();
+	private final Collection<Resource> types = new HashSet<>();
 
 	private final Map<Resource, Set<Resource>> forwardChainCache = new HashMap<>();
 	private final Map<Resource, Set<Resource>> backwardsChainCache = new HashMap<>();
@@ -71,7 +73,7 @@ public class RdfsSubClassOfReasoner {
 	}
 
 	private void addSubClassOfStatement(Statement st) {
-		subClassOfStatements.add(st);
+		subClassOfStatements.add(Statements.stripContext(st));
 		types.add(st.getSubject());
 		types.add((Resource) st.getObject());
 	}
@@ -153,6 +155,12 @@ public class RdfsSubClassOfReasoner {
 		RdfsSubClassOfReasoner rdfsSubClassOfReasoner = new RdfsSubClassOfReasoner();
 
 		try (Stream<? extends Statement> stream = shaclSailConnection.getStatements(null, RDFS.SUBCLASSOF, null, false)
+				.stream()) {
+			stream.forEach(rdfsSubClassOfReasoner::addSubClassOfStatement);
+		}
+
+		try (Stream<? extends Statement> stream = shaclSailConnection
+				.getStatements(null, RDFS.SUBCLASSOF, null, false, RDF4J.SHACL_SHAPE_GRAPH)
 				.stream()) {
 			stream.forEach(rdfsSubClassOfReasoner::addSubClassOfStatement);
 		}

--- a/core/sail/shacl/src/test/resources/test-cases/class/subclass/invalid/case6/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/class/subclass/invalid/case6/query1.rq
@@ -1,0 +1,13 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 a ex:CustomCustomPerson ;
+	ex:knows ex:peter.
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/class/subclass/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/class/subclass/shacl.ttl
@@ -14,3 +14,5 @@ ex:PersonShape
 		sh:class ex:Person ;
 	] .
 
+ex:CustomPerson rdfs:subClassOf ex:Person.
+ex:CustomCustomPerson rdfs:subClassOf ex:CustomPerson.

--- a/core/sail/shacl/src/test/resources/test-cases/class/subclass/valid/case6/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/class/subclass/valid/case6/query1.rq
@@ -1,0 +1,28 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 a ex:Person ;
+	ex:knows ex:peter.
+
+ex:peter a ex:CustomCustomPerson.
+
+ex:validPerson2 a ex:CustomPerson ;
+	ex:knows ex:steve.
+
+ex:steve a ex:CustomCustomPerson.
+
+
+ex:validPerson2 a ex:Person ;
+	ex:knows ex:rebecca.
+
+ex:rebecca a ex:DataSubClassPerson.
+
+
+ex:DataSubClassPerson rdfs:subClassOf ex:Person.
+}

--- a/core/sail/shacl/src/test/resources/test-cases/class/subclass/valid/case6/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/class/subclass/valid/case6/query2.rq
@@ -7,9 +7,9 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 INSERT DATA {
 
-ex:validPerson1 a ex:Person ;
-	ex:knows ex:peter.
+ex:validPerson2 a ex:CustomPerson ;
+	ex:knows ex:steve.
 
-ex:peter a ex:CustomCustomPerson.
+ex:steve a ex:CustomCustomPerson.
 
 }

--- a/core/sail/shacl/src/test/resources/test-cases/class/subclass/valid/case6/query3.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/class/subclass/valid/case6/query3.rq
@@ -7,9 +7,11 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 INSERT DATA {
 
-ex:validPerson1 a ex:Person ;
-	ex:knows ex:peter.
+ex:validPerson3 a ex:Person ;
+	ex:knows ex:rebecca.
 
-ex:peter a ex:CustomCustomPerson.
+ex:rebecca a ex:DataSubClassPerson.
+
+ex:DataSubClassPerson rdfs:subClassOf ex:Person.
 
 }


### PR DESCRIPTION
GitHub issue resolved: #2577 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Retrieve `rdfs:subClassOf` statements fro the shapes graph too.

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

