### PR TITLE
GH-2958 fix cast of rectangle shape

### DIFF
--- a/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
+++ b/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
@@ -847,8 +847,11 @@ public class LuceneIndex extends AbstractLuceneIndex {
 			q = LatLonShape.newLineQuery(geoField, relation, (Line) shape);
 		} else if (shape instanceof Line[]) {
 			q = LatLonShape.newLineQuery(geoField, relation, (Line[]) shape);
-		} else if (shape instanceof Rectangle[]) {
+		} else if (shape instanceof Rectangle) {
 			Rectangle box = (Rectangle) shape;
+			q = LatLonShape.newBoxQuery(geoField, relation, box.minLat, box.minLon, box.maxLat, box.maxLon);
+		} else if (shape instanceof Rectangle[]) {
+			Rectangle box = ((Rectangle[]) shape)[0];
 			q = LatLonShape.newBoxQuery(geoField, relation, box.minLat, box.minLon, box.maxLat, box.maxLon);
 		}
 		return q;


### PR DESCRIPTION
GitHub issue resolved: #2958  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- allow both a Rectangle and 1-element Rectangle array (instead of checking if an instance is an array and then cast it to a non-array)

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [x] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

