### PR TITLE
GH-2456 add epic update workflow

### DIFF
--- a/.github/workflows/update-epics.yml
+++ b/.github/workflows/update-epics.yml
@@ -1,0 +1,14 @@
+name: Update epics
+on:
+  issues:
+    types: [opened, created, closed, reopened, deleted]
+jobs:
+  epics:
+    runs-on: ubuntu-latest
+    name: Update epic issues
+    steps:
+      - name: Run epics action
+        uses: cloudaper/epics-action@v1
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          epic-label-name: epic


### PR DESCRIPTION
GitHub issue resolved: #2456  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Automatically updates task lists on epics, marking resolved issues as checked off. See https://github.com/marketplace/actions/epic-issues-for-github

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

