### PR TITLE
GH-2732 cache skolem IRI + added test

### DIFF
--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParserTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParserTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Bart Hanssens
+ */
+public class AbstractRDFParserTest {
+	private MyRDFParser parser;
+
+	private class MyRDFParser extends AbstractRDFParser {
+		@Override
+		public RDFFormat getRDFFormat() {
+			throw new UnsupportedOperationException("Not supported yet.");
+		}
+
+		@Override
+		public void parse(InputStream in, String baseURI) throws IOException, RDFParseException, RDFHandlerException {
+			throw new UnsupportedOperationException("Not supported yet.");
+		}
+
+		@Override
+		public void parse(Reader reader, String baseURI) throws IOException, RDFParseException, RDFHandlerException {
+			throw new UnsupportedOperationException("Not supported yet.");
+		}
+
+		public Resource getBNode() {
+			return createNode();
+		}
+
+		public Resource getBNode(String id) {
+			return createNode(id);
+		}
+	};
+
+	@Before
+	public void setUp() throws Exception {
+		parser = new MyRDFParser();
+	}
+
+	@Test
+	public void testSkolemOrigin() throws Exception {
+		parser.getParserConfig().set(BasicParserSettings.SKOLEMIZE_ORIGIN, "http://www.example.com");
+
+		assertTrue(parser.getBNode().toString().startsWith("http://www.example.com"));
+		assertTrue(parser.getBNode("12").toString().startsWith("http://www.example.com"));
+	}
+
+	@Test
+	public void testSkolemOriginReset() throws Exception {
+		parser.getParserConfig().set(BasicParserSettings.SKOLEMIZE_ORIGIN, "http://www.example.com");
+		parser.getParserConfig().set(BasicParserSettings.SKOLEMIZE_ORIGIN, "");
+
+		assertFalse(parser.getBNode().toString().startsWith("http://www.example.com"));
+		assertTrue(parser.getBNode().toString().startsWith("_"));
+		assertTrue(parser.getBNode("12").toString().endsWith("12"));
+	}
+}

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -143,8 +143,8 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		// 12 supported in JSONLDParser + 12 from AbstractRDFParser
-		assertEquals(24, parser.getSupportedSettings().size());
+		// 13 supported in JSONLDParser + 12 from AbstractRDFParser
+		assertEquals(25, parser.getSupportedSettings().size());
 	}
 
 	@Test

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
@@ -637,7 +637,7 @@ public abstract class AbstractNQuadsParserUnitTest {
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		assertThat(parser.getSupportedSettings()).hasSize(13);
+		assertThat(parser.getSupportedSettings()).hasSize(14);
 	}
 
 	protected abstract RDFParser createRDFParser();

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -289,7 +289,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		assertEquals(13, createRDFParser().getSupportedSettings().size());
+		assertEquals(14, createRDFParser().getSupportedSettings().size());
 	}
 
 	@Test

--- a/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserCustomTest.java
+++ b/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserCustomTest.java
@@ -140,8 +140,8 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		// 17 supported in RDFJSONParser + 12 from AbstractRDFParser
-		assertEquals(29, parser.getSupportedSettings().size());
+		// 17 supported in RDFJSONParser + 13 from AbstractRDFParser
+		assertEquals(30, parser.getSupportedSettings().size());
 	}
 
 	@Test

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserCustomTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserCustomTest.java
@@ -214,7 +214,7 @@ public class RDFXMLParserCustomTest {
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		assertEquals(25, Rio.createParser(RDFFormat.RDFXML).getSupportedSettings().size());
+		assertEquals(26, Rio.createParser(RDFFormat.RDFXML).getSupportedSettings().size());
 	}
 
 	@Test

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
@@ -195,7 +195,7 @@ public class TriGParserCustomTest {
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		assertThat(Rio.createParser(RDFFormat.TRIG).getSupportedSettings()).hasSize(14);
+		assertThat(Rio.createParser(RDFFormat.TRIG).getSupportedSettings()).hasSize(15);
 	}
 
 	@Test

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
@@ -185,7 +185,7 @@ public class CustomTurtleParserTest {
 
 	@Test
 	public void testSupportedSettings() throws Exception {
-		assertThat(parser.getSupportedSettings()).hasSize(14);
+		assertThat(parser.getSupportedSettings()).hasSize(15);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #2732 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added skolemize_origin to the list of supported settings + increase number of supported settings in various tests
- check if skolemize_origin setting has been changed
    - if so, cache the parsediri (or null) in a local variable, instead of parsing the origin each and every time
- added test case
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

