### PR TITLE
GH-2667 n-triples baseuri doc

### DIFF
--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -85,7 +85,8 @@ public class NTriplesParser extends AbstractRDFParser {
 	 *
 	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>. The InputStream is
 	 *                supposed to contain 7-bit US-ASCII characters, as per the N-Triples specification.
-	 * @param baseURI The URI associated with the data in the InputStream, must not be <tt>null</tt>.
+	 * @param baseURI The URI associated with the data in the InputStream (ignored, N-Triples does not support relative
+	 *                IRIs).
 	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
@@ -97,7 +98,6 @@ public class NTriplesParser extends AbstractRDFParser {
 		if (in == null) {
 			throw new IllegalArgumentException("Input stream can not be 'null'");
 		}
-		// Note: baseURI will be checked in parse(Reader, String)
 
 		try {
 			parse(new InputStreamReader(new BOMInputStream(in, false), StandardCharsets.UTF_8), baseURI);
@@ -111,7 +111,8 @@ public class NTriplesParser extends AbstractRDFParser {
 	 * Implementation of the <tt>parse(Reader, String)</tt> method defined in the RDFParser interface.
 	 *
 	 * @param reader  The Reader from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the Reader, must not be <tt>null</tt>.
+	 * @param baseURI The URI associated with the data in the Reader (ignored, N-Triples does not support relative
+	 *                IRIs).
 	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
@@ -125,9 +126,6 @@ public class NTriplesParser extends AbstractRDFParser {
 		try {
 			if (reader == null) {
 				throw new IllegalArgumentException("Reader can not be 'null'");
-			}
-			if (baseURI == null) {
-				throw new IllegalArgumentException("base URI can not be 'null'");
 			}
 
 			if (rdfHandler != null) {


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #2667 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Much of the N-Triples parser code is copy/paste of the Turtle parser code, however baseURI is never called / used (which makes sense, because N-Triples does not support relative IRIs)

* changed javadoc to mention that baseURI is ignored
* remove the not null check for baseURI, because it is not used anyway

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

