### PR TITLE
GH-2624: support pass through of single source federated queries

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.common.iteration.DistinctIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.federated.algebra.PassThroughTupleExpr;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvaluationStatistics;
@@ -93,6 +94,8 @@ public class FedXConnection extends AbstractSailConnection {
 			TupleExpr query, Dataset dataset, BindingSet bindings,
 			boolean includeInferred) throws SailException {
 
+		final TupleExpr _orgQuery = query;
+
 		FederationEvalStrategy strategy = federationContext.getStrategy();
 
 		long start = 0;
@@ -104,6 +107,13 @@ public class FedXConnection extends AbstractSailConnection {
 			}
 			queryInfo = new QueryInfo(queryString, getOriginalBaseURI(bindings), getOriginalQueryType(bindings),
 					getOriginalMaxExecutionTime(bindings), includeInferred, federationContext, dataset);
+
+			// check if we have pass-through result handler information for single source queries
+			if (query instanceof PassThroughTupleExpr) {
+				PassThroughTupleExpr node = ((PassThroughTupleExpr) query);
+				queryInfo.setResultHandler(node.getResultHandler());
+				query = node.getExpr();
+			}
 
 			if (log.isDebugEnabled()) {
 				log.debug("Optimization start (Query: " + queryInfo.getQueryID() + ")");
@@ -150,6 +160,13 @@ public class FedXConnection extends AbstractSailConnection {
 			}
 			CloseableIteration<? extends BindingSet, QueryEvaluationException> res = strategy.evaluate(query,
 					queryBindings);
+
+			// mark the query as PassedThrough, such that outer result handlers are aware of this
+			// Note: for SingleSourceQuery (i.e. where we use pass through) res is explicitly
+			// EmptyIteration. Thus we can use it as indicator
+			if (_orgQuery instanceof PassThroughTupleExpr && res instanceof EmptyIteration) {
+				((PassThroughTupleExpr) _orgQuery).setPassedThrough(true);
+			}
 			res = new StopRemainingExecutionsOnCloseIteration(res, queryInfo);
 			return res;
 		} catch (QueryEvaluationException e) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/PassThroughTupleExpr.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/PassThroughTupleExpr.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.algebra;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.rdf4j.federated.structures.FedXTupleQuery;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.federated.util.QueryAlgebraUtil;
+import org.eclipse.rdf4j.query.TupleQueryResultHandler;
+import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
+import org.eclipse.rdf4j.query.algebra.QueryModelVisitor;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Marker {@link TupleExpr} that is used from {@link FedXTupleQuery#evaluate(TupleQueryResultHandler)} to allow for
+ * passing through of results to the handler.
+ * <p>
+ * Passing through of results to the handler is supported for {@link SingleSourceQuery}s, i.e. if the original query is
+ * sent as is to the single relevant source. In this case no materialization and in-memory handling through FedX is
+ * done, if a {@link TupleQueryResultHandler} is supplied.
+ * </p>
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public class PassThroughTupleExpr extends AbstractQueryModelNode implements FedXTupleExpr {
+
+	private static final long serialVersionUID = 24797808099470499L;
+
+	private final TupleExpr parsedQuery;
+
+	private final TupleQueryResultHandler resultHandler;
+
+	private boolean successfullyPassedThrough = false;
+
+	public PassThroughTupleExpr(TupleExpr parsedQuery, TupleQueryResultHandler resultHandler) {
+		super();
+		this.parsedQuery = parsedQuery;
+		this.resultHandler = resultHandler;
+	}
+
+	@Override
+	public <X extends Exception> void visitChildren(QueryModelVisitor<X> visitor) throws X {
+		parsedQuery.visit(visitor);
+
+	}
+
+	public TupleQueryResultHandler getResultHandler() {
+		return resultHandler;
+	}
+
+	public TupleExpr getExpr() {
+		return parsedQuery;
+	}
+
+	/**
+	 * 
+	 * @return if the query result has already been passed through to the supplied {@link TupleQueryResultHandler}
+	 */
+	public boolean isPassedThrough() {
+		return successfullyPassedThrough;
+	}
+
+	public void setPassedThrough(boolean flag) {
+		this.successfullyPassedThrough = flag;
+	}
+
+	@Override
+	public Set<String> getBindingNames() {
+		return parsedQuery.getBindingNames();
+	}
+
+	@Override
+	public Set<String> getAssuredBindingNames() {
+		return parsedQuery.getAssuredBindingNames();
+	}
+
+	@Override
+	public PassThroughTupleExpr clone() {
+		return new PassThroughTupleExpr(parsedQuery, resultHandler);
+	}
+
+	@Override
+	public <X extends Exception> void visit(QueryModelVisitor<X> visitor) throws X {
+		visitor.meetOther(parsedQuery);
+	}
+
+	@Override
+	public List<String> getFreeVars() {
+		return Lists.newArrayList(QueryAlgebraUtil.getFreeVars(parsedQuery));
+	}
+
+	@Override
+	public QueryInfo getQueryInfo() {
+		throw new UnsupportedOperationException("Not supported to retrieve query info on this marker node");
+	}
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
@@ -8,11 +8,13 @@
 package org.eclipse.rdf4j.federated.structures;
 
 import java.math.BigInteger;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.rdf4j.federated.FederationContext;
+import org.eclipse.rdf4j.federated.algebra.PassThroughTupleExpr;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTask;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.model.IRI;
@@ -20,6 +22,8 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResultHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +51,8 @@ public class QueryInfo {
 	private final long start;
 	private final boolean includeInferred;
 	private final Dataset dataset;
+
+	private TupleQueryResultHandler resultHandler = null;
 
 	private final FederationContext federationContext;
 
@@ -159,6 +165,27 @@ public class QueryInfo {
 			throw new QueryEvaluationException("Query is aborted or closed, cannot accept new tasks");
 		}
 		scheduledSubtasks.add(task);
+	}
+
+	/**
+	 * Returns a {@link TupleQueryResultHandler} if this query is executed using.
+	 * {@link TupleQuery#evaluate(TupleQueryResultHandler)}.
+	 * 
+	 * @return the {@link TupleQueryResultHandler} that can be used for pass through
+	 * @see PassThroughTupleExpr
+	 */
+	public Optional<TupleQueryResultHandler> getResultHandler() {
+		return Optional.ofNullable(resultHandler);
+	}
+
+	/**
+	 * Set the {@link TupleQueryResultHandler} if the query is executed using
+	 * {@link TupleQuery#evaluate(TupleQueryResultHandler)} allowing for passing through results to the handler.
+	 * 
+	 * @param resultHandler the {@link TupleQueryResultHandler}
+	 */
+	public void setResultHandler(TupleQueryResultHandler resultHandler) {
+		this.resultHandler = resultHandler;
 	}
 
 	/**


### PR DESCRIPTION
GitHub issue resolved: #2624 

This change provides an optimization to the FedX federation engine to
allow pass-through of query results for single source queries, if a
TupleQueryResultHandler was supplied (i.e. if the query was executed
through TupleQuery#evaluate(handler).

The implementation is done through a helper tuple expression (to
propagate information into the federation evaluation strategy. Also we
use a number of marker interfaces.

The implementation is covered by unit tests whose assertions are very
strict and will ensure to find errors if other parts of the framework
change.

Note that if no pass-through is possible, the same logic as before is
applied.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

