### PR TITLE
GH-2756 ShaclSail + RDFS + NativeStore sometimes deadlocks

### DIFF
--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerConnection.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerConnection.java
@@ -754,8 +754,10 @@ public class SchemaCachingRDFSInferencerConnection extends InferencerConnectionW
 
 		super.rollback();
 
-		sail.clearInferenceTables();
-		regenerateCacheAndInferenceMaps(false);
+		if (statementsAdded || statementsRemoved || schemaChange) {
+			sail.clearInferenceTables();
+			regenerateCacheAndInferenceMaps(false);
+		}
 
 		statementsRemoved = false;
 		statementsAdded = false;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -748,7 +748,7 @@ public class ShaclSail extends NotifyingSailWrapper {
 	public boolean isSerializableValidation() {
 		if (getBaseSail() instanceof SchemaCachingRDFSInferencer) {
 			if (serializableValidation) {
-				logger.error("SchemaCachingRDFSInferencer is not supported when using serializable validation!");
+				logger.warn("SchemaCachingRDFSInferencer is not supported when using serializable validation!");
 			}
 			return false;
 		}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -666,7 +666,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 				shapesModifiedInCurrentTransaction = true;
 				shapesAfterRefresh = sail.getShapes(shapesRepoConnection);
 			} else {
-				shapesAfterRefresh = null;
+				shapesAfterRefresh = shapesBeforeRefresh;
 			}
 
 			stats.setEmpty(isEmpty());

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -733,8 +733,10 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 			preparedHasRun = true;
 
+			shapesRepoConnection.prepare();
 			previousStateConnection.prepare();
 			super.prepare();
+
 		}
 
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -57,8 +57,6 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 	private static final Logger logger = LoggerFactory.getLogger(ShaclSailConnection.class);
 
-	private List<Shape> shapes;
-
 	private final SailConnection previousStateConnection;
 	private final SailConnection serializableConnection;
 	private final SailConnection previousStateSerializableConnection;
@@ -175,8 +173,6 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		}
 
 		stats.setBaseSailEmpty(isEmpty());
-
-		this.shapes = sail.getShapes(shapesRepoConnection);
 
 		if (this.transactionSettings
 				.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Disabled ||
@@ -658,7 +654,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 				}
 			}
 
-			List<Shape> shapesBeforeRefresh = this.shapes;
+			List<Shape> shapesBeforeRefresh = sail.getCurrentShapes();
 			List<Shape> shapesAfterRefresh;
 
 			if (isShapeRefreshNeeded) {
@@ -854,7 +850,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		}
 
 		prepareValidation();
-		ValidationReport validate = validate(this.shapes, true);
+		ValidationReport validate = validate(sail.getCurrentShapes(), true);
 
 		return new ShaclSailValidationException(validate).getValidationReport();
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationReport.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationReport.java
@@ -58,6 +58,8 @@ public class ValidationReport {
 		model.add(getId(), RDF.TYPE, SHACL.VALIDATION_REPORT);
 		model.add(getId(), RDF4J.TRUNCATED, BooleanLiteral.valueOf(truncated));
 
+		model.setNamespace(SHACL.NS);
+
 		HashSet<Resource> rdfListDedupe = new HashSet<>();
 
 		for (ValidationResult result : validationResult) {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/DeadlockTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/DeadlockTest.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl;
 
 import java.io.File;

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/MultithreadedMemoryStoreTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/MultithreadedMemoryStoreTest.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/MultithreadedNativeStoreRDFSTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/MultithreadedNativeStoreRDFSTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -15,12 +15,12 @@ import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
+import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencer;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 
-public class MultithreadedNativeStoreTest extends MultithreadedTest {
+public class MultithreadedNativeStoreRDFSTest extends MultithreadedTest {
 
 	File file;
 
@@ -36,18 +36,18 @@ public class MultithreadedNativeStoreTest extends MultithreadedTest {
 	@Before
 	public void before() {
 		file = Files.newTemporaryFolder();
-		System.out.println("Max memory: " + Runtime.getRuntime().maxMemory() / 1024 / 1024 + " MB");
 	}
 
 	@Override
 	NotifyingSail getBaseSail() {
 		NativeStore nativeStore = new NativeStore(file);
-		try (NotifyingSailConnection connection = nativeStore.getConnection()) {
+		SchemaCachingRDFSInferencer schemaCachingRDFSInferencer = new SchemaCachingRDFSInferencer(nativeStore);
+		try (NotifyingSailConnection connection = schemaCachingRDFSInferencer.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
 			connection.clear();
 			connection.commit();
 		}
-		return nativeStore;
+		return schemaCachingRDFSInferencer;
 	}
 
 }

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ReduceNumberOfPlansTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ReduceNumberOfPlansTest.java
@@ -42,7 +42,7 @@ public class ReduceNumberOfPlansTest {
 			refreshAddedRemovedStatements(connection);
 			try (ConnectionsGroup connectionsGroup = connection.getConnectionsGroup()) {
 
-				List<PlanNode> collect = shaclSail.getShapes()
+				List<PlanNode> collect = shaclSail.getCurrentShapes()
 						.stream()
 						.map(shape -> shape.generatePlans(connectionsGroup, false, false))
 						.filter(s -> !(s instanceof EmptyNode))
@@ -55,7 +55,7 @@ public class ReduceNumberOfPlansTest {
 			refreshAddedRemovedStatements(connection);
 			try (ConnectionsGroup connectionsGroup = connection.getConnectionsGroup()) {
 
-				List<PlanNode> collect2 = shaclSail.getShapes()
+				List<PlanNode> collect2 = shaclSail.getCurrentShapes()
 						.stream()
 						.map(shape -> shape.generatePlans(connectionsGroup, false, false))
 						.filter(s -> !(s instanceof EmptyNode))
@@ -100,7 +100,7 @@ public class ReduceNumberOfPlansTest {
 			refreshAddedRemovedStatements(connection);
 			try (ConnectionsGroup connectionsGroup = connection.getConnectionsGroup()) {
 
-				List<PlanNode> collect1 = shaclSail.getShapes()
+				List<PlanNode> collect1 = shaclSail.getCurrentShapes()
 						.stream()
 						.map(shape -> shape.generatePlans(connectionsGroup, false, false))
 						.filter(s -> !(s instanceof EmptyNode))
@@ -114,7 +114,7 @@ public class ReduceNumberOfPlansTest {
 			refreshAddedRemovedStatements(connection);
 			try (ConnectionsGroup connectionsGroup = connection.getConnectionsGroup()) {
 
-				List<PlanNode> collect2 = shaclSail.getShapes()
+				List<PlanNode> collect2 = shaclSail.getCurrentShapes()
 						.stream()
 						.map(shape -> shape.generatePlans(connectionsGroup, false, false))
 						.filter(s -> !(s instanceof EmptyNode))
@@ -126,7 +126,7 @@ public class ReduceNumberOfPlansTest {
 			refreshAddedRemovedStatements(connection);
 			try (ConnectionsGroup connectionsGroup = connection.getConnectionsGroup()) {
 
-				List<PlanNode> collect3 = shaclSail.getShapes()
+				List<PlanNode> collect3 = shaclSail.getCurrentShapes()
 						.stream()
 						.map(shape -> shape.generatePlans(connectionsGroup, false, false))
 						.filter(s -> !(s instanceof EmptyNode))

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionalIsolationTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionalIsolationTest.java
@@ -689,127 +689,131 @@ public class TransactionalIsolationTest {
 			SailRepository sailRepository = new SailRepository(shaclSail);
 			sailRepository.init();
 
-			CountDownLatch countDownLatch = new CountDownLatch(2);
+			try {
 
-			Runnable t1 = () -> {
+				CountDownLatch countDownLatch = new CountDownLatch(2);
+
+				Runnable t1 = () -> {
+
+					try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+						connection.begin(IsolationLevels.SNAPSHOT);
+						for (int k = 0; k < 1000; k++) {
+							addInTransaction(connection, "ex:steve" + k + " a ex:Person .");
+
+						}
+
+						countDownLatch.countDown();
+						try {
+							countDownLatch.await();
+						} catch (InterruptedException e) {
+							throw new IllegalStateException();
+						}
+
+						try {
+							connection.commit();
+						} catch (Throwable ignored) {
+						}
+
+					}
+
+				};
+
+				Thread thread1 = new Thread(t1);
+
+				thread1.start();
+
+				Runnable t2 = () -> {
+					try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+						connection.begin(IsolationLevels.SNAPSHOT);
+						StringReader shaclRules = new StringReader(String.join("\n", "",
+								"@prefix ex: <http://example.com/ns#> .",
+								"@prefix sh: <http://www.w3.org/ns/shacl#> .",
+								"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
+								"@prefix foaf: <http://xmlns.com/foaf/0.1/>.",
+
+								"ex:PersonShape",
+								"        a sh:NodeShape  ;",
+								"        sh:targetClass ex:Person ;",
+								"        sh:property [",
+								"                sh:path ex:age ;",
+								"                sh:minCount 1 ;",
+								"        ] ;" +
+										"        sh:property [",
+								"                sh:path ex:age ;",
+								"                sh:minCount 1 ;",
+								"        ] ;" +
+										"        sh:property [",
+								"                sh:path ex:age ;",
+								"                sh:minCount 1 ;",
+								"        ] ;" +
+										"        sh:property [",
+								"                sh:path ex:age ;",
+								"                sh:minCount 1 ;",
+								"        ] ;" +
+										"        sh:property [",
+								"                sh:path ex:age ;",
+								"                sh:minCount 1 ;",
+								"        ] ;" +
+										"        sh:property [",
+								"                sh:path ex:age ;",
+								"                sh:minCount 1 ;",
+								"        ] ;" +
+										"        sh:property [",
+								"                sh:path ex:age ;",
+								"                sh:minCount 1 ;",
+								"        ] ;" +
+										" ."));
+
+						try {
+							connection.add(shaclRules, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+						} catch (IOException e) {
+							throw new IllegalStateException();
+						}
+
+						countDownLatch.countDown();
+						try {
+							countDownLatch.await();
+						} catch (InterruptedException e) {
+							throw new IllegalStateException();
+						}
+
+						try {
+							connection.commit();
+						} catch (Throwable ignored) {
+						}
+					}
+
+				};
+
+				Thread thread2 = new Thread(t2);
+
+				thread2.start();
+
+				thread1.join();
+				thread2.join();
 
 				try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+					connection.begin();
+					ValidationReport validationReport = ((ShaclSailConnection) connection.getSailConnection())
+							.revalidate();
 
-					connection.begin(IsolationLevels.SNAPSHOT);
-					for (int k = 0; k < 1000; k++) {
-						addInTransaction(connection, "ex:steve" + k + " a ex:Person .");
-
+					if (!validationReport.conforms()) {
+						Model statements = validationReport.asModel();
+						WriterConfig writerConfig = new WriterConfig();
+						writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
+						writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
+						Rio.write(statements, System.out, RDFFormat.TURTLE, writerConfig);
 					}
 
-					countDownLatch.countDown();
-					try {
-						countDownLatch.await();
-					} catch (InterruptedException e) {
-						throw new IllegalStateException();
-					}
+					assertTrue(validationReport.conforms());
 
-					try {
-						connection.commit();
-					} catch (Throwable ignored) {
-					}
-
+					connection.commit();
 				}
-
-			};
-
-			Thread thread1 = new Thread(t1);
-
-			thread1.start();
-
-			Runnable t2 = () -> {
-				try (SailRepositoryConnection connection = sailRepository.getConnection()) {
-
-					connection.begin(IsolationLevels.SNAPSHOT);
-					StringReader shaclRules = new StringReader(String.join("\n", "",
-							"@prefix ex: <http://example.com/ns#> .",
-							"@prefix sh: <http://www.w3.org/ns/shacl#> .",
-							"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
-							"@prefix foaf: <http://xmlns.com/foaf/0.1/>.",
-
-							"ex:PersonShape",
-							"        a sh:NodeShape  ;",
-							"        sh:targetClass ex:Person ;",
-							"        sh:property [",
-							"                sh:path ex:age ;",
-							"                sh:minCount 1 ;",
-							"        ] ;" +
-									"        sh:property [",
-							"                sh:path ex:age ;",
-							"                sh:minCount 1 ;",
-							"        ] ;" +
-									"        sh:property [",
-							"                sh:path ex:age ;",
-							"                sh:minCount 1 ;",
-							"        ] ;" +
-									"        sh:property [",
-							"                sh:path ex:age ;",
-							"                sh:minCount 1 ;",
-							"        ] ;" +
-									"        sh:property [",
-							"                sh:path ex:age ;",
-							"                sh:minCount 1 ;",
-							"        ] ;" +
-									"        sh:property [",
-							"                sh:path ex:age ;",
-							"                sh:minCount 1 ;",
-							"        ] ;" +
-									"        sh:property [",
-							"                sh:path ex:age ;",
-							"                sh:minCount 1 ;",
-							"        ] ;" +
-									" ."));
-
-					try {
-						connection.add(shaclRules, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
-					} catch (IOException e) {
-						throw new IllegalStateException();
-					}
-
-					countDownLatch.countDown();
-					try {
-						countDownLatch.await();
-					} catch (InterruptedException e) {
-						throw new IllegalStateException();
-					}
-
-					try {
-						connection.commit();
-					} catch (Throwable ignored) {
-					}
-				}
-
-			};
-
-			Thread thread2 = new Thread(t2);
-
-			thread2.start();
-
-			thread1.join();
-			thread2.join();
-
-			try (SailRepositoryConnection connection = sailRepository.getConnection()) {
-				connection.begin();
-				ValidationReport validationReport = ((ShaclSailConnection) connection.getSailConnection()).revalidate();
-
-				if (!validationReport.conforms()) {
-					Model statements = validationReport.asModel();
-					WriterConfig writerConfig = new WriterConfig();
-					writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
-					writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
-					Rio.write(statements, System.out, RDFFormat.TURTLE, writerConfig);
-				}
-
-				assertTrue(validationReport.conforms());
-
-				connection.commit();
+			} finally {
+				sailRepository.shutDown();
 			}
-
-			sailRepository.shutDown();
 
 		}
 	}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ShaclLoadingBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ShaclLoadingBenchmark.java
@@ -928,47 +928,47 @@ public class ShaclLoadingBenchmark {
 					"                          # sh:severity   sh:Violation",
 					"                  ] ."));
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules1, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules2, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules3, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules4, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules5, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules6, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules7, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules8, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules9, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules10, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 
-			connection.begin();
+			connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);
 			connection.add(shaclRules11, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			connection.commit();
 		}


### PR DESCRIPTION
GitHub issue resolved: #2756 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - Remove shapes cache in ShaclSail
 - Clean up locking now that we don't have to keep a cache in sync
 - Disable serializable validation (with SNAPSHOT isolation) when used with the RDFS reasoner (since this causes deadlocks)

The shapes cache was initially created back when parsing shapes was slow. Since then we have tremendously improved the performance of parsing shapes so removing the cache causes very marginal performance impacts, but it obviously depends on the number of shapes. 

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

