### PR TITLE
minor fix to alignment of images in news items

### DIFF
--- a/site/layouts/_default/index.html
+++ b/site/layouts/_default/index.html
@@ -15,6 +15,7 @@
       </div>
       <div class="news_item_description">
         {{ .Content }}
+        <br clear="all"/>
       </div>
     </div>
   {{ end }}
@@ -27,6 +28,7 @@
       </div>
       <div class="news_item_description">
         {{ .Summary }}
+        <br clear="all"/>
       </div>
       <div style="text-align: right; font-size: smaller;">
         <a href="{{.Permalink}}">[read more]</a>

--- a/site/layouts/_default/summary.html
+++ b/site/layouts/_default/summary.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright (c) 2019 Eclipse Foundation, Inc.
 
   This program and the accompanying materials are made available under the
@@ -17,6 +17,7 @@
       </div>
       <div class="news_item_description">
         {{ .Summary }}
+        <br clear="all">
       </div>
       <div style="text-align: right; font-size: smaller;">
         <a href="{{.Permalink}}">[read more]</a>


### PR DESCRIPTION

Briefly describe the changes proposed in this PR:

- ensures images do not overflow to next news items when shown in a list

(my bad for not actually logging an issue for this first, but it's a really minor thing in the site content rather than the code)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

