### PR TITLE
GH-1942 Rio RDF and QueryResult Writer support for non-default character encoding

### DIFF
--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
@@ -7,11 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio;
 
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
@@ -28,26 +26,8 @@ import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
 public abstract class AbstractQueryResultWriter implements QueryResultWriter {
 
 	private WriterConfig writerConfig = new WriterConfig();
-	private final OutputStream outputStream;
 
 	private boolean encodeRDFStar;
-
-	/**
-	 * Default constructor.
-	 *
-	 */
-	protected AbstractQueryResultWriter() {
-		this(null);
-	}
-
-	protected AbstractQueryResultWriter(OutputStream out) {
-		this.outputStream = out;
-	}
-
-	@Override
-	public Optional<OutputStream> getOutputStream() {
-		return Optional.ofNullable(outputStream);
-	}
 
 	@Override
 	public void setWriterConfig(WriterConfig config) {

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
@@ -11,6 +11,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.rdf4j.common.io.Sink;
+import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.rio.RioSetting;
@@ -23,7 +25,7 @@ import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
  *
  * @author Peter Ansell
  */
-public abstract class AbstractQueryResultWriter implements QueryResultWriter {
+public abstract class AbstractQueryResultWriter implements QueryResultWriter, Sink {
 
 	private WriterConfig writerConfig = new WriterConfig();
 
@@ -42,6 +44,11 @@ public abstract class AbstractQueryResultWriter implements QueryResultWriter {
 	@Override
 	public Collection<RioSetting<?>> getSupportedSettings() {
 		return Collections.emptyList();
+	}
+
+	@Override
+	public FileFormat getFileFormat() {
+		return getQueryResultFormat();
 	}
 
 	@Override

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultWriter.java
@@ -7,13 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio;
 
-import java.io.OutputStream;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Optional;
 
-import org.eclipse.rdf4j.common.annotation.Experimental;
-import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.query.QueryResultHandler;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.rio.RioSetting;
@@ -30,22 +26,6 @@ public interface QueryResultWriter extends QueryResultHandler {
 	 * Gets the query result format that this writer uses.
 	 */
 	QueryResultFormat getQueryResultFormat();
-
-	/**
-	 * Gets the {@link OutputStream} this writer writes to, if it uses one.
-	 *
-	 * @return an optional OutputStream
-	 * @implNote This temporary default method is only supplied for backward compatibility. Concrete implementations are
-	 *           expected to override.
-	 * @apiNote This method is currently considered experimental / for internal use only, and is likely to change in a
-	 *          future release without guarantees for backward compatibility. Use at your own risk.
-	 * @since 3.2.0
-	 */
-	@InternalUseOnly
-	@Experimental
-	default Optional<OutputStream> getOutputStream() {
-		return Optional.empty();
-	}
 
 	/**
 	 * Handles a namespace prefix declaration. If this is called, it should be called before {@link #startDocument()} to

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/QueryResultWriter.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.resultio;
 
 import java.io.OutputStream;
+import java.io.Writer;
 import java.util.Collection;
 import java.util.Optional;
 

--- a/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultWriter.java
+++ b/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultWriter.java
@@ -50,13 +50,14 @@ import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+import org.eclipse.rdf4j.rio.ByteSink;
 
 /**
  * Writer for the binary tuple result format. The format is explained in {@link BinaryQueryResultConstants}.
  *
  * @author Arjohn Kampman
  */
-public class BinaryQueryResultWriter extends AbstractQueryResultWriter implements TupleQueryResultWriter {
+public class BinaryQueryResultWriter extends AbstractQueryResultWriter implements TupleQueryResultWriter, ByteSink {
 
 	/*-----------*
 	 * Variables *
@@ -85,20 +86,15 @@ public class BinaryQueryResultWriter extends AbstractQueryResultWriter implement
 
 	protected boolean tupleVariablesFound = false;
 
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
-
 	public BinaryQueryResultWriter(OutputStream out) {
-		super(out);
 		this.out = new DataOutputStream(out);
 	}
 
-	/*---------*
-	 * Methods *
-	 *---------*/
-
 	@Override
+	public OutputStream getOutputStream() {
+		return out;
+	}
+
 	public final TupleQueryResultFormat getTupleQueryResultFormat() {
 		return TupleQueryResultFormat.BINARY;
 	}

--- a/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultWriter.java
+++ b/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultWriter.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.rdf4j.common.io.ByteSink;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -50,7 +51,6 @@ import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
-import org.eclipse.rdf4j.rio.ByteSink;
 
 /**
  * Writer for the binary tuple result format. The format is explained in {@link BinaryQueryResultConstants}.

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
@@ -91,7 +91,7 @@ abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implem
 	}
 
 	@Override
-	public Writer getWriter() {
+	public final Writer getWriter() {
 		return writer;
 	}
 

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
@@ -81,6 +82,14 @@ abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implem
 		super(out);
 		try {
 			jg = JSON_FACTORY.createGenerator(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+		} catch (IOException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	protected AbstractSPARQLJSONWriter(Writer writer) {
+		try {
+			jg = JSON_FACTORY.createGenerator(writer);
 		} catch (IOException e) {
 			throw new IllegalArgumentException(e);
 		}

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
@@ -31,6 +31,7 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.BasicQueryWriterSettings;
 import org.eclipse.rdf4j.query.resultio.QueryResultWriter;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
@@ -45,7 +46,7 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter;
  *
  * @author Peter Ansell
  */
-abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implements QueryResultWriter {
+abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implements QueryResultWriter, CharSink {
 
 	private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
@@ -59,10 +60,6 @@ abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implem
 		JSON_FACTORY.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
 		JSON_FACTORY.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
 	}
-
-	/*-----------*
-	 * Variables *
-	 *-----------*/
 
 	protected boolean firstTupleWritten = false;
 
@@ -78,21 +75,24 @@ abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implem
 
 	protected final JsonGenerator jg;
 
+	private final Writer writer;
+
 	protected AbstractSPARQLJSONWriter(OutputStream out) {
-		super(out);
-		try {
-			jg = JSON_FACTORY.createGenerator(new OutputStreamWriter(out, StandardCharsets.UTF_8));
-		} catch (IOException e) {
-			throw new IllegalArgumentException(e);
-		}
+		this(new OutputStreamWriter(out, StandardCharsets.UTF_8));
 	}
 
 	protected AbstractSPARQLJSONWriter(Writer writer) {
+		this.writer = writer;
 		try {
 			jg = JSON_FACTORY.createGenerator(writer);
 		} catch (IOException e) {
 			throw new IllegalArgumentException(e);
 		}
+	}
+
+	@Override
+	public Writer getWriter() {
+		return writer;
 	}
 
 	@Override

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -31,7 +32,6 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.BasicQueryWriterSettings;
 import org.eclipse.rdf4j.query.resultio.QueryResultWriter;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLBooleanJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLBooleanJSONWriter.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
@@ -26,6 +27,10 @@ public class SPARQLBooleanJSONWriter extends AbstractSPARQLJSONWriter implements
 
 	public SPARQLBooleanJSONWriter(OutputStream out) {
 		super(out);
+	}
+
+	public SPARQLBooleanJSONWriter(Writer writer) {
+		super(writer);
 	}
 
 	/*---------*

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONWriter.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
@@ -28,6 +29,10 @@ public class SPARQLResultsJSONWriter extends AbstractSPARQLJSONWriter implements
 
 	public SPARQLResultsJSONWriter(OutputStream out) {
 		super(out);
+	}
+
+	public SPARQLResultsJSONWriter(Writer writer) {
+		super(writer);
 	}
 
 	/*---------*

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.common.xml.XMLWriter;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -58,7 +59,6 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.BasicQueryWriterSettings;
 import org.eclipse.rdf4j.query.resultio.QueryResultWriter;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
@@ -34,6 +34,7 @@ import static org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLConstan
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -102,6 +103,10 @@ abstract class AbstractSPARQLXMLWriter extends AbstractQueryResultWriter impleme
 		super(out);
 		this.xmlWriter = new XMLWriter(out);
 		this.xmlWriter.setPrettyPrint(true);
+	}
+
+	protected AbstractSPARQLXMLWriter(Writer writer) {
+		this(new XMLWriter(writer));
 	}
 
 	protected AbstractSPARQLXMLWriter(XMLWriter xmlWriter) {

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
@@ -58,6 +58,7 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.BasicQueryWriterSettings;
 import org.eclipse.rdf4j.query.resultio.QueryResultWriter;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
@@ -69,7 +70,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Peter Ansell
  */
-abstract class AbstractSPARQLXMLWriter extends AbstractQueryResultWriter implements QueryResultWriter {
+abstract class AbstractSPARQLXMLWriter extends AbstractQueryResultWriter implements QueryResultWriter, CharSink {
 
 	/*-----------*
 	 * Variables *
@@ -100,7 +101,6 @@ abstract class AbstractSPARQLXMLWriter extends AbstractQueryResultWriter impleme
 	 *--------------*/
 
 	protected AbstractSPARQLXMLWriter(OutputStream out) {
-		super(out);
 		this.xmlWriter = new XMLWriter(out);
 		this.xmlWriter.setPrettyPrint(true);
 	}
@@ -114,9 +114,10 @@ abstract class AbstractSPARQLXMLWriter extends AbstractQueryResultWriter impleme
 		this.xmlWriter.setPrettyPrint(true);
 	}
 
-	/*---------*
-	 * Methods *
-	 *---------*/
+	@Override
+	public Writer getWriter() {
+		return xmlWriter.getWriter();
+	}
 
 	/**
 	 * Enables/disables addition of indentation characters and newlines in the XML document. By default, pretty-printing

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLBooleanXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLBooleanXMLWriter.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.query.resultio.sparqlxml;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 
 import org.eclipse.rdf4j.common.xml.XMLWriter;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
@@ -27,6 +28,10 @@ public class SPARQLBooleanXMLWriter extends AbstractSPARQLXMLWriter implements B
 
 	public SPARQLBooleanXMLWriter(OutputStream out) {
 		super(out);
+	}
+
+	public SPARQLBooleanXMLWriter(Writer writer) {
+		super(writer);
 	}
 
 	public SPARQLBooleanXMLWriter(XMLWriter xmlWriter) {

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsXMLWriter.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.resultio.sparqlxml;
 
 import java.io.OutputStream;
+import java.io.Writer;
 
 import org.eclipse.rdf4j.common.xml.XMLWriter;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
@@ -25,6 +26,10 @@ public class SPARQLResultsXMLWriter extends AbstractSPARQLXMLWriter implements T
 
 	public SPARQLResultsXMLWriter(OutputStream out) {
 		super(out);
+	}
+
+	public SPARQLResultsXMLWriter(Writer writer) {
+		super(writer);
 	}
 
 	public SPARQLResultsXMLWriter(XMLWriter xmlWriter) {

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/BooleanTextWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/BooleanTextWriter.java
@@ -43,7 +43,11 @@ public class BooleanTextWriter extends AbstractQueryResultWriter implements Bool
 	 *--------------*/
 
 	public BooleanTextWriter(OutputStream out) {
-		writer = new OutputStreamWriter(out, StandardCharsets.US_ASCII);
+		this(new OutputStreamWriter(out, StandardCharsets.US_ASCII));
+	}
+
+	public BooleanTextWriter(Writer writer) {
+		this.writer = writer;
 	}
 
 	/*---------*

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
@@ -46,8 +46,11 @@ public class SPARQLResultsCSVWriter extends AbstractQueryResultWriter implements
 	 */
 	public SPARQLResultsCSVWriter(OutputStream out) {
 		super(out);
-		Writer w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-		writer = new BufferedWriter(w, 1024);
+		writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024);
+	}
+
+	public SPARQLResultsCSVWriter(Writer writer) {
+		this.writer = writer;
 	}
 
 	@Override

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+import org.eclipse.rdf4j.rio.CharSink;
 
 /**
  * TupleQueryResultWriter for the SPARQL CSV (Comma-Separated Values) format.
@@ -35,7 +36,7 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
  * @see <a href="http://www.w3.org/TR/sparql11-results-csv-tsv/#csv">SPARQL 1.1 Query Results CSV Format</a>
  * @author Jeen Broekstra
  */
-public class SPARQLResultsCSVWriter extends AbstractQueryResultWriter implements TupleQueryResultWriter {
+public class SPARQLResultsCSVWriter extends AbstractQueryResultWriter implements TupleQueryResultWriter, CharSink {
 
 	private Writer writer;
 
@@ -45,12 +46,15 @@ public class SPARQLResultsCSVWriter extends AbstractQueryResultWriter implements
 	 * @param out
 	 */
 	public SPARQLResultsCSVWriter(OutputStream out) {
-		super(out);
-		writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024);
+		this(new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024));
 	}
 
 	public SPARQLResultsCSVWriter(Writer writer) {
 		this.writer = writer;
+	}
+
+	public Writer getWriter() {
+		return writer;
 	}
 
 	@Override

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
@@ -15,6 +15,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -28,7 +29,6 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
-import org.eclipse.rdf4j.rio.CharSink;
 
 /**
  * TupleQueryResultWriter for the SPARQL CSV (Comma-Separated Values) format.

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
@@ -15,6 +15,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.common.text.StringUtil;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -31,7 +32,6 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
-import org.eclipse.rdf4j.rio.CharSink;
 
 /**
  * TupleQueryResultWriter for the SPARQL TSV (Tab-Separated Values) format.

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
@@ -51,8 +51,11 @@ public class SPARQLResultsTSVWriter extends AbstractQueryResultWriter implements
 	 */
 	public SPARQLResultsTSVWriter(OutputStream out) {
 		super(out);
-		Writer w = new OutputStreamWriter(out, StandardCharsets.UTF_8);
-		writer = new BufferedWriter(w, 1024);
+		writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024);
+	}
+
+	public SPARQLResultsTSVWriter(Writer writer) {
+		this.writer = writer;
 	}
 
 	@Override

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVWriter.java
@@ -31,6 +31,7 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+import org.eclipse.rdf4j.rio.CharSink;
 
 /**
  * TupleQueryResultWriter for the SPARQL TSV (Tab-Separated Values) format.
@@ -38,7 +39,7 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
  * @see <a href="http://www.w3.org/TR/sparql11-results-csv-tsv/#tsv">SPARQL 1.1 Query Results TSV Format</a>
  * @author Jeen Broekstra
  */
-public class SPARQLResultsTSVWriter extends AbstractQueryResultWriter implements TupleQueryResultWriter {
+public class SPARQLResultsTSVWriter extends AbstractQueryResultWriter implements TupleQueryResultWriter, CharSink {
 
 	protected Writer writer;
 
@@ -50,12 +51,16 @@ public class SPARQLResultsTSVWriter extends AbstractQueryResultWriter implements
 	 * @param out
 	 */
 	public SPARQLResultsTSVWriter(OutputStream out) {
-		super(out);
-		writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024);
+		this(new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8), 1024));
 	}
 
 	public SPARQLResultsTSVWriter(Writer writer) {
 		this.writer = writer;
+	}
+
+	@Override
+	public Writer getWriter() {
+		return writer;
 	}
 
 	@Override

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/ByteSink.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/ByteSink.java
@@ -1,0 +1,27 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio;
+
+import java.io.OutputStream;
+
+/**
+ * A ByteSink write data as raw bytes directly to an {@link OutputStream}.
+ * 
+ * @author Jeen Broekstra
+ * @since 3.5.0
+ */
+public interface ByteSink {
+
+	/**
+	 * get the {@link OutputStream} used by this {@link ByteSink}.
+	 * 
+	 * @return an {@link OutputStream}
+	 * @since 3.5.0
+	 */
+	OutputStream getOutputStream();
+}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/CharSink.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/CharSink.java
@@ -1,0 +1,28 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio;
+
+import java.io.Writer;
+
+/**
+ * A CharSink writes data as characters to a {@link Writer}.
+ * 
+ * @author Jeen Broekstra
+ * @since 3.5.0
+ * @see ByteSink
+ */
+public interface CharSink {
+
+	/**
+	 * get the {@link Writer} used by this {@link CharSink}.
+	 * 
+	 * @return an {@link Writer}
+	 * @since 3.5.0
+	 */
+	Writer getWriter();
+}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFWriter.java
@@ -10,10 +10,6 @@ package org.eclipse.rdf4j.rio;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Optional;
-
-import org.eclipse.rdf4j.common.annotation.Experimental;
-import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 
 /**
  * An interface for RDF document writers. To allow RDF document writers to be created through reflection, all
@@ -26,22 +22,6 @@ public interface RDFWriter extends RDFHandler {
 	 * Gets the RDF format that this RDFWriter uses.
 	 */
 	public RDFFormat getRDFFormat();
-
-	/**
-	 * Gets the {@link OutputStream} this writer writes to, if it uses one.
-	 *
-	 * @return an optional OutputStream
-	 * @implNote This temporary default method is only supplied for backward compatibility. Concrete implementations are
-	 *           expected to override.
-	 * @apiNote This method is currently considered experimental / for internal use only, and is likely to change in a
-	 *          future release without guarantees for backward compatibility. Use at your own risk.
-	 * @since 3.2.0
-	 */
-	@InternalUseOnly
-	@Experimental
-	public default Optional<OutputStream> getOutputStream() {
-		return Optional.empty();
-	}
 
 	/**
 	 * Sets all supplied writer configuration options.

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
@@ -7,12 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.eclipse.rdf4j.model.Resource;
@@ -44,25 +42,7 @@ public abstract class AbstractRDFWriter implements RDFWriter {
 
 	private boolean writingStarted;
 
-	private final OutputStream outputStream;
-
 	protected Consumer<Statement> statementConsumer;
-
-	/**
-	 * Default constructor.
-	 */
-	protected AbstractRDFWriter() {
-		this(null);
-	}
-
-	protected AbstractRDFWriter(OutputStream out) {
-		this.outputStream = out;
-	}
-
-	@Override
-	public Optional<OutputStream> getOutputStream() {
-		return Optional.ofNullable(outputStream);
-	}
 
 	@Override
 	public void handleNamespace(String prefix, String uri) throws RDFHandlerException {

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
@@ -13,6 +13,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import org.eclipse.rdf4j.common.io.Sink;
+import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
@@ -28,7 +30,7 @@ import org.eclipse.rdf4j.rio.WriterConfig;
  *
  * @author Peter Ansell
  */
-public abstract class AbstractRDFWriter implements RDFWriter {
+public abstract class AbstractRDFWriter implements RDFWriter, Sink {
 
 	/**
 	 * Mapping from namespace prefixes to namespace names.
@@ -58,6 +60,11 @@ public abstract class AbstractRDFWriter implements RDFWriter {
 	@Override
 	public WriterConfig getWriterConfig() {
 		return this.writerConfig;
+	}
+
+	@Override
+	public FileFormat getFileFormat() {
+		return getRDFFormat();
 	}
 
 	/*

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -7,10 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -22,7 +24,11 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -320,6 +326,33 @@ public abstract class RDFWriterTest {
 		rdfParser.setRDFHandler(new StatementCollector(result));
 		rdfParser.parse(reader, baseURI);
 		return result;
+	}
+
+	@Test
+	public void testRoundTrip_NonDefaultCharEncoding() throws Exception {
+		assumeTrue(
+				"Writer for format " + rdfWriterFactory.getRDFFormat().getName() + " does not use character encoding",
+				rdfWriterFactory.getRDFFormat().hasCharset());
+
+		// use Windows-1250 character encoding instead of format default
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		Writer charWriter = new OutputStreamWriter(out, "windows-1250");
+		RDFWriter rdfWriter = rdfWriterFactory.getWriter(charWriter);
+
+		String originalString = "Fahrvergnügen";
+		rdfWriter.startRDF();
+		rdfWriter.handleStatement(vf.createStatement(uri1, uri1, vf.createLiteral(originalString)));
+		rdfWriter.endRDF();
+
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		Reader reader = new InputStreamReader(in, "windows-1250");
+		RDFParser rdfParser = rdfParserFactory.getParser();
+		rdfParser.setValueFactory(vf);
+		Model model = new LinkedHashModel();
+		rdfParser.setRDFHandler(new StatementCollector(model));
+		rdfParser.parse(reader, "");
+
+		assertThat(model.objects()).allMatch(v -> v.stringValue().equals(originalString));
 	}
 
 	@Test

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.rdf4j.common.io.ByteSink;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -39,7 +40,6 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
-import org.eclipse.rdf4j.rio.ByteSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
@@ -39,6 +39,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.rio.ByteSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -47,7 +48,7 @@ import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 /**
  * @author Arjohn Kampman
  */
-public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter {
+public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter, ByteSink {
 
 	private final BlockingQueue<Statement> statementQueue;
 
@@ -66,7 +67,6 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter {
 	}
 
 	public BinaryRDFWriter(OutputStream out, int bufferSize) {
-		super(out);
 		this.out = new DataOutputStream(new BufferedOutputStream(out));
 		this.statementQueue = new ArrayBlockingQueue<>(bufferSize);
 		this.valueFreq = new HashMap<>(3 * bufferSize);
@@ -76,6 +76,11 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter {
 	@Override
 	public RDFFormat getRDFFormat() {
 		return RDFFormat.BINARY;
+	}
+
+	@Override
+	public OutputStream getOutputStream() {
+		return out;
 	}
 
 	@Override
@@ -298,4 +303,5 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter {
 		}
 		out.write(buf, 0, stringBytes);
 	}
+
 }

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -45,7 +46,7 @@ import com.github.jsonldjava.utils.JsonUtils;
  *
  * @author Peter Ansell
  */
-public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
+public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter, CharSink {
 
 	private final Model model = new LinkedHashModel();
 
@@ -71,7 +72,6 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @param baseURI      base URI
 	 */
 	public JSONLDWriter(OutputStream outputStream, String baseURI) {
-		super(outputStream);
 		this.baseURI = baseURI;
 		this.writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
 	}
@@ -94,6 +94,11 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
 	public JSONLDWriter(Writer writer, String baseURI) {
 		this.baseURI = baseURI;
 		this.writer = writer;
+	}
+
+	@Override
+	public Writer getWriter() {
+		return writer;
 	}
 
 	@Override

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -19,11 +19,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
@@ -14,9 +14,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 
+import org.eclipse.rdf4j.common.io.CharSink;
+import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -142,6 +143,11 @@ public class N3Writer implements RDFWriter, CharSink {
 	@Override
 	public void handleComment(String comment) throws RDFHandlerException {
 		ttlWriter.handleComment(comment);
+	}
+
+	@Override
+	public FileFormat getFileFormat() {
+		return getRDFFormat();
 	}
 
 }

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
@@ -13,10 +13,10 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Optional;
 
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -28,7 +28,7 @@ import org.eclipse.rdf4j.rio.turtle.TurtleWriter;
  * An implementation of the RDFWriter interface that writes RDF documents in N3 format. Note: the current implementation
  * simply wraps a {@link TurtleWriter} and writes documents in Turtle format, which is a subset of N3.
  */
-public class N3Writer implements RDFWriter {
+public class N3Writer implements RDFWriter, CharSink {
 
 	/*-----------*
 	 * Variables *
@@ -88,6 +88,11 @@ public class N3Writer implements RDFWriter {
 	 *---------*/
 
 	@Override
+	public Writer getWriter() {
+		return ttlWriter.getWriter();
+	}
+
+	@Override
 	public RDFFormat getRDFFormat() {
 		return RDFFormat.N3;
 	}
@@ -139,8 +144,4 @@ public class N3Writer implements RDFWriter {
 		ttlWriter.handleComment(comment);
 	}
 
-	@Override
-	public Optional<OutputStream> getOutputStream() {
-		return ttlWriter.getOutputStream();
-	}
 }

--- a/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
+++ b/core/rio/n3/src/main/java/org/eclipse/rdf4j/rio/n3/N3Writer.java
@@ -8,7 +8,9 @@
 package org.eclipse.rdf4j.rio.n3;
 
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -32,7 +34,7 @@ public class N3Writer implements RDFWriter {
 	 * Variables *
 	 *-----------*/
 
-	private TurtleWriter ttlWriter;
+	private final TurtleWriter ttlWriter;
 
 	/**
 	 * A collection of configuration options for this writer.
@@ -59,7 +61,7 @@ public class N3Writer implements RDFWriter {
 	 * @param baseIRI used to relativize IRIs to relative IRIs.
 	 */
 	public N3Writer(OutputStream out, ParsedIRI baseIRI) {
-		ttlWriter = new TurtleWriter(out, baseIRI);
+		this(new OutputStreamWriter(out, StandardCharsets.UTF_8), baseIRI);
 	}
 
 	/**

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
@@ -16,13 +16,13 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.common.text.ASCIIUtil;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -35,16 +36,12 @@ import org.eclipse.rdf4j.rio.helpers.NTriplesWriterSettings;
  * An implementation of the RDFWriter interface that writes RDF documents in N-Triples format. The N-Triples format is
  * defined in <a href="http://www.w3.org/TR/rdf-testcases/#ntriples">this section</a> of the RDF Test Cases document.
  */
-public class NTriplesWriter extends AbstractRDFWriter implements RDFWriter {
+public class NTriplesWriter extends AbstractRDFWriter implements RDFWriter, CharSink {
 
 	protected final Writer writer;
 
 	private boolean xsdStringToPlainLiteral = true;
 	private boolean escapeUnicode;
-
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
 
 	/**
 	 * Creates a new NTriplesWriter that will write to the supplied OutputStream.
@@ -52,7 +49,6 @@ public class NTriplesWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @param out The OutputStream to write the N-Triples document to.
 	 */
 	public NTriplesWriter(OutputStream out) {
-		super(out);
 		this.writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
 	}
 
@@ -65,9 +61,10 @@ public class NTriplesWriter extends AbstractRDFWriter implements RDFWriter {
 		this.writer = writer;
 	}
 
-	/*---------*
-	 * Methods *
-	 *---------*/
+	@Override
+	public Writer getWriter() {
+		return writer;
+	}
 
 	@Override
 	public RDFFormat getRDFFormat() {

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -25,7 +26,6 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.Literals;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -9,7 +9,9 @@ package org.eclipse.rdf4j.rio.rdfjson;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -45,9 +47,7 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter;
  */
 public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 
-	private Writer writer;
-
-	private OutputStream outputStream;
+	private final Writer writer;
 
 	private Model graph;
 
@@ -55,8 +55,8 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 
 	public RDFJSONWriter(final OutputStream out, final RDFFormat actualFormat) {
 		super(out);
-		this.outputStream = out;
 		this.actualFormat = actualFormat;
+		this.writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
 	}
 
 	public RDFJSONWriter(final Writer writer, final RDFFormat actualFormat) {
@@ -68,20 +68,10 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	public void endRDF() throws RDFHandlerException {
 		checkWritingStarted();
 		try {
-			if (this.writer != null) {
-				try (final JsonGenerator jg = configureNewJsonFactory().createGenerator(this.writer);) {
-					RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
-				} finally {
-					this.writer.flush();
-				}
-			} else if (this.outputStream != null) {
-				try (final JsonGenerator jg = configureNewJsonFactory().createGenerator(this.outputStream);) {
-					RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
-				} finally {
-					this.outputStream.flush();
-				}
-			} else {
-				throw new IllegalStateException("The output stream and the writer were both null.");
+			try (final JsonGenerator jg = configureNewJsonFactory().createGenerator(this.writer);) {
+				RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
+			} finally {
+				this.writer.flush();
 			}
 		} catch (final IOException e) {
 			throw new RDFHandlerException(e);

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -25,6 +25,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -45,7 +46,7 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter;
  *
  * @author Peter Ansell p_ansell@yahoo.com
  */
-public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
+public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter, CharSink {
 
 	private final Writer writer;
 
@@ -54,7 +55,6 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	private final RDFFormat actualFormat;
 
 	public RDFJSONWriter(final OutputStream out, final RDFFormat actualFormat) {
-		super(out);
 		this.actualFormat = actualFormat;
 		this.writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
 	}
@@ -62,6 +62,11 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter {
 	public RDFJSONWriter(final Writer writer, final RDFFormat actualFormat) {
 		this.writer = writer;
 		this.actualFormat = actualFormat;
+	}
+
+	@Override
+	public Writer getWriter() {
+		return writer;
 	}
 
 	@Override

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
@@ -15,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.common.xml.XMLUtil;
 import org.eclipse.rdf4j.model.BNode;
@@ -26,7 +27,6 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
@@ -40,8 +40,8 @@ import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
  */
 public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter {
 
-	protected ParsedIRI baseIRI;
-	protected Writer writer;
+	protected final ParsedIRI baseIRI;
+	protected final Writer writer;
 	protected String defaultNamespace;
 	protected boolean headerWritten = false;
 	protected Resource lastWrittenSubject = null;

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
@@ -26,6 +26,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -38,7 +39,7 @@ import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
 /**
  * An implementation of the RDFWriter interface that writes RDF documents in XML-serialized RDF format.
  */
-public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter {
+public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter, CharSink {
 
 	protected final ParsedIRI baseIRI;
 	protected final Writer writer;
@@ -64,7 +65,6 @@ public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @param baseIRI base URI
 	 */
 	public RDFXMLWriter(OutputStream out, ParsedIRI baseIRI) {
-		super(out);
 		this.baseIRI = baseIRI;
 		this.writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
 		namespaceTable = new LinkedHashMap<>();
@@ -94,6 +94,11 @@ public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter {
 	@Override
 	public RDFFormat getRDFFormat() {
 		return RDFFormat.RDFXML;
+	}
+
+	@Override
+	public Writer getWriter() {
+		return writer;
 	}
 
 	protected void writeHeader() throws IOException {

--- a/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
+++ b/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.common.xml.XMLWriter;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -30,7 +31,6 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -45,20 +45,12 @@ import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
  */
 public class TriXWriter extends AbstractRDFWriter implements RDFWriter, CharSink {
 
-	/*-----------*
-	 * Variables *
-	 *-----------*/
-
 	private final XMLWriter xmlWriter;
 
 	private boolean inActiveContext = false;
 
 	private boolean convertRDFStar;
 	private Resource currentContext = null;
-
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
 
 	/**
 	 * Creates a new TriXWriter that will write to the supplied OutputStream.
@@ -211,5 +203,4 @@ public class TriXWriter extends AbstractRDFWriter implements RDFWriter, CharSink
 			return context1.equals(context2);
 		}
 	}
-
 }

--- a/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
+++ b/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -42,7 +43,7 @@ import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
  *
  * @author Arjohn Kampman
  */
-public class TriXWriter extends AbstractRDFWriter implements RDFWriter {
+public class TriXWriter extends AbstractRDFWriter implements RDFWriter, CharSink {
 
 	/*-----------*
 	 * Variables *
@@ -65,7 +66,6 @@ public class TriXWriter extends AbstractRDFWriter implements RDFWriter {
 	 * @param out The OutputStream to write the RDF/XML document to.
 	 */
 	public TriXWriter(OutputStream out) {
-		super(out);
 		this.xmlWriter = new XMLWriter(out);
 		this.xmlWriter.setPrettyPrint(true);
 	}
@@ -84,9 +84,10 @@ public class TriXWriter extends AbstractRDFWriter implements RDFWriter {
 		this.xmlWriter.setPrettyPrint(true);
 	}
 
-	/*---------*
-	 * Methods *
-	 *---------*/
+	@Override
+	public Writer getWriter() {
+		return xmlWriter.getWriter();
+	}
 
 	@Override
 	public RDFFormat getRDFFormat() {
@@ -210,4 +211,5 @@ public class TriXWriter extends AbstractRDFWriter implements RDFWriter {
 			return context1.equals(context2);
 		}
 	}
+
 }

--- a/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
+++ b/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
@@ -48,7 +48,7 @@ public class TriXWriter extends AbstractRDFWriter implements RDFWriter {
 	 * Variables *
 	 *-----------*/
 
-	private XMLWriter xmlWriter;
+	private final XMLWriter xmlWriter;
 
 	private boolean inActiveContext = false;
 

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -123,7 +123,6 @@ public class ArrangedWriter extends AbstractRDFWriter {
 	}
 
 	public ArrangedWriter(RDFWriter delegate, int size, boolean repeatBlankNodes) {
-		super(delegate.getOutputStream().orElse(null));
 		this.delegate = delegate;
 		this.targetQueueSize = size;
 		this.repeatBlankNodes = repeatBlankNodes;

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -42,6 +42,7 @@ import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.util.RDFCollections;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -53,7 +54,7 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
  * An implementation of the RDFWriter interface that writes RDF documents in Turtle format. The Turtle format is defined
  * in <a href="http://www.dajobe.org/2004/01/turtle/">in this document</a>.
  */
-public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
+public class TurtleWriter extends AbstractRDFWriter implements RDFWriter, CharSink {
 
 	private static final int LINE_WRAP = 80;
 
@@ -66,10 +67,6 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 	private static final IRI REST = new SimpleIRI(RDF.REST.stringValue()) {
 		private static final long serialVersionUID = -7951518099940758898L;
 	};
-
-	/*-----------*
-	 * Variables *
-	 *-----------*/
 
 	/**
 	 * Size of statement buffer used for pretty printing and blank node inlining. Set to Long.MAX_VALUE to buffer
@@ -98,10 +95,6 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 
 	private ModelFactory modelFactory = new LinkedHashModelFactory();
 
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
-
 	/**
 	 * Creates a new TurtleWriter that will write to the supplied OutputStream.
 	 *
@@ -114,11 +107,10 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 	/**
 	 * Creates a new TurtleWriter that will write to the supplied OutputStream.
 	 *
-	 * @param out     The OutputStream to write the Turtle document to.
+	 * @param out     The OutputStream to write the Turtle document to. The writer will use
 	 * @param baseIRI
 	 */
 	public TurtleWriter(OutputStream out, ParsedIRI baseIRI) {
-		super(out);
 		this.baseIRI = baseIRI;
 		this.writer = new IndentingWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
 	}
@@ -143,9 +135,10 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 		this.writer = new IndentingWriter(writer);
 	}
 
-	/*---------*
-	 * Methods *
-	 *---------*/
+	@Override
+	public Writer getWriter() {
+		return writer;
+	}
 
 	@Override
 	public RDFFormat getRDFFormat() {

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.common.io.IndentingWriter;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.common.text.StringUtil;
@@ -42,7 +43,6 @@ import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.util.RDFCollections;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.eclipse.rdf4j.rio.CharSink;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
@@ -107,7 +107,7 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter, CharSi
 	/**
 	 * Creates a new TurtleWriter that will write to the supplied OutputStream.
 	 *
-	 * @param out     The OutputStream to write the Turtle document to. The writer will use
+	 * @param out     The OutputStream to write the Turtle document to.
 	 * @param baseIRI
 	 */
 	public TurtleWriter(OutputStream out, ParsedIRI baseIRI) {

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/io/ByteSink.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/io/ByteSink.java
@@ -5,24 +5,24 @@
  * which accompanies this distribution, and is available at 
  * http://www.eclipse.org/org/documents/edl-v10.php. 
  *******************************************************************************/
-package org.eclipse.rdf4j.rio;
+package org.eclipse.rdf4j.common.io;
 
-import java.io.Writer;
+import java.io.OutputStream;
 
 /**
- * A CharSink writes data as characters to a {@link Writer}.
+ * A ByteSink writes data as raw bytes directly to an {@link OutputStream}.
  * 
  * @author Jeen Broekstra
  * @since 3.5.0
- * @see ByteSink
  */
-public interface CharSink {
+public interface ByteSink extends Sink {
 
 	/**
-	 * get the {@link Writer} used by this {@link CharSink}.
+	 * get the {@link OutputStream} used by this {@link ByteSink}.
 	 * 
-	 * @return an {@link Writer}
+	 * @return an {@link OutputStream}
 	 * @since 3.5.0
 	 */
-	Writer getWriter();
+	OutputStream getOutputStream();
+
 }

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/io/CharSink.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/io/CharSink.java
@@ -1,0 +1,29 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.common.io;
+
+import java.io.Writer;
+
+/**
+ * A CharSink writes data as characters to a {@link Writer}.
+ * 
+ * @author Jeen Broekstra
+ * @since 3.5.0
+ * @see ByteSink
+ */
+public interface CharSink extends Sink {
+
+	/**
+	 * get the {@link Writer} used by this {@link CharSink}.
+	 * 
+	 * @return an {@link Writer}
+	 * @since 3.5.0
+	 */
+	Writer getWriter();
+
+}

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/io/Sink.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/io/Sink.java
@@ -5,23 +5,23 @@
  * which accompanies this distribution, and is available at 
  * http://www.eclipse.org/org/documents/edl-v10.php. 
  *******************************************************************************/
-package org.eclipse.rdf4j.rio;
+package org.eclipse.rdf4j.common.io;
 
-import java.io.OutputStream;
+import org.eclipse.rdf4j.common.lang.FileFormat;
 
 /**
- * A ByteSink write data as raw bytes directly to an {@link OutputStream}.
+ * 
+ * A Sink writes data in a particular {@link FileFormat}.
  * 
  * @author Jeen Broekstra
  * @since 3.5.0
  */
-public interface ByteSink {
+public interface Sink {
 
 	/**
-	 * get the {@link OutputStream} used by this {@link ByteSink}.
+	 * Get the {@link FileFormat} this sink uses.
 	 * 
-	 * @return an {@link OutputStream}
-	 * @since 3.5.0
+	 * @return a {@link FileFormat}.
 	 */
-	OutputStream getOutputStream();
+	FileFormat getFileFormat();
 }

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/xml/XMLWriter.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/xml/XMLWriter.java
@@ -162,6 +162,13 @@ public class XMLWriter {
 	}
 
 	/**
+	 * @return the writer
+	 */
+	public Writer getWriter() {
+		return _writer;
+	}
+
+	/**
 	 * Sets the string that should be used for indentation when pretty-printing is enabled. The default indentation
 	 * string is a tab character.
 	 *
@@ -197,7 +204,7 @@ public class XMLWriter {
 	 * Finishes writing and flushes the OutputStream or Writer that this XMLWriter is writing to.
 	 */
 	public void endDocument() throws IOException {
-		_writer.flush();
+		getWriter().flush();
 	}
 
 	/**
@@ -393,7 +400,7 @@ public class XMLWriter {
 	 * Writes a string.
 	 */
 	protected void _write(String s) throws IOException {
-		_writer.write(s);
+		getWriter().write(s);
 	}
 
 	/**


### PR DESCRIPTION
GitHub issue resolved: #1942  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- Added Writer constructors to all character format QueryResultWriter classes
- Consistent handling of Writer (or Writer based) fields from OutputStream and Writer constructors in QueryResultWriter and RDFWriter classes
- added roundtrip test for writers/parsers that support character encoding-based serializations

Contains contributions by @erikgb (from original PR #2106 ), with minor updates.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

