### PR TITLE
Gh 2940 nativestore tempdir

### DIFF
--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTmpDatadirTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTmpDatadirTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors,.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class NativeStoreTmpDatadirTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Test
+	public void testNoTmpDatadir() throws IOException {
+		File dataDir = tempFolder.newFolder();
+		NativeStore store = new NativeStore(dataDir);
+
+		store.initialize();
+		assertTrue("Data dir not set correctly", dataDir.equals(store.getDataDir()));
+
+		store.shutDown();
+		assertTrue("Data dir does not exist anymore", dataDir.exists());
+	}
+
+	@Test
+	public void testTmpDatadir() throws IOException {
+		NativeStore store = new NativeStore();
+		store.initialize();
+		File dataDir = store.getDataDir();
+		assertTrue("Temp data dir not created", dataDir != null && dataDir.exists());
+
+		store.shutDown();
+		assertFalse("Temp data dir still exists", dataDir.exists());
+	}
+
+	@Test
+	public void testTmpDatadirReinit() throws IOException {
+		NativeStore store = new NativeStore();
+		store.initialize();
+		File dataDir1 = store.getDataDir();
+		store.shutDown();
+
+		store.initialize();
+		File dataDir2 = store.getDataDir();
+		store.shutDown();
+		assertFalse("Temp data dirs are the same", dataDir1.equals(dataDir2));
+	}
+
+	@Test
+	public void testDatadirMix() throws IOException {
+		File dataDir = tempFolder.newFolder();
+		NativeStore store = new NativeStore(dataDir);
+
+		store.initialize();
+		store.shutDown();
+
+		store.setDataDir(null);
+		store.initialize();
+		File tmpDataDir = store.getDataDir();
+		store.shutDown();
+
+		assertFalse("Temp data dir still exists", tmpDataDir.exists());
+		assertTrue("Data dir does not exist anymore", dataDir.exists());
+	}
+}

--- a/site/content/documentation/programming/repository.md
+++ b/site/content/documentation/programming/repository.md
@@ -59,9 +59,13 @@ memStore.setSyncDelay(1000L);
 Repository repo = new SailRepository(memStore);
 ```
 
+ The MemoryStore is designed for datasets with fewer than 100,000 triples.
+
 ### Native RDF Repository
 
-A Native RDF Repository does not keep its data in main memory, but instead stores it directly to disk (in a binary format optimized for compact storage and fast retrieval). It is an efficient, scalable and fast solution for RDF storage of datasets that are too large to keep entirely in memory.
+The NativeStore saves data to disk in a binary format which is optimized for compact storage and fast retrieval. If there is sufficient physical memory, the Native store will act like the MemoryStore on most operating systems because the read/write commands will be cached by the OS.
+
+It is therefore an efficient, scalable and fast solution for datasets with up to 100 million triples (and probably even more).
 
 The code for creation of a Native RDF repository is almost identical to that of a main memory repository:
 
@@ -84,6 +88,20 @@ import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 File dataDir = new File("/path/to/datadir/");
 String indexes = "spoc,posc,cosp";
 Repository repo = new SailRepository(new NativeStore(dataDir, indexes));
+```
+
+{{< tag " New in RDF4J 3.7" >}}
+
+If a data directory is not set, a temporary directory will be created when the native store is initialized and (contrary to the previous examples) subsequently deleted when the repository is shut down.
+
+This is convenient when the repository is only used as a means to transform large RDF files.
+
+```java
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
+...
+Repository repo = new SailRepository(new NativeStore());
 ```
 
 ### Elasticserch RDF Repository


### PR DESCRIPTION
GitHub issue resolved: #2940 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- set temp data dir instead of throwing an exception (will be deleted on shutdown)
- added tests for tmp datadir, including one when re-initializing after shutdown
- corrected minor typo
- slightly improved the nativestore/memstore website documentation on amount triples + explaine use case

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

