### PR TITLE
GH-2830 handle rdf list statements in correct order

### DIFF
--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterInliningTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterInliningTest.java
@@ -1,0 +1,60 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.turtle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Comparator;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.ValueComparator;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.junit.Test;
+
+/**
+ * Integration tests on blank node inlining behavior of the TurtleWriter.
+ *
+ * @implNote added as integration test instead of unit test because we reuse code from rdf4j-queryalgebra-evaluation
+ *           (for statement sorting), which would introduce a cyclic dependency in the rio-turtle module.
+ * 
+ * @author Jeen Broekstra
+ */
+public class TurtleWriterInliningTest {
+
+	@Test
+	public void testInlineList_CustomOrder() throws Exception {
+		String inlinedListTurtle = "[] <http://www.z.org#a> (<http://www.z.org#o> <http://www.z.org#z>) .";
+		Model model = Rio.parse(new StringReader(inlinedListTurtle), RDFFormat.TURTLE);
+
+		ArrayList<Statement> statements = new ArrayList<>(model);
+
+		// do custom sorting using a SPARQL algebra ValueComparator
+		ValueComparator valueComparator = new ValueComparator();
+		statements.sort(Comparator.comparing(Statement::getObject, valueComparator));
+
+		model = new LinkedHashModel(statements);
+
+		WriterConfig writerConfig = new WriterConfig();
+		writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		Rio.write(model, baos, RDFFormat.TURTLE, writerConfig);
+
+		String actual = baos.toString("UTF-8");
+
+		assertThat(actual).contains(inlinedListTurtle);
+	}
+}

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -870,6 +870,9 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter, CharSi
 		// give rdf:type preference over other predicates.
 		processPredicate(contextData, subject, RDF.TYPE, processedSubjects, processedPredicates);
 
+		// handle RDF Collection statements separately, to make sure we process them in the correct order
+		processPredicate(contextData, subject, RDF.FIRST, processedSubjects, processedPredicates);
+
 		// retrieve other statement from this context with the same
 		// subject, and output them grouped by predicate
 		for (IRI predicate : contextData.filter(subject, null, null).predicates()) {


### PR DESCRIPTION
GitHub issue resolved: #2830 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- make sure we handle rdf:first predicate on a subject before others, to ensure RDF collection statements are processed in the right order
- added regression test (in compliance because we need queryalgebra classes for handling custom sorting)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

