### PR TITLE
GH-2918 switch to CachedThreadPool to avoid deadlocks in interdependent queries

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTest.java
@@ -7,10 +7,29 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.http;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class HTTPRepositoryTest extends RepositoryTest {
 
@@ -37,4 +56,40 @@ public class HTTPRepositoryTest extends RepositoryTest {
 		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
 	}
 
+	@Test(timeout = 10_000)
+	public void testSubqueryDeadlock() throws Exception {
+		String mainQueryStr = "SELECT ?property WHERE { ?property a rdf:Property . }";
+		String subQueryStr = "SELECT ?range WHERE { ?property rdfs:range ?range . }";
+
+		try (RepositoryConnection conn = this.testRepository.getConnection()) {
+
+			conn.begin();
+			// we need sufficient data for the main query to not complete immediately - it should still be
+			// background-parsing when the subquery is executed to trigger potential deadlock
+			for (int i = 0; i < 1_000; i++) {
+				IRI subject = iri("foo:bar-" + i);
+				conn.add(subject, RDF.TYPE, RDF.PROPERTY);
+				conn.add(subject, RDFS.RANGE, FOAF.PERSON);
+			}
+			conn.commit();
+
+			final TupleQuery main = conn.prepareTupleQuery(mainQueryStr);
+			final TupleQueryResult mainResult = main.evaluate();
+			while (mainResult.hasNext()) {
+				final BindingSet current = mainResult.next();
+				final IRI u = (IRI) current.getValue("property");
+
+				final TupleQuery subQuery = conn.prepareTupleQuery(subQueryStr);
+				subQuery.setBinding("property", u);
+				try (final TupleQueryResult sqResult = subQuery.evaluate()) {
+					final Set<IRI> rangesSparql = sqResult.stream()
+							.map(bs -> bs.getValue("range"))
+							.filter(Value::isIRI)
+							.map(v -> (IRI) v)
+							.collect(Collectors.toSet());
+					assertThat(rangesSparql).hasSize(1);
+				}
+			}
+		}
+	}
 }

--- a/compliance/repository/src/test/resources/logback-test.xml
+++ b/compliance/repository/src/test/resources/logback-test.xml
@@ -5,8 +5,9 @@
 			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %msg%n</pattern>
 		</encoder>
 	</appender>
+	<logger name="org.eclipse.rdf4j" level="info"/>
 	<root>
-		<level value="info"/>
+		<level value="warn"/>
 		<appender-ref ref="STDOUT"/>
 	</root>
 </configuration>

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -115,8 +115,8 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 					thread.setDaemon(true);
 					return thread;
 				});
-		threadPoolExecutor.allowCoreThreadTimeOut(true);
 		threadPoolExecutor.setKeepAliveTime(180, TimeUnit.SECONDS);
+		threadPoolExecutor.allowCoreThreadTimeOut(true);
 		this.executor = threadPoolExecutor;
 	}
 

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SharedHttpClientSessionManager.java
@@ -117,8 +117,6 @@ public class SharedHttpClientSessionManager implements HttpClientSessionManager,
 
 		Integer corePoolSize = Integer.getInteger(CORE_POOL_SIZE_PROPERTY, 1);
 		((ThreadPoolExecutor) threadPoolExecutor).setCorePoolSize(corePoolSize);
-		((ThreadPoolExecutor) threadPoolExecutor).setKeepAliveTime(180, TimeUnit.SECONDS);
-		((ThreadPoolExecutor) threadPoolExecutor).allowCoreThreadTimeOut(true);
 		this.executor = threadPoolExecutor;
 	}
 

--- a/site/content/documentation/programming/repository.md
+++ b/site/content/documentation/programming/repository.md
@@ -215,9 +215,9 @@ RDF4J REST API). The HTTP client session is managed by the {{< javadoc
 "http/client/HttpClientSessionManager.html" >}}, which in turn depends
 on the Apache HttpClient.
 
-The session uses a scheduled thread pool executor to handle multithreaded
+The session uses a caching thread pool executor to handle multithreaded
 access to a remote endpoint, defined by default to use a thread pool with a
-core size of 4.
+core size of 1.
 
 To configure this to use a different core pool size, you can specify the
 `org.eclipse.rdf4j.client.executors.corePoolSize` system property with a

--- a/site/content/documentation/programming/repository.md
+++ b/site/content/documentation/programming/repository.md
@@ -217,9 +217,9 @@ on the Apache HttpClient.
 
 The session uses a scheduled thread pool executor to handle multithreaded
 access to a remote endpoint, defined by default to use a thread pool with a
-core size of 1.
+core size of 4.
 
-To configure this to use a different core size, you can specify the
+To configure this to use a different core pool size, you can specify the
 `org.eclipse.rdf4j.client.executors.corePoolSize` system property with a
 different number.
 


### PR DESCRIPTION
GitHub issue resolved: #2918 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- switch to CachedThreadPool executor since it has better behavior for spawning new threads as needed
- allow core threads to be terminated when keepAlive timeout has passed to conserve resources
- RDF4JProtocolSession uses a separate scheduled executor specifically for its transaction ping functionality
- added regression test

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

