### PR TITLE
GH-2658 Literal/ValueFactory java.time support

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -9,6 +9,8 @@ package org.eclipse.rdf4j.model;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
 import java.util.Date;
 
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -18,6 +20,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
  * statements} based on the RDF-1.1 Concepts and Abstract Syntax, a W3C Recommendation.
  *
  * @author Arjohn Kampman
+ *
  * @see <a href="http://www.w3.org/TR/rdf11-concepts/">RDF-1.1 Concepts and Abstract Syntax</a>
  */
 public interface ValueFactory {
@@ -195,6 +198,54 @@ public interface ValueFactory {
 	 * date/time datatype.
 	 */
 	public Literal createLiteral(BigInteger bigInteger);
+
+	/**
+	 * Creates a new literal representing a temporal accessor value.
+	 *
+	 * @param value the temporal accessor value for the literal
+	 *
+	 * @return a literal representing the specified temporal accessor {@code value} with the appropriate
+	 *         {@linkplain Literal#temporalAccessorValue() XML Schema date/time datatype}
+	 *
+	 * @throws NullPointerException     if {@code value} is {@code null}
+	 * @throws IllegalArgumentException if {@code value} cannot be represented by an XML Schema date/time datatype
+	 *
+	 * @since 3.5.0
+	 * @author Alessandro Bollini
+	 *
+	 * @apiNote See datatype-related API notes for {@link Literal#temporalAccessorValue()}.
+	 *
+	 * @implNote the default method implementation throws an {@link UnsupportedOperationException} and is only supplied
+	 *           as a stop-gap measure for backward compatibility: concrete classes implementing this interface are
+	 *           expected to override it.
+	 */
+	public default Literal createLiteral(TemporalAccessor value) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Creates a new literal representing a temporal amount value.
+	 *
+	 * @param value the temporal amount value for the literal
+	 * 
+	 * @return a literal representing the specified temporal amount {@code value} with the appropriate
+	 *         {@linkplain Literal#temporalAmountValue() XML Schema duration datatype}
+	 *
+	 * @throws NullPointerException     if {@code value} is {@code null}
+	 * @throws IllegalArgumentException if {@code value} cannot be represented by an XML Schema duration datatype
+	 *
+	 * @since 3.5.0
+	 * @author Alessandro Bollini
+	 *
+	 * @apiNote See datatype-related API notes for {@link Literal#temporalAmountValue()}.
+	 *
+	 * @implNote the default method implementation throws an {@link UnsupportedOperationException} and is only supplied
+	 *           as a stop-gap measure for backward compatibility: concrete classes implementing this interface are
+	 *           expected to override it.
+	 */
+	public default Literal createLiteral(TemporalAmount value) {
+		throw new UnsupportedOperationException();
+	}
 
 	/**
 	 * Creates a new literal representing the specified calendar that is typed using the appropriate XML Schema

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
@@ -8,15 +8,49 @@
 
 package org.eclipse.rdf4j.model.base;
 
+import static java.lang.Math.abs;
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.OFFSET_SECONDS;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.MONTHS;
+import static java.time.temporal.ChronoUnit.NANOS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.time.temporal.ChronoUnit.YEARS;
 import static java.util.Objects.requireNonNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.DateTimeException;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
@@ -68,22 +102,6 @@ public abstract class AbstractLiteral implements Literal {
 	private static final IRI XSD_DURATION_DAYTIME = new GenericIRI(XSD, "dayTimeDuration");
 	private static final IRI XSD_DURATION_YEARMONTH = new GenericIRI(XSD, "yearMonthDuration");
 
-	private static final String POSITIVE_INFINITY = "INF";
-	private static final String NEGATIVE_INFINITY = "-INF";
-	private static final String NAN = "NaN";
-
-	private static final ThreadLocal<DatatypeFactory> DATATYPE_FACTORY = ThreadLocal.withInitial(() -> {
-		try {
-
-			return DatatypeFactory.newInstance(); // not guaranteed to be thread-safe
-
-		} catch (DatatypeConfigurationException e) {
-
-			throw new RuntimeException("unable to create datatype factory", e);
-
-		}
-	});
-
 	static boolean reserved(IRI datatype) {
 		return RDF_LANGSTRING.equals(datatype);
 	}
@@ -114,17 +132,7 @@ public abstract class AbstractLiteral implements Literal {
 
 	@Override
 	public boolean booleanValue() {
-		return value(label -> Optional.of(label)
-
-				.map(String::trim)
-
-				.map(normalized -> (normalized.equals("true") || normalized.equals("1")) ? Boolean.TRUE
-						: (normalized.equals("false") || normalized.equals("0")) ? Boolean.FALSE
-								: null
-				)
-
-				.orElse(null)
-		);
+		return value(BooleanLiteral::parseBoolean);
 	}
 
 	@Override
@@ -149,20 +157,12 @@ public abstract class AbstractLiteral implements Literal {
 
 	@Override
 	public float floatValue() {
-		return value(label -> label.equals(POSITIVE_INFINITY) ? Float.POSITIVE_INFINITY
-				: label.equals(NEGATIVE_INFINITY) ? Float.NEGATIVE_INFINITY
-						: label.equals(NAN) ? Float.NaN
-								: Float.parseFloat(label)
-		);
+		return value(NumberLiteral::parseFloat);
 	}
 
 	@Override
 	public double doubleValue() {
-		return value(label -> label.equals(POSITIVE_INFINITY) ? Double.POSITIVE_INFINITY
-				: label.equals(NEGATIVE_INFINITY) ? Double.NEGATIVE_INFINITY
-						: label.equals(NAN) ? Double.NaN
-								: Double.parseDouble(label)
-		);
+		return value(NumberLiteral::parseDouble);
 	}
 
 	@Override
@@ -176,8 +176,18 @@ public abstract class AbstractLiteral implements Literal {
 	}
 
 	@Override
+	public TemporalAccessor temporalAccessorValue() throws DateTimeException {
+		return value(TemporalAccessorLiteral::parseTemporalAccessor);
+	}
+
+	@Override
+	public TemporalAmount temporalAmountValue() throws DateTimeException {
+		return value(TemporalAmountLiteral::parseTemporalAmount);
+	}
+
+	@Override
 	public XMLGregorianCalendar calendarValue() {
-		return value(label -> DATATYPE_FACTORY.get().newXMLGregorianCalendar(label));
+		return value(CalendarLiteral::parseCalendar);
 	}
 
 	@Override
@@ -234,7 +244,7 @@ public abstract class AbstractLiteral implements Literal {
 
 		TypedLiteral(String label, IRI datatype) {
 			this.label = label;
-			this.datatype = (datatype != null) ? datatype : XSD_STRING;
+			this.datatype = datatype != null ? datatype : XSD_STRING;
 		}
 
 		@Override
@@ -287,6 +297,19 @@ public abstract class AbstractLiteral implements Literal {
 
 		private static final long serialVersionUID = -1162147873619834622L;
 
+		static Boolean parseBoolean(String label) {
+			return Optional.of(label)
+
+					.map(String::trim)
+
+					.map(normalized -> normalized.equals("true") || normalized.equals("1") ? Boolean.TRUE
+							: normalized.equals("false") || normalized.equals("0") ? Boolean.FALSE
+									: null
+					)
+
+					.orElse(null);
+		}
+
 		private boolean value;
 
 		BooleanLiteral(boolean value) {
@@ -319,6 +342,38 @@ public abstract class AbstractLiteral implements Literal {
 
 		private static final long serialVersionUID = -3201912818064851702L;
 
+		private static final String POSITIVE_INFINITY = "INF";
+		private static final String NEGATIVE_INFINITY = "-INF";
+		private static final String NAN = "NaN";
+
+		static float parseFloat(String label) {
+			return label.equals(POSITIVE_INFINITY) ? Float.POSITIVE_INFINITY
+					: label.equals(NEGATIVE_INFINITY) ? Float.NEGATIVE_INFINITY
+							: label.equals(NAN) ? Float.NaN
+									: Float.parseFloat(label);
+		}
+
+		static double parseDouble(String label) {
+			return label.equals(POSITIVE_INFINITY) ? Double.POSITIVE_INFINITY
+					: label.equals(NEGATIVE_INFINITY) ? Double.NEGATIVE_INFINITY
+							: label.equals(NAN) ? Double.NaN
+									: Double.parseDouble(label);
+		}
+
+		private static String toString(float value) {
+			return value == Float.POSITIVE_INFINITY ? POSITIVE_INFINITY
+					: value == Float.NEGATIVE_INFINITY ? NEGATIVE_INFINITY
+							: Float.isNaN(value) ? NAN
+									: Float.toString(value);
+		}
+
+		private static String toString(double value) {
+			return value == Double.POSITIVE_INFINITY ? POSITIVE_INFINITY
+					: value == Double.NEGATIVE_INFINITY ? NEGATIVE_INFINITY
+							: Double.isNaN(value) ? NAN
+									: Double.toString(value);
+		}
+
 		protected Number value;
 
 		private String label;
@@ -341,25 +396,11 @@ public abstract class AbstractLiteral implements Literal {
 		}
 
 		NumberLiteral(float value) {
-			this(
-					value,
-					value == Float.POSITIVE_INFINITY ? POSITIVE_INFINITY
-							: value == Float.NEGATIVE_INFINITY ? NEGATIVE_INFINITY
-									: Float.isNaN(value) ? NAN
-											: Float.toString(value),
-					XSD_FLOAT
-			);
+			this(value, toString(value), XSD_FLOAT);
 		}
 
 		NumberLiteral(double value) {
-			this(
-					value,
-					value == Double.POSITIVE_INFINITY ? POSITIVE_INFINITY
-							: value == Double.NEGATIVE_INFINITY ? NEGATIVE_INFINITY
-									: Double.isNaN(value) ? NAN
-											: Double.toString(value),
-					XSD_DOUBLE
-			);
+			this(value, toString(value), XSD_DOUBLE);
 		}
 
 		NumberLiteral(Number value, String label, IRI datatype) {
@@ -455,9 +496,428 @@ public abstract class AbstractLiteral implements Literal {
 
 	}
 
+	static class TemporalAccessorLiteral extends AbstractLiteral {
+
+		private static final long serialVersionUID = -6089251668767105663L;
+
+		private static final ChronoField[] FIELDS = {
+				YEAR, MONTH_OF_YEAR, DAY_OF_MONTH,
+				HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE, NANO_OF_SECOND,
+				OFFSET_SECONDS
+		};
+
+		private static final DateTimeFormatter LOCAL_TIME_FORMATTER = new DateTimeFormatterBuilder()
+
+				.appendValue(HOUR_OF_DAY, 2)
+				.appendLiteral(':')
+				.appendValue(MINUTE_OF_HOUR, 2)
+				.appendLiteral(':')
+				.appendValue(SECOND_OF_MINUTE, 2)
+
+				.optionalStart()
+				.appendFraction(NANO_OF_SECOND, 1, 9, true)
+
+				.toFormatter();
+
+		private static final DateTimeFormatter OFFSET_TIME_FORMATTER = new DateTimeFormatterBuilder()
+
+				.append(LOCAL_TIME_FORMATTER)
+
+				.optionalStart()
+				.appendOffsetId()
+
+				.toFormatter();
+
+		private static final DateTimeFormatter LOCAL_DATE_FORMATTER = new DateTimeFormatterBuilder()
+
+				.appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
+
+				.optionalStart()
+				.appendLiteral('-')
+				.appendValue(MONTH_OF_YEAR, 2)
+
+				.optionalStart()
+				.appendLiteral('-')
+				.appendValue(DAY_OF_MONTH, 2)
+
+				.toFormatter();
+
+		private static final DateTimeFormatter OFFSET_DATE_FORMATTER = new DateTimeFormatterBuilder()
+
+				.append(LOCAL_DATE_FORMATTER)
+
+				.optionalStart()
+				.appendOffsetId()
+
+				.toFormatter();
+
+		private static final DateTimeFormatter DATETIME_FORMATTER = new DateTimeFormatterBuilder()
+
+				.append(LOCAL_DATE_FORMATTER)
+
+				.optionalStart()
+				.appendLiteral('T')
+				.append(LOCAL_TIME_FORMATTER)
+				.optionalEnd()
+
+				.optionalStart()
+				.appendOffsetId()
+
+				.toFormatter();
+
+		private static final DateTimeFormatter DASH_FORMATTER = new DateTimeFormatterBuilder()
+
+				.appendLiteral("--")
+
+				.optionalStart()
+				.appendValue(MONTH_OF_YEAR, 2)
+				.optionalEnd()
+
+				.optionalStart()
+				.appendLiteral('-')
+				.appendValue(DAY_OF_MONTH, 2)
+
+				.toFormatter();
+
+		private static final Map<Integer, IRI> DATATYPES = datatypes();
+		private static final Map<IRI, DateTimeFormatter> FORMATTERS = formatters();
+
+		static TemporalAccessor parseTemporalAccessor(String label) throws DateTimeException {
+
+			final TemporalAccessor value = formatter(label).parse(label);
+
+			if (!DATATYPES.containsKey(key(value))) {
+				throw new DateTimeException(String.format(
+						"label <%s> is not a valid lexical representation of an XML Schema date/time datatype", label
+				));
+			}
+
+			return value;
+		}
+
+		private static Map<Integer, IRI> datatypes() {
+
+			final Map<Integer, IRI> datatypes = new HashMap<>();
+
+			final int date = key(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH);
+			final int time = key(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE);
+			final int nano = key(NANO_OF_SECOND);
+			final int zone = key(OFFSET_SECONDS);
+
+			datatypes.put(date + time, XSD_DATETIME);
+			datatypes.put(date + time + nano, XSD_DATETIME);
+			datatypes.put((date + time + zone), XSD_DATETIME);
+			datatypes.put((date + time + nano + zone), XSD_DATETIME);
+
+			datatypes.put(time, XSD_TIME);
+			datatypes.put(time + nano, XSD_TIME);
+			datatypes.put(time + zone, XSD_TIME);
+			datatypes.put(time + nano + zone, XSD_TIME);
+
+			datatypes.put(date, XSD_DATE);
+			datatypes.put(date + zone, XSD_DATE);
+
+			datatypes.put(key(YEAR, MONTH_OF_YEAR), XSD_GYEARMONTH);
+			datatypes.put(key(YEAR), XSD_GYEAR);
+			datatypes.put(key(MONTH_OF_YEAR, DAY_OF_MONTH), XSD_GMONTHDAY);
+			datatypes.put(key(DAY_OF_MONTH), XSD_GDAY);
+			datatypes.put(key(MONTH_OF_YEAR), XSD_GMONTH);
+
+			return datatypes;
+		}
+
+		private static Map<IRI, DateTimeFormatter> formatters() {
+
+			final Map<IRI, DateTimeFormatter> formatters = new HashMap<>();
+
+			formatters.put(XSD_DATETIME, DATETIME_FORMATTER);
+			formatters.put(XSD_TIME, OFFSET_TIME_FORMATTER);
+			formatters.put(XSD_DATE, OFFSET_DATE_FORMATTER);
+
+			formatters.put(XSD_GYEARMONTH, LOCAL_DATE_FORMATTER);
+			formatters.put(XSD_GYEAR, LOCAL_DATE_FORMATTER);
+			formatters.put(XSD_GMONTHDAY, DASH_FORMATTER);
+			formatters.put(XSD_GDAY, DASH_FORMATTER);
+			formatters.put(XSD_GMONTH, DASH_FORMATTER);
+
+			return formatters;
+		}
+
+		private static DateTimeFormatter formatter(String label) {
+			if (label.startsWith("--")) {
+
+				return DASH_FORMATTER;
+
+			} else if (label.length() >= 8 && label.charAt(2) == ':') {
+
+				return OFFSET_TIME_FORMATTER;
+
+			} else {
+
+				return DATETIME_FORMATTER;
+
+			}
+		}
+
+		private static int key(TemporalAccessor value) {
+			return key(value::isSupported, FIELDS);
+		}
+
+		private static int key(ChronoField... fields) {
+			return key(field -> true, fields);
+		}
+
+		private static int key(Predicate<ChronoField> include, ChronoField... fields) {
+
+			int index = 0;
+
+			for (ChronoField field : fields) {
+				if (include.test(field)) {
+					index += 1 << field.ordinal() + 1;
+				}
+			}
+
+			return index;
+		}
+
+		private TemporalAccessor value;
+
+		private String label;
+		private IRI datatype;
+
+		TemporalAccessorLiteral(TemporalAccessor value) {
+
+			this.value = value;
+
+			final IRI datatype = DATATYPES.get(key(value));
+
+			if (datatype == null) {
+				throw new IllegalArgumentException(String.format(
+						"value <%s> cannot be represented by an XML Schema date/time datatype", value
+				));
+			}
+
+			this.label = FORMATTERS.get(datatype).format(value);
+			this.datatype = datatype;
+		}
+
+		@Override
+		public String getLabel() {
+			return label;
+		}
+
+		@Override
+		public Optional<String> getLanguage() {
+			return Optional.empty();
+		}
+
+		@Override
+		public IRI getDatatype() {
+			return datatype;
+		}
+
+		@Override
+		public TemporalAccessor temporalAccessorValue() {
+			return value;
+		}
+
+	}
+
+	static class TemporalAmountLiteral extends AbstractLiteral {
+
+		private static final long serialVersionUID = -447302801371093467L;
+
+		private static final Collection<ChronoUnit> UNITS = EnumSet.of(
+				YEARS, MONTHS, DAYS, HOURS, MINUTES, SECONDS, NANOS
+		);
+
+		private static final Pattern PATTERN = Pattern.compile("(?<sign>-)?" +
+				"P" +
+				"(?:(?<" + YEARS + ">\\d+)Y)?" +
+				"(?:(?<" + MONTHS + ">\\d+)M)?" +
+				"(?:(?<" + DAYS + ">\\d+)D)?" +
+				"(?<time>T)?" +
+				"(?:(?<" + HOURS + ">\\d+)H)?" +
+				"(?:(?<" + MINUTES + ">\\d+)M)?" +
+				"(?:(?<" + SECONDS + ">\\d+)(?:\\.(?<" + NANOS + ">\\d+))?S)?"
+		);
+
+		private TemporalAmount value;
+
+		private String label;
+
+		TemporalAmountLiteral(TemporalAmount value) {
+
+			final List<TemporalUnit> units = value.getUnits();
+
+			if (units.isEmpty() || !UNITS.containsAll(units)) {
+				throw new IllegalArgumentException(String.format(
+						"value <%s> cannot be represented by an XML Schema duration datatype", value
+				));
+			}
+
+			this.value = value;
+			this.label = toString(value);
+		}
+
+		static TemporalAmount parseTemporalAmount(CharSequence label) {
+
+			final Matcher matcher = PATTERN.matcher(label);
+
+			if (!matcher.matches()) {
+				throw new DateTimeException(String.format(
+						"label <%s> is not a valid lexical representation of an XML Schema duration datatype", label
+				));
+			}
+
+			final boolean sign = matcher.group("sign") != null;
+			final boolean time = matcher.group("time") != null;
+
+			final Map<ChronoUnit, Long> components = new EnumMap<>(ChronoUnit.class);
+
+			for (final ChronoUnit unit : UNITS) {
+
+				final String group = matcher.group(unit.toString());
+
+				if (group != null) {
+					try {
+
+						final long value = Long.parseUnsignedLong(unit == NANOS
+								? (group + "000000000").substring(0, 9)
+								: group
+						);
+
+						components.put(unit, sign ? -value : value);
+
+					} catch (final NumberFormatException e) {
+
+						throw new DateTimeParseException(e.getMessage(), group, matcher.start(unit.toString()));
+
+					}
+				}
+
+			}
+
+			if (components.isEmpty() || time && Stream.of(HOURS, MINUTES, SECONDS).noneMatch(components::containsKey)) {
+				throw new DateTimeException(String.format(
+						"label <%s> is not a valid lexical representation of an XML Schema duration datatype", label
+				));
+			}
+
+			return new ComponentTemporalAmount(components);
+
+		}
+
+		private static String toString(TemporalAmount value) {
+
+			final Collection<TemporalUnit> units = value.getUnits();
+
+			final long years = units.contains(YEARS) ? value.get(YEARS) : 0L;
+			final long months = units.contains(MONTHS) ? value.get(MONTHS) : 0L;
+			final long days = units.contains(DAYS) ? value.get(DAYS) : 0L;
+
+			final long hours = units.contains(HOURS) ? value.get(HOURS) : 0L;
+			final long minutes = units.contains(MINUTES) ? value.get(MINUTES) : 0L;
+			final long seconds = units.contains(SECONDS) ? value.get(SECONDS) : 0L;
+			final long nanos = units.contains(NANOS) ? value.get(NANOS) : 0L;
+
+			final boolean positive = years > 0 || months > 0 || days > 0
+					|| hours > 0 || minutes > 0 || seconds > 0 || nanos > 0;
+
+			final boolean negative = years < 0 || months < 0 || days < 0
+					|| hours < 0 || minutes < 0 || seconds < 0 || nanos < 0;
+
+			if (positive && negative) {
+				throw new IllegalArgumentException(String.format(
+						"value <%s> cannot be represented by an XML Schema duration datatype", value
+				));
+			}
+
+			final StringBuilder builder = new StringBuilder(3 * value.getUnits().size());
+
+			if (negative) {
+				builder.append('-');
+			}
+
+			builder.append("P");
+
+			if (years != 0L) {
+				builder.append(abs(years)).append("Y");
+			}
+
+			if (months != 0L) {
+				builder.append(abs(months)).append("M");
+			}
+
+			if (days != 0L) {
+				builder.append(abs(days)).append("D");
+			}
+
+			if (hours != 0L || minutes != 0L || seconds != 0L || nanos != 0L) {
+				builder.append("T");
+			}
+
+			if (hours != 0L) {
+				builder.append(abs(hours)).append("H");
+			}
+
+			if (minutes != 0L) {
+				builder.append(abs(minutes)).append("M");
+			}
+
+			if (nanos != 0L) {
+
+				builder.append(abs(seconds) + abs(nanos) / 1_000_000_000L)
+						.append('.')
+						.append(String.format("%09d", abs(nanos) % 1_000_000_000L))
+						.append("S");
+
+			} else if (seconds != 0L) {
+
+				builder.append(abs(seconds)).append("S");
+
+			}
+
+			return builder.toString();
+		}
+
+		@Override
+		public String getLabel() {
+			return label;
+		}
+
+		@Override
+		public Optional<String> getLanguage() {
+			return Optional.empty();
+		}
+
+		@Override
+		public IRI getDatatype() {
+			return XSD_DURATION;
+		}
+
+		@Override
+		public TemporalAmount temporalAmountValue() throws DateTimeException {
+			return value;
+		}
+
+	}
+
 	static class CalendarLiteral extends AbstractLiteral {
 
 		private static final long serialVersionUID = 9131700079460615839L;
+
+		private static final ThreadLocal<DatatypeFactory> DATATYPE_FACTORY = ThreadLocal.withInitial(() -> {
+			try {
+
+				return DatatypeFactory.newInstance(); // not guaranteed to be thread-safe
+
+			} catch (DatatypeConfigurationException e) {
+
+				throw new RuntimeException("unable to create datatype factory", e);
+
+			}
+		});
 
 		private static final Map<QName, IRI> DATATYPES = datatypes();
 
@@ -466,13 +926,15 @@ public abstract class AbstractLiteral implements Literal {
 			final Map<QName, IRI> datatypes = new HashMap<>();
 
 			datatypes.put(DatatypeConstants.DATETIME, XSD_DATETIME);
-			datatypes.put(DatatypeConstants.DATE, XSD_DATE);
 			datatypes.put(DatatypeConstants.TIME, XSD_TIME);
+			datatypes.put(DatatypeConstants.DATE, XSD_DATE);
+
 			datatypes.put(DatatypeConstants.GYEARMONTH, XSD_GYEARMONTH);
-			datatypes.put(DatatypeConstants.GMONTHDAY, XSD_GMONTHDAY);
 			datatypes.put(DatatypeConstants.GYEAR, XSD_GYEAR);
-			datatypes.put(DatatypeConstants.GMONTH, XSD_GMONTH);
+			datatypes.put(DatatypeConstants.GMONTHDAY, XSD_GMONTHDAY);
 			datatypes.put(DatatypeConstants.GDAY, XSD_GDAY);
+			datatypes.put(DatatypeConstants.GMONTH, XSD_GMONTH);
+
 			datatypes.put(DatatypeConstants.DURATION, XSD_DURATION);
 			datatypes.put(DatatypeConstants.DURATION_DAYTIME, XSD_DURATION_DAYTIME);
 			datatypes.put(DatatypeConstants.DURATION_YEARMONTH, XSD_DURATION_YEARMONTH);
@@ -485,12 +947,16 @@ public abstract class AbstractLiteral implements Literal {
 			final IRI datatype = DATATYPES.get(qname);
 
 			if (datatype == null) {
-				throw new IllegalArgumentException((String.format(
-						"QName <%s> cannot be mapped to an XSD datatype IRI", qname
-				)));
+				throw new IllegalArgumentException(String.format(
+						"QName <%s> cannot be mapped to an XML Schema date/time datatype", qname
+				));
 			}
 
 			return datatype;
+		}
+
+		private static XMLGregorianCalendar parseCalendar(String label) {
+			return DATATYPE_FACTORY.get().newXMLGregorianCalendar(label);
 		}
 
 		private XMLGregorianCalendar value;

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
@@ -118,7 +118,7 @@ public abstract class AbstractLiteral implements Literal {
 	 *
 	 * @throws NullPointerException if {@code mapper} is {@code null}
 	 */
-	protected <V> V value(Function<String, V> mapper) {
+	private <V> V value(Function<String, V> mapper) {
 		return Optional
 				.of(getLabel())
 				.map(requireNonNull(mapper, "null mapper"))

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
@@ -12,6 +12,8 @@ import static org.eclipse.rdf4j.model.base.AbstractLiteral.reserved;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Objects;
@@ -36,6 +38,8 @@ import org.eclipse.rdf4j.model.base.AbstractLiteral.DecimalLiteral;
 import org.eclipse.rdf4j.model.base.AbstractLiteral.IntegerLiteral;
 import org.eclipse.rdf4j.model.base.AbstractLiteral.NumberLiteral;
 import org.eclipse.rdf4j.model.base.AbstractLiteral.TaggedLiteral;
+import org.eclipse.rdf4j.model.base.AbstractLiteral.TemporalAccessorLiteral;
+import org.eclipse.rdf4j.model.base.AbstractLiteral.TemporalAmountLiteral;
 import org.eclipse.rdf4j.model.base.AbstractLiteral.TypedLiteral;
 import org.eclipse.rdf4j.model.base.AbstractStatement.GenericStatement;
 import org.eclipse.rdf4j.model.base.AbstractTriple.GenericTriple;
@@ -118,7 +122,7 @@ public abstract class AbstractValueFactory implements ValueFactory {
 		Objects.requireNonNull(label, "null label");
 		Objects.requireNonNull(language, "null language");
 
-		if (label.isEmpty()) {
+		if (language.isEmpty()) {
 			throw new IllegalArgumentException("empty language tag");
 		}
 
@@ -174,6 +178,22 @@ public abstract class AbstractValueFactory implements ValueFactory {
 		Objects.requireNonNull(bigDecimal, "null bigDecimal");
 
 		return new DecimalLiteral(bigDecimal);
+	}
+
+	@Override
+	public Literal createLiteral(TemporalAccessor value) {
+
+		Objects.requireNonNull(value, "null value");
+
+		return new TemporalAccessorLiteral(value);
+	}
+
+	@Override
+	public Literal createLiteral(TemporalAmount value) {
+
+		Objects.requireNonNull(value, "null value");
+
+		return new TemporalAmountLiteral(value);
 	}
 
 	@Override

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/ComponentTemporalAmount.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/ComponentTemporalAmount.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.model.base;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Component-based temporal amount value.
+ *
+ * <p>
+ * Represents temporal amount values as a collection of {@link ChronoUnit} components.
+ * </p>
+ *
+ * @author Alessandro Bollini
+ * @since 3.5.0
+ *
+ * @apiNote {@link java.time} doesn't include concrete {@link TemporalAmount} classes able to represent XML Schema
+ *          duration values including both date and time components.
+ */
+class ComponentTemporalAmount implements TemporalAmount {
+
+	private final Map<? extends TemporalUnit, Long> components;
+	private final List<TemporalUnit> units;
+
+	ComponentTemporalAmount(Map<? extends TemporalUnit, Long> components) {
+
+		this.components = components;
+
+		this.units = unmodifiableList(components.keySet()
+				.stream()
+				.sorted(comparing(TemporalUnit::getDuration).reversed()) // as per getUnits() specs
+				.collect(toList())
+		);
+
+	}
+
+	@Override
+	public long get(TemporalUnit unit) {
+		return components.getOrDefault(unit, 0L);
+	}
+
+	@Override
+	public List<TemporalUnit> getUnits() {
+		return units;
+	}
+
+	@Override
+	public Temporal addTo(Temporal temporal) {
+
+		Temporal value = temporal;
+
+		for (final Map.Entry<? extends TemporalUnit, Long> component : components.entrySet()) {
+			value = value.plus(component.getValue(), component.getKey());
+		}
+
+		return value;
+	}
+
+	@Override
+	public Temporal subtractFrom(Temporal temporal) {
+
+		Temporal value = temporal;
+
+		for (final Map.Entry<? extends TemporalUnit, Long> component : components.entrySet()) {
+			value = value.minus(component.getValue(), component.getKey());
+		}
+
+		return value;
+	}
+
+}

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/ValueFactoryTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/ValueFactoryTest.java
@@ -8,22 +8,61 @@
 
 package org.eclipse.rdf4j.model;
 
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.SECOND_OF_DAY;
+import static java.time.temporal.ChronoUnit.HALF_DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.YEARS;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_BOOLEAN;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_BYTE;
+import static org.eclipse.rdf4j.model.LiteralTest.XSD_DATE;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_DATETIME;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_DECIMAL;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_DOUBLE;
+import static org.eclipse.rdf4j.model.LiteralTest.XSD_DURATION;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_FLOAT;
+import static org.eclipse.rdf4j.model.LiteralTest.XSD_GDAY;
+import static org.eclipse.rdf4j.model.LiteralTest.XSD_GMONTH;
+import static org.eclipse.rdf4j.model.LiteralTest.XSD_GMONTHDAY;
+import static org.eclipse.rdf4j.model.LiteralTest.XSD_GYEAR;
+import static org.eclipse.rdf4j.model.LiteralTest.XSD_GYEARMONTH;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_INT;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_INTEGER;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_LONG;
 import static org.eclipse.rdf4j.model.LiteralTest.XSD_SHORT;
+import static org.eclipse.rdf4j.model.LiteralTest.XSD_TIME;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.Date;
+import java.util.List;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -188,6 +227,281 @@ public abstract class ValueFactoryTest {
 		assertThat(literal.decimalValue()).isEqualTo(value);
 		assertThat(literal.getLabel()).isEqualTo("42.0");
 		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_DECIMAL);
+	}
+
+	@Test
+	public void testCreateLiteralTemporalNull() {
+		assertThatNullPointerException().isThrownBy(() -> factory().createLiteral((TemporalAccessor) null));
+	}
+
+	@Test
+	public void testCreateLiteralTemporalLocalDateTime() {
+
+		final LocalDateTime value = LocalDateTime.parse("2020-09-30T01:02:03.004");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_DATETIME);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalOffsetDateTime() {
+
+		final OffsetDateTime value = OffsetDateTime.parse("2020-09-30T01:02:03.004Z");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_DATETIME);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalLocalTime() {
+
+		final LocalTime value = LocalTime.parse("01:02:03.004");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_TIME);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalOffsetTime() {
+
+		final OffsetTime value = OffsetTime.parse("01:02:03.004Z");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_TIME);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalLocalDate() {
+
+		final LocalDate value = LocalDate.parse("2020-11-14");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_DATE);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalOffsetDate() {
+
+		final String label = "2020-09-30Z";
+
+		final TemporalAccessor value = new DateTimeFormatterBuilder() // OffsetDate not supported by java.time
+				.append(DateTimeFormatter.ISO_LOCAL_DATE)
+				.appendOffsetId()
+				.toFormatter()
+				.parse(label);
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(label);
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_DATE);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalYearMonth() {
+
+		final YearMonth value = YearMonth.parse("2020-09");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_GYEARMONTH);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalYear() {
+
+		final Year value = Year.parse("2020");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_GYEAR);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalMonthDay() {
+
+		final MonthDay value = MonthDay.parse("--11-14");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_GMONTHDAY);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalDay() {
+
+		final TemporalAccessor value = new TemporalAccessor() {
+
+			@Override
+			public boolean isSupported(TemporalField field) {
+				return field.equals(DAY_OF_MONTH);
+			}
+
+			@Override
+			public long getLong(TemporalField field) {
+				if (field == DAY_OF_MONTH) {
+					return 14;
+				} else {
+					throw new UnsupportedTemporalTypeException(field.toString());
+				}
+			}
+
+		};
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo("---14");
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_GDAY);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalMonth() {
+
+		final Month value = Month.NOVEMBER;
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo("--11");
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_GMONTH);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalAccessorUnsupported() {
+
+		final TemporalAccessor accessor = new TemporalAccessor() {
+
+			@Override
+			public boolean isSupported(TemporalField field) {
+				return field.equals(SECOND_OF_DAY);
+			}
+
+			@Override
+			public long getLong(TemporalField field) {
+				if (field == SECOND_OF_DAY) {
+					return 123;
+				} else {
+					throw new UnsupportedTemporalTypeException(field.toString());
+				}
+			}
+
+		};
+
+		assertThatIllegalArgumentException().isThrownBy(() -> factory().createLiteral(accessor));
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalPeriod() {
+
+		final Period value = Period.parse("P1Y");
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAmountValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_DURATION);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalDuration() {
+
+		final Duration value = Duration.ofSeconds(7);
+
+		final Literal literal = factory().createLiteral(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAmountValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype().stringValue()).isEqualTo(XSD_DURATION);
+
+	}
+
+	@Test
+	public void testCreateLiteralTemporalAmountUnsupported() {
+
+		class TestAmount implements TemporalAmount {
+
+			private final List<TemporalUnit> units;
+
+			private TestAmount(ChronoUnit... units) {
+				this.units = unmodifiableList(asList(units));
+			}
+
+			@Override
+			public long get(TemporalUnit unit) {
+				return unit.isDateBased() ? 1 : -1;
+			}
+
+			@Override
+			public List<TemporalUnit> getUnits() {
+				return units;
+			}
+
+			@Override
+			public Temporal addTo(Temporal temporal) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public Temporal subtractFrom(Temporal temporal) {
+				throw new UnsupportedOperationException();
+			}
+
+		}
+
+		assertThatIllegalArgumentException().as("unsupported components")
+				.isThrownBy(() -> factory().createLiteral(new TestAmount(HALF_DAYS)));
+
+		assertThatIllegalArgumentException().as("mixed sign components")
+				.isThrownBy(() -> factory().createLiteral(new TestAmount(YEARS, HOURS)));
+
 	}
 
 	@Test

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/AbstractValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/AbstractValueFactory.java
@@ -39,7 +39,7 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
  *             {@link org.eclipse.rdf4j.model.base.AbstractValueFactory}.
  */
 @Deprecated
-public abstract class AbstractValueFactory implements ValueFactory {
+public abstract class AbstractValueFactory extends org.eclipse.rdf4j.model.base.AbstractValueFactory {
 
 	/* Constants */
 

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
@@ -10,6 +10,8 @@ package org.eclipse.rdf4j.model.impl;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URISyntaxException;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
 import java.util.Date;
 
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -191,6 +193,16 @@ public class ValidatingValueFactory implements ValueFactory {
 	@Override
 	public Literal createLiteral(BigInteger bigInteger) {
 		return delegate.createLiteral(bigInteger);
+	}
+
+	@Override
+	public Literal createLiteral(TemporalAccessor value) {
+		return delegate.createLiteral(value);
+	}
+
+	@Override
+	public Literal createLiteral(TemporalAmount value) {
+		return delegate.createLiteral(value);
 	}
 
 	@Override

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarDecodingValueFactory.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarDecodingValueFactory.java
@@ -9,6 +9,8 @@ package org.eclipse.rdf4j.rio.helpers;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
 import java.util.Date;
 
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -113,6 +115,16 @@ class RDFStarDecodingValueFactory implements ValueFactory {
 	@Override
 	public Literal createLiteral(BigInteger bigInteger) {
 		return delegate.createLiteral(bigInteger);
+	}
+
+	@Override
+	public Literal createLiteral(TemporalAccessor value) {
+		return delegate.createLiteral(value);
+	}
+
+	@Override
+	public Literal createLiteral(TemporalAmount value) {
+		return delegate.createLiteral(value);
 	}
 
 	@Override


### PR DESCRIPTION
GitHub issue resolved: #2658

Briefly describe the changes proposed in this PR:

- add Literal.temporalAccessor/AmountValue() methods
- add ValueFactory.createLiteral(TemporalAccessor/Amount) methods
- implement new methods in AbstractLiteral and AbstractValueFactory

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

