### PR TITLE
GH-2876 Upgrade to JUnit5

### DIFF
--- a/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneGeoSPARQLTest.java
+++ b/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneGeoSPARQLTest.java
@@ -14,8 +14,8 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.repository.RepositoryException;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class LuceneGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLTest {
 
@@ -37,14 +37,14 @@ public class LuceneGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLTest {
 	}
 
 	@Test
-	@Ignore // JTS is required
+	@Disabled // JTS is required
 	@Override
 	public void testIntersectionQuery() throws RepositoryException, MalformedQueryException, QueryEvaluationException {
 		super.testIntersectionQuery();
 	}
 
 	@Test
-	@Ignore // JTS is required
+	@Disabled // JTS is required
 	@Override
 	public void testComplexIntersectionQuery()
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/BackgroundGraphResultHangTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/BackgroundGraphResultHangTest.java
@@ -7,20 +7,22 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFParser;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * @author Damyan Ognyanov
@@ -46,21 +48,19 @@ public class BackgroundGraphResultHangTest {
 
 	}
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
-	@Test(timeout = 1000)
+	@Test
+	@Timeout(value = 1, unit = TimeUnit.SECONDS)
 	public void testBGRHang() throws Exception {
 		String data = "@not-rdf";
+		Exception exception = assertThrows(QueryEvaluationException.class, () -> {
+			BackgroundGraphResult gRes = new BackgroundGraphResult(new DummyParser(),
+					new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8,
+					"http://base.org");
 
-		BackgroundGraphResult gRes = new BackgroundGraphResult(new DummyParser(),
-				new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8,
-				"http://base.org");
-
-		thrown.expect(QueryEvaluationException.class);
-		gRes.run();
-		gRes.getNamespaces();
-		gRes.hasNext();
+			gRes.run();
+			gRes.getNamespaces();
+			gRes.hasNext();
+		});
 	}
 
 }

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
@@ -34,7 +34,7 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 /**
@@ -47,7 +47,7 @@ public class RDF4JProtocolSessionTest extends SPARQLProtocolSessionTest {
 	private String testHeader = "X-testing-header";
 	private String testValue = "foobar";
 
-	private String serverURL = "http://localhost:" + wireMockRule.port() + "/rdf4j-server";
+	private String serverURL = "http://localhost:" + wireMockServer.port() + "/rdf4j-server";
 	private String repositoryID = "test";
 
 	RDF4JProtocolSession getRDF4JSession() {

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.http.client;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -42,12 +43,13 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriter;
 import org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLStarResultsXMLWriter;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.WireMockServer;
 
 /**
  * Unit tests for {@link SPARQLProtocolSession}
@@ -56,15 +58,26 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
  */
 public class SPARQLProtocolSessionTest {
 
-	@ClassRule
-	public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort());
+	public static WireMockServer wireMockServer;
+
+	@BeforeAll
+	public static void setPort() {
+		wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
+		wireMockServer.start();
+		configureFor(wireMockServer.port());
+	}
+
+	@AfterAll
+	public static void closeMockPort() {
+		wireMockServer.stop();
+	}
 
 	SPARQLProtocolSession sparqlSession;
 
 	String testHeader = "X-testing-header";
 	String testValue = "foobar";
 
-	String serverURL = "http://localhost:" + wireMockRule.port() + "/rdf4j-server";
+	String serverURL = "http://localhost:" + wireMockServer.port() + "/rdf4j-server";
 	String repositoryID = "test";
 
 	SPARQLProtocolSession createProtocolSession() {
@@ -78,7 +91,7 @@ public class SPARQLProtocolSessionTest {
 		return session;
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		sparqlSession = createProtocolSession();
 	}

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SesameHTTPClientTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SesameHTTPClientTest.java
@@ -8,17 +8,13 @@
 package org.eclipse.rdf4j.http.client;
 
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Ignore("FIXME: Migrate this test to Apache HTTP Client 4 methods")
+@Disabled("FIXME: Migrate this test to Apache HTTP Client 4 methods")
 public class SesameHTTPClientTest {
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	private RDF4JProtocolSession httpClient = new RDF4JProtocolSession(null, null);
 
@@ -38,13 +34,11 @@ public class SesameHTTPClientTest {
 	@Test
 	public void setUsernameAndPassword_should_throw_exception_when_serverUrl_not_set() {
 
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Server URL has not been set");
+		Exception exception = assertThrows(IllegalStateException.class, () -> {
+			httpClient.setUsernameAndPassword("user01", "secret");
+		}, "Server URL has not been set");
 
 		// assertFalse(httpClient.getHttpClient().getParams().isAuthenticationPreemptive());
-
-		httpClient.setUsernameAndPassword("user01", "secret");
-
 		fail("Don't reach this point");
 	}
 

--- a/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/ProtocolTest.java
+++ b/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/ProtocolTest.java
@@ -8,7 +8,6 @@
 
 package org.eclipse.rdf4j.http.protocol;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.rdf4j.http.protocol.Protocol.CONFIG;
 import static org.eclipse.rdf4j.http.protocol.Protocol.CONTEXTS;
 import static org.eclipse.rdf4j.http.protocol.Protocol.NAMESPACES;
@@ -23,15 +22,16 @@ import static org.eclipse.rdf4j.http.protocol.Protocol.getRepositoryConfigLocati
 import static org.eclipse.rdf4j.http.protocol.Protocol.getRepositoryID;
 import static org.eclipse.rdf4j.http.protocol.Protocol.getRepositoryLocation;
 import static org.eclipse.rdf4j.http.protocol.Protocol.getServerLocation;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProtocolTest {
 
@@ -44,19 +44,19 @@ public class ProtocolTest {
 	@Test
 	public void testGetProtocolLocation() {
 		String result = getProtocolLocation(serverLocation);
-		assertThat(result).isEqualTo(serverLocation + "/" + PROTOCOL);
+		assertEquals(result, serverLocation + "/" + PROTOCOL);
 	}
 
 	@Test
 	public void testGetConfigLocation() {
 		String result = getConfigLocation(serverLocation);
-		assertThat(result).isEqualTo(serverLocation + "/" + CONFIG);
+		assertEquals(result, serverLocation + "/" + CONFIG);
 	}
 
 	@Test
 	public void testGetRepositoriesLocation() {
 		String result = getRepositoriesLocation(serverLocation);
-		assertThat(result).isEqualTo(serverLocation + "/" + REPOSITORIES);
+		assertEquals(result, serverLocation + "/" + REPOSITORIES);
 	}
 
 	@Test
@@ -78,25 +78,25 @@ public class ProtocolTest {
 	@Test
 	public void testGetRepositoryLocation() {
 		String result = getRepositoryLocation(serverLocation, repositoryID);
-		assertThat(result).isEqualTo(repositoryLocation);
+		assertEquals(result, repositoryLocation);
 	}
 
 	@Test
 	public void testGetRepositoryConfigLocation() {
 		String result = getRepositoryConfigLocation(repositoryLocation);
-		assertThat(result).isEqualTo(repositoryLocation + "/" + CONFIG);
+		assertEquals(result, repositoryLocation + "/" + CONFIG);
 	}
 
 	@Test
 	public void testGetContextsLocation() {
 		String result = getContextsLocation(repositoryLocation);
-		assertThat(result).isEqualTo(repositoryLocation + "/" + CONTEXTS);
+		assertEquals(result, repositoryLocation + "/" + CONTEXTS);
 	}
 
 	@Test
 	public void testGetNamespacesLocation() {
 		String result = getNamespacesLocation(repositoryLocation);
-		assertThat(result).isEqualTo(repositoryLocation + "/" + NAMESPACES);
+		assertEquals(result, repositoryLocation + "/" + NAMESPACES);
 	}
 
 	@Test
@@ -142,8 +142,9 @@ public class ProtocolTest {
 		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testParseIRIvsTriple() {
-		Protocol.decodeURI("<<<urn:a><urn:b><urn:c>>>", SimpleValueFactory.getInstance());
+		Exception exception = assertThrows(IllegalArgumentException.class,
+				() -> Protocol.decodeURI("<<<urn:a><urn:b><urn:c>>>", SimpleValueFactory.getInstance()));
 	}
 }

--- a/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionReaderTest.java
+++ b/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionReaderTest.java
@@ -7,9 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.protocol.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,7 +24,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/BNodeTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/BNodeTest.java
@@ -11,7 +11,7 @@ package org.eclipse.rdf4j.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract {@link BNode} test suite.

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -320,7 +321,7 @@ public abstract class LiteralTest {
 
 		assertThat(literal("INF", datatype).floatValue()).isInstanceOf(type).isEqualTo(Float.POSITIVE_INFINITY);
 		assertThat(literal("-INF", datatype).floatValue()).isInstanceOf(type).isEqualTo(Float.NEGATIVE_INFINITY);
-		assertThat(literal("NaN", datatype).floatValue()).isInstanceOf(type).isEqualTo(Float.NaN);
+		assertTrue(Float.isNaN(literal("NaN", datatype).floatValue()));
 
 		// assertThatIllegalArgumentException().as("not normalized")
 		// .isThrownBy(() -> literal("\t100", datatype).floatValue());
@@ -344,7 +345,7 @@ public abstract class LiteralTest {
 
 		assertThat(literal("INF", datatype).doubleValue()).isInstanceOf(type).isEqualTo(Double.POSITIVE_INFINITY);
 		assertThat(literal("-INF", datatype).doubleValue()).isInstanceOf(type).isEqualTo(Double.NEGATIVE_INFINITY);
-		assertThat(literal("NaN", datatype).doubleValue()).isInstanceOf(type).isEqualTo(Double.NaN);
+		assertTrue(Double.isNaN(literal("NaN", datatype).doubleValue()));
 
 		// assertThatIllegalArgumentException().as("not normalized")
 		// .isThrownBy(() -> literal("\t100", datatype).doubleValue());

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,19 +35,16 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.7.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
-			<version>5.7.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.19.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,14 +31,23 @@
 	<description>Core modules for RDF4J</description>
 	<dependencies>
 		<!-- shared test dependencies -->
+		<!-- Testing: JUnit -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.7.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>5.7.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
+			<version>3.19.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/queryrender/src/test/java/org/eclipse/rdf4j/queryrender/RenderUtilsTest.java
+++ b/core/queryrender/src/test/java/org/eclipse/rdf4j/queryrender/RenderUtilsTest.java
@@ -8,11 +8,11 @@
 
 package org.eclipse.rdf4j.queryrender;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RenderUtilsTest {
 	@Test

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
@@ -8,7 +8,10 @@
 package org.eclipse.rdf4j.rio.nquads;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -32,10 +35,9 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
 import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test for the N-Quads parser that uses the tests that are available
@@ -59,14 +61,14 @@ public abstract class AbstractNQuadsParserUnitTest {
 
 	private TestRDFHandler rdfHandler;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = createRDFParser();
 		rdfHandler = new TestRDFHandler();
 		parser.setRDFHandler(this.rdfHandler);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		parser = null;
 	}
@@ -111,7 +113,7 @@ public abstract class AbstractNQuadsParserUnitTest {
 				"<http://s> <http://p> <http://o> <http://g>".getBytes());
 		try {
 			parser.parse(bais, "http://test.base.uri");
-			Assert.fail("Expected exception when not inserting a trailing period at the end of a statement.");
+			fail("Expected exception when not inserting a trailing period at the end of a statement.");
 		} catch (RDFParseException rdfpe) {
 			// FIXME: Enable this test when first line number is 1 in parser
 			// instead of -1
@@ -135,9 +137,9 @@ public abstract class AbstractNQuadsParserUnitTest {
 						.getBytes());
 		try {
 			parser.parse(bais, "http://base-uri");
-			Assert.fail("Expected exception when there is non-whitespace characters after a period.");
+			fail("Expected exception when there is non-whitespace characters after a period.");
 		} catch (RDFParseException rdfpe) {
-			Assert.assertEquals(1, rdfpe.getLineNumber());
+			assertEquals(1, rdfpe.getLineNumber());
 			// FIXME: Enable column numbers when parser supports them
 			// Assert.assertEquals(44, rdfpe.getColumnNumber());
 		}
@@ -157,9 +159,9 @@ public abstract class AbstractNQuadsParserUnitTest {
 						.getBytes());
 		try {
 			parser.parse(bais, "http://base-uri");
-			Assert.fail("Expected exception when there is non-whitespace characters after a period.");
+			fail("Expected exception when there is non-whitespace characters after a period.");
 		} catch (RDFParseException rdfpe) {
-			Assert.assertEquals(1, rdfpe.getLineNumber());
+			assertEquals(1, rdfpe.getLineNumber());
 			// FIXME: Enable column numbers when parser supports them
 			// Assert.assertEquals(44, rdfpe.getColumnNumber());
 		}
@@ -184,7 +186,7 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final TestRDFHandler rdfHandler = new TestRDFHandler();
 		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
-		Assert.assertEquals(rdfHandler.getStatements().size(), 0);
+		assertEquals(rdfHandler.getStatements().size(), 0);
 	}
 
 	/**
@@ -198,13 +200,13 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final TestRDFHandler rdfHandler = new TestRDFHandler();
 		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
-		assertThat(rdfHandler.getStatements()).hasSize(1);
+		assertEquals(1, rdfHandler.getStatements().size());
 		final Statement statement = rdfHandler.getStatements().iterator().next();
-		Assert.assertEquals("http://www.v/dat/4b", statement.getSubject().stringValue());
-		Assert.assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
-		Assert.assertTrue(statement.getObject() instanceof IRI);
-		Assert.assertEquals("http://sin/value/2", statement.getObject().stringValue());
-		Assert.assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
+		assertEquals("http://www.v/dat/4b", statement.getSubject().stringValue());
+		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
+		assertTrue(statement.getObject() instanceof IRI);
+		assertEquals("http://sin/value/2", statement.getObject().stringValue());
+		assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
 	}
 
 	/**
@@ -220,11 +222,11 @@ public abstract class AbstractNQuadsParserUnitTest {
 		parser.parse(bais, "http://test.base.uri");
 		assertThat(rdfHandler.getStatements()).hasSize(1);
 		final Statement statement = rdfHandler.getStatements().iterator().next();
-		Assert.assertTrue(statement.getSubject() instanceof BNode);
-		Assert.assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
-		Assert.assertTrue(statement.getObject() instanceof IRI);
-		Assert.assertEquals("http://sin/value/2", statement.getObject().stringValue());
-		Assert.assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
+		assertTrue(statement.getSubject() instanceof BNode);
+		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
+		assertTrue(statement.getObject() instanceof IRI);
+		assertEquals("http://sin/value/2", statement.getObject().stringValue());
+		assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
 	}
 
 	/**
@@ -240,11 +242,11 @@ public abstract class AbstractNQuadsParserUnitTest {
 		parser.parse(bais, "http://test.base.uri");
 		assertThat(rdfHandler.getStatements()).hasSize(1);
 		final Statement statement = rdfHandler.getStatements().iterator().next();
-		Assert.assertTrue(statement.getSubject() instanceof BNode);
-		Assert.assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
-		Assert.assertTrue(statement.getObject() instanceof Literal);
-		Assert.assertEquals("2010-05-02", statement.getObject().stringValue());
-		Assert.assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
+		assertTrue(statement.getSubject() instanceof BNode);
+		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
+		assertTrue(statement.getObject() instanceof Literal);
+		assertEquals("2010-05-02", statement.getObject().stringValue());
+		assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
 	}
 
 	/**
@@ -259,14 +261,14 @@ public abstract class AbstractNQuadsParserUnitTest {
 		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
 		final Statement statement = rdfHandler.getStatements().iterator().next();
-		Assert.assertEquals("http://www.v/dat/4b2-21", statement.getSubject().stringValue());
-		Assert.assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
-		Assert.assertTrue(statement.getObject() instanceof Literal);
+		assertEquals("http://www.v/dat/4b2-21", statement.getSubject().stringValue());
+		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
+		assertTrue(statement.getObject() instanceof Literal);
 		Literal object = (Literal) statement.getObject();
-		Assert.assertEquals("2010-05-02", object.stringValue());
-		Assert.assertEquals("en", object.getLanguage().orElse(null));
-		Assert.assertEquals(RDF.LANGSTRING, object.getDatatype());
-		Assert.assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
+		assertEquals("2010-05-02", object.stringValue());
+		assertEquals("en", object.getLanguage().orElse(null));
+		assertEquals(RDF.LANGSTRING, object.getDatatype());
+		assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
 	}
 
 	/**
@@ -282,14 +284,14 @@ public abstract class AbstractNQuadsParserUnitTest {
 		parser.setRDFHandler(rdfHandler);
 		parser.parse(bais, "http://test.base.uri");
 		final Statement statement = rdfHandler.getStatements().iterator().next();
-		Assert.assertEquals("http://www.v/dat/4b2-21", statement.getSubject().stringValue());
-		Assert.assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
-		Assert.assertTrue(statement.getObject() instanceof Literal);
+		assertEquals("http://www.v/dat/4b2-21", statement.getSubject().stringValue());
+		assertEquals("http://www.w3.org/20/ica#dtend", statement.getPredicate().stringValue());
+		assertTrue(statement.getObject() instanceof Literal);
 		Literal object = (Literal) statement.getObject();
-		Assert.assertEquals("2010", object.stringValue());
-		Assert.assertFalse(object.getLanguage().isPresent());
-		Assert.assertEquals("http://www.w3.org/2001/XMLSchema#integer", object.getDatatype().toString());
-		Assert.assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
+		assertEquals("2010", object.stringValue());
+		assertFalse(object.getLanguage().isPresent());
+		assertEquals("http://www.w3.org/2001/XMLSchema#integer", object.getDatatype().toString());
+		assertEquals("http://sin.siteserv.org/def/", statement.getContext().stringValue());
 	}
 
 	/**
@@ -306,11 +308,11 @@ public abstract class AbstractNQuadsParserUnitTest {
 		parser.setRDFHandler(rdfHandler);
 		try {
 			parser.parse(bais, "http://test.base.uri");
-			Assert.fail("Expected exception when passing in a datatype using an N3 style prefix");
+			fail("Expected exception when passing in a datatype using an N3 style prefix");
 		} catch (RDFParseException rdfpe) {
-			Assert.assertEquals(1, rdfpe.getLineNumber());
+			assertEquals(1, rdfpe.getLineNumber());
 			// FIXME: Enable column numbers when parser supports them
-			// Assert.assertEquals(69, rdfpe.getColumnNumber());
+			// assertEquals(69, rdfpe.getColumnNumber());
 		}
 	}
 
@@ -350,9 +352,9 @@ public abstract class AbstractNQuadsParserUnitTest {
 
 		rdfHandler.assertHandler(1);
 		final Value object = rdfHandler.getStatements().iterator().next().getObject();
-		Assert.assertTrue(object instanceof Literal);
+		assertTrue(object instanceof Literal);
 		final String literalContent = ((Literal) object).getLabel();
-		Assert.assertEquals("Line text 1\nLine text 2", literalContent);
+		assertEquals("Line text 1\nLine text 2", literalContent);
 	}
 
 	/**
@@ -374,24 +376,24 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final Statement statement = rdfHandler.getStatements().iterator().next();
 
 		final Resource subject = statement.getSubject();
-		Assert.assertTrue(subject instanceof IRI);
+		assertTrue(subject instanceof IRI);
 		final String subjectURI = subject.toString();
-		Assert.assertEquals("http://s/はむ", subjectURI);
+		assertEquals("http://s/はむ", subjectURI);
 
 		final Resource predicate = statement.getPredicate();
-		Assert.assertTrue(predicate instanceof IRI);
+		assertTrue(predicate instanceof IRI);
 		final String predicateURI = predicate.toString();
-		Assert.assertEquals("http://p/はむ", predicateURI);
+		assertEquals("http://p/はむ", predicateURI);
 
 		final Value object = statement.getObject();
-		Assert.assertTrue(object instanceof IRI);
+		assertTrue(object instanceof IRI);
 		final String objectURI = object.toString();
-		Assert.assertEquals("http://o/はむ", objectURI);
+		assertEquals("http://o/はむ", objectURI);
 
 		final Resource graph = statement.getContext();
-		Assert.assertTrue(graph instanceof IRI);
+		assertTrue(graph instanceof IRI);
 		final String graphURI = graph.toString();
-		Assert.assertEquals("http://g/はむ", graphURI);
+		assertEquals("http://g/はむ", graphURI);
 	}
 
 	@Test
@@ -406,7 +408,7 @@ public abstract class AbstractNQuadsParserUnitTest {
 
 		rdfHandler.assertHandler(1);
 		final Literal obj = (Literal) rdfHandler.getStatements().iterator().next().getObject();
-		Assert.assertEquals(INPUT_LITERAL_PLAIN, obj.getLabel());
+		assertEquals(INPUT_LITERAL_PLAIN, obj.getLabel());
 	}
 
 	@Test
@@ -415,11 +417,11 @@ public abstract class AbstractNQuadsParserUnitTest {
 				"<http://s> <http://p> \"\\u123X\" <http://g> .".getBytes());
 		try {
 			parser.parse(bais, "http://test.base.uri");
-			Assert.fail("Expected exception when an incorrect unicode character is included");
+			fail("Expected exception when an incorrect unicode character is included");
 		} catch (RDFParseException rdfpe) {
-			Assert.assertEquals(1, rdfpe.getLineNumber());
+			assertEquals(1, rdfpe.getLineNumber());
 			// FIXME: Enable column numbers when parser supports them
-			// Assert.assertEquals(30, rdfpe.getColumnNumber());
+			// assertEquals(30, rdfpe.getColumnNumber());
 		}
 	}
 
@@ -432,13 +434,13 @@ public abstract class AbstractNQuadsParserUnitTest {
 				"<http://a> <http://b> \"\\\" <http://c> .".getBytes());
 		try {
 			parser.parse(bais, "http://test.base.uri");
-			Assert.fail("Expected exception when a literal is not closed");
+			fail("Expected exception when a literal is not closed");
 		} catch (RDFParseException rdfpe) {
 			// FIXME: Enable this test when first line number is 1 in parser
 			// instead of -1
-			// Assert.assertEquals(1, rdfpe.getLineNumber());
+			// assertEquals(1, rdfpe.getLineNumber());
 			// FIXME: Enable column numbers when parser supports them
-			// Assert.assertEquals(39, rdfpe.getColumnNumber());
+			// assertEquals(39, rdfpe.getColumnNumber());
 		}
 	}
 
@@ -506,12 +508,12 @@ public abstract class AbstractNQuadsParserUnitTest {
 		parser.getParserConfig().set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
 		try {
 			parser.parse(bais, "http://test.base.uri");
-			Assert.fail("Expected exception when passing in a datatype using an N3 style prefix");
+			fail("Expected exception when passing in a datatype using an N3 style prefix");
 		} catch (RDFParseException rdfpe) {
 			// FIXME: Fix line numbers for validation errors during the line
-			// Assert.assertEquals(1, rdfpe.getLineNumber());
+			// assertEquals(1, rdfpe.getLineNumber());
 			// FIXME: Enable column numbers when parser supports them
-			// Assert.assertEquals(152, rdfpe.getColumnNumber());
+			// assertEquals(152, rdfpe.getColumnNumber());
 		}
 	}
 
@@ -529,7 +531,7 @@ public abstract class AbstractNQuadsParserUnitTest {
 			fail("Did not find expected exception");
 		} catch (RDFParseException rdfpe) {
 			// FIXME: Fix line numbers for validation errors during the line
-			// Assert.assertEquals(1, rdfpe.getLineNumber());
+			// assertEquals(1, rdfpe.getLineNumber());
 		}
 	}
 
@@ -546,10 +548,10 @@ public abstract class AbstractNQuadsParserUnitTest {
 
 		try {
 			parser.parse(bais, "http://test.base.uri");
-			Assert.fail("Expected exception when encountering an invalid line");
+			fail("Expected exception when encountering an invalid line");
 		} catch (RDFParseException rdfpe) {
-			Assert.assertEquals(2, rdfpe.getLineNumber());
-			// Assert.assertEquals(50, rdfpe.getColumnNumber());
+			assertEquals(2, rdfpe.getLineNumber());
+			// assertEquals(50, rdfpe.getColumnNumber());
 		}
 	}
 
@@ -572,10 +574,10 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final Collection<Statement> statements = rdfHandler.getStatements();
 		int i = 0;
 		for (Statement nextStatement : statements) {
-			Assert.assertEquals("http://s" + i, nextStatement.getSubject().stringValue());
-			Assert.assertEquals("http://p" + i, nextStatement.getPredicate().stringValue());
-			Assert.assertEquals("http://o" + i, nextStatement.getObject().stringValue());
-			Assert.assertEquals("http://g" + i, nextStatement.getContext().stringValue());
+			assertEquals("http://s" + i, nextStatement.getSubject().stringValue());
+			assertEquals("http://p" + i, nextStatement.getPredicate().stringValue());
+			assertEquals("http://o" + i, nextStatement.getObject().stringValue());
+			assertEquals("http://g" + i, nextStatement.getContext().stringValue());
 			i++;
 		}
 	}
@@ -604,8 +606,8 @@ public abstract class AbstractNQuadsParserUnitTest {
 	private class TestParseLocationListener extends SimpleParseLocationListener {
 
 		private void assertListener(int row, int col) {
-			Assert.assertEquals("Unexpected last row", row, this.getLineNo());
-			Assert.assertEquals("Unexpected last col", col, this.getColumnNo());
+			assertEquals("Unexpected last row", row, this.getLineNo());
+			assertEquals("Unexpected last col", col, this.getColumnNo());
 		}
 
 	}
@@ -629,9 +631,9 @@ public abstract class AbstractNQuadsParserUnitTest {
 		}
 
 		public void assertHandler(int expected) {
-			Assert.assertTrue("Never started.", started);
-			Assert.assertTrue("Never ended.", ended);
-			Assert.assertEquals("Unexpected number of statements.", expected, getStatements().size());
+			assertTrue(started, "Never started.");
+			assertTrue(ended, "Never ended.");
+			assertEquals("Unexpected number of statements.", expected, getStatements().size());
 		}
 	}
 

--- a/core/sail/elasticsearch-store/pom.xml
+++ b/core/sail/elasticsearch-store/pom.xml
@@ -27,8 +27,8 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/sail/extensible-store/pom.xml
+++ b/core/sail/extensible-store/pom.xml
@@ -55,8 +55,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -560,19 +560,16 @@
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-engine</artifactId>
 				<version>${junit.version}</version>
-				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.junit.vintage</groupId>
 				<artifactId>junit-vintage-engine</artifactId>
 				<version>${junit.version}</version>
-				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-params</artifactId>
 				<version>${junit.version}</version>
-				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,7 @@
 		<guava.version>29.0-jre</guava.version>
 		<jmhVersion>1.21</jmhVersion>
 		<servlet.version>3.1.0</servlet.version>
+		<junit.version>5.7.1</junit.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -556,24 +557,43 @@
 			</dependency>
 			<!-- Testing: JUnit -->
 			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>4.13.1</version>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-engine</artifactId>
+				<version>${junit.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.vintage</groupId>
+				<artifactId>junit-vintage-engine</artifactId>
+				<version>${junit.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-params</artifactId>
+				<version>${junit.version}</version>
+				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>2.23.4</version>
+				<version>3.8.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-junit-jupiter</artifactId>
+				<version>3.8.0</version>
+				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>com.github.tomakehurst</groupId>
 				<artifactId>wiremock-jre8</artifactId>
-				<version>2.23.2</version>
+				<version>2.27.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>
 				<artifactId>assertj-core</artifactId>
-				<version>3.11.1</version>
+				<version>3.19.0</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.jsonld-java</groupId>

--- a/testsuites/lucene/pom.xml
+++ b/testsuites/lucene/pom.xml
@@ -21,8 +21,8 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/testsuites/model/pom.xml
+++ b/testsuites/model/pom.xml
@@ -16,8 +16,8 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/testsuites/model/src/main/java/org/eclipse/rdf4j/model/AbstractModelPerformanceTest.java
+++ b/testsuites/model/src/main/java/org/eclipse/rdf4j/model/AbstractModelPerformanceTest.java
@@ -7,12 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -24,7 +24,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeAll
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
@@ -33,7 +33,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterAll
 	@Override
 	public void tearDown() throws Exception {
 		super.tearDown();
@@ -44,7 +44,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	 * {@link org.eclipse.rdf4j.model.Model#add(org.eclipse.rdf4j.model.Resource, org.eclipse.rdf4j.model.IRI, org.eclipse.rdf4j.model.Value, org.eclipse.rdf4j.model.Resource[])}
 	 * .
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfAddResourceURIValueResourceArray() {
 		fail("Not yet implemented"); // TODO
@@ -53,7 +53,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#getNamespaces()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfGetNamespaces() {
 		fail("Not yet implemented"); // TODO
@@ -62,7 +62,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#getNamespace(java.lang.String)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfGetNamespace() {
 		fail("Not yet implemented"); // TODO
@@ -71,7 +71,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#setNamespace(java.lang.String, java.lang.String)} .
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfSetNamespaceStringString() {
 		fail("Not yet implemented"); // TODO
@@ -80,7 +80,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#setNamespace(org.eclipse.rdf4j.model.Namespace)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfSetNamespaceNamespace() {
 		fail("Not yet implemented"); // TODO
@@ -89,7 +89,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#removeNamespace(java.lang.String)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfRemoveNamespace() {
 		fail("Not yet implemented"); // TODO
@@ -100,7 +100,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	 * {@link org.eclipse.rdf4j.model.Model#contains(org.eclipse.rdf4j.model.Resource, org.eclipse.rdf4j.model.IRI, org.eclipse.rdf4j.model.Value, org.eclipse.rdf4j.model.Resource[])}
 	 * .
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfContainsResourceURIValueResourceArray() {
 		fail("Not yet implemented"); // TODO
@@ -109,7 +109,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#clear(org.eclipse.rdf4j.model.Resource[])}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfClearResourceArray() {
 		fail("Not yet implemented"); // TODO
@@ -120,7 +120,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	 * {@link org.eclipse.rdf4j.model.Model#remove(org.eclipse.rdf4j.model.Resource, org.eclipse.rdf4j.model.IRI, org.eclipse.rdf4j.model.Value, org.eclipse.rdf4j.model.Resource[])}
 	 * .
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfRemoveResourceURIValueResourceArray() {
 		fail("Not yet implemented"); // TODO
@@ -131,7 +131,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	 * {@link org.eclipse.rdf4j.model.Model#filter(org.eclipse.rdf4j.model.Resource, org.eclipse.rdf4j.model.IRI, org.eclipse.rdf4j.model.Value, org.eclipse.rdf4j.model.Resource[])}
 	 * .
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfFilter() {
 		fail("Not yet implemented"); // TODO
@@ -140,7 +140,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#subjects()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfSubjects() {
 		fail("Not yet implemented"); // TODO
@@ -149,7 +149,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#predicates()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfPredicates() {
 		fail("Not yet implemented"); // TODO
@@ -158,7 +158,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#objects()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfObjects() {
 		fail("Not yet implemented"); // TODO
@@ -167,7 +167,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#contexts()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfContexts() {
 		fail("Not yet implemented"); // TODO
@@ -176,7 +176,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#iterator()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfIterator() {
 		fail("Not yet implemented"); // TODO
@@ -185,7 +185,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#size()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfSize() {
 		fail("Not yet implemented"); // TODO
@@ -194,7 +194,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#isEmpty()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfIsEmpty() {
 		fail("Not yet implemented"); // TODO
@@ -203,7 +203,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#contains(java.lang.Object)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfContainsObject() {
 		fail("Not yet implemented"); // TODO
@@ -212,7 +212,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#add(java.lang.Object)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfAddE() {
 		fail("Not yet implemented"); // TODO
@@ -221,7 +221,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#remove(java.lang.Object)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfRemoveObject() {
 		fail("Not yet implemented"); // TODO
@@ -230,7 +230,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#containsAll(java.util.Collection)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfContainsAll() {
 		fail("Not yet implemented"); // TODO
@@ -239,7 +239,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#addAll(java.util.Collection)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfAddAll() {
 		fail("Not yet implemented"); // TODO
@@ -248,7 +248,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#removeAll(java.util.Collection)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfRemoveAll() {
 		fail("Not yet implemented"); // TODO
@@ -257,7 +257,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#retainAll(java.util.Collection)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfRetainAll() {
 		fail("Not yet implemented"); // TODO
@@ -266,7 +266,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Set#clear()}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfClear() {
 		fail("Not yet implemented"); // TODO
@@ -275,7 +275,7 @@ public abstract class AbstractModelPerformanceTest extends ModelTest {
 	/**
 	 * Test method for {@link java.util.Collection#removeIf(java.util.function.Predicate)}.
 	 */
-	@Ignore("TODO: Implement me!")
+	@Disabled("TODO: Implement me!")
 	@Test
 	public final void testPerfRemoveIf() {
 		fail("Not yet implemented"); // TODO

--- a/testsuites/model/src/main/java/org/eclipse/rdf4j/model/ModelNamespacesTest.java
+++ b/testsuites/model/src/main/java/org/eclipse/rdf4j/model/ModelNamespacesTest.java
@@ -7,10 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 
@@ -20,9 +20,9 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * An abstract test class to test the handling of namespaces by {@link Model} implementations.
@@ -45,7 +45,7 @@ public abstract class ModelNamespacesTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		testModel = getModelImplementation();
 	}
@@ -53,7 +53,7 @@ public abstract class ModelNamespacesTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		testModel = null;
 	}
@@ -65,8 +65,8 @@ public abstract class ModelNamespacesTest {
 	public final void testGetNamespacesEmpty() {
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
-		assertTrue("Namespaces must initially be empty", namespaces.isEmpty());
+		assertNotNull(namespaces, "Namespaces set must not be null");
+		assertTrue(namespaces.isEmpty(), "Namespaces must initially be empty");
 	}
 
 	/**
@@ -78,12 +78,13 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces, "Namespaces set must not be null");
 		assertFalse(namespaces.isEmpty());
 		assertEquals(1, namespaces.size());
 
-		assertTrue("Did not find the expected namespace in the set",
-				namespaces.contains(new SimpleNamespace(RDF.PREFIX, RDF.NAMESPACE)));
+		assertTrue(
+				namespaces.contains(new SimpleNamespace(RDF.PREFIX, RDF.NAMESPACE)),
+				"Did not find the expected namespace in the set");
 	}
 
 	/**
@@ -99,7 +100,7 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces, "Namespaces set must not be null");
 		assertFalse(namespaces.isEmpty());
 		assertEquals(5, namespaces.size());
 
@@ -117,8 +118,8 @@ public abstract class ModelNamespacesTest {
 	public final void testGetNamespaceEmpty() {
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
-		assertTrue("Namespaces must initially be empty", namespaces.isEmpty());
+		assertNotNull(namespaces, "Namespaces set must not be null");
+		assertTrue(namespaces.isEmpty(), "Namespaces must initially be empty");
 
 		assertFalse(testModel.getNamespace(RDF.PREFIX).isPresent());
 		assertFalse(testModel.getNamespace(RDFS.PREFIX).isPresent());
@@ -136,12 +137,12 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces, "Namespaces set must not be null");
 		assertFalse(namespaces.isEmpty());
 		assertEquals(1, namespaces.size());
 
-		assertTrue("Did not find the expected namespace in the set",
-				namespaces.contains(new SimpleNamespace(RDFS.PREFIX, RDFS.NAMESPACE)));
+		assertTrue(namespaces.contains(new SimpleNamespace(RDFS.PREFIX, RDFS.NAMESPACE)),
+				"Did not find the expected namespace in the set");
 
 		assertFalse(testModel.getNamespace(RDF.PREFIX).isPresent());
 		assertEquals(new SimpleNamespace(RDFS.PREFIX, RDFS.NAMESPACE), testModel.getNamespace(RDFS.PREFIX).get());
@@ -163,7 +164,7 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces, "Namespaces set must not be null");
 		assertFalse(namespaces.isEmpty());
 		assertEquals(5, namespaces.size());
 
@@ -184,7 +185,7 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces, "Namespaces set must not be null");
 		assertEquals(1, namespaces.size());
 
 		assertEquals(new SimpleNamespace("r", RDFS.NAMESPACE), testModel.getNamespace("r").orElse(null));
@@ -203,7 +204,7 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces, "Namespaces set must not be null");
 		assertFalse(namespaces.isEmpty());
 		assertEquals(5, namespaces.size());
 
@@ -224,7 +225,7 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces, "Namespaces set must not be null");
 		assertEquals(1, namespaces.size());
 
 		assertEquals(new SimpleNamespace("r", RDFS.NAMESPACE), testModel.getNamespace("r").orElse(null));
@@ -237,8 +238,7 @@ public abstract class ModelNamespacesTest {
 	public final void testRemoveNamespaceEmpty() {
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
-		assertTrue("Namespaces must initially be empty", namespaces.isEmpty());
+		assertNotNull(namespaces, "Namespaces set must not be null");
 
 		assertFalse(testModel.removeNamespace(RDF.NAMESPACE).isPresent());
 		assertFalse(testModel.removeNamespace(RDFS.NAMESPACE).isPresent());
@@ -256,12 +256,14 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces,
+				"Namespaces set must not be null");
 		assertFalse(namespaces.isEmpty());
 		assertEquals(1, namespaces.size());
 
-		assertTrue("Did not find the expected namespace in the set",
-				namespaces.contains(new SimpleNamespace(DC.PREFIX, DC.NAMESPACE)));
+		assertTrue(
+				namespaces.contains(new SimpleNamespace(DC.PREFIX, DC.NAMESPACE)),
+				"Did not find the expected namespace in the set");
 
 		assertFalse(testModel.removeNamespace(RDF.NAMESPACE).isPresent());
 		assertFalse(testModel.removeNamespace(RDFS.NAMESPACE).isPresent());
@@ -271,8 +273,8 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespacesAfter = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespacesAfter);
-		assertTrue("Namespaces must now be empty", namespacesAfter.isEmpty());
+		assertNotNull(namespacesAfter, "Namespaces set must not be null");
+		assertTrue(namespacesAfter.isEmpty(), "Namespaces must now be empty");
 	}
 
 	/**
@@ -288,7 +290,7 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespaces = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespaces);
+		assertNotNull(namespaces, "Namespaces set must not be null");
 		assertFalse(namespaces.isEmpty());
 		assertEquals(5, namespaces.size());
 
@@ -301,8 +303,8 @@ public abstract class ModelNamespacesTest {
 
 		Set<Namespace> namespacesAfter = testModel.getNamespaces();
 
-		assertNotNull("Namespaces set must not be null", namespacesAfter);
-		assertTrue("Namespaces must now be empty", namespacesAfter.isEmpty());
+		assertNotNull(namespacesAfter, "Could not find parser for this format.");
+		assertTrue(namespacesAfter.isEmpty(), "Namespaces must now be empty");
 	}
 
 }

--- a/testsuites/model/src/main/java/org/eclipse/rdf4j/model/ModelTest.java
+++ b/testsuites/model/src/main/java/org/eclipse/rdf4j/model/ModelTest.java
@@ -7,12 +7,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
@@ -22,25 +24,21 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Abstract test suite for implementations of the {@link Model} interface
  *
  * @author Peter Ansell
  */
+@TestInstance(Lifecycle.PER_CLASS)
+@Timeout(value = 1000, unit = MILLISECONDS)
 public abstract class ModelTest {
-
-	@Rule
-	public Timeout timeout = Timeout.millis(10000);
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	protected Literal literal1;
 
@@ -246,7 +244,7 @@ public abstract class ModelTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		uri1 = vf.createIRI("urn:test:uri:1");
 		uri2 = vf.createIRI("urn:test:uri:2");
@@ -262,7 +260,7 @@ public abstract class ModelTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/testsuites/pom.xml
+++ b/testsuites/pom.xml
@@ -23,4 +23,12 @@
 		<module>geosparql</module>
 		<module>benchmark</module>
 	</modules>
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>${junit.version}</version>
+			<scope>compile</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/testsuites/queryresultio/pom.xml
+++ b/testsuites/queryresultio/pom.xml
@@ -16,8 +16,8 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOBooleanTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOBooleanTest.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.resultio;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test for QueryResultIO.

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOTest.java
@@ -8,10 +8,10 @@
 
 package org.eclipse.rdf4j.query.resultio;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -40,8 +40,7 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandler;
 import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.query.impl.IteratingTupleQueryResult;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -97,7 +96,7 @@ public abstract class AbstractQueryResultIOTest {
 			format = QueryResultIO.getBooleanParserFormatForFileName(fileName);
 		}
 
-		assertTrue("Could not find parser for this format.", format.isPresent());
+		assertTrue(format.isPresent(), "Could not find parser for this format.");
 		assertEquals(getFormat(), format.get());
 	}
 
@@ -520,7 +519,7 @@ public abstract class AbstractQueryResultIOTest {
 
 		try {
 			parser.parse(in);
-			Assert.fail("Did not find expected parse exception");
+			fail("Did not find expected parse exception");
 		} catch (QueryResultParseException expected) {
 
 		}
@@ -706,7 +705,7 @@ public abstract class AbstractQueryResultIOTest {
 		BooleanQueryResultParser parser = QueryResultIO.createBooleanParser(format);
 		try {
 			parser.parse(in);
-			Assert.fail("Did not find expected parse exception");
+			fail("Did not find expected parse exception");
 		} catch (QueryResultParseException e) {
 
 		}

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOTupleTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultIOTupleTest.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.query.resultio;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.impl.IteratingTupleQueryResult;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test for QueryResultIO.

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractTupleQueryResultWriterTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractTupleQueryResultWriterTest.java
@@ -28,7 +28,7 @@ import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Generic tests for {@link TupleQueryResultWriter} implementations.

--- a/tools/config/pom.xml
+++ b/tools/config/pom.xml
@@ -20,8 +20,8 @@
 			<artifactId>logback-classic</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/tools/config/src/test/java/org/eclipse/rdf4j/common/app/AppVersionTest.java
+++ b/tools/config/src/test/java/org/eclipse/rdf4j/common/app/AppVersionTest.java
@@ -7,11 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.app;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.rdf4j.RDF4J;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen

--- a/tools/console/pom.xml
+++ b/tools/console/pom.xml
@@ -44,8 +44,13 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -57,6 +62,11 @@
 			<!-- needs extra dependencies: objenesis & hamcrest -->
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/ConsoleIOTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/ConsoleIOTest.java
@@ -11,27 +11,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ConsoleIOTest {
-	@Rule
-	public final TemporaryFolder LOCATION = new TemporaryFolder();
+
+	@TempDir
+	public File location;
 
 	private ConsoleIO io;
 
-	@Before
+	@BeforeEach
 	public void initConsoleObject() throws IOException {
 		InputStream input = mock(InputStream.class);
 		OutputStream out = mock(OutputStream.class);
 		ConsoleState info = mock(ConsoleState.class);
-		when(info.getDataDirectory()).thenReturn(LOCATION.getRoot());
+		when(info.getDataDirectory()).thenReturn(location);
 
 		io = new ConsoleIO(input, out, info);
 	}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/UtilTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/UtilTest.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 
@@ -17,9 +17,9 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -27,13 +27,13 @@ import org.junit.Test;
 public class UtilTest {
 	private static Repository repo;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setupClass() {
 		repo = new SailRepository(new MemoryStore());
 		repo.initialize();
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownClass() {
 		repo.shutDown();
 	}
@@ -49,7 +49,7 @@ public class UtilTest {
 		String[] tokens = { "command", ONE, TWO };
 		Resource[] ctxs = Util.getContexts(tokens, 1, repo);
 
-		assertTrue("Not equal", Arrays.equals(check, ctxs));
+		assertTrue(Arrays.equals(check, ctxs), "Not equal");
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class UtilTest {
 		String[] tokens = { "command", "command2", "NULL" };
 
 		Resource[] ctxs = Util.getContexts(tokens, 2, repo);
-		assertTrue("Not null", ctxs[0] == null);
+		assertTrue(ctxs[0] == null, "Not null");
 	}
 
 	@Test
@@ -77,6 +77,6 @@ public class UtilTest {
 
 		String expect = " one, two\n" + " three\n" + " four\n" + " five, six\n" + " seven\n" + " eight";
 		String fmt = Util.formatToWidth(10, " ", str, ", ");
-		assertTrue("Format not OK", expect.equals(fmt));
+		assertTrue(expect.equals(fmt), "Format not OK");
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
@@ -47,16 +47,19 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 /**
  * @author Dale Visser
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class AbstractCommandTest {
 
 	/*
@@ -64,11 +67,9 @@ public class AbstractCommandTest {
 	 *
 	 * Note, .silent() was added in Mockito 2, so has been removed until we update.
 	 */
-	@Rule
-	public MockitoRule abstractCommandTestMockitoRule = MockitoJUnit.rule(); // .silent();
 
-	@Rule
-	public final TemporaryFolder LOCATION = new TemporaryFolder();
+	@TempDir
+	public File locationFile;
 
 	protected RepositoryManager manager;
 
@@ -86,7 +87,7 @@ public class AbstractCommandTest {
 			{ WorkDir.NAME, new WorkDir() }
 	}).collect(Collectors.toMap(m -> (String) m[0], m -> (ConsoleSetting) m[1]));
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		if (manager != null) {
 			manager.shutDown();
@@ -193,7 +194,7 @@ public class AbstractCommandTest {
 	 * @param cmd console command
 	 */
 	protected void setWorkingDir(ConsoleCommand cmd) {
-		WorkDir location = new WorkDir(Paths.get(LOCATION.getRoot().getAbsolutePath()));
+		WorkDir location = new WorkDir(Paths.get(locationFile.getAbsolutePath()));
 		cmd.settings.put(WorkDir.NAME, location);
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,9 +18,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import org.eclipse.rdf4j.RDF4JException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.utils.JsonUtils;
 
@@ -32,16 +32,16 @@ public class ConvertTest extends AbstractCommandTest {
 	private Convert cmd;
 	private File from;
 
-	@Before
+	@BeforeEach
 	public void setup() throws IOException, RDF4JException {
 		when(mockConsoleIO.askProceed("File exists, continue ?", false)).thenReturn(Boolean.TRUE);
 		cmd = new Convert(mockConsoleIO, mockConsoleState, defaultSettings);
 
-		from = LOCATION.newFile("alien.ttl");
+		from = new File(locationFile, "alien.ttl");
 		copyFromResource("convert/alien.ttl", from);
 	}
 
-	@After
+	@AfterEach
 	@Override
 	public void tearDown() {
 		from.delete();
@@ -49,10 +49,10 @@ public class ConvertTest extends AbstractCommandTest {
 
 	@Test
 	public final void testConvert() throws IOException {
-		File json = LOCATION.newFile("alien.jsonld");
+		File json = new File(locationFile, "alien.jsonld");
 		cmd.execute("convert", from.getAbsolutePath(), json.getAbsolutePath());
 
-		assertTrue("File is empty", json.length() > 0);
+		assertTrue(json.length() > 0, "File is empty");
 
 		Object o = null;
 		try {
@@ -60,17 +60,17 @@ public class ConvertTest extends AbstractCommandTest {
 		} catch (IOException ioe) {
 			//
 		}
-		assertTrue("Invalid JSON", o != null);
+		assertTrue(o != null, "Invalid JSON");
 	}
 
 	@Test
 	public final void testConvertWorkDir() throws IOException {
 		setWorkingDir(cmd);
 
-		File json = LOCATION.newFile("alien.jsonld");
+		File json = new File(locationFile, "alien.jsonld");
 		cmd.execute("convert", from.getName(), json.getName());
 
-		assertTrue("File is empty", json.length() > 0);
+		assertTrue(json.length() > 0, "File is empty");
 
 		Object o = null;
 		try {
@@ -78,14 +78,14 @@ public class ConvertTest extends AbstractCommandTest {
 		} catch (IOException ioe) {
 			//
 		}
-		assertTrue("Invalid JSON", o != null);
+		assertTrue(o != null, "Invalid JSON");
 	}
 
 	@Test
 	public final void testConvertParseError() throws IOException {
-		File wrong = LOCATION.newFile("wrong.nt");
+		File wrong = new File(locationFile, "wrong.nt");
 		Files.write(wrong.toPath(), "error".getBytes());
-		File json = LOCATION.newFile("empty.jsonld");
+		File json = new File(locationFile, "empty.jsonld");
 
 		cmd.execute("convert", wrong.toString(), json.toString());
 		verify(mockConsoleIO).writeError(anyString());
@@ -94,7 +94,7 @@ public class ConvertTest extends AbstractCommandTest {
 
 	@Test
 	public final void testConvertInvalidFormat() throws IOException {
-		File qyx = LOCATION.newFile("alien.qyx");
+		File qyx = new File(locationFile, "alien.qyx");
 		cmd.execute("convert", from.toString(), qyx.toString());
 		verify(mockConsoleIO).writeError("No RDF writer for " + qyx.toString());
 	}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
@@ -24,8 +24,8 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
 import org.eclipse.rdf4j.repository.sail.config.ProxyRepositoryConfig;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dale Visser
@@ -38,9 +38,9 @@ public class DropTest extends AbstractCommandTest {
 
 	private Drop drop;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws UnsupportedEncodingException, IOException, RDF4JException {
-		manager = new LocalRepositoryManager(LOCATION.getRoot());
+		manager = new LocalRepositoryManager(locationFile);
 
 		addRepositories("drop", MEMORY_MEMBER_ID1);
 		manager.addRepositoryConfig(new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -21,8 +21,8 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.io.Files;
 
@@ -35,9 +35,9 @@ public class ExportTest extends AbstractCommandTest {
 
 	private Export cmd;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws IOException, RDF4JException {
-		manager = new LocalRepositoryManager(LOCATION.getRoot());
+		manager = new LocalRepositoryManager(locationFile);
 
 		addRepositories("export", MEMORY_MEMBER);
 
@@ -50,12 +50,12 @@ public class ExportTest extends AbstractCommandTest {
 
 	@Test
 	public final void testExportAll() throws RepositoryException, IOException {
-		File nq = LOCATION.newFile("all.nq");
+		File nq = new File(locationFile, "all.nq");
 		cmd.execute("export", nq.getAbsolutePath());
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
-		assertTrue("File is empty", nq.length() > 0);
-		assertEquals("Number of contexts incorrect", 3, exp.contexts().size());
+		assertTrue(nq.length() > 0, "File is empty");
+		assertEquals(3, exp.contexts().size(), "Number of contexts incorrect");
 
 		nq.delete();
 	}
@@ -64,23 +64,23 @@ public class ExportTest extends AbstractCommandTest {
 	public final void testExportWorkDir() throws RepositoryException, IOException {
 		setWorkingDir(cmd);
 
-		File nq = LOCATION.newFile("all.nq");
+		File nq = new File(locationFile, "all.nq");
 		cmd.execute("export", nq.getName());
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
-		assertTrue("File is empty", nq.length() > 0);
-		assertEquals("Number of contexts incorrect", 3, exp.contexts().size());
+		assertTrue(nq.length() > 0, "File is empty");
+		assertEquals(3, exp.contexts().size(), "Number of contexts incorrect");
 	}
 
 	@Test
 	public final void testExportContexts() throws RepositoryException, IOException {
-		File nq = LOCATION.newFile("default.nq");
+		File nq = new File(locationFile, "default.nq");
 		cmd.execute("export", nq.getAbsolutePath(), "null", "http://example.org/ns/context/resurrection");
 		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
 
-		assertTrue("File is empty", nq.length() > 0);
+		assertTrue(nq.length() > 0, "File is empty");
 
-		assertEquals("Number of contexts incorrect", 2, exp.contexts().size());
-		assertEquals("Number of triples incorrect", 4, exp.size());
+		assertEquals(2, exp.contexts().size(), "Number of contexts incorrect");
+		assertEquals(4, exp.size(), "Number of triples incorrect");
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/FederateTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/FederateTest.java
@@ -8,12 +8,14 @@
 package org.eclipse.rdf4j.console.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -29,10 +31,9 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sparql.config.SPARQLRepositoryConfig;
 import org.eclipse.rdf4j.repository.sparql.config.SPARQLRepositoryFactory;
 import org.eclipse.rdf4j.sail.federation.config.FederationConfig;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 
 /**
@@ -58,15 +59,17 @@ public class FederateTest extends AbstractCommandTest {
 
 	private static final String FED_DESCRIPTION = "Test Federation Title";
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File tempDir;
 
 	@InjectMocks
 	private Federate federate;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		manager = new LocalRepositoryManager(tempDir.newFolder("federate-test-repository-manager"));
+		File baseDir = new File(tempDir, "federate-test-repository-manager");
+		assertTrue(baseDir.mkdir());
+		manager = new LocalRepositoryManager(baseDir);
 		addRepositories("federate", MEMORY_MEMBER_ID1, MEMORY_MEMBER_ID2, HTTP_MEMBER_ID, HTTP2_MEMBER_ID,
 				SPARQL_MEMBER_ID, SPARQL2_MEMBER_ID);
 		when(mockConsoleState.getManager()).thenReturn(manager);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/LoadTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/LoadTest.java
@@ -23,8 +23,8 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
 import org.eclipse.rdf4j.repository.sail.config.ProxyRepositoryConfig;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -37,9 +37,9 @@ public class LoadTest extends AbstractCommandTest {
 
 	private Load cmd;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws UnsupportedEncodingException, IOException, RDF4JException {
-		manager = new LocalRepositoryManager(LOCATION.getRoot());
+		manager = new LocalRepositoryManager(locationFile);
 
 		addRepositories("load", MEMORY_MEMBER_ID1);
 		manager.addRepositoryConfig(new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));
@@ -51,7 +51,7 @@ public class LoadTest extends AbstractCommandTest {
 
 	@Test
 	public final void testLoad() throws RepositoryException, IOException {
-		File f = LOCATION.newFile("alien.ttl");
+		File f = new File(locationFile, "alien.ttl");
 		copyFromResource("load/alien.ttl", f);
 
 		cmd.execute("load", f.getAbsolutePath());
@@ -62,7 +62,7 @@ public class LoadTest extends AbstractCommandTest {
 	public final void testLoadWorkDir() throws RepositoryException, IOException {
 		setWorkingDir(cmd);
 
-		File f = LOCATION.newFile("alien.ttl");
+		File f = new File(locationFile, "alien.ttl");
 		copyFromResource("load/alien.ttl", f);
 
 		cmd.execute("load", f.getName());

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SetParametersTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SetParametersTest.java
@@ -14,8 +14,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test setting parameters
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class SetParametersTest extends AbstractCommandTest {
 	SetParameters setParameters;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		Map<String, ConsoleSetting> settings = new HashMap<>();
 		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,8 +23,8 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test SPARQL command
@@ -36,9 +36,9 @@ public class SparqlTest extends AbstractCommandTest {
 
 	private Sparql cmd;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws IOException, RDF4JException {
-		manager = new LocalRepositoryManager(LOCATION.getRoot());
+		manager = new LocalRepositoryManager(locationFile);
 
 		addRepositories("sparql", MEMORY_MEMBER);
 		TupleAndGraphQueryEvaluator tqe = new TupleAndGraphQueryEvaluator(mockConsoleIO, mockConsoleState,
@@ -63,7 +63,7 @@ public class SparqlTest extends AbstractCommandTest {
 
 	@Test
 	public final void testInputFile() throws IOException {
-		File f = LOCATION.newFile("select.qr");
+		File f = new File(locationFile, "select.qr");
 		copyFromResource("sparql/select.qr", f);
 
 		cmd.executeQuery("sparql INFILE=\"" + f.getAbsolutePath() + "\"", "sparql");
@@ -74,7 +74,7 @@ public class SparqlTest extends AbstractCommandTest {
 	public final void testInputFileWorkdir() throws IOException {
 		setWorkingDir(cmd);
 
-		File f = LOCATION.newFile("select.qr");
+		File f = new File(locationFile, "select.qr");
 		copyFromResource("sparql/select.qr", f);
 
 		cmd.executeQuery("sparql INFILE=\"select.qr\"", "sparql");
@@ -83,38 +83,38 @@ public class SparqlTest extends AbstractCommandTest {
 
 	@Test
 	public final void testOutputFileConstruct() throws IOException {
-		File f = LOCATION.newFile("out.ttl");
+		File f = new File(locationFile, "out.ttl");
 
 		cmd.executeQuery("sparql OUTFILE=\"" + f.getAbsolutePath() + "\" construct { ?s ?p ?o } where { ?s ?p ?o }",
 				"sparql");
 		verify(mockConsoleIO, never()).writeError(anyString());
 
-		assertTrue("File does not exist", f.exists());
-		assertTrue("Empty file", f.length() > 0);
+		assertTrue(f.exists(), "File does not exist");
+		assertTrue(f.length() > 0, "Empty file");
 
 		Model m = Rio.parse(new FileReader(f), "", RDFFormat.TURTLE);
-		assertTrue("Empty model", m.size() > 0);
+		assertTrue(m.size() > 0, "Empty model");
 	}
 
 	@Test
 	public final void testOutputFileConstructWorkdir() throws IOException {
 		setWorkingDir(cmd);
 
-		File f = LOCATION.newFile("out.ttl");
+		File f = new File(locationFile, "out.ttl");
 
 		cmd.executeQuery("sparql OUTFILE=\"out.ttl\" construct { ?s ?p ?o } where { ?s ?p ?o }", "sparql");
 		verify(mockConsoleIO, never()).writeError(anyString());
 
-		assertTrue("File does not exist", f.exists());
-		assertTrue("Empty file", f.length() > 0);
+		assertTrue(f.exists(), "File does not exist");
+		assertTrue(f.length() > 0, "Empty file");
 
 		Model m = Rio.parse(new FileReader(f), "", RDFFormat.TURTLE);
-		assertTrue("Empty model", m.size() > 0);
+		assertTrue(m.size() > 0, "Empty model");
 	}
 
 	@Test
 	public final void testOutputFileWrongFormat() throws IOException {
-		File f = LOCATION.newFile("out.ttl");
+		File f = new File(locationFile, "out.ttl");
 
 		// SELECT should use sparql result format, not a triple file format
 		cmd.executeQuery("sparql OUTFILE=\"" + f.getAbsolutePath() + "\" select ?s ?p ?o where { ?s ?p ?o }",
@@ -125,10 +125,10 @@ public class SparqlTest extends AbstractCommandTest {
 
 	@Test
 	public final void testInputOutputFile() throws IOException {
-		File fin = LOCATION.newFile("select.qr");
+		File fin = new File(locationFile, "select.qr");
 		copyFromResource("sparql/select.qr", fin);
 
-		File fout = LOCATION.newFile("out.srj");
+		File fout = new File(locationFile, "out.srj");
 
 		cmd.executeQuery("sparql infile=\"" + fin.getAbsolutePath() + "\"" +
 				" outfile=\"" + fout.getAbsolutePath() + "\"", "sparql");
@@ -136,16 +136,16 @@ public class SparqlTest extends AbstractCommandTest {
 		verify(mockConsoleIO, never()).writeError(anyString());
 		assertFalse(mockConsoleIO.wasErrorWritten());
 
-		assertTrue("File does not exist", fout.exists());
-		assertTrue("Empty file", fout.length() > 0);
+		assertTrue(fout.exists(), "File does not exist");
+		assertTrue(fout.length() > 0, "Empty file");
 	}
 
 	@Test
 	public final void testInputOutputFilePrefix() throws IOException {
-		File fin = LOCATION.newFile("select-prefix.qr");
+		File fin = new File(locationFile, "select-prefix.qr");
 		copyFromResource("sparql/select-prefix.qr", fin);
 
-		File fout = LOCATION.newFile("out.srj");
+		File fout = new File(locationFile, "out.srj");
 
 		cmd.executeQuery("sparql infile=\"" + fin.getAbsolutePath() + "\"" +
 				" outfile=\"" + fout.getAbsolutePath() + "\"", "sparql");
@@ -153,7 +153,7 @@ public class SparqlTest extends AbstractCommandTest {
 		verify(mockConsoleIO, never()).writeError(anyString());
 		assertFalse(mockConsoleIO.wasErrorWritten());
 
-		assertTrue("File does not exist", fout.exists());
-		assertTrue("Empty file", fout.length() > 0);
+		assertTrue(fout.exists(), "File does not exist");
+		assertTrue(fout.length() > 0, "Empty file");
 	}
 }

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -24,8 +24,8 @@ import java.nio.file.Files;
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test verify command
@@ -36,12 +36,12 @@ public class VerifyTest extends AbstractCommandTest {
 	private Verify cmd;
 	private ConsoleIO io;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws IOException, RDF4JException {
 		InputStream input = mock(InputStream.class);
 		OutputStream out = mock(OutputStream.class);
 		ConsoleState info = mock(ConsoleState.class);
-		when(info.getDataDirectory()).thenReturn(LOCATION.getRoot());
+		when(info.getDataDirectory()).thenReturn(locationFile);
 
 		io = new ConsoleIO(input, out, info);
 
@@ -56,7 +56,7 @@ public class VerifyTest extends AbstractCommandTest {
 	 * @throws IOException
 	 */
 	private String copyFromRes(String str) throws IOException {
-		File f = LOCATION.newFile(str);
+		File f = new File(locationFile, str);
 		copyFromResource("verify/" + str, f);
 		return f.getAbsolutePath();
 	}
@@ -109,7 +109,7 @@ public class VerifyTest extends AbstractCommandTest {
 
 	@Test
 	public final void testShaclInvalid() throws IOException {
-		File report = LOCATION.newFile();
+		File report = new File(locationFile, "testShaclInvalid");
 		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_invalid.ttl"), report.toString());
 		assertTrue(io.wasErrorWritten());
 		assertTrue(Files.size(report.toPath()) > 0);
@@ -117,7 +117,8 @@ public class VerifyTest extends AbstractCommandTest {
 
 	@Test
 	public final void testShaclValid() throws IOException {
-		File report = LOCATION.newFile();
+		File report = new File(locationFile, "testShaclValid");
+		assertTrue(report.createNewFile());
 		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_valid.ttl"), report.toString());
 
 		verify(mockConsoleIO, never()).writeError(anyString());
@@ -132,7 +133,8 @@ public class VerifyTest extends AbstractCommandTest {
 		copyFromRes("ok.ttl");
 		copyFromRes("shacl_valid.ttl");
 
-		File report = LOCATION.newFile();
+		File report = new File(locationFile, "testShaclValidWorkDir");
+		assertTrue(report.createNewFile());
 		cmd.execute("verify", "ok.ttl", "shacl_valid.ttl", report.getName());
 
 		verify(mockConsoleIO, never()).writeError(anyString());

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.command.SetParameters;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -32,7 +32,7 @@ public abstract class AbstractSettingTest {
 	SetParameters setParameters;
 	Map<String, ConsoleSetting> settings = new HashMap<>();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/ConsoleWidthTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/ConsoleWidthTest.java
@@ -10,8 +10,8 @@ package org.eclipse.rdf4j.console.setting;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test console width
@@ -19,7 +19,7 @@ import org.junit.Test;
  * @author Bart Hanssens
  */
 public class ConsoleWidthTest extends AbstractSettingTest {
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() {
 		settings.put(ConsoleWidth.NAME, new ConsoleWidth());

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/LogLevelTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/LogLevelTest.java
@@ -7,13 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.setting;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
@@ -27,7 +27,7 @@ import ch.qos.logback.classic.Logger;
 public class LogLevelTest extends AbstractSettingTest {
 	private Level originalLevel;
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() {
 		originalLevel = ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).getLevel();
@@ -35,7 +35,7 @@ public class LogLevelTest extends AbstractSettingTest {
 		super.setUp();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(originalLevel);
 	}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/PrefixesTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/PrefixesTest.java
@@ -7,13 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.setting;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 /**
@@ -22,7 +22,7 @@ import org.mockito.ArgumentCaptor;
  * @author Bart Hanssens
  */
 public class PrefixesTest extends AbstractSettingTest {
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() {
 		settings.put(Prefixes.NAME, new Prefixes());
@@ -47,7 +47,7 @@ public class PrefixesTest extends AbstractSettingTest {
 		setParameters.execute("set", "prefixes");
 		ArgumentCaptor<String> s = ArgumentCaptor.forClass(String.class);
 		verify(mockConsoleIO).writeln(s.capture());
-		assertTrue("Does not contain dcterms", s.getValue().contains(DCTERMS.NAMESPACE));
+		assertTrue(s.getValue().contains(DCTERMS.NAMESPACE), "Does not contain dcterms");
 
 		verifyNoMoreInteractions(mockConsoleIO);
 	}
@@ -60,7 +60,7 @@ public class PrefixesTest extends AbstractSettingTest {
 		setParameters.execute("set", "prefixes");
 		ArgumentCaptor<String> s = ArgumentCaptor.forClass(String.class);
 		verify(mockConsoleIO).writeln(s.capture());
-		assertTrue("Does not contain dcterms", s.getValue().contains(DCTERMS.NAMESPACE));
+		assertTrue(s.getValue().contains(DCTERMS.NAMESPACE), "Does not contain dcterms");
 
 		verifyNoMoreInteractions(mockConsoleIO);
 	}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/QueryPrefixTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/QueryPrefixTest.java
@@ -10,8 +10,8 @@ package org.eclipse.rdf4j.console.setting;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test query prefix setting
@@ -19,7 +19,7 @@ import org.junit.Test;
  * @author Bart Hanssens
  */
 public class QueryPrefixTest extends AbstractSettingTest {
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() {
 		settings.put(QueryPrefix.NAME, new QueryPrefix());

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/ShowPrefixTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/ShowPrefixTest.java
@@ -10,8 +10,8 @@ package org.eclipse.rdf4j.console.setting;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test show prefix setting
@@ -19,7 +19,7 @@ import org.junit.Test;
  * @author Bart Hanssens
  */
 public class ShowPrefixTest extends AbstractSettingTest {
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() {
 		settings.put(ShowPrefix.NAME, new ShowPrefix());

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -136,7 +136,6 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -130,25 +130,13 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.4.2</version>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.4.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.4.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-runner</artifactId>
-			<version>1.4.2</version>
+			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategyTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategyTest.java
@@ -16,7 +16,10 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class RepositoryWriteStrategyTest {
 
 	private RepositoryWriteStrategy strategy;

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -147,23 +147,28 @@
 	<dependencies>
 		<!-- shared test dependencies -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
+			<artifactId>mockito-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -63,8 +63,8 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
GitHub issue resolved: #2876

Briefly describe the changes proposed in this PR:
This is a JUnit5 upgrade most changes are in the POMs as we are still using the JUnit4 APIs via junit vintage.
It does update a number of dependencies to newer versions which might need special review.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

