### PR TITLE
Smallmap

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSet.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSet.java
@@ -7,9 +7,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,12 +31,18 @@ import org.eclipse.rdf4j.util.iterators.ConvertingIterator;
  * An implementation of the {@link BindingSet} interface that is used to evalate query object models. This
  * implementations differs from {@link MapBindingSet} in that it maps variable names to Value objects and that the
  * Binding objects are created lazily.
+ *
+ * Also has an optimisation that it tries to use a very small map backed by a single array. And only switches to a
+ * heavier hash map once we have more contents.
+ * 
  */
 public class QueryBindingSet extends AbstractBindingSet {
 
 	private static final long serialVersionUID = -2010715346095527301L;
 
-	private final Map<String, Value> bindings;
+	private static final int SWITCH_TO_MAP = 16;
+
+	private Map<String, Value> bindings;
 
 	public QueryBindingSet() {
 		this(8);
@@ -39,18 +51,32 @@ public class QueryBindingSet extends AbstractBindingSet {
 	public QueryBindingSet(int capacity) {
 		// Create bindings map with some extra space for new bindings and
 		// compensating for HashMap's load factor
-		bindings = new HashMap<>(capacity * 2);
+		if (capacity > SWITCH_TO_MAP) {
+			bindings = new HashMap<String, Value>(capacity * 2);
+		} else {
+			bindings = new SmallMap();
+		}
 	}
 
 	public QueryBindingSet(BindingSet bindingSet) {
-		 bindings = bindingsFrom(bindingSet);
+		bindings = bindingsFrom(bindingSet);
 	}
 
-	private static Map<String, Value> bindingsFrom(BindingSet bindingSet){
+	private static Map<String, Value> bindingsFrom(BindingSet bindingSet) {
 		if (bindingSet instanceof QueryBindingSet) {
-			return new HashMap<>(((QueryBindingSet) bindingSet).bindings);
+			final Map<String, Value> map = ((QueryBindingSet) bindingSet).bindings;
+			if (map instanceof SmallMap) {
+				return new SmallMap((SmallMap) map);
+			} else {
+				return new HashMap<>(map);
+			}
 		} else {
-			Map<String, Value> bindings = new HashMap<>(bindingSet.size() * 2);
+			Map<String, Value> bindings;
+//			if (bindingSet.size() > SWITCH_TO_MAP) {
+			bindings = new HashMap<>(bindingSet.size() * 2);
+//			} else {
+//				bindings = new SmallMap();
+//			}
 			for (Binding binding : bindingSet) {
 				bindings.put(binding.getName(), binding.getValue());
 			}
@@ -59,12 +85,8 @@ public class QueryBindingSet extends AbstractBindingSet {
 	}
 
 	public void addAll(BindingSet bindingSet) {
-		if (bindingSet instanceof QueryBindingSet) {
-			bindings.putAll(((QueryBindingSet) bindingSet).bindings);
-		} else {
-			for (Binding binding : bindingSet) {
-				this.addBinding(binding);
-			}
+		for (Binding binding : bindingSet) {
+			this.setBinding(binding.getName(), binding.getValue());
 		}
 	}
 
@@ -93,7 +115,12 @@ public class QueryBindingSet extends AbstractBindingSet {
 	}
 
 	public void setBinding(String name, Value value) {
-		bindings.put(name, value);
+		try {
+			bindings.put(name, value);
+		} catch (RuntimeException e) {
+			bindings = new HashMap<>(bindings);
+			bindings.put(name, value);
+		}
 	}
 
 	public void removeBinding(String name) {
@@ -162,5 +189,221 @@ public class QueryBindingSet extends AbstractBindingSet {
 		} else {
 			return super.equals(other);
 		}
+	}
+
+	private static class SmallMap
+			extends AbstractMap<String, Value> {
+		private final Object[] keysValues = new Object[SWITCH_TO_MAP];
+
+		public SmallMap() {
+		}
+
+		public SmallMap(SmallMap map) {
+			System.arraycopy(map.keysValues, 0, keysValues, 0, SWITCH_TO_MAP);
+		}
+
+		@Override
+		public int size() {
+
+			int size = 0;
+			for (int i = 0; i < keysValues.length; i = i + 2) {
+				if (keysValues[i] != null) {
+					size++;
+				}
+			}
+			return size;
+		}
+
+		private Iterator<Entry<String, Value>> iterator() {
+			return new Iterator<Entry<String, Value>>() {
+				int cursor = 0;
+
+				@Override
+				public boolean hasNext() {
+					while (cursor < keysValues.length) {
+						if (keysValues[cursor] != null && keysValues[cursor + 1] != null) {
+							return true;
+						} else {
+							cursor += 2;
+						}
+					}
+					return false;
+				}
+
+				@Override
+				public Entry<String, Value> next() {
+					String key = (String) keysValues[cursor++];
+					int valueCursor = cursor;
+					Value value = (Value) keysValues[cursor++];
+					return new Entry<String, Value>() {
+
+						@Override
+						public String getKey() {
+							return key;
+						}
+
+						@Override
+						public Value getValue() {
+							return value;
+						}
+
+						@Override
+						public Value setValue(Value value) {
+							Value old = (Value) keysValues[valueCursor];
+							keysValues[valueCursor] = value;
+							return old;
+						}
+					};
+				}
+			};
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return size() == 0;
+		}
+
+		@Override
+		public boolean containsKey(Object key) {
+			for (int i = 0; i < keysValues.length; i = i + 2) {
+				if (key.equals(keysValues[i])) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public Value get(Object key) {
+			for (int i = 0; i < keysValues.length; i = i + 2) {
+				if (key.equals(keysValues[i])) {
+					return (Value) keysValues[i + 1];
+				}
+			}
+			return null;
+		}
+
+		@Override
+		public Value put(String key, Value value) {
+			for (int i = 0; i < keysValues.length; i = i + 2) {
+				if (key.equals(keysValues[i])) {
+					keysValues[i] = key;
+					Value oldValue = (Value) keysValues[i + 1];
+					keysValues[i + 1] = value;
+					return oldValue;
+				}
+			}
+			for (int i = 0; i < keysValues.length; i = i + 2) {
+				if (keysValues[i] == null) {
+					keysValues[i] = key;
+					keysValues[i + 1] = value;
+					return null;
+				}
+			}
+			throw new RuntimeException("Out of space");
+		}
+
+		@Override
+		public Value remove(Object key) {
+			for (int i = 0; i < keysValues.length; i = i + 2) {
+				if (key.equals(keysValues[i])) {
+					keysValues[i] = null;
+					Value old = (Value) keysValues[i + 1];
+					keysValues[i + 1] = null;
+					return old;
+				}
+			}
+			return null;
+		}
+
+		@Override
+		public void clear() {
+			Arrays.fill(keysValues, null);
+		}
+
+		@Override
+		public Set<String> keySet() {
+			Set<String> keys = new HashSet<>();
+			for (int i = 0; i < keysValues.length; i = i + 2) {
+				if (keysValues[i] != null) {
+					keys.add((String) keysValues[i]);
+				}
+			}
+			return keys;
+		}
+
+		@Override
+		public Collection<Value> values() {
+			List<Value> values = new ArrayList<>();
+			for (int i = 1; i < keysValues.length; i = i + 2) {
+				if (keysValues[i] != null) {
+					values.add((Value) keysValues[i]);
+				}
+			}
+			return values;
+		}
+
+		@Override
+		public Set<Entry<String, Value>> entrySet() {
+			SmallMap map = this;
+			return new AbstractSet<Entry<String, Value>>() {
+
+				@Override
+				public int size() {
+					return map.size();
+				}
+
+				@Override
+				public boolean isEmpty() {
+					return map.isEmpty();
+				}
+
+				@Override
+				public boolean contains(Object o) {
+					return map.containsKey(o);
+				}
+
+				@Override
+				public Iterator<Entry<String, Value>> iterator() {
+					return map.iterator();
+				}
+
+				@Override
+				public boolean retainAll(Collection<?> c) {
+					boolean changed = false;
+					for (int i = 0; i < keysValues.length; i = i + 2) {
+						if (keysValues[i] != null) {
+							if (!c.contains(keysValues[i])) {
+								keysValues[i] = null;
+								keysValues[i + 1] = null;
+								changed = true;
+							}
+						}
+					}
+					return changed;
+				}
+
+				@Override
+				public boolean removeAll(Collection<?> c) {
+					boolean changed = false;
+					for (int i = 0; i < keysValues.length; i = i + 2) {
+						if (keysValues[i] != null) {
+							if (c.contains(keysValues[i])) {
+								keysValues[i] = null;
+								keysValues[i + 1] = null;
+								changed = true;
+							}
+						}
+					}
+					return changed;
+				}
+
+				@Override
+				public void clear() {
+					Arrays.fill(keysValues, null);
+				}
+			};
+		}
+
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSet.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSet.java
@@ -43,8 +43,19 @@ public class QueryBindingSet extends AbstractBindingSet {
 	}
 
 	public QueryBindingSet(BindingSet bindingSet) {
-		this(bindingSet.size());
-		addAll(bindingSet);
+		 bindings = bindingsFrom(bindingSet);
+	}
+
+	private static Map<String, Value> bindingsFrom(BindingSet bindingSet){
+		if (bindingSet instanceof QueryBindingSet) {
+			return new HashMap<>(((QueryBindingSet) bindingSet).bindings);
+		} else {
+			Map<String, Value> bindings = new HashMap<>(bindingSet.size() * 2);
+			for (Binding binding : bindingSet) {
+				bindings.put(binding.getName(), binding.getValue());
+			}
+			return bindings;
+		}
 	}
 
 	public void addAll(BindingSet bindingSet) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -456,17 +456,16 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 	}
 
 	private static final class ConvertingStatementsToBindingsIteration
-	    extends ConvertingIteration<Statement, BindingSet, QueryEvaluationException>
-	{
+			extends ConvertingIteration<Statement, BindingSet, QueryEvaluationException> {
 		private final BindingSet bindings;
 		private final Var subjVar;
 		private final Var predVar;
 		private final Var conVar;
 		private final Var objVar;
 
-		private ConvertingStatementsToBindingsIteration(Iteration<? extends Statement, ? extends QueryEvaluationException> iter,
-		    BindingSet bindings, Var subjVar, Var predVar, Var conVar, Var objVar)
-		{
+		private ConvertingStatementsToBindingsIteration(
+				Iteration<? extends Statement, ? extends QueryEvaluationException> iter,
+				BindingSet bindings, Var subjVar, Var predVar, Var conVar, Var objVar) {
 			super(iter);
 			this.bindings = bindings;
 			this.subjVar = subjVar;
@@ -487,30 +486,26 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 			return result;
 		}
 
-		private void trySetContext(final Var conVar, Statement st, QueryBindingSet result)
-		{
+		private void trySetContext(final Var conVar, Statement st, QueryBindingSet result) {
 			if (conVar != null && !conVar.isConstant() && !result.hasBinding(conVar.getName())
 					&& st.getContext() != null) {
 				result.addBinding(conVar.getName(), st.getContext());
 			}
 		}
 
-		private void trySetObject(final Var objVar, Statement st, QueryBindingSet result)
-		{
+		private void trySetObject(final Var objVar, Statement st, QueryBindingSet result) {
 			if (objVar != null && !objVar.isConstant() && !result.hasBinding(objVar.getName())) {
 				result.addBinding(objVar.getName(), st.getObject());
 			}
 		}
 
-		private void trySetPredicate(final Var predVar, Statement st, QueryBindingSet result)
-		{
+		private void trySetPredicate(final Var predVar, Statement st, QueryBindingSet result) {
 			if (predVar != null && !predVar.isConstant() && !result.hasBinding(predVar.getName())) {
 				result.addBinding(predVar.getName(), st.getPredicate());
 			}
 		}
 
-		private void trySetSubject(final Var subjVar, Statement st, QueryBindingSet result)
-		{
+		private void trySetSubject(final Var subjVar, Statement st, QueryBindingSet result) {
 			if (subjVar != null && !subjVar.isConstant() && !result.hasBinding(subjVar.getName())) {
 				result.addBinding(subjVar.getName(), st.getSubject());
 			}
@@ -682,7 +677,8 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 			};
 
 			// Return an iterator that converts the statements to var bindings
-			resultingIterator = new ConvertingStatementsToBindingsIteration(stIter3, bindings, subjVar, predVar, conVar, objVar);
+			resultingIterator = new ConvertingStatementsToBindingsIteration(stIter3, bindings, subjVar, predVar, conVar,
+					objVar);
 			allGood = true;
 
 			return resultingIterator;


### PR DESCRIPTION
GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

QueryBindingSet Map usage has a major overhead that we can avoid in the cases of small numbers of bindings by just using an array. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

