### PR TITLE
GH-2670 baseuri optional

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
@@ -30,12 +30,12 @@ public class FederationSparqlTest {
 		repoFed.initialize();
 
 		try (RepositoryConnection conn = repo1.getConnection()) {
-			conn.add(getClass().getResource("/testcases-sparql-1.0-w3c/data-r2/algebra/var-scope-join-1.ttl"), null,
-					null, conn.getValueFactory().createIRI("http://example/g1"));
+			conn.add(getClass().getResource("/testcases-sparql-1.0-w3c/data-r2/algebra/var-scope-join-1.ttl"),
+					conn.getValueFactory().createIRI("http://example/g1"));
 		}
 		try (RepositoryConnection conn = repo2.getConnection()) {
-			conn.add(getClass().getResource("/testcases-sparql-1.0-w3c/data-r2/algebra/var-scope-join-1.ttl"), null,
-					null, conn.getValueFactory().createIRI("http://example/g2"));
+			conn.add(getClass().getResource("/testcases-sparql-1.0-w3c/data-r2/algebra/var-scope-join-1.ttl"),
+					conn.getValueFactory().createIRI("http://example/g2"));
 		}
 
 		String query = "PREFIX : <http://example/> SELECT * { graph :g1 {?X  :name 'paul'} { graph :g2 {?Y :name 'george' . OPTIONAL { ?X :email ?Z } } } }";

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -720,12 +720,39 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * Adds RDF data from an InputStream to the repository, optionally to one or more named contexts.
 	 *
 	 * @param in         An InputStream from which RDF data can be read.
-	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against.
 	 * @param dataFormat The serialization format of the data.
 	 * @param contexts   The contexts to add the data to. If one or more contexts are supplied the method ignores
 	 *                   contextual information in the actual data. If no contexts are supplied the contextual
 	 *                   information in the input stream is used, if no context information is available the data is
 	 *                   added without any context.
+	 * @throws IOException                  If an I/O error occurred while reading from the input stream.
+	 * @throws UnsupportedRDFormatException If no parser is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * @throws RepositoryException          If the data could not be added to the repository, for example because the
+	 *                                      repository is not writable.
+	 * @since 3.5.0
+	 */
+	default void add(InputStream in, RDFFormat dataFormat, Resource... contexts)
+			throws IOException, RDFParseException, RepositoryException {
+		add(in, null, dataFormat, contexts);
+	}
+
+	/**
+	 * Adds RDF data from an InputStream to the repository, optionally to one or more named contexts.
+	 *
+	 * @param in         An InputStream from which RDF data can be read.
+	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against. May be
+	 *                   <code>null</code>.
+	 *                   <p>
+	 *                   Note that if the data contains an embedded base URI, that embedded base URI will overrule the
+	 *                   value supplied here (see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a> section
+	 *                   5.1 for details).
+	 * @param dataFormat The serialization format of the data.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are supplied the method ignores
+	 *                   contextual information in the actual data. If no contexts are supplied the contextual
+	 *                   information in the input stream is used, if no context information is available the data is
+	 *                   added without any context.
+	 * 
 	 * @throws IOException                  If an I/O error occurred while reading from the input stream.
 	 * @throws UnsupportedRDFormatException If no parser is available for the specified RDF format.
 	 * @throws RDFParseException            If an error was found while parsing the RDF data.
@@ -742,7 +769,36 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * be preferred.</b>
 	 *
 	 * @param reader     A Reader from which RDF data can be read.
-	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against.
+	 * @param dataFormat The serialization format of the data.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are specified the data is added to
+	 *                   these contexts, ignoring any context information in the data itself.
+	 * 
+	 * @throws IOException                  If an I/O error occurred while reading from the reader.
+	 * @throws UnsupportedRDFormatException If no parser is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * @throws RepositoryException          If the data could not be added to the repository, for example because the
+	 *                                      repository is not writable.
+	 * 
+	 * @since 3.5.0
+	 */
+	default void add(Reader reader, RDFFormat dataFormat, Resource... contexts)
+			throws IOException, RDFParseException, RepositoryException {
+		add(reader, null, dataFormat, contexts);
+	}
+
+	/**
+	 * Adds RDF data from a Reader to the repository, optionally to one or more named contexts. <b>Note: using a Reader
+	 * to upload byte-based data means that you have to be careful not to destroy the data's character encoding by
+	 * enforcing a default character encoding upon the bytes. If possible, adding such data using an InputStream is to
+	 * be preferred.</b>
+	 *
+	 * @param reader     A Reader from which RDF data can be read.
+	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against. May be
+	 *                   <code>null</code>.
+	 *                   <p>
+	 *                   Note that if the data contains an embedded base URI, that embedded base URI will overrule the
+	 *                   value supplied here (see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a> section
+	 *                   5.1 for details).
 	 * @param dataFormat The serialization format of the data.
 	 * @param contexts   The contexts to add the data to. If one or more contexts are specified the data is added to
 	 *                   these contexts, ignoring any context information in the data itself.
@@ -759,10 +815,60 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * Adds the RDF data that can be found at the specified URL to the repository, optionally to one or more named
 	 * contexts.
 	 *
+	 * @param url      The URL of the RDF data.
+	 * @param contexts The contexts to add the data to. If one or more contexts are specified the data is added to these
+	 *                 contexts, ignoring any context information in the data itself.
+	 * 
+	 * @throws IOException                  If an I/O error occurred while reading from the URL.
+	 * @throws UnsupportedRDFormatException If the RDF format could not be recognized.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * @throws RepositoryException          If the data could not be added to the repository, for example because the
+	 *                                      repository is not writable.
+	 * 
+	 * @since 3.5.0
+	 */
+	default void add(URL url, Resource... contexts)
+			throws IOException, RDFParseException, RepositoryException {
+		add(url, null, null, contexts);
+	}
+
+	/**
+	 * Adds the RDF data that can be found at the specified URL to the repository, optionally to one or more named
+	 * contexts.
+	 *
+	 * @param url        The URL of the RDF data.
+	 * @param dataFormat The serialization format of the data. If set to <tt>null</tt>, the format will be automatically
+	 *                   determined by examining the content type in the HTTP response header, and failing that, the
+	 *                   file name extension of the supplied URL.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are specified the data is added to
+	 *                   these contexts, ignoring any context information in the data itself.
+	 * 
+	 * @throws IOException                  If an I/O error occurred while reading from the URL.
+	 * @throws UnsupportedRDFormatException If no parser is available for the specified RDF format, or the RDF format
+	 *                                      could not be automatically determined.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * @throws RepositoryException          If the data could not be added to the repository, for example because the
+	 *                                      repository is not writable.
+	 * 
+	 * @since 3.5.0
+	 */
+	default void add(URL url, RDFFormat dataFormat, Resource... contexts)
+			throws IOException, RDFParseException, RepositoryException {
+		add(url, null, dataFormat, contexts);
+	}
+
+	/**
+	 * Adds the RDF data that can be found at the specified URL to the repository, optionally to one or more named
+	 * contexts.
+	 *
 	 * @param url        The URL of the RDF data.
 	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against. This defaults to the
 	 *                   value of {@link java.net.URL#toExternalForm() url.toExternalForm()} if the value is set to
 	 *                   <tt>null</tt>.
+	 *                   <p>
+	 *                   Note that if the data contains an embedded base URI, that embedded base URI will overrule the
+	 *                   value supplied here (see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a> section
+	 *                   5.1 for details).
 	 * @param dataFormat The serialization format of the data. If set to <tt>null</tt>, the format will be automatically
 	 *                   determined by examining the content type in the HTTP response header, and failing that, the
 	 *                   file name extension of the supplied URL.
@@ -781,10 +887,63 @@ public interface RepositoryConnection extends AutoCloseable {
 	/**
 	 * Adds RDF data from the specified file to a specific contexts in the repository.
 	 *
+	 * @param file     A file containing RDF data.
+	 * @param contexts The contexts to add the data to. Note that this parameter is a vararg and as such is optional. If
+	 *                 no contexts are specified, the data is added to any context specified in the actual data file, or
+	 *                 if the data contains no context, it is added without context. If one or more contexts are
+	 *                 specified the data is added to these contexts, ignoring any context information in the data
+	 *                 itself.
+	 * 
+	 * @throws IOException                  If an I/O error occurred while reading from the file.
+	 * @throws UnsupportedRDFormatException If the RDF format of the supplied file could not be recognized.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * @throws RepositoryException          If the data could not be added to the repository, for example because the
+	 *                                      repository is not writable.
+	 * 
+	 * @since 3.5.0
+	 */
+	default void add(File file, Resource... contexts)
+			throws IOException, RDFParseException, RepositoryException {
+		add(file, null, null, contexts);
+	}
+
+	/**
+	 * Adds RDF data from the specified file to a specific contexts in the repository.
+	 *
+	 * @param file       A file containing RDF data.
+	 * @param dataFormat The serialization format of the data. If set to <tt>null</tt>, the format will be automatically
+	 *                   determined by examining the file name extension of the supplied File.
+	 * @param contexts   The contexts to add the data to. Note that this parameter is a vararg and as such is optional.
+	 *                   If no contexts are specified, the data is added to any context specified in the actual data
+	 *                   file, or if the data contains no context, it is added without context. If one or more contexts
+	 *                   are specified the data is added to these contexts, ignoring any context information in the data
+	 *                   itself.
+	 * 
+	 * @throws IOException                  If an I/O error occurred while reading from the file.
+	 * @throws UnsupportedRDFormatException If no parser is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * @throws RepositoryException          If the data could not be added to the repository, for example because the
+	 *                                      repository is not writable.
+	 * 
+	 * @since 3.5.0
+	 */
+	default void add(File file, RDFFormat dataFormat, Resource... contexts)
+			throws IOException, RDFParseException, RepositoryException {
+		add(file, null, dataFormat, contexts);
+	}
+
+	/**
+	 * Adds RDF data from the specified file to a specific contexts in the repository.
+	 *
 	 * @param file       A file containing RDF data.
 	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against. This defaults to the
 	 *                   value of {@link java.io.File#toURI() file.toURI()} if the value is set to <tt>null</tt>.
-	 * @param dataFormat The serialization format of the data.
+	 *                   <p>
+	 *                   Note that if the data contains an embedded base URI, that embedded base URI will overrule the
+	 *                   value supplied here (see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a> section
+	 *                   5.1 for details).
+	 * @param dataFormat The serialization format of the data. If set to <tt>null</tt>, the format will be automatically
+	 *                   determined by examining the file name extension of the supplied File.
 	 * @param contexts   The contexts to add the data to. Note that this parameter is a vararg and as such is optional.
 	 *                   If no contexts are specified, the data is added to any context specified in the actual data
 	 *                   file, or if the data contains no context, it is added without context. If one or more contexts

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFParser.java
@@ -21,10 +21,6 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
  */
 public interface RDFParser {
 
-	/*-----------*
-	 * Constants *
-	 *-----------*/
-
 	/**
 	 * @deprecated These settings are not recognised and will be removed in a future version. Use
 	 *             {@link BasicParserSettings#FAIL_ON_UNKNOWN_DATATYPES}
@@ -48,10 +44,6 @@ public interface RDFParser {
 		 */
 		NORMALIZE
 	}
-
-	/*---------*
-	 * Methods *
-	 *---------*/
 
 	/**
 	 * Gets the RDF format that this parser can parse.
@@ -115,6 +107,7 @@ public interface RDFParser {
 	 *
 	 * @param setting The setting to change.
 	 * @param value   The value to change.
+	 * 
 	 * @return Either a copy of this parser, if it is immutable, or this object, to allow chaining of method calls.
 	 */
 	public <T> RDFParser set(RioSetting<T> setting, T value);
@@ -160,10 +153,26 @@ public interface RDFParser {
 	public void setDatatypeHandling(DatatypeHandling datatypeHandling);
 
 	/**
+	 * Parses the data from the supplied InputStream.
+	 *
+	 * @param in The InputStream from which to read the data.
+	 * 
+	 * @throws IOException         If an I/O error occurred while data was read from the InputStream.
+	 * @throws RDFParseException   If the parser has found an unrecoverable parse error.
+	 * @throws RDFHandlerException If the configured statement handler has encountered an unrecoverable error.
+	 * 
+	 * @since 3.5.0
+	 */
+	public default void parse(InputStream in) throws IOException, RDFParseException, RDFHandlerException {
+		parse(in, null);
+	}
+
+	/**
 	 * Parses the data from the supplied InputStream, using the supplied baseURI to resolve any relative URI references.
 	 *
 	 * @param in      The InputStream from which to read the data.
-	 * @param baseURI The URI associated with the data in the InputStream.
+	 * @param baseURI The URI associated with the data in the InputStream. May be <code>null</code>.
+	 * 
 	 * @throws IOException         If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException   If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException If the configured statement handler has encountered an unrecoverable error.
@@ -171,10 +180,26 @@ public interface RDFParser {
 	public void parse(InputStream in, String baseURI) throws IOException, RDFParseException, RDFHandlerException;
 
 	/**
+	 * Parses the data from the supplied Reader.
+	 *
+	 * @param reader The Reader from which to read the data.
+	 * 
+	 * @throws IOException         If an I/O error occurred while data was read from the InputStream.
+	 * @throws RDFParseException   If the parser has found an unrecoverable parse error.
+	 * @throws RDFHandlerException If the configured statement handler has encountered an unrecoverable error.
+	 * 
+	 * @since 3.5.0
+	 */
+	public default void parse(Reader reader) throws IOException, RDFParseException, RDFHandlerException {
+		parse(reader, null);
+	}
+
+	/**
 	 * Parses the data from the supplied Reader, using the supplied baseURI to resolve any relative URI references.
 	 *
 	 * @param reader  The Reader from which to read the data.
-	 * @param baseURI The URI associated with the data in the InputStream.
+	 * @param baseURI The URI associated with the data in the InputStream. May be <code>null</code>.
+	 * 
 	 * @throws IOException         If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException   If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException If the configured statement handler has encountered an unrecoverable error.

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFParser.java
@@ -171,7 +171,12 @@ public interface RDFParser {
 	 * Parses the data from the supplied InputStream, using the supplied baseURI to resolve any relative URI references.
 	 *
 	 * @param in      The InputStream from which to read the data.
-	 * @param baseURI The URI associated with the data in the InputStream. May be <code>null</code>.
+	 * @param baseURI The URI associated with the data in the InputStream. May be <code>null</code>. Parsers for syntax
+	 *                formats that do not support relative URIs will ignore this argument.
+	 *                <p>
+	 *                Note that if the data contains an embedded base URI, that embedded base URI will overrule the
+	 *                value supplied here (see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a> section 5.1
+	 *                for details).
 	 * 
 	 * @throws IOException         If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException   If the parser has found an unrecoverable parse error.
@@ -198,7 +203,12 @@ public interface RDFParser {
 	 * Parses the data from the supplied Reader, using the supplied baseURI to resolve any relative URI references.
 	 *
 	 * @param reader  The Reader from which to read the data.
-	 * @param baseURI The URI associated with the data in the InputStream. May be <code>null</code>.
+	 * @param baseURI The URI associated with the data in the InputStream. May be <code>null</code>. Parsers for syntax
+	 *                formats that do not support relative URIs will ignore this argument.
+	 *                <p>
+	 *                Note that if the data contains an embedded base URI, that embedded base URI will overrule the
+	 *                value supplied here (see <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a> section 5.1
+	 *                for details).
 	 * 
 	 * @throws IOException         If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException   If the parser has found an unrecoverable parse error.

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/Rio.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/Rio.java
@@ -198,7 +198,30 @@ public class Rio {
 	 * Adds RDF data from an {@link InputStream} to a {@link Model}, optionally to one or more named contexts.
 	 *
 	 * @param in         An InputStream from which RDF data can be read.
-	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against.
+	 * @param dataFormat The serialization format of the data.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are supplied the method ignores
+	 *                   contextual information in the actual data. If no contexts are supplied the contextual
+	 *                   information in the input stream is used, if no context information is available the data is
+	 *                   added without any context.
+	 * @return A {@link Model} containing the parsed statements.
+	 * @throws IOException                  If an I/O error occurred while reading from the input stream.
+	 * @throws UnsupportedRDFormatException If no {@link RDFParser} is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * 
+	 * @since 3.5.0
+	 */
+	public static Model parse(InputStream in, RDFFormat dataFormat, Resource... contexts)
+			throws IOException, RDFParseException, UnsupportedRDFormatException {
+		return parse(in, null, dataFormat, new ParserConfig(), SimpleValueFactory.getInstance(),
+				new ParseErrorLogger(), contexts);
+	}
+
+	/**
+	 * Adds RDF data from an {@link InputStream} to a {@link Model}, optionally to one or more named contexts.
+	 *
+	 * @param in         An InputStream from which RDF data can be read.
+	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against. May be
+	 *                   <code>null</code>.
 	 * @param dataFormat The serialization format of the data.
 	 * @param contexts   The contexts to add the data to. If one or more contexts are supplied the method ignores
 	 *                   contextual information in the actual data. If no contexts are supplied the contextual
@@ -216,32 +239,11 @@ public class Rio {
 	}
 
 	/**
-	 * Adds RDF data from a {@link Reader} to a {@link Model}, optionally to one or more named contexts. <b>Note: using
-	 * a Reader to upload byte-based data means that you have to be careful not to destroy the data's character encoding
-	 * by enforcing a default character encoding upon the bytes. If possible, adding such data using an InputStream is
-	 * to be preferred.</b>
-	 *
-	 * @param reader     A Reader from which RDF data can be read.
-	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against.
-	 * @param dataFormat The serialization format of the data.
-	 * @param contexts   The contexts to add the data to. If one or more contexts are specified the data is added to
-	 *                   these contexts, ignoring any context information in the data itself.
-	 * @return A {@link Model} containing the parsed statements.
-	 * @throws IOException                  If an I/O error occurred while reading from the reader.
-	 * @throws UnsupportedRDFormatException If no {@link RDFParser} is available for the specified RDF format.
-	 * @throws RDFParseException            If an error was found while parsing the RDF data.
-	 */
-	public static Model parse(Reader reader, String baseURI, RDFFormat dataFormat, Resource... contexts)
-			throws IOException, RDFParseException, UnsupportedRDFormatException {
-		return parse(reader, baseURI, dataFormat, new ParserConfig(), SimpleValueFactory.getInstance(),
-				new ParseErrorLogger(), contexts);
-	}
-
-	/**
 	 * Adds RDF data from an {@link InputStream} to a {@link Model}, optionally to one or more named contexts.
 	 *
 	 * @param in           An InputStream from which RDF data can be read.
-	 * @param baseURI      The base URI to resolve any relative URIs that are in the data against.
+	 * @param baseURI      The base URI to resolve any relative URIs that are in the data against. May be
+	 *                     <code>null</code>.
 	 * @param dataFormat   The serialization format of the data.
 	 * @param settings     The {@link ParserConfig} containing settings for configuring the parser.
 	 * @param valueFactory The {@link ValueFactory} used by the parser to create statements.
@@ -267,7 +269,8 @@ public class Rio {
 	 * Adds RDF data from an {@link InputStream} to a {@link Model}, optionally to one or more named contexts.
 	 *
 	 * @param in           An InputStream from which RDF data can be read.
-	 * @param baseURI      The base URI to resolve any relative URIs that are in the data against.
+	 * @param baseURI      The base URI to resolve any relative URIs that are in the data against. May be
+	 *                     <code>null</code>.
 	 * @param dataFormat   The serialization format of the data.
 	 * @param settings     The {@link ParserConfig} containing settings for configuring the parser.
 	 * @param valueFactory The {@link ValueFactory} used by the parser to create statements.
@@ -303,8 +306,55 @@ public class Rio {
 	 * by enforcing a default character encoding upon the bytes. If possible, adding such data using an InputStream is
 	 * to be preferred.</b>
 	 *
+	 * @param reader     A Reader from which RDF data can be read.
+	 * @param dataFormat The serialization format of the data.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are specified the data is added to
+	 *                   these contexts, ignoring any context information in the data itself.
+	 * @return A {@link Model} containing the parsed statements.
+	 * @throws IOException                  If an I/O error occurred while reading from the reader.
+	 * @throws UnsupportedRDFormatException If no {@link RDFParser} is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * 
+	 * @since 3.5.0
+	 */
+	public static Model parse(Reader reader, RDFFormat dataFormat, Resource... contexts)
+			throws IOException, RDFParseException, UnsupportedRDFormatException {
+		return parse(reader, null, dataFormat, new ParserConfig(), SimpleValueFactory.getInstance(),
+				new ParseErrorLogger(), contexts);
+	}
+
+	/**
+	 * Adds RDF data from a {@link Reader} to a {@link Model}, optionally to one or more named contexts. <b>Note: using
+	 * a Reader to upload byte-based data means that you have to be careful not to destroy the data's character encoding
+	 * by enforcing a default character encoding upon the bytes. If possible, adding such data using an InputStream is
+	 * to be preferred.</b>
+	 *
+	 * @param reader     A Reader from which RDF data can be read.
+	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against. May be
+	 *                   <code>null</code>.
+	 * @param dataFormat The serialization format of the data.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are specified the data is added to
+	 *                   these contexts, ignoring any context information in the data itself.
+	 * @return A {@link Model} containing the parsed statements.
+	 * @throws IOException                  If an I/O error occurred while reading from the reader.
+	 * @throws UnsupportedRDFormatException If no {@link RDFParser} is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 */
+	public static Model parse(Reader reader, String baseURI, RDFFormat dataFormat, Resource... contexts)
+			throws IOException, RDFParseException, UnsupportedRDFormatException {
+		return parse(reader, baseURI, dataFormat, new ParserConfig(), SimpleValueFactory.getInstance(),
+				new ParseErrorLogger(), contexts);
+	}
+
+	/**
+	 * Adds RDF data from a {@link Reader} to a {@link Model}, optionally to one or more named contexts. <b>Note: using
+	 * a Reader to upload byte-based data means that you have to be careful not to destroy the data's character encoding
+	 * by enforcing a default character encoding upon the bytes. If possible, adding such data using an InputStream is
+	 * to be preferred.</b>
+	 *
 	 * @param reader       A Reader from which RDF data can be read.
-	 * @param baseURI      The base URI to resolve any relative URIs that are in the data against.
+	 * @param baseURI      The base URI to resolve any relative URIs that are in the data against. May be
+	 *                     <code>null</code>.
 	 * @param dataFormat   The serialization format of the data.
 	 * @param settings     The {@link ParserConfig} containing settings for configuring the parser.
 	 * @param valueFactory The {@link ValueFactory} used by the parser to create statements.
@@ -331,7 +381,8 @@ public class Rio {
 	 * to be preferred.</b>
 	 *
 	 * @param reader       A Reader from which RDF data can be read.
-	 * @param baseURI      The base URI to resolve any relative URIs that are in the data against.
+	 * @param baseURI      The base URI to resolve any relative URIs that are in the data against. May be
+	 *                     <code>null</code>.
 	 * @param dataFormat   The serialization format of the data.
 	 * @param settings     The {@link ParserConfig} containing settings for configuring the parser.
 	 * @param valueFactory The {@link ValueFactory} used by the parser to create statements.

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/BaseURIHandlingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/BaseURIHandlingTest.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -7,6 +14,12 @@ import java.io.InputStream;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.junit.Test;
 
+/**
+ * Test cases for handling of base URIs by {@link RDFParser} implementations.
+ * 
+ * @author Jeen Broekstra
+ *
+ */
 public abstract class BaseURIHandlingTest {
 
 	@Test

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/BaseURIHandlingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/BaseURIHandlingTest.java
@@ -1,0 +1,85 @@
+package org.eclipse.rdf4j.rio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+import org.junit.Test;
+
+public abstract class BaseURIHandlingTest {
+
+	@Test
+	public void testParseWithoutBaseUri_Absolute() throws Exception {
+		StatementCollector collector = new StatementCollector();
+		RDFParser parser = getParserFactory().getParser();
+		parser.setRDFHandler(collector);
+		parser.parse(getDataWithAbsoluteIris());
+		assertThat(collector.getStatements()).isNotEmpty();
+	}
+
+	@Test(expected = RDFParseException.class)
+	public void testParseWithoutBaseUri_Relative() throws Exception {
+		StatementCollector collector = new StatementCollector();
+		RDFParser parser = getParserFactory().getParser();
+		parser.setRDFHandler(collector);
+		parser.parse(getDataWithRelativeIris());
+	}
+
+	@Test
+	public void testParseWithoutBaseUri_Relative_InternalBase() throws Exception {
+		StatementCollector collector = new StatementCollector();
+		RDFParser parser = getParserFactory().getParser();
+		parser.setRDFHandler(collector);
+		parser.parse(getDataWithRelativeIris_InternalBase());
+		assertThat(collector.getStatements()).isNotEmpty();
+	}
+
+	@Test
+	public void testParseWithBaseUri_Relative_InternalBase() throws Exception {
+		StatementCollector collector = new StatementCollector();
+
+		String baseURI = "http://example.org/custom-supplied";
+		RDFParser parser = getParserFactory().getParser();
+		parser.setRDFHandler(collector);
+		parser.parse(getDataWithRelativeIris_InternalBase(), baseURI);
+		assertThat(collector.getStatements()).isNotEmpty();
+
+		// check that the supplied base URI was not used over the internally declared one
+		assertThat(collector.getStatements()).noneMatch(st -> st.getSubject().stringValue().startsWith(baseURI)
+				|| st.getPredicate().stringValue().startsWith(baseURI)
+				|| st.getObject().stringValue().startsWith(baseURI));
+	}
+
+	@Test
+	public void testParseWithBaseUri_Relative() throws Exception {
+		StatementCollector collector = new StatementCollector();
+		RDFParser parser = getParserFactory().getParser();
+		parser.setRDFHandler(collector);
+		parser.parse(getDataWithRelativeIris(), "http://example.org/");
+		assertThat(collector.getStatements()).isNotEmpty();
+	}
+
+	protected abstract RDFParserFactory getParserFactory();
+
+	/**
+	 * Get an {@link InputStream} with data serialized in the parser format, containing no relative IRIs
+	 * 
+	 */
+	protected abstract InputStream getDataWithAbsoluteIris();
+
+	/**
+	 * Get an {@link InputStream} with data serialized in the parser format, containing some relative IRIs, and no base
+	 * IRI provided inside the data itself.
+	 * 
+	 */
+	protected abstract InputStream getDataWithRelativeIris();
+
+	/**
+	 * Get an {@link InputStream} with data serialized in the parser format, containing some relative IRIs, and a base
+	 * IRI provided inside the data itself.
+	 * 
+	 */
+	protected abstract InputStream getDataWithRelativeIris_InternalBase();
+
+}

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTParser.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTParser.java
@@ -90,16 +90,6 @@ public class HDTParser extends AbstractRDFParser {
 		return result;
 	}
 
-	/**
-	 * Implementation of the <tt>parse(InputStream, String)</tt> method defined in the RDFParser interface.
-	 *
-	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the InputStream. Ignored, HDT does not support relative URIs.
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied input stream or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public synchronized void parse(InputStream in, String baseURI)
 			throws IOException, RDFParseException, RDFHandlerException {

--- a/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTParser.java
+++ b/core/rio/hdt/src/main/java/org/eclipse/rdf4j/rio/hdt/HDTParser.java
@@ -94,7 +94,7 @@ public class HDTParser extends AbstractRDFParser {
 	 * Implementation of the <tt>parse(InputStream, String)</tt> method defined in the RDFParser interface.
 	 *
 	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the InputStream, must not be <tt>null</tt>.
+	 * @param baseURI The URI associated with the data in the InputStream. Ignored, HDT does not support relative URIs.
 	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -115,7 +115,7 @@ public class JSONLDParser extends AbstractRDFParser implements RDFParser {
 					valueFactory, getParserConfig(), getParseErrorListener(), nodeID -> createNode(nodeID),
 					() -> createNode());
 
-			final JsonLdOptions options = new JsonLdOptions(baseURI);
+			final JsonLdOptions options = baseURI != null ? new JsonLdOptions(baseURI) : new JsonLdOptions();
 			options.useNamespaces = true;
 
 			DocumentLoader loader = getParserConfig().get(JSONLDSettings.DOCUMENT_LOADER);

--- a/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
+++ b/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
@@ -65,9 +65,6 @@ public class NQuadsParser extends NTriplesParser {
 			if (reader == null) {
 				throw new IllegalArgumentException("Reader can not be 'null'");
 			}
-			if (baseURI == null) {
-				throw new IllegalArgumentException("base URI can not be 'null'");
-			}
 
 			if (rdfHandler != null) {
 				rdfHandler.startRDF();

--- a/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
+++ b/core/rio/nquads/src/main/java/org/eclipse/rdf4j/rio/nquads/NQuadsParser.java
@@ -46,7 +46,6 @@ public class NQuadsParser extends NTriplesParser {
 		if (inputStream == null) {
 			throw new IllegalArgumentException("Input stream can not be 'null'");
 		}
-		// Note: baseURI will be checked in parse(Reader, String)
 
 		try {
 			parse(new InputStreamReader(new BOMInputStream(inputStream, false), StandardCharsets.UTF_8), baseURI);

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -80,18 +80,6 @@ public class NTriplesParser extends AbstractRDFParser {
 		return RDFFormat.NTRIPLES;
 	}
 
-	/**
-	 * Implementation of the <tt>parse(InputStream, String)</tt> method defined in the RDFParser interface.
-	 *
-	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>. The InputStream is
-	 *                supposed to contain 7-bit US-ASCII characters, as per the N-Triples specification.
-	 * @param baseURI The URI associated with the data in the InputStream (ignored, N-Triples does not support relative
-	 *                IRIs).
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied input stream or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public synchronized void parse(InputStream in, String baseURI)
 			throws IOException, RDFParseException, RDFHandlerException {
@@ -107,17 +95,6 @@ public class NTriplesParser extends AbstractRDFParser {
 		}
 	}
 
-	/**
-	 * Implementation of the <tt>parse(Reader, String)</tt> method defined in the RDFParser interface.
-	 *
-	 * @param reader  The Reader from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the Reader (ignored, N-Triples does not support relative
-	 *                IRIs).
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied reader or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public synchronized void parse(Reader reader, String baseURI)
 			throws IOException, RDFParseException, RDFHandlerException {

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
@@ -179,16 +179,6 @@ public class RDFXMLParser extends XMLReaderBasedParser implements ErrorHandler {
 		return getParserConfig().get(XMLParserSettings.PARSE_STANDALONE_DOCUMENTS);
 	}
 
-	/**
-	 * Parses the data from the supplied InputStream, using the supplied baseURI to resolve any relative URI references.
-	 *
-	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the InputStream. May be <tt>null</tt>.
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied input stream or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public synchronized void parse(InputStream in, String baseURI)
 			throws IOException, RDFParseException, RDFHandlerException {
@@ -202,16 +192,6 @@ public class RDFXMLParser extends XMLReaderBasedParser implements ErrorHandler {
 		parse(inputSource);
 	}
 
-	/**
-	 * Parses the data from the supplied Reader, using the supplied baseURI to resolve any relative URI references.
-	 *
-	 * @param reader  The Reader from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the InputStream. May be <tt>null</tt>.
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler has encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied reader or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public synchronized void parse(Reader reader, String baseURI)
 			throws IOException, RDFParseException, RDFHandlerException {

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParser.java
@@ -183,7 +183,7 @@ public class RDFXMLParser extends XMLReaderBasedParser implements ErrorHandler {
 	 * Parses the data from the supplied InputStream, using the supplied baseURI to resolve any relative URI references.
 	 *
 	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the InputStream, must not be <tt>null</tt>.
+	 * @param baseURI The URI associated with the data in the InputStream. May be <tt>null</tt>.
 	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
@@ -194,9 +194,6 @@ public class RDFXMLParser extends XMLReaderBasedParser implements ErrorHandler {
 			throws IOException, RDFParseException, RDFHandlerException {
 		if (in == null) {
 			throw new IllegalArgumentException("Input stream cannot be 'null'");
-		}
-		if (baseURI == null) {
-			throw new IllegalArgumentException("Base URI cannot be 'null'");
 		}
 
 		InputSource inputSource = new InputSource(new BOMInputStream(in, false));
@@ -209,7 +206,7 @@ public class RDFXMLParser extends XMLReaderBasedParser implements ErrorHandler {
 	 * Parses the data from the supplied Reader, using the supplied baseURI to resolve any relative URI references.
 	 *
 	 * @param reader  The Reader from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the InputStream, must not be <tt>null</tt>.
+	 * @param baseURI The URI associated with the data in the InputStream. May be <tt>null</tt>.
 	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException      If the configured statement handler has encountered an unrecoverable error.

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
@@ -147,7 +147,9 @@ class SAXFilter implements ContentHandler {
 	}
 
 	public void setDocumentURI(String documentURI) {
-		this.documentURI = createBaseURI(documentURI);
+		if (documentURI != null) {
+			this.documentURI = createBaseURI(documentURI);
+		}
 	}
 
 	public void setParseStandAloneDocuments(boolean standAloneDocs) {
@@ -290,7 +292,9 @@ class SAXFilter implements ContentHandler {
 		elInfoStack.push(deferredElement);
 		rdfContextStackHeight++;
 
-		rdfParser.setBaseURI(deferredElement.baseURI.toString());
+		if (deferredElement.baseURI != null) {
+			rdfParser.setBaseURI(deferredElement.baseURI.toString());
+		}
 		rdfParser.setXMLLang(deferredElement.xmlLang);
 
 		rdfParser.startElement(deferredElement.namespaceURI, deferredElement.localName, deferredElement.qName,
@@ -348,7 +352,9 @@ class SAXFilter implements ContentHandler {
 			// Check for any deferred start elements
 			if (deferredElement != null) {
 				// Start element still deferred, this is an empty element
-				rdfParser.setBaseURI(deferredElement.baseURI.toString());
+				if (deferredElement.baseURI != null) {
+					rdfParser.setBaseURI(deferredElement.baseURI.toString());
+				}
 				rdfParser.setXMLLang(deferredElement.xmlLang);
 
 				rdfParser.emptyElement(deferredElement.namespaceURI, deferredElement.localName, deferredElement.qName,

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/SAXFilter.java
@@ -667,8 +667,8 @@ class SAXFilter implements ContentHandler {
 		}
 
 		public void setBaseURI(String uriString) {
-			// Resolve the specified base URI against the inherited base URI
-			baseURI = baseURI.resolve(createBaseURI(uriString));
+			// Resolve the specified base URI against the inherited base URI (if any)
+			baseURI = baseURI != null ? baseURI.resolve(createBaseURI(uriString)) : createBaseURI(uriString);
 		}
 
 		public void setNamespaceMappings(Map<String, String> namespaceMappings) {

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLBaseURIHandlingTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLBaseURIHandlingTest.java
@@ -1,0 +1,43 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.rdfxml;
+
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.rio.BaseURIHandlingTest;
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+
+/**
+ * @author Jeen Broekstra
+ */
+public class RDFXMLBaseURIHandlingTest extends BaseURIHandlingTest {
+
+	@Override
+	protected InputStream getDataWithAbsoluteIris() {
+		return RDFXMLBaseURIHandlingTest.class
+				.getResourceAsStream("/org/eclipse/rdf4j/rio/rdfxml/rdfxml-absolute-iris.rdf");
+	}
+
+	@Override
+	protected InputStream getDataWithRelativeIris() {
+		return RDFXMLBaseURIHandlingTest.class
+				.getResourceAsStream("/org/eclipse/rdf4j/rio/rdfxml/rdfxml-relative-iris-missing-base.rdf");
+	}
+
+	@Override
+	protected InputStream getDataWithRelativeIris_InternalBase() {
+		return RDFXMLBaseURIHandlingTest.class
+				.getResourceAsStream("/org/eclipse/rdf4j/rio/rdfxml/rdfxml-relative-iris-internal-base.rdf");
+	}
+
+	@Override
+	protected RDFParserFactory getParserFactory() {
+		return new RDFXMLParserFactory();
+	}
+
+}

--- a/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/rdfxml-absolute-iris.rdf
+++ b/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/rdfxml-absolute-iris.rdf
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:ex="http://example.org/">
+<rdf:Description rdf:about="http://example.org/SomeSubject1">
+	<ex:label>label for subject</ex:label>
+</rdf:Description>
+</rdf:RDF>

--- a/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/rdfxml-relative-iris-internal-base.rdf
+++ b/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/rdfxml-relative-iris-internal-base.rdf
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:ex="http://example.org/"
+	xml:base="http://example.org/">
+	
+<rdf:Description rdf:about="/SomeSubject1">
+	<ex:label>label for subject</ex:label>
+</rdf:Description>
+</rdf:RDF>

--- a/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/rdfxml-relative-iris-missing-base.rdf
+++ b/core/rio/rdfxml/src/test/resources/org/eclipse/rdf4j/rio/rdfxml/rdfxml-relative-iris-missing-base.rdf
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:ex="http://example.org/">
+<rdf:Description rdf:about="/SomeSubject1">
+	<ex:label>label for subject</ex:label>
+</rdf:Description>
+</rdf:RDF>

--- a/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXParser.java
+++ b/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXParser.java
@@ -109,52 +109,30 @@ public class TriXParser extends XMLReaderBasedParser implements ErrorHandler {
 		return results;
 	}
 
-	/**
-	 * Parses the data from the supplied InputStream, using the supplied baseURI to resolve any relative URI references.
-	 *
-	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the InputStream, must not be <tt>null</tt>.
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied input stream or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public void parse(InputStream in, String baseURI) throws IOException, RDFParseException, RDFHandlerException {
 		if (in == null) {
 			throw new IllegalArgumentException("Input stream cannot be 'null'");
 		}
-		if (baseURI == null) {
-			throw new IllegalArgumentException("Base URI cannot be 'null'");
-		}
 
 		InputSource inputSource = new InputSource(new BOMInputStream(in, false));
-		inputSource.setSystemId(baseURI);
+		if (baseURI != null) {
+			inputSource.setSystemId(baseURI);
+		}
 
 		parse(inputSource);
 	}
 
-	/**
-	 * Parses the data from the supplied Reader, using the supplied baseURI to resolve any relative URI references.
-	 *
-	 * @param reader  The Reader from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the InputStream, must not be <tt>null</tt>.
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler has encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied reader or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public void parse(Reader reader, String baseURI) throws IOException, RDFParseException, RDFHandlerException {
 		if (reader == null) {
 			throw new IllegalArgumentException("Reader cannot be 'null'");
 		}
-		if (baseURI == null) {
-			throw new IllegalArgumentException("Base URI cannot be 'null'");
-		}
 
 		InputSource inputSource = new InputSource(reader);
-		inputSource.setSystemId(baseURI);
+		if (baseURI != null) {
+			inputSource.setSystemId(baseURI);
+		}
 
 		parse(inputSource);
 	}

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -113,7 +113,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 *
 	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>. The InputStream is
 	 *                supposed to contain UTF-8 encoded Unicode characters, as per the Turtle specification.
-	 * @param baseURI The URI associated with the data in the InputStream, must not be <tt>null</tt>.
+	 * @param baseURI The URI associated with the data in the InputStream. May be <tt>null</tt>.
 	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
@@ -139,7 +139,7 @@ public class TurtleParser extends AbstractRDFParser {
 	 * Implementation of the <tt>parse(Reader, String)</tt> method defined in the RDFParser interface.
 	 *
 	 * @param reader  The Reader from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the Reader, must not be <tt>null</tt>.
+	 * @param baseURI The URI associated with the data in the Reader. May be <tt>null</tt>.
 	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
 	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
 	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
@@ -154,9 +154,6 @@ public class TurtleParser extends AbstractRDFParser {
 			if (reader == null) {
 				throw new IllegalArgumentException("Reader must not be 'null'");
 			}
-			if (baseURI == null) {
-				throw new IllegalArgumentException("base URI must not be 'null'");
-			}
 
 			if (rdfHandler != null) {
 				rdfHandler.startRDF();
@@ -168,8 +165,10 @@ public class TurtleParser extends AbstractRDFParser {
 			// Allow at most 8 characters to be pushed back:
 			this.reader = new PushbackReader(reader, 10);
 
-			// Store normalized base URI
-			setBaseURI(baseURI);
+			if (baseURI != null) {
+				// Store normalized base URI
+				setBaseURI(baseURI);
+			}
 
 			reportLocation();
 

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -108,24 +108,12 @@ public class TurtleParser extends AbstractRDFParser {
 		return result;
 	}
 
-	/**
-	 * Implementation of the <tt>parse(InputStream, String)</tt> method defined in the RDFParser interface.
-	 *
-	 * @param in      The InputStream from which to read the data, must not be <tt>null</tt>. The InputStream is
-	 *                supposed to contain UTF-8 encoded Unicode characters, as per the Turtle specification.
-	 * @param baseURI The URI associated with the data in the InputStream. May be <tt>null</tt>.
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied input stream or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public synchronized void parse(InputStream in, String baseURI)
 			throws IOException, RDFParseException, RDFHandlerException {
 		if (in == null) {
 			throw new IllegalArgumentException("Input stream must not be 'null'");
 		}
-		// Note: baseURI will be checked in parse(Reader, String)
 
 		try {
 			parse(new InputStreamReader(new BOMInputStream(in, false), StandardCharsets.UTF_8), baseURI);
@@ -135,16 +123,6 @@ public class TurtleParser extends AbstractRDFParser {
 		}
 	}
 
-	/**
-	 * Implementation of the <tt>parse(Reader, String)</tt> method defined in the RDFParser interface.
-	 *
-	 * @param reader  The Reader from which to read the data, must not be <tt>null</tt>.
-	 * @param baseURI The URI associated with the data in the Reader. May be <tt>null</tt>.
-	 * @throws IOException              If an I/O error occurred while data was read from the InputStream.
-	 * @throws RDFParseException        If the parser has found an unrecoverable parse error.
-	 * @throws RDFHandlerException      If the configured statement handler encountered an unrecoverable error.
-	 * @throws IllegalArgumentException If the supplied reader or base URI is <tt>null</tt>.
-	 */
 	@Override
 	public synchronized void parse(Reader reader, String baseURI)
 			throws IOException, RDFParseException, RDFHandlerException {

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleBaseURIHandlingTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleBaseURIHandlingTest.java
@@ -1,0 +1,41 @@
+/******************************************************************************* 
+ * Copyright (c) 2020 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtle;
+
+import java.io.InputStream;
+
+import org.eclipse.rdf4j.rio.BaseURIHandlingTest;
+import org.eclipse.rdf4j.rio.RDFParserFactory;
+
+/**
+ * @author jeen
+ *
+ */
+public class TurtleBaseURIHandlingTest extends BaseURIHandlingTest {
+
+	@Override
+	protected RDFParserFactory getParserFactory() {
+		return new TurtleParserFactory();
+	}
+
+	@Override
+	protected InputStream getDataWithAbsoluteIris() {
+		return getClass().getResourceAsStream("/org/eclipse/rdf4j/rio/turtle/turtle-absolute-iris.ttl");
+	}
+
+	@Override
+	protected InputStream getDataWithRelativeIris() {
+		return getClass().getResourceAsStream("/org/eclipse/rdf4j/rio/turtle/turtle-relative-iris-missing-base.ttl");
+	}
+
+	@Override
+	protected InputStream getDataWithRelativeIris_InternalBase() {
+		return getClass().getResourceAsStream("/org/eclipse/rdf4j/rio/turtle/turtle-relative-iris-internal-base.ttl");
+	}
+
+}

--- a/core/rio/turtle/src/test/resources/org/eclipse/rdf4j/rio/turtle/turtle-absolute-iris.ttl
+++ b/core/rio/turtle/src/test/resources/org/eclipse/rdf4j/rio/turtle/turtle-absolute-iris.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example.org/>.
+
+<http://example.org/SomeSubject1>  ex:label "label for subject" .

--- a/core/rio/turtle/src/test/resources/org/eclipse/rdf4j/rio/turtle/turtle-relative-iris-internal-base.ttl
+++ b/core/rio/turtle/src/test/resources/org/eclipse/rdf4j/rio/turtle/turtle-relative-iris-internal-base.ttl
@@ -1,0 +1,4 @@
+@prefix ex: <http://example.org/>.
+@base <http://example.org/> .
+
+</SomeSubject1>  ex:label "label for subject" .

--- a/core/rio/turtle/src/test/resources/org/eclipse/rdf4j/rio/turtle/turtle-relative-iris-missing-base.ttl
+++ b/core/rio/turtle/src/test/resources/org/eclipse/rdf4j/rio/turtle/turtle-relative-iris-missing-base.ttl
@@ -1,0 +1,3 @@
+@prefix ex: <http://example.org/>.
+
+</SomeSubject1>  ex:label "label for subject" .

--- a/core/sail/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/EvaluationModeTest.java
+++ b/core/sail/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/EvaluationModeTest.java
@@ -46,7 +46,7 @@ public class EvaluationModeTest {
 		Repository repo = new SailRepository(spinSail);
 		repo.initialize();
 		try (RepositoryConnection conn = repo.getConnection()) {
-			conn.add(getClass().getResource("/testcases/testEvaluationMode.ttl"), null, null);
+			conn.add(getClass().getResource("/testcases/testEvaluationMode.ttl"));
 			TupleQuery tq = conn.prepareTupleQuery(
 					"prefix spin: <http://spinrdf.org/spin#> prefix ex: <ex:> select ?s where {?s ex:prop ?t. ?s a ex:TestClass. ?t a ex:TestClass. ex:Query spin:select ?t}");
 			Set<String> results = new HashSet<>();


### PR DESCRIPTION
GitHub issue resolved: #2670  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- method overloads in Rio interfaces to allow omission of base URI when not relevant
- method overloads in RepositoryConnection interfaces to allow omission of base URI when not relevant
- added regression tests
- clarified expectations of input arguments on Javadoc

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

