### PR TITLE
GH-2627 allow result writers to accept other formats for passthrough

### DIFF
--- a/core/http/client/pom.xml
+++ b/core/http/client/pom.xml
@@ -98,6 +98,12 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-queryresultio-sparqljson</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
@@ -21,48 +21,28 @@ import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
-import java.util.Locale;
 
 import org.apache.http.Header;
-import org.apache.http.HeaderElement;
-import org.apache.http.HeaderIterator;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.ParseException;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.message.BasicHeader;
-import org.apache.http.params.HttpParams;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 /**
  * Unit tests for {@link RDF4JProtocolSession}
  *
  * @author Jeen Broekstra
  */
-public class RDF4JProtocolSessionTest {
-
-	@ClassRule
-	public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
-
-	private RDF4JProtocolSession subject;
+public class RDF4JProtocolSessionTest extends SPARQLProtocolSessionTest {
 
 	private String testHeader = "X-testing-header";
 	private String testValue = "foobar";
@@ -70,20 +50,24 @@ public class RDF4JProtocolSessionTest {
 	private String serverURL = "http://localhost:" + wireMockRule.port() + "/rdf4j-server";
 	private String repositoryID = "test";
 
-	@Before
-	public void setUp() throws Exception {
-		subject = new SharedHttpClientSessionManager().createRDF4JProtocolSession(serverURL);
-		subject.setRepository(Protocol.getRepositoryLocation(serverURL, repositoryID));
+	RDF4JProtocolSession getRDF4JSession() {
+		return (RDF4JProtocolSession) sparqlSession;
+	}
+
+	RDF4JProtocolSession createProtocolSession() {
+		RDF4JProtocolSession session = new SharedHttpClientSessionManager().createRDF4JProtocolSession(serverURL);
+		session.setRepository(Protocol.getRepositoryLocation(serverURL, repositoryID));
 		HashMap<String, String> additionalHeaders = new HashMap<>();
 		additionalHeaders.put(testHeader, testValue);
-		subject.setAdditionalHttpHeaders(additionalHeaders);
+		session.setAdditionalHttpHeaders(additionalHeaders);
+		return session;
 	}
 
 	@Test
 	public void testCreateRepositoryExecutesPut() throws Exception {
 		stubFor(put(urlEqualTo("/rdf4j-server/repositories/test")).willReturn(aResponse().withStatus(200)));
 		RepositoryConfig config = new RepositoryConfig("test");
-		subject.createRepository(config);
+		getRDF4JSession().createRepository(config);
 		verify(putRequestedFor(urlEqualTo("/rdf4j-server/repositories/test")));
 		verifyHeader("/rdf4j-server/repositories/test");
 	}
@@ -94,7 +78,7 @@ public class RDF4JProtocolSessionTest {
 
 		stubFor(post(urlEqualTo("/rdf4j-server/repositories/test/config")).willReturn(aResponse().withStatus(200)));
 
-		subject.updateRepository(config);
+		getRDF4JSession().updateRepository(config);
 
 		verify(postRequestedFor(urlEqualTo("/rdf4j-server/repositories/test/config")));
 		verifyHeader("/rdf4j-server/repositories/test/config");
@@ -105,7 +89,7 @@ public class RDF4JProtocolSessionTest {
 		stubFor(get(urlEqualTo("/rdf4j-server/repositories/test/size"))
 				.willReturn(aResponse().withStatus(200).withBody("8")));
 
-		assertThat(subject.size()).isEqualTo(8);
+		assertThat(getRDF4JSession().size()).isEqualTo(8);
 		verifyHeader("/rdf4j-server/repositories/test/size");
 	}
 
@@ -119,7 +103,7 @@ public class RDF4JProtocolSessionTest {
 						.withHeader("Content-Type", RDFFormat.NTRIPLES.getDefaultMIMEType())
 						.withBodyFile("repository-config.nt")));
 
-		subject.getRepositoryConfig(new StatementCollector());
+		getRDF4JSession().getRepositoryConfig(new StatementCollector());
 
 		verify(getRequestedFor(urlEqualTo("/rdf4j-server/repositories/test/config")));
 
@@ -133,249 +117,36 @@ public class RDF4JProtocolSessionTest {
 						.withHeader("Content-Type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
 						.withBodyFile("repository-list.xml")));
 
-		assertThat(subject.getRepositoryList().getBindingNames()).contains("id");
+		assertThat(getRDF4JSession().getRepositoryList().getBindingNames()).contains("id");
 		verifyHeader("/rdf4j-server/repositories");
 	}
 
 	@Test
 	public void testClose() throws Exception {
+		// re-init protocol session with cache-timeout set
+		sparqlSession.close();
 		System.setProperty(Protocol.CACHE_TIMEOUT_PROPERTY, "1");
-		subject = new SharedHttpClientSessionManager().createRDF4JProtocolSession(serverURL);
-		subject.setRepository(Protocol.getRepositoryLocation(serverURL, repositoryID));
+		sparqlSession = createProtocolSession();
 
-		String transactionStartUrl = Protocol.getTransactionsLocation(subject.getRepositoryURL());
+		String transactionStartUrl = Protocol.getTransactionsLocation(getRDF4JSession().getRepositoryURL());
 
 		stubFor(post(urlEqualTo("/rdf4j-server/repositories/test/transactions"))
 				.willReturn(aResponse().withStatus(201).withHeader("Location", transactionStartUrl + "/1")));
 		stubFor(post("/rdf4j-server/repositories/test/transactions/1?action=PING")
 				.willReturn(aResponse().withStatus(200).withBody("2000")));
 
-		subject.beginTransaction(IsolationLevels.SERIALIZABLE);
+		getRDF4JSession().beginTransaction(IsolationLevels.SERIALIZABLE);
 		Thread.sleep(2000);
 
 		verify(moreThanOrExactly(2),
 				postRequestedFor(urlEqualTo("/rdf4j-server/repositories/test/transactions/1?action=PING")));
 
-		subject.close();
+		getRDF4JSession().close();
 		Thread.sleep(1000);
 
 		// we should not have received any further pings after the session was closed.
 		verify(lessThanOrExactly(3),
 				postRequestedFor(urlEqualTo("/rdf4j-server/repositories/test/transactions/1?action=PING")));
-	}
-
-	@Test
-	public void getContentTypeSerialisationTest() {
-
-		{
-			HttpResponse httpResponse = withContentType("application/shacl-validation-report+n-quads");
-			RDFFormat format = SPARQLProtocolSession.getContentTypeSerialisation(httpResponse);
-
-			assertThat(format).isEqualTo(RDFFormat.NQUADS);
-		}
-
-		{
-			HttpResponse httpResponse = withContentType("application/shacl-validation-report+ld+json");
-			RDFFormat format = SPARQLProtocolSession.getContentTypeSerialisation(httpResponse);
-
-			assertThat(format).isEqualTo(RDFFormat.JSONLD);
-		}
-
-		{
-			HttpResponse httpResponse = withContentType("text/shacl-validation-report+turtle");
-			RDFFormat format = SPARQLProtocolSession.getContentTypeSerialisation(httpResponse);
-
-			assertThat(format).isEqualTo(RDFFormat.TURTLE);
-		}
-	}
-
-	private HttpResponse withContentType(String contentType) {
-		Header header = new Header() {
-			@Override
-			public String getName() {
-				return null;
-			}
-
-			@Override
-			public String getValue() {
-				return null;
-			}
-
-			@Override
-			public HeaderElement[] getElements() throws ParseException {
-
-				HeaderElement[] elements = { new HeaderElement() {
-					@Override
-					public String getName() {
-						return contentType;
-					}
-
-					@Override
-					public String getValue() {
-						return null;
-					}
-
-					@Override
-					public NameValuePair[] getParameters() {
-						return new NameValuePair[0];
-					}
-
-					@Override
-					public NameValuePair getParameterByName(String name) {
-						return null;
-					}
-
-					@Override
-					public int getParameterCount() {
-						return 0;
-					}
-
-					@Override
-					public NameValuePair getParameter(int index) {
-						return null;
-					}
-				} };
-				return elements;
-			}
-		};
-
-		return new HttpResponse() {
-			@Override
-			public ProtocolVersion getProtocolVersion() {
-				return null;
-			}
-
-			@Override
-			public boolean containsHeader(String name) {
-				return false;
-			}
-
-			@Override
-			public Header[] getHeaders(String name) {
-				Header[] headers = { header };
-				return headers;
-			}
-
-			@Override
-			public Header getFirstHeader(String name) {
-				return null;
-			}
-
-			@Override
-			public Header getLastHeader(String name) {
-				return null;
-			}
-
-			@Override
-			public Header[] getAllHeaders() {
-				return new Header[0];
-			}
-
-			@Override
-			public void addHeader(Header header1) {
-
-			}
-
-			@Override
-			public void addHeader(String name, String value) {
-
-			}
-
-			@Override
-			public void setHeader(Header header1) {
-
-			}
-
-			@Override
-			public void setHeader(String name, String value) {
-
-			}
-
-			@Override
-			public void setHeaders(Header[] headers) {
-
-			}
-
-			@Override
-			public void removeHeader(Header header1) {
-
-			}
-
-			@Override
-			public void removeHeaders(String name) {
-
-			}
-
-			@Override
-			public HeaderIterator headerIterator() {
-				return null;
-			}
-
-			@Override
-			public HeaderIterator headerIterator(String name) {
-				return null;
-			}
-
-			@Override
-			public HttpParams getParams() {
-				return null;
-			}
-
-			@Override
-			public void setParams(HttpParams params) {
-
-			}
-
-			@Override
-			public StatusLine getStatusLine() {
-				return null;
-			}
-
-			@Override
-			public void setStatusLine(StatusLine statusline) {
-
-			}
-
-			@Override
-			public void setStatusLine(ProtocolVersion ver, int code) {
-
-			}
-
-			@Override
-			public void setStatusLine(ProtocolVersion ver, int code, String reason) {
-
-			}
-
-			@Override
-			public void setStatusCode(int code) throws IllegalStateException {
-
-			}
-
-			@Override
-			public void setReasonPhrase(String reason) throws IllegalStateException {
-
-			}
-
-			@Override
-			public HttpEntity getEntity() {
-				return null;
-			}
-
-			@Override
-			public void setEntity(HttpEntity entity) {
-
-			}
-
-			@Override
-			public Locale getLocale() {
-				return null;
-			}
-
-			@Override
-			public void setLocale(Locale loc) {
-
-			}
-		};
 	}
 
 	private void verifyHeader(String path) {

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
@@ -1,0 +1,340 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Locale;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.ParseException;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.params.HttpParams;
+import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResultHandler;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriter;
+import org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLStarResultsXMLWriter;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+/**
+ * Unit tests for {@link SPARQLProtocolSession}
+ *
+ * @author Jeen Broekstra
+ */
+public class SPARQLProtocolSessionTest {
+
+	@ClassRule
+	public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+
+	SPARQLProtocolSession sparqlSession;
+
+	String testHeader = "X-testing-header";
+	String testValue = "foobar";
+
+	String serverURL = "http://localhost:" + wireMockRule.port() + "/rdf4j-server";
+	String repositoryID = "test";
+
+	SPARQLProtocolSession createProtocolSession() {
+		SPARQLProtocolSession session = new SharedHttpClientSessionManager().createRDF4JProtocolSession(serverURL);
+		session.setQueryURL(Protocol.getRepositoryLocation(serverURL, repositoryID));
+		session.setUpdateURL(
+				Protocol.getStatementsLocation(Protocol.getRepositoryLocation(serverURL, repositoryID)));
+		HashMap<String, String> additionalHeaders = new HashMap<>();
+		additionalHeaders.put(testHeader, testValue);
+		session.setAdditionalHttpHeaders(additionalHeaders);
+		return session;
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		sparqlSession = createProtocolSession();
+	}
+
+	@Test
+	public void testTupleQuery_NoPassthrough() throws Exception {
+		stubFor(post(urlEqualTo("/rdf4j-server/repositories/test"))
+				.willReturn(aResponse().withStatus(200)
+						.withHeader("Content-Type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
+						.withBodyFile("repository-list.xml")));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		TupleQueryResultHandler handler = Mockito.spy(new SPARQLStarResultsJSONWriter(out));
+		sparqlSession.sendTupleQuery(QueryLanguage.SPARQL, "SELECT * WHERE { ?s ?p ?o}", null, null, true, -1, handler);
+
+		// If not passed through, the QueryResultWriter methods should have been invoked
+		verify(handler, times(1)).startQueryResult(anyList());
+
+		// check that the OutputStream received content in JSON format
+		assertThat(out.toString()).startsWith("{");
+	}
+
+	@Test
+	public void testTupleQuery_Passthrough() throws Exception {
+		stubFor(post(urlEqualTo("/rdf4j-server/repositories/test"))
+				.willReturn(aResponse().withStatus(200)
+						.withHeader("Content-Type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
+						.withBodyFile("repository-list.xml")));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		SPARQLStarResultsXMLWriter handler = Mockito.spy(new SPARQLStarResultsXMLWriter(out));
+		sparqlSession.sendTupleQuery(QueryLanguage.SPARQL, "SELECT * WHERE { ?s ?p ?o}", null, null, true, -1, handler);
+
+		// SPARQL* XML sink should accept SPARQL/XML data and pass directly to OutputStream
+		verify(handler, never()).startQueryResult(anyList());
+
+		// check that the OutputStream received content in XML format
+		assertThat(out.toString()).startsWith("<");
+	}
+
+	@Test
+	public void getContentTypeSerialisationTest() {
+		{
+			HttpResponse httpResponse = withContentType("application/shacl-validation-report+n-quads");
+			RDFFormat format = SPARQLProtocolSession.getContentTypeSerialisation(httpResponse);
+
+			assertThat(format).isEqualTo(RDFFormat.NQUADS);
+		}
+
+		{
+			HttpResponse httpResponse = withContentType("application/shacl-validation-report+ld+json");
+			RDFFormat format = SPARQLProtocolSession.getContentTypeSerialisation(httpResponse);
+
+			assertThat(format).isEqualTo(RDFFormat.JSONLD);
+		}
+
+		{
+			HttpResponse httpResponse = withContentType("text/shacl-validation-report+turtle");
+			RDFFormat format = SPARQLProtocolSession.getContentTypeSerialisation(httpResponse);
+
+			assertThat(format).isEqualTo(RDFFormat.TURTLE);
+		}
+	}
+
+	/* private methods */
+
+	private HttpResponse withContentType(String contentType) {
+		Header header = new Header() {
+			@Override
+			public String getName() {
+				return null;
+			}
+
+			@Override
+			public String getValue() {
+				return null;
+			}
+
+			@Override
+			public HeaderElement[] getElements() throws ParseException {
+
+				HeaderElement[] elements = { new HeaderElement() {
+					@Override
+					public String getName() {
+						return contentType;
+					}
+
+					@Override
+					public String getValue() {
+						return null;
+					}
+
+					@Override
+					public NameValuePair[] getParameters() {
+						return new NameValuePair[0];
+					}
+
+					@Override
+					public NameValuePair getParameterByName(String name) {
+						return null;
+					}
+
+					@Override
+					public int getParameterCount() {
+						return 0;
+					}
+
+					@Override
+					public NameValuePair getParameter(int index) {
+						return null;
+					}
+				} };
+				return elements;
+			}
+		};
+
+		return new HttpResponse() {
+			@Override
+			public ProtocolVersion getProtocolVersion() {
+				return null;
+			}
+
+			@Override
+			public boolean containsHeader(String name) {
+				return false;
+			}
+
+			@Override
+			public Header[] getHeaders(String name) {
+				Header[] headers = { header };
+				return headers;
+			}
+
+			@Override
+			public Header getFirstHeader(String name) {
+				return null;
+			}
+
+			@Override
+			public Header getLastHeader(String name) {
+				return null;
+			}
+
+			@Override
+			public Header[] getAllHeaders() {
+				return new Header[0];
+			}
+
+			@Override
+			public void addHeader(Header header1) {
+
+			}
+
+			@Override
+			public void addHeader(String name, String value) {
+
+			}
+
+			@Override
+			public void setHeader(Header header1) {
+
+			}
+
+			@Override
+			public void setHeader(String name, String value) {
+
+			}
+
+			@Override
+			public void setHeaders(Header[] headers) {
+
+			}
+
+			@Override
+			public void removeHeader(Header header1) {
+
+			}
+
+			@Override
+			public void removeHeaders(String name) {
+
+			}
+
+			@Override
+			public HeaderIterator headerIterator() {
+				return null;
+			}
+
+			@Override
+			public HeaderIterator headerIterator(String name) {
+				return null;
+			}
+
+			@Override
+			public HttpParams getParams() {
+				return null;
+			}
+
+			@Override
+			public void setParams(HttpParams params) {
+
+			}
+
+			@Override
+			public StatusLine getStatusLine() {
+				return null;
+			}
+
+			@Override
+			public void setStatusLine(StatusLine statusline) {
+
+			}
+
+			@Override
+			public void setStatusLine(ProtocolVersion ver, int code) {
+
+			}
+
+			@Override
+			public void setStatusLine(ProtocolVersion ver, int code, String reason) {
+
+			}
+
+			@Override
+			public void setStatusCode(int code) throws IllegalStateException {
+
+			}
+
+			@Override
+			public void setReasonPhrase(String reason) throws IllegalStateException {
+
+			}
+
+			@Override
+			public HttpEntity getEntity() {
+				return null;
+			}
+
+			@Override
+			public void setEntity(HttpEntity entity) {
+
+			}
+
+			@Override
+			public Locale getLocale() {
+				return null;
+			}
+
+			@Override
+			public void setLocale(Locale loc) {
+
+			}
+		};
+	}
+
+	private void verifyHeader(String path) {
+		verify(anyRequestedFor(urlEqualTo(path)).withHeader(testHeader, containing(testValue)));
+	}
+}

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriter.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 import java.io.OutputStream;
 
+import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 
@@ -34,5 +35,12 @@ public class SPARQLStarResultsJSONWriter extends SPARQLResultsJSONWriter impleme
 	@Override
 	public TupleQueryResultFormat getQueryResultFormat() {
 		return getTupleQueryResultFormat();
+	}
+
+	@Override
+	public boolean acceptsFileFormat(FileFormat format) {
+		// since SPARQL*/JSON is a superset of regular SPARQL/JSON, this Sink also accepts regular SPARQL/JSON
+		// serialization
+		return super.acceptsFileFormat(format) || TupleQueryResultFormat.JSON.equals(format);
 	}
 }

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarResultsXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarResultsXMLWriter.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.resultio.sparqlxml;
 import java.io.OutputStream;
 
 import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 
@@ -35,6 +36,11 @@ public class SPARQLStarResultsXMLWriter extends SPARQLResultsXMLWriter {
 	@Override
 	public final TupleQueryResultFormat getTupleQueryResultFormat() {
 		return TupleQueryResultFormat.SPARQL_STAR;
+	}
+
+	@Override
+	public boolean acceptsFileFormat(FileFormat format) {
+		return super.acceptsFileFormat(format) || TupleQueryResultFormat.SPARQL.equals(format);
 	}
 
 }

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriter.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriter.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 
+import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -63,6 +64,13 @@ public class TriGStarWriter extends TriGWriter {
 	@Override
 	public RDFFormat getRDFFormat() {
 		return RDFFormat.TRIGSTAR;
+	}
+
+	@Override
+	public boolean acceptsFileFormat(FileFormat format) {
+		// since TriG* is a superset of regular TriG, this Sink also accepts regular TriG
+		// serialization
+		return super.acceptsFileFormat(format) || RDFFormat.TRIG.equals(format);
 	}
 
 	@Override

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriter.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 
+import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -63,6 +64,13 @@ public class TurtleStarWriter extends TurtleWriter {
 	@Override
 	public RDFFormat getRDFFormat() {
 		return RDFFormat.TURTLESTAR;
+	}
+
+	@Override
+	public boolean acceptsFileFormat(FileFormat format) {
+		// since Turtle* is a superset of regular Turtle, this Sink also accepts regular Turtle
+		// serialization
+		return super.acceptsFileFormat(format) || RDFFormat.TURTLE.equals(format);
 	}
 
 	@Override

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/io/Sink.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/io/Sink.java
@@ -11,7 +11,7 @@ import org.eclipse.rdf4j.common.lang.FileFormat;
 
 /**
  * 
- * A Sink writes data in a particular {@link FileFormat}.
+ * A Sink writes a data stream in a particular {@link FileFormat}.
  * 
  * @author Jeen Broekstra
  * @since 3.5.0
@@ -21,7 +21,22 @@ public interface Sink {
 	/**
 	 * Get the {@link FileFormat} this sink uses.
 	 * 
-	 * @return a {@link FileFormat}.
+	 * @return a {@link FileFormat}. May not be <code>null</code>.
 	 */
 	FileFormat getFileFormat();
+
+	/**
+	 * Check if this Sink accepts the supplied {@link FileFormat}.
+	 * 
+	 * @implNote the default implementation of this method only returns {@code true} if the supplied format is equal to
+	 *           the format supplied by {@link #getFileFormat()}. Specific Sink implementations can choose to override
+	 *           this behavior if they wish to indicate they can also accept other formats.
+	 * 
+	 * @param format the {@link FileFormat} to check.
+	 * @return {@code true} if the sink accepts the supplied format, {@code false} otherwise.
+	 */
+	default boolean acceptsFileFormat(FileFormat format) {
+		return getFileFormat().equals(format);
+	}
+
 }


### PR DESCRIPTION
GitHub issue resolved: #2627  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- Added `Sink.acceptFileFormat` to let a sink optionally indicate it can accept formats other than its own
- discovered (and fixed) minor bug in pass-through handling: we should flush after copying
- Added tests for pass-through handling

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

