### PR TITLE
GH-2822 documentation updates and fixes to links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Welcome to the Eclipse RDF4J repository
 
+![RDF4J](https://github.com/eclipse/rdf4j/blob/master/site/static/images/rdf4j-logo-orange-114.png)
+
 This is the main code repository for the Eclipse RDF4J project. 
 
 [![master status](https://github.com/eclipse/rdf4j/workflows/master%20status/badge.svg)](https://github.com/eclipse/rdf4j/actions?query=workflow%3A%22master+status%22)
@@ -9,9 +11,9 @@ Visit the [project website](https://rdf4j.org/) for news, documentation, and dow
 
 ## Installation and usage
 
-For installation and usage instructions of the RDF4J Workbench and Server applications, see [RDF4J Server, Workbench, and Console](https://rdf4j.org/documentation/#rdf4j-server-workbench-and-console). 
+For installation and usage instructions of the RDF4J Workbench and Server applications, see [RDF4J Server and Workbench](https://rdf4j.org/documentation/tools/server-workbench). 
 
-For installation and usage instructions of the RDF4J Java libaries, see [Programming with RDF4J](https://rdf4j.org/documentation/#programming-with-rdf4j). 
+For installation and usage instructions of the RDF4J Java libaries, see [Programming with RDF4J](https://rdf4j.org/documentation/programming). 
 
 ### Building from source
 
@@ -45,10 +47,9 @@ The short version:
 2. Create an issue in the [issue tracker](https://github.com/eclipse/rdf4j/issues) that describes your improvement, new feature, or bug fix - or if you're picking up an existing issue, comment on that issue that you intend to provide a solution for it.
 3. Fork the GitHub repository.
 4. Create a new branch (starting from master) for your changes. Name your branch like this: `GH-1234-short-description-here` where 1234 is the Github issue number.
-5. Make your changes on this branch. Apply the [rdf4j code formatting guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting). Don't forget to include unit tests.
-6. **sign off** every commit (using the `-s` flag).
-7. Run `mvn verify` from the project root to make sure all tests succeed (both your own new ones, and existing).
-8. Use meaningful commit messages and include the issue number in each commit message.
+5. Make your changes on this branch. Apply the [RDF4J code formatting guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting). Don't forget to include unit tests.
+7. Commit your changes into the branch. Use meaningful commit messages. Reference the issue number in each commit message (for example "GH-276: added null check"). **IMPORTANT**: *sign off* every commit (using the `-s` flag). 
+8. Run `mvn verify` from the project root to make sure all tests succeed (both your own new ones, and existing).
 9. Once your fix is complete, put it up for review by opening a Pull Request against the master branch in the central Github repository. If you have a lot of commits on your PR, make sure to [squash your commits](https://rdf4j.org/documentation/developer/squashing).
 
 These steps are explained in more detail in the [Contributor

--- a/site/content/documentation/programming/repository.md
+++ b/site/content/documentation/programming/repository.md
@@ -327,43 +327,7 @@ The RepositoryProvider creates and keeps a singleton instance of RepositoryManag
 
 ### Creating a Federation
 
-It is possible to create a virtual repository that is a federation of existing repositories. The following code illustrates how to use the RepositoryManagerFederator class to create a federation. It assumes you already have a reference to a RepositoryManager instance, and is a simplified form of what the RDF4J Console runs when its federate command is invoked:
-
-```java
-void federate(RepositoryManager manager, String fedID, String description,
-	Collection<String> memberIDs, boolean readonly, boolean distinct)
-	throws MalformedURLException, RDF4JException {
-    if (manager.hasRepositoryConfig(fedID)) {
-	System.err.println(fedID + " already exists.");
-    }
-    else if (validateMembers(manager, readonly, memberIDs)) {
-	RepositoryManagerFederator rmf =
-	    new RepositoryManagerFederator(manager);
-	rmf.addFed(fedID, description, memberIDs, readonly, distinct);
-	System.out.writeln("Federation created.");
-    }
-}
-boolean validateMembers(RepositoryManager manager, boolean readonly,
-	 Collection<String> memberIDs)
-	 throws RDF4JException {
-    boolean result = true;
-    for (String memberID : memberIDs) {
-	if (manager.hasRepositoryConfig(memberID)) {
-	    if (!readonly) {
-		if (!manager.getRepository(memberID).isWritable()) {
-		    result = false;
-		    System.err.println(memberID + " is read-only.");
-		}
-	    }
-	}
-	else {
-	   result = false;
-	   System.err.println(memberID + " does not exist.");
-	}
-    }
-    return result;
-}
-```
+RDF4J has the option to create a repository that acts as a federation of stores. For more information about this, see the [FedX federation](/documentation/programming/federation) documentation.
 
 ## Using a repository: RepositoryConnections
 
@@ -648,8 +612,6 @@ TupleQueryResult keywordQueryResult = keywordQuery.evaluate();
 
 #### Explaining queries
 
-> New in RDF4J 3.2.0 - Experimental feature
-
 SPARQL queries are translated to query plans and then run through an optimization pipeline before they get evaluated and
 the results returned. The query explain feature gives a peek into what decisions are being made and how they affect
 the performance of your query.
@@ -659,7 +621,7 @@ Explaining queries currently only works if you are using one of the built in sto
 If you are connecting to a remote RDF4J Server, using the Workbench or connecting to a third party database then you will get an
 UnsupportedException.
 
-In 3.2.0 queries have a new method `explain(...)` that returns an `Explanation` explaining how the query will be, or has been, evaluated.
+In RDF4J 3.2.0, queries have a new method `explain(...)` that returns an `Explanation` explaining how the query will be, or has been, evaluated.
 
  ```java
  try (SailRepositoryConnection connection = sailRepository.getConnection()) {
@@ -989,7 +951,7 @@ Projection (resultSizeActual=9, totalTimeActual=0.448ms, selfTimeActual=0.007ms)
 
 Notice that `ArbitraryLengthPath` produces 5 results and that the entire query runs in 0.164ms instead of 1.5s.
 
-Another way to visualize the query plan is to use the Graphiz DOT format with `query.explain(Explanation.Level.Timed).toDot()`. 
+Another way to visualize the query plan is to use the Graphiz DOT format with `query.explain(Explanation.Level.Timed).toDot()`.
 This visualization makes it easier to see which part of the query is slowest by looking at the color coding.
 
 <img src="../images/query-plan-explanation.png" alt="Picture of query explanation visualized with Graphviz." class="img-responsive"/>


### PR DESCRIPTION
GitHub issue resolved: #2822  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- replaced obsolete federation code example with redirect to FedX documentation
- fixed outdated links in main project readme
- added our logo to the readme because it looks nice

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

