### PR TITLE
GH-2760: fixes Literals.getXsdDatatype() to work also with custom Literal implementations

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -73,7 +73,7 @@ public class Literals {
 		if (l instanceof SimpleLiteral) {
 			return ((SimpleLiteral) l).getXsdDatatype();
 		}
-		return Optional.empty();
+		return XSD.Datatype.from(l.getDatatype());
 	}
 
 	/**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -30,7 +30,7 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
  *
  * @author Arjohn Kampman
  * @author Peter Ansell
- * 
+ *
  * @See {@link Values}
  */
 public class Literals {
@@ -73,7 +73,7 @@ public class Literals {
 		if (l instanceof SimpleLiteral) {
 			return ((SimpleLiteral) l).getXsdDatatype();
 		}
-		return XSD.Datatype.from(l.getDatatype());
+		return Optional.empty();
 	}
 
 	/**

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtil.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtil.java
@@ -158,8 +158,8 @@ public class QueryEvaluationUtil {
 		boolean leftLangLit = Literals.isLanguageLiteral(leftLit);
 		boolean rightLangLit = Literals.isLanguageLiteral(rightLit);
 
-		// for purposes of query evaluation in SPARQL, simple literals and
-		// string-typed literals with the same lexical value are considered equal.
+		// for purposes of query evaluation in SPARQL, simple literals and string-typed literals with the same lexical
+		// value are considered equal.
 		IRI commonDatatype = null;
 		if (QueryEvaluationUtil.isSimpleLiteral(leftLit) && QueryEvaluationUtil.isSimpleLiteral(rightLit)) {
 			commonDatatype = XSD.STRING;
@@ -191,14 +191,12 @@ public class QueryEvaluationUtil {
 				} else if (!strict && leftXsdDatatype.isDurationDatatype() && rightXsdDatatype.isDurationDatatype()) {
 					commonDatatype = XSD.DURATION;
 				}
-			} else if (commonDatatype == null && (leftXsdDatatype != null || rightXsdDatatype != null)) {
+			} else if (commonDatatype == null && (leftXsdDatatype == null || rightXsdDatatype == null)) {
 				if (leftDatatype.equals(rightDatatype)) {
 					commonDatatype = leftDatatype;
 				} else if (XMLDatatypeUtil.isNumericDatatype(leftDatatype)
 						&& XMLDatatypeUtil.isNumericDatatype(rightDatatype)) {
-					// left and right arguments have different datatypes, try to find
-					// a
-					// more general, shared datatype
+					// left and right arguments have different datatypes, try to find a more general, shared datatype
 					if (leftDatatype.equals(XSD.DOUBLE) || rightDatatype.equals(XSD.DOUBLE)) {
 						commonDatatype = XSD.DOUBLE;
 					} else if (leftDatatype.equals(XSD.FLOAT) || rightDatatype.equals(XSD.FLOAT)) {
@@ -238,9 +236,8 @@ public class QueryEvaluationUtil {
 
 						compareResult = left.compare(right);
 
-						// Note: XMLGregorianCalendar.compare() returns compatible
-						// values
-						// (-1, 0, 1) but INDETERMINATE needs special treatment
+						// Note: XMLGregorianCalendar.compare() returns compatible values (-1, 0, 1) but INDETERMINATE
+						// needs special treatment
 						if (compareResult == DatatypeConstants.INDETERMINATE) {
 							// If we compare two xsd:dateTime we should use the specific comparison specified in SPARQL
 							// 1.1
@@ -266,8 +263,7 @@ public class QueryEvaluationUtil {
 						compareResult = leftLit.getLabel().compareTo(rightLit.getLabel());
 					}
 				} catch (IllegalArgumentException e) {
-					// One of the basic-type method calls failed, try syntactic match
-					// before throwing an error
+					// One of the basic-type method calls failed, try syntactic match before throwing an error
 					if (leftLit.equals(rightLit)) {
 						switch (operator) {
 						case EQ:
@@ -311,11 +307,9 @@ public class QueryEvaluationUtil {
 			if (!literalsEqual) {
 				if (!leftLangLit && !rightLangLit && isSupportedDatatype(leftDatatype)
 						&& isSupportedDatatype(rightDatatype)) {
-					// left and right arguments have incompatible but supported
-					// datatypes
+					// left and right arguments have incompatible but supported datatypes
 
-					// we need to check that the lexical-to-value mapping for both
-					// datatypes succeeds
+					// we need to check that the lexical-to-value mapping for both datatypes succeeds
 					if (!XMLDatatypeUtil.isValidValue(leftLit.getLabel(), leftDatatype)) {
 						throw new ValueExprEvaluationException("not a valid datatype value: " + leftLit);
 					}
@@ -363,8 +357,7 @@ public class QueryEvaluationUtil {
 								"Unable to compare date types with other supported types");
 					}
 				} else if (!leftLangLit && !rightLangLit) {
-					// For literals with unsupported datatypes we don't know if their
-					// values are equal
+					// For literals with unsupported datatypes we don't know if their values are equal
 					throw new ValueExprEvaluationException("Unable to compare literals with unsupported types");
 				}
 			}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
@@ -543,6 +543,21 @@ public class QueryEvaluationUtilTest {
 		}
 	}
 
+	/**
+	 * Reporoduces GH-2760: an NPE has been thrown when comparing custom literal implementations
+	 */
+	@Test
+	public void testCompareWithOnlyCustomLiterals() {
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+		Literal left = getCustomLiteral(vf.createLiteral(1));
+
+		Literal right = getCustomLiteral(vf.createLiteral(6));
+		// GH-2760: should not throw an NPE, simply try all avaliable comparator operators
+		for (CompareOp op : Compare.CompareOp.values()) {
+			QueryEvaluationUtil.compareLiterals(left, right, op, true);
+		}
+	}
+
 	private Literal getCustomLiteral(Literal nested) {
 		Literal right = new Literal() {
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
@@ -472,7 +472,9 @@ public class QueryEvaluationUtilTest {
 		// GH-2760: should not throw an NPE, simply try all avaliable comparator operators
 		for (CompareOp op : Compare.CompareOp.values()) {
 			QueryEvaluationUtil.compareLiterals(left, right, op, true);
+			QueryEvaluationUtil.compareLiterals(right, left, op, true);
 		}
+
 	}
 
 	/**
@@ -491,6 +493,11 @@ public class QueryEvaluationUtilTest {
 			} catch (ValueExprEvaluationException e) {
 				assertEquals("Unable to compare strings with other supported types", e.getMessage());
 			}
+			try {
+				QueryEvaluationUtil.compareLiterals(right, left, op, true);
+			} catch (ValueExprEvaluationException e) {
+				assertEquals("Unable to compare strings with other supported types", e.getMessage());
+			}
 		}
 	}
 
@@ -506,6 +513,32 @@ public class QueryEvaluationUtilTest {
 				QueryEvaluationUtil.compareLiterals(left, right, op, true);
 			} catch (ValueExprEvaluationException e) {
 				assertEquals("Indeterminate result for date/time comparison", e.getMessage());
+			}
+			try {
+				QueryEvaluationUtil.compareLiterals(right, left, op, true);
+			} catch (ValueExprEvaluationException e) {
+				assertEquals("Indeterminate result for date/time comparison", e.getMessage());
+			}
+		}
+	}
+
+	@Test
+	public void testCompareCustomDatatypes() {
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+		Literal left = vf.createLiteral(1);
+
+		Literal right = vf.createLiteral("I", vf.createIRI("http://example.org/romanNumeral"));
+		// GH-2760: should not throw an NPE, simply try all avaliable comparator operators
+		for (CompareOp op : Compare.CompareOp.values()) {
+			try {
+				QueryEvaluationUtil.compareLiterals(left, right, op, true);
+			} catch (ValueExprEvaluationException e) {
+				assertEquals("Unable to compare literals with unsupported types", e.getMessage());
+			}
+			try {
+				QueryEvaluationUtil.compareLiterals(right, left, op, true);
+			} catch (ValueExprEvaluationException e) {
+				assertEquals("Unable to compare literals with unsupported types", e.getMessage());
 			}
 		}
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
@@ -14,10 +14,18 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Optional;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.query.algebra.Compare;
 import org.eclipse.rdf4j.query.algebra.Compare.CompareOp;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.junit.Before;
@@ -451,4 +459,89 @@ public class QueryEvaluationUtilTest {
 				QueryEvaluationUtil.compareLiterals(lit1, lit2, op, strict));
 	}
 
+	/**
+	 * Reporoduces GH-2760: an NPE has been thrown when comparing custom literal implementations
+	 */
+	@Test
+	public void testCompareWithCustomLiterals() {
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+		Literal left = vf.createLiteral((int) 5);
+		Literal right = new Literal() {
+			Literal nested = vf.createLiteral((int) 6);
+
+			@Override
+			public String stringValue() {
+				return nested.stringValue();
+			}
+
+			@Override
+			public short shortValue() {
+				return nested.shortValue();
+			}
+
+			@Override
+			public long longValue() {
+				return nested.longValue();
+			}
+
+			@Override
+			public BigInteger integerValue() {
+				return nested.integerValue();
+			}
+
+			@Override
+			public int intValue() {
+				return nested.intValue();
+			}
+
+			@Override
+			public Optional<String> getLanguage() {
+				return nested.getLanguage();
+			}
+
+			@Override
+			public String getLabel() {
+				return nested.getLabel();
+			}
+
+			@Override
+			public IRI getDatatype() {
+				return nested.getDatatype();
+			}
+
+			@Override
+			public float floatValue() {
+				return nested.floatValue();
+			}
+
+			@Override
+			public double doubleValue() {
+				return nested.doubleValue();
+			}
+
+			@Override
+			public BigDecimal decimalValue() {
+				return nested.decimalValue();
+			}
+
+			@Override
+			public XMLGregorianCalendar calendarValue() {
+				return nested.calendarValue();
+			}
+
+			@Override
+			public byte byteValue() {
+				return nested.byteValue();
+			}
+
+			@Override
+			public boolean booleanValue() {
+				return nested.booleanValue();
+			}
+		};
+		// GH-2760: should not throw an NPE, simply try all avaliable comparator operators
+		for (CompareOp op : Compare.CompareOp.values()) {
+			QueryEvaluationUtil.compareLiterals(left, right, op, true);
+		}
+	}
 }


### PR DESCRIPTION
 Added test reproducing GH-2760 - an NPE in QueryEvaluationUtil.compareLiterals()

Signed-off-by: damyan.ognyanov <damyan.ognyanov@ontotext.com>


GitHub issue resolved: #2760 

Briefly describe the changes proposed in this PR:

Literals.getXsdDatatype() used to return Optional.empty() which the argument was not an instance of `SimpleLiteral` that cause the `QueryEvaluationUtil.compareLiterals()` to hit NPE while at least one of its arguments was not an instance of `SimpleLiteral`

Added also a test case reproducing #2760

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

