### PR TITLE
GH-2737 move RDFa prefixes to Namespaces class + use them in Console

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Namespaces.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Namespaces.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,96 @@ import org.eclipse.rdf4j.model.impl.SimpleNamespace;
  * @author Peter Ansell
  */
 public class Namespaces {
+
+	/**
+	 * Set of RDFa 1.1 "initial context" namespaces
+	 *
+	 * @see http://www.w3.org/2011/rdfa-context/rdfa-1.1
+	 * @see http://www.w3.org/2013/json-ld-context/rdfa11
+	 */
+	public static final Set<Namespace> DEFAULT_RDFA11;
+
+	/**
+	 * RDFa initial namespaces + additional set of prefixes for RDF4J
+	 */
+	public static final Set<Namespace> DEFAULT_RDF4J;
+
+	static {
+		// RDFa initial context
+		Set<Namespace> aNamespaces = new HashSet<>();
+
+		// Vocabulary Prefixes of W3C Documents (Recommendations or Notes)
+		aNamespaces.add(new SimpleNamespace("as", "https://www.w3.org/ns/activitystreams#"));
+		aNamespaces.add(new SimpleNamespace("csvw", "http://www.w3.org/ns/csvw#"));
+		aNamespaces.add(new SimpleNamespace("dcat", "http://www.w3.org/ns/dcat#"));
+		aNamespaces.add(new SimpleNamespace("dqv", "http://www.w3.org/ns/dqv#"));
+		aNamespaces.add(new SimpleNamespace("duv", "https://www.w3.org/TR/vocab-duv#"));
+		aNamespaces.add(new SimpleNamespace("grddl", "http://www.w3.org/2003/g/data-view#"));
+		aNamespaces.add(new SimpleNamespace("jsonld", "http://www.w3.org/ns/json-ld#"));
+		aNamespaces.add(new SimpleNamespace("ldp", "http://www.w3.org/ns/ldp#"));
+		aNamespaces.add(new SimpleNamespace("ma", "http://www.w3.org/ns/ma-ont#"));
+		aNamespaces.add(new SimpleNamespace("oa", "http://www.w3.org/ns/oa#"));
+		aNamespaces.add(new SimpleNamespace("odrl", "http://www.w3.org/ns/odrl/2/"));
+		aNamespaces.add(new SimpleNamespace("org", "http://www.w3.org/ns/org#"));
+		aNamespaces.add(new SimpleNamespace("owl", "http://www.w3.org/2002/07/owl#"));
+		aNamespaces.add(new SimpleNamespace("prov", "http://www.w3.org/ns/prov#"));
+		aNamespaces.add(new SimpleNamespace("qb", "http://purl.org/linked-data/cube#"));
+		aNamespaces.add(new SimpleNamespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"));
+		aNamespaces.add(new SimpleNamespace("rdfa", "http://www.w3.org/ns/rdfa#"));
+		aNamespaces.add(new SimpleNamespace("rdfs", "http://www.w3.org/2000/01/rdf-schema#"));
+		aNamespaces.add(new SimpleNamespace("rif", "http://www.w3.org/2007/rif#"));
+		aNamespaces.add(new SimpleNamespace("rr", "http://www.w3.org/ns/r2rml#"));
+		aNamespaces.add(new SimpleNamespace("sd", "http://www.w3.org/ns/sparql-service-description#"));
+		aNamespaces.add(new SimpleNamespace("skos", "http://www.w3.org/2004/02/skos/core#"));
+		aNamespaces.add(new SimpleNamespace("skosxl", "http://www.w3.org/2008/05/skos-xl#"));
+		aNamespaces.add(new SimpleNamespace("ssn", "http://www.w3.org/ns/ssn/"));
+		aNamespaces.add(new SimpleNamespace("sosa", "http://www.w3.org/ns/sosa/"));
+		aNamespaces.add(new SimpleNamespace("time", "http://www.w3.org/2006/time#"));
+		aNamespaces.add(new SimpleNamespace("void", "http://rdfs.org/ns/void#"));
+		aNamespaces.add(new SimpleNamespace("wdr", "http://www.w3.org/2007/05/powder#"));
+		aNamespaces.add(new SimpleNamespace("wdrs", "http://www.w3.org/2007/05/powder-s#"));
+		aNamespaces.add(new SimpleNamespace("xhv", "http://www.w3.org/1999/xhtml/vocab#"));
+		aNamespaces.add(new SimpleNamespace("xml", "http://www.w3.org/XML/1998/namespace"));
+		aNamespaces.add(new SimpleNamespace("xsd", "http://www.w3.org/2001/XMLSchema#"));
+
+		// Some vocabularies are currently in development at W3C
+		aNamespaces.add(new SimpleNamespace("earl", "http://www.w3.org/ns/earl#"));
+
+		// Widely used Vocabulary prefixes based on the vocabulary usage on the Semantic Web
+		aNamespaces.add(new SimpleNamespace("cc", "http://creativecommons.org/ns#"));
+		aNamespaces.add(new SimpleNamespace("ctag", "http://commontag.org/ns#"));
+		aNamespaces.add(new SimpleNamespace("dc", "http://purl.org/dc/terms/"));
+		aNamespaces.add(new SimpleNamespace("dc11", "http://purl.org/dc/elements/1.1/"));
+		aNamespaces.add(new SimpleNamespace("dcterms", "http://purl.org/dc/terms/"));
+		aNamespaces.add(new SimpleNamespace("foaf", "http://xmlns.com/foaf/0.1/"));
+		aNamespaces.add(new SimpleNamespace("gr", "http://purl.org/goodrelations/v1#"));
+		aNamespaces.add(new SimpleNamespace("ical", "http://www.w3.org/2002/12/cal/icaltzd#"));
+		aNamespaces.add(new SimpleNamespace("og", "http://ogp.me/ns#"));
+		aNamespaces.add(new SimpleNamespace("rev", "http://purl.org/stuff/rev#"));
+		aNamespaces.add(new SimpleNamespace("sioc", "http://rdfs.org/sioc/ns#"));
+		aNamespaces.add(new SimpleNamespace("v", "http://rdf.data-vocabulary.org/#"));
+		aNamespaces.add(new SimpleNamespace("vcard", "http://www.w3.org/2006/vcard/ns#"));
+		aNamespaces.add(new SimpleNamespace("schema", "http://schema.org/"));
+
+		// Terms defined by W3C Documents
+		aNamespaces.add(new SimpleNamespace("describedby", "http://www.w3.org/2007/05/powder-s#describedby"));
+		aNamespaces.add(new SimpleNamespace("license", "http://www.w3.org/1999/xhtml/vocab#license"));
+		aNamespaces.add(new SimpleNamespace("role", "http://www.w3.org/1999/xhtml/vocab#role"));
+
+		DEFAULT_RDFA11 = Collections.unmodifiableSet(aNamespaces);
+
+		// Additional namespaces, used when this set was still part of BasicParserSettings
+		Set<Namespace> bNamespaces = new HashSet<>();
+
+		bNamespaces.addAll(aNamespaces);
+		bNamespaces.add(new SimpleNamespace("cat", "http://www.w3.org/ns/dcat#"));
+		bNamespaces.add(new SimpleNamespace("cnt", "http://www.w3.org/2008/content#"));
+		bNamespaces.add(new SimpleNamespace("gldp", "http://www.w3.org/ns/people#"));
+		bNamespaces.add(new SimpleNamespace("ht", "http://www.w3.org/2006/http#"));
+		bNamespaces.add(new SimpleNamespace("ptr", "http://www.w3.org/2009/pointers#"));
+
+		DEFAULT_RDF4J = Collections.unmodifiableSet(bNamespaces);
+	}
 
 	/**
 	 * Converts a set of {@link Namespace}s into a map containing the {@link Namespace#getPrefix()} strings as keys,

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -10,13 +10,12 @@ package org.eclipse.rdf4j.rio.helpers;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.Namespace;
-import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+import org.eclipse.rdf4j.model.util.Namespaces;
 import org.eclipse.rdf4j.rio.DatatypeHandler;
 import org.eclipse.rdf4j.rio.DatatypeHandlerRegistry;
 import org.eclipse.rdf4j.rio.LanguageHandler;
@@ -32,84 +31,6 @@ import org.slf4j.LoggerFactory;
  * @author Peter Ansell
  */
 public class BasicParserSettings {
-
-	/**
-	 * Vocabulary Prefixes of W3C Documents (Recommendations or Notes)
-	 *
-	 * @see http://www.w3.org/2011/rdfa-context/rdfa-1.1
-	 * @see http://www.w3.org/2013/json-ld-context/rdfa11
-	 */
-	private static final Set<Namespace> _DEFAULT_PREFIX;
-
-	static {
-		Set<Namespace> aNamespaces = new HashSet<>();
-
-		// Vocabulary Prefixes of W3C Documents (Recommendations or Notes)
-		aNamespaces.add(new SimpleNamespace("as", "https://www.w3.org/ns/activitystreams#"));
-		aNamespaces.add(new SimpleNamespace("csvw", "http://www.w3.org/ns/csvw#"));
-		aNamespaces.add(new SimpleNamespace("dcat", "http://www.w3.org/ns/dcat#"));
-		aNamespaces.add(new SimpleNamespace("dqv", "http://www.w3.org/ns/dqv#"));
-		aNamespaces.add(new SimpleNamespace("duv", "https://www.w3.org/TR/vocab-duv#"));
-		aNamespaces.add(new SimpleNamespace("grddl", "http://www.w3.org/2003/g/data-view#"));
-		aNamespaces.add(new SimpleNamespace("ldp", "http://www.w3.org/ns/ldp#"));
-		aNamespaces.add(new SimpleNamespace("ma", "http://www.w3.org/ns/ma-ont#"));
-		aNamespaces.add(new SimpleNamespace("oa", "http://www.w3.org/ns/oa#"));
-		aNamespaces.add(new SimpleNamespace("org", "http://www.w3.org/ns/org#"));
-		aNamespaces.add(new SimpleNamespace("owl", "http://www.w3.org/2002/07/owl#"));
-		aNamespaces.add(new SimpleNamespace("prov", "http://www.w3.org/ns/prov#"));
-		aNamespaces.add(new SimpleNamespace("qb", "http://purl.org/linked-data/cube#"));
-		aNamespaces.add(new SimpleNamespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#"));
-		aNamespaces.add(new SimpleNamespace("rdfa", "http://www.w3.org/ns/rdfa#"));
-		aNamespaces.add(new SimpleNamespace("rdfs", "http://www.w3.org/2000/01/rdf-schema#"));
-		aNamespaces.add(new SimpleNamespace("rif", "http://www.w3.org/2007/rif#"));
-		aNamespaces.add(new SimpleNamespace("rr", "http://www.w3.org/ns/r2rml#"));
-		aNamespaces.add(new SimpleNamespace("sd", "http://www.w3.org/ns/sparql-service-description#"));
-		aNamespaces.add(new SimpleNamespace("skos", "http://www.w3.org/2004/02/skos/core#"));
-		aNamespaces.add(new SimpleNamespace("skosxl", "http://www.w3.org/2008/05/skos-xl#"));
-		aNamespaces.add(new SimpleNamespace("ssn", "http://www.w3.org/ns/ssn/"));
-		aNamespaces.add(new SimpleNamespace("sosa", "http://www.w3.org/ns/sosa/"));
-		aNamespaces.add(new SimpleNamespace("time", "http://www.w3.org/2006/time#"));
-		aNamespaces.add(new SimpleNamespace("void", "http://rdfs.org/ns/void#"));
-		aNamespaces.add(new SimpleNamespace("wdr", "http://www.w3.org/2007/05/powder#"));
-		aNamespaces.add(new SimpleNamespace("wdrs", "http://www.w3.org/2007/05/powder-s#"));
-		aNamespaces.add(new SimpleNamespace("xhv", "http://www.w3.org/1999/xhtml/vocab#"));
-		aNamespaces.add(new SimpleNamespace("xml", "http://www.w3.org/XML/1998/namespace"));
-		aNamespaces.add(new SimpleNamespace("xsd", "http://www.w3.org/2001/XMLSchema#"));
-
-		// Some vocabularies are currently in development at W3C
-		aNamespaces.add(new SimpleNamespace("earl", "http://www.w3.org/ns/earl#"));
-		aNamespaces.add(new SimpleNamespace("odrl", "http://www.w3.org/ns/odrl/2/"));
-
-		// Widely used Vocabulary prefixes based on the vocabulary usage on the Semantic Web
-		aNamespaces.add(new SimpleNamespace("cc", "http://creativecommons.org/ns#"));
-		aNamespaces.add(new SimpleNamespace("ctag", "http://commontag.org/ns#"));
-		aNamespaces.add(new SimpleNamespace("dc", "http://purl.org/dc/terms/"));
-		aNamespaces.add(new SimpleNamespace("dc11", "http://purl.org/dc/elements/1.1/"));
-		aNamespaces.add(new SimpleNamespace("dcterms", "http://purl.org/dc/terms/"));
-		aNamespaces.add(new SimpleNamespace("foaf", "http://xmlns.com/foaf/0.1/"));
-		aNamespaces.add(new SimpleNamespace("gr", "http://purl.org/goodrelations/v1#"));
-		aNamespaces.add(new SimpleNamespace("ical", "http://www.w3.org/2002/12/cal/icaltzd#"));
-		aNamespaces.add(new SimpleNamespace("og", "http://ogp.me/ns#"));
-		aNamespaces.add(new SimpleNamespace("rev", "http://purl.org/stuff/rev#"));
-		aNamespaces.add(new SimpleNamespace("sioc", "http://rdfs.org/sioc/ns#"));
-		aNamespaces.add(new SimpleNamespace("v", "http://rdf.data-vocabulary.org/#"));
-		aNamespaces.add(new SimpleNamespace("vcard", "http://www.w3.org/2006/vcard/ns#"));
-		aNamespaces.add(new SimpleNamespace("schema", "http://schema.org/"));
-
-		// Terms defined by W3C Documents
-		aNamespaces.add(new SimpleNamespace("describedby", "http://www.w3.org/2007/05/powder-s#describedby"));
-		aNamespaces.add(new SimpleNamespace("license", "http://www.w3.org/1999/xhtml/vocab#license"));
-		aNamespaces.add(new SimpleNamespace("role", "http://www.w3.org/1999/xhtml/vocab#role"));
-
-		// JSON-LD Context
-		aNamespaces.add(new SimpleNamespace("cat", "http://www.w3.org/ns/dcat#"));
-		aNamespaces.add(new SimpleNamespace("cnt", "http://www.w3.org/2008/content#"));
-		aNamespaces.add(new SimpleNamespace("gldp", "http://www.w3.org/ns/people#"));
-		aNamespaces.add(new SimpleNamespace("ht", "http://www.w3.org/2006/http#"));
-		aNamespaces.add(new SimpleNamespace("ptr", "http://www.w3.org/2009/pointers#"));
-
-		_DEFAULT_PREFIX = Collections.unmodifiableSet(aNamespaces);
-	}
 
 	private final static Logger log = LoggerFactory.getLogger(BasicParserSettings.class);
 
@@ -286,11 +207,12 @@ public class BasicParserSettings {
 	 * Namespaces specified within the RDF document being parsed will override these defaults
 	 * </p>
 	 * <p>
-	 * Defaults to <a href="http://www.w3.org/2011/rdfa-context/rdfa-1.1">this list</a>.
+	 * Defaults to {@link Namespaces.DEFAULT_RDF4J} the RDFa 1.1 initial context + some additional prefixes.
 	 * </p>
 	 */
 	public static final RioSetting<Set<Namespace>> NAMESPACES = new RioSettingImpl<>(
-			"org.eclipse.rdf4j.rio.namespaces", "Collection of default namespaces to use for parsing", _DEFAULT_PREFIX);
+			"org.eclipse.rdf4j.rio.namespaces", "Collection of default namespaces to use for parsing",
+			Namespaces.DEFAULT_RDF4J);
 
 	/**
 	 * Boolean setting for parser to determine whether it should process RDF* triples encoded as RDF-compatible special

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettingsTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettingsTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+import org.eclipse.rdf4j.model.util.Namespaces;
+import org.junit.Test;
+
+public class BasicParserSettingsTest {
+	@Test
+	public void testAdditionalPrefixes() {
+		assertTrue("No additional prefixes", Namespaces.DEFAULT_RDF4J.size() > Namespaces.DEFAULT_RDFA11.size());
+	}
+
+	@Test
+	public void testImmutable() {
+		try {
+			Namespaces.DEFAULT_RDF4J.add(new SimpleNamespace("ex", "http://www.example.com"));
+			fail("Not immutable");
+		} catch (UnsupportedOperationException use) {
+			// ok
+		}
+	}
+}

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
@@ -13,22 +13,9 @@ import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+import org.eclipse.rdf4j.model.util.Namespaces;
 import org.eclipse.rdf4j.model.util.URIUtil;
-import org.eclipse.rdf4j.model.vocabulary.DCAT;
-import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
-import org.eclipse.rdf4j.model.vocabulary.FOAF;
-import org.eclipse.rdf4j.model.vocabulary.ODRL2;
-import org.eclipse.rdf4j.model.vocabulary.ORG;
-import org.eclipse.rdf4j.model.vocabulary.OWL;
-import org.eclipse.rdf4j.model.vocabulary.PROV;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.ROV;
-import org.eclipse.rdf4j.model.vocabulary.SKOS;
-import org.eclipse.rdf4j.model.vocabulary.TIME;
-import org.eclipse.rdf4j.model.vocabulary.VCARD4;
-import org.eclipse.rdf4j.model.vocabulary.VOID;
-import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
  * Namespace prefix setting
@@ -38,24 +25,10 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
 public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 	public final static String NAME = "prefixes";
 
-	public final static Set<Namespace> DEFAULT = new HashSet<>();
+	public final static Set<Namespace> DEFAULT = new HashSet<>(Namespaces.DEFAULT_RDFA11);
 
 	static {
-		DEFAULT.add(DCAT.NS);
-		DEFAULT.add(DCTERMS.NS);
-		DEFAULT.add(FOAF.NS);
-		DEFAULT.add(ODRL2.NS);
-		DEFAULT.add(ORG.NS);
-		DEFAULT.add(OWL.NS);
-		DEFAULT.add(PROV.NS);
-		DEFAULT.add(RDF.NS);
-		DEFAULT.add(RDFS.NS);
 		DEFAULT.add(ROV.NS);
-		DEFAULT.add(SKOS.NS);
-		DEFAULT.add(TIME.NS);
-		DEFAULT.add(VCARD4.NS);
-		DEFAULT.add(VOID.NS);
-		DEFAULT.add(XSD.NS);
 	}
 
 	@Override


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #2737 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- Correction for documentation: default list is actually RDFa 1.1 initial context + a few others
- Moved the list from rio.helpers.BasicParserSettings to model.util.Namespaces
- Made this initial context public, so it can be reused
- Reuse it in Console

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

