### PR TITLE
GH-2957 Optimize RDFJSONWriter to stream output

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFJSONWriterSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFJSONWriterSettings.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.helpers;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+
+/**
+ * A selection of writer settings specific to RDF/JSON parsers.
+ * <p>
+ * Settings can be overridden by means of a system property, but only if specified at JVM startup time.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+public class RDFJSONWriterSettings {
+
+	/**
+	 * Boolean setting for RDF/JSON writer to determine whether it should stream output which can result in duplicate
+	 * object keys. By default, the writer sorts output in-memory first to avoid duplicate keys.
+	 * <p>
+	 * Defaults to false.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.rdfjson.allow_multiple_object_values}.
+	 */
+	public static final RioSetting<Boolean> ALLOW_MULTIPLE_OBJECT_VALUES = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.rdfjson.allow_multiple_object_values", "Allow multiple object values",
+			Boolean.FALSE);
+
+	private RDFJSONWriterSettings() {
+	}
+
+}

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -13,6 +13,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -20,16 +21,20 @@ import org.eclipse.rdf4j.common.io.CharSink;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.eclipse.rdf4j.rio.helpers.RDFJSONWriterSettings;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerationException;
@@ -49,13 +54,17 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter, CharS
 
 	private final RDFFormat actualFormat;
 
-	protected Resource lastWrittenSubject;
+	private Model graph;
 
-	protected IRI lastWrittenPredicate;
+	private Resource lastWrittenSubject;
+
+	private IRI lastWrittenPredicate;
 
 	private JsonGenerator jg;
 
 	private boolean isEmptyStream;
+
+	private boolean isStreaming;
 
 	public RDFJSONWriter(final OutputStream out, final RDFFormat actualFormat) {
 		this.actualFormat = actualFormat;
@@ -76,9 +85,7 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter, CharS
 	public void startRDF() throws RDFHandlerException {
 		super.startRDF();
 		try {
-			isEmptyStream = true;
-			lastWrittenPredicate = null;
-			lastWrittenSubject = null;
+			isStreaming = getWriterConfig().get(RDFJSONWriterSettings.ALLOW_MULTIPLE_OBJECT_VALUES);
 			jg = configureNewJsonFactory().createGenerator(writer);
 			if (getWriterConfig().get(BasicWriterSettings.PRETTY_PRINT)) {
 				Indenter indenter = DefaultIndenter.SYSTEM_LINEFEED_INSTANCE;
@@ -86,7 +93,14 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter, CharS
 						.withObjectIndenter(indenter);
 				jg.setPrettyPrinter(pp);
 			}
-			jg.writeStartObject();
+			if (isStreaming) {
+				isEmptyStream = true;
+				lastWrittenPredicate = null;
+				lastWrittenSubject = null;
+				jg.writeStartObject();
+			} else {
+				graph = new TreeModel();
+			}
 		} catch (final IOException e) {
 			throw new RDFHandlerException(e);
 		}
@@ -96,16 +110,21 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter, CharS
 	public void endRDF() throws RDFHandlerException {
 		checkWritingStarted();
 		try {
-			if (!isEmptyStream) {
-				jg.writeEndArray();
+			try {
+				if (isStreaming) {
+					if (!isEmptyStream) {
+						jg.writeEndArray();
+					}
+					jg.writeEndObject();
+					lastWrittenPredicate = null;
+					lastWrittenSubject = null;
+				} else {
+					RDFJSONWriter.modelToRdfJsonInternal(this.graph, this.getWriterConfig(), jg);
+				}
+			} finally {
+				jg.close();
+				writer.flush();
 			}
-			jg.writeEndObject();
-			jg.close();
-
-			lastWrittenPredicate = null;
-			lastWrittenSubject = null;
-
-			writer.flush();
 		} catch (final IOException e) {
 			throw new RDFHandlerException(e);
 		}
@@ -121,6 +140,7 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter, CharS
 		final Set<RioSetting<?>> results = new HashSet<>(super.getSupportedSettings());
 
 		results.add(BasicWriterSettings.PRETTY_PRINT);
+		results.add(RDFJSONWriterSettings.ALLOW_MULTIPLE_OBJECT_VALUES);
 
 		return results;
 	}
@@ -139,6 +159,129 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter, CharS
 
 	@Override
 	public void consumeStatement(final Statement statement) throws RDFHandlerException {
+		if (isStreaming) {
+			consumeStreamingStatement(statement);
+		} else {
+			graph.add(statement);
+		}
+	}
+
+	/**
+	 * Helper method to reduce complexity of the JSON serialisation algorithm Any null contexts will only be serialised
+	 * to JSON if there are also non-null contexts in the contexts array
+	 *
+	 * @param object   The RDF value to serialise
+	 * @param contexts The set of contexts that are relevant to this object, including null contexts as they are found.
+	 * @param jg       the {@link JsonGenerator} to write to.
+	 * @throws IOException
+	 * @throws JsonGenerationException
+	 */
+	public static void writeObject(final Value object, final Set<Resource> contexts, final JsonGenerator jg)
+			throws JsonGenerationException, IOException {
+		jg.writeStartObject();
+		if (object instanceof Literal) {
+			jg.writeObjectField(RDFJSONUtility.VALUE, object.stringValue());
+
+			jg.writeObjectField(RDFJSONUtility.TYPE, RDFJSONUtility.LITERAL);
+			final Literal l = (Literal) object;
+
+			if (Literals.isLanguageLiteral(l)) {
+				jg.writeObjectField(RDFJSONUtility.LANG, l.getLanguage().orElse(null));
+			} else {
+				jg.writeObjectField(RDFJSONUtility.DATATYPE, l.getDatatype().stringValue());
+			}
+		} else if (object instanceof BNode) {
+			jg.writeObjectField(RDFJSONUtility.VALUE, resourceToString((BNode) object));
+
+			jg.writeObjectField(RDFJSONUtility.TYPE, RDFJSONUtility.BNODE);
+		} else if (object instanceof IRI) {
+			jg.writeObjectField(RDFJSONUtility.VALUE, resourceToString((IRI) object));
+
+			jg.writeObjectField(RDFJSONUtility.TYPE, RDFJSONUtility.URI);
+		}
+
+		if (contexts != null && !contexts.isEmpty() && !(contexts.size() == 1 && contexts.iterator().next() == null)) {
+			jg.writeArrayFieldStart(RDFJSONUtility.GRAPHS);
+			for (final Resource nextContext : contexts) {
+				if (nextContext == null) {
+					jg.writeNull();
+				} else {
+					jg.writeString(resourceToString(nextContext));
+				}
+			}
+			jg.writeEndArray();
+		}
+
+		jg.writeEndObject();
+	}
+
+	/**
+	 * Returns the correct syntax for a Resource, depending on whether it is a URI or a Blank Node (ie, BNode)
+	 *
+	 * @param uriOrBnode The resource to serialise to a string
+	 * @return The string value of the sesame resource
+	 */
+	public static String resourceToString(final Resource uriOrBnode) {
+		if (uriOrBnode instanceof IRI) {
+			return uriOrBnode.stringValue();
+		} else {
+			return "_:" + ((BNode) uriOrBnode).getID();
+		}
+	}
+
+	public static void modelToRdfJsonInternal(final Model graph, final WriterConfig writerConfig,
+			final JsonGenerator jg) throws IOException {
+		if (writerConfig.get(BasicWriterSettings.PRETTY_PRINT)) {
+			// SES-2011: Always use \n for consistency
+			Indenter indenter = DefaultIndenter.SYSTEM_LINEFEED_INSTANCE;
+			// By default Jackson does not pretty print, so enable this unless
+			// PRETTY_PRINT setting is disabled
+			DefaultPrettyPrinter pp = new DefaultPrettyPrinter().withArrayIndenter(indenter)
+					.withObjectIndenter(indenter);
+			jg.setPrettyPrinter(pp);
+		}
+		jg.writeStartObject();
+		for (final Resource nextSubject : graph.subjects()) {
+			jg.writeObjectFieldStart(RDFJSONWriter.resourceToString(nextSubject));
+			for (final IRI nextPredicate : graph.filter(nextSubject, null, null).predicates()) {
+				jg.writeArrayFieldStart(nextPredicate.stringValue());
+				for (final Value nextObject : graph.filter(nextSubject, nextPredicate, null).objects()) {
+					// contexts are optional, so this may return empty in some
+					// scenarios depending on the interpretation of the way contexts
+					// work
+					final Set<Resource> contexts = graph.filter(nextSubject, nextPredicate, nextObject).contexts();
+
+					RDFJSONWriter.writeObject(nextObject, contexts, jg);
+				}
+				jg.writeEndArray();
+			}
+			jg.writeEndObject();
+		}
+		jg.writeEndObject();
+	}
+
+	/**
+	 * Get an instance of JsonFactory.
+	 *
+	 * @return A newly configured JsonFactory based on the currently enabled settings
+	 */
+	private JsonFactory configureNewJsonFactory() {
+		final JsonFactory nextJsonFactory = new JsonFactory();
+		// Disable features that may work for most JSON where the field names are
+		// in limited supply,
+		// but does not work for RDF/JSON where a wide range of URIs are used for
+		// subjects and predicates
+		nextJsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+		nextJsonFactory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
+		nextJsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+		return nextJsonFactory;
+	}
+
+	/**
+	 * Consumes statement when RDF/JSON writer is streaming output.
+	 */
+	private void consumeStreamingStatement(final Statement statement) throws RDFHandlerException {
 		Resource subj = statement.getSubject();
 		IRI pred = statement.getPredicate();
 		Value obj = statement.getObject();
@@ -167,87 +310,12 @@ public class RDFJSONWriter extends AbstractRDFWriter implements RDFWriter, CharS
 				lastWrittenPredicate = pred;
 			}
 
-			RDFJSONWriter.writeObject(obj, context, jg);
+			writeObject(obj, Collections.singleton(context), jg);
 			if (isEmptyStream) {
 				isEmptyStream = false;
 			}
 		} catch (final IOException e) {
 			throw new RDFHandlerException(e);
 		}
-	}
-
-	/**
-	 * Helper method to reduce complexity of the JSON serialisation algorithm Any null contexts will only be serialised
-	 * to JSON if there are also non-null contexts in the contexts array
-	 *
-	 * @param object  The RDF value to serialise
-	 * @param context The context that is relevant to this object, including null contexts as they are found.
-	 * @param jg      the {@link JsonGenerator} to write to.
-	 * @throws IOException
-	 * @throws JsonGenerationException
-	 */
-	public static void writeObject(final Value object, final Resource context, final JsonGenerator jg)
-			throws JsonGenerationException, IOException {
-		jg.writeStartObject();
-		if (object instanceof Literal) {
-			jg.writeObjectField(RDFJSONUtility.VALUE, object.stringValue());
-
-			jg.writeObjectField(RDFJSONUtility.TYPE, RDFJSONUtility.LITERAL);
-			final Literal l = (Literal) object;
-
-			if (Literals.isLanguageLiteral(l)) {
-				jg.writeObjectField(RDFJSONUtility.LANG, l.getLanguage().orElse(null));
-			} else {
-				jg.writeObjectField(RDFJSONUtility.DATATYPE, l.getDatatype().stringValue());
-			}
-		} else if (object instanceof BNode) {
-			jg.writeObjectField(RDFJSONUtility.VALUE, resourceToString((BNode) object));
-
-			jg.writeObjectField(RDFJSONUtility.TYPE, RDFJSONUtility.BNODE);
-		} else if (object instanceof IRI) {
-			jg.writeObjectField(RDFJSONUtility.VALUE, resourceToString((IRI) object));
-
-			jg.writeObjectField(RDFJSONUtility.TYPE, RDFJSONUtility.URI);
-		}
-
-		if (context != null) {
-			jg.writeArrayFieldStart(RDFJSONUtility.GRAPHS);
-			jg.writeString(resourceToString(context));
-			jg.writeEndArray();
-		}
-
-		jg.writeEndObject();
-	}
-
-	/**
-	 * Returns the correct syntax for a Resource, depending on whether it is a URI or a Blank Node (ie, BNode)
-	 *
-	 * @param uriOrBnode The resource to serialise to a string
-	 * @return The string value of the sesame resource
-	 */
-	public static String resourceToString(final Resource uriOrBnode) {
-		if (uriOrBnode instanceof IRI) {
-			return uriOrBnode.stringValue();
-		} else {
-			return "_:" + ((BNode) uriOrBnode).getID();
-		}
-	}
-
-	/**
-	 * Get an instance of JsonFactory.
-	 *
-	 * @return A newly configured JsonFactory based on the currently enabled settings
-	 */
-	private JsonFactory configureNewJsonFactory() {
-		final JsonFactory nextJsonFactory = new JsonFactory();
-		// Disable features that may work for most JSON where the field names are
-		// in limited supply,
-		// but does not work for RDF/JSON where a wide range of URIs are used for
-		// subjects and predicates
-		nextJsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
-		nextJsonFactory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
-		nextJsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
-
-		return nextJsonFactory;
 	}
 }

--- a/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONStreamingWriterTest.java
+++ b/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONStreamingWriterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfjson;
 
-import java.io.IOException;
 import java.io.InputStream;
 
 import org.eclipse.rdf4j.model.Model;
@@ -16,23 +15,24 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.RDFJSONWriterSettings;
 
 /**
- * JUnit test for the RDF/JSON parser.
+ * JUnit test for the RDF/JSON streaming writer.
  *
- * @author Peter Ansell
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
  */
-public class RDFJSONWriterTest extends RDFWriterTest {
+public class RDFJSONStreamingWriterTest extends RDFWriterTest {
 
-	public RDFJSONWriterTest() {
+	public RDFJSONStreamingWriterTest() {
 		super(new RDFJSONWriterFactory(), new RDFJSONParserFactory());
 	}
 
 	@Override
 	protected Model parse(InputStream reader, String baseURI)
-			throws RDFParseException, RDFHandlerException, IOException {
+			throws RDFParseException, RDFHandlerException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat()));
 	}
@@ -43,4 +43,8 @@ public class RDFJSONWriterTest extends RDFWriterTest {
 				RDFJSONWriterSettings.ALLOW_MULTIPLE_OBJECT_VALUES };
 	}
 
+	@Override
+	protected void setupWriterConfig(WriterConfig config) {
+		config.set(RDFJSONWriterSettings.ALLOW_MULTIPLE_OBJECT_VALUES, true);
+	}
 }


### PR DESCRIPTION
GitHub issue resolved: #2957 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Reimplemented RDFJSONWriter to stream output rather than storing all statements consumed in a TreeModel before writing output. 