### PR TITLE
Fixes GH-2618 by allowing TripleRef anonymous vars in DELETE/WHERE

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/UpdateExprBuilder.java
@@ -146,6 +146,7 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 
 		where = graphPattern.buildTupleExpr();
 		graphPattern = parentGP;
+		Map<String, Object> tripleVars = TripleRefCollector.process(where);
 
 		TupleExpr deleteExpr = where.clone();
 
@@ -154,6 +155,11 @@ public class UpdateExprBuilder extends TupleExprBuilder {
 		VarCollector collector = new VarCollector();
 		deleteExpr.visit(collector);
 		for (Var var : collector.getCollectedVars()) {
+			// skip vars that are provided by ValueExprTripleRef - added as Extentsion
+			if (tripleVars.containsKey(var.getName())) {
+				continue;
+			}
+
 			if (var.isAnonymous() && !var.hasValue()) {
 				throw new VisitorException("DELETE WHERE may not contain blank nodes");
 			}

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestSparqlStarParser.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestSparqlStarParser.java
@@ -991,4 +991,17 @@ public class TestSparqlStarParser {
 		StatementPattern st = (StatementPattern) join.getRightArg();
 		assertEquals("expect same Var", ref.getExprVar().getName(), st.getSubjectVar().getName());
 	}
+
+	/*-
+	 * Expected to do not throw exception about use of BNodes in DELETE
+	 * see https://github.com/eclipse/rdf4j/issues/2618
+	 * @throws Exception
+	 */
+	@Test
+	public void testDeleteWhereRDFStar() {
+		String update = "DELETE\r\n" +
+				"WHERE { << <u:1> <u:2> <u:3> >> ?p ?o }";
+		ParsedUpdate q = parser.parseUpdate(update, null);
+		assertNotNull(q);
+	}
 }


### PR DESCRIPTION
Signed-off-by: damyan.ognyanov <damyan.ognyanov@ontotext.com>


GitHub issue resolved: #2618 

Briefly describe the changes proposed in this PR:

Allow anonymous vars introduced by TripleRef to be reffered in head of the DELETE update when DELETE/WHERE update is processed
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

