### PR TITLE
GH-2632 rsx:targetShape bug when using sh:or or sh:and

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/AndPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/AndPropertyShape.java
@@ -11,11 +11,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
@@ -288,9 +290,22 @@ public class AndPropertyShape extends PathPropertyShape {
 
 	@Override
 	public Stream<StatementPattern> getStatementPatterns() {
-		return and
-				.stream()
+		StatementPattern subject = new StatementPattern(
+				new Var("?this"),
+				new Var(UUID.randomUUID().toString()),
+				new Var(UUID.randomUUID().toString())
+		);
+
+		StatementPattern object = new StatementPattern(
+				new Var(UUID.randomUUID().toString()),
+				new Var(UUID.randomUUID().toString()),
+				new Var("?this")
+		);
+
+		Stream<StatementPattern> statementPatternStream = and.stream()
 				.flatMap(Collection::stream)
 				.flatMap(PropertyShape::getStatementPatterns);
+
+		return Stream.concat(statementPatternStream, Stream.of(subject, object));
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
@@ -327,9 +328,9 @@ public class OrPropertyShape extends PathPropertyShape {
 			String pathQuery2 = getPath().getQuery(targetVar, randomVariable(), null);
 
 			query = "{\n" + AbstractBulkJoinPlanNode.VALUES_INJECTION_POINT + "\n " + query.replaceAll("(?m)^", "\t")
-					+ " \n} UNION {\n\t" + AbstractBulkJoinPlanNode.VALUES_INJECTION_POINT + "\n\t" + targetVar + " "
-					+ randomVariable() + " "
-					+ randomVariable() + ".\n\tFILTER(NOT EXISTS {\n " + pathQuery2.replaceAll("(?m)^", "\t")
+					+ " \n} UNION {\n\t" + AbstractBulkJoinPlanNode.VALUES_INJECTION_POINT + "\n" +
+					"\t" + targetVar + " " + randomVariable() + " " + randomVariable() + ".\n" +
+					"\tFILTER(NOT EXISTS {\n " + pathQuery2.replaceAll("(?m)^", "\t")
 					+ " \n})\n}";
 
 			return query;
@@ -360,6 +361,23 @@ public class OrPropertyShape extends PathPropertyShape {
 
 	@Override
 	public Stream<StatementPattern> getStatementPatterns() {
-		return or.stream().flatMap(Collection::stream).flatMap(PropertyShape::getStatementPatterns);
+
+		StatementPattern subject = new StatementPattern(
+				new Var("?this"),
+				new Var(UUID.randomUUID().toString()),
+				new Var(UUID.randomUUID().toString())
+		);
+
+		StatementPattern object = new StatementPattern(
+				new Var(UUID.randomUUID().toString()),
+				new Var(UUID.randomUUID().toString()),
+				new Var("?this")
+		);
+
+		Stream<StatementPattern> statementPatternStream = or.stream()
+				.flatMap(Collection::stream)
+				.flatMap(PropertyShape::getStatementPatterns);
+
+		return Stream.concat(statementPatternStream, Stream.of(subject, object));
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetShape.java
@@ -91,7 +91,7 @@ public class TargetShape extends NodeShape {
 
 	}
 
-	private PlanNode getInnerPlanRemovedOrAdded(ConnectionsGroup connectionsGroup, SailConnection removedStatements) {
+	private PlanNode getInnerPlanRemovedOrAdded(ConnectionsGroup connectionsGroup, SailConnection connection) {
 
 		// @formatter:off
 		/*
@@ -107,7 +107,7 @@ public class TargetShape extends NodeShape {
 
 			PlanNode statementsThatMatchPattern = new TrimTuple(
 					new UnorderedSelect(
-							removedStatements,
+							connection,
 							null,
 							((IRI) statementPattern.getPredicateVar().getValue()),
 							(statementPattern.getObjectVar().getValue()),
@@ -140,7 +140,8 @@ public class TargetShape extends NodeShape {
 	@Override
 	public String getQuery(String subjectVariable, String objectVariable,
 			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
-		return targetShape.buildSparqlValidNodes(subjectVariable);
+		String s = targetShape.buildSparqlValidNodes(subjectVariable);
+		return s;
 
 	}
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -332,10 +332,6 @@ abstract public class AbstractShaclTest {
 					if (!(sailException.getCause() instanceof ShaclSailValidationException)) {
 						throw sailException;
 					}
-					exception = true;
-					logger.debug(sailException.getMessage());
-
-					printResults(sailException);
 				}
 			}
 

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/targetShapeAnd/invalid/case4/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/targetShapeAnd/invalid/case4/query1.rq
@@ -1,0 +1,13 @@
+
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:a ex:b ex:validPerson1 .
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValueIn/targetShapeOr/invalid/case4/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValueIn/targetShapeOr/invalid/case4/query1.rq
@@ -1,0 +1,13 @@
+
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 ex:a ex:b .
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValueIn/targetShapeOr/invalid/case5/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValueIn/targetShapeOr/invalid/case5/query1.rq
@@ -1,0 +1,11 @@
+
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+        ex:a ex:b ex:validPerson1  .
+}


### PR DESCRIPTION
GitHub issue resolved: #2632  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Fixes a bug in rsx:targetShape when suing `sh:or` or `sh:and`.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

