### PR TITLE
GH-2791 LIMIT and OFFSET should be applied to the solution sequence before the CONSTRUCT query form

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -742,6 +742,23 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		// Apply result ordering
 		tupleExpr = processOrderClause(node.getOrderClause(), tupleExpr, null);
 
+		// process limit and offset clauses
+		ASTLimit limitNode = node.getLimit();
+		long limit = -1L;
+		if (limitNode != null) {
+			limit = (Long) limitNode.jjtAccept(this, null);
+		}
+
+		ASTOffset offsetNode = node.getOffset();
+		long offset = -1;
+		if (offsetNode != null) {
+			offset = (Long) offsetNode.jjtAccept(this, null);
+		}
+
+		if (offset >= 1 || limit >= 0) {
+			tupleExpr = new Slice(tupleExpr, offset, limit);
+		}
+
 		// Process construct clause
 		ASTConstruct constructNode = node.getConstruct();
 		if (!constructNode.isWildcard()) {
@@ -758,23 +775,6 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			} catch (MalformedQueryException e) {
 				throw new VisitorException(e.getMessage());
 			}
-		}
-
-		// process limit and offset clauses
-		ASTLimit limitNode = node.getLimit();
-		long limit = -1L;
-		if (limitNode != null) {
-			limit = (Long) limitNode.jjtAccept(this, null);
-		}
-
-		ASTOffset offsetNode = node.getOffset();
-		long offset = -1;
-		if (offsetNode != null) {
-			offset = (Long) offsetNode.jjtAccept(this, null);
-		}
-
-		if (offset >= 1 || limit >= 0) {
-			tupleExpr = new Slice(tupleExpr, offset, limit);
 		}
 
 		return tupleExpr;

--- a/testsuites/sparql/src/main/resources/testdata-query/dataset-construct-modifiers.ttl
+++ b/testsuites/sparql/src/main/resources/testdata-query/dataset-construct-modifiers.ttl
@@ -1,0 +1,18 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix site: <http://example.org/stats#> .
+
+<urn:1> foaf:name "Alice" ;
+  site:hits 2349 ;
+  foaf:nick "Al" .
+
+<urn:2> foaf:name "Bob" ;
+  site:hits 105 ;
+  foaf:nick "Bo" .
+
+<urn:3> foaf:name "Eve" ;
+  site:hits 181 ;
+  foaf:nick "Ev" .
+
+<urn:4> foaf:name "Samuel" ;
+  site:hits 11 ;
+  foaf:nick "Sam" .


### PR DESCRIPTION
Signed-off-by: Alexey Ivanov <amivanoff@gmail.com>

GitHub issue resolved: #2791

Briefly describe the changes proposed in this PR:

* LIMIT and OFFSET swapped before the CONSTRUCT query form

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

