### PR TITLE
GH-2727 simplified path expression processing and fixed nested inverse optional handling

### DIFF
--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParseBenchmark.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParseBenchmark.java
@@ -68,4 +68,21 @@ public class SPARQLParseBenchmark {
 
 	}
 
+	@Benchmark
+	public int complexPathExpressionQuery() {
+		int temp = 0;
+		for (int i = 0; i < 1000; i++) {
+			String sparqlQuery = "select * where { ?a (<foo:comment>/^(<foo:subClassOf>|(<foo:type>/<foo:label>))/<foo:type>)* ?b }";
+
+			SPARQLParser parser = new SPARQLParser();
+
+			ParsedQuery q = parser.parseQuery(sparqlQuery, null);
+
+			temp += q.hashCode();
+		}
+
+		return temp;
+
+	}
+
 }

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -84,37 +84,34 @@ public class QueryPlanRetrievalTest {
 			Query query = connection.prepareTupleQuery(TUPLE_QUERY);
 
 			String actual = query.explain(Explanation.Level.Unoptimized).toString();
-
-			String expected = "Projection\n" +
-					"╠══ProjectionElemList\n" +
-					"║     ProjectionElem \"a\"\n" +
-					"╚══Filter\n" +
-					"   ├──Compare (!=)\n" +
-					"   │     Var (name=c)\n" +
-					"   │     Var (name=d)\n" +
-					"   └──LeftJoin\n" +
-					"      ╠══Join\n" +
-					"      ║  ├──Join\n" +
-					"      ║  │  ╠══LeftJoin (new scope)\n" +
-					"      ║  │  ║  ├──SingletonSet\n" +
-					"      ║  │  ║  └──StatementPattern\n" +
-					"      ║  │  ║        Var (name=d)\n" +
-					"      ║  │  ║        Var (name=e)\n" +
-					"      ║  │  ║        Var (name=f)\n" +
-					"      ║  │  ╚══StatementPattern\n" +
-					"      ║  │        Var (name=a)\n" +
-					"      ║  │        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
-					+
-					"      ║  │        Var (name=c)\n" +
-					"      ║  └──StatementPattern\n" +
-					"      ║        Var (name=a)\n" +
-					"      ║        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
-					+
-					"      ║        Var (name=d)\n" +
-					"      ╚══StatementPattern\n" +
-					"            Var (name=d)\n" +
-					"            Var (name=e)\n" +
-					"            Var (name=f)\n";
+			String expected = "Projection\n"
+					+ "╠══ProjectionElemList\n"
+					+ "║     ProjectionElem \"a\"\n"
+					+ "╚══Filter\n"
+					+ "   ├──Compare (!=)\n"
+					+ "   │     Var (name=c)\n"
+					+ "   │     Var (name=d)\n"
+					+ "   └──LeftJoin\n"
+					+ "      ╠══Join\n"
+					+ "      ║  ├──LeftJoin (new scope)\n"
+					+ "      ║  │  ╠══SingletonSet\n"
+					+ "      ║  │  ╚══StatementPattern\n"
+					+ "      ║  │        Var (name=d)\n"
+					+ "      ║  │        Var (name=e)\n"
+					+ "      ║  │        Var (name=f)\n"
+					+ "      ║  └──Join\n"
+					+ "      ║     ╠══StatementPattern\n"
+					+ "      ║     ║     Var (name=a)\n"
+					+ "      ║     ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+ "      ║     ║     Var (name=c)\n"
+					+ "      ║     ╚══StatementPattern\n"
+					+ "      ║           Var (name=a)\n"
+					+ "      ║           Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+ "      ║           Var (name=d)\n"
+					+ "      ╚══StatementPattern\n"
+					+ "            Var (name=d)\n"
+					+ "            Var (name=e)\n"
+					+ "            Var (name=f)\n";
 
 			Assert.assertEquals(expected, actual);
 
@@ -536,48 +533,46 @@ public class QueryPlanRetrievalTest {
 			Query query = connection.prepareTupleQuery(SUB_QUERY);
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
-			String expected = "Projection (resultSizeActual=4)\n" +
-					"╠══ProjectionElemList\n" +
-					"║     ProjectionElem \"a\"\n" +
-					"╚══Join (HashJoinIteration) (resultSizeActual=4)\n" +
-					"   ├──Projection (new scope) (resultSizeActual=4)\n" +
-					"   │  ╠══ProjectionElemList\n" +
-					"   │  ║     ProjectionElem \"a\"\n" +
-					"   │  ╚══StatementPattern (resultSizeActual=4)\n" +
-					"   │        Var (name=a)\n" +
-					"   │        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
-					+
-					"   │        Var (name=type)\n" +
-					"   └──Projection (new scope) (resultSizeActual=2)\n" +
-					"      ╠══ProjectionElemList\n" +
-					"      ║     ProjectionElem \"a\"\n" +
-					"      ╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
-					"         ├──Join (JoinIterator) (resultSizeActual=2)\n" +
-					"         │  ╠══Filter (resultSizeActual=44)\n" +
-					"         │  ║  ├──Compare (!=)\n" +
-					"         │  ║  │     Var (name=c)\n" +
-					"         │  ║  │     Var (name=d)\n" +
-					"         │  ║  └──Join (JoinIterator) (resultSizeActual=48)\n" +
-					"         │  ║     ╠══LeftJoin (new scope) (LeftJoinIterator) (resultSizeActual=12)\n" +
-					"         │  ║     ║  ├──SingletonSet (resultSizeActual=1)\n" +
-					"         │  ║     ║  └──StatementPattern (resultSizeActual=12)\n" +
-					"         │  ║     ║        Var (name=d)\n" +
-					"         │  ║     ║        Var (name=e)\n" +
-					"         │  ║     ║        Var (name=f)\n" +
-					"         │  ║     ╚══StatementPattern (resultSizeActual=48)\n" +
-					"         │  ║           Var (name=a)\n" +
-					"         │  ║           Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
-					+
-					"         │  ║           Var (name=c)\n" +
-					"         │  ╚══StatementPattern (resultSizeActual=2)\n" +
-					"         │        Var (name=a)\n" +
-					"         │        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
-					+
-					"         │        Var (name=d)\n" +
-					"         └──StatementPattern (resultSizeActual=2)\n" +
-					"               Var (name=d)\n" +
-					"               Var (name=e)\n" +
-					"               Var (name=f)\n";
+			String expected = "Projection (resultSizeActual=4)\n"
+					+ "╠══ProjectionElemList\n"
+					+ "║     ProjectionElem \"a\"\n"
+					+ "╚══Join (HashJoinIteration) (resultSizeActual=4)\n"
+					+ "   ├──Projection (new scope) (resultSizeActual=4)\n"
+					+ "   │  ╠══ProjectionElemList\n"
+					+ "   │  ║     ProjectionElem \"a\"\n"
+					+ "   │  ╚══StatementPattern (resultSizeActual=4)\n"
+					+ "   │        Var (name=a)\n"
+					+ "   │        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+ "   │        Var (name=type)\n"
+					+ "   └──Projection (new scope) (resultSizeActual=2)\n"
+					+ "      ╠══ProjectionElemList\n"
+					+ "      ║     ProjectionElem \"a\"\n"
+					+ "      ╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n"
+					+ "         ├──Join (JoinIterator) (resultSizeActual=2)\n"
+					+ "         │  ╠══LeftJoin (new scope) (LeftJoinIterator) (resultSizeActual=12)\n"
+					+ "         │  ║  ├──SingletonSet (resultSizeActual=1)\n"
+					+ "         │  ║  └──StatementPattern (resultSizeActual=12)\n"
+					+ "         │  ║        Var (name=d)\n"
+					+ "         │  ║        Var (name=e)\n"
+					+ "         │  ║        Var (name=f)\n"
+					+ "         │  ╚══Filter (resultSizeActual=2)\n"
+					+ "         │     ├──Compare (!=)\n"
+					+ "         │     │     Var (name=c)\n"
+					+ "         │     │     Var (name=d)\n"
+					+ "         │     └──Join (JoinIterator) (resultSizeActual=6)\n"
+					+ "         │        ╠══StatementPattern (resultSizeActual=48)\n"
+					+ "         │        ║     Var (name=a)\n"
+					+ "         │        ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+ "         │        ║     Var (name=c)\n"
+					+ "         │        ╚══StatementPattern (resultSizeActual=6)\n"
+					+ "         │              Var (name=a)\n"
+					+ "         │              Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+ "         │              Var (name=d)\n"
+					+ "         └──StatementPattern (resultSizeActual=2)\n"
+					+ "               Var (name=d)\n"
+					+ "               Var (name=e)\n"
+					+ "               Var (name=f)\n";
+
 			Assert.assertEquals(expected, actual);
 
 		}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
@@ -66,6 +66,8 @@ public class QueryBenchmark {
 	private static final String query2;
 	private static final String query3;
 	private static final String query4;
+	private static final String query7_pathexpression1;
+	private static final String query8_pathexpression2;
 
 	static {
 		try {
@@ -73,6 +75,10 @@ public class QueryBenchmark {
 			query2 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query2.qr"), StandardCharsets.UTF_8);
 			query3 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query3.qr"), StandardCharsets.UTF_8);
 			query4 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query4.qr"), StandardCharsets.UTF_8);
+			query7_pathexpression1 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query7-pathexpression1.qr"),
+					StandardCharsets.UTF_8);
+			query8_pathexpression2 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query8-pathexpression2.qr"),
+					StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
@@ -82,7 +88,7 @@ public class QueryBenchmark {
 
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
-				.include("QueryBenchmark.groupByQuery") // adapt to run other benchmark tests
+				.include("QueryBenchmark") // adapt to run other benchmark tests
 				// .addProfiler("stack", "lines=20;period=1;top=20")
 				.forks(1)
 				.build();
@@ -189,6 +195,25 @@ public class QueryBenchmark {
 		}
 		return hasStatement();
 
+	}
+
+	@Benchmark
+	public List<BindingSet> pathExpressionQuery1() {
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query7_pathexpression1)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public List<BindingSet> pathExpressionQuery2() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return Iterations.asList(connection
+					.prepareTupleQuery(query8_pathexpression2)
+					.evaluate());
+		}
 	}
 
 	private boolean hasStatement() {

--- a/core/sail/memory/src/test/resources/benchmarkFiles/query7-pathexpression1.qr
+++ b/core/sail/memory/src/test/resources/benchmarkFiles/query7-pathexpression1.qr
@@ -1,0 +1,13 @@
+prefix dcat: <http://www.w3.org/ns/dcat#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix vcard: <http://www.w3.org/2006/vcard/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT * 
+WHERE {
+    ?catalog dcat:dataset/(dct:identifier|dct:title) ?idOrTitle .
+}

--- a/core/sail/memory/src/test/resources/benchmarkFiles/query8-pathexpression2.qr
+++ b/core/sail/memory/src/test/resources/benchmarkFiles/query8-pathexpression2.qr
@@ -1,0 +1,13 @@
+prefix dcat: <http://www.w3.org/ns/dcat#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix vcard: <http://www.w3.org/2006/vcard/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT * 
+WHERE {
+   ?dataset ^dcat:dataset/dcat:themeTaxonomy <http://publications.europa.eu/resource/authority/data-theme> .
+ }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -2025,6 +2025,32 @@ public abstract class ComplexSPARQLQueryTest {
 	}
 
 	@Test
+	/**
+	 * @see https://github.com/eclipse/rdf4j/issues/2727
+	 */
+	public void testNestedInversePropertyPathWithZeroLength() throws Exception {
+		String insert = "insert data {\n"
+				+ "    <urn:1> <urn:prop> <urn:object> .\n"
+				+ "    <urn:2> <urn:prop> <urn:mid:1> .\n"
+				+ "    <urn:mid:1> <urn:prop> <urn:object> .\n"
+				+ "    <urn:3> <urn:prop> <urn:mid:2> .\n"
+				+ "    <urn:mid:2> <urn:prop> <urn:mid:3> .\n"
+				+ "    <urn:mid:3> <urn:prop> <urn:object> .\n"
+				+ "}";
+
+		String query = "select * where { \n"
+				+ "    <urn:object> (^<urn:prop>)? ?o .\n"
+				+ "}";
+
+		conn.prepareUpdate(insert).execute();
+
+		TupleQuery tq = conn.prepareTupleQuery(query);
+
+		List<BindingSet> result = QueryResults.asList(tq.evaluate());
+		assertThat(result).hasSize(4);
+	}
+
+	@Test
 	public void testSES2147PropertyPathsWithIdenticalSubsPreds() throws Exception {
 
 		StringBuilder data = new StringBuilder();


### PR DESCRIPTION
GitHub issue resolved: #2727  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- refactor of property path processing to a cleaner tree-visitor approach instead of a massive if-else. 
- simplified path modifier processing code (old code was still written for {min,max} syntax which is no longer supported)
- added regression test for GH-2727

To explain the main ideas behind the refactor:

A SPARQL path expression is parsed into an AST tree structure. Each path expression is a PathAlternative, consisting of one more PathSequences. Each PathSequence, in turn, consists of one or more PathElements. PathElements have optional modifiers (?, + and *), and can be either negated or inverted (or both). Note that a PathElement itself can be a nested path expression again.

In the previous code, the entire path expression processing was handled in a single visitor method, the `visit(PathSequence)`.  It kept internal state, manually inspected its child elements (instead of letting the visitor pattern handle it), and was generally a mess of if-else conditions and special-case handling. What it also did was manipulate the global GraphPattern field directly, instead of just returning the produced TupleExpr. 

The refactor splits this out, so that processing logic is more local to the specific element: path sequences deal with introducing intermediate variables, keeping the context of what the "current" start and end variables of the sequence are. The details of processing each element of the path are now in `visit(PathElt)`. This checks if the element is nested (and if so defers back to the visitor to handle the nested expression), or negated, or inverse. It also handles all path modifiers. 

The handling of path modifiers has also been significantly changed. Previously it had convoluted logic that dealt with building up a tree of Unions to handle things like "at least 2, at most 5". This was introduced when SPARQL was still in draft and had this `{min, max}` syntax for path expressions. I removed this because the logic was hard to follow, essentially unused, and produced buggy behavior in several cases. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

