### PR TITLE
do not run api comparison checks in build phase

### DIFF
--- a/.github/workflows/develop-status.yml
+++ b/.github/workflows/develop-status.yml
@@ -27,6 +27,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-
     - name: Build
-      run: mvn -B clean install -Pquick,\!formatting
+      run: mvn -B clean install -Pquick,\!formatting -Djapicmp.skip
     - name: Compliance tests
       run: mvn -B verify -Pcompliance,\!formatting --file pom.xml

--- a/.github/workflows/master-status.yml
+++ b/.github/workflows/master-status.yml
@@ -27,6 +27,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-
     - name: Build
-      run: mvn -B clean install -Pquick,\!formatting
+      run: mvn -B clean install -Pquick,\!formatting -Djapicmp.skip
     - name: Compliance tests
       run: mvn -B verify -Pcompliance,\!formatting --file pom.xml


### PR DESCRIPTION
- should only happen in verify/test phase
- this avoids problems with module reorg across versions


