### PR TITLE
GH-2889 Documentation typos in Model and REST API

### DIFF
--- a/site/content/documentation/programming/model.md
+++ b/site/content/documentation/programming/model.md
@@ -20,9 +20,9 @@ RDF statements are represented by the {{< javadoc "Statement" "model/Statement.h
 To create new values and statements, you can use the {{< javadoc "Values" "model/util/Values.html" >}}  and {{< javadoc "Statements" "model/util/Statements.html" >}} static factory methods, which provide easy creation of new `IRI`s, `Literal`s, `BNode`s, `Triple`s and `Statement`s based on a variety of different input objects.
 
 ```java
-import static org.eclipse.model.util.Statements.statement;
-import static org.eclipse.model.util.Values.iri;
-import static org.eclipse.model.util.Values.literal;
+import static org.eclipse.rdf4j.model.util.Statements.statement;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 
 IRI bob = iri("http://example.org/bob");
 IRI nameProp = iri("http://example.org/name");
@@ -43,7 +43,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 ValueFactory factory = SimpleValueFactory.getInstance();
 ```
 
-For performance reasons, the `SimpleValueFactory` provides only basic input validation. The {{< javadoc "ValidatingValueFactory" "model/impl/ValidatingValueFactory.html" >}} is stricter, albeit somewhat slower (though this should not be noticable unless you are working with very significant amounts of data).
+For performance reasons, the `SimpleValueFactory` provides only basic input validation. The {{< javadoc "ValidatingValueFactory" "model/impl/ValidatingValueFactory.html" >}} is stricter, albeit somewhat slower (though this should not be noticeable unless you are working with very significant amounts of data).
 
 You can also obtain a `ValueFactory` from the {{< javadoc "Repository" "repository/Repository.html" >}} you are working with, and in fact, this is the recommend approach. For more information about this see the [Repository API documentation](/documentation/programming/repository/).
 
@@ -109,7 +109,7 @@ for (Resource person: model.filter(null, RDF.TYPE, FOAF.PERSON).subjects()) {
 
 The `filter()` method returns a `Model` again. However, the `Model` returned by this method is still backed by the original `Model`. Thus, changes that you make to this returned `Model` will automatically be reflected in the original `Model` as well.
 
-RDF4J provides three default implementations of the `Model` interface: {{< javadoc "org.eclipse.model.mpl.DynamicModel" "model/impl/DynamicModel.html" >}}, {{< javadoc "org.eclipse.rdf4j.model.impl.LinkedHashModel" "model/impl/LinkedHashModel.html" >}}, and {{< javadoc "org.eclipse.rdf4j.model.impl.TreeModel" "model/impl/TreeModel.html" >}}. The difference between them is in their performance for different kinds of lookups and insertion patterns (see their respective javadoc entries for details). These differences are only really noticable when dealing with quite large collections of statements, however. 
+RDF4J provides three default implementations of the `Model` interface: {{< javadoc "org.eclipse.rdf4j.model.impl.DynamicModel" "model/impl/DynamicModel.html" >}}, {{< javadoc "org.eclipse.rdf4j.model.impl.LinkedHashModel" "model/impl/LinkedHashModel.html" >}}, and {{< javadoc "org.eclipse.rdf4j.model.impl.TreeModel" "model/impl/TreeModel.html" >}}. The difference between them is in their performance for different kinds of lookups and insertion patterns (see their respective javadoc entries for details). These differences are only really noticeable when dealing with quite large collections of statements, however. 
 
 ## Building RDF Models with the ModelBuilder
 
@@ -207,9 +207,9 @@ As an example, suppose we wish to add the above list of three string literals as
 The {{< javadoc "RDFCollections" "model/util/RDFCollections.html" >}} utility allows us to do this, as follows:
 
 ```java
-import static org.eclipse.model.util.Values.bnode;
-import static org.eclipse.model.util.Values.iri;
-import static org.eclipse.model.util.Values.literal;
+import static org.eclipse.rdf4j.model.util.Values.bnode;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 
 String ns = "http://example.org/";
 // IRI for ex:favoriteLetters

--- a/site/content/documentation/reference/rest-api.md
+++ b/site/content/documentation/reference/rest-api.md
@@ -8,7 +8,7 @@ The RDF4J server REST API is a HTTP Protocol that covers a fully compliant imple
 <!--more-->
 The current version of the API additionally supports the [SPARQL 1.1 Graph Store HTTP Protocol W3C Recommendation](https://www.w3.org/TR/sparql11-http-rdf-update/). The RDF4J REST API extends the W3C standards in several aspects, the most important of which is that it supports a full database transaction mechanism.
 
-The [REST architectural style](https://en.wikipedia.org/wiki/Representational_state_transfer) implies that URLs are used to represent the various resources that are available on a server. Here, we give a summary of the resources that are available from a RDF4J server sinstance with the HTTP-methods that can be used on them. In this overview, `<RDF4J_URL>` is used to denote the location of the RDF4J server instance, e.g. `http://localhost:8080/rdf4j-server`. Likewise, `<REP_ID>` denotes the ID of a specific repository (e.g. “mem-rdf”), and `<PREFIX>` denotes a namespace prefix (e.g. “rdfs”).
+The [REST architectural style](https://en.wikipedia.org/wiki/Representational_state_transfer) implies that URLs are used to represent the various resources that are available on a server. Here, we give a summary of the resources that are available from a RDF4J server instance with the HTTP-methods that can be used on them. In this overview, `<RDF4J_URL>` is used to denote the location of the RDF4J server instance, e.g. `http://localhost:8080/rdf4j-server`. Likewise, `<REP_ID>` denotes the ID of a specific repository (e.g. “mem-rdf”), and `<PREFIX>` denotes a namespace prefix (e.g. “rdfs”).
 
 The following is an overview of the resources that are available from RDF4J server.
 
@@ -894,7 +894,7 @@ Parameters:
 
 - `query`: The query to evaluate.
 - `queryLn` (optional): Specifies the query language that is used for the query. Acceptable values are strings denoting the query languages supported by the server, i.e. `serql` for SeRQL queries and `sparql` for SPARQL queries. If not specified, the server assumes the query is a SPARQL query.
-- `infer` (optional): Specifies whether inferred statements should be included in the query evaluation. Inferred statements are included by default. Specifying any value other than `true` (ignoring case) restricts the query evluation to explicit statements only.
+- `infer` (optional): Specifies whether inferred statements should be included in the query evaluation. Inferred statements are included by default. Specifying any value other than `true` (ignoring case) restricts the query evaluation to explicit statements only.
 
 Request Headers:
 
@@ -970,7 +970,7 @@ Response:
 
 ### Aborting a transaction by executing a DELETE
 
-An active transaction can be aborted by means of a HTTP `DELETE` request on the transaction resource. This will execute a transaction rollback on the repository and will close the transacion. After executing a `DELETE`, further operations on the same transaction will result in an error.
+An active transaction can be aborted by means of a HTTP `DELETE` request on the transaction resource. This will execute a transaction rollback on the repository and will close the transaction. After executing a `DELETE`, further operations on the same transaction will result in an error.
 
 #### Example: rollback transaction by means of a HTTP DELETE
 
@@ -1005,14 +1005,14 @@ The following tables summarizes the MIME types for various document formats that
 
 | Format                    | MIME type                              |
 |---------------------------|----------------------------------------|
-| SPARQL Query Results XML  | application/sparq-results+xml          |
-| SPARQL Query Results JSON | application/sparq-results+json         |
+| SPARQL Query Results XML  | application/sparql-results+xml          |
+| SPARQL Query Results JSON | application/sparql-results+json         |
 | Binary Results Format     | application/x-binary-rdf-results-table |
 
 ### MIME types for boolean result formats
 
 | Format                    | MIME type                      |
 |---------------------------|--------------------------------|
-| SPARQL Query Results XML  | application/sparq-results+xml  |
-| SPARQL Query Results JSON | application/sparq-results+json |
+| SPARQL Query Results XML  | application/sparql-results+xml  |
+| SPARQL Query Results JSON | application/sparql-results+json |
 | Plain Text Boolean Result | text/boolean                   |

--- a/tools/server/src/main/webapp/swagger.yaml
+++ b/tools/server/src/main/webapp/swagger.yaml
@@ -726,7 +726,7 @@ paths:
         tags:
           - transactions
         summary: Abort a transaction
-        description: An active transaction can be aborted by means of a HTTP DELETE request on the transaction resource. This will execute a transaction rollback on the repository and will close the transacion. After executing a DELETE, further operations on the same transaction will result in an error.
+        description: An active transaction can be aborted by means of a HTTP DELETE request on the transaction resource. This will execute a transaction rollback on the repository and will close the transaction. After executing a DELETE, further operations on the same transaction will result in an error.
         parameters:
           - name: repositoryID
             in: path


### PR DESCRIPTION
Signed-off-by: Alexey Ivanov <amivanoff@gmail.com>


GitHub issue resolved: #2889

Briefly describe the changes proposed in this PR:

* Documentation typos in Model and REST API
* Collecting more typos

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

