### PR TITLE
GH-2908 LeftOuterJoin will sometimes miss the last left element

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LeftOuterJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LeftOuterJoin.java
@@ -86,7 +86,6 @@ public class LeftOuterJoin implements PlanNode {
 									nextRight = rightIterator.next();
 								} else {
 									nextRight = null;
-									break;
 								}
 							}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LoggingCloseableIteration.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LoggingCloseableIteration.java
@@ -11,6 +11,7 @@ public abstract class LoggingCloseableIteration implements CloseableIteration<Va
 	private final ValidationExecutionLogger validationExecutionLogger;
 	private final PlanNode planNode;
 	private final Logger logger = LoggerFactory.getLogger(getClass());
+	private boolean empty = false;
 
 	public LoggingCloseableIteration(PlanNode planNode, ValidationExecutionLogger validationExecutionLogger) {
 		this.planNode = planNode;
@@ -43,7 +44,11 @@ public abstract class LoggingCloseableIteration implements CloseableIteration<Va
 
 	@Override
 	public final boolean hasNext() throws SailException {
-		return localHasNext();
+		boolean hasNext = localHasNext();
+		if (!hasNext)
+			empty = true;
+		assert !hasNext || !empty : this.getClass();
+		return hasNext;
 	}
 
 	protected abstract ValidationTuple loggingNext() throws SailException;


### PR DESCRIPTION
GitHub issue resolved: #2908 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - fix for LeftOuterJoin
 - detect when iterators return false from hasNext() but true when called again
 
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

