### PR TITLE
GH 2666 jetty federated fix

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,12 +17,16 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.http.HttpConnection;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
 import org.eclipse.rdf4j.http.client.util.HttpClientBuilders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +61,42 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 	private volatile HttpClientBuilder httpClientBuilder;
 
 	private final Map<SPARQLProtocolSession, Boolean> openSessions = new ConcurrentHashMap<>();
+
+	private static final HttpRequestRetryHandler retryHandlerStale = new RetryHandlerStale();
+
+	/**
+	 * Retry handler: closes stale connections and suggests to simply retry the HTTP request once. Just closing the
+	 * stale connection is enough: the connection will be reopened elsewhere. This seems to be necessary for Jetty
+	 * 9.4.24+.
+	 * 
+	 * Other HTTP issues are considered to be more severe, so these requests are not retried.
+	 */
+	private static class RetryHandlerStale implements HttpRequestRetryHandler {
+		private final Logger logger = LoggerFactory.getLogger(RetryHandlerStale.class);
+
+		@Override
+		public boolean retryRequest(IOException ioe, int count, HttpContext context) {
+			// only try this once
+			if (count > 1) {
+				return false;
+			}
+			HttpClientContext clientContext = HttpClientContext.adapt(context);
+			HttpConnection conn = clientContext.getConnection();
+
+			synchronized (this) {
+				if (conn.isStale()) {
+					try {
+						logger.warn("Closing stale connection");
+						conn.close();
+						return true;
+					} catch (IOException e) {
+						logger.error("Error closing stale connection", e);
+					}
+				}
+			}
+			return false;
+		}
+	}
 
 	/*--------------*
 	 * Constructors *
@@ -211,9 +252,11 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 		if (nextHttpClientBuilder != null) {
 			return nextHttpClientBuilder.build();
 		}
+
 		return HttpClientBuilder.create()
+				.evictExpiredConnections()
+				.setRetryHandler(retryHandlerStale)
 				.useSystemProperties()
-				.disableAutomaticRetries()
 				.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
 				.build();
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<slf4j.version>1.7.30</slf4j.version>
 		<logback.version>1.1.11</logback.version>
-		<httpclient.version>4.5.12</httpclient.version>
+		<httpclient.version>4.5.13</httpclient.version>
 		<httpcore.version>4.4.13</httpcore.version>
 		<jackson.version>2.10.5</jackson.version>
 		<jsonldjava.version>0.13.2</jsonldjava.version>
@@ -305,7 +305,7 @@
 		<solr.version>7.7.2</solr.version>
 		<elasticsearch.version>6.8.8</elasticsearch.version>
 		<servlet.version>3.1.0</servlet.version>
-		<jetty.version>9.4.24.v20191120</jetty.version>
+		<jetty.version>9.4.34.v20201102</jetty.version>
 		<spring.version>5.2.9.RELEASE</spring.version>
 		<guava.version>29.0-jre</guava.version>
 		<jmhVersion>1.21</jmhVersion>


### PR DESCRIPTION
GitHub issue resolved: #2666 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- bump Jetty and HttpClient version
- added custom retry handler to (only) retry stale connections, which became an issue for Jetty 9.4.24+
(doesn't seem to occur that often, but is happening in federated tests)

There are different ways to solve this, but 
- retries were explicitly disabled in #647 (including omnipotent requests)
- Apache HttpClient offers the option to retry stale connections at `RequestConfig` level, but this method `setStaleConnectionCheckEnabled` has been deprecated
- another HttpClient option is a ConnectionPool with a separate monitoring thread, but this seems to add more complexity and may need additional (sizing) configuration

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

