### PR TITLE
GH-2890 Add Step/Path interfaces to model-api module

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/IRI.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/IRI.java
@@ -31,7 +31,7 @@ package org.eclipse.rdf4j.model;
  *           specs.
  */
 @SuppressWarnings("deprecation")
-public interface IRI extends URI, Resource {
+public interface IRI extends URI, Resource, Step, Path.Hop {
 
 	@Override
 	default boolean isIRI() {
@@ -57,6 +57,59 @@ public interface IRI extends URI, Resource {
 	 */
 	@Override
 	String getLocalName();
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return {@code false}
+	 */
+	@Override
+	default boolean isInverse() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return {@code false}
+	 */
+	@Override
+	default boolean isOptional() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return {@code false}
+	 */
+	@Override
+	default boolean isRepeatable() {
+		return false;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return this IRI
+	 */
+	@Override
+	default IRI getIRI() {
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	default <V> V accept(Visitor<V> visitor) {
+
+		if (visitor == null) {
+			throw new NullPointerException("null visitor");
+		}
+
+		return visitor.visit(this);
+	}
 
 	/**
 	 * Compares this IRI to another object.

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/Link.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/Link.java
@@ -1,0 +1,24 @@
+package org.eclipse.rdf4j.model;
+
+/**
+ * Generic property path.
+ *
+ * <p>
+ * Represents a directed property path of unknown length between two {@linkplain Value values} in an RDF graph.
+ * </p>
+ *
+ * @author Alessandro Bollini
+ * @see <a href="https://www.w3.org/TR/sparql11-query/#propertypaths">SPARQL 1.1 Query Language – 9.1 Property Path
+ *      Syntax</a>
+ * @since 3.7.0
+ */
+public interface Link {
+
+	/**
+	 * Checks if this link is inverse.
+	 *
+	 * @return {@code true}, if this link is inverse; {@code false}, otherwise
+	 */
+	public boolean isInverse();
+
+}

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/Path.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/Path.java
@@ -1,0 +1,631 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.model;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Variable length property path.
+ *
+ * <p>
+ * Represents a directed variable length property path between two {@linkplain Value values} in an RDF graph.
+ * </p>
+ *
+ * @author Alessandro Bollini
+ * @see <a href="https://www.w3.org/TR/sparql11-query/#propertypaths">SPARQL 1.1 Query Language – 9.1 Property Path
+ *      Syntax</a>
+ * @since 3.7.0
+ */
+public interface Path extends Link {
+
+	/**
+	 * Creates a sequence path.
+	 *
+	 * @param paths the paths to be included in the sequence path
+	 *
+	 * @return a new sequence path including the given {@code paths}
+	 *
+	 * @throws NullPointerException if {@code paths} is null or contains null elements
+	 */
+	public static Path seq(Path... paths) {
+
+		if (paths == null || Arrays.stream(paths).anyMatch(Objects::isNull)) {
+			throw new NullPointerException("null paths");
+		}
+
+		if (paths.length == 0) {
+			throw new IllegalArgumentException("empty path list");
+		}
+
+		return seq(asList(paths));
+	}
+
+	/**
+	 * Creates a sequence path.
+	 *
+	 * @param paths the paths to be included in the sequence path
+	 *
+	 * @return a new sequence path including the given {@code paths}
+	 *
+	 * @throws NullPointerException if {@code paths} is null or contains null elements
+	 */
+	public static Path seq(Collection<? extends Path> paths) {
+
+		if (paths == null || paths.stream().anyMatch(Objects::isNull)) {
+			throw new NullPointerException("null paths");
+		}
+
+		if (paths.isEmpty()) {
+			throw new IllegalArgumentException("empty path list");
+		}
+
+		return paths.size() == 1 ? paths.iterator().next()
+				: new PathDefault.Seq(
+						unmodifiableList(new ArrayList<>(paths)), false, false, false
+				);
+	}
+
+	/**
+	 * Creates an alternative path.
+	 *
+	 * @param paths the paths to be included in the alternative path
+	 *
+	 * @return a new alternative path including the given {@code paths}
+	 *
+	 * @throws NullPointerException if {@code paths} is null or contains null elements
+	 */
+	public static Path alt(Path... paths) {
+
+		if (paths == null || Arrays.stream(paths).anyMatch(Objects::isNull)) {
+			throw new NullPointerException("null paths");
+		}
+
+		if (paths.length == 0) {
+			throw new IllegalArgumentException("empty path set");
+		}
+
+		return alt(asList(paths));
+	}
+
+	/**
+	 * Creates an alternative path.
+	 *
+	 * @param paths the paths to be included in the alternative path
+	 *
+	 * @return a new alternative path including the given {@code paths}
+	 *
+	 * @throws NullPointerException if {@code paths} is null or contains null elements
+	 */
+	public static Path alt(Collection<? extends Path> paths) {
+
+		if (paths == null || paths.stream().anyMatch(Objects::isNull)) {
+			throw new NullPointerException("null paths");
+		}
+
+		if (paths.isEmpty()) {
+			throw new IllegalArgumentException("empty path set");
+		}
+
+		return paths.size() == 1 ? paths.iterator().next()
+				: new PathDefault.Alt(
+						unmodifiableSet(new LinkedHashSet<>(paths)), false, false, false
+				);
+	}
+
+	/**
+	 * Creates a negated property set.
+	 *
+	 * @param steps the predicate path steps to be excluded from the negated property set
+	 *
+	 * @return a new negated property set excluding the given {@code steps}
+	 *
+	 * @throws NullPointerException if {@code steps} is null or contains null elements
+	 */
+	public static Path not(Step... steps) {
+
+		if (steps == null || Arrays.stream(steps).anyMatch(Objects::isNull)) {
+			throw new NullPointerException("null steps");
+		}
+
+		if (steps.length == 0) {
+			throw new IllegalArgumentException("empty path set");
+		}
+
+		return not(asList(steps));
+	}
+
+	/**
+	 * Creates a negated property set.
+	 *
+	 * @param steps the predicate paths to be excluded from the negated property set
+	 *
+	 * @return a new negated property set excluding the given {@code steps}
+	 *
+	 * @throws NullPointerException     if {@code steps} is null or contains null elements
+	 * @throws IllegalArgumentException if {@code steps} contains either {@linkplain #isOptional() optional} or
+	 *                                  {@linkplain #isRepeatable() repeatable} steps
+	 */
+	public static Path not(Collection<? extends Step> steps) {
+
+		if (steps == null || steps.stream().anyMatch(Objects::isNull)) {
+			throw new NullPointerException("null paths");
+		}
+
+		if (steps.isEmpty()) {
+			throw new IllegalArgumentException("empty path set");
+		}
+
+		return new PathDefault.Not(
+				unmodifiableSet(new LinkedHashSet<>(steps)), false, false, false
+		);
+	}
+
+	/**
+	 * Creates an inverse path.
+	 *
+	 * @param path the path to be inverted
+	 *
+	 * @return a new inverse path derived from {@code path}
+	 *
+	 * @throws NullPointerException if {@code path} is null
+	 */
+	public static Path inverse(Path path) {
+
+		if (path == null) {
+			throw new NullPointerException("null path");
+		}
+
+		return path.accept(new Visitor<Path>() {
+
+			@Override
+			protected Path visit(Hop hop) {
+				return new PathDefault.Hop(hop.getIRI(), true, hop.isOptional(), hop.isRepeatable());
+			}
+
+			@Override
+			protected Path visit(Seq seq) {
+				return new PathDefault.Seq(seq.getPaths(), true, seq.isOptional(), seq.isRepeatable());
+			}
+
+			@Override
+			protected Path visit(Alt alt) {
+				return new PathDefault.Alt(alt.getPaths(), true, alt.isOptional(), alt.isRepeatable());
+			}
+
+			@Override
+			protected Path visit(Not not) {
+				return new PathDefault.Not(not.getSteps(), true, not.isOptional(), not.isRepeatable());
+			}
+
+		});
+	}
+
+	/**
+	 * Creates an optional path.
+	 *
+	 * @param path the path to be made optional
+	 *
+	 * @return a new optional path derived from {@code path}
+	 *
+	 * @throws NullPointerException if {@code path} is null
+	 */
+	public static Path optional(Path path) {
+
+		if (path == null) {
+			throw new NullPointerException("null path");
+		}
+
+		return path.accept(new Visitor<Path>() {
+
+			@Override
+			protected Path visit(Hop hop) {
+				return new PathDefault.Hop(hop.getIRI(), hop.isInverse(), true, hop.isRepeatable());
+			}
+
+			@Override
+			protected Path visit(Seq seq) {
+				return new PathDefault.Seq(seq.getPaths(), seq.isInverse(), true, seq.isRepeatable());
+			}
+
+			@Override
+			protected Path visit(Alt alt) {
+				return new PathDefault.Alt(alt.getPaths(), alt.isInverse(), true, alt.isRepeatable());
+			}
+
+			@Override
+			protected Path visit(Not not) {
+				return new PathDefault.Not(not.getSteps(), not.isInverse(), true, not.isRepeatable());
+			}
+
+		});
+	}
+
+	/**
+	 * Creates a repeatable path.
+	 *
+	 * @param path the path to be made repeatable
+	 *
+	 * @return a new repeatable path derived from {@code path}
+	 *
+	 * @throws NullPointerException if {@code path} is null
+	 */
+	public static Path repeatable(Path path) {
+
+		if (path == null) {
+			throw new NullPointerException("null path");
+		}
+
+		return path.accept(new Visitor<Path>() {
+
+			@Override
+			protected Path visit(Hop hop) {
+				return new PathDefault.Hop(hop.getIRI(), hop.isInverse(), hop.isOptional(), true);
+			}
+
+			@Override
+			protected Path visit(Seq seq) {
+				return new PathDefault.Seq(seq.getPaths(), seq.isInverse(), seq.isOptional(), true);
+			}
+
+			@Override
+			protected Path visit(Alt alt) {
+				return new PathDefault.Alt(alt.getPaths(), alt.isInverse(), alt.isOptional(), true);
+			}
+
+			@Override
+			protected Path visit(Not not) {
+				return new PathDefault.Not(not.getSteps(), not.isInverse(), not.isOptional(), true);
+			}
+
+		});
+	}
+
+	/**
+	 * Creates a multiple ({@linkplain #optional(Path) optional}/{@linkplain #repeatable(Path) repeatable}) path.
+	 *
+	 * @param path the path to be made multiple
+	 *
+	 * @return a new multiple path derived from {@code path}
+	 *
+	 * @throws NullPointerException if {@code path} is null
+	 */
+	public static Path multiple(Path path) {
+
+		if (path == null) {
+			throw new NullPointerException("null path");
+		}
+
+		return path.accept(new Visitor<Path>() {
+
+			@Override
+			protected Path visit(Hop hop) {
+				return new PathDefault.Hop(hop.getIRI(), hop.isInverse(), true, true);
+			}
+
+			@Override
+			protected Path visit(Seq seq) {
+				return new PathDefault.Seq(seq.getPaths(), seq.isInverse(), true, true);
+			}
+
+			@Override
+			protected Path visit(Alt alt) {
+				return new PathDefault.Alt(alt.getPaths(), alt.isInverse(), true, true);
+			}
+
+			@Override
+			protected Path visit(Not not) {
+				return new PathDefault.Not(not.getSteps(), not.isInverse(), true, true);
+			}
+
+		});
+	}
+
+	/**
+	 * Converts a path to a textual representation.
+	 *
+	 * @param path the path to be formatted
+	 *
+	 * @return a fully parenthesized SPARQL expression representing {@code path} with full IRIs
+	 *
+	 * @throws NullPointerException if {@code path} is null
+	 */
+	public static String format(Path path) {
+
+		if (path == null) {
+			throw new NullPointerException("null path");
+		}
+
+		return path.accept(new PathFormatter()).toString();
+	}
+
+	/**
+	 * Checks if this path is optional.
+	 *
+	 * @return {@code true}, if this path is optional; {@code false}, otherwise
+	 */
+	public boolean isOptional();
+
+	/**
+	 * Checks if this path is repeatable.
+	 *
+	 * @return {@code true}, if this path is repeatable; {@code false}, otherwise
+	 */
+	public boolean isRepeatable();
+
+	/**
+	 * Accepts a path visitor.
+	 *
+	 * @param visitor a path visitor
+	 * @param <V>     the type of the result returned by {@code visitor}
+	 *
+	 * @return the (possibly null) value computed by {@code visitor} according to the type of this path
+	 *
+	 * @throws NullPointerException if {@code visitor} is null
+	 */
+	public <V> V accept(Visitor<V> visitor);
+
+	/**
+	 * Predicate path.
+	 *
+	 * <p>
+	 * Represents a path composed by a single predicate IRI.
+	 * </p>
+	 *
+	 * @implNote {@link #equals(Object)}/{@link #hashCode()} contracts conflicts with those specified by {@link IRI},
+	 *           which extends this interface: in order to preserve equality consistency, plain direct predicate paths
+	 *           must be represented only with IRIs; concrete classes implementing this interface must ensure that no
+	 *           instance is created with coincident {@code false}
+	 *           {@link #isInverse()}/{@link #isOptional()}/{@link #isRepeatable()} values.
+	 */
+	public static interface Hop extends Path {
+
+		/**
+		 * Retrieves the IRI of this predicate path.
+		 *
+		 * @return the IRI of this path
+		 */
+		public IRI getIRI();
+
+		/**
+		 * Checks if this predicate path is equal to a reference object.
+		 *
+		 * @param object the reference object
+		 *
+		 * @return {@code true}, if the reference object is an instance of {@code Step} and the {@link #getIRI()},
+		 *         {@link #isInverse()}, {@link #isOptional()} and {@link #isRepeatable()} values ot this path and of
+		 *         the reference object are equal to each other; {@code false}, otherwise
+		 *
+		 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+		 *           {@code equals(Object)} method must be implemented exactly as described in this specs.
+		 */
+		public boolean equals(Object object);
+
+		/**
+		 * Computes the hash code of this predicate path.
+		 *
+		 * @return a hash code for this path computed as:<br>
+		 *
+		 *         {@link #getIRI()}{@code .hashCode()}<br>
+		 *         {@code ^Boolean.hashCode(}{@link #isInverse()}{@code )}<br>
+		 *         {@code ^Boolean.hashCode(}{@link #isOptional()}{@code )}<br>
+		 *         {@code ^Boolean.hashCode(}{@link #isRepeatable()}{@code )}
+		 *
+		 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+		 *           {@code hashCode()} method must be implemented exactly as described in this specs.
+		 */
+		public int hashCode();
+
+	}
+
+	/**
+	 * Sequence path.
+	 *
+	 * <p>
+	 * Represents a path composed by a list of sequential paths.
+	 * </p>
+	 */
+	public static interface Seq extends Path {
+
+		/**
+		 * Retrieves the paths of this sequence path.
+		 *
+		 * @return the paths of this sequence path
+		 */
+		public List<Path> getPaths();
+
+		/**
+		 * Checks if this sequence path is equal to a reference object.
+		 *
+		 * @param object the reference object
+		 *
+		 * @return {@code true}, if the reference object is an instance of {@code Seq} and the {@link #getPaths()},
+		 *         {@link #isInverse()}, {@link #isOptional()} and {@link #isRepeatable()} values ot this path and of
+		 *         the reference object are equal to each other; {@code false}, otherwise
+		 *
+		 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+		 *           {@code equals(Object)} method must be implemented exactly as described in this specs.
+		 */
+		public boolean equals(Object object);
+
+		/**
+		 * Computes the hash code of this sequence path.
+		 *
+		 * @return a hash code for this path computed as:
+		 *
+		 *         {@link #getPaths()}{@code .hashCode()} {@code ^Boolean.hashCode(}{@link #isInverse()}{@code )}
+		 *         {@code ^Boolean.hashCode(}{@link #isOptional()}{@code )}
+		 *         {@code ^Boolean.hashCode(}{@link #isRepeatable()}{@code )}
+		 *
+		 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+		 *           {@code hashCode()} method must be implemented exactly as described in this specs.
+		 */
+		public int hashCode();
+
+	}
+
+	/**
+	 * Alternative path.
+	 *
+	 * <p>
+	 * Represents a path composed by a set of alternative paths.
+	 * </p>
+	 */
+	public static interface Alt extends Path {
+
+		/**
+		 * Retrieves the paths of this alternative path.
+		 *
+		 * @return the paths of this path
+		 */
+		public Set<Path> getPaths();
+
+		/**
+		 * Checks if this alternative path is equal to a reference object.
+		 *
+		 * @param object the reference object
+		 *
+		 * @return {@code true}, if the reference object is an instance of {@code Alt} and the {@link #getPaths()},
+		 *         {@link #isInverse()}, {@link #isOptional()} and {@link #isRepeatable()} values ot this path and of
+		 *         the reference object are equal to each other; {@code false}, otherwise
+		 *
+		 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+		 *           {@code equals(Object)} method must be implemented exactly as described in this specs.
+		 */
+		public boolean equals(Object object);
+
+		/**
+		 * Computes the hash code of this alternative path.
+		 *
+		 * @return a hash code for this path computed as:
+		 *
+		 *         {@link #getPaths()}{@code .hashCode()} {@code ^Boolean.hashCode(}{@link #isInverse()}{@code )}
+		 *         {@code ^Boolean.hashCode(}{@link #isOptional()}{@code )}
+		 *         {@code ^Boolean.hashCode(}{@link #isRepeatable()}{@code )}
+		 *
+		 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+		 *           {@code hashCode()} method must be implemented exactly as described in this specs.
+		 */
+		public int hashCode();
+
+	}
+
+	/**
+	 * Negated property set.
+	 *
+	 * <p>
+	 * Represents a path composed by a set of excluded {@linkplain Step predicate path steps}.
+	 * </p>
+	 */
+	public static interface Not extends Path {
+
+		/**
+		 * Retrieves the predicate path steps of this negated property set.
+		 *
+		 * @return the predicate path stepss of this negated property set
+		 */
+		public Set<Step> getSteps();
+
+		/**
+		 * Checks if this negated property set is equal to a reference object.
+		 *
+		 * @param object the reference object
+		 *
+		 * @return {@code true}, if the reference object is an instance of {@code Not} and the {@link #getSteps()},
+		 *         {@link #isInverse()}, {@link #isOptional()} and {@link #isRepeatable()} values ot this property set
+		 *         and of the reference object are equal to each other; {@code false}, otherwise
+		 *
+		 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+		 *           {@code equals(Object)} method must be implemented exactly as described in this specs.
+		 */
+		public boolean equals(Object object);
+
+		/**
+		 * Computes the hash code of this negated property set.
+		 *
+		 * @return a hash code for this property set computed as:
+		 *
+		 *         {@link #getSteps()}{@code .hashCode()} {@code ^Boolean.hashCode(}{@link #isInverse()}{@code )}
+		 *         {@code ^Boolean.hashCode(}{@link #isOptional()}{@code )}
+		 *         {@code ^Boolean.hashCode(}{@link #isRepeatable()}{@code )}
+		 *
+		 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+		 *           {@code hashCode()} method must be implemented exactly as described in this specs.
+		 */
+		public int hashCode();
+
+	}
+
+	/**
+	 * Path visitor.
+	 *
+	 * <p>
+	 * Visits paths returning a value computed according to their type.
+	 * </p>
+	 *
+	 * @param <V> the type of the result returned by the visitor
+	 */
+	public abstract static class Visitor<V> {
+
+		/**
+		 * Visits a predicate path.
+		 *
+		 * @param hop the predicate path to be visited
+		 *
+		 * @return a value computed on the basis of the visited {@code step} path
+		 *
+		 * @throws NullPointerException if {@code step} is null
+		 */
+		protected abstract V visit(Hop hop);
+
+		/**
+		 * Visits a sequence path.
+		 *
+		 * @param seq the sequence path to be visited
+		 *
+		 * @return a value computed on the basis of the visited {@code seq} path
+		 *
+		 * @throws NullPointerException if {@code seq} is null
+		 */
+		protected abstract V visit(Seq seq);
+
+		/**
+		 * Visits an alternative path.
+		 *
+		 * @param alt the alternative path to be visited
+		 *
+		 * @return a value computed on the basis of the visited {@code alt} path
+		 *
+		 * @throws NullPointerException if {@code alt} is null
+		 */
+		protected abstract V visit(Alt alt);
+
+		/**
+		 * Visits a negated property set.
+		 *
+		 * @param not the egated property set to be visited
+		 *
+		 * @return a value computed on the basis of the visited {@code not} property set
+		 *
+		 * @throws NullPointerException if {@code not} is null
+		 */
+		protected abstract V visit(Not not);
+
+	}
+
+}

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/PathDefault.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/PathDefault.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.model;
+
+import static org.eclipse.rdf4j.model.Path.format;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Default variable length property path implementations.
+ *
+ * @author Alessandro Bollini
+ * @since 3.7.0
+ */
+abstract class PathDefault<T> implements Path {
+
+	private final T value;
+
+	private final boolean inverse;
+	private final boolean optional;
+	private final boolean repeatable;
+
+	PathDefault(T value, boolean inverse, boolean optional, boolean repeatable) {
+
+		this.value = value;
+
+		this.inverse = inverse;
+		this.optional = optional;
+		this.repeatable = repeatable;
+	}
+
+	protected T getValue() {
+		return value;
+	}
+
+	@Override
+	public boolean isInverse() {
+		return inverse;
+	}
+
+	@Override
+	public boolean isOptional() {
+		return optional;
+	}
+
+	@Override
+	public boolean isRepeatable() {
+		return repeatable;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return this == object || getClass().isInstance(object)
+				&& value.equals(((PathDefault<?>) object).value)
+				&& inverse == ((PathDefault<?>) object).inverse
+				&& optional == ((PathDefault<?>) object).optional
+				&& repeatable == ((PathDefault<?>) object).repeatable;
+	}
+
+	@Override
+	public int hashCode() {
+		return value.hashCode()
+				^ Boolean.hashCode(inverse)
+				^ Boolean.hashCode(optional)
+				^ Boolean.hashCode(repeatable);
+	}
+
+	@Override
+	public String toString() {
+		return format(this);
+	}
+
+	static final class Hop extends PathDefault<IRI> implements Path.Hop {
+
+		Hop(IRI value, boolean inverse, boolean optional, boolean repeatable) {
+
+			super(value, inverse, optional, repeatable);
+
+			if (!inverse && !optional && !repeatable) {
+				throw new AssertionError("plain direct predicate paths should be represented with an IRI");
+			}
+
+		}
+
+		@Override
+		public IRI getIRI() {
+			return getValue();
+		}
+
+		@Override
+		public <V> V accept(Visitor<V> visitor) {
+
+			if (visitor == null) {
+				throw new NullPointerException("null visitor");
+			}
+
+			return visitor.visit(this);
+		}
+
+	}
+
+	static final class Seq extends PathDefault<List<Path>> implements Path.Seq {
+
+		Seq(List<Path> value, boolean inverse, boolean optional, boolean repeatable) {
+			super(value, inverse, optional, repeatable);
+		}
+
+		@Override
+		public List<Path> getPaths() {
+			return getValue();
+		}
+
+		@Override
+		public <V> V accept(Visitor<V> visitor) {
+
+			if (visitor == null) {
+				throw new NullPointerException("null visitor");
+			}
+
+			return visitor.visit(this);
+		}
+
+	}
+
+	static final class Alt extends PathDefault<Set<Path>> implements Path.Alt {
+
+		Alt(Set<Path> value, boolean inverse, boolean optional, boolean repeatable) {
+			super(value, inverse, optional, repeatable);
+		}
+
+		@Override
+		public Set<Path> getPaths() {
+			return getValue();
+		}
+
+		@Override
+		public <V> V accept(Visitor<V> visitor) {
+
+			if (visitor == null) {
+				throw new NullPointerException("null visitor");
+			}
+
+			return visitor.visit(this);
+		}
+
+	}
+
+	static final class Not extends PathDefault<Set<Step>> implements Path.Not {
+
+		Not(Set<Step> value, boolean inverse, boolean optional, boolean repeatable) {
+			super(value, inverse, optional, repeatable);
+		}
+
+		@Override
+		public Set<Step> getSteps() {
+			return getValue();
+		}
+
+		@Override
+		public <V> V accept(Visitor<V> visitor) {
+
+			if (visitor == null) {
+				throw new NullPointerException("null visitor");
+			}
+
+			return visitor.visit(this);
+		}
+
+	}
+
+}

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/PathFormatter.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/PathFormatter.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.model;
+
+import java.util.Iterator;
+import java.util.function.Consumer;
+
+/**
+ * Property path formatter.
+ *
+ * @author Alessandro Bollini
+ * @since 3.7.0
+ */
+final class PathFormatter extends Path.Visitor<StringBuilder> {
+
+	private final StringBuilder builder = new StringBuilder(10);
+
+	@Override
+	protected StringBuilder visit(Path.Hop hop) {
+
+		inverse(hop);
+		edge(hop.getIRI());
+		count(hop);
+
+		return builder;
+	}
+
+	@Override
+	protected StringBuilder visit(Path.Seq seq) {
+
+		inverse(seq);
+		list(seq.getPaths(), '/', path -> path.accept(this));
+		count(seq);
+		return builder;
+	}
+
+	@Override
+	protected StringBuilder visit(Path.Alt alt) {
+
+		inverse(alt);
+		list(alt.getPaths(), '|', path -> path.accept(this));
+		count(alt);
+
+		return builder;
+	}
+
+	@Override
+	protected StringBuilder visit(Path.Not not) {
+
+		inverse(not);
+		builder.append('!');
+		list(not.getSteps(), '|', this::step);
+		count(not);
+
+		return builder;
+	}
+
+	private void inverse(Link link) {
+		if (link.isInverse()) {
+			builder.append('^');
+		}
+	}
+
+	private void step(Step step) {
+		inverse(step);
+		edge(step.getIRI());
+	}
+
+	private void edge(IRI iri) {
+		builder.append('<').append(iri.stringValue()).append('>');
+	}
+
+	private void count(Path path) {
+		if (path.isRepeatable()) {
+			builder.append(path.isOptional() ? '*' : '+');
+		} else if (path.isOptional()) {
+			builder.append('?');
+		}
+	}
+
+	private <T> void list(Iterable<T> paths, char separator, Consumer<T> formatter) {
+
+		builder.append('(');
+
+		for (final Iterator<T> iterator = paths.iterator(); iterator.hasNext();) {
+
+			formatter.accept(iterator.next());
+
+			if (iterator.hasNext()) {
+				builder.append(separator);
+			}
+
+		}
+
+		builder.append(')');
+	}
+
+}

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/Step.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/Step.java
@@ -1,0 +1,91 @@
+package org.eclipse.rdf4j.model;
+
+/**
+ * Single step property path.
+ *
+ * <p>
+ * Represents a directed single step property path between two {@linkplain Value values} in an RDF graph.
+ * </p>
+ *
+ * @implNote {@link #equals(Object)}/{@link #hashCode()} contracts conflicts with those specified by {@link IRI}, which
+ *           extends this interface: in order to preserve equality consistency, plain direct steps must be represented
+ *           only with IRIs; concrete classes implementing this interface must ensure that no instance is created with a
+ *           {@code false} {@link #isInverse()} value.
+ * 
+ * @author Alessandro Bollini
+ * @see <a href="https://www.w3.org/TR/sparql11-query/#propertypaths">SPARQL 1.1 Query Language – 9.1 Property Path
+ *      Syntax</a>
+ * @since 3.7.0
+ */
+public interface Step extends Link {
+
+	/**
+	 * Creates an inverse step.
+	 *
+	 * @param step the step to be inverted
+	 *
+	 * @return a new inverse step derived from {@code step}
+	 *
+	 * @throws NullPointerException if {@code step} is null
+	 */
+	public static Step inverse(Step step) {
+
+		if (step == null) {
+			throw new NullPointerException("null step");
+		}
+
+		return new StepDefault(step.getIRI(), true);
+	}
+
+	/**
+	 * Converts a step to a textual representation.
+	 *
+	 * @param step the step to be formatted
+	 *
+	 * @return a SPARQL expression representing {@code step} with a full IRI
+	 *
+	 * @throws NullPointerException if {@code step} is null
+	 */
+	public static String format(Step step) {
+
+		if (step == null) {
+			throw new NullPointerException("null step");
+		}
+
+		return (step.isInverse() ? "^<" : "<") + step.getIRI().stringValue() + ">";
+	}
+
+	/**
+	 * Retrieves the IRI of this predicate path step.
+	 *
+	 * @return the IRI of this step
+	 */
+	public IRI getIRI();
+
+	/**
+	 * Checks if this step is equal to a reference object.
+	 *
+	 * @param object the reference object
+	 *
+	 * @return {@code true}, if the reference object is an instance of {@code Step} and the {@link #getIRI()} value of
+	 *         this step and of the reference object are equal to each other; {@code false}, otherwise
+	 *
+	 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+	 *           {@code equals(Object)} method must be implemented exactly as described in this specs.
+	 */
+	public boolean equals(Object object);
+
+	/**
+	 * Computes the hash code of this step.
+	 *
+	 * @return a hash code for this step computed as:<br>
+	 *
+	 *         {@link #getIRI()}{@code .hashCode()}<br>
+	 *         {@code ^Boolean.hashCode(}{@link #isInverse()}{@code )}
+	 *
+	 * @implNote In order to ensure interoperability of concrete classes implementing this interface, the
+	 *           {@code hashCode()} method must be implemented exactly as described in this specs.
+	 */
+	public int hashCode();
+
+}

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/StepDefault.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/StepDefault.java
@@ -1,0 +1,55 @@
+package org.eclipse.rdf4j.model;
+
+import static org.eclipse.rdf4j.model.Step.format;
+
+/**
+ * Default single step property path implementations.
+ *
+ * @author Alessandro Bollini
+ * @since 3.7.0
+ */
+public final class StepDefault implements Step {
+
+	private final IRI iri;
+
+	private final boolean inverse;
+
+	StepDefault(IRI iri, boolean inverse) {
+
+		if (!inverse) {
+			throw new AssertionError("plain direct steps should be represented with an IRI");
+		}
+
+		this.inverse = inverse;
+		this.iri = iri;
+	}
+
+	@Override
+	public boolean isInverse() {
+		return inverse;
+	}
+
+	@Override
+	public IRI getIRI() {
+		return iri;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		return this == object || object instanceof Step
+				&& iri.equals(((Step) object).getIRI())
+				&& inverse == ((Link) object).isInverse();
+	}
+
+	@Override
+	public int hashCode() {
+		return iri.hashCode()
+				^ Boolean.hashCode(inverse);
+	}
+
+	@Override
+	public String toString() {
+		return format(this);
+	}
+
+}

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/PathTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/PathTest.java
@@ -1,0 +1,371 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.model;
+
+import static java.lang.String.format;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.fail;
+import static org.eclipse.rdf4j.model.Path.alt;
+import static org.eclipse.rdf4j.model.Path.format;
+import static org.eclipse.rdf4j.model.Path.inverse;
+import static org.eclipse.rdf4j.model.Path.multiple;
+import static org.eclipse.rdf4j.model.Path.not;
+import static org.eclipse.rdf4j.model.Path.optional;
+import static org.eclipse.rdf4j.model.Path.repeatable;
+import static org.eclipse.rdf4j.model.Path.seq;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.rdf4j.model.Path.Alt;
+import org.eclipse.rdf4j.model.Path.Hop;
+import org.eclipse.rdf4j.model.Path.Not;
+import org.eclipse.rdf4j.model.Path.Seq;
+import org.eclipse.rdf4j.model.base.AbstractIRI;
+import org.junit.Test;
+
+public final class PathTest {
+
+	private static final IRI x = iri("x");
+	private static final IRI y = iri("y");
+
+	private static AbstractIRI iri(String name) {
+		return new AbstractIRI() {
+
+			@Override
+			public String getNamespace() {
+				return "test";
+			}
+
+			@Override
+			public String getLocalName() {
+				return name;
+			}
+
+		};
+	}
+
+	@Test
+	public void testFormatNesteds() {
+		assertThat(format(seq(inverse(optional(alt(x, seq(x, y)))), multiple(not(x))))).isEqualTo(format(
+				"(^(%1$s|(%1$s/%2$s))?/!(%1$s)*)", format(x), format(y)
+		));
+	}
+
+	public static final class Hops {
+
+		private final Path path = x;
+
+		private static IRI getIRI(Path path) {
+			return path.accept(new Path.Visitor<IRI>() {
+
+				@Override
+				protected IRI visit(Hop hop) {
+					return hop.getIRI();
+				}
+
+				@Override
+				protected IRI visit(Seq seq) {
+					return fail("unexpected seq path");
+				}
+
+				@Override
+				protected IRI visit(Alt alt) {
+					return fail("unexpected alt path");
+				}
+
+				@Override
+				protected IRI visit(Not not) {
+					return fail("unexpected not path");
+				}
+
+			});
+		}
+
+		@Test
+		public void testCreation() {
+
+			assertThat(getIRI(path)).isEqualTo(x);
+
+			assertThat(path.isInverse()).isFalse();
+			assertThat(path.isOptional()).isFalse();
+			assertThat(path.isRepeatable()).isFalse();
+
+		}
+
+		@Test
+		public void testInverse() {
+			assertThat(inverse(path).isInverse()).isTrue();
+			assertThat(inverse(inverse(path)).isInverse()).isTrue();
+			assertThat(getIRI(inverse(path))).isEqualTo(x);
+		}
+
+		@Test
+		public void testOptional() {
+			assertThat(optional(path).isOptional()).isTrue();
+			assertThat(optional(optional(path)).isOptional()).isTrue();
+			assertThat(getIRI(optional(path))).isEqualTo(x);
+		}
+
+		@Test
+		public void testRepeatable() {
+			assertThat(repeatable(path).isRepeatable()).isTrue();
+			assertThat(repeatable(repeatable(path)).isRepeatable()).isTrue();
+			assertThat(getIRI(repeatable(path))).isEqualTo(x);
+		}
+
+		@Test
+		public void testFormat() {
+			assertThat(format(path)).isEqualTo(format("%s", format(x)));
+			assertThat(format(inverse(path))).isEqualTo(format("^%s", format(x)));
+			assertThat(format(optional(path))).isEqualTo(format("%s?", format(x)));
+			assertThat(format(repeatable(path))).isEqualTo(format("%s+", format(x)));
+			assertThat(format(multiple(path))).isEqualTo(format("%s*", format(x)));
+		}
+
+	}
+
+	public static final class Seqs {
+
+		private final Path path = seq(x, y);
+
+		private static List<Path> getSeq(Path path) {
+			return path.accept(new Path.Visitor<List<Path>>() {
+
+				@Override
+				protected List<Path> visit(Hop hop) {
+					return fail("unexpected step path");
+				}
+
+				@Override
+				protected List<Path> visit(Seq seq) {
+					return seq.getPaths();
+				}
+
+				@Override
+				protected List<Path> visit(Alt alt) {
+					return fail("unexpected alt path");
+				}
+
+				@Override
+				protected List<Path> visit(Not not) {
+					return fail("unexpected not path");
+				}
+
+			});
+		}
+
+		@Test
+		public void testCreation() {
+
+			assertThat(getSeq(path)).containsExactly(x, y);
+
+			assertThat(path.isInverse()).isFalse();
+			assertThat(path.isOptional()).isFalse();
+			assertThat(path.isRepeatable()).isFalse();
+
+		}
+
+		@Test
+		public void testInverse() {
+			assertThat(inverse(path).isInverse()).isTrue();
+			assertThat(inverse(inverse(path)).isInverse()).isTrue();
+		}
+
+		@Test
+		public void testOptional() {
+			assertThat(optional(path).isOptional()).isTrue();
+			assertThat(optional(optional(path)).isOptional()).isTrue();
+		}
+
+		@Test
+		public void testRepeatable() {
+			assertThat(repeatable(path).isRepeatable()).isTrue();
+			assertThat(repeatable(repeatable(path)).isRepeatable()).isTrue();
+		}
+
+		@Test
+		public void testFormat() {
+			assertThat(format(path)).isEqualTo(format("(%s/%s)", format(x), format(y)));
+			assertThat(format(inverse(path))).isEqualTo(format("^(%s/%s)", format(x), format(y)));
+			assertThat(format(optional(path))).isEqualTo(format("(%s/%s)?", format(x), format(y)));
+			assertThat(format(repeatable(path))).isEqualTo(format("(%s/%s)+", format(x), format(y)));
+			assertThat(format(multiple(path))).isEqualTo(format("(%s/%s)*", format(x), format(y)));
+		}
+
+		@Test
+		public void testOptimizeSingleton() {
+			assertThat(seq(x)).isEqualTo(x);
+		}
+
+		@Test
+		public void testReportEmpty() {
+			assertThatIllegalArgumentException().isThrownBy(Path::seq);
+		}
+
+	}
+
+	public static final class Alts {
+
+		private final Path path = alt(x, y);
+
+		private static Set<Path> getAlt(Path path) {
+			return path.accept(new Path.Visitor<Set<Path>>() {
+
+				@Override
+				protected Set<Path> visit(Hop hop) {
+					return fail("unexpected step path");
+				}
+
+				@Override
+				protected Set<Path> visit(Seq seq) {
+					return fail("unexpected seq path");
+				}
+
+				@Override
+				protected Set<Path> visit(Alt alt) {
+					return alt.getPaths();
+				}
+
+				@Override
+				protected Set<Path> visit(Not not) {
+					return fail("unexpected not path");
+				}
+
+			});
+		}
+
+		@Test
+		public void testCreation() {
+
+			assertThat(getAlt(path)).containsExactly(x, y);
+
+			assertThat(path.isInverse()).isFalse();
+			assertThat(path.isOptional()).isFalse();
+			assertThat(path.isRepeatable()).isFalse();
+
+		}
+
+		@Test
+		public void testInverse() {
+			assertThat(inverse(path).isInverse()).isTrue();
+			assertThat(inverse(inverse(path)).isInverse()).isTrue();
+		}
+
+		@Test
+		public void testOptional() {
+			assertThat(optional(path).isOptional()).isTrue();
+			assertThat(optional(optional(path)).isOptional()).isTrue();
+		}
+
+		@Test
+		public void testRepeatable() {
+			assertThat(repeatable(path).isRepeatable()).isTrue();
+			assertThat(repeatable(repeatable(path)).isRepeatable()).isTrue();
+		}
+
+		@Test
+		public void testFormatAlts() {
+			assertThat(format(path)).isEqualTo(format("(%s|%s)", format(x), format(y)));
+			assertThat(format(inverse(path))).isEqualTo(format("^(%s|%s)", format(x), format(y)));
+			assertThat(format(optional(path))).isEqualTo(format("(%s|%s)?", format(x), format(y)));
+			assertThat(format(repeatable(path))).isEqualTo(format("(%s|%s)+", format(x), format(y)));
+			assertThat(format(multiple(path))).isEqualTo(format("(%s|%s)*", format(x), format(y)));
+		}
+
+		@Test
+		public void testOptimizeSingleton() {
+			assertThat(alt(x)).isEqualTo(x);
+		}
+
+		@Test
+		public void testReportEmpty() {
+			assertThatIllegalArgumentException().isThrownBy(Path::alt);
+		}
+
+	}
+
+	public static final class Nots {
+
+		private final Path path = not(x, y);
+
+		private static Set<Step> getNot(Path path) {
+			return path.accept(new Path.Visitor<Set<Step>>() {
+
+				@Override
+				protected Set<Step> visit(Path.Hop hop) {
+					return fail("unexpected step path");
+				}
+
+				@Override
+				protected Set<Step> visit(Seq seq) {
+					return fail("unexpected seq path");
+				}
+
+				@Override
+				protected Set<Step> visit(Alt alt) {
+					return fail("unexpected alt path");
+				}
+
+				@Override
+				protected Set<Step> visit(Not not) {
+					return not.getSteps();
+				}
+
+			});
+		}
+
+		@Test
+		public void testCreation() {
+
+			assertThat(getNot(path)).containsExactly(x, y);
+
+			assertThat(path.isInverse()).isFalse();
+			assertThat(path.isOptional()).isFalse();
+			assertThat(path.isRepeatable()).isFalse();
+
+		}
+
+		@Test
+		public void testInverse() {
+			assertThat(inverse(path).isInverse()).isTrue();
+			assertThat(inverse(inverse(path)).isInverse()).isTrue();
+		}
+
+		@Test
+		public void testOptional() {
+			assertThat(optional(path).isOptional()).isTrue();
+			assertThat(optional(optional(path)).isOptional()).isTrue();
+		}
+
+		@Test
+		public void testRepeatable() {
+			assertThat(repeatable(path).isRepeatable()).isTrue();
+			assertThat(repeatable(repeatable(path)).isRepeatable()).isTrue();
+		}
+
+		@Test
+		public void testFormatNots() {
+			assertThat(format(path)).isEqualTo(format("!(%s|%s)", format(x), format(y)));
+			assertThat(format(inverse(path))).isEqualTo(format("^!(%s|%s)", format(x), format(y)));
+			assertThat(format(optional(path))).isEqualTo(format("!(%s|%s)?", format(x), format(y)));
+			assertThat(format(repeatable(path))).isEqualTo(format("!(%s|%s)+", format(x), format(y)));
+			assertThat(format(multiple(path))).isEqualTo(format("!(%s|%s)*", format(x), format(y)));
+		}
+
+		@Test
+		public void testReportEmpty() {
+			assertThatIllegalArgumentException().isThrownBy(Path::not);
+		}
+
+	}
+
+}

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/StepTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/StepTest.java
@@ -1,0 +1,45 @@
+package org.eclipse.rdf4j.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.Step.format;
+import static org.eclipse.rdf4j.model.Step.inverse;
+
+import org.eclipse.rdf4j.model.base.AbstractIRI;
+import org.junit.Test;
+
+public class StepTest {
+
+	private static final IRI iri = new AbstractIRI() {
+
+		@Override
+		public String getNamespace() {
+			return "test";
+		}
+
+		@Override
+		public String getLocalName() {
+			return "x";
+		}
+
+	};
+
+	@Test
+	public void testCreation() {
+		assertThat(iri.getIRI()).isEqualTo(iri);
+		assertThat(iri.isInverse()).isFalse();
+	}
+
+	@Test
+	public void testInverse() {
+		assertThat(inverse(iri).isInverse()).isTrue();
+		assertThat(inverse(inverse(iri)).isInverse()).isTrue();
+		assertThat(inverse(iri).getIRI()).isEqualTo(iri);
+	}
+
+	@Test
+	public void testFormat() {
+		assertThat(format(iri)).isEqualTo(String.format("<%s>", iri.stringValue()));
+		assertThat(format(inverse(iri))).isEqualTo(String.format("^<%s>", iri.stringValue()));
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Alessandro Bollini <22@metreeca.com>


GitHub issue resolved: #2890

Briefly describe the changes proposed in this PR:

- Add Step/Path interfaces and default implementations to `model-api` module, to support use cases like data modelling and linked data navigation

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

