### PR TITLE
GH-2683 avoid full SHACL report in log at warning level

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -1142,7 +1142,8 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	protected ErrorInfo getErrorInfo(HttpResponse response) throws RepositoryException {
 		try {
 			ErrorInfo errInfo = ErrorInfo.parse(EntityUtils.toString(response.getEntity()));
-			logger.warn("Server reports problem: {}", errInfo.getErrorMessage());
+			logger.warn("Server reports problem: {} (enable debug logging for full details)", errInfo.getErrorType());
+			logger.debug("full error message: {}", errInfo.getErrorMessage());
 			return errInfo;
 		} catch (IOException e) {
 			logger.warn("Unable to retrieve error info from server");


### PR DESCRIPTION
GitHub issue resolved: #2683  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- minimal fix in logging at client side, to avoid full shacl report being logged at warning level

Possible followup is to take a good hard look at how the validation report is sent in the first place, and see if we can reuse the exsitng ErrorInfo / ErrorType functionality for it somehow. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

