### PR TITLE
GH-2011 back to merge-commits as our preferred strategy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,14 +5,13 @@ Briefly describe the changes proposed in this PR:
 
 <!-- short description of your change goes here -->
 
----- 
+----
 PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):
 
  - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
  - [ ] I've added tests for the changes I made
  - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
+ - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
  - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
  - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)
-
-Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.
 

--- a/site/content/documentation/developer/merge-strategy.md
+++ b/site/content/documentation/developer/merge-strategy.md
@@ -3,10 +3,26 @@ title: "RDF4J merge strategy"
 toc: true
 ---
 
-RDF4J values a clean, linear commit history on our main branches. To achieve this, we default to using [Squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits) as our merge strategy for all new features, improvements, or bug fixes.
+RDF4J values a clean but accurate commit history on our main branches, where
+commits are meaningfully described and linked back to the issue that they
+address. To achieve this, we merge everything using merge-commits, and we may
+ask you to [squash](/documentation/developer/squashing) your pull request branch before we
+merge it.
+
 <!--more-->
 
-See also: [developer workflow](/documentation/developer/workflow/)
+We use merge-commits exclusively to merge pull requests into our main branches
+as this preserves the history of changes and who made those changes accurately.
+You as a contributor are completely free to use rebasing, squashing or merge on
+your own branches as you see fit, of course.
+
+Note: we previously experimented with using 'squash-and-merge' as our Pull
+Request strategy. The advantage of this was that it kept the main branch
+history nicely linear, and automatically squashes all changes in a Pull Request
+into a single commit. However, squash-and-merge sometimes overwrites the Author
+field of a commit, which introduces problems in terms of IP provenance. For
+that reason, we have decided to switch back to a simpler 'merge-commit'
+strategy. See also [Github issue 2011](https://github.com/eclipse/rdf4j/issues/2011).
 
 ## Self-contained changes, pull requests, and commits
 
@@ -17,9 +33,8 @@ We expect every pull request to be a self-contained change. Note that that does
 not mean that a pull request can only contain a single commit: it can have
 several commits that together form a self-contained change.
 
-If a pull request is properly self-contained, merging it using squash and merge
-will result in a single, self-contained commit on the main branch that
-completely addresses a single issue.
+We do, however, prefer fewer commits before merging, so if you have created a
+long list of commits on our branch, we may ask you to [squash](/documentation/developer/squashing) it first.
 
 ### Commit messages
 
@@ -38,55 +53,13 @@ Examples of poor commit messages:
 - "GH-666 typo"
 - "GH-1234 fixed the problem"
 
-You may ask why we bother with this when we're going to squash everything into
-a single commit anyway. We still prefer meaningful commits because:
+We prefer meaningful commits because:
 
 - it makes reviewing the pull request easier;
-- in a squash and merge, each individual commit message is added as a bullet
-  list point in the description, so it is helpful if it is meaningful even
-  after squashing.
+- after your PR has been merged, your commit messages become part of the main branch's history, and having each commit linked to an issue and meaningfully described makes it easier to figure what got changed where and why.
 
 That said, if occassionally a less "perfect" commit message slips through, that's
 fine. We're all human.
 
 And oh yeah: don't forget to [sign off your commits](/documentation/developer/workflow/#patch-requests)!
-
-## Motivation
-
-We use squash and merge because we value a clean, linear history over a more
-detailed, accurate history for our main branches. There are several reasons we
-value this:
-
-1. it makes the history tree easier to read, with no "branch spaghetti"
-2. it makes it more obvious what feature a particular change relates to when
-   using blame or bisect tools. Because changes are self-contained, every
-   commit on the main branch relates to a single feature or fix, and the
-   context of any particular line changed as part of that is immediately
-   obvious.
-
-A common objection is that using squash and merge, you lose the (potentially
-valuable) information the individual commits gave you. This is not quite true:
-Github preserves the original commit history on the (closed) pull request page.
-Since the squash and merge commit message refers back to this pull request
-with a number, it can be easily found back even years later.
-
-For an excellent in-depth discussion of the advantages of using squash and
-merge, we recommend reading this blog article: [Two Years of squash
-merge](https://blog.dnsimple.com/2019/01/two-years-of-squash-merge/).
-
-## Exceptions
-
-There is one standard exception to the rule: pull requests that involve
-bringing our main branches (`master` and `develop`) in sync with each other use
-a merge commit. The main reason for this is that here, it is more important to
-track progression through time accurately, and we do want to preserve
-individual commits.
-
-In very rare cases, by exception, we allow a feature pull request to be merged
-using a merge commit. This will only be done if the following conditions are
-all met:
-
-1. the author explicitly comments on the pull request that this is necessary (and why), and;
-2. the author can show that the PR has been rebased (not merged!) so that the result of the merge will be near-linear, and;
-3. the project lead has given explicit approval of the intent to use a merge commit.
 

--- a/site/content/documentation/developer/squashing.md
+++ b/site/content/documentation/developer/squashing.md
@@ -8,13 +8,13 @@ When submitting a pull request to RDF4J, we sometimes ask that you squash your c
 On the command line, the process is as follows:
 
 1. Make sure your local _master_ and _develop_ branches are up to date with the upstream.
-2. Check out your pull request branch. 
-3. Run `git rebase -i master --signoff` (or `git rebase -i develop --signoff` if your branch started from the _develop_ branch).  
+2. Check out your pull request branch.
+3. Run `git rebase -i master --signoff` (or `git rebase -i develop --signoff` if your branch started from the _develop_ branch).
    The `--signoff` flag here makes sure that the new commit produced by the squash operation is correctly signed off.
    You should see a list of commits, each commit starting with the word `pick`.
-   Make sure the first commit says "pick" and change the rest from "pick" to "squash". 
+   Make sure the first commit says "pick" and change the rest from "pick" to "squash".
 4. Save and close the editor.
-   It will give you the opportunity to change the commit message. 
+   It will give you the opportunity to change the commit message. This is where you make sure the message is meaningful and starts with the issue number.
 5. Save and close the editor again.
-   Then you have to force push the final, squashed commit: `git push --force-with-lease origin`.
+   Then you have to force-push the final, squashed commit: `git push --force-with-lease origin`.
 

--- a/site/content/documentation/developer/workflow.md
+++ b/site/content/documentation/developer/workflow.md
@@ -63,9 +63,10 @@ will always be possible to merge your issue branch into `develop` later if
 necessary. However, if you start from `develop`, merging into `master` will not
 be possible, and you're therefore committed to the next minor/major release.
 
-RDF4J uses 'squash and merge' as its pull request merge strategy, to preserve a
-clean history. Read more about our strategy and the motivation for in this
-article: [RDF4J merge strategy](/documentation/developer/merge-strategy/).
+RDF4J uses 'merge-commits' as its pull request merge strategy. We aim to
+achieve a clean but accurate history. Read more about our strategy and the
+motivation for it in this article: [RDF4J merge
+strategy](/documentation/developer/merge-strategy/).
 
 ### Patch Requests
 
@@ -80,10 +81,9 @@ If the change is a bug fix, contains no new features, and does not change any pu
 5. Any modifications can be made to the _issue_ branch as recommended.
 6. Once any necessary changes have been made, project committers can mark the PR as approved.
 7. Project committers should then determine what patch release this fix will be included in by updating the milestone label of both the PR and the issue.
-8. Once a Pull Request is approved and scheduled, it can be merged into the `master` branch, using 'squash and merge'.
+8. Once a Pull Request is approved and scheduled, it can be merged into the `master` branch.
 9. After a PR has been merged into the `master` branch, the `master` branch should
-then be merged into the `develop` branch by the project committer that merged the PR,
-any conflicts (such as due to new features) should be resolved. This merge should happen using a merge-commit.
+then be merged into the `develop` branch by the project committer that merged the PR, any conflicts (such as due to new features) should be resolved.
 
 ### Feature Requests
 
@@ -95,7 +95,7 @@ should be merged into the `develop` branch.
 Project committers that are contributing to a branch should periodically
 pull changes from the `develop` branch (by either rebasing or merging) to minimize conflicts later on.
 Once a feature is complete a PR should be created using the feature branch and target the `develop` branch.
-Then follow similar steps to a patch request to schedule and merge into `develop`, using 'squash and merge'.
+Then follow similar steps to a patch request to schedule and merge into `develop`.
 
 Minor and major releases require a formal [release
 review](https://www.eclipse.org/projects/handbook/#release-review), and because


### PR DESCRIPTION
GitHub issue resolved: #2011   <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- back to specifying 'merge-commit' as our PR merge strategy

---- 
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

Note: we merge all feature pull requests using [squash and merge](https://help.github.com/en/github/administering-a-repository/about-merge-methods-on-github#squashing-your-merge-commits). See [RDF4J git merge strategy](https://rdf4j.org/documentation/developer/merge-strategy/) for more details.

