### PR TITLE
GH-2675 add new RepositoryConnection.prepare method

### DIFF
--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
@@ -37,6 +37,8 @@ public abstract class Protocol {
 		UPDATE,
 		/** Keep alive ping @since 2.3 */
 		PING,
+		/** prepare */
+		PREPARE,
 		/** commit */
 		COMMIT,
 		/** rollback */
@@ -78,12 +80,13 @@ public abstract class Protocol {
 	 * Protocol version.
 	 *
 	 * <ul>
+	 * <li>12: since RDF4J 3.5.0</li>
 	 * <li>11: since RDF4J 3.3.0</li>
 	 * <li>10: since RDF4J 3.1.0</li>
 	 * <li>9: since RDF4J 3.0.0</li>
 	 * </ul>
 	 */
-	public static final String VERSION = "11";
+	public static final String VERSION = "12";
 
 	/**
 	 * Parameter name for the 'subject' parameter of a statement query.

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -661,6 +661,35 @@ public interface RepositoryConnection extends AutoCloseable {
 	}
 
 	/**
+	 * Checks for an error state in the active transaction that would force the transaction to be rolled back. This is
+	 * an optional call; calling or not calling this method should have no effect on the outcome of {@link #commit()} or
+	 * {@link #rollback()}. A call to this method must be followed by (in the same thread) with a call to
+	 * {@link #prepare()} , {@link #commit()}, {@link #rollback()}, or {@link #close()} . This method may be called
+	 * multiple times within the same transaction by the same thread. If this method returns normally, the caller can
+	 * reasonably expect that a subsequent call to {@link #commit()} will also return normally. If this method returns
+	 * with an exception the caller should treat the exception as if it came from a call to {@link #commit()}.
+	 *
+	 * @throws UnknownTransactionStateException If the transaction state can not be determined (this can happen for
+	 *                                          instance when communication between client and server fails or
+	 *                                          times-out). It does not indicate a problem with the integrity of the
+	 *                                          store.
+	 * @throws RepositoryException              If there is an active transaction and it cannot be committed.
+	 * @throws IllegalStateException            If the connection has been closed or prepare was already called by
+	 *                                          another thread.
+	 * 
+	 * @implNote this default method is a temporary no-op implementation to ensure backward compatibility. Implementing
+	 *           classes should override.
+	 * 
+	 * @since 3.5.0
+	 * @see #commit()
+	 * @see #begin()
+	 * @see #rollback()
+	 */
+	default void prepare() throws RepositoryException {
+		// silently ignore
+	}
+
+	/**
 	 * Commits the active transaction. This operation ends the active transaction.
 	 *
 	 * @throws UnknownTransactionStateException if the transaction state can not be determined. This can happen for
@@ -670,6 +699,7 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * @see #isActive()
 	 * @see #begin()
 	 * @see #rollback()
+	 * @see #prepare()
 	 */
 	void commit() throws RepositoryException;
 

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -677,8 +677,8 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * @throws IllegalStateException            If the connection has been closed or prepare was already called by
 	 *                                          another thread.
 	 * 
-	 * @implNote this default method is a temporary no-op implementation to ensure backward compatibility. Implementing
-	 *           classes should override.
+	 * @implNote this default method throws an {@link UnsupportedOperationException} and is a temporary measure to
+	 *           ensure backward compatibility only. Implementing classes should override.
 	 * 
 	 * @since 3.5.0
 	 * @see #commit()
@@ -686,7 +686,7 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * @see #rollback()
 	 */
 	default void prepare() throws RepositoryException {
-		// silently ignore
+		throw new UnsupportedOperationException();
 	}
 
 	/**

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/RepositoryConnectionWrapper.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/RepositoryConnectionWrapper.java
@@ -230,6 +230,11 @@ public class RepositoryConnectionWrapper extends AbstractRepositoryConnection
 	}
 
 	@Override
+	public void prepare() throws RepositoryException {
+		getDelegate().prepare();
+	}
+
+	@Override
 	public void commit() throws RepositoryException {
 		getDelegate().commit();
 	}

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepository.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepository.java
@@ -354,19 +354,28 @@ public class HTTPRepository extends AbstractRepository implements HttpClientDepe
 			synchronized (this) {
 				result = compatibleMode;
 				if (result == null) {
-					try (RDF4JProtocolSession client = createHTTPClient()) {
-						final String serverProtocolVersion = client.getServerProtocol();
-
-						// protocol version 7 supports the new transaction
-						// handling. If the server is older, we need to run in
-						// backward-compatible mode.
-						result = compatibleMode = (Integer.parseInt(serverProtocolVersion) < 7);
-					} catch (NumberFormatException | IOException e) {
-						throw new RepositoryException("could not read protocol version from server: ", e);
-					}
+					// protocol version 7 supports the new transaction
+					// handling. If the server is older, we need to run in
+					// backward-compatible mode.
+					result = compatibleMode = (getServerProtocolVersion() < 7);
 				}
 			}
 		}
 		return result;
+	}
+
+	/**
+	 * Get the RDF4J Server's protocol version, as an integer
+	 * 
+	 * @return the protocol version implemented by the RDF4J, as an integer number.
+	 */
+	int getServerProtocolVersion() {
+		try (RDF4JProtocolSession client = createHTTPClient()) {
+			final String serverProtocolVersion = client.getServerProtocol();
+			return Integer.parseInt(serverProtocolVersion);
+		} catch (NumberFormatException | IOException e) {
+			throw new RepositoryException("could not read protocol version from server: ", e);
+		}
+
 	}
 }

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
@@ -298,6 +298,7 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 	public void prepare() throws RepositoryException {
 		if (this.getRepository().getServerProtocolVersion() < 12) {
 			// Action.PREPARE is not supported in Servers using protocols older than version 12.
+			logger.warn("Prepare operation not supported by server (requires protocol version 12)");
 			return;
 		}
 

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
@@ -295,6 +295,23 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 	}
 
 	@Override
+	public void prepare() throws RepositoryException {
+		if (this.getRepository().getServerProtocolVersion() < 12) {
+			// Action.PREPARE is not supported in Servers using protocols older than version 12.
+			return;
+		}
+
+		flushTransactionState(Action.PREPARE);
+		try {
+			client.prepareTransaction();
+		} catch (RepositoryException e) {
+			throw e;
+		} catch (RDF4JException | IllegalStateException | IOException e) {
+			throw new RepositoryException(e);
+		}
+	}
+
+	@Override
 	public void commit() throws RepositoryException {
 
 		if (this.getRepository().useCompatibleMode()) {
@@ -603,6 +620,7 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 			case GET:
 			case UPDATE:
 			case COMMIT:
+			case PREPARE:
 			case QUERY:
 			case SIZE:
 				if (toAdd != null) {

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -199,6 +199,16 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	}
 
 	@Override
+	public void prepare() throws RepositoryException {
+		try {
+			sailConnection.flush();
+			sailConnection.prepare();
+		} catch (SailException e) {
+			throw new RepositoryException(e);
+		}
+	}
+
+	@Override
 	public void commit() throws RepositoryException {
 		try {
 			sailConnection.flush();

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -23,7 +23,6 @@ import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.common.iteration.Iteration;
 import org.eclipse.rdf4j.common.iteration.SingletonIteration;
-import org.eclipse.rdf4j.common.transaction.TransactionSetting;
 import org.eclipse.rdf4j.http.client.HttpClientDependent;
 import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
 import org.eclipse.rdf4j.model.BNode;
@@ -403,6 +402,11 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 			return new SPARQLTupleQuery(client, base, query);
 		}
 		throw new UnsupportedQueryLanguageException("Unsupported query language " + ql);
+	}
+
+	@Override
+	public void prepare() throws RepositoryException {
+		// no-op, not supported in SPARQL protocol
 	}
 
 	@Override

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -406,7 +406,7 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 
 	@Override
 	public void prepare() throws RepositoryException {
-		// no-op, not supported in SPARQL protocol
+		throw new UnsupportedOperationException("SPARQL protocol has no support for 2-phase commit");
 	}
 
 	@Override

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/SerializableTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/optimistic/SerializableTest.java
@@ -152,6 +152,17 @@ public class SerializableTest {
 	}
 
 	@Test
+	public void testPrepare_safePattern() throws Exception {
+		a.begin(level);
+		b.begin(level);
+		a.add(PICASSO, RDF.TYPE, PAINTER);
+		b.add(REMBRANDT, RDF.TYPE, PAINTER);
+		assertEquals(1, size(a, null, RDF.TYPE, PAINTER, false));
+		a.commit();
+		b.prepare();
+	}
+
+	@Test
 	public void test_afterPattern() throws Exception {
 		a.begin(level);
 		b.begin(level);
@@ -185,6 +196,25 @@ public class SerializableTest {
 		a.commit();
 		try {
 			b.commit();
+			fail();
+		} catch (RepositoryException e) {
+			// e.printStackTrace();
+			assertTrue(e.getCause() instanceof SailConflictException
+					|| e.getMessage().contains("Observed State has Changed"));
+			b.rollback();
+		}
+	}
+
+	@Test
+	public void testPrepare_conflictPattern() throws Exception {
+		a.begin(level);
+		b.begin(level);
+		a.add(PICASSO, RDF.TYPE, PAINTER);
+		b.add(REMBRANDT, RDF.TYPE, PAINTER);
+		assertEquals(1, size(b, null, RDF.TYPE, PAINTER, false));
+		a.commit();
+		try {
+			b.prepare();
 			fail();
 		} catch (RepositoryException e) {
 			// e.printStackTrace();

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryConfigRepository.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryConfigRepository.java
@@ -153,6 +153,11 @@ public class RepositoryConfigRepository extends AbstractRepository {
 			}
 
 			@Override
+			public void prepare() throws RepositoryException {
+				// no-op
+			}
+
+			@Override
 			public void commit() throws RepositoryException {
 				Set<String> ids = new LinkedHashSet<>();
 				ids.addAll(manager.getRepositoryIDs());
@@ -310,6 +315,7 @@ public class RepositoryConfigRepository extends AbstractRepository {
 			private UnsupportedOperationException unsupported() {
 				return new UnsupportedOperationException("Query operations are not supported on the SYSTEM repository");
 			}
+
 		};
 	}
 

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
@@ -148,6 +148,18 @@ class Transaction implements AutoCloseable {
 	 * @throws ExecutionException
 	 * @throws InterruptedException
 	 */
+	void prepare() throws InterruptedException, ExecutionException {
+		Future<Boolean> result = submit(() -> {
+			txnConnection.prepare();
+			return true;
+		});
+		getFromFuture(result);
+	}
+
+	/**
+	 * @throws ExecutionException
+	 * @throws InterruptedException
+	 */
 	void commit() throws InterruptedException, ExecutionException {
 		Future<Boolean> result = submit(() -> {
 			txnConnection.commit();

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -243,10 +243,12 @@ public class TransactionController extends AbstractController {
 				format = Rio.getParserFormatForMIMEType(request.getContentType())
 						.orElseThrow(Rio.unsupportedFormat(request.getContentType()));
 				transaction.delete(format, request.getInputStream(), baseURI);
-
 				break;
 			case UPDATE:
 				return getSparqlUpdateResult(transaction, request, response);
+			case PREPARE:
+				transaction.prepare();
+				break;
 			case COMMIT:
 				transaction.commit();
 				// If commit fails with an exception, deregister should be skipped so the user


### PR DESCRIPTION
GitHub issue resolved: #2675  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added RepositoryConnection.prepare and implementations in core classes
- added handling over remote protocol
- added tests, including a SHACL-specific use case test


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

