### PR TITLE
GH-2846 transaction settings to control parallel validation and cache

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -967,10 +967,62 @@ public class ShaclSail extends NotifyingSailWrapper {
 
 	public static class TransactionSettings {
 
+		@Experimental
+		public enum PerformanceHint implements TransactionSetting {
+
+			/**
+			 * Run validation is parallel (multithreaded).
+			 */
+			ParallelValidation("ParallelValidation"),
+			/**
+			 * Run validation serially (single threaded)
+			 */
+			SerialValidation("SerialValidation"),
+			/**
+			 * Cache intermediate results. Uses more memory but can reduce validation time.
+			 */
+			CacheEnabled("CacheEnabled"),
+			/**
+			 * Do not cache intermediate results.
+			 */
+			CacheDisabled("CacheDisabled");
+
+			private final String value;
+
+			PerformanceHint(String value) {
+				this.value = value;
+			}
+
+			@Override
+			public String getName() {
+				return ValidationApproach.class.getCanonicalName();
+			}
+
+			@Override
+			public String getValue() {
+				return value;
+			}
+
+		}
+
 		public enum ValidationApproach implements TransactionSetting {
 
+			/**
+			 * Do not run any validation. This could potentially lead to your database becoming invalid.
+			 */
 			Disabled("Disabled"),
+
+			/**
+			 * Let the SHACL engine decide on the best approach for validating. This typically means that it will use
+			 * transactional validation except when changing the SHACL Shape.
+			 */
 			Auto("Auto"),
+
+			/**
+			 * Use a validation approach that is optimized for bulk operations such as adding or removing large amounts
+			 * of data. This will automatically disable parallel validation and turn off caching. Add performance hints
+			 * to enable parallel validation or caching if you have enough resources (RAM).
+			 */
 			Bulk("Bulk");
 
 			private final String value;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -107,7 +107,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 	}
 
 	private Settings getDefaultSettings(ShaclSail sail) {
-		return new Settings(sail.isCacheSelectNodes(), sail.isValidationEnabled());
+		return new Settings(sail.isCacheSelectNodes(), sail.isValidationEnabled(), sail.isParallelValidation());
 	}
 
 	@Override
@@ -126,14 +126,38 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 		currentIsolationLevel = level;
 
-		transactionSettings = getDefaultSettings(sail);
+		Settings localTransactionSettings = new Settings();
+
 		Arrays.stream(transactionSettingsRaw)
 				.filter(Objects::nonNull)
 				.forEach(setting -> {
 					if (setting instanceof ShaclSail.TransactionSettings.ValidationApproach) {
-						transactionSettings.validationApproach = (ShaclSail.TransactionSettings.ValidationApproach) setting;
+						localTransactionSettings.validationApproach = (ShaclSail.TransactionSettings.ValidationApproach) setting;
+					}
+					if (setting instanceof ShaclSail.TransactionSettings.PerformanceHint) {
+						switch (((ShaclSail.TransactionSettings.PerformanceHint) setting)) {
+						case ParallelValidation:
+							localTransactionSettings.parallelValidation = true;
+							break;
+						case SerialValidation:
+							localTransactionSettings.parallelValidation = false;
+							break;
+						case CacheDisabled:
+							localTransactionSettings.cacheSelectedNodes = false;
+							break;
+						case CacheEnabled:
+							localTransactionSettings.cacheSelectedNodes = true;
+							break;
+						}
 					}
 				});
+
+		transactionSettings = getDefaultSettings(sail);
+		transactionSettings.applyTransactionSettings(localTransactionSettings);
+
+		assert transactionSettings.parallelValidation != null;
+		assert transactionSettings.cacheSelectedNodes != null;
+		assert transactionSettings.validationApproach != null;
 
 		assert addedStatements == null;
 		assert removedStatements == null;
@@ -152,8 +176,10 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 		stats.setBaseSailEmpty(isEmpty());
 
-		if (transactionSettings.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Disabled ||
-				transactionSettings.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Bulk) {
+		if (this.transactionSettings
+				.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Disabled ||
+				this.transactionSettings
+						.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Bulk) {
 			removeConnectionListener(this);
 		} else if (stats.isBaseSailEmpty()) {
 			removeConnectionListener(this);
@@ -498,9 +524,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 	}
 
 	private boolean isParallelValidation() {
-		// bulk validation should use little memory so should not run validation in parallel
-		return sail.isParallelValidation()
-				&& transactionSettings.getValidationApproach() != ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+		return transactionSettings.isParallelValidation();
 	}
 
 	void fillAddedAndRemovedStatementRepositories() {
@@ -866,16 +890,27 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		return new ShaclSailValidationException(validate).getValidationReport();
 	}
 
+	Settings getTransactionSettings() {
+		return transactionSettings;
+	}
+
 	public static class Settings {
 
-		private ShaclSail.TransactionSettings.ValidationApproach validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Auto;
-		private boolean cacheSelectedNodes = false;
+		private ShaclSail.TransactionSettings.ValidationApproach validationApproach;
+		private Boolean cacheSelectedNodes;
+		private Boolean parallelValidation;
 
-		public Settings(boolean cacheSelectNodes, boolean validationEnabled) {
+		public Settings() {
+		}
+
+		public Settings(boolean cacheSelectNodes, boolean validationEnabled, boolean parallelValidation) {
 			this.cacheSelectedNodes = cacheSelectNodes;
 			if (!validationEnabled) {
 				validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Disabled;
+			} else {
+				this.validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Auto;
 			}
+			this.parallelValidation = parallelValidation;
 		}
 
 		public ShaclSail.TransactionSettings.ValidationApproach getValidationApproach() {
@@ -883,9 +918,35 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		}
 
 		public boolean isCacheSelectNodes() {
-			return cacheSelectedNodes && validationApproach != ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+			return cacheSelectedNodes;
 		}
 
+		public boolean isParallelValidation() {
+			return parallelValidation;
+		}
+
+		void applyTransactionSettings(Settings transactionSettingsLocal) {
+			// apply restrictions first
+			if (transactionSettingsLocal.validationApproach == ShaclSail.TransactionSettings.ValidationApproach.Bulk) {
+				validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+				cacheSelectedNodes = false;
+				parallelValidation = false;
+			}
+
+			// override settings
+			if (transactionSettingsLocal.parallelValidation != null) {
+				parallelValidation = transactionSettingsLocal.parallelValidation;
+			}
+
+			if (transactionSettingsLocal.cacheSelectedNodes != null) {
+				cacheSelectedNodes = transactionSettingsLocal.cacheSelectedNodes;
+			}
+
+			if (transactionSettingsLocal.validationApproach != null) {
+				validationApproach = transactionSettingsLocal.validationApproach;
+			}
+
+		}
 	}
 
 	static class ShapePlanNodeTuple {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionSettingsTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionSettingsTest.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl;
+
+import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.NotifyingSailConnection;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Test;
+
+public class TransactionSettingsTest {
+
+	@Test
+	public void testBulk() {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+		shaclSail.setParallelValidation(true);
+		shaclSail.setCacheSelectNodes(true);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
+
+			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
+			ShaclSailConnection.Settings transactionSettings = sailConnection.getTransactionSettings();
+
+			assert transactionSettings.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+			assert !transactionSettings.isCacheSelectNodes();
+			assert !transactionSettings.isParallelValidation();
+
+			connection.commit();
+
+		}
+
+		sailRepository.shutDown();
+
+	}
+
+	@Test
+	public void testBulkParallel() {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+		shaclSail.setParallelValidation(true);
+		shaclSail.setCacheSelectNodes(true);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk,
+					ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation);
+
+			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
+			ShaclSailConnection.Settings transactionSettings = sailConnection.getTransactionSettings();
+
+			assert transactionSettings.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+			assert !transactionSettings.isCacheSelectNodes();
+			assert transactionSettings.isParallelValidation();
+
+			connection.commit();
+
+		}
+
+		sailRepository.shutDown();
+
+	}
+
+	@Test
+	public void testBulkParallelCache() {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+		shaclSail.setParallelValidation(true);
+		shaclSail.setCacheSelectNodes(true);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk,
+					ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation,
+					ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled);
+
+			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
+			ShaclSailConnection.Settings transactionSettings = sailConnection.getTransactionSettings();
+
+			assert transactionSettings.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+			assert transactionSettings.isCacheSelectNodes();
+			assert transactionSettings.isParallelValidation();
+
+			connection.commit();
+
+		}
+
+		sailRepository.shutDown();
+
+	}
+
+	@Test
+	public void testDefault() {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+		shaclSail.setParallelValidation(true);
+		shaclSail.setCacheSelectNodes(true);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin();
+
+			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
+			ShaclSailConnection.Settings transactionSettings = sailConnection.getTransactionSettings();
+
+			assert transactionSettings.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Auto;
+			assert transactionSettings.isCacheSelectNodes();
+			assert transactionSettings.isParallelValidation();
+
+			connection.commit();
+
+		}
+
+		sailRepository.shutDown();
+
+	}
+
+	@Test
+	public void testNulls() {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin();
+
+			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
+			ShaclSailConnection.Settings transactionSettings = sailConnection.getTransactionSettings();
+
+			assert transactionSettings.getValidationApproach() != null;
+			assert transactionSettings.isCacheSelectNodes();
+			assert transactionSettings.isParallelValidation();
+
+			connection.commit();
+
+		}
+
+		sailRepository.shutDown();
+
+	}
+
+	@Test
+	public void testDefaultOverride() {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+		shaclSail.setParallelValidation(true);
+		shaclSail.setCacheSelectNodes(true);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin(ShaclSail.TransactionSettings.PerformanceHint.CacheDisabled,
+					ShaclSail.TransactionSettings.PerformanceHint.SerialValidation);
+
+			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
+			ShaclSailConnection.Settings transactionSettings = sailConnection.getTransactionSettings();
+
+			assert transactionSettings.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Auto;
+			assert !transactionSettings.isCacheSelectNodes();
+			assert !transactionSettings.isParallelValidation();
+
+			connection.commit();
+
+		}
+
+		sailRepository.shutDown();
+
+	}
+
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexLargeBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexLargeBenchmark.java
@@ -463,31 +463,33 @@ public class ComplexLargeBenchmark {
 
 	}
 
-//	@Benchmark
-//	public void noPreloadingBulkParallelCached() {
-//
-//		try {
-//			SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
-//
-//			((ShaclSail) repository.getSail()).setParallelValidation(false);
-//			((ShaclSail) repository.getSail()).setCacheSelectNodes(false);
-//
-//			try (SailRepositoryConnection connection = repository.getConnection()) {
-//				connection.begin(IsolationLevels.NONE,
-//						ShaclSail.TransactionSettings.ValidationApproach.BulkParallelCache);
-//				try (InputStream resourceAsStream = getData()) {
-//					connection.add(resourceAsStream, "", RDFFormat.TURTLE);
-//				}
-//				connection.commit();
-//			}
-//
-//			repository.shutDown();
-//
-//		} catch (IOException e) {
-//			throw new RuntimeException(e);
-//		}
-//
-//	}
+	@Benchmark
+	public void noPreloadingBulkParallelCached() {
+
+		try {
+			SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+
+			((ShaclSail) repository.getSail()).setParallelValidation(false);
+			((ShaclSail) repository.getSail()).setCacheSelectNodes(false);
+
+			try (SailRepositoryConnection connection = repository.getConnection()) {
+				connection.begin(IsolationLevels.NONE,
+						ShaclSail.TransactionSettings.ValidationApproach.Bulk,
+						ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation,
+						ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled);
+				try (InputStream resourceAsStream = getData()) {
+					connection.add(resourceAsStream, "", RDFFormat.TURTLE);
+				}
+				connection.commit();
+			}
+
+			repository.shutDown();
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
 
 	@Benchmark
 	public void noPreloadingRevalidateNativeStore() throws IOException {


### PR DESCRIPTION

GitHub issue resolved: #2846  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - new transaction settings to control parallel validation and cache
 - allow for settings to override Bulk validation and sail level settings

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

