### PR TITLE
GH-2782 javadoc and rename for SPARQLCOnnection#setSilentClear

### DIFF
--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.repository.sparql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -151,9 +152,9 @@ public class SPARQLConnectionTest {
 	}
 
 	@Test
-	public void testSilentModeSparqlConnection() throws Exception {
-		subject.enableSilentMode(true);
-		assertThat(subject.isSilentMode() == true);
+	public void testSilentClear() throws Exception {
+		subject.setSilentClear(true);
+		assertThat(subject.isSilentClear());
 
 		ArgumentCaptor<String> sparqlUpdateCaptor = ArgumentCaptor.forClass(String.class);
 		subject.begin();
@@ -164,5 +165,21 @@ public class SPARQLConnectionTest {
 
 		String sparqlUpdate = sparqlUpdateCaptor.getValue();
 		assertThat(sparqlUpdate).containsOnlyOnce("CLEAR SILENT");
+	}
+
+	@Test
+	public void testSilentClear_NamedGraph() throws Exception {
+		subject.setSilentClear(true);
+		assertThat(subject.isSilentClear());
+
+		ArgumentCaptor<String> sparqlUpdateCaptor = ArgumentCaptor.forClass(String.class);
+		subject.begin();
+		subject.clear(iri("http://example.org/"));
+		subject.commit();
+
+		verify(client).sendUpdate(any(), sparqlUpdateCaptor.capture(), any(), any(), anyBoolean(), anyInt(), any());
+
+		String sparqlUpdate = sparqlUpdateCaptor.getValue();
+		assertThat(sparqlUpdate).containsOnlyOnce("CLEAR SILENT GRAPH <http://example.org/>");
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #2782  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- renamed `enableSilentMode` to `setSilentClear` to make role and scope more obvious
- added javadoc documentation and an additional test

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

