### PR TITLE
GH-2755 fix javadoc tags in package-info.java

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/package-info.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/package-info.java
@@ -1,10 +1,9 @@
-@Deprecated
 @InternalUseOnly
 /**
  * Implementations of {@link Iteration} relevant to query evaluation.
  *
- * @deprecated since 3.0. This feature is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @apiNote This feature is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/algebra/package-info.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/algebra/package-info.java
@@ -2,7 +2,7 @@
 /**
  * Algebra operators for the federation sail
  *
- * @deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
+ * @apiNote deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
  *
  */
 package org.eclipse.rdf4j.sail.federation.algebra;

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/config/package-info.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/config/package-info.java
@@ -2,7 +2,7 @@
 /**
  * Config for the federation sail
  *
- * @deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
+ * @apiNote deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
  *
  */
 package org.eclipse.rdf4j.sail.federation.config;

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/package-info.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/evaluation/package-info.java
@@ -2,7 +2,7 @@
 /**
  * Query evaluation functionality for the Federation Sail.
  *
- * @deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
+ * @apiNote deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
  *
  */
 package org.eclipse.rdf4j.sail.federation.evaluation;

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/optimizers/package-info.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/optimizers/package-info.java
@@ -2,7 +2,7 @@
 /**
  * Optimizers for the federation sail
  *
- * @deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
+ * @apiNote deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
  *
  */
 package org.eclipse.rdf4j.sail.federation.optimizers;

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/package-info.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/package-info.java
@@ -2,7 +2,7 @@
 /**
  * A Sail implementation for federated access to multiple databases.
  *
- * @deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
+ * @apiNote deprecated since 3.1.0. This module will be replaced by the new FedX federation module.
  *
  */
 package org.eclipse.rdf4j.sail.federation;

--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/config/package-info.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/config/package-info.java
@@ -3,7 +3,7 @@
 /**
  * The Lucene SPIN Sail - configuration
  *
- * @deprecated since 3.0. This prototype Sail implementation will be removed in a future major release of RDF4J.
+ * @apiNote deprecated since 3.0. This prototype Sail implementation will be removed in a future major release of RDF4J.
  */
 package org.eclipse.rdf4j.lucene.spin.config;
 

--- a/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/package-info.java
+++ b/core/sail/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/package-info.java
@@ -3,7 +3,7 @@
 /**
  * The Lucene SPIN Sail
  *
- * @deprecated since 3.0. This prototype Sail implementation will be removed in a future major release of RDF4J.
+ * @apiNote deprecated since 3.0. This prototype Sail implementation will be removed in a future major release of RDF4J.
  */
 package org.eclipse.rdf4j.lucene.spin;
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/package-info.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/package-info.java
@@ -1,10 +1,9 @@
-@Deprecated
 @InternalUseOnly
 /**
  * MemoryStore-specific implementations of the core RDF model objects.
  *
- * @deprecated since 3.0. This feature is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @apiNote This feature is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
 package org.eclipse.rdf4j.sail.memory.model;
 

--- a/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/NonSerializables.java
+++ b/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/NonSerializables.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.model;
 import java.util.Map;
 import java.util.UUID;
 
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.util.UUIDable;
 
 import com.google.common.cache.Cache;
@@ -20,9 +21,10 @@ import com.google.common.cache.CacheBuilder;
  * entries to be garbage-collected when no longer used.
  *
  * @author Mark
- * @deprecated this feature is for internal use only: its existence, signature or behavior may change without warning
- *             from one release to the next.
+ * @apiNote this feature is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
+@InternalUseOnly
 public class NonSerializables {
 
 	private static final Cache<UUID, Object> registry = CacheBuilder.newBuilder().weakValues().build();

--- a/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/SailModel.java
+++ b/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/SailModel.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.common.iteration.Iteration;
@@ -41,9 +42,10 @@ import org.eclipse.rdf4j.sail.SailException;
  *
  * @author Mark
  *
- * @deprecated this feature is for internal use only: its existence, signature or behavior may change without warning
- *             from one release to the next.
+ * @apiNote this feature is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
+@InternalUseOnly
 public class SailModel extends AbstractModel {
 
 	private static final long serialVersionUID = -2104886971549374410L;

--- a/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/package-info.java
+++ b/core/sail/model/src/main/java/org/eclipse/rdf4j/sail/model/package-info.java
@@ -1,9 +1,8 @@
-@Deprecated
 @InternalUseOnly
 /**
  *
- * @deprecated since 3.0. This package is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @apiNote This package is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
 package org.eclipse.rdf4j.sail.model;
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/btree/package-info.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/btree/package-info.java
@@ -1,10 +1,9 @@
-@Deprecated
 @InternalUseOnly
 /**
  * B-Tree on disk implementation.
  *
- * @deprecated since 3.0. This package is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @apiNote This package is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
 package org.eclipse.rdf4j.sail.nativerdf.btree;
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/package-info.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/package-info.java
@@ -1,10 +1,9 @@
-@Deprecated
 @InternalUseOnly
 /**
  * File and data storage functionality.
  *
- * @deprecated Since 3.0. This package is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @apiNote This package is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
 package org.eclipse.rdf4j.sail.nativerdf.datastore;
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/model/package-info.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/model/package-info.java
@@ -1,10 +1,9 @@
-@Deprecated
 @InternalUseOnly
 /**
  * Native implementations of the RDF Model interfaces.
  *
- * @deprecated since 3.0. This package is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @apiNote This package is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
 package org.eclipse.rdf4j.sail.nativerdf.model;
 


### PR DESCRIPTION
GitHub issue resolved: #2755  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Removed use of `@deprecated` javadoc tag in `package-info.java`, and removed `@Deprecated` annotation in several places. 

(mostly did this because Eclipse considers a `@deprecated` javadoc tag in package-info an error, and it annoyed me)


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

