### PR TITLE
GH-2317 (not)in function

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/BinaryOperator.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/BinaryOperator.java
@@ -21,7 +21,7 @@ enum BinaryOperator implements SparqlOperator {
 
 	private String operator;
 
-	private BinaryOperator(String operator) {
+	BinaryOperator(String operator) {
 		this.operator = operator;
 	}
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ConnectiveOperation.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ConnectiveOperation.java
@@ -14,5 +14,6 @@ package org.eclipse.rdf4j.sparqlbuilder.constraint;
 class ConnectiveOperation extends Operation<ConnectiveOperation> {
 	ConnectiveOperation(ConnectiveOperator operator) {
 		super(operator);
+		parenthesize();
 	}
 }

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ConnectiveOperator.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ConnectiveOperator.java
@@ -24,7 +24,7 @@ enum ConnectiveOperator implements SparqlOperator {
 
 	private String operator;
 
-	private ConnectiveOperator(String operator) {
+	ConnectiveOperator(String operator) {
 		this.operator = operator;
 	}
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
@@ -208,6 +208,32 @@ public class Expressions {
 		return new CustomFunction(functionIri).addOperand(operands);
 	}
 
+	/**
+	 * {@code operand IN (expression1, expression2...)}
+	 * 
+	 * @param searchTerm
+	 * @param expressions
+	 * @return an {@code IN} function
+	 *
+	 * @see <a href="https://www.w3.org/TR/sparql11-query/#func-in">SPARQL IN Function</a>
+	 */
+	public static Expression<?> in(Operand searchTerm, Operand... expressions) {
+		return new In(searchTerm, expressions);
+	}
+
+	/**
+	 * {@code operand NOT IN (expression1, expression2...)}
+	 * 
+	 * @param searchTerm
+	 * @param expressions
+	 * @return an {@code NOT IN} function
+	 *
+	 * @see <a href="https://www.w3.org/TR/sparql11-query/#func-not-in">SPARQL NOT IN Function</a>
+	 */
+	public static Expression<?> notIn(Operand searchTerm, Operand... expressions) {
+		return new In(searchTerm, false, expressions);
+	}
+
 	// ... etc...
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/In.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/In.java
@@ -1,0 +1,24 @@
+package org.eclipse.rdf4j.sparqlbuilder.constraint;
+
+public class In extends Function {
+	private Operand searchTerm;
+
+	In(Operand searchTerm, Operand... expressions) {
+		this(searchTerm, true, expressions);
+	}
+
+	In(Operand searchTerm, boolean in, Operand... expressions) {
+		super(in ? SparqlFunction.IN : SparqlFunction.NOT_IN);
+		this.searchTerm = searchTerm;
+		addOperand(expressions);
+	}
+
+	@Override
+	public String getQueryString() {
+		StringBuilder inExpression = new StringBuilder();
+		inExpression.append(searchTerm.getQueryString()).append(" ");
+		inExpression.append(super.getQueryString());
+
+		return inExpression.toString();
+	}
+}

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Operation.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Operation.java
@@ -23,9 +23,6 @@ abstract class Operation<T extends Operation<T>> extends Expression<T> {
 	Operation(SparqlOperator operator, int operandLimit) {
 		super(operator);
 		this.operandLimit = operandLimit;
-		if (operator instanceof ConnectiveOperator) {
-			parenthesize();
-		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/SparqlAggregate.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/SparqlAggregate.java
@@ -25,7 +25,7 @@ public enum SparqlAggregate implements SparqlOperator {
 
 	private String function;
 
-	private SparqlAggregate(String function) {
+	SparqlAggregate(String function) {
 		this.function = function;
 	}
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/SparqlFunction.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/SparqlFunction.java
@@ -28,6 +28,8 @@ public enum SparqlFunction implements SparqlOperator {
 	FLOOR("FLOOR"),
 	HOURS("HOURS"),
 	IF("IF"),
+	IN("IN", true),
+	NOT_IN("NOT IN", true),
 	IRI("IRI"),
 	IS_BLANK("isBLANK"),
 	IS_IRI("isIRI"),
@@ -70,13 +72,22 @@ public enum SparqlFunction implements SparqlOperator {
 	YEAR("YEAR");
 
 	private String function;
+	private boolean pad;
 
-	private SparqlFunction(String function) {
-		this.function = function;
+	SparqlFunction(String function) {
+		this(function, false);
 	}
 
-	@Override
+	SparqlFunction(String function, boolean pad) {
+		this.function = function;
+		this.pad = pad;
+	}
+
+	boolean pad() {
+		return this.pad;
+	}
+
 	public String getQueryString() {
-		return function;
+		return function + (pad ? " " : "");
 	}
 }

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/UnaryOperator.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/UnaryOperator.java
@@ -18,7 +18,7 @@ enum UnaryOperator implements SparqlOperator {
 
 	private String operator;
 
-	private UnaryOperator(String operator) {
+	UnaryOperator(String operator) {
 		this.operator = operator;
 	}
 

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section17Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section17Test.java
@@ -1,0 +1,31 @@
+package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
+
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
+import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.Test;
+
+public class Section17Test extends BaseExamples {
+	@Test
+	public void example_17_4_1_9() {
+		Prefix rdf = SparqlBuilder.prefix("rdf", Rdf.iri("http://example.com"));
+		Variable attributeIRI = SparqlBuilder.var("attribute_iri");
+		Iri type = rdf.iri("type");
+		Expression in = Expressions.in(attributeIRI, type);
+		p(in);
+	}
+
+	@Test
+	public void example_17_4_1_10() {
+		Prefix rdf = SparqlBuilder.prefix("rdf", Rdf.iri("http://example.com"));
+		Variable attributeIRI = SparqlBuilder.var("attribute_iri");
+		Iri type = rdf.iri("type");
+		Expression notIn = Expressions.notIn(attributeIRI, type);
+		p(notIn);
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: GH-2317

Briefly describe the changes proposed in this PR:
add support for sparql [NOT]IN operators

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [X] I've added tests for the changes I made
 - [X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [X] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

