### PR TITLE
GH-2698 make Java version check non-fatal

### DIFF
--- a/scripts/milestone-release.sh
+++ b/scripts/milestone-release.sh
@@ -57,12 +57,14 @@ fi
 # check Java version
 if  !  mvn -v | grep -q "Java version: 1.8."; then
   echo "";
-  echo "You need to use Java 8!";
-  echo "mvn -v";
-  echo "";
-  exit 1;
+  echo "Java 1.8 expected but not detected";
+  read -rp "Continue (y/n)?" choice
+  case "${choice}" in
+      y|Y ) echo "";;
+      n|N ) exit;;
+      * ) echo "unknown response, exiting"; exit;;
+  esac
 fi
-
 
 # check that we are on main or develop
 if  ! git status --porcelain --branch | grep -q "## main...origin/main"; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -69,12 +69,14 @@ fi
 # check Java version
 if  !  mvn -v | grep -q "Java version: 1.8."; then
   echo "";
-  echo "You need to use Java 8!";
-  echo "mvn -v";
-  echo "";
-  exit 1;
+  echo "Java 1.8 expected but not detected";
+  read -rp "Continue (y/n)?" choice
+  case "${choice}" in
+      y|Y ) echo "";;
+      n|N ) exit;;
+      * ) echo "unknown response, exiting"; exit;;
+  esac
 fi
-
 
 # check that we are on main
 if  ! git status --porcelain --branch | grep -q "## main...origin/main"; then


### PR DESCRIPTION
GitHub issue resolved: #2698  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Java 1.8 check now asks to continue instead of just exiting immediately.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

