### PR TITLE
main shacl tests are not integration tests

### DIFF
--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
@@ -18,9 +18,9 @@ import org.junit.runners.Parameterized;
  * @author Håvard Ottestad
  */
 @RunWith(Parameterized.class)
-public class ShaclIT extends AbstractShaclTest {
+public class ShaclTest extends AbstractShaclTest {
 
-	public ShaclIT(String testCasePath, String path, ExpectedResult expectedResult, IsolationLevel isolationLevel) {
+	public ShaclTest(String testCasePath, String path, ExpectedResult expectedResult, IsolationLevel isolationLevel) {
 		super(testCasePath, path, expectedResult, isolationLevel);
 	}
 
@@ -31,6 +31,10 @@ public class ShaclIT extends AbstractShaclTest {
 
 	@Test
 	public void testSingleTransaction() {
+		// we don't need to run this test for every isolation level
+		if (isolationLevel != IsolationLevels.NONE) {
+			return;
+		}
 		runWithAutomaticLogging(() -> runTestCaseSingleTransaction(testCasePath, path, expectedResult, isolationLevel));
 	}
 


### PR DESCRIPTION


GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Main SHACL test suite has been marked as integration tests even though they are the main unit tests for the ShaclSail that checks that constraints work.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits down to one or a few meaningful commits
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
 - [ ] every commit has been [signed off](https://stackoverflow.com/questions/1962094/what-is-the-sign-off-feature-in-git-for)

