### PR TITLE
GH-2650 simple codeowners file assigning all core committers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Each line is a file pattern followed by one or more owners.
+
+# The committer team are the default owners for everything in
+# the repo. 
+*       @eclipse/technology-rdf4j-committers


### PR DESCRIPTION
GitHub issue resolved: #2650  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- simple CODEOWNERS file with only one rule
- we can refine later if we want to assign specific parts of the code base to specific people 
- the intent is not to make people the sole guardian of (a piece of) the code base, merely as an aid to assign reviewers to a PR more easily. 
