### PR TITLE
GH-2739 tell maven to produce java 1.8 compatible bytecode even when …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,7 @@
 		<guava.version>29.0-jre</guava.version>
 		<jmhVersion>1.21</jmhVersion>
 		<servlet.version>3.1.0</servlet.version>
+		<maven.compiler.release>8</maven.compiler.release>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
GitHub issue resolved: GH-2739

Briefly describe the changes proposed in this PR: Make java-9+ javac generate java 1.8 bytecode and APIs.
By adding one line to the pom.xml. 
Draft pull request to test on java 1.8

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

