### PR TITLE
GH-2968 remove git sign-off requirement, and github link on profile

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,21 +14,11 @@ Before you dive in, here are some things you need to know.
 
 Eclipse RDF4J is a project governed by the [Eclipse Foundation](http://www.eclipse.org/), which has strict [policies and guidelines](https://wiki.eclipse.org/Development_Resources#Policies_and_Guidelines) regarding contributions and intellectual property rights.
 
-In order for any contributions to RDF4J to be accepted, you MUST do the following things:
-
 ### Sign the Eclipse Contributor Agreement
 You must digitally sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php). You can do this as follows: 
 
-* If you haven't done so already, [register an Eclipse account](https://dev.eclipse.org/site_login/createaccount.php). Use the same email address when you register for the account that you intend to use on Git commit records. 
-* Log into the [Eclipse projects forge](http://www.eclipse.org/contribute/cla); click on the "Eclipse Contributor Agreement" tab; and complete the form. See the [ECA FAQ](https://www.eclipse.org/legal/ecafaq.php) for more info. 
-
-### Link your Github and Eclipse accounts
-
-Add your github username in your [Eclipse account settings](https://dev.eclipse.org/site_login/#open_tab_accountsettings).
-
-### Sign-off every commit
-
-Every commit you make in your patch or pull request MUST be "signed off". You do this by adding the `-s` flag when you make the commit(s).
+* If you haven't done so already, [register an Eclipse account](https://accounts.eclipse.org/user/register). **Important**: Use the same email address that you will use on Git commits as the author address. 
+* Open the [ECA form](https://accounts.eclipse.org/user/eca) and complete it. See the [ECA FAQ](https://www.eclipse.org/legal/ecafaq.php) for more info. 
 
 ## Creating your contribution
 
@@ -36,15 +26,14 @@ Once the legalities are out of the way you can dig in. Here's how:
 
 1. Create an issue in the [issue tracker](https://github.com/eclipse/rdf4j/issues) that describes your improvement, new feature, or bug fix. Alternatively, comment on an existing issue to indicate you're keen to help solve it.
 2. Fork the repository on GitHub.
-3. Create a new branch for your changes starting from the `main` branch. See [Workflow](#workflow) for details.
+3. Create a new branch for your changes starting from the `main` branch. Name your branch like this: `GH-1234-short-description-here` where 1234 is the Github issue number. See [Workflow](#workflow) for details.
 4. Make your changes. Apply the [RDF4J code formatting guidelines](#code-formatting)
 5. Make sure you include tests. We use JUnit 4 with AssertJ and Mockito. Have a look around for existing tests to get some idea, and of course feel free to ask advice.
 6. Make sure the test suite passes after your changes: you can run `mvn verify` to run tests locally.
-7. Commit your changes into the branch. Use meaningful commit messages. Reference the issue number in the commit message (for example "GH-276: added null check").
-8. **Sign off** every commit you do, using the `-s` flag (as explained in the [legal stuff](#legal-stuff)).
-9. Push your changes to your branch in your forked repository.
-10. Once you're ready, [squash your commits](https://rdf4j.org/documentation/developer/squashing) into one or two meaningful commits.
-11. Use GitHub to submit a pull request (PR) for your contribution back to `main` in the central RDF4J repository.  Once you have submitted your PR, do not use your branch for any other development (unless asked to do so by the reviewers of your PR). 
+7. Commit your changes into the branch. Make sure the commit author name and e-mail correspond to what you used to sign the ECA. Use meaningful commit messages. Reference the issue number in the commit message (for example "GH-276: added null check").
+8. Push your changes to your branch in your forked repository.
+9. Optionally [squash your commits](https://rdf4j.org/documentation/developer/squashing) to clean up the commit history.
+10. Use GitHub to submit a pull request (PR) for your contribution back to `main` in the central RDF4J repository.  Once you have submitted your PR, do not use your branch for any other development (unless asked to do so by the reviewers of your PR). 
 
 Once you've put up a PR, we will review your contribution, possibly make some suggestions for improvements, and once everything is complete it will be merged into the `main` branch (if it's a bug fix to be included in the next maintenance release) or into the `develop` branch (if it's a feature or improvement to be included in the next minor or major release).
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@ guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md).
 
 The short version:
 
-1. Digitally sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php). You can do this by logging into the [Eclipse projects forge](http://www.eclipse.org/contribute/cla); click on "Eclipse Contributor Agreement"; and Complete the form. Be sure to use the same email address when you register for the account that you intend to use on Git commit records. See the [ECA FAQ](https://www.eclipse.org/legal/ecafaq.php) for more info. 
+1. Digitally sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php), as follows: 
+     * [Register an Eclipse account](https://accounts.eclipse.org/user/register). **Important**: Use the same email address that you will use on Git commits as the author address. 
+     * Open the [ECA form](https://accounts.eclipse.org/user/eca) and complete it. See the [ECA FAQ](https://www.eclipse.org/legal/ecafaq.php) for more info. 
 2. Create an issue in the [issue tracker](https://github.com/eclipse/rdf4j/issues) that describes your improvement, new feature, or bug fix - or if you're picking up an existing issue, comment on that issue that you intend to provide a solution for it.
 3. Fork the GitHub repository.
 4. Create a new branch (starting from main) for your changes. Name your branch like this: `GH-1234-short-description-here` where 1234 is the Github issue number.
 5. Make your changes on this branch. Apply the [RDF4J code formatting guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting). Don't forget to include unit tests.
-7. Commit your changes into the branch. Use meaningful commit messages. Reference the issue number in each commit message (for example "GH-276: added null check"). **IMPORTANT**: *sign off* every commit (using the `-s` flag). 
-8. Run `mvn verify` from the project root to make sure all tests succeed (both your own new ones, and existing).
+7. Run `mvn verify` from the project root to make sure all tests succeed (both your own new ones, and existing).
+8. Commit your changes into the branch. Make sure the commit author name and e-mail correspond to what you used to sign the ECA. Use meaningful commit messages. Reference the issue number in each commit message (for example "GH-276: added null check").
 9. Once your fix is complete, put it up for review by opening a Pull Request against the main branch in the central Github repository. If you have a lot of commits on your PR, make sure to [squash your commits](https://rdf4j.org/documentation/developer/squashing).
 
 These steps are explained in more detail in the [Contributor

--- a/site/content/documentation/developer/merge-strategy.md
+++ b/site/content/documentation/developer/merge-strategy.md
@@ -13,8 +13,9 @@ merge it.
 
 We use merge-commits exclusively to merge pull requests into our main branches
 as this preserves the history of changes and who made those changes accurately.
-You as a contributor are completely free to use rebasing, squashing or merge on
-your own branches as you see fit, of course.
+You as a contributor are completely free to use rebasing, squashing or merging
+on your own branches as you see fit, of course - as long as you make sure that
+history of your branch is clean when it's time to merge your PR.
 
 Note: we previously experimented with using 'squash-and-merge' as our Pull
 Request strategy. The advantage of this was that it kept the main branch
@@ -60,6 +61,3 @@ We prefer meaningful commits because:
 
 That said, if occassionally a less "perfect" commit message slips through, that's
 fine. We're all human.
-
-And oh yeah: don't forget to [sign off your commits](/documentation/developer/workflow/#patch-requests)!
-

--- a/site/content/documentation/developer/squashing.md
+++ b/site/content/documentation/developer/squashing.md
@@ -4,7 +4,7 @@ toc: true
 autonumbering: true
 ---
 
-When submitting a pull request to RDF4J, we sometimes ask that you squash your commits, either so you can clean up the commit history a bit, or for example when some of your commits weren't correctly signed off. Here we explain a simple way to do that.
+When submitting a pull request to RDF4J, we sometimes ask that you squash your commits, to clean up the commit history a bit. Here we explain a simple way to do that.
 
 <!--more-->
 
@@ -14,8 +14,7 @@ On the command line, a relatively simple way to squash commits is as follows:
 
 1. Make sure your local `main` and `develop` branches are up to date with the upstream.
 2. Check out your pull request branch.
-3. Run `git rebase -i main --signoff` (or `git rebase -i develop --signoff` if your branch started from the _develop_ branch).
-    - The `--signoff` flag here makes sure that the new commit produced by the squash operation is correctly signed off.
+3. Run `git rebase -i main` (or `git rebase -i develop` if your branch started from the _develop_ branch).
     - You should see a list of commits, each commit starting with the word `pick`.
    - Make sure the first commit says "pick" and change the rest from "pick" to "squash".
 4. Save and close the editor.
@@ -59,7 +58,7 @@ git checkout GH-1234-my-feature-branch
 The second step is starting an "interactive rebase", using the following command:
 
 ```bash
-git rebase -i develop --signoff
+git rebase -i develop
 ```
 
 In this command, `develop` identifies the branch against which we


### PR DESCRIPTION


GitHub issue resolved: #2968  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- removed git sign-off requirement, and github link on profile in README, CONTRIBUTING, and squashing documentation. Neither are required any longer (though it's not a problem if people continue to do it either, of course).

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

