### PR TITLE
GH-2724 Add more tests to validate behaviour of QueryBindingSet.

### DIFF
--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSetTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSetTest.java
@@ -9,10 +9,10 @@ package org.eclipse.rdf4j.query.algebra.evaluation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -94,20 +94,23 @@ public class QueryBindingSetTest {
 			bs.addBinding("foo", vf.createIRI("urn:foo"));
 			fail();
 		} catch (AssertionError e) {
+			// The current implementation sets an assertion.
+			// however the behavior that is expected is that
+			// after adding an existing binding only the last
+			// set one is returned.
 			return;
 		}
 	}
 
 	@Test
-	public void testNonSharedBackingMap()
-			throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+	public void testNonSharedBackingMap() {
 		QueryBindingSet bs = new QueryBindingSet();
 		bs.addBinding("foo", vf.createIRI("urn:foo"));
 		bs.addBinding("bar", vf.createIRI("urn:bar"));
 		QueryBindingSet bs2 = new QueryBindingSet(bs);
-		final Field declaredField = QueryBindingSet.class.getDeclaredField("bindings");
-		declaredField.setAccessible(true);
-		assertTrue(declaredField.get(bs) != declaredField.get(bs2));
+		bs2.addBinding("boo", vf.createIRI("urn:boo"));
+		assertNotEquals(bs.size(), bs2.size());
+		assertFalse(bs.hasBinding("boo"));
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Jerven bolleman <jerven.bolleman@sib.swiss>


GitHub issue resolved: #2715 

Briefly describe the changes proposed in this PR:

Add new tests for the QueryBindingSet to make sure new implementations do not break existing usage.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [X] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

