### PR TITLE
GH-2784 scripts for release, release-notes and news item

### DIFF
--- a/scripts/milestone-release.sh
+++ b/scripts/milestone-release.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+
+cd ..
+
+echo ""
+echo "The release script requires several external command line tools:"
+echo " - git"
+echo " - mvn"
+echo " - gh (the GitHub CLI, see https://github.com/cli/cli)"
+echo " - xmlllint (http://xmlsoft.org/xmllint.html)"
+
+echo ""
+echo "This script will stop if an unhandled error occurs";
+echo "Do not change any files in this directory while the script is running!"
+set -e -o pipefail
+
+
+read -rp "Start the release process (y/n)?" choice
+case "${choice}" in
+  y|Y ) echo "";;
+  n|N ) exit;;
+  * ) echo "unknown response, exiting"; exit;;
+esac
+
+# verify required tools are installed
+if ! command -v git &> /dev/null; then
+    echo "";
+    echo "git command not found!";
+    echo "";
+    exit 1;
+fi
+
+if ! command -v mvn &> /dev/null; then
+    echo "";
+    echo "mvn command not found!";
+    echo  "See https://maven.apache.org/";
+    echo "";
+    exit 1;
+fi
+
+if ! command -v gh &> /dev/null; then
+    echo "";
+    echo "gh command not found!";
+    echo  "See https://github.com/cli/cli";
+    echo "";
+    exit 1;
+fi
+
+if ! command -v xmllint &> /dev/null; then
+    echo "";
+    echo "xmllint command not found!";
+    echo "See http://xmlsoft.org/xmllint.html"
+    echo "";
+    exit 1;
+fi
+
+# check Java version
+if  !  mvn -v | grep -q "Java version: 1.8."; then
+  echo "";
+  echo "You need to use Java 8!";
+  echo "mvn -v";
+  echo "";
+  exit 1;
+fi
+
+
+# check that we are on master
+if  ! git status --porcelain --branch | grep -q "## master...origin/master"; then
+  if  ! git status --porcelain --branch | grep -q "## develop...origin/develop"; then
+    echo""
+    echo "You need to be on master or develop!";
+    echo "";
+    exit 1;
+  fi
+fi
+
+echo "Running git pull to make sure we are up to date"
+git pull
+
+# check that we are not ahead or behind
+if  ! git status --porcelain --branch | grep -q "## master...origin/master"; then
+  if  ! git status --porcelain --branch | grep -q "## develop...origin/develop"; then
+    echo""
+    echo "There is something wrong with your git. It seems you are not up to date with master. Run git status";
+    echo "";
+    exit 1;
+  fi
+fi
+
+# check that there are no uncomitted or untracked files
+if  ! [[ $(git status --porcelain) == "" ]]; then
+    echo "";
+    echo "There are uncomitted or untracked files! Commit, delete or unstage files. Run git status for more info.";
+    exit 1;
+fi
+
+# check that we have push access
+if ! git push --dry-run > /dev/null 2>&1; then
+    echo "";
+    echo "Could not push to the repository! Check that you have sufficient access rights.";
+    echo "";
+    exit 1;
+fi
+
+ORIGINAL_BRANCH=""
+if  git status --porcelain --branch | grep -q "## master...origin/master"; then
+  ORIGINAL_BRANCH="master";
+fi
+if  git status --porcelain --branch | grep -q "## develop...origin/develop"; then
+  ORIGINAL_BRANCH="develop";
+fi
+
+echo "Running mvn clean";
+mvn clean;
+
+MVN_CURRENT_SNAPSHOT_VERSION=$(xmllint --xpath "//*[local-name()='project']/*[local-name()='version']/text()" pom.xml)
+
+echo "";
+echo "Your current maven snapshot version is: '${MVN_CURRENT_SNAPSHOT_VERSION}'"
+echo ""
+echo "What is the version you would like to release?"
+read -rp "Version: " MVN_VERSION_RELEASE
+echo ""
+echo "Your maven release version will be: '${MVN_VERSION_RELEASE}'"
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+
+# set maven version
+mvn versions:set -DnewVersion="${MVN_VERSION_RELEASE}"
+
+# set the MVN_VERSION_RELEASE version again just to be on the safe side
+MVN_VERSION_RELEASE=$(xmllint --xpath "//*[local-name()='project']/*[local-name()='version']/text()" pom.xml)
+
+# find out a way to test that we set the correct version!
+
+#Remove backup files. Finally, commit the version number changes:
+mvn versions:commit
+mvn -P compliance versions:commit
+
+
+BRANCH="releases/${MVN_VERSION_RELEASE}"
+
+# delete old release branch if it exits
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  git branch --delete --force "${BRANCH}" &>/dev/null
+fi
+
+# checkout branch for release, commit this maven version and tag commit
+git checkout -b "${BRANCH}"
+git commit -s -a -m "release ${MVN_VERSION_RELEASE}"
+git tag "${MVN_VERSION_RELEASE}"
+
+echo "";
+echo "Pushing release branch to github"
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+
+# push release branch and tag
+git push -u origin "${BRANCH}"
+git push origin "${MVN_VERSION_RELEASE}"
+
+echo "";
+echo "You need to tell Jenkins to start the release deployment processes, for SDK and maven artifacts"
+echo "- SDK deployment: https://ci.eclipse.org/rdf4j/job/rdf4j-deploy-release-sdk/ "
+echo "- Maven deployment: https://ci.eclipse.org/rdf4j/job/rdf4j-deploy-release-ossrh/ "
+echo "(if you are on linux or windows, remember to use CTRL+SHIFT+C to copy)."
+echo "Log in, then choose 'Build with Parameters' and type in ${MVN_VERSION_RELEASE}"
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+
+mvn clean
+
+
+echo "Build javadocs"
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+
+git checkout "${MVN_VERSION_RELEASE}"
+mvn clean install -DskipTests -Djapicmp.skip
+mvn package -Passembly,!formatting -Djapicmp.skip -DskipTests --batch-mode
+
+git checkout "${ORIGINAL_BRANCH}"
+RELEASE_NOTES_BRANCH="${MVN_VERSION_RELEASE}-release-notes"
+git checkout -b "${RELEASE_NOTES_BRANCH}"
+
+tar -cvzf "site/static/javadoc/${MVN_VERSION_RELEASE}.tgz" target/site/apidocs
+
+git commit -s -a -m "javadocs for ${MVN_VERSION_RELEASE}"
+git push --set-upstream origin "${RELEASE_NOTES_BRANCH}"
+gh pr create -B develop --title "${RELEASE_NOTES_BRANCH}" --body "Javadocs, release-notes and news item for ${MVN_VERSION_RELEASE}"
+
+git checkout "${ORIGINAL_BRANCH}"
+mvn clean
+
+
+cd scripts
+
+
+
+echo "DONE!"
+
+
+
+echo ""
+echo "You will now want to inform the community about the new milestone build!"
+echo " - Check if all recently completed issues have the correct milestone: https://github.com/eclipse/rdf4j/projects/19"
+echo " - For issues closed in the current milestone, those issues need to be tagged with the RDF4J milestone number"
+
+echo ""
+echo "To generate the news item and release-notes you will want to run the following command:"
+echo "./release-notes.sh ${MVN_VERSION_RELEASE} empty.md milestone-news-item.md ${RELEASE_NOTES_BRANCH}"

--- a/scripts/milestone-release.sh
+++ b/scripts/milestone-release.sh
@@ -64,7 +64,7 @@ if  !  mvn -v | grep -q "Java version: 1.8."; then
 fi
 
 
-# check that we are on master
+# check that we are on master or develop
 if  ! git status --porcelain --branch | grep -q "## master...origin/master"; then
   if  ! git status --porcelain --branch | grep -q "## develop...origin/develop"; then
     echo""
@@ -185,22 +185,21 @@ git commit -s -a -m "javadocs for ${MVN_VERSION_RELEASE}"
 git push --set-upstream origin "${RELEASE_NOTES_BRANCH}"
 gh pr create -B develop --title "${RELEASE_NOTES_BRANCH}" --body "Javadocs, release-notes and news item for ${MVN_VERSION_RELEASE}"
 
+echo "Javadocs are in git branch ${RELEASE_NOTES_BRANCH}"
+
 git checkout "${ORIGINAL_BRANCH}"
 mvn clean
 
-
 cd scripts
 
-
-
+echo ""
 echo "DONE!"
-
-
 
 echo ""
 echo "You will now want to inform the community about the new milestone build!"
 echo " - Check if all recently completed issues have the correct milestone: https://github.com/eclipse/rdf4j/projects/19"
-echo " - For issues closed in the current milestone, those issues need to be tagged with the RDF4J milestone number"
+echo " - For issues closed in the current milestone, those issues need to be tagged with the RDF4J milestone number (use Github labels M1, M2 or M3)"
+echo "Remember that milestone builds are not releases!"
 
 echo ""
 echo "To generate the news item and release-notes you will want to run the following command:"

--- a/scripts/patch-release.sh
+++ b/scripts/patch-release.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+cd ..
 
 increment_version() {
  local v=$1
@@ -7,10 +8,10 @@ increment_version() {
     local rgx='^((?:[0-9]+\.)*)([0-9]+)($)'
  else
     local rgx='^((?:[0-9]+\.){'$(($2-1))'})([0-9]+)(\.|$)'
-    for (( p=`grep -o "\."<<<".$v"|wc -l`; p<$2; p++)); do
+    for (( p=$(grep -o "\."<<<".$v"|wc -l); p<$2; p++)); do
        v+=.0; done; fi
- val=`echo -e "$v" | perl -pe 's/^.*'$rgx'.*$/$2/'`
- echo "$v" | perl -pe s/$rgx.*$'/${1}'`printf %0${#val}s $(($val+1))`/
+ val=$(echo -e "$v" | perl -pe 's/^.*'$rgx'.*$/$2/')
+ echo "$v" | perl -pe s/$rgx.*$'/${1}'$(printf %0${#val}s $(($val+1)))/
 }
 
 echo ""
@@ -26,7 +27,7 @@ echo "Do not change any files in this directory while the script is running!"
 set -e -o pipefail
 
 
-read -p "Start the release process (y/n)?" choice
+read -rp "Start the release process (y/n)?" choice
 case "${choice}" in
   y|Y ) echo "";;
   n|N ) exit;;
@@ -95,7 +96,7 @@ if  ! [[ $(git status --porcelain -u no  --branch) == "## master...origin/master
 fi
 
 # check that there are no uncomitted or untracked files
-if  ! [[ `git status --porcelain` == "" ]]; then
+if  ! [[ $(git status --porcelain) == "" ]]; then
     echo "";
     echo "There are uncomitted or untracked files! Commit, delete or unstage files. Run git status for more info.";
     exit 1;
@@ -117,16 +118,16 @@ MVN_CURRENT_SNAPSHOT_VERSION=$(xmllint --xpath "//*[local-name()='project']/*[lo
 # replace "SNAPSHOT" with ""
 MVN_VERSION_RELEASE="${MVN_CURRENT_SNAPSHOT_VERSION/-SNAPSHOT/}"
 
-MVN_NEXT_SNAPSHOT_VERSION="$(increment_version $MVN_VERSION_RELEASE 3)-SNAPSHOT"
+MVN_NEXT_SNAPSHOT_VERSION="$(increment_version "$MVN_VERSION_RELEASE" 3)-SNAPSHOT"
 
 echo "";
-echo "Your current maven snapshot version is: ${MVN_CURRENT_SNAPSHOT_VERSION}"
-echo "Your maven release version will be: ${MVN_VERSION_RELEASE}"
-echo "Your next maven snapshot version will be: ${MVN_NEXT_SNAPSHOT_VERSION}"
-read -n 1 -s -r -p "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+echo "Your current maven snapshot version is: '${MVN_CURRENT_SNAPSHOT_VERSION}'"
+echo "Your maven release version will be: '${MVN_VERSION_RELEASE}'"
+echo "Your next maven snapshot version will be: '${MVN_NEXT_SNAPSHOT_VERSION}'"
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 # set maven version
-mvn versions:set -DnewVersion=${MVN_VERSION_RELEASE}
+mvn versions:set -DnewVersion="${MVN_VERSION_RELEASE}"
 
 # set the MVN_VERSION_RELEASE version again just to be on the safe side
 MVN_VERSION_RELEASE=$(xmllint --xpath "//*[local-name()='project']/*[local-name()='version']/text()" pom.xml)
@@ -146,16 +147,16 @@ if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
 fi
 
 # checkout branch for release, commit this maven version and tag commit
-git checkout -b ${BRANCH}
+git checkout -b "${BRANCH}"
 git commit -s -a -m "release ${MVN_VERSION_RELEASE}"
 git tag "${MVN_VERSION_RELEASE}"
 
 echo "";
 echo "Pushing release branch to github"
-read -n 1 -s -r -p "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 # push release branch and tag
-git push -u origin ${BRANCH}
+git push -u origin "${BRANCH}"
 git push origin "${MVN_VERSION_RELEASE}"
 
 echo "";
@@ -164,7 +165,7 @@ echo "- SDK deployment: https://ci.eclipse.org/rdf4j/job/rdf4j-deploy-release-sd
 echo "- Maven deployment: https://ci.eclipse.org/rdf4j/job/rdf4j-deploy-release-ossrh/ "
 echo "(if you are on linux or windows, remember to use CTRL+SHIFT+C to copy)."
 echo "Log in, then choose 'Build with Parameters' and type in ${MVN_VERSION_RELEASE}"
-read -n 1 -s -r -p "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 # Cleanup
 mvn clean
@@ -172,11 +173,11 @@ mvn clean
 # Set a new SNAPSHOT version
 echo "";
 echo "Setting the next snapshot version to: ${MVN_NEXT_SNAPSHOT_VERSION}"
-read -n 1 -s -r -p "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 
 # set maven version
-mvn versions:set -DnewVersion=${MVN_NEXT_SNAPSHOT_VERSION}
+mvn versions:set -DnewVersion="${MVN_NEXT_SNAPSHOT_VERSION}"
 
 #Remove backup files. Finally, commit the version number changes:
 mvn versions:commit
@@ -190,7 +191,7 @@ git push
 
 echo "";
 echo "About to create PR"
-read -n 1 -s -r -p "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 echo "";
 
 echo "Creating pull request to merge release branch back into master"
@@ -198,7 +199,7 @@ gh pr create --title "next development iteration: ${MVN_NEXT_SNAPSHOT_VERSION}" 
 
 echo "";
 echo "Preparing a merge-branch to merge into develop"
-read -n 1 -s -r -p "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 
 git checkout develop
@@ -206,10 +207,10 @@ git pull
 
 MVN_VERSION_DEVELOP=$(xmllint --xpath "//*[local-name()='project']/*[local-name()='version']/text()" pom.xml)
 
-git checkout ${BRANCH}
+git checkout "${BRANCH}"
 
 git checkout -b "merge_master_into_develop_after_release_${MVN_VERSION_RELEASE}"
-mvn versions:set -DnewVersion=${MVN_VERSION_DEVELOP}
+mvn versions:set -DnewVersion="${MVN_VERSION_DEVELOP}"
 mvn versions:commit
 mvn -P compliance versions:commit
 git commit -s -a -m "set correct version"
@@ -218,28 +219,43 @@ git push --set-upstream origin "merge_master_into_develop_after_release_${MVN_VE
 echo "Creating pull request to merge the merge-branch into develop"
 gh pr create -B develop --title "sync develop branch after release ${MVN_VERSION_RELEASE}" --body "Merge using merge commit rather than rebase"
 echo "It's ok to merge this PR later, so wait for the Jenkins tests to finish."
-read -n 1 -s -r -p "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
 
 git checkout master
+mvn clean
+
+echo "Build javadocs"
+read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+
+git checkout "${MVN_VERSION_RELEASE}"
+mvn clean install -DskipTests -Djapicmp.skip
+mvn package -Passembly,!formatting -Djapicmp.skip -DskipTests --batch-mode
+
+git checkout master
+RELEASE_NOTES_BRANCH="${MVN_VERSION_RELEASE}-release-notes"
+git checkout -b "${RELEASE_NOTES_BRANCH}"
+
+tar -cvzf "site/static/javadoc/${MVN_VERSION_RELEASE}.tgz" target/site/apidocs
+git commit -s -a -m "javadocs for ${MVN_VERSION_RELEASE}"
+git push --set-upstream origin "${RELEASE_NOTES_BRANCH}"
+gh pr create -B develop --title "${RELEASE_NOTES_BRANCH}" --body "Javadocs, release-notes and news item for ${MVN_VERSION_RELEASE}"
+
+git checkout master
+mvn clean
+
+cd scripts
 
 echo "DONE!"
 
-# the news file on github should be 302 if the release is 3.0.2, so replace "." twice
-NEWS_FILE_NAME=$MVN_VERSION_RELEASE
-NEWS_FILE_NAME=${NEWS_FILE_NAME/./}
-NEWS_FILE_NAME=${NEWS_FILE_NAME/./}
+
 
 echo ""
 echo "You will now want to inform the community about the new release!"
 echo " - Check if all recently completed issues have the correct milestone: https://github.com/eclipse/rdf4j/projects/19"
+echo " - Create a new milestone for ${MVN_NEXT_SNAPSHOT_VERSION/-SNAPSHOT/} : https://github.com/eclipse/rdf4j/milestones/new"
 echo " - Close the ${MVN_VERSION_RELEASE} milestone: https://github.com/eclipse/rdf4j/milestones"
 echo "     - Make sure that all issues in the milestone are closed, or move them to the next milestone"
-echo " - Create a new milestone for ${MVN_NEXT_SNAPSHOT_VERSION/-SNAPSHOT/} : https://github.com/eclipse/rdf4j/milestones/new"
-echo "     - Go to the milestone, click the 'closed' tab and copy the link for later"
-echo " - Go to https://github.com/eclipse/rdf4j/tree/master/site/content/release-notes and create ${MVN_VERSION_RELEASE}.md"
-echo " - Edit the following file https://github.com/eclipse/rdf4j/blob/master/site/content/download.md"
-echo " - Go to https://github.com/eclipse/rdf4j/tree/master/site/content/news and create rdf4j-${NEWS_FILE_NAME}.md"
-echo " - Go to https://github.com/eclipse/rdf4j/releases/new and create a release for the ${MVN_VERSION_RELEASE} tag. Add a link to the release notes in the description."
-echo " - Upload the javadocs by adding a compressed tar.gz archive called ${MVN_VERSION_RELEASE}.tgz to site/static/javadoc/"
-echo "     - Aggregated javadoc can be found in target/site/apidocs or in the SDK zip file"
-echo "     - Make sure to also replace the site/static/javadoc/latest file with a copy. Do not use a symlink."
+
+echo ""
+echo "To generate the news item and release-notes you will want to run the following command:"
+echo "./release-notes.sh ${MVN_VERSION_RELEASE} patch-release-notes.md milestone-news-item.md ${RELEASE_NOTES_BRANCH}"

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+MVN_VERSION_RELEASE_RAW=$1
+RELEASE_NOTES_TEMPLATE=$2
+NEWS_ITEM_TEMPLATE=$3
+BRANCH=$4
+
+# We handle both "1.2.3" and "1.2.3-M1"
+IFS='-' read -ra MVN_VERSION_RELEASE_ARRAY <<< "${MVN_VERSION_RELEASE_RAW}"
+
+export MVN_VERSION_RELEASE=${MVN_VERSION_RELEASE_ARRAY[0]}
+
+IFS='M' read -ra M_ARRAY <<< "${MVN_VERSION_RELEASE_ARRAY[1]}"
+
+# $M is the milestone build number, eg. 4 in 1.2.3-M4
+export M=${M_ARRAY[1]}
+
+if ! [[ ${BRANCH} == "" ]]; then
+  git checkout "${BRANCH}"
+  git pull
+fi
+
+echo ""
+echo "The script requires several external command line tools:"
+echo " - git"
+echo " - mvn"
+echo " - gh (the GitHub CLI, see https://github.com/cli/cli)"
+echo " - jq (https://stedolan.github.io/jq/)"
+
+echo ""
+echo "This script will stop if an unhandled error occurs";
+echo "Do not change any files in this directory while the script is running!"
+echo ""
+set -e -o pipefail
+
+if [ ! -f templates/"${RELEASE_NOTES_TEMPLATE}" ]; then
+    echo "File not found!"
+    echo "templates/${RELEASE_NOTES_TEMPLATE}"
+    exit 1;
+fi
+
+
+if [ ! -f templates/"${NEWS_ITEM_TEMPLATE}" ]; then
+    echo "File not found!"
+    echo "templates/${NEWS_ITEM_TEMPLATE}"
+    exit 1;
+fi
+
+# All builds except milestone builds need to have their milestones closed on Github before we continue.
+if [[ ${M} == "" ]]; then
+
+  echo "Please make sure that you have cleaned up and closed the milestone connected to ${MVN_VERSION_RELEASE}";
+  read -n 1 -srp "Press any key to continue (ctrl+c to cancel)"; printf "\n\n";
+
+  SHOULD_BE_NULL_IF_MILESTONE_IS_CLOSED=$(curl  -s -H "Accept: application/vnd.github.v3+json"  https://api.github.com/repos/eclipse/rdf4j/milestones?state=open | jq '.[] | select(.title == "'"${MVN_VERSION_RELEASE}"'") | .number')
+  echo "${SHOULD_BE_NULL_IF_MILESTONE_IS_CLOSED}"
+  if  ! [[ ${SHOULD_BE_NULL_IF_MILESTONE_IS_CLOSED} == "" ]]; then
+      echo "";
+      echo "Milestone not closed!";
+      echo "https://github.com/eclipse/rdf4j/milestone/${SHOULD_BE_NULL_IF_MILESTONE_IS_CLOSED}";
+      exit 1;
+  fi
+
+fi
+
+echo "Version: ${MVN_VERSION_RELEASE}";
+
+
+# first try to get the GITHUB_MILESTONE number from the closed milestones
+export GITHUB_MILESTONE
+GITHUB_MILESTONE=$(curl  -s -H "Accept: application/vnd.github.v3+json"  https://api.github.com/repos/eclipse/rdf4j/milestones?state=closed | jq '.[] | select(.title == "'"${MVN_VERSION_RELEASE}"'") | .number')
+
+# then try to get the GITHUB_MILESTONE number from the open milestones (this should only be relevant for RDF4J Milestone builds).
+if  [[ ${GITHUB_MILESTONE} == "" ]]; then
+    GITHUB_MILESTONE=$(curl  -s -H "Accept: application/vnd.github.v3+json"  https://api.github.com/repos/eclipse/rdf4j/milestones | jq '.[] | select(.title == "'"${MVN_VERSION_RELEASE}"'") | .number')
+fi
+
+if  [[ ${GITHUB_MILESTONE} == "" ]]; then
+    echo "";
+    echo "Milestone not found matching '${MVN_VERSION_RELEASE}'";
+    exit 1;
+fi
+
+export NUMBER_OF_CLOSED_ISSUES
+NUMBER_OF_CLOSED_ISSUES=$(curl  -s -H "Accept: application/vnd.github.v3+json"  https://api.github.com/repos/eclipse/rdf4j/milestones/${GITHUB_MILESTONE}  | jq '.closed_issues')
+
+echo "Milestone: https://github.com/eclipse/rdf4j/milestone/${GITHUB_MILESTONE}"
+echo "Number of closed issues: ${NUMBER_OF_CLOSED_ISSUES}"
+
+export DATETIME
+DATETIME=$(date +"%Y-%m-%dT%H:%M:%S%z")
+
+echo "Datetime: ${DATETIME}"
+
+echo ""
+echo "Using envsubst to generate content from templates."
+RELEASE_NOTES=$(cat templates/"${RELEASE_NOTES_TEMPLATE}" | envsubst)
+NEWS_ITEM=$(cat templates/"${NEWS_ITEM_TEMPLATE}" | envsubst)
+
+
+NEWS_FILENAME=${MVN_VERSION_RELEASE_RAW}
+NEWS_FILENAME=${NEWS_FILENAME/./}
+NEWS_FILENAME=${NEWS_FILENAME/./}
+NEWS_FILENAME="rdf4j-${NEWS_FILENAME}.md"
+
+RELEASE_NOTES_FILENAME="${MVN_VERSION_RELEASE_RAW}.md"
+
+# We do not create release-notes for Milestone builds
+if [[ ${M} == "" ]]; then
+  echo "Writing release notes to ../site/content/release-notes/${RELEASE_NOTES_FILENAME}"
+  echo "${RELEASE_NOTES}" > "../site/content/release-notes/${RELEASE_NOTES_FILENAME}"
+fi
+
+echo "Writing news item to ../site/content/news/${NEWS_FILENAME}"
+echo "${NEWS_ITEM}" > "../site/content/news/${NEWS_FILENAME}"
+
+if ! [[ ${BRANCH} == "" ]]; then
+  git commit -s -a -m "news item and release-notes if relevant for ${MVN_VERSION_RELEASE_RAW}"
+  git push
+fi
+
+echo ""
+echo "DONE!"
+
+echo ""
+echo "You will need to manually edit download.md"
+echo "The current branch can be used for that"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -240,11 +240,14 @@ git commit -s -a -m "javadocs for ${MVN_VERSION_RELEASE}"
 git push --set-upstream origin "${RELEASE_NOTES_BRANCH}"
 gh pr create -B develop --title "${RELEASE_NOTES_BRANCH}" --body "Javadocs, release-notes and news item for ${MVN_VERSION_RELEASE}"
 
+echo "Javadocs are in git branch ${RELEASE_NOTES_BRANCH}"
+
 git checkout master
 mvn clean
 
 cd scripts
 
+echo ""
 echo "DONE!"
 
 

--- a/scripts/templates/milestone-news-item.md
+++ b/scripts/templates/milestone-news-item.md
@@ -1,0 +1,20 @@
+---
+title: "RDF4J ${MVN_VERSION_RELEASE} Milestone ${M}"
+date: ${DATETIME}
+layout: "single"
+categories: ["news"]
+---
+Milestone number ${M} of the upcoming ${MVN_VERSION_RELEASE} release of RDF4J is now available for download.
+
+RDF4J ${MVN_VERSION_RELEASE} is a minor release focusing on ... .
+
+This milestone build is not yet feature-complete, but we are putting it out to receive early feedback on all the improvements we have put in.
+
+<!--more-->
+
+ - [issues fixed in ${MVN_VERSION_RELEASE} Milestone 1](https://github.com/eclipse/rdf4j/issues?q=is%3Aissue+label%3AM${M}+is%3Aclosed+milestone%3A${MVN_VERSION_RELEASE})
+ - [issues planned for ${MVN_VERSION_RELEASE}](https://github.com/eclipse/rdf4j/milestone/${GITHUB_MILESTONE})
+
+### Links
+
+- [Download RDF4J](/download/)

--- a/scripts/templates/milestone-news-item.md
+++ b/scripts/templates/milestone-news-item.md
@@ -12,7 +12,7 @@ This milestone build is not yet feature-complete, but we are putting it out to r
 
 <!--more-->
 
- - [issues fixed in ${MVN_VERSION_RELEASE} Milestone 1](https://github.com/eclipse/rdf4j/issues?q=is%3Aissue+label%3AM${M}+is%3Aclosed+milestone%3A${MVN_VERSION_RELEASE})
+ - [issues fixed in ${MVN_VERSION_RELEASE} Milestone ${M}](https://github.com/eclipse/rdf4j/issues?q=is%3Aissue+label%3AM${M}+is%3Aclosed+milestone%3A${MVN_VERSION_RELEASE})
  - [issues planned for ${MVN_VERSION_RELEASE}](https://github.com/eclipse/rdf4j/milestone/${GITHUB_MILESTONE})
 
 ### Links

--- a/scripts/templates/patch-news-item.md
+++ b/scripts/templates/patch-news-item.md
@@ -1,0 +1,15 @@
+---
+title: "RDF4J ${MVN_VERSION_RELEASE} released"
+date: ${DATETIME}
+layout: "single"
+categories: ["news"]
+---
+RDF4J ${MVN_VERSION_RELEASE} is now available. This is a patch release fixing ${NUMBER_OF_CLOSED_ISSUES} bugs.
+
+For more details, have a look at the [release notes](/release-notes/${MVN_VERSION_RELEASE}).
+<!--more-->
+### Links
+
+- [Download RDF4J](/download/)
+- [release notes](/release-notes/${MVN_VERSION_RELEASE}).
+

--- a/scripts/templates/patch-release-notes.md
+++ b/scripts/templates/patch-release-notes.md
@@ -1,0 +1,7 @@
+---
+title: "${MVN_VERSION_RELEASE}"
+toc: true
+---
+RDF4J ${MVN_VERSION_RELEASE} is a patch release that fixes ${NUMBER_OF_CLOSED_ISSUES} issues.
+
+For a complete overview, see [all issues fixed in ${MVN_VERSION_RELEASE}](https://github.com/eclipse/rdf4j/milestone/${GITHUB_MILESTONE}?closed=1).


### PR DESCRIPTION

GitHub issue resolved: #2784 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - moved release scripts into new directory
 - made one script for patch release and another for milestone build
 - created script for generating news item and release-notes from templates

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

