### PR TITLE
GH-2661 fixed getSupportedSettings, added regression tests

### DIFF
--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
@@ -8,8 +8,8 @@
 package org.eclipse.rdf4j.query.resultio;
 
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -61,7 +61,7 @@ public abstract class AbstractQueryResultWriter implements QueryResultWriter {
 
 	@Override
 	public Collection<RioSetting<?>> getSupportedSettings() {
-		return Collections.emptyList();
+		return Arrays.asList(BasicWriterSettings.ENCODE_RDF_STAR, BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL);
 	}
 
 	@Override

--- a/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultWriter.java
+++ b/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultWriter.java
@@ -32,6 +32,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +51,7 @@ import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.resultio.AbstractQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
+import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * Writer for the binary tuple result format. The format is explained in {@link BinaryQueryResultConstants}.
@@ -106,6 +108,11 @@ public class BinaryQueryResultWriter extends AbstractQueryResultWriter implement
 	@Override
 	public final TupleQueryResultFormat getQueryResultFormat() {
 		return getTupleQueryResultFormat();
+	}
+
+	@Override
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/core/queryresultio/binary/src/test/java/org/eclipse/rdf4j/query/resultio/binary/BinaryTupleQueryResultWriterTest.java
+++ b/core/queryresultio/binary/src/test/java/org/eclipse/rdf4j/query/resultio/binary/BinaryTupleQueryResultWriterTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.resultio.binary;
 import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * @author jeen
@@ -25,6 +26,11 @@ public class BinaryTupleQueryResultWriterTest extends AbstractTupleQueryResultWr
 	@Override
 	protected TupleQueryResultWriterFactory getWriterFactory() {
 		return new BinaryQueryResultWriterFactory();
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {};
 	}
 
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
@@ -339,11 +339,8 @@ abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implem
 	@Override
 	public final Collection<RioSetting<?>> getSupportedSettings() {
 		Set<RioSetting<?>> result = new HashSet<>(super.getSupportedSettings());
-
 		result.add(BasicQueryWriterSettings.JSONP_CALLBACK);
 		result.add(BasicWriterSettings.PRETTY_PRINT);
-		result.add(BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL);
-		result.add(BasicWriterSettings.ENCODE_RDF_STAR);
 
 		return result;
 	}

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONWriterTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLResultsJSONWriterTest.java
@@ -8,8 +8,11 @@
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.BasicQueryWriterSettings;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 public class SPARQLResultsJSONWriterTest extends AbstractTupleQueryResultWriterTest {
 
@@ -23,4 +26,13 @@ public class SPARQLResultsJSONWriterTest extends AbstractTupleQueryResultWriterT
 		return new SPARQLResultsJSONWriterFactory();
 	}
 
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicWriterSettings.PRETTY_PRINT,
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL,
+				BasicWriterSettings.ENCODE_RDF_STAR,
+				BasicQueryWriterSettings.JSONP_CALLBACK
+		};
+	}
 }

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriterTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriterTest.java
@@ -8,8 +8,11 @@
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.BasicQueryWriterSettings;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 public class SPARQLStarResultsJSONWriterTest extends AbstractTupleQueryResultWriterTest {
 
@@ -21,5 +24,15 @@ public class SPARQLStarResultsJSONWriterTest extends AbstractTupleQueryResultWri
 	@Override
 	protected TupleQueryResultWriterFactory getWriterFactory() {
 		return new SPARQLStarResultsJSONWriterFactory();
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicWriterSettings.PRETTY_PRINT,
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL,
+				BasicWriterSettings.ENCODE_RDF_STAR,
+				BasicQueryWriterSettings.JSONP_CALLBACK
+		};
 	}
 }

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/AbstractSPARQLXMLWriter.java
@@ -370,8 +370,10 @@ abstract class AbstractSPARQLXMLWriter extends AbstractQueryResultWriter impleme
 		Set<RioSetting<?>> result = new HashSet<>(super.getSupportedSettings());
 
 		result.add(BasicWriterSettings.PRETTY_PRINT);
-		result.add(BasicQueryWriterSettings.ADD_SESAME_QNAME);
 		result.add(BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL);
+		result.add(BasicWriterSettings.ENCODE_RDF_STAR);
+		result.add(BasicQueryWriterSettings.ADD_SESAME_QNAME);
+		result.add(XMLWriterSettings.INCLUDE_XML_PI);
 
 		return result;
 	}

--- a/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarXMLTupleQueryResultWriterTest.java
+++ b/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarXMLTupleQueryResultWriterTest.java
@@ -8,8 +8,12 @@
 package org.eclipse.rdf4j.query.resultio.sparqlxml;
 
 import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.BasicQueryWriterSettings;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
 
 /**
  * @author Jeen Broekstra
@@ -27,4 +31,14 @@ public class SPARQLStarXMLTupleQueryResultWriterTest extends AbstractTupleQueryR
 		return new SPARQLStarResultsXMLWriterFactory();
 	}
 
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicQueryWriterSettings.ADD_SESAME_QNAME,
+				BasicWriterSettings.PRETTY_PRINT,
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL,
+				BasicWriterSettings.ENCODE_RDF_STAR,
+				XMLWriterSettings.INCLUDE_XML_PI
+		};
+	}
 }

--- a/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleQueryResultWriterTest.java
+++ b/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleQueryResultWriterTest.java
@@ -8,8 +8,12 @@
 package org.eclipse.rdf4j.query.resultio.sparqlxml;
 
 import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
+import org.eclipse.rdf4j.query.resultio.BasicQueryWriterSettings;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
 
 /**
  * @author Jeen Broekstra
@@ -25,6 +29,17 @@ public class SPARQLXMLTupleQueryResultWriterTest extends AbstractTupleQueryResul
 	@Override
 	protected TupleQueryResultWriterFactory getWriterFactory() {
 		return new SPARQLResultsXMLWriterFactory();
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicQueryWriterSettings.ADD_SESAME_QNAME,
+				BasicWriterSettings.PRETTY_PRINT,
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL,
+				BasicWriterSettings.ENCODE_RDF_STAR,
+				XMLWriterSettings.INCLUDE_XML_PI
+		};
 	}
 
 }

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleQueryResultWriterTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleQueryResultWriterTest.java
@@ -10,6 +10,8 @@ package org.eclipse.rdf4j.query.resultio.text.csv;
 import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -39,5 +41,13 @@ public class SPARQLCSVTupleQueryResultWriterTest extends AbstractTupleQueryResul
 	@Ignore("pending implementation of RDF* extensions for the csv format")
 	@Test
 	public void testRDFStarHandling_DeepNesting() throws Exception {
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicWriterSettings.ENCODE_RDF_STAR,
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL
+		};
 	}
 }

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleQueryResultWriterTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleQueryResultWriterTest.java
@@ -10,6 +10,8 @@ package org.eclipse.rdf4j.query.resultio.text.tsv;
 import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 /**
  * @author Jeen Broekstra
@@ -25,5 +27,13 @@ public class SPARQLStarTSVTupleQueryResultWriterTest extends AbstractTupleQueryR
 	@Override
 	protected TupleQueryResultWriterFactory getWriterFactory() {
 		return new SPARQLStarResultsTSVWriterFactory();
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicWriterSettings.ENCODE_RDF_STAR,
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL
+		};
 	}
 }

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleQueryResultWriterTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleQueryResultWriterTest.java
@@ -10,6 +10,8 @@ package org.eclipse.rdf4j.query.resultio.text.tsv;
 import org.eclipse.rdf4j.query.resultio.AbstractTupleQueryResultWriterTest;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 /**
  * @author Jeen Broekstra
@@ -25,5 +27,13 @@ public class SPARQLTSVTupleQueryResultWriterTest extends AbstractTupleQueryResul
 	@Override
 	protected TupleQueryResultWriterFactory getWriterFactory() {
 		return new SPARQLResultsTSVWriterFactory();
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicWriterSettings.ENCODE_RDF_STAR,
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL
+		};
 	}
 }

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRioSetting.java
@@ -83,4 +83,9 @@ public abstract class AbstractRioSetting<T> implements RioSetting<T> {
 		return getKey().hashCode();
 	}
 
+	@Override
+	public String toString() {
+		return getKey();
+	}
+
 }

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1824,6 +1825,23 @@ public abstract class RDFWriterTest {
 		// 4 for triple1 (contained in triple5)
 		assertEquals(22, parsedOutput.size());
 	}
+
+	@Test
+	public void testGetSupportedSettings() throws Exception {
+		RDFWriter writer = rdfWriterFactory.getWriter(System.out);
+
+		Collection<RioSetting<?>> supportedSettings = writer.getSupportedSettings();
+		assertThat(supportedSettings).containsExactlyInAnyOrder(getExpectedSupportedSettings());
+	}
+
+	/**
+	 * Get the {@link RioSetting}s expected to be returned by {@link RDFWriter#getSupportedSettings()}. Used by
+	 * {@link #testGetSupportedSettings()} to determine if the output of {@link RDFWriter#getSupportedSettings()} is as
+	 * expected for the concrete writer implementation.
+	 * 
+	 * @return an array of {@link RioSetting}s.
+	 */
+	protected abstract RioSetting<?>[] getExpectedSupportedSettings();
 
 	@Test
 	public void testHandlingSequenceCloseableWriter() throws IOException {

--- a/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
+++ b/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * @author Arjohn Kampman
@@ -31,4 +32,10 @@ public class BinaryRDFWriterBackgroundTest extends RDFWriterTest {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat()));
 	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] {};
+	}
+
 }

--- a/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterTest.java
+++ b/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterTest.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.rio.binary;
 
 import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
 
 /**
  * @author Arjohn Kampman
@@ -16,5 +17,10 @@ public class BinaryRDFWriterTest extends RDFWriterTest {
 
 	public BinaryRDFWriterTest() {
 		super(new BinaryRDFWriterFactory(), new BinaryRDFParserFactory());
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] {};
 	}
 }

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -15,6 +15,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -179,8 +180,9 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter {
 
 	@Override
 	public Collection<RioSetting<?>> getSupportedSettings() {
-		Collection<RioSetting<?>> result = super.getSupportedSettings();
-
+		final Collection<RioSetting<?>> result = new HashSet<>(super.getSupportedSettings());
+		result.add(BasicWriterSettings.PRETTY_PRINT);
+		result.add(BasicWriterSettings.BASE_DIRECTIVE);
 		result.add(JSONLDSettings.COMPACT_ARRAYS);
 		result.add(JSONLDSettings.HIERARCHICAL_VIEW);
 		result.add(JSONLDSettings.JSONLD_MODE);

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
@@ -28,8 +28,10 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONLDMode;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
@@ -109,5 +111,19 @@ public class JSONLDWriterBackgroundTest extends RDFWriterTest {
 					model.getNamespaces().size() >= 1);
 			assertEquals(exNs, model.getNamespace("ex").get().getName());
 		}
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] {
+				BasicWriterSettings.BASE_DIRECTIVE,
+				BasicWriterSettings.PRETTY_PRINT,
+				JSONLDSettings.COMPACT_ARRAYS,
+				JSONLDSettings.HIERARCHICAL_VIEW,
+				JSONLDSettings.JSONLD_MODE,
+				JSONLDSettings.PRODUCE_GENERALIZED_RDF,
+				JSONLDSettings.USE_RDF_TYPE,
+				JSONLDSettings.USE_NATIVE_TYPES
+		};
 	}
 }

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterTest.java
@@ -28,8 +28,10 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONLDMode;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
@@ -121,5 +123,19 @@ public class JSONLDWriterTest extends RDFWriterTest {
 					model.getNamespaces().size() >= 1);
 			assertEquals(exNs, model.getNamespace("ex").get().getName());
 		}
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] {
+				BasicWriterSettings.BASE_DIRECTIVE,
+				BasicWriterSettings.PRETTY_PRINT,
+				JSONLDSettings.COMPACT_ARRAYS,
+				JSONLDSettings.HIERARCHICAL_VIEW,
+				JSONLDSettings.JSONLD_MODE,
+				JSONLDSettings.PRODUCE_GENERALIZED_RDF,
+				JSONLDSettings.USE_RDF_TYPE,
+				JSONLDSettings.USE_NATIVE_TYPES
+		};
 	}
 }

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsWriterTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsWriterTest.java
@@ -20,7 +20,9 @@ import org.eclipse.rdf4j.rio.RDFParserFactory;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.NTriplesWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.junit.After;
 import org.junit.Assert;
@@ -146,5 +148,13 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 		Assert.assertEquals("Unexpected number of lines.", 1, lines.length);
 		Assert.assertTrue(lines[0].startsWith(
 				"<http://test.example.org/test/subject/1> <http://other.example.com/test/predicate/1> \"test literal\"^^<http://www.w3.org/2001/XMLSchema#string> _:"));
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] {
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL,
+				NTriplesWriterSettings.ESCAPE_UNICODE
+		};
 	}
 }

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesWriterTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesWriterTest.java
@@ -1,0 +1,35 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.ntriples;
+
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.NTriplesWriterSettings;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public abstract class AbstractNTriplesWriterTest extends RDFWriterTest {
+
+	protected AbstractNTriplesWriterTest(RDFWriterFactory writerF, RDFParserFactory parserF) {
+		super(writerF, parserF);
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] {
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL,
+				NTriplesWriterSettings.ESCAPE_UNICODE
+		};
+	}
+
+}

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterBackgroundTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterBackgroundTest.java
@@ -14,14 +14,13 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 
 /**
  * JUnit test for the N-Triples parser/writer combination.
  *
  * @author Peter Ansell
  */
-public class NTriplesWriterBackgroundTest extends RDFWriterTest {
+public class NTriplesWriterBackgroundTest extends AbstractNTriplesWriterTest {
 
 	public NTriplesWriterBackgroundTest() {
 		super(new NTriplesWriterFactory(), new NTriplesParserFactory());

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterTest.java
@@ -7,14 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.ntriples;
 
-import org.eclipse.rdf4j.rio.RDFWriterTest;
-
 /**
  * JUnit test for the RDF/JSON parser.
  *
  * @author Peter Ansell
  */
-public class NTriplesWriterTest extends RDFWriterTest {
+public class NTriplesWriterTest extends AbstractNTriplesWriterTest {
 
 	public NTriplesWriterTest() {
 		super(new NTriplesWriterFactory(), new NTriplesParserFactory());

--- a/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriterTest.java
+++ b/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriterTest.java
@@ -15,6 +15,8 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 /**
  * JUnit test for the RDF/JSON parser.
@@ -32,6 +34,11 @@ public class RDFJSONWriterTest extends RDFWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat()));
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] { BasicWriterSettings.PRETTY_PRINT };
 	}
 
 }

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
@@ -12,6 +12,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -29,6 +31,7 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
@@ -94,6 +97,17 @@ public class RDFXMLWriter extends AbstractRDFWriter implements RDFWriter {
 	@Override
 	public RDFFormat getRDFFormat() {
 		return RDFFormat.RDFXML;
+	}
+
+	@Override
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		final Collection<RioSetting<?>> settings = new HashSet<>(super.getSupportedSettings());
+		settings.add(BasicWriterSettings.BASE_DIRECTIVE);
+		settings.add(XMLWriterSettings.USE_SINGLE_QUOTES);
+		settings.add(XMLWriterSettings.QUOTES_TO_ENTITIES_IN_TEXT);
+		settings.add(XMLWriterSettings.INCLUDE_ROOT_RDF_TAG);
+		settings.add(XMLWriterSettings.INCLUDE_XML_PI);
+		return settings;
 	}
 
 	protected void writeHeader() throws IOException {

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/util/RDFXMLPrettyWriter.java
@@ -7,16 +7,28 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfxml.util;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Stack;
 
 import org.eclipse.rdf4j.common.net.ParsedIRI;
-import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriter;
 
@@ -193,6 +205,13 @@ public class RDFXMLPrettyWriter extends RDFXMLWriter implements Closeable, Flush
 
 			writer.flush();
 		}
+	}
+
+	@Override
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		final Collection<RioSetting<?>> settings = new HashSet<>(super.getSupportedSettings());
+		settings.add(BasicWriterSettings.INLINE_BLANK_NODES);
+		return settings;
 	}
 
 	@Override

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/AbstractRDFXMLWriterTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/AbstractRDFXMLWriterTest.java
@@ -1,0 +1,37 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.rdfxml;
+
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public abstract class AbstractRDFXMLWriterTest extends RDFWriterTest {
+
+	protected AbstractRDFXMLWriterTest(RDFWriterFactory writerF, RDFParserFactory parserF) {
+		super(writerF, parserF);
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting[] {
+				BasicWriterSettings.BASE_DIRECTIVE,
+				XMLWriterSettings.INCLUDE_XML_PI,
+				XMLWriterSettings.INCLUDE_ROOT_RDF_TAG,
+				XMLWriterSettings.QUOTES_TO_ENTITIES_IN_TEXT,
+				XMLWriterSettings.USE_SINGLE_QUOTES
+		};
+	}
+}

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterBackgroundTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterBackgroundTest.java
@@ -28,13 +28,13 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriterFactory;
 import org.junit.Test;
 
-public class RDFXMLPrettyWriterBackgroundTest extends RDFWriterTest {
+public class RDFXMLPrettyWriterBackgroundTest extends AbstractRDFXMLWriterTest {
 
 	private static ValueFactory vf = SimpleValueFactory.getInstance();
 
@@ -140,4 +140,10 @@ public class RDFXMLPrettyWriterBackgroundTest extends RDFWriterTest {
 
 		assertEquals(Arrays.asList("<rdf:RDF", "<rdf:Bag", "<rdf:_2", "<rdf:li", "<rdf:_3", "<rdf:li"), rdfLines);
 	}
+
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		List<RioSetting<?>> inherited = new ArrayList<>(Arrays.asList(super.getExpectedSupportedSettings()));
+		inherited.add(BasicWriterSettings.INLINE_BLANK_NODES);
+		return inherited.toArray(new RioSetting<?>[] {});
+	};
 }

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterTest.java
@@ -9,7 +9,12 @@ package org.eclipse.rdf4j.rio.rdfxml;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,17 +22,25 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
-import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.eclipse.rdf4j.rio.*;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriter;
 import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriterFactory;
 import org.junit.Test;
 
-public class RDFXMLPrettyWriterTest extends RDFWriterTest {
+public class RDFXMLPrettyWriterTest extends AbstractRDFXMLWriterTest {
 
 	private static ValueFactory vf = SimpleValueFactory.getInstance();
 
@@ -165,4 +178,10 @@ public class RDFXMLPrettyWriterTest extends RDFWriterTest {
 		List<String> rdfLines = rdfOpenTags(writer.toString());
 		assertEquals(Arrays.asList("<rdf:RDF", "<rdf:Bag", "<rdf:_2", "<rdf:li", "<rdf:_3", "<rdf:li"), rdfLines);
 	}
+
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		List<RioSetting<?>> inherited = new ArrayList<>(Arrays.asList(super.getExpectedSupportedSettings()));
+		inherited.add(BasicWriterSettings.INLINE_BLANK_NODES);
+		return inherited.toArray(new RioSetting<?>[] {});
+	};
 }

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterBackgroundTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterBackgroundTest.java
@@ -14,11 +14,10 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
-public class RDFXMLWriterBackgroundTest extends RDFWriterTest {
+public class RDFXMLWriterBackgroundTest extends AbstractRDFXMLWriterTest {
 
 	public RDFXMLWriterBackgroundTest() {
 		super(new RDFXMLWriterFactory(), new RDFXMLParserFactory());

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterTest.java
@@ -12,14 +12,13 @@ import java.io.StringWriter;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class RDFXMLWriterTest extends RDFWriterTest {
+public class RDFXMLWriterTest extends AbstractRDFXMLWriterTest {
 
 	public RDFXMLWriterTest() {
 		super(new RDFXMLWriterFactory(), new RDFXMLParserFactory());
@@ -83,4 +82,5 @@ public class RDFXMLWriterTest extends RDFWriterTest {
 
 		return outputWriter.toString();
 	}
+
 }

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/AbstractTriGWriterTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/AbstractTriGWriterTest.java
@@ -1,0 +1,35 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.trig;
+
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+
+/**
+ * @author Jeen Broesktra
+ *
+ */
+public abstract class AbstractTriGWriterTest extends RDFWriterTest {
+
+	protected AbstractTriGWriterTest(RDFWriterFactory writerF, RDFParserFactory parserF) {
+		super(writerF, parserF);
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL,
+				BasicWriterSettings.PRETTY_PRINT,
+				BasicWriterSettings.INLINE_BLANK_NODES,
+				BasicWriterSettings.BASE_DIRECTIVE
+		};
+	}
+}

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGPrettyWriterBackgroundTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGPrettyWriterBackgroundTest.java
@@ -14,7 +14,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
@@ -23,7 +22,7 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
  *
  * @author Peter Ansell
  */
-public class TriGPrettyWriterBackgroundTest extends RDFWriterTest {
+public class TriGPrettyWriterBackgroundTest extends AbstractTriGWriterTest {
 
 	public TriGPrettyWriterBackgroundTest() {
 		super(new TriGWriterFactory(), new TriGParserFactory());

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGPrettyWriterTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGPrettyWriterTest.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trig;
 
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
@@ -16,7 +15,7 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
  *
  * @author Peter Ansell
  */
-public class TriGPrettyWriterTest extends RDFWriterTest {
+public class TriGPrettyWriterTest extends AbstractTriGWriterTest {
 
 	public TriGPrettyWriterTest() {
 		super(new TriGWriterFactory(), new TriGParserFactory());

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGWriterBackgroundTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGWriterBackgroundTest.java
@@ -14,14 +14,13 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 /**
  * @author Arjohn Kampman
  */
-public class TriGWriterBackgroundTest extends RDFWriterTest {
+public class TriGWriterBackgroundTest extends AbstractTriGWriterTest {
 
 	public TriGWriterBackgroundTest() {
 		super(new TriGWriterFactory(), new TriGParserFactory());

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGWriterTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGWriterTest.java
@@ -7,14 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trig;
 
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 /**
  * @author Arjohn Kampman
  */
-public class TriGWriterTest extends RDFWriterTest {
+public class TriGWriterTest extends AbstractTriGWriterTest {
 
 	public TriGWriterTest() {
 		super(new TriGWriterFactory(), new TriGParserFactory());
@@ -24,5 +23,4 @@ public class TriGWriterTest extends RDFWriterTest {
 	protected void setupWriterConfig(WriterConfig config) {
 		config.set(BasicWriterSettings.PRETTY_PRINT, false);
 	}
-
 }

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarPrettyWriterTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarPrettyWriterTest.java
@@ -7,14 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trigstar;
 
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.trig.AbstractTriGWriterTest;
 
 /**
  * @author Pavel Mihaylov
  */
-public class TriGStarPrettyWriterTest extends RDFWriterTest {
+public class TriGStarPrettyWriterTest extends AbstractTriGWriterTest {
 	public TriGStarPrettyWriterTest() {
 		super(new TriGStarWriterFactory(), new TriGStarParserFactory());
 	}

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterTest.java
@@ -7,14 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trigstar;
 
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.trig.AbstractTriGWriterTest;
 
 /**
  * @author Pavel Mihaylov
  */
-public class TriGStarWriterTest extends RDFWriterTest {
+public class TriGStarWriterTest extends AbstractTriGWriterTest {
 	public TriGStarWriterTest() {
 		super(new TriGStarWriterFactory(), new TriGStarParserFactory());
 	}

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -13,6 +13,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Map;
@@ -45,6 +46,7 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
@@ -150,6 +152,16 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 	@Override
 	public RDFFormat getRDFFormat() {
 		return RDFFormat.TURTLE;
+	}
+
+	@Override
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		final Collection<RioSetting<?>> settings = new HashSet<>(super.getSupportedSettings());
+		settings.add(BasicWriterSettings.BASE_DIRECTIVE);
+		settings.add(BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL);
+		settings.add(BasicWriterSettings.PRETTY_PRINT);
+		settings.add(BasicWriterSettings.INLINE_BLANK_NODES);
+		return settings;
 	}
 
 	@Override

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/AbstractTurtleWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/AbstractTurtleWriterTest.java
@@ -1,0 +1,35 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtle;
+
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+import org.eclipse.rdf4j.rio.RDFWriterFactory;
+import org.eclipse.rdf4j.rio.RDFWriterTest;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public abstract class AbstractTurtleWriterTest extends RDFWriterTest {
+
+	protected AbstractTurtleWriterTest(RDFWriterFactory writerF, RDFParserFactory parserF) {
+		super(writerF, parserF);
+	}
+
+	@Override
+	protected RioSetting<?>[] getExpectedSupportedSettings() {
+		return new RioSetting<?>[] {
+				BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL,
+				BasicWriterSettings.PRETTY_PRINT,
+				BasicWriterSettings.INLINE_BLANK_NODES,
+				BasicWriterSettings.BASE_DIRECTIVE
+		};
+	}
+}

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtlePrettyWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtlePrettyWriterTest.java
@@ -11,14 +11,13 @@ import java.io.IOException;
 
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 /**
  * @author Arjohn Kampman
  */
-public class TurtlePrettyWriterTest extends RDFWriterTest {
+public class TurtlePrettyWriterTest extends AbstractTurtleWriterTest {
 
 	private boolean inlineBlankNodes = true;
 

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterTest.java
@@ -16,7 +16,6 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
@@ -26,7 +25,7 @@ import org.junit.Test;
 /**
  * @author Arjohn Kampman
  */
-public class TurtleWriterTest extends RDFWriterTest {
+public class TurtleWriterTest extends AbstractTurtleWriterTest {
 
 	private IRI uri1;
 

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarPrettyWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarPrettyWriterTest.java
@@ -7,14 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtlestar;
 
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.turtle.AbstractTurtleWriterTest;
 
 /**
  * @author Pavel Mihaylov
  */
-public class TurtleStarPrettyWriterTest extends RDFWriterTest {
+public class TurtleStarPrettyWriterTest extends AbstractTurtleWriterTest {
 	public TurtleStarPrettyWriterTest() {
 		super(new TurtleStarWriterFactory(), new TurtleStarParserFactory());
 	}

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterTest.java
@@ -7,14 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtlestar;
 
-import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.turtle.AbstractTurtleWriterTest;
 
 /**
  * @author Pavel Mihaylov
  */
-public class TurtleStarWriterTest extends RDFWriterTest {
+public class TurtleStarWriterTest extends AbstractTurtleWriterTest {
 	public TurtleStarWriterTest() {
 		super(new TurtleStarWriterFactory(), new TurtleStarParserFactory());
 	}

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractTupleQueryResultWriterTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractTupleQueryResultWriterTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
@@ -23,6 +24,7 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
+import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
@@ -134,6 +136,23 @@ public abstract class AbstractTupleQueryResultWriterTest {
 		assertThat(actualT2.getPredicate()).isEqualTo(RDF.TYPE);
 		assertThat(actualT2.getObject()).isEqualTo(RDFS.CLASS);
 	}
+
+	@Test
+	public void testGetSupportedSettings() throws Exception {
+		TupleQueryResultWriter writer = getWriterFactory().getWriter(System.out);
+
+		Collection<RioSetting<?>> supportedSettings = writer.getSupportedSettings();
+		assertThat(supportedSettings).containsExactlyInAnyOrder(getExpectedSupportedSettings());
+	}
+
+	/**
+	 * Get the {@link RioSetting}s expected to be returned by {@link QueryResultWriter#getSupportedSettings()}. Used by
+	 * {@link #testGetSupportedSettings()} to determine if the output of
+	 * {@link QueryResultWriter#getSupportedSettings()} is as expected for the concrete writer implementation.
+	 * 
+	 * @return an array of {@link RioSetting}s.
+	 */
+	protected abstract RioSetting<?>[] getExpectedSupportedSettings();
 
 	protected abstract TupleQueryResultParserFactory getParserFactory();
 


### PR DESCRIPTION
GitHub issue resolved: #2661  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- fixes JSONLDWriter problem with unmodifiable collection
- adds tests for all RDFWriters and QueryResultWriters on the supported settings
- corrects all existing writers to give back a complete list of supported settings

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

