### PR TITLE
GH-2676 add BufferedWriter to avoid charset encoding overhead in OutputStreamWriter

### DIFF
--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -122,7 +123,9 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter {
 	public TurtleWriter(OutputStream out, ParsedIRI baseIRI) {
 		super(out);
 		this.baseIRI = baseIRI;
-		this.writer = new IndentingWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+		// The BufferedWriter is here to avoid to many calls to the CharEncoder
+		// see javadoc of OutputStreamWriter.
+		this.writer = new IndentingWriter(new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8)));
 	}
 
 	/**

--- a/core/util/src/main/java/org/eclipse/rdf4j/common/io/IndentingWriter.java
+++ b/core/util/src/main/java/org/eclipse/rdf4j/common/io/IndentingWriter.java
@@ -148,6 +148,20 @@ public class IndentingWriter extends Writer {
 	}
 
 	@Override
+	public void write(String str, int off, int len)
+			throws IOException {
+		if (!indentationWritten) {
+			for (int i = 0; i < indentationLevel; i++) {
+				out.write(indentationString);
+			}
+
+			indentationWritten = true;
+		}
+		charactersSinceEOL += len;
+		out.write(str, off, len);
+	}
+
+	@Override
 	public void write(char cbuf[], int off, int len) throws IOException {
 		if (!indentationWritten) {
 			for (int i = 0; i < indentationLevel; i++) {


### PR DESCRIPTION
…to avoid needing

to encode latin1 strings


GitHub issue resolved: #2676

Briefly describe the changes proposed in this PR:

This buffers the outputwriter in the turtle writer which avoids a lot of Charset encoder overhead.
It also adds one method to the IndentingWriter that postpones when a String is converted into char[].
That might be useful if the String is an latin1 string and coversion to UTF-8 is a nop in that case.

In my testing it roughly doubles the speed at which a turtle file is writen.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

