### PR TITLE
GH-2789 added factory methods for language-tagged literals

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
@@ -25,6 +25,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.ValidatingValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
@@ -204,6 +205,36 @@ public class Values {
 	 */
 	public static Literal literal(ValueFactory vf, String lexicalValue) {
 		return vf.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"));
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied lexical value.
+	 * 
+	 * @param lexicalValue the lexical value for the literal
+	 * @param languageTag  the language tag for the literal.
+	 * 
+	 * @return a new {@link Literal} of type {@link RDF#LANGSTRING}
+	 * 
+	 * @throws NullPointerException if the supplied lexical value or language tag is <code>null</code>.
+	 */
+	public static Literal literal(String lexicalValue, String languageTag) {
+		return literal(VALUE_FACTORY, lexicalValue, languageTag);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied lexical value.
+	 *
+	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param lexicalValue the lexical value for the literal
+	 * @param languageTag  the language tag for the literal.
+	 * 
+	 * @return a new {@link Literal} of type {@link RDF#LANGSTRING}
+	 * 
+	 * @throws NullPointerException if any of the input parameters is <code>null</code>
+	 */
+	public static Literal literal(ValueFactory vf, String lexicalValue, String languageTag) {
+		return vf.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"),
+				Objects.requireNonNull(languageTag, "languageTag may not be null"));
 	}
 
 	/**

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
@@ -176,6 +176,43 @@ public class ValuesTest {
 	}
 
 	@Test
+	public void testLanguageTaggedLiteral() {
+		String lexValue = "a literal";
+		String languageTag = "en";
+		Literal literal = literal(lexValue, languageTag);
+
+		assertThat(literal.getLabel()).isEqualTo(lexValue);
+		assertThat(literal.getLanguage()).isNotEmpty().contains(languageTag);
+		assertThat(literal.getDatatype()).isEqualTo(RDF.LANGSTRING);
+	}
+
+	@Test
+	public void testLanguageTaggedLiteral_InjectedValueFactory() {
+		String lexValue = "a literal";
+		String languageTag = "en";
+		literal(vf, lexValue, languageTag);
+		verify(vf).createLiteral(lexValue, languageTag);
+	}
+
+	@Test
+	public void testLanguageTaggedLiteralNull1() {
+		String lexicalValue = null;
+		String languageTag = "en";
+		assertThatThrownBy(() -> literal(lexicalValue, languageTag))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("lexicalValue may not be null");
+	}
+
+	@Test
+	public void testLanguageTaggedLiteralNull2() {
+		String lexicalValue = "a literal";
+		String languageTag = null;
+		assertThatThrownBy(() -> literal(lexicalValue, languageTag))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("languageTag may not be null");
+	}
+
+	@Test
 	public void testValidTypedLiteral() {
 		String lexValue = "42";
 		Literal literal = literal(lexValue, XSD.INT);
@@ -209,7 +246,8 @@ public class ValuesTest {
 	@Test
 	public void testTypedLiteralNull2() {
 		String lexValue = "42";
-		assertThatThrownBy(() -> literal(lexValue, null))
+		IRI datatype = null;
+		assertThatThrownBy(() -> literal(lexValue, datatype))
 				.isInstanceOf(NullPointerException.class)
 				.hasMessageContaining("datatype may not be null");
 	}
@@ -573,4 +611,5 @@ public class ValuesTest {
 		assertThat(l).isNotNull();
 		assertThat(l.getDatatype()).isEqualTo(XSD.STRING);
 	}
+
 }


### PR DESCRIPTION
GitHub issue resolved: #2789  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added missing factory methods for creation of language-tagged literals
- added unit tests

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

