### PR TITLE
GH-2843 hashcode for literals needs to include lang tag and datatype

### DIFF
--- a/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/IsomorphicTest.java
+++ b/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/IsomorphicTest.java
@@ -9,23 +9,19 @@
 package org.eclipse.rdf4j.model.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.TreeModel;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class IsomorphicTest {
@@ -218,6 +214,47 @@ public class IsomorphicTest {
 	public void testValidationReport_Changed() throws IOException {
 		Model m1 = getModel("shaclValidationReport.ttl");
 		Model m2 = getModel("shaclValidationReport-changed.ttl");
+
+		assertThat(Models.isomorphic(m1, m2)).isFalse();
+	}
+
+	@Test
+	public void testIsomorphicDatatype() throws Exception {
+		String d1 = "@prefix ex: <http://example.com/ns#> .\n"
+				+ "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n"
+				+ "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+				+ "@prefix sh: <http://www.w3.org/ns/shacl#> .\n"
+				+ "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n"
+				+ "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+				+ "@prefix rsx: <http://rdf4j.org/shacl-extensions#> .\n"
+				+ "\n"
+				+ "ex:PersonShape sh:not [\n"
+				+ "      sh:not [\n"
+				+ "          sh:maxCount 3;\n"
+				+ "          sh:path ex:ssn\n"
+				+ "        ]\n"
+				+ "    ];\n"
+				+ "  sh:targetClass ex:Person .";
+
+		Model m1 = Rio.parse(new StringReader(d1), RDFFormat.TURTLE);
+
+		String d2 = "@prefix ex: <http://example.com/ns#> .\n"
+				+ "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n"
+				+ "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+				+ "@prefix sh: <http://www.w3.org/ns/shacl#> .\n"
+				+ "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n"
+				+ "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+				+ "@prefix rsx: <http://rdf4j.org/shacl-extensions#> .\n"
+				+ "\n"
+				+ "ex:PersonShape sh:not [\n"
+				+ "      sh:not [\n"
+				+ "          sh:maxCount \"3\"^^xsd:long;\n"
+				+ "          sh:path ex:ssn\n"
+				+ "        ]\n"
+				+ "    ];\n"
+				+ "  sh:targetClass ex:Person .";
+
+		Model m2 = Rio.parse(new StringReader(d2), RDFFormat.TURTLE);
 
 		assertThat(Models.isomorphic(m1, m2)).isFalse();
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/GraphComparisons.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/GraphComparisons.java
@@ -26,9 +26,11 @@ import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.DynamicModelFactory;
 import org.slf4j.Logger;
@@ -412,6 +414,9 @@ class GraphComparisons {
 			if (value.isBNode()) {
 				return currentNodeMapping.get((BNode) value);
 			}
+			if (value.isLiteral()) {
+				return getStaticLiteralHashCode((Literal) value);
+			}
 			return staticValueMapping.computeIfAbsent(value,
 					v -> hashFunction.hashString(v.stringValue(), Charsets.UTF_8));
 		}
@@ -424,8 +429,12 @@ class GraphComparisons {
 			if (value.isBNode()) {
 				return previousNodeMapping.get((BNode) value);
 			}
+			if (value.isLiteral()) {
+				return getStaticLiteralHashCode((Literal) value);
+			}
 			return staticValueMapping.computeIfAbsent(value,
 					v -> hashFunction.hashString(v.stringValue(), Charsets.UTF_8));
+
 		}
 
 		public void setCurrentHashCode(BNode bnode, HashCode hashCode) {
@@ -495,6 +504,23 @@ class GraphComparisons {
 					.map(h -> new BigInteger(1, h.asBytes()))
 					.reduce(BigInteger.ZERO, (v1, v2) -> v1.add(v2));
 			return size;
+		}
+
+		private HashCode getStaticLiteralHashCode(Literal value) {
+			// GH-2834: we need to include language and datatype when computing a unique hash code for literals
+			return staticValueMapping.computeIfAbsent(value,
+					v -> {
+						Literal l = (Literal) v;
+						List<HashCode> hashSequence = new ArrayList<>(3);
+
+						hashSequence.add(hashFunction.hashString(l.getLabel(), Charsets.UTF_8));
+						l.getLanguage()
+								.map(lang -> hashFunction.hashString(lang, Charsets.UTF_8))
+								.ifPresent(h -> hashSequence.add(h));
+						hashSequence.add(hashFunction.hashString(l.getDatatype().stringValue(), Charsets.UTF_8));
+						return Hashing.combineOrdered(hashSequence);
+					}
+			);
 		}
 
 		private Multimap<HashCode, BNode> getCurrentHashCodeMapping() {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/GraphComparisons.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/GraphComparisons.java
@@ -514,8 +514,14 @@ class GraphComparisons {
 						List<HashCode> hashSequence = new ArrayList<>(3);
 
 						hashSequence.add(hashFunction.hashString(l.getLabel(), Charsets.UTF_8));
+
+						// Per BCP47, language tags are case-insensitive. Use normalized form to ensure consistency if
+						// possible, otherwise just use lower-case.
 						l.getLanguage()
-								.map(lang -> hashFunction.hashString(lang, Charsets.UTF_8))
+								.map(lang -> hashFunction.hashString(
+										Literals.isValidLanguageTag(lang) ? Literals.normalizeLanguageTag(lang)
+												: lang.toLowerCase(),
+										Charsets.UTF_8))
 								.ifPresent(h -> hashSequence.add(h));
 						hashSequence.add(hashFunction.hashString(l.getDatatype().stringValue(), Charsets.UTF_8));
 						return Hashing.combineOrdered(hashSequence);

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/GraphComparisonsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/GraphComparisonsTest.java
@@ -6,8 +6,6 @@ import static org.eclipse.rdf4j.model.util.Values.bnode;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,11 +14,9 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.TreeModel;
-import org.eclipse.rdf4j.model.util.GraphComparisons.Partitioning;
 import org.junit.Test;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Multimap;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;

--- a/core/sail/shacl/src/test/resources/test-cases/complex/targetShapeAndQualifiedShape/invalid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/complex/targetShapeAndQualifiedShape/invalid/case1/report.ttl
@@ -4,33 +4,34 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
+  <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
-      sh:sourceShape _:node1euloem3vx313;
-      sh:focusNode <http://example-langstr.com/3>;
-      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ], [ a sh:ValidationResult;
-      sh:sourceShape _:node1euloem3vx313;
-      sh:focusNode <http://example-langstr.com/1>;
-      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ], [ a sh:ValidationResult;
-      sh:sourceShape _:node1euloem3vx313;
       sh:focusNode <http://example-langstr.com/2>;
       sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
       sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ];
-  <http://rdf4j.org/schema/rdf4j#truncated> false;
-  sh:conforms false .
+      sh:sourceShape _:node1eusclgncx281
+    ], [ a sh:ValidationResult;
+      sh:focusNode <http://example-langstr.com/3>;
+      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
+      sh:sourceShape _:node1eusclgncx281
+    ], [ a sh:ValidationResult;
+      sh:focusNode <http://example-langstr.com/1>;
+      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
+      sh:sourceShape _:node1eusclgncx281
+    ] .
 
-_:node1euloem3vx313 a sh:PropertyShape;
+_:node1eusclgncx281 a sh:PropertyShape;
+  sh:path <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+  sh:qualifiedMaxCount 1;
   sh:qualifiedValueShape [ a sh:NodeShape;
       sh:datatype xsd:string
-    ];
-  sh:path <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-  sh:qualifiedMaxCount "1"^^xsd:long .
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/minExclusive/simple/invalid/case8/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/minExclusive/simple/invalid/case8/report.ttl
@@ -4,18 +4,19 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
-      sh:value 6.0;
       sh:resultPath ex:phoneNumber;
-      sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:MinExclusiveConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
-          sh:path ex:phoneNumber;
-          sh:minExclusive 6
-        ]
+          sh:minExclusive 6;
+          sh:path ex:phoneNumber
+        ];
+      sh:value 6.0
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/complex/invalid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/complex/invalid/case1/report.ttl
@@ -4,20 +4,21 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
+  <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
-      sh:sourceShape [ a sh:PropertyShape;
-          sh:qualifiedValueShape [ a sh:NodeShape;
-              sh:datatype xsd:string
-            ];
-          sh:path <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-          sh:qualifiedMaxCount "1"^^xsd:long
-        ];
       sh:focusNode [];
       sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
       sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ];
-  <http://rdf4j.org/schema/rdf4j#truncated> false;
-  sh:conforms false .
+      sh:sourceShape [ a sh:PropertyShape;
+          sh:path <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+          sh:qualifiedMaxCount 1;
+          sh:qualifiedValueShape [ a sh:NodeShape;
+              sh:datatype xsd:string
+            ]
+        ]
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/complex/invalid/case2/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/complex/invalid/case2/report.ttl
@@ -4,20 +4,21 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
+  <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
-      sh:sourceShape [ a sh:PropertyShape;
-          sh:qualifiedValueShape [ a sh:NodeShape;
-              sh:datatype xsd:string
-            ];
-          sh:path <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-          sh:qualifiedMaxCount "1"^^xsd:long
-        ];
       sh:focusNode ex:node1;
       sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
       sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ];
-  <http://rdf4j.org/schema/rdf4j#truncated> false;
-  sh:conforms false .
+      sh:sourceShape [ a sh:PropertyShape;
+          sh:path <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+          sh:qualifiedMaxCount 1;
+          sh:qualifiedValueShape [ a sh:NodeShape;
+              sh:datatype xsd:string
+            ]
+        ]
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/complex/invalid/case3/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/complex/invalid/case3/report.ttl
@@ -4,39 +4,40 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:result [ a sh:ValidationResult;
-      sh:sourceShape _:node1eulvg5mcx3;
-      sh:focusNode [];
-      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ], [ a sh:ValidationResult;
-      sh:sourceShape _:node1eulvg5mcx3;
-      sh:focusNode [];
-      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ], [ a sh:ValidationResult;
-      sh:sourceShape _:node1eulvg5mcx3;
-      sh:focusNode [];
-      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ], [ a sh:ValidationResult;
-      sh:focusNode [];
-      sh:sourceShape _:node1eulvg5mcx3;
-      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
-      sh:resultSeverity sh:Violation
-    ];
   <http://rdf4j.org/schema/rdf4j#truncated> false;
-  sh:conforms false .
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      sh:focusNode [];
+      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
+      sh:sourceShape _:node1euscn4vix3
+    ], [ a sh:ValidationResult;
+      sh:focusNode [];
+      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
+      sh:sourceShape _:node1euscn4vix3
+    ], [ a sh:ValidationResult;
+      sh:focusNode [];
+      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
+      sh:sourceShape _:node1euscn4vix3
+    ], [ a sh:ValidationResult;
+      sh:focusNode [];
+      sh:resultPath <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
+      sh:sourceShape _:node1euscn4vix3
+    ] .
 
-_:node1eulvg5mcx3 a sh:PropertyShape;
+_:node1euscn4vix3 a sh:PropertyShape;
+  sh:path <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
+  sh:qualifiedMaxCount 1;
   sh:qualifiedValueShape [ a sh:NodeShape;
       sh:datatype xsd:string
-    ];
-  sh:path <http://example.com/ontology#uniqStrOrLangstrEnDeAllDialects>;
-  sh:qualifiedMaxCount "1"^^xsd:long .
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/complex/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/complex/shacl.ttl
@@ -34,5 +34,5 @@
       sh:qualifiedValueShape [ a sh:NodeShape;
           sh:datatype <http://www.w3.org/2001/XMLSchema#string>
         ];
-      sh:qualifiedMaxCount "1"^^<http://www.w3.org/2001/XMLSchema#long>
+      sh:qualifiedMaxCount 1
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/invalid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/invalid/case1/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:parent;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:parent;
+          sh:qualifiedMaxCount 1;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:sex;
-              sh:hasValue ex:female
-            ];
-          sh:qualifiedMaxCount "1"^^xsd:long
+              sh:hasValue ex:female;
+              sh:path ex:sex
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/invalid/case2/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/invalid/case2/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:parent;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:parent;
+          sh:qualifiedMaxCount 1;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:sex;
-              sh:hasValue ex:female
-            ];
-          sh:qualifiedMaxCount "1"^^xsd:long
+              sh:hasValue ex:female;
+              sh:path ex:sex
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/invalid/case3/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/invalid/case3/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:parent;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:parent;
+          sh:qualifiedMaxCount 1;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:sex;
-              sh:hasValue ex:female
-            ];
-          sh:qualifiedMaxCount "1"^^xsd:long
+              sh:hasValue ex:female;
+              sh:path ex:sex
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/invalid/case4/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/invalid/case4/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:parent;
-      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMaxCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:parent;
+          sh:qualifiedMaxCount 1;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:sex;
-              sh:hasValue ex:female
-            ];
-          sh:qualifiedMaxCount "1"^^xsd:long
+              sh:hasValue ex:female;
+              sh:path ex:sex
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/maxCountSimple/shacl.ttl
@@ -15,5 +15,5 @@ ex:PersonShape
 			sh:path ex:sex ;
 			sh:hasValue ex:female ;
 		] ;
-		sh:qualifiedMaxCount "1"^^xsd:long ;
+		sh:qualifiedMaxCount 1 ;
 	] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case1/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:parent;
-      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:parent;
+          sh:qualifiedMinCount 1;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:sex;
-              sh:hasValue ex:female
-            ];
-          sh:qualifiedMinCount "1"^^xsd:long
+              sh:hasValue ex:female;
+              sh:path ex:sex
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case2/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case2/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:parent;
-      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:parent;
+          sh:qualifiedMinCount 1;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:sex;
-              sh:hasValue ex:female
-            ];
-          sh:qualifiedMinCount "1"^^xsd:long
+              sh:hasValue ex:female;
+              sh:path ex:sex
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case3/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case3/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:parent;
-      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:parent;
+          sh:qualifiedMinCount 1;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:sex;
-              sh:hasValue ex:female
-            ];
-          sh:qualifiedMinCount "1"^^xsd:long
+              sh:hasValue ex:female;
+              sh:path ex:sex
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case4/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case4/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:temp;
-      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:temp;
+          sh:qualifiedMinCount 2;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:val;
-              sh:datatype xsd:string
-            ];
-          sh:qualifiedMinCount "2"^^xsd:long
+              sh:datatype xsd:string;
+              sh:path ex:val
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case5/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/invalid/case5/report.ttl
@@ -4,21 +4,22 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
 
 [] a sh:ValidationReport;
-  sh:conforms false;
   <http://rdf4j.org/schema/rdf4j#truncated> false;
+  sh:conforms false;
   sh:result [ a sh:ValidationResult;
       sh:focusNode ex:validPerson1;
       sh:resultPath ex:parent;
-      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:QualifiedMinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
           sh:path ex:parent;
+          sh:qualifiedMinCount 1;
           sh:qualifiedValueShape [ a sh:PropertyShape;
-              sh:path ex:sex;
-              sh:hasValue ex:female
-            ];
-          sh:qualifiedMinCount "1"^^xsd:long
+              sh:hasValue ex:female;
+              sh:path ex:sex
+            ]
         ]
     ] .

--- a/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/shacl.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/qualifiedShape/minCountSimple/shacl.ttl
@@ -15,7 +15,7 @@ ex:PersonShape
 			sh:path ex:sex ;
 			sh:hasValue ex:female ;
 		] ;
-		sh:qualifiedMinCount "1"^^xsd:long ;
+		sh:qualifiedMinCount 1 ;
 	]
 	.
 
@@ -30,6 +30,6 @@ ex:PersonShape2
         		sh:path ex:val ;
         		sh:datatype xsd:string ;
         	] ;
-        	sh:qualifiedMinCount "2"^^xsd:long ;
+        	sh:qualifiedMinCount 2 ;
         ]
 	.


### PR DESCRIPTION
GitHub issue resolved: #2843  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- hash code calculation for literals now includes language tag and datatype
- added regression test

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

