### PR TITLE
GH-2711 fix japicmp setup

### DIFF
--- a/.github/workflows/develop-status.yml
+++ b/.github/workflows/develop-status.yml
@@ -27,6 +27,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-
     - name: Build
-      run: mvn -B clean install -Pquick,\!formatting -Djapicmp.skip
+      run: mvn -B clean install -Pquick,\!formatting
     - name: Compliance tests
       run: mvn -B verify -Pcompliance,\!formatting --file pom.xml

--- a/.github/workflows/master-status.yml
+++ b/.github/workflows/master-status.yml
@@ -27,6 +27,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-
     - name: Build
-      run: mvn -B clean install -Pquick,\!formatting -Djapicmp.skip
+      run: mvn -B clean install -Pquick,\!formatting 
     - name: Compliance tests
       run: mvn -B verify -Pcompliance,\!formatting --file pom.xml

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Verify formatting
       run: mvn -B formatter:validate impsort:check xml-format:xml-check
     - name: Build
-      run: mvn -B clean install -Pquick,\!formatting -Djapicmp.skip
+      run: mvn -B clean install -Pquick,\!formatting
     - name: Run tests
       run: mvn -B verify -Pcompliance,\!formatting --file pom.xml
     - name: Print test failures

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -61,7 +61,8 @@
 						<dependency>
 							<groupId>${project.groupId}</groupId>
 							<artifactId>rdf4j-util</artifactId>
-							<version>${project.version}</version>
+							<version>${last.japicmp.compare.version}</version>
+							<type>jar</type>
 						</dependency>
 					</oldVersions>
 					<newVersions>

--- a/core/util/pom.xml
+++ b/core/util/pom.xml
@@ -40,27 +40,6 @@
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
-				<configuration>
-					<oldVersions>
-						<dependency>
-							<groupId>${project.groupId}</groupId>
-							<artifactId>rdf4j-model</artifactId>
-							<version>${project.version}</version>
-						</dependency>
-					</oldVersions>
-					<newVersions>
-						<dependency>
-							<groupId>${project.groupId}</groupId>
-							<artifactId>rdf4j-model-api</artifactId>
-							<version>${project.version}</version>
-						</dependency>
-						<dependency>
-							<groupId>${project.groupId}</groupId>
-							<artifactId>rdf4j-model</artifactId>
-							<version>${project.version}</version>
-						</dependency>
-					</newVersions>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -868,6 +868,8 @@
 							<excludes>
 								<exclude>@org.eclipse.rdf4j.common.annotation.InternalUseOnly</exclude>
 								<exclude>@org.eclipse.rdf4j.common.annotation.Experimental</exclude>
+								<exclude>org.eclipse.rdf4j.common.annotation.InternalUseOnly</exclude>
+								<exclude>org.eclipse.rdf4j.common.annotation.Experimental</exclude>
 								<!-- GH-2538 bug fix, not considered backward incompatible -->
 								<exclude>org.eclipse.rdf4j.model.Namespace#equals(java.lang.Object)</exclude>
 								<exclude>org.eclipse.rdf4j.model.Namespace#hashCode()</exclude>


### PR DESCRIPTION
GitHub issue resolved: #2711  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- fixes configuration problem / circular dependency issue in japicmp setup for rdf4j-util by making the two annotation classes exceptions
- fixes wrong version problem in japicmp setup for rdf4j-model
- reverts earlier change to github actions to skip japicmp check on build, should no longer be necessary. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

