### PR TITLE
GH-2678 FedX to pass through TransactionSettings to WriteStrategy

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.common.iteration.DistinctIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.common.transaction.TransactionSetting;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvaluationStatistics;
@@ -86,6 +87,12 @@ public class FedXConnection extends AbstractSailConnection {
 		super(federation);
 		this.federation = federation;
 		this.federationContext = federationContext;
+	}
+
+	@Override
+	public void setTransactionSettings(TransactionSetting... settings) {
+		super.setTransactionSettings(settings);
+		this.getWriteStrategyInternal().setTransactionSettings(settings);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/ReadOnlyWriteStrategy.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.write;
 
+import org.eclipse.rdf4j.common.transaction.TransactionSetting;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
@@ -38,6 +39,11 @@ public class ReadOnlyWriteStrategy implements WriteStrategy {
 
 	@Override
 	public void rollback() throws RepositoryException {
+		// no-op
+	}
+
+	@Override
+	public void setTransactionSettings(TransactionSetting... transactionSettings) throws RepositoryException {
 		// no-op
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategy.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.write;
 
+import org.eclipse.rdf4j.common.transaction.TransactionSetting;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
@@ -29,7 +30,10 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 public class RepositoryWriteStrategy implements WriteStrategy {
 
 	private final Repository writeRepository;
+
 	private RepositoryConnection connection = null;
+
+	private TransactionSetting[] transactionSettings;
 
 	public RepositoryWriteStrategy(Repository writeRepository) {
 		super();
@@ -46,7 +50,11 @@ public class RepositoryWriteStrategy implements WriteStrategy {
 	@Override
 	public void begin() throws RepositoryException {
 		createConnection();
-		connection.begin();
+		if (transactionSettings != null && transactionSettings.length > 0) {
+			connection.begin(transactionSettings);
+		} else {
+			connection.begin();
+		}
 	}
 
 	@Override
@@ -91,5 +99,10 @@ public class RepositoryWriteStrategy implements WriteStrategy {
 	public void clearNamespaces() throws RepositoryException {
 		createConnection();
 		connection.clearNamespaces();
+	}
+
+	@Override
+	public void setTransactionSettings(TransactionSetting... transactionSettings) throws RepositoryException {
+		this.transactionSettings = transactionSettings;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/WriteStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/write/WriteStrategy.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.write;
 
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.common.transaction.TransactionSetting;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
@@ -24,6 +26,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
  * @see RepositoryWriteStrategy
  * @see ReadOnlyWriteStrategy
  */
+@Experimental
 public interface WriteStrategy extends AutoCloseable {
 	/**
 	 * Close this write strategy (e.g. close a shared {@link RepositoryException}).
@@ -32,6 +35,14 @@ public interface WriteStrategy extends AutoCloseable {
 	 */
 	@Override
 	void close() throws RepositoryException;
+
+	/**
+	 * Assign {@link TransactionSetting}s to be used for the next transaction.
+	 * 
+	 * @param transactionSettings one or more {@link TransactionSetting}s
+	 * @throws RepositoryException
+	 */
+	void setTransactionSettings(TransactionSetting... transactionSettings) throws RepositoryException;
 
 	/**
 	 * Begin a transaction.

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategyTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategyTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.write;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.rdf4j.common.transaction.TransactionSetting;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RepositoryWriteStrategyTest {
+
+	private RepositoryWriteStrategy strategy;
+	private Repository writeRepository;
+	private RepositoryConnection connection;
+
+	@BeforeEach
+	public void setUp() {
+		writeRepository = mock(Repository.class);
+		connection = mock(RepositoryConnection.class);
+		when(writeRepository.getConnection()).thenReturn(connection);
+
+		strategy = new RepositoryWriteStrategy(writeRepository);
+	}
+
+	@Test
+	public void testBegin() throws Exception {
+		strategy.begin();
+		verify(connection).begin();
+	}
+
+	@Test
+	public void testSetTransactionSettings() throws Exception {
+		TransactionSetting setting = mock(TransactionSetting.class);
+		strategy.setTransactionSettings(setting);
+
+		strategy.begin();
+		// check that the setting is passed when begin is called
+		verify(connection).begin(setting);
+
+		strategy.setTransactionSettings((TransactionSetting[]) null);
+		strategy.begin();
+		verify(connection).begin();
+
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #2678  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- implement SailConnection.setTransactionSettings in FedXConnection
- add handling to WriteStrategy


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

