### PR TITLE
GH-2855 optimize sh:minCount when doing transactional validation

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.BulkedExternalLeftOuterJoin;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.EmptyNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.GroupByCountFilter;
+import org.eclipse.rdf4j.sail.shacl.ast.planNodes.LeftOuterJoin;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.TrimToTarget;
@@ -54,12 +55,17 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 			target = getTargetChain().getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 					.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
 							false);
+		} else {
+			// we can assume that we are not doing bulk validation, so it is worth checking our added statements before
+			// we go to the base sail
+
+			PlanNode addedByPath = getTargetChain().getPath().get().getAdded(connectionsGroup, null);
+			LeftOuterJoin leftOuterJoin = new LeftOuterJoin(target, addedByPath);
+			target = new GroupByCountFilter(leftOuterJoin, count -> count < minCount);
 		}
 
-		target = new Unique(new TrimToTarget(target), false);
-
 		PlanNode relevantTargetsWithPath = new BulkedExternalLeftOuterJoin(
-				target,
+				new Unique(new TrimToTarget(target), false),
 				connectionsGroup.getBaseConnection(),
 				getTargetChain().getPath()
 						.get()


### PR DESCRIPTION
GitHub issue resolved: #2855 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - validate against "added" before validating against the base sail
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

