### PR TITLE
GH-1325 added Values convenience functions for quick IRI, Literal, BNode, and Triple creation

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/Triple.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/Triple.java
@@ -10,8 +10,8 @@ package org.eclipse.rdf4j.model;
 import org.eclipse.rdf4j.common.annotation.Experimental;
 
 /**
- * An RDF* triple. Triples have a subject, predicate and object. Unlike {@link Statement}, a triple never has an
- * associated context.
+ * An RDF* embedded triple. Embedded triples have a subject, predicate and object. Unlike {@link Statement}, a triple
+ * never has an associated context.
  * <p>
  * Additional utility functionality for working with {@code Triple} objects is available in the
  * {@code org.eclipse.rdf4j.model.util.Statements} utility class.

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -188,14 +188,12 @@ public interface ValueFactory {
 	public Literal createLiteral(double value);
 
 	/**
-	 * Creates a new literal representing the specified bigDecimal that is typed using the appropriate XML Schema
-	 * date/time datatype.
+	 * Creates a new literal representing the specified bigDecimal that is typed as an <tt>xsd:Decimal</tt>.
 	 */
 	public Literal createLiteral(BigDecimal bigDecimal);
 
 	/**
-	 * Creates a new literal representing the specified bigInteger that is typed using the appropriate XML Schema
-	 * date/time datatype.
+	 * Creates a new literal representing the specified bigInteger that is typed as an <tt>xsd:Integer</tt>.
 	 */
 	public Literal createLiteral(BigInteger bigInteger);
 
@@ -252,7 +250,7 @@ public interface ValueFactory {
 	 * date/time datatype.
 	 *
 	 * @param calendar The value for the literal.
-	 * @return An typed literal for the specified calendar.
+	 * @return A typed literal for the specified calendar.
 	 */
 	public Literal createLiteral(XMLGregorianCalendar calendar);
 

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -30,6 +30,8 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
  *
  * @author Arjohn Kampman
  * @author Peter Ansell
+ * 
+ * @See {@link Values}
  */
 public class Literals {
 
@@ -381,7 +383,9 @@ public class Literals {
 	 * @param object       an object to be converted to a typed literal.
 	 * @return a typed literal representation of the supplied object.
 	 * @throws NullPointerException If the object was null.
+	 * @deprecated since 3.5.0 - use {@link Values#literal(Object)} instead.
 	 */
+	@Deprecated
 	public static Literal createLiteral(ValueFactory valueFactory, Object object) {
 		try {
 			return createLiteral(valueFactory, object, false);
@@ -402,7 +406,9 @@ public class Literals {
 	 * @return a typed literal representation of the supplied object.
 	 * @throws LiteralUtilException If the literal could not be created.
 	 * @throws NullPointerException If the object was null.
+	 * @deprecated since 3.5.0 - use {@link Values#literal(Object, boolean)} instead.
 	 */
+	@Deprecated
 	public static Literal createLiteralOrFail(ValueFactory valueFactory, Object object) throws LiteralUtilException {
 		return createLiteral(valueFactory, object, true);
 	}
@@ -463,7 +469,9 @@ public class Literals {
 	 * @param object an object to check for the possibility of being converted to a typed literal.
 	 * @return True if a literal could be created from the given object, based solely on its type and the methods
 	 *         available on the {@link ValueFactory} interface and false otherwise. Returns false if the object is null.
+	 * @deprecated since 3.5.0
 	 */
+	@Deprecated
 	public static boolean canCreateLiteral(Object object) {
 		if (object == null) {
 			// Cannot create a literal from a null

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
@@ -128,7 +128,9 @@ public class Statements {
 	 * @param statement a statement to convert to an RDF* triple
 	 * @return an {@link Triple RDF* triple} with the same subject, predicate and object as the input statement.
 	 * @since 3.4.0
+	 * @deprecated since 3.5.0 - use {@link Values#triple(Statement)} instead
 	 */
+	@Deprecated
 	public static Triple toTriple(Statement statement) {
 		return toTriple(SimpleValueFactory.getInstance(), statement);
 	}
@@ -140,7 +142,10 @@ public class Statements {
 	 * @param statement a statement to convert to an RDF* triple
 	 * @return an {@link Triple RDF* triple} with the same subject, predicate and object as the input statement.
 	 * @since 3.4.0
+	 * 
+	 * @deprecated since 3.5.0 - use {@link Values#triple(ValueFactory, Statement)} instead
 	 */
+	@Deprecated
 	public static Triple toTriple(ValueFactory vf, Statement statement) {
 		return vf.createTriple(statement.getSubject(), statement.getPredicate(), statement.getObject());
 	}
@@ -181,6 +186,41 @@ public class Statements {
 	 */
 	public static Statement toStatement(ValueFactory vf, Triple triple, Resource context) {
 		return vf.createStatement(triple.getSubject(), triple.getPredicate(), triple.getObject(), context);
+	}
+
+	/**
+	 * Create a {@link Statement} from the supplied subject, predicate, object and context.
+	 *
+	 * @param subject   the statement subject
+	 * @param predicate the statement predicate
+	 * @param object    the statement object
+	 * @param context   the context to assign to the {@link Statement}. May be null to indicate no context.
+	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and having the
+	 *         supplied context.
+	 * @throws NullPointerException if any of subject, predicate, or object are <code>null</code>.
+	 * @since 3.5.0
+	 */
+	public static Statement statement(Resource subject, IRI predicate, Value object,
+			Resource context) {
+		return statement(SimpleValueFactory.getInstance(), subject, predicate, object, context);
+	}
+
+	/**
+	 * Create a {@link Statement} from the supplied subject, predicate, object and context.
+	 *
+	 * @param vf        the {@link ValueFactory} to use for creating the {@link Statement} object.
+	 * @param subject   the statement subject
+	 * @param predicate the statement predicate
+	 * @param object    the statement object
+	 * @param context   the context to assign to the {@link Statement}. May be null to indicate no context.
+	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and having the
+	 *         supplied context.
+	 * @throws NullPointerException if any of vf, subject, predicate, or object are <code>null</code>.
+	 * @since 3.5.0
+	 */
+	public static Statement statement(ValueFactory vf, Resource subject, IRI predicate, Value object,
+			Resource context) {
+		return vf.createStatement(subject, predicate, object, context);
 	}
 
 	/**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
@@ -10,7 +10,10 @@ package org.eclipse.rdf4j.model.util;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.temporal.TemporalAccessor;
+import java.util.Date;
 import java.util.Objects;
+
+import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -25,7 +28,8 @@ import org.eclipse.rdf4j.model.impl.ValidatingValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
- * Convenience functions to quickly create {@link Value} objects without having to create a {@link ValueFactory} first.
+ * Factory methods to quickly create {@link Value} objects ( {@link IRI}, {@link Literal}, {@link BNode}, and
+ * {@link Triple}) without having to create a {@link ValueFactory} first.
  * <p>
  * Example usage:
  * 
@@ -39,6 +43,8 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
  * 
  * @author Jeen Broekstra
  * @since 3.5.0
+ * 
+ * @see Statements
  */
 public class Values {
 
@@ -59,12 +65,30 @@ public class Values {
 	 * Create a new {@link IRI} using the supplied iri string
 	 * 
 	 * @param iri a string representing a valid (absolute) iri
+	 * 
 	 * @return an {@link IRI} object for the supplied iri string.
+	 * 
 	 * @throws NullPointerException     if the suppplied iri is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI.
 	 */
 	public static IRI iri(String iri) throws IllegalArgumentException {
-		return VALUE_FACTORY.createIRI(Objects.requireNonNull(iri, "iri may not be null"));
+		return iri(VALUE_FACTORY, iri);
+	}
+
+	/**
+	 * Create a new {@link IRI} using the supplied iri string
+	 * 
+	 * @param vf  the {@link ValueFactory} to use for creation of the IRI.
+	 * @param iri a string representing a valid (absolute) iri
+	 * 
+	 * @return an {@link IRI} object for the supplied iri string.
+	 * 
+	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
+	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI by the supplied
+	 *                                  {@link ValueFactory} .
+	 */
+	public static IRI iri(ValueFactory vf, String iri) throws IllegalArgumentException {
+		return vf.createIRI(Objects.requireNonNull(iri, "iri may not be null"));
 	}
 
 	/**
@@ -72,12 +96,31 @@ public class Values {
 	 * 
 	 * @param namespace the IRI's namespace
 	 * @param localName the IRI's local name
+	 * 
 	 * @return an {@link IRI} object for the supplied IRI namespace and localName.
-	 * @throws NullPointerException     if the suppplied namespace or localName is <code>null</code>.
+	 * 
+	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI.
 	 */
 	public static IRI iri(String namespace, String localName) throws IllegalArgumentException {
-		return VALUE_FACTORY.createIRI(Objects.requireNonNull(namespace, "namespace may not be null"),
+		return iri(VALUE_FACTORY, namespace, localName);
+	}
+
+	/**
+	 * Create a new {@link IRI} using the supplied namespace and local name
+	 * 
+	 * @param vf        the {@link ValueFactory} to use for creation of the IRI.
+	 * @param namespace the IRI's namespace
+	 * @param localName the IRI's local name
+	 * 
+	 * @return an {@link IRI} object for the supplied IRI namespace and localName.
+	 * 
+	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
+	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI by the supplied
+	 *                                  {@link ValueFactory}
+	 */
+	public static IRI iri(ValueFactory vf, String namespace, String localName) throws IllegalArgumentException {
+		return vf.createIRI(Objects.requireNonNull(namespace, "namespace may not be null"),
 				Objects.requireNonNull(localName, "localName may not be null"));
 	}
 
@@ -89,32 +132,78 @@ public class Values {
 	 * @return a new {@link BNode}
 	 */
 	public static BNode bnode() {
-		return VALUE_FACTORY.createBNode();
+		return bnode(VALUE_FACTORY);
+	}
+
+	/**
+	 * Creates a new {@link BNode}
+	 * 
+	 * @param vf the {@link ValueFactory} to use for creation of the {@link BNode}
+	 * 
+	 * @return a new {@link BNode}
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>
+	 */
+	public static BNode bnode(ValueFactory vf) {
+		return vf.createBNode();
 	}
 
 	/**
 	 * Creates a new {@link BNode} with the supplied node identifier.
 	 * 
 	 * @param nodeId the node identifier
+	 * 
 	 * @return a new {@link BNode}
+	 * 
 	 * @throws NullPointerException     if the supplied node identifier is <code>null</code>.
 	 * @throws IllegalArgumentException if the supplied node identifier is not valid
 	 */
 	public static BNode bnode(String nodeId) throws IllegalArgumentException {
-		return VALUE_FACTORY.createBNode(Objects.requireNonNull(nodeId, "nodeId may not be null"));
+		return bnode(VALUE_FACTORY, nodeId);
 	}
 
-	/* literal factory methods */
+	/**
+	 * Creates a new {@link BNode} with the supplied node identifier.
+	 * 
+	 * @param vf     the {@link ValueFactory} to use for creation of the {@link BNode}
+	 * @param nodeId the node identifier
+	 * 
+	 * @return a new {@link BNode}
+	 * 
+	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
+	 * @throws IllegalArgumentException if the supplied node identifier is not valid
+	 */
+	public static BNode bnode(ValueFactory vf, String nodeId) throws IllegalArgumentException {
+		return vf.createBNode(Objects.requireNonNull(nodeId, "nodeId may not be null"));
+	}
+
+	/* Literal factory methods */
 
 	/**
 	 * Creates a new {@link Literal} with the supplied lexical value.
 	 * 
 	 * @param lexicalValue the lexical value for the literal
+	 * 
 	 * @return a new {@link Literal} of type {@link XSD#STRING}
+	 * 
 	 * @throws NullPointerException if the supplied lexical value is <code>null</code>.
 	 */
 	public static Literal literal(String lexicalValue) {
-		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"));
+		return literal(VALUE_FACTORY, lexicalValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied lexical value.
+	 *
+	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param lexicalValue the lexical value for the literal
+	 * 
+	 * @return a new {@link Literal} of type {@link XSD#STRING}
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>
+	 */
+	public static Literal literal(ValueFactory vf, String lexicalValue) {
+		return vf.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"));
 	}
 
 	/**
@@ -122,12 +211,30 @@ public class Values {
 	 * 
 	 * @param lexicalValue the lexical value for the literal
 	 * @param datatype     the datatype URI
+	 * 
 	 * @return a new {@link Literal} with the supplied lexical value and datatype
+	 * 
 	 * @throws NullPointerException     if the supplied lexical value or datatype is <code>null</code>.
 	 * @throws IllegalArgumentException if the supplied lexical value is not valid for the given datatype
 	 */
 	public static Literal literal(String lexicalValue, IRI datatype) throws IllegalArgumentException {
-		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"),
+		return literal(VALUE_FACTORY, lexicalValue, datatype);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied lexical value and datatype.
+	 * 
+	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param lexicalValue the lexical value for the literal
+	 * @param datatype     the datatype URI
+	 * 
+	 * @return a new {@link Literal} with the supplied lexical value and datatype
+	 * 
+	 * @throws NullPointerException     if any of the input parameters is <code>null</code>.
+	 * @throws IllegalArgumentException if the supplied lexical value is not valid for the given datatype
+	 */
+	public static Literal literal(ValueFactory vf, String lexicalValue, IRI datatype) throws IllegalArgumentException {
+		return vf.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"),
 				Objects.requireNonNull(datatype, "datatype may not be null"));
 	}
 
@@ -135,105 +242,323 @@ public class Values {
 	 * Creates a new {@link Literal} with the supplied boolean value
 	 * 
 	 * @param booleanValue a boolean value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#BOOLEAN} with the supplied value
 	 */
 	public static Literal literal(boolean booleanValue) {
-		return VALUE_FACTORY.createLiteral(booleanValue);
+		return literal(VALUE_FACTORY, booleanValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied boolean value
+	 * 
+	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param booleanValue a boolean value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#BOOLEAN} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, boolean booleanValue) {
+		return vf.createLiteral(booleanValue);
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied byte value
 	 * 
 	 * @param byteValue a byte value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#BYTE} with the supplied value
 	 */
 	public static Literal literal(byte byteValue) {
-		return VALUE_FACTORY.createLiteral(byteValue);
+		return literal(VALUE_FACTORY, byteValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied byte value
+	 * 
+	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param byteValue a byte value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#BYTE} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, byte byteValue) {
+		return vf.createLiteral(byteValue);
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied short value
 	 * 
 	 * @param shortValue a short value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#SHORT} with the supplied value
 	 */
 	public static Literal literal(short shortValue) {
-		return VALUE_FACTORY.createLiteral(shortValue);
+		return literal(VALUE_FACTORY, shortValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied short value
+	 * 
+	 * @param vf         the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param shortValue a short value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#SHORT} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, short shortValue) {
+		return vf.createLiteral(shortValue);
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied int value
 	 * 
 	 * @param intValue an int value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#INT} with the supplied value
 	 */
 	public static Literal literal(int intValue) {
-		return VALUE_FACTORY.createLiteral(intValue);
+		return literal(VALUE_FACTORY, intValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied int value
+	 * 
+	 * @param vf       the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param intValue an int value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#INT} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, int intValue) {
+		return vf.createLiteral(intValue);
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied long value
 	 * 
 	 * @param longValue a long value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#LONG} with the supplied value
 	 */
 	public static Literal literal(long longValue) {
-		return VALUE_FACTORY.createLiteral(longValue);
+		return literal(VALUE_FACTORY, longValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied long value
+	 * 
+	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param longValue a long value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#LONG} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, long longValue) {
+		return vf.createLiteral(longValue);
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied float value
 	 * 
-	 * @param floatValue an float value
+	 * @param floatValue a float value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#FLOAT} with the supplied value
 	 */
 	public static Literal literal(float floatValue) {
-		return VALUE_FACTORY.createLiteral(floatValue);
+		return literal(VALUE_FACTORY, floatValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied float value
+	 * 
+	 * @param vf         the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param floatValue a float value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#FLOAT} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, float floatValue) {
+		return vf.createLiteral(floatValue);
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied double value
 	 * 
 	 * @param doubleValue a double value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#DOUBLE} with the supplied value
 	 */
 	public static Literal literal(double doubleValue) {
-		return VALUE_FACTORY.createLiteral(doubleValue);
+		return literal(VALUE_FACTORY, doubleValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied double value
+	 * 
+	 * @param vf          the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param doubleValue a double value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#DOUBLE} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, double doubleValue) {
+		return vf.createLiteral(doubleValue);
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied {@link BigDecimal} value
 	 * 
 	 * @param bigDecimal a {@link BigDecimal} value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#DECIMAL} with the supplied value
+	 * 
 	 * @throws NullPointerException if the supplied bigDecimal is <code>null</code>.
 	 */
 	public static Literal literal(BigDecimal bigDecimal) {
-		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(bigDecimal, "bigDecimal may not be null"));
+		return literal(VALUE_FACTORY, bigDecimal);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied {@link BigDecimal} value
+	 * 
+	 * @param vf         the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param bigDecimal a {@link BigDecimal} value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#DECIMAL} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, BigDecimal bigDecimal) {
+		return vf.createLiteral(Objects.requireNonNull(bigDecimal, "bigDecimal may not be null"));
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied {@link BigInteger} value
 	 * 
 	 * @param bigInteger a {@link BigInteger} value
+	 * 
 	 * @return a {@link Literal} of type {@link XSD#INTEGER} with the supplied value
+	 * 
 	 * @throws NullPointerException if the supplied bigInteger is <code>null</code>.
 	 */
 	public static Literal literal(BigInteger bigInteger) {
-		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(bigInteger, "bigInteger may not be null"));
+		return literal(VALUE_FACTORY, bigInteger);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied {@link BigInteger} value
+	 * 
+	 * @param vf         the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param bigInteger a {@link BigInteger} value
+	 * 
+	 * @return a {@link Literal} of type {@link XSD#INTEGER} with the supplied value
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
+	 */
+	public static Literal literal(ValueFactory vf, BigInteger bigInteger) {
+		return vf.createLiteral(Objects.requireNonNull(bigInteger, "bigInteger may not be null"));
 	}
 
 	/**
 	 * Creates a new {@link Literal} with the supplied {@link TemporalAccessor} value
 	 * 
 	 * @param value a {@link TemporalAccessor} value.
+	 * 
 	 * @return a {@link Literal} with the supplied calendar value and the appropriate {@link XSD} date/time datatype for
 	 *         the specific value.
+	 * 
 	 * @throws NullPointerException     if the supplied {@link TemporalAccessor} value is <code>null</code>.
 	 * @throws IllegalArgumentException if value cannot be represented by an XML Schema date/time datatype
 	 */
 	public static Literal literal(TemporalAccessor value) throws IllegalArgumentException {
-		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(value, "value may not be null"));
+		return literal(VALUE_FACTORY, value);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied {@link TemporalAccessor} value
+	 *
+	 * @param vf    the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param value a {@link TemporalAccessor} value.
+	 * 
+	 * @return a {@link Literal} with the supplied calendar value and the appropriate {@link XSD} date/time datatype for
+	 *         the specific value.
+	 * 
+	 * @throws NullPointerException     if any of the input parameters is <code>null</code>..
+	 * @throws IllegalArgumentException if value cannot be represented by an XML Schema date/time datatype
+	 */
+	public static Literal literal(ValueFactory vf, TemporalAccessor value) throws IllegalArgumentException {
+		return vf.createLiteral(Objects.requireNonNull(value, "value may not be null"));
+	}
+
+	/**
+	 * Creates a new typed {@link Literal} out of the supplied object, mapping the runtime type of the object to the
+	 * appropriate {@link XSD} datatype. If no mapping is available, the method returns a literal with the string
+	 * representation of the supplied object as the value, and {@link XSD#STRING} as the datatype.
+	 * <p>
+	 * Recognized types are {@link Boolean}, {@link Byte}, {@link Double}, {@link Float}, {@link Integer}, {@link Long},
+	 * {@link Short}, {@link XMLGregorianCalendar } , {@link TemporalAccessor} and {@link Date}.
+	 *
+	 * @param object an object to be converted to a typed literal.
+	 * 
+	 * @return a typed literal representation of the supplied object.
+	 * 
+	 * @throws NullPointerException if the input parameter is <code>null</code>..
+	 */
+	public static Literal literal(Object object) {
+		return literal(VALUE_FACTORY, object, false);
+	}
+
+	/**
+	 * Creates a new typed {@link Literal} out of the supplied object, mapping the runtime type of the object to the
+	 * appropriate {@link XSD} datatype.
+	 * <p>
+	 * Recognized types are {@link Boolean}, {@link Byte}, {@link Double}, {@link Float}, {@link Integer}, {@link Long},
+	 * {@link Short}, {@link XMLGregorianCalendar } , {@link TemporalAccessor} and {@link Date}.
+	 *
+	 * @param object            an object to be converted to a typed literal.
+	 * @param failOnUnknownType If no mapping is available and <code>failOnUnknownType</code> is <code>false</code> the
+	 *                          method returns a literal with the string representation of the supplied object as the
+	 *                          value, and {@link XSD#STRING} as the datatype. If set to <code>true</code> the method
+	 *                          throws an {@link IllegalArgumentException} if no mapping available.
+	 * 
+	 * @return a typed literal representation of the supplied object.
+	 * 
+	 * @throws NullPointerException if the input parameter is <code>null</code>..
+	 */
+	public static Literal literal(Object object, boolean failOnUnknownType) {
+		return literal(VALUE_FACTORY, object, failOnUnknownType);
+	}
+
+	/**
+	 * Creates a new typed {@link Literal} out of the supplied object, mapping the runtime type of the object to the
+	 * appropriate {@link XSD} datatype.
+	 * <p>
+	 * Recognized types are {@link Boolean}, {@link Byte}, {@link Double}, {@link Float}, {@link Integer}, {@link Long},
+	 * {@link Short}, {@link XMLGregorianCalendar }, {@link TemporalAccessor} and {@link Date}.
+	 *
+	 * @param valueFactory      the {@link ValueFactory}to use for creation of the {@link Literal}
+	 * @param object            an object to be converted to a typed literal.
+	 * @param failOnUnknownType If no mapping is available and <code>failOnUnknownType</code> is <code>false</code> the
+	 *                          method returns a literal with the string representation of the supplied object as the
+	 *                          value, and {@link XSD#STRING} as the datatype. If set to <code>true</code> the method
+	 *                          throws an {@link IllegalArgumentException} if no mapping available.
+	 * 
+	 * @return a typed literal representation of the supplied object.
+	 * 
+	 * @throws NullPointerException     if any of the input parameters is <code>null</code>.
+	 * @throws IllegalArgumentException if <code>failOnUnknownType</code> is set to <code>true</code> and the runtime
+	 *                                  type of the supplied object could not be mapped.
+	 */
+	public static Literal literal(ValueFactory vf, Object object, boolean failOnUnknownType) {
+		return createLiteralFromObject(vf, object, failOnUnknownType);
 	}
 
 	/* triple factory methods */
@@ -244,11 +569,29 @@ public class Values {
 	 * @param subject   the Triple subject
 	 * @param predicate the Triple predicate
 	 * @param object    the Triple object
+	 * 
 	 * @return a {@link Triple} with the supplied subject, predicate, and object.
+	 * 
 	 * @throws NullPointerException if any of the supplied input parameters is <code>null</code>.
 	 */
 	public static Triple triple(Resource subject, IRI predicate, Value object) {
-		return VALUE_FACTORY.createTriple(
+		return triple(VALUE_FACTORY, subject, predicate, object);
+	}
+
+	/**
+	 * Creates a new {@link Triple RDF* embedded triple} with the supplied subject, predicate, and object.
+	 * 
+	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Triple}
+	 * @param subject   the Triple subject
+	 * @param predicate the Triple predicate
+	 * @param object    the Triple object
+	 * 
+	 * @return a {@link Triple} with the supplied subject, predicate, and object.
+	 * 
+	 * @throws NullPointerException if any of the supplied input parameters is <code>null</code>.
+	 */
+	public static Triple triple(ValueFactory vf, Resource subject, IRI predicate, Value object) {
+		return vf.createTriple(
 				Objects.requireNonNull(subject, "subject may not be null"),
 				Objects.requireNonNull(predicate, "predicate may not be null"),
 				Objects.requireNonNull(object, "object may not be null")
@@ -260,11 +603,30 @@ public class Values {
 	 * {@link Statement}.
 	 *
 	 * @param statement the {@link Statement} from which to construct a {@link Triple}
+	 * 
 	 * @return a {@link Triple} with the same subject, predicate, and object as the supplied Statement.
+	 * 
+	 * @throws NullPointerException if statement is <code>null</code>.
 	 */
 	public static Triple triple(Statement statement) {
 		Objects.requireNonNull(statement, "statement may not be null");
 		return VALUE_FACTORY.createTriple(statement.getSubject(), statement.getPredicate(), statement.getObject());
+	}
+
+	/**
+	 * Creates a new {@link Triple RDF* embedded triple} using the subject, predicate and object from the supplied
+	 * {@link Statement}.
+	 * 
+	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Triple}
+	 * @param statement the {@link Statement} from which to construct a {@link Triple}
+	 * 
+	 * @return a {@link Triple} with the same subject, predicate, and object as the supplied Statement.
+	 * 
+	 * @throws NullPointerException if any of the supplied input parameters is <code>null</code>.
+	 */
+	public static Triple triple(ValueFactory vf, Statement statement) {
+		Objects.requireNonNull(statement, "statement may not be null");
+		return vf.createTriple(statement.getSubject(), statement.getPredicate(), statement.getObject());
 	}
 
 	/**
@@ -276,4 +638,57 @@ public class Values {
 		return VALUE_FACTORY;
 	}
 
+	/* private methods */
+
+	/**
+	 * Creates a typed {@link Literal} out of the supplied object, mapping the runtime type of the object to the
+	 * appropriate XML Schema type. If no mapping is available, the method throws an exception if the boolean parameter
+	 * is true, or if it is false it returns a literal with the string representation of the supplied object as the
+	 * value, and {@link XSD#STRING} as the datatype. Recognized types are {@link Boolean}, {@link Byte},
+	 * {@link Double}, {@link Float}, {@link Integer}, {@link Long}, {@link Short}, {@link XMLGregorianCalendar } , and
+	 * {@link Date}.
+	 *
+	 * @param valueFactory            The {@link ValueFactory} to use when creating the result.
+	 * @param object                  an object to be converted to a typed literal.
+	 * @param throwExceptionOnFailure If true throws a {@link LiteralUtilException} when the object is not recognised.
+	 *                                If false it returns a string typed literal based on the objects toString method.
+	 * @return a typed literal representation of the supplied object.
+	 * @throws IllegalArgumentException If the literal could not be created.
+	 * @throws NullPointerException     If the object was null.
+	 */
+	private static Literal createLiteralFromObject(ValueFactory valueFactory, Object object,
+			boolean throwExceptionOnFailure)
+			throws IllegalArgumentException {
+		Objects.requireNonNull(valueFactory, "valueFactory may not be null");
+		Objects.requireNonNull(object, "object may not be null");
+
+		if (object instanceof Boolean) {
+			return valueFactory.createLiteral(((Boolean) object).booleanValue());
+		} else if (object instanceof Byte) {
+			return valueFactory.createLiteral(((Byte) object).byteValue());
+		} else if (object instanceof Double) {
+			return valueFactory.createLiteral(((Double) object).doubleValue());
+		} else if (object instanceof Float) {
+			return valueFactory.createLiteral(((Float) object).floatValue());
+		} else if (object instanceof Integer) {
+			return valueFactory.createLiteral(((Integer) object).intValue());
+		} else if (object instanceof Long) {
+			return valueFactory.createLiteral(((Long) object).longValue());
+		} else if (object instanceof Short) {
+			return valueFactory.createLiteral(((Short) object).shortValue());
+		} else if (object instanceof XMLGregorianCalendar) {
+			return valueFactory.createLiteral((XMLGregorianCalendar) object);
+		} else if (object instanceof Date) {
+			return valueFactory.createLiteral((Date) object);
+		} else if (object instanceof TemporalAccessor) {
+			return valueFactory.createLiteral((TemporalAccessor) object);
+		} else if (object instanceof String) {
+			return valueFactory.createLiteral(object.toString(), XSD.STRING);
+		} else {
+			if (throwExceptionOnFailure) {
+				throw new IllegalArgumentException("Unrecognized object type: " + object);
+			}
+			return valueFactory.createLiteral(object.toString(), XSD.STRING);
+		}
+	}
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
@@ -1,0 +1,279 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.model.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.temporal.TemporalAccessor;
+import java.util.Objects;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.impl.ValidatingValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+
+/**
+ * Convenience functions to quickly create {@link Value} objects without having to create a {@link ValueFactory} first.
+ * <p>
+ * Example usage:
+ * 
+ * <pre>
+ * import static org.eclipse.rdf4j.model.util.Values.iri;
+ * 
+ * ... 
+ * IRI foo = iri("http://example.org/foo");
+ * </pre>
+ * <p>
+ * 
+ * @author Jeen Broekstra
+ * @since 3.5.0
+ */
+public class Values {
+
+	/**
+	 * Internal shared value factory used for creating all values. We use a {@link ValidatingValueFactory} to ensure
+	 * created values are syntactically legal.
+	 */
+	private static final ValueFactory VALUE_FACTORY = new ValidatingValueFactory(SimpleValueFactory.getInstance());
+
+	/* private constructor */
+
+	private Values() {
+	}
+
+	/* IRI factory methods */
+
+	/**
+	 * Create a new {@link IRI} using the supplied iri string
+	 * 
+	 * @param iri a string representing a valid (absolute) iri
+	 * @return an {@link IRI} object for the supplied iri string.
+	 * @throws NullPointerException     if the suppplied iri is <code>null</code>
+	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI.
+	 */
+	public static IRI iri(String iri) throws IllegalArgumentException {
+		return VALUE_FACTORY.createIRI(Objects.requireNonNull(iri, "iri may not be null"));
+	}
+
+	/**
+	 * Create a new {@link IRI} using the supplied namespace and local name
+	 * 
+	 * @param namespace the IRI's namespace
+	 * @param localName the IRI's local name
+	 * @return an {@link IRI} object for the supplied IRI namespace and localName.
+	 * @throws NullPointerException     if the suppplied namespace or localName is <code>null</code>.
+	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI.
+	 */
+	public static IRI iri(String namespace, String localName) throws IllegalArgumentException {
+		return VALUE_FACTORY.createIRI(Objects.requireNonNull(namespace, "namespace may not be null"),
+				Objects.requireNonNull(localName, "localName may not be null"));
+	}
+
+	/* blank node factory methods */
+
+	/**
+	 * Creates a new {@link BNode}
+	 * 
+	 * @return a new {@link BNode}
+	 */
+	public static BNode bnode() {
+		return VALUE_FACTORY.createBNode();
+	}
+
+	/**
+	 * Creates a new {@link BNode} with the supplied node identifier.
+	 * 
+	 * @param nodeId the node identifier
+	 * @return a new {@link BNode}
+	 * @throws NullPointerException     if the supplied node identifier is <code>null</code>.
+	 * @throws IllegalArgumentException if the supplied node identifier is not valid
+	 */
+	public static BNode bnode(String nodeId) throws IllegalArgumentException {
+		return VALUE_FACTORY.createBNode(Objects.requireNonNull(nodeId, "nodeId may not be null"));
+	}
+
+	/* literal factory methods */
+
+	/**
+	 * Creates a new {@link Literal} with the supplied lexical value.
+	 * 
+	 * @param lexicalValue the lexical value for the literal
+	 * @return a new {@link Literal} of type {@link XSD#STRING}
+	 * @throws NullPointerException if the supplied lexical value is <code>null</code>.
+	 */
+	public static Literal literal(String lexicalValue) {
+		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"));
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied lexical value and datatype.
+	 * 
+	 * @param lexicalValue the lexical value for the literal
+	 * @param datatype     the datatype URI
+	 * @return a new {@link Literal} with the supplied lexical value and datatype
+	 * @throws NullPointerException     if the supplied lexical value or datatype is <code>null</code>.
+	 * @throws IllegalArgumentException if the supplied lexical value is not valid for the given datatype
+	 */
+	public static Literal literal(String lexicalValue, IRI datatype) throws IllegalArgumentException {
+		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"),
+				Objects.requireNonNull(datatype, "datatype may not be null"));
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied boolean value
+	 * 
+	 * @param booleanValue a boolean value
+	 * @return a {@link Literal} of type {@link XSD#BOOLEAN} with the supplied value
+	 */
+	public static Literal literal(boolean booleanValue) {
+		return VALUE_FACTORY.createLiteral(booleanValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied byte value
+	 * 
+	 * @param byteValue a byte value
+	 * @return a {@link Literal} of type {@link XSD#BYTE} with the supplied value
+	 */
+	public static Literal literal(byte byteValue) {
+		return VALUE_FACTORY.createLiteral(byteValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied short value
+	 * 
+	 * @param shortValue a short value
+	 * @return a {@link Literal} of type {@link XSD#SHORT} with the supplied value
+	 */
+	public static Literal literal(short shortValue) {
+		return VALUE_FACTORY.createLiteral(shortValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied int value
+	 * 
+	 * @param intValue an int value
+	 * @return a {@link Literal} of type {@link XSD#INT} with the supplied value
+	 */
+	public static Literal literal(int intValue) {
+		return VALUE_FACTORY.createLiteral(intValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied long value
+	 * 
+	 * @param longValue a long value
+	 * @return a {@link Literal} of type {@link XSD#LONG} with the supplied value
+	 */
+	public static Literal literal(long longValue) {
+		return VALUE_FACTORY.createLiteral(longValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied float value
+	 * 
+	 * @param floatValue an float value
+	 * @return a {@link Literal} of type {@link XSD#FLOAT} with the supplied value
+	 */
+	public static Literal literal(float floatValue) {
+		return VALUE_FACTORY.createLiteral(floatValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied double value
+	 * 
+	 * @param doubleValue a double value
+	 * @return a {@link Literal} of type {@link XSD#DOUBLE} with the supplied value
+	 */
+	public static Literal literal(double doubleValue) {
+		return VALUE_FACTORY.createLiteral(doubleValue);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied {@link BigDecimal} value
+	 * 
+	 * @param bigDecimal a {@link BigDecimal} value
+	 * @return a {@link Literal} of type {@link XSD#DECIMAL} with the supplied value
+	 * @throws NullPointerException if the supplied bigDecimal is <code>null</code>.
+	 */
+	public static Literal literal(BigDecimal bigDecimal) {
+		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(bigDecimal, "bigDecimal may not be null"));
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied {@link BigInteger} value
+	 * 
+	 * @param bigInteger a {@link BigInteger} value
+	 * @return a {@link Literal} of type {@link XSD#INTEGER} with the supplied value
+	 * @throws NullPointerException if the supplied bigInteger is <code>null</code>.
+	 */
+	public static Literal literal(BigInteger bigInteger) {
+		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(bigInteger, "bigInteger may not be null"));
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied {@link TemporalAccessor} value
+	 * 
+	 * @param value a {@link TemporalAccessor} value.
+	 * @return a {@link Literal} with the supplied calendar value and the appropriate {@link XSD} date/time datatype for
+	 *         the specific value.
+	 * @throws NullPointerException     if the supplied {@link TemporalAccessor} value is <code>null</code>.
+	 * @throws IllegalArgumentException if value cannot be represented by an XML Schema date/time datatype
+	 */
+	public static Literal literal(TemporalAccessor value) throws IllegalArgumentException {
+		return VALUE_FACTORY.createLiteral(Objects.requireNonNull(value, "value may not be null"));
+	}
+
+	/* triple factory methods */
+
+	/**
+	 * Creates a new {@link Triple RDF* embedded triple} with the supplied subject, predicate, and object.
+	 *
+	 * @param subject   the Triple subject
+	 * @param predicate the Triple predicate
+	 * @param object    the Triple object
+	 * @return a {@link Triple} with the supplied subject, predicate, and object.
+	 * @throws NullPointerException if any of the supplied input parameters is <code>null</code>.
+	 */
+	public static Triple triple(Resource subject, IRI predicate, Value object) {
+		return VALUE_FACTORY.createTriple(
+				Objects.requireNonNull(subject, "subject may not be null"),
+				Objects.requireNonNull(predicate, "predicate may not be null"),
+				Objects.requireNonNull(object, "object may not be null")
+		);
+	}
+
+	/**
+	 * Creates a new {@link Triple RDF* embedded triple} using the subject, predicate and object from the supplied
+	 * {@link Statement}.
+	 *
+	 * @param statement the {@link Statement} from which to construct a {@link Triple}
+	 * @return a {@link Triple} with the same subject, predicate, and object as the supplied Statement.
+	 */
+	public static Triple triple(Statement statement) {
+		Objects.requireNonNull(statement, "statement may not be null");
+		return VALUE_FACTORY.createTriple(statement.getSubject(), statement.getPredicate(), statement.getObject());
+	}
+
+	/**
+	 * Get a {@link ValueFactory}.
+	 * 
+	 * @return a {@link ValueFactory}.
+	 */
+	public static ValueFactory getValueFactory() {
+		return VALUE_FACTORY;
+	}
+
+}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
@@ -1,0 +1,327 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.model.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.rdf4j.model.util.Values.bnode;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
+import static org.eclipse.rdf4j.model.util.Values.triple;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.junit.Test;
+
+/**
+ * Unit tests on {@link Values} convenience functions.
+ * <p>
+ * Note that this is not intended to be a complete compliance suite for handling all possible cases of syntactically
+ * (il)legal inputs: that kind of testing is handled at the level of the {@link ValueFactory} implementations. We merely
+ * test common cases against user expectations here.
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class ValuesTest {
+
+	@Test
+	public void testValidIri() {
+		IRI validIRI = iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+		assertThat(validIRI).isEqualTo(RDF.TYPE);
+	}
+
+	@Test
+	public void testValidIr2() {
+		IRI validIRI = iri(RDF.NAMESPACE, "type");
+		assertThat(validIRI).isEqualTo(RDF.TYPE);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidIri1() {
+		iri("http://an invalid iri/");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidIri2() {
+		iri("http://valid-namespace.org/", "invalid localname");
+	}
+
+	@Test
+	public void testIriNull() {
+		assertThatThrownBy(() -> iri(null))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("iri may not be null");
+	}
+
+	@Test
+	public void testIriNamespaceNull() {
+		assertThatThrownBy(() -> iri(null, "type"))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("namespace may not be null");
+	}
+
+	@Test
+	public void testIriLocalNameNull() {
+		assertThatThrownBy(() -> iri(RDF.NAMESPACE, null))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("localName may not be null");
+
+	}
+
+	@Test
+	public void testBnode() {
+		BNode bnode = bnode();
+		assertThat(bnode).isNotNull();
+		assertThat(bnode.getID()).isNotNull();
+	}
+
+	@Test
+	public void testBnodeWithId() {
+		String nodeId = "foobar";
+		BNode bnode = bnode(nodeId);
+		assertThat(bnode).isNotNull();
+		assertThat(bnode.getID()).isEqualTo(nodeId);
+	}
+
+	@Test
+	public void testBnodeNull() {
+		assertThatThrownBy(() -> bnode(null))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("nodeId may not be null");
+	}
+
+	@Test
+	public void testStringLiteral() {
+		String lexValue = "a literal";
+		Literal literal = literal(lexValue);
+
+		assertThat(literal.getLabel()).isEqualTo(lexValue);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.STRING);
+	}
+
+	@Test
+	public void testStringLiteralNull() {
+		String lexicalValue = null;
+		assertThatThrownBy(() -> literal(lexicalValue))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("lexicalValue may not be null");
+	}
+
+	@Test
+	public void testValidTypedLiteral() {
+		String lexValue = "42";
+		Literal literal = literal(lexValue, XSD.INT);
+
+		assertThat(literal.getLabel()).isEqualTo(lexValue);
+		assertThat(literal.intValue()).isEqualTo(42);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.INT);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidTypedLiteral() {
+		String lexValue = "fourty two";
+		literal(lexValue, XSD.INT);
+	}
+
+	@Test
+	public void testTypedLiteralNull1() {
+		String lexValue = null;
+		assertThatThrownBy(() -> literal(lexValue, XSD.INT))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("lexicalValue may not be null");
+	}
+
+	@Test
+	public void testTypedLiteralNull2() {
+		String lexValue = "42";
+		assertThatThrownBy(() -> literal(lexValue, null))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("datatype may not be null");
+	}
+
+	@Test
+	public void testBooleanLiteral() {
+		Literal literal = literal(true);
+		assertThat(literal.getLabel()).isEqualTo("true");
+		assertThat(literal.booleanValue()).isTrue();
+		assertThat(literal.getDatatype()).isEqualTo(XSD.BOOLEAN);
+
+		literal = literal(false);
+		assertThat(literal.getLabel()).isEqualTo("false");
+		assertThat(literal.booleanValue()).isFalse();
+		assertThat(literal.getDatatype()).isEqualTo(XSD.BOOLEAN);
+	}
+
+	@Test
+	public void testByteLiteral() {
+		byte value = 42;
+		Literal literal = literal(value);
+		assertThat(literal.getLabel()).isEqualTo("42");
+		assertThat(literal.byteValue()).isEqualTo(value);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.BYTE);
+	}
+
+	@Test
+	public void testShortLiteral() {
+		short value = 42;
+		Literal literal = literal(value);
+		assertThat(literal.getLabel()).isEqualTo("42");
+		assertThat(literal.shortValue()).isEqualTo(value);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.SHORT);
+	}
+
+	@Test
+	public void testIntLiteral() {
+		int value = 42;
+		Literal literal = literal(value);
+		assertThat(literal.getLabel()).isEqualTo("42");
+		assertThat(literal.intValue()).isEqualTo(value);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.INT);
+	}
+
+	@Test
+	public void testLongLiteral() {
+		long value = Long.MAX_VALUE;
+		Literal literal = literal(value);
+		assertThat(literal.longValue()).isEqualTo(value);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.LONG);
+	}
+
+	@Test
+	public void testFloatLiteral() {
+		float value = 42.313f;
+		Literal literal = literal(value);
+		assertThat(literal.floatValue()).isEqualTo(value);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.FLOAT);
+	}
+
+	@Test
+	public void testDoubleLiteral() {
+		double value = 42.313;
+		Literal literal = literal(value);
+		assertThat(literal.doubleValue()).isEqualTo(value);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.DOUBLE);
+	}
+
+	@Test
+	public void testBigDecimalLiteral() {
+		BigDecimal value = new BigDecimal(42.313);
+		Literal literal = literal(value);
+		assertThat(literal.decimalValue()).isEqualTo(value);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.DECIMAL);
+	}
+
+	@Test
+	public void testBigDecimalLiteralNull() {
+		BigDecimal value = null;
+
+		assertThatThrownBy(() -> literal(value))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("bigDecimal may not be null");
+
+	}
+
+	@Test
+	public void testBigIntegerLiteral() {
+		BigInteger value = BigInteger.valueOf(42_000_000_000_000_000l);
+		Literal literal = literal(value);
+		assertThat(literal.integerValue()).isEqualTo(value);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.INTEGER);
+	}
+
+	@Test
+	public void testBigIntegerLiteralNull() {
+		BigInteger value = null;
+
+		assertThatThrownBy(() -> literal(value))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("bigInteger may not be null");
+	}
+
+	@Test
+	public void testTemporalAccessorLiteral() {
+		LocalDateTime value = LocalDateTime.parse("2020-09-30T01:02:03.004");
+		Literal literal = literal(value);
+
+		assertThat(literal).isNotNull();
+		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
+		assertThat(literal.getLabel()).isEqualTo(value.toString());
+		assertThat(literal.getDatatype()).isEqualTo(XSD.DATETIME);
+	}
+
+	@Test
+	public void testTemporalAccessorLiteralNull() {
+		final LocalDateTime value = null;
+
+		assertThatThrownBy(() -> literal(value))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("value may not be null");
+
+	}
+
+	@Test
+	public void testTriple() {
+		Triple triple = triple(RDF.ALT, RDF.TYPE, RDFS.CONTAINER);
+
+		assertThat(triple).isNotNull();
+		assertThat(triple.getSubject()).isEqualTo(RDF.ALT);
+		assertThat(triple.getPredicate()).isEqualTo(RDF.TYPE);
+		assertThat(triple.getObject()).isEqualTo(RDFS.CONTAINER);
+	}
+
+	@Test
+	public void testTripleNull() {
+		assertThatThrownBy(() -> triple(null, RDF.TYPE, RDFS.CONTAINER))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("subject may not be null");
+
+		assertThatThrownBy(() -> triple(RDF.ALT, null, RDFS.CONTAINER))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("predicate may not be null");
+
+		assertThatThrownBy(() -> triple(RDF.ALT, RDF.TYPE, null))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("object may not be null");
+	}
+
+	@Test
+	public void testTripleFromStatement() {
+		Statement st = SimpleValueFactory.getInstance().createStatement(RDF.ALT, RDF.TYPE, RDFS.CONTAINER);
+		Triple triple = triple(st);
+		assertThat(triple).isNotNull();
+		assertThat(triple.getSubject()).isEqualTo(st.getSubject());
+		assertThat(triple.getPredicate()).isEqualTo(st.getPredicate());
+		assertThat(triple.getObject()).isEqualTo(st.getObject());
+	}
+
+	@Test
+	public void testTripleFromStatementNull() {
+		assertThatThrownBy(() -> triple(null))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("statement may not be null");
+	}
+
+	@Test
+	public void testGetValueFactory() {
+		ValueFactory vf = Values.getValueFactory();
+		assertThat(vf).isNotNull();
+	}
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,29 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.rdf4j</groupId>
-	<artifactId>examples</artifactId>
-	<version>1.0-SNAPSHOT</version>
-	<properties>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
-	</properties>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-bom</artifactId>
-				<version>3.3.0</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+	<artifactId>rdf4j-examples</artifactId>
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j</artifactId>
+		<version>3.5.0-SNAPSHOT</version>
+	</parent>
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-storage</artifactId>
 			<type>pom</type>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -32,4 +21,22 @@
 			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<id>ossrh</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>1.6.8</version>
+						<configuration>
+							<!-- we do not want to deploy the examples to Sonatype -->
+							<skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example01BuildModel.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example01BuildModel.java
@@ -7,11 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.model;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -24,17 +25,12 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 public class Example01BuildModel {
 
 	public static void main(String[] args) {
-
-		// We use a ValueFactory to create the building blocks of our RDF statements: IRIs, blank nodes
-		// and literals.
-		ValueFactory vf = SimpleValueFactory.getInstance();
-
 		// We want to reuse this namespace when creating several building blocks.
 		String ex = "http://example.org/";
 
 		// Create IRIs for the resources we want to add.
-		IRI picasso = vf.createIRI(ex, "Picasso");
-		IRI artist = vf.createIRI(ex, "Artist");
+		IRI picasso = iri(ex, "Picasso");
+		IRI artist = iri(ex, "Artist");
 
 		// Create a new, empty Model object.
 		Model model = new TreeModel();
@@ -43,10 +39,10 @@ public class Example01BuildModel {
 		model.add(picasso, RDF.TYPE, artist);
 
 		// second statement: Picasso's first name is "Pablo".
-		model.add(picasso, FOAF.FIRST_NAME, vf.createLiteral("Pablo"));
+		model.add(picasso, FOAF.FIRST_NAME, literal("Pablo"));
 
 		// to see what's in our model, let's just print it to the screen
-		for(Statement st: model) {
+		for (Statement st : model) {
 			System.out.println(st);
 		}
 	}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example02BuildModel.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example02BuildModel.java
@@ -27,12 +27,12 @@ public class Example02BuildModel {
 		Model model = builder
 				.setNamespace("ex", "http://example.org/")
 				.subject("ex:Picasso")
-					.add(RDF.TYPE, "ex:Artist")		// Picasso is an Artist
-					.add(FOAF.FIRST_NAME, "Pablo") 	// his first name is "Pablo"
+				.add(RDF.TYPE, "ex:Artist") // Picasso is an Artist
+				.add(FOAF.FIRST_NAME, "Pablo") // his first name is "Pablo"
 				.build();
 
 		// To see what's in our model, let's just print it to the screen
-		for(Statement st: model) {
+		for (Statement st : model) {
 			System.out.println(st);
 		}
 	}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example03LiteralDatatypes.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example03LiteralDatatypes.java
@@ -31,41 +31,40 @@ public class Example03LiteralDatatypes {
 	public static void main(String[] args) {
 
 		ValueFactory vf = SimpleValueFactory.getInstance();
-		
+
 		// Create a new RDF model containing information about the painting "The Potato Eaters"
 		ModelBuilder builder = new ModelBuilder();
 		Model model = builder
 				.setNamespace("ex", "http://example.org/")
 				.subject("ex:PotatoEaters")
-					// this painting was created on April 1, 1885
-					.add("ex:creationDate", vf.createLiteral("1885-04-01T00:00:00Z", XMLSchema.DATETIME))
-					// You can also pass in a Java Date object directly: 
-				    //.add("ex:creationDate", new GregorianCalendar(1885, Calendar.APRIL, 1).getTime())
-					
-					// the painting shows 5 people
-					.add("ex:peopleDepicted", 5)
+				// this painting was created on April 1, 1885
+				.add("ex:creationDate", vf.createLiteral("1885-04-01T00:00:00Z", XMLSchema.DATETIME))
+				// You can also pass in a Java Date object directly:
+				// .add("ex:creationDate", new GregorianCalendar(1885, Calendar.APRIL, 1).getTime())
+
+				// the painting shows 5 people
+				.add("ex:peopleDepicted", 5)
 				.build();
 
 		// To see what's in our model, let's just print stuff to the screen
-		for(Statement st: model) {
+		for (Statement st : model) {
 			// we want to see the object values of each property
 			IRI property = st.getPredicate();
 			Value value = st.getObject();
 			if (value instanceof Literal) {
-				Literal literal = (Literal)value;
+				Literal literal = (Literal) value;
 				System.out.println("datatype: " + literal.getDatatype());
-				
+
 				// get the value of the literal directly as a Java primitive.
 				if (property.getLocalName().equals("peopleDepicted")) {
 					int peopleDepicted = literal.intValue();
 					System.out.println(peopleDepicted + " people are depicted in this painting");
-				}
-				else if (property.getLocalName().equals("creationDate")) {
+				} else if (property.getLocalName().equals("creationDate")) {
 					XMLGregorianCalendar calendar = literal.calendarValue();
 					Date date = calendar.toGregorianCalendar().getTime();
 					System.out.println("The painting was created on " + date);
 				}
-				
+
 				// you can also just get the lexical value (a string) without worrying about the datatype
 				System.out.println("Lexical value: '" + literal.getLabel() + "'");
 			}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example04LanguageTags.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example04LanguageTags.java
@@ -26,24 +26,24 @@ public class Example04LanguageTags {
 	public static void main(String[] args) {
 
 		ValueFactory vf = SimpleValueFactory.getInstance();
-		
+
 		// Create a new RDF model containing some information about the painting "The Potato Eaters"
 		ModelBuilder builder = new ModelBuilder();
 		Model model = builder
 				.setNamespace("ex", "http://example.org/")
 				.subject("ex:PotatoEaters")
-					// In English, this painting is called "The Potato Eaters"
-				    .add(DC.TITLE, vf.createLiteral("The Potato Eaters", "en"))
-				    // In Dutch, it's called "De Aardappeleters"
-					.add(DC.TITLE,  vf.createLiteral("De Aardappeleters", "nl"))
+				// In English, this painting is called "The Potato Eaters"
+				.add(DC.TITLE, vf.createLiteral("The Potato Eaters", "en"))
+				// In Dutch, it's called "De Aardappeleters"
+				.add(DC.TITLE, vf.createLiteral("De Aardappeleters", "nl"))
 				.build();
 
 		// To see what's in our model, let's just print it to the screen
-		for(Statement st: model) {
+		for (Statement st : model) {
 			// we want to see the object values of each statement
 			Value value = st.getObject();
 			if (value instanceof Literal) {
-				Literal title = (Literal)value;
+				Literal title = (Literal) value;
 				System.out.println("language: " + title.getLanguage().orElse("unknown"));
 				System.out.println(" title: " + title.getLabel());
 			}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example05BlankNode.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example05BlankNode.java
@@ -19,8 +19,7 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 /**
  * RDF Tutorial example 05: Adding blank nodes to an RDF Model.
  *
- * In this example, we show how you can use a blank node for representing composite
- * objects - in this case, an address.
+ * In this example, we show how you can use a blank node for representing composite objects - in this case, an address.
  *
  * @author Jeen Broekstra
  */
@@ -38,20 +37,20 @@ public class Example05BlankNode {
 		builder
 				.setNamespace("ex", "http://example.org/")
 				.subject("ex:Picasso")
-					.add(RDF.TYPE, "ex:Artist")
-					.add(FOAF.FIRST_NAME, "Pablo")
+				.add(RDF.TYPE, "ex:Artist")
+				.add(FOAF.FIRST_NAME, "Pablo")
 				// this is where it becomes new: we add the address by linking the blank node
 				// to picasso via the `ex:homeAddress` property, and then adding facts _about_ the address
-					.add("ex:homeAddress", address) // link the blank node
-				.subject(address)			// switch the subject
-					.add("ex:street", "31 Art Gallery")
-					.add("ex:city", "Madrid")
-					.add("ex:country", "Spain");
+				.add("ex:homeAddress", address) // link the blank node
+				.subject(address) // switch the subject
+				.add("ex:street", "31 Art Gallery")
+				.add("ex:city", "Madrid")
+				.add("ex:country", "Spain");
 
 		Model model = builder.build();
 
 		// To see what's in our model, let's just print it to the screen
-		for(Statement st: model) {
+		for (Statement st : model) {
 			System.out.println(st);
 		}
 	}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example06WriteRdfXml.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example06WriteRdfXml.java
@@ -21,8 +21,7 @@ import org.eclipse.rdf4j.rio.Rio;
 /**
  * RDF Tutorial example 06: Writing an RDF model in RDF/XML syntax
  *
- * In this example, we show how you can use the Rio Parser/writer toolkit to write your
- * model in RDF/XML syntax.
+ * In this example, we show how you can use the Rio Parser/writer toolkit to write your model in RDF/XML syntax.
  *
  * @author Jeen Broekstra
  */
@@ -39,13 +38,13 @@ public class Example06WriteRdfXml {
 		builder
 				.setNamespace("ex", "http://example.org/")
 				.subject("ex:Picasso")
-					.add(RDF.TYPE, "ex:Artist")
-					.add(FOAF.FIRST_NAME, "Pablo")
-					.add("ex:homeAddress", address) // link the blank node
-				.subject(address)			// switch the subject
-					.add("ex:street", "31 Art Gallery")
-					.add("ex:city", "Madrid")
-					.add("ex:country", "Spain");
+				.add(RDF.TYPE, "ex:Artist")
+				.add(FOAF.FIRST_NAME, "Pablo")
+				.add("ex:homeAddress", address) // link the blank node
+				.subject(address) // switch the subject
+				.add("ex:street", "31 Art Gallery")
+				.add("ex:city", "Madrid")
+				.add("ex:country", "Spain");
 
 		Model model = builder.build();
 

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example07WriteTurtle.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example07WriteTurtle.java
@@ -20,8 +20,7 @@ import org.eclipse.rdf4j.rio.Rio;
 /**
  * RDF Tutorial example 07: Writing an RDF model in Turtle syntax
  *
- * In this example, we show how you can use the Rio Parser/writer toolkit to write your
- * model in Turtle syntax.
+ * In this example, we show how you can use the Rio Parser/writer toolkit to write your model in Turtle syntax.
  *
  * @author Jeen Broekstra
  * @see
@@ -39,13 +38,13 @@ public class Example07WriteTurtle {
 		builder
 				.setNamespace("ex", "http://example.org/")
 				.subject("ex:Picasso")
-					.add(RDF.TYPE, "ex:Artist")
-					.add(FOAF.FIRST_NAME, "Pablo")
-					.add("ex:homeAddress", address) // link the blank node
-				.subject(address)			// switch the subject
-					.add("ex:street", "31 Art Gallery")
-					.add("ex:city", "Madrid")
-					.add("ex:country", "Spain");
+				.add(RDF.TYPE, "ex:Artist")
+				.add(FOAF.FIRST_NAME, "Pablo")
+				.add("ex:homeAddress", address) // link the blank node
+				.subject(address) // switch the subject
+				.add("ex:street", "31 Art Gallery")
+				.add("ex:city", "Madrid")
+				.add("ex:country", "Spain");
 
 		Model model = builder.build();
 

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example08ReadTurtle.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example08ReadTurtle.java
@@ -7,13 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.model;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * RDF Tutorial example 08: Reading a Turtle syntax file to create a Model
@@ -36,7 +36,7 @@ public class Example08ReadTurtle {
 		Model model = Rio.parse(input, "", RDFFormat.TURTLE);
 
 		// To check that we have correctly read the file, let's print out the model to the screen again
-		for (Statement statement: model) {
+		for (Statement statement : model) {
 			System.out.println(statement);
 		}
 	}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example09Filter.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example09Filter.java
@@ -7,13 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.model;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * RDF Tutorial example 09: Reading a Turtle syntax file to create a Model
@@ -32,8 +32,6 @@ public class Example09Filter {
 		// read the file 'example-data-artists.ttl' as an InputStream.
 		InputStream input = Example09Filter.class.getResourceAsStream("/" + filename);
 
-
-
 		// Rio also accepts a java.io.Reader as input for the parser.
 		Model model = Rio.parse(input, "", RDFFormat.TURTLE);
 
@@ -48,9 +46,9 @@ public class Example09Filter {
 		Model aboutVanGogh = model.filter(vanGogh, null, null);
 
 		// Iterate over the statements that are about Van Gogh
-		for (Statement st: aboutVanGogh) {
+		for (Statement st : aboutVanGogh) {
 			// the subject will always be `ex:VanGogh`, an IRI, so we can safely cast it
-			IRI subject = (IRI)st.getSubject();
+			IRI subject = (IRI) st.getSubject();
 			// the property predicate can be anything, but it's always an IRI
 			IRI predicate = st.getPredicate();
 
@@ -64,13 +62,11 @@ public class Example09Filter {
 			if (object instanceof Literal) {
 				// it's a literal value. Let's print it out nicely, in quotes, and without any ugly
 				// datatype stuff
-				System.out.println("\"" + ((Literal)object).getLabel() + "\"");
-			}
-			else if (object instanceof  IRI) {
+				System.out.println("\"" + ((Literal) object).getLabel() + "\"");
+			} else if (object instanceof IRI) {
 				// it's an IRI. Just print out the local part (without the namespace)
-				System.out.println(((IRI)object).getLocalName());
-			}
-			else {
+				System.out.println(((IRI) object).getLocalName());
+			} else {
 				// it's a blank node. Just print it out as-is.
 				System.out.println(object);
 			}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example10PropertyValues.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example10PropertyValues.java
@@ -7,15 +7,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.model;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
 import org.eclipse.rdf4j.examples.model.vocabulary.EX;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Set;
 
 /**
  * RDF Tutorial example 10: Getting all values of a property for a particular subject.
@@ -43,10 +43,10 @@ public class Example10PropertyValues {
 		// resources that identify paintings by Van Gogh.
 		Set<Value> paintings = model.filter(vanGogh, EX.CREATOR_OF, null).objects();
 
-		for (Value painting: paintings) {
+		for (Value painting : paintings) {
 			if (painting instanceof Resource) {
 				// our value is either an IRI or a blank node. Retrieve its properties and print.
-				Model paintingProperties = model.filter((Resource)painting, null, null);
+				Model paintingProperties = model.filter((Resource) painting, null, null);
 
 				// write the info about this painting to the console in Turtle format
 				System.out.println("--- information about painting: " + painting);

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example11SinglePropertyValue.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example11SinglePropertyValue.java
@@ -7,6 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.model;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Set;
+
 import org.eclipse.rdf4j.examples.model.vocabulary.EX;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -16,22 +21,16 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Optional;
-import java.util.Set;
-
 /**
- * RDF Tutorial example 11: Getting a single property value for a particular subject.
- * In this example, we show how you can get retrieve each artist's first name and print it.
+ * RDF Tutorial example 11: Getting a single property value for a particular subject. In this example, we show how you
+ * can get retrieve each artist's first name and print it.
  *
  * @author Jeen Broekstra
  */
 public class Example11SinglePropertyValue {
 
 	public static void main(String[] args)
-			throws IOException
-	{
+			throws IOException {
 
 		String filename = "example-data-artists.ttl";
 

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example12BuildModelWithNamedGraphs.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/Example12BuildModelWithNamedGraphs.java
@@ -7,6 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.model;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Optional;
+
 import org.eclipse.rdf4j.examples.model.vocabulary.EX;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -20,24 +25,18 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Optional;
-
 /**
  * RDF Tutorial example 12: Building a Model with named graphs
  *
- * In this example, we show how you can use the context mechanism to add statements separate named
- * graphs within the same Model.
+ * In this example, we show how you can use the context mechanism to add statements separate named graphs within the
+ * same Model.
  *
  * @author Jeen Broekstra
  */
 public class Example12BuildModelWithNamedGraphs {
 
 	public static void main(String[] args)
-			throws IOException
-	{
+			throws IOException {
 		// We'll use a ModelBuilder to create two named graphs, one containing data about
 		// picasso, the other about Van Gogh.
 		ModelBuilder builder = new ModelBuilder();
@@ -46,21 +45,20 @@ public class Example12BuildModelWithNamedGraphs {
 		// in named graph 1, we add info about Picasso
 		builder.namedGraph("ex:namedGraph1")
 				.subject("ex:Picasso")
-					.add(RDF.TYPE, EX.ARTIST)
-					.add(FOAF.FIRST_NAME, "Pablo");
+				.add(RDF.TYPE, EX.ARTIST)
+				.add(FOAF.FIRST_NAME, "Pablo");
 
 		// in named graph2, we add info about Van Gogh.
 		builder.namedGraph("ex:namedGraph2")
-			.subject("ex:VanGogh")
+				.subject("ex:VanGogh")
 				.add(RDF.TYPE, EX.ARTIST)
 				.add(FOAF.FIRST_NAME, "Vincent");
-
 
 		// We're done building, create our Model
 		Model model = builder.build();
 
 		// each named graph is stored as a separate context in our Model
-		for (Resource context: model.contexts()) {
+		for (Resource context : model.contexts()) {
 			System.out.println("Named graph " + context + " contains: ");
 
 			// write _only_ the statemements in the current named graph to the console, in N-Triples format

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/model/vocabulary/EX.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/model/vocabulary/EX.java
@@ -11,9 +11,9 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
- * Vocabulary constants for the 'http://example.org/' namespace.
- * It's a good idea to always create a vocabulary class such as this one when you program with RDF4J. It makes
- * it far easier to reuse certain resources and properties in various places in your code.
+ * Vocabulary constants for the 'http://example.org/' namespace. It's a good idea to always create a vocabulary class
+ * such as this one when you program with RDF4J. It makes it far easier to reuse certain resources and properties in
+ * various places in your code.
  */
 public class EX {
 

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/repository/Example13AddRDFToDatabase.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/repository/Example13AddRDFToDatabase.java
@@ -28,8 +28,7 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
 public class Example13AddRDFToDatabase {
 
 	public static void main(String[] args)
-			throws IOException
-	{
+			throws IOException {
 
 		// First load our RDF file as a Model.
 		String filename = "example-data-artists.ttl";
@@ -57,8 +56,7 @@ public class Example13AddRDFToDatabase {
 					System.out.println("db contains: " + st);
 				}
 			}
-		}
-		finally {
+		} finally {
 			// before our program exits, make sure the database is properly shut down.
 			db.shutDown();
 		}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/repository/Example14AddRDFToDatabase.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/repository/Example14AddRDFToDatabase.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.repository;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.repository.Repository;
@@ -17,9 +20,6 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 /**
  * RDF Tutorial example 14: Adding an RDF file directly to the database
  *
@@ -28,8 +28,7 @@ import java.io.InputStream;
 public class Example14AddRDFToDatabase {
 
 	public static void main(String[] args)
-			throws IOException
-	{
+			throws IOException {
 		// Create a new Repository.
 		Repository db = new SailRepository(new MemoryStore());
 		db.init();
@@ -37,10 +36,9 @@ public class Example14AddRDFToDatabase {
 		// Open a connection to the database
 		try (RepositoryConnection conn = db.getConnection()) {
 			String filename = "example-data-artists.ttl";
-			try (InputStream input =
-					Example14AddRDFToDatabase.class.getResourceAsStream("/" + filename)) {
+			try (InputStream input = Example14AddRDFToDatabase.class.getResourceAsStream("/" + filename)) {
 				// add the RDF data from the inputstream directly to our database
-				conn.add(input, "", RDFFormat.TURTLE );
+				conn.add(input, "", RDFFormat.TURTLE);
 			}
 
 			// let's check that our data is actually in the database
@@ -50,8 +48,7 @@ public class Example14AddRDFToDatabase {
 					System.out.println("db contains: " + st);
 				}
 			}
-		}
-		finally {
+		} finally {
 			// before our program exits, make sure the database is properly shut down.
 			db.shutDown();
 		}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/repository/Example15SimpleSPARQLQuery.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/repository/Example15SimpleSPARQLQuery.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.repository;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -22,9 +25,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 /**
  * RDF Tutorial example 15: executing a simple SPARQL query on the database
  *
@@ -33,8 +33,7 @@ import java.io.InputStream;
 public class Example15SimpleSPARQLQuery {
 
 	public static void main(String[] args)
-			throws IOException
-	{
+			throws IOException {
 		// Create a new Repository.
 		Repository db = new SailRepository(new MemoryStore());
 		db.init();
@@ -42,10 +41,9 @@ public class Example15SimpleSPARQLQuery {
 		// Open a connection to the database
 		try (RepositoryConnection conn = db.getConnection()) {
 			String filename = "example-data-artists.ttl";
-			try (InputStream input =
-					Example15SimpleSPARQLQuery.class.getResourceAsStream("/" + filename)) {
+			try (InputStream input = Example15SimpleSPARQLQuery.class.getResourceAsStream("/" + filename)) {
 				// add the RDF data from the inputstream directly to our database
-				conn.add(input, "", RDFFormat.TURTLE );
+				conn.add(input, "", RDFFormat.TURTLE);
 			}
 
 			// We do a simple SPARQL SELECT-query that retrieves all resources of type `ex:Artist`,
@@ -70,8 +68,7 @@ public class Example15SimpleSPARQLQuery {
 					System.out.println("?n = " + solution.getValue("n"));
 				}
 			}
-		}
-		finally {
+		} finally {
 			// Before our program exits, make sure the database is properly shut down.
 			db.shutDown();
 		}

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/repository/Example16SPARQLConstructQuery.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/repository/Example16SPARQLConstructQuery.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.repository;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
@@ -19,9 +22,6 @@ import org.eclipse.rdf4j.rio.RDFHandler;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 /**
  * RDF Tutorial example 16: executing a SPARQL CONSTRUCT query on the database
  *
@@ -30,8 +30,7 @@ import java.io.InputStream;
 public class Example16SPARQLConstructQuery {
 
 	public static void main(String[] args)
-			throws IOException
-	{
+			throws IOException {
 		// Create a new Repository.
 		Repository db = new SailRepository(new MemoryStore());
 		db.init();
@@ -39,10 +38,9 @@ public class Example16SPARQLConstructQuery {
 		// Open a connection to the database
 		try (RepositoryConnection conn = db.getConnection()) {
 			String filename = "example-data-artists.ttl";
-			try (InputStream input =
-					Example16SPARQLConstructQuery.class.getResourceAsStream("/" + filename)) {
+			try (InputStream input = Example16SPARQLConstructQuery.class.getResourceAsStream("/" + filename)) {
 				// add the RDF data from the inputstream directly to our database
-				conn.add(input, "", RDFFormat.TURTLE );
+				conn.add(input, "", RDFFormat.TURTLE);
 			}
 
 			// We do a simple SPARQL CONSTRUCT-query that retrieves all statements about artists,
@@ -69,8 +67,7 @@ public class Example16SPARQLConstructQuery {
 					System.out.println(st);
 				}
 			}
-		}
-		finally {
+		} finally {
 			// Before our program exits, make sure the database is properly shut down.
 			db.shutDown();
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 		<module>testsuites</module>
 		<module>compliance</module>
 		<module>bom</module>
+		<module>examples</module>
 	</modules>
 	<profiles>
 		<profile>

--- a/site/content/documentation/programming/model.md
+++ b/site/content/documentation/programming/model.md
@@ -13,7 +13,28 @@ The core of the RDF4J framework is the RDF Model API (see the [Model API Javadoc
 
 RDF statements are represented by the {{< javadoc "Statement" "model/Statement.html" >}} interface. Each `Statement` has a subject, predicate, object and (optionally) a context. Each of these 4 items is a {{< javadoc "Value" "model/Value.html" >}}. The `Value` interface is further specialized into {{< javadoc "Resource" "model/Resource.html" >}}, and {{< javadoc "Literal" "model/Literal.html" >}}. `Resource` represents any RDF value that is either a {{< javadoc "BNode" "model/BNode.html" >}} or an {{< javadoc "IRI" "model/IRI.html" >}}. `Literal` represents RDF literal values (strings, dates, integer numbers, and so on).
 
-To create new values and statements, you can use a {{< javadoc "ValueFactory" "model/ValueFactory.html" >}}. You can use a default `ValueFactory` implementation called {{< javadoc "SimpleValueFactory" "model/impl/SimpleValueFactory.html" >}}:
+### Creating new building blocks: the `Values` and `Statements` factory methods
+
+{{< tag " New in RDF4J 3.5 " >}}
+
+To create new values and statements, you can use the {{< javadoc "Values" "model/util/Values.html" >}}  and {{< javadoc "Statements" "model/util/Statements.html" >}} static factory methods, which provide easy creation of new `IRI`s, `Literal`s, `BNode`s, `Triple`s and `Statement`s based on a variety of different input objects.
+
+```java
+import static org.eclipse.model.util.Statements.statement;
+import static org.eclipse.model.util.Values.iri;
+import static org.eclipse.model.util.Values.literal;
+
+IRI bob = iri("http://example.org/bob");
+IRI nameProp = iri("http://example.org/name");
+Literal bobsName = literal("Bob");
+Literal bobsAge = literal(42);
+
+Statement st = statement(bob, name, bobsName);
+```
+
+### Using a `ValueFactory`
+
+If you want more control than the static factory methods provide, you can also use a {{< javadoc "ValueFactory" "model/ValueFactory.html" >}} instance. You can obtain one from {{< javadoc "Values" "model/util/Values.html" >}}, or you can directly use a singleton `ValueFactory` implementation called {{< javadoc "SimpleValueFactory" "model/impl/SimpleValueFactory.html" >}}:
 
 ```java
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -22,11 +43,19 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 ValueFactory factory = SimpleValueFactory.getInstance();
 ```
 
-For performance reasons, the `SimpleValueFactory` provides only basic input validation. The {{< javadoc "ValidatingValueFactory" "model/impl/ValidatingValueFactory.html" >}} is stricter, albeit somewhat slower.
+For performance reasons, the `SimpleValueFactory` provides only basic input validation. The {{< javadoc "ValidatingValueFactory" "model/impl/ValidatingValueFactory.html" >}} is stricter, albeit somewhat slower (though this should not be noticable unless you are working with very significant amounts of data).
 
 You can also obtain a `ValueFactory` from the {{< javadoc "Repository" "repository/Repository.html" >}} you are working with, and in fact, this is the recommend approach. For more information about this see the [Repository API documentation](/documentation/programming/repository/).
 
 Regardless of how you obtain your `ValueFactory`, once you have it, you can use it to create new `IRI`s, `Literal`s, and `Statement`s:
+
+```java
+IRI bob = iri(factory, "http://example.org/bob");
+IRI name = iri(factory,"http://example.org/name");
+Literal bobsName = literal(factory, "Bob");
+Statement nameStatement = statement(factory, bob, name, bobsName);
+```
+Or if you prefer, using the `Valuefactory` directly:
 
 ```java
 IRI bob = factory.createIRI("http://example.org/bob");
@@ -38,7 +67,7 @@ Statement nameStatement = factory.createStatement(bob, name, bobsName);
 The Model API also provides pre-defined IRIs for several well-known vocabularies, such as RDF, RDFS, OWL, DC (Dublin Core), FOAF (Friend-of-a-Friend), and more. These constants can all be found in the `org.eclipse.rdf4j.model.vocabulary` package, and can be quite handy in quick creation of RDF statements (or in querying a `Repository`, as we shall see later):
 
 ```java
-Statement typeStatement = factory.createStatement(bob, RDF.TYPE, FOAF.PERSON);
+Statement typeStatement = Values.statement(bob, RDF.TYPE, FOAF.PERSON);
 ```
 
 ## The Model interface
@@ -49,7 +78,7 @@ The above interfaces and classes show how we can create the individual building 
 
 ```java
 // create a new Model to put statements in
-Model model = new LinkedHashModel();
+Model model = DynamicModelFactory.createEmptyModel();
 // add an RDF statement
 model.add(typeStatement);
 // add another RDF statement by simply providing subject, predicate, and object.
@@ -80,11 +109,11 @@ for (Resource person: model.filter(null, RDF.TYPE, FOAF.PERSON).subjects()) {
 
 The `filter()` method returns a `Model` again. However, the `Model` returned by this method is still backed by the original `Model`. Thus, changes that you make to this returned `Model` will automatically be reflected in the original `Model` as well.
 
-Rdf4j provides two default implementations of the `Model` interface: {{< javadoc "org.eclipse.rdf4j.model.impl.LinkedHashModel" "model/impl/LinkedHashModel.html" >}}, and {{< javadoc "org.eclipse.rdf4j.model.impl.TreeModel" "model/impl/TreeModel.html" >}}. The difference between the two is in their performance for different kinds of lookups and insertion patterns (see their respective javadoc entries for details). These differences are only really noticable when dealing with quite large collections of statements, however.
+RDF4J provides three default implementations of the `Model` interface: {{< javadoc "org.eclipse.model.mpl.DynamicModel" "model/impl/DynamicModel.html" >}}, {{< javadoc "org.eclipse.rdf4j.model.impl.LinkedHashModel" "model/impl/LinkedHashModel.html" >}}, and {{< javadoc "org.eclipse.rdf4j.model.impl.TreeModel" "model/impl/TreeModel.html" >}}. The difference between them is in their performance for different kinds of lookups and insertion patterns (see their respective javadoc entries for details). These differences are only really noticable when dealing with quite large collections of statements, however. 
 
 ## Building RDF Models with the ModelBuilder
 
-Since version 2.1, rdf4j provides a {{< javadoc "ModelBuilder" "model/util/ModelBuilder.html" >}} utility. The `ModelBuilder` provides a fluent API to quickly and efficiently create RDF models programmatically.
+Since version 2.1, RDF4J provides a {{< javadoc "ModelBuilder" "model/util/ModelBuilder.html" >}} utility. The `ModelBuilder` provides a fluent API to quickly and efficiently create RDF models programmatically.
 
 Here’s a simple code example that demonstrates how to quickly create an RDF graph with some FOAF data:
 
@@ -178,16 +207,19 @@ As an example, suppose we wish to add the above list of three string literals as
 The {{< javadoc "RDFCollections" "model/util/RDFCollections.html" >}} utility allows us to do this, as follows:
 
 ```java
+import static org.eclipse.model.util.Values.bnode;
+import static org.eclipse.model.util.Values.iri;
+import static org.eclipse.model.util.Values.literal;
+
 String ns = "http://example.org/";
-ValueFactory vf = SimpleValueFactory.getInstance();
 // IRI for ex:favoriteLetters
-IRI favoriteLetters = vf.createIRI(ns, "favoriteLetters");
+IRI favoriteLetters = iri(ns, "favoriteLetters");
 // IRI for ex:John
-IRI john = vf.createIRI(ns, "John");
+IRI john = iri(ns, "John");
 // create a list of letters
-List<Literal> letters = Arrays.asList(new Literal[] { vf.createLiteral("A"), vf.createLiteral("B"), vf.createLiteral("C") });
+List<Literal> letters = Arrays.asList(new Literal[] { literal("A"), literal("B"), literal("C") });
 // create a head resource for our list
-Resource head = vf.createBNode();
+Resource head = bnode();
 // convert our list and add it to a newly-created Model
 Model aboutJohn = RDFCollections.asRDF(letters, head, new LinkedHashModel());
 // set the ex:favoriteLetters property to link to the head of the list
@@ -263,8 +295,8 @@ RDF4J offers utility conversion functions very similar to the utilities for RDF 
 For example, to create the above RDF container, we can do this:
 
 ```java
-List<Literal> letters = Arrays.asList(new Literal[] { vf.createLiteral("A"), vf.createLiteral("B"), vf.createLiteral("C") });
-IRI myBag = vf.createIRI("urn:myBag");
+List<Literal> letters = Arrays.asList(new Literal[] { literal("A"), literal("B"), literal("C") });
+IRI myBag = iri("urn:myBag");
 Model letterBag = RDFContainers.toRDF(RDF.BAG, letters, myBag, new TreeModel());
 ```
 

--- a/site/content/documentation/tutorials/getting-started.md
+++ b/site/content/documentation/tutorials/getting-started.md
@@ -88,16 +88,16 @@ Eclipse RDF4J is a Java API for RDF: it allows you to create, parse, write, stor
 {{< example "Example 01" "model/Example01BuildModel.java" >}} shows how we can create the RDF model we introduced above using RDF4J:
 
 ```java {linenos=inline}
-// We use a ValueFactory to create the building blocks of our RDF statements:
-// IRIs, blank nodes and literals.
-ValueFactory vf = SimpleValueFactory.getInstance();
+// We use some static factory methods to easily create IRIs and Literals
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 
 // We want to reuse this namespace when creating several building blocks.
 String ex = "http://example.org/";
 
 // Create IRIs for the resources we want to add.
-IRI picasso = vf.createIRI(ex, "Picasso");
-IRI artist = vf.createIRI(ex, "Artist");
+IRI picasso = iri(ex, "Picasso");
+IRI artist = iri(ex, "Artist");
 
 // Create a new, empty Model object.
 Model model = new TreeModel();
@@ -106,12 +106,12 @@ Model model = new TreeModel();
 model.add(picasso, RDF.TYPE, artist);
 
 // second statement: Picasso's first name is "Pablo".
-model.add(picasso, FOAF.FIRST_NAME, vf.createLiteral("Pablo"));
+model.add(picasso, FOAF.FIRST_NAME, literal("Pablo"));
 ```
 
-Let's take a closer look at this. Lines 1-10 are necessary preparation: we use a {{< javadoc "ValueFactory" "model/ValueFactory.html" >}} to create resources , which we will later use to add facts to our model.
+Let's take a closer look at this. Lines 1-10 are necessary preparation: we use {{< javadoc "Values" "model/util/Values.html" >}} factory methods to create resources , which we will later use to add facts to our model.
 
-On line 13, we create a new, empty model. RDF4J comes with several {{< javadoc "Model" "model/Model.html" >}} implementations, the ones you will most commonly encounter are {{< javadoc "TreeModel" "model/impl/TreeModel.html" >}} and {{< javadoc "LinkedHashModel" "model/impl/LinkedHashModel.html" >}}. The difference is in how they index data internally - which has a performance impact when working with very large models. For our purposes however, it doesn't really matter which implementation you use.
+On line 13, we create a new, empty model. RDF4J comes with several {{< javadoc "Model" "model/Model.html" >}} implementations, the ones you will most commonly encounter are {{< javadoc "DynamicModel" "model/impl/DynamicModel.html" >}}, {{< javadoc "TreeModel" "model/impl/TreeModel.html" >}} and {{< javadoc "LinkedHashModel" "model/impl/LinkedHashModel.html" >}}. The difference is in how they index data internally - which has a performance impact when working with very large models. For our purposes however, it doesn't really matter which implementation you use.
 
 On lines 16 and 19, we add our two facts that we know about Picasso: that's he's an artist, and that his first name is "Pablo".
 


### PR DESCRIPTION
GitHub issue resolved: #1325  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- A new utility class `org.eclipse.rdf4j.model.util.Values` with static factory methods for quick creation of all value types. This allows easier code at the client end, e.g. instead of 

```java
   import org.eclipse.rdf4j.model.impl.SimpleValueFactory;

   IRI example =    SimpleValueFactory.getInstance().createIRI("http://www.example.org/");
```

We can now do 

```java
   import org.eclipse.rdf4j.model.util.Values;

   IRI example =    Values.iri("http://www.example.org/");
```

or even:

```java
   import static org.eclipse.rdf4j.model.util.Values.iri;

   IRI example =  iri("http://www.example.org/");
```

- The utility methods are deliberately quite strict about checking syntactic validity of input arguments (including checks for nulls). 

- Migrated several existing static methods from `Statements` and `Literals` into `Values` for consistency, marked existing methods deprecated.

- Updated documentation for Model API and Repository API, as well as (part of) the Tutorial
- As a side effect / cleanup thing, made the examples directory a proper maven module so we can more easily keep it up to date (and extend the set of code examples as well) 


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

