### PR TITLE
GH-2260 don't add xsd namespace for xsd:string literals

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/ModelBuilder.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/ModelBuilder.java
@@ -79,6 +79,8 @@ public class ModelBuilder {
 
 	/**
 	 * Create a new {@link ModelBuilder} which will append to the supplied {@link Model}.
+	 * 
+	 * @param model
 	 */
 	public ModelBuilder(Model model) {
 		this.model = model;
@@ -199,8 +201,11 @@ public class ModelBuilder {
 		}
 
 		if (objectValue == null) {
-			model.setNamespace(XSD.NS);
-			objectValue = Literals.createLiteral(SimpleValueFactory.getInstance(), object);
+			Literal literal = Values.literal(object);
+			if (!literal.getDatatype().equals(XSD.STRING)) {
+				model.setNamespace(XSD.NS);
+			}
+			objectValue = literal;
 		}
 
 		if (currentNamedGraph != null) {

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelBuilderTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelBuilderTest.java
@@ -10,6 +10,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -106,5 +107,19 @@ public class ModelBuilderTest {
 		testBuilder.add(RDF.TYPE, RDF.PROPERTY);
 
 		assertTrue(model.contains(FOAF.PERSON, RDF.TYPE, RDF.PROPERTY, RDF.ALT));
+	}
+
+	@Test
+	public void testNSAddedForDatatype() {
+		testBuilder.add("ex:Person", FOAF.AGE, 42);
+
+		assertTrue(model.getNamespaces().contains(XSD.NS));
+	}
+
+	@Test
+	public void testNSNotAddedForDatatypeString() {
+		testBuilder.add("ex:Person", FOAF.NAME, "John Doe");
+
+		assertFalse(model.getNamespaces().contains(XSD.NS));
 	}
 }


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #2260 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- replace call to deprecated method
- don't add XSD namespace when the literal is of type xsd:string
- add tests

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

