### PR TITLE
GH-2967 fix nulllpointerexception in SailSourceModel.remove

### DIFF
--- a/core/sail/nativerdf/pom.xml
+++ b/core/sail/nativerdf/pom.xml
@@ -85,6 +85,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-model-testsuite</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
 			<version>${jmhVersion}</version>

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/SailSourceModel.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/SailSourceModel.java
@@ -284,13 +284,10 @@ class SailSourceModel extends AbstractModel {
 				CloseableIteration<? extends Statement, SailException> stmts;
 				stmts = dataset().getStatements(subj, pred, obj, contexts);
 				try {
-
 					while (stmts.hasNext()) {
 						Statement st = stmts.next();
-
-						sink.deprecate(st);
+						sink().deprecate(st);
 					}
-
 				} finally {
 					stmts.close();
 				}
@@ -367,12 +364,10 @@ class SailSourceModel extends AbstractModel {
 			CloseableIteration<? extends Statement, SailException> stmts;
 			stmts = dataset().getStatements(subj, pred, obj, contexts);
 			try {
-
 				while (stmts.hasNext()) {
 					Statement st = stmts.next();
-					sink.deprecate(st);
+					sink().deprecate(st);
 				}
-
 			} finally {
 				stmts.close();
 			}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/SailSourceModelTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/SailSourceModelTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.sail.SailException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SailSourceModelTest {
+
+	static SailSourceModel sailSourceModel;
+
+	@TempDir
+	static Path datadir;
+
+	@BeforeAll
+	public static void setUp() throws SailException, IOException {
+		NativeSailStore store = new NativeSailStore(datadir.toFile(), "spoc");
+		sailSourceModel = new SailSourceModel(store);
+	}
+
+	@Test
+	public void testSimpleAdd() {
+		sailSourceModel.add(RDF.TYPE, RDF.TYPE, RDF.TYPE);
+		assertThat(sailSourceModel.contains(RDF.TYPE, RDF.TYPE, RDF.TYPE));
+	}
+
+	@Test
+	public void testSimpleRemove() {
+		sailSourceModel.remove(RDF.TYPE, RDF.TYPE, RDF.TYPE);
+		assertThat(sailSourceModel.contains(RDF.TYPE, RDF.TYPE, RDF.TYPE)).isFalse();
+	}
+
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/SailSourceModelTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/SailSourceModelTest.java
@@ -8,39 +8,50 @@
 package org.eclipse.rdf4j.sail.nativerdf;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
-import java.nio.file.Path;
+import java.nio.file.Files;
+import java.util.Iterator;
 
+import org.eclipse.rdf4j.model.ModelTest;
+import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.sail.SailException;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-public class SailSourceModelTest {
-
-	static SailSourceModel sailSourceModel;
-
-	@TempDir
-	static Path datadir;
-
-	@BeforeAll
-	public static void setUp() throws SailException, IOException {
-		NativeSailStore store = new NativeSailStore(datadir.toFile(), "spoc");
-		sailSourceModel = new SailSourceModel(store);
-	}
+public class SailSourceModelTest extends ModelTest {
 
 	@Test
-	public void testSimpleAdd() {
+	public void testRemove() {
+		SailSourceModel sailSourceModel = getNewModel();
 		sailSourceModel.add(RDF.TYPE, RDF.TYPE, RDF.TYPE);
-		assertThat(sailSourceModel.contains(RDF.TYPE, RDF.TYPE, RDF.TYPE));
-	}
-
-	@Test
-	public void testSimpleRemove() {
 		sailSourceModel.remove(RDF.TYPE, RDF.TYPE, RDF.TYPE);
 		assertThat(sailSourceModel.contains(RDF.TYPE, RDF.TYPE, RDF.TYPE)).isFalse();
+	}
+
+	@Test
+	public void testRemoveTermIteration() {
+		SailSourceModel sailSourceModel = getNewModel();
+		sailSourceModel.add(RDF.TYPE, RDF.TYPE, RDF.TYPE);
+		sailSourceModel.removeTermIteration((Iterator<Statement>) mock(Iterator.class), RDF.TYPE, RDF.TYPE, RDF.TYPE);
+		assertThat(sailSourceModel.contains(RDF.TYPE, RDF.TYPE, RDF.TYPE)).isFalse();
+	}
+
+	@Test
+	@Override
+	@Disabled
+	public void testGetStatements_ConcurrentModificationOfModel() {
+	}
+
+	@Override
+	protected SailSourceModel getNewModel() {
+		try {
+			NativeSailStore store = new NativeSailStore(Files.createTempDirectory("SailSourceModelTest-").toFile(),
+					"spoc");
+			return new SailSourceModel(store);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 }

--- a/testsuites/model/src/main/java/org/eclipse/rdf4j/model/ModelTest.java
+++ b/testsuites/model/src/main/java/org/eclipse/rdf4j/model/ModelTest.java
@@ -265,7 +265,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testGetStatements_SingleLiteral() {
+	public void testGetStatements_SingleLiteral() {
 		Model model = getNewModelObjectSingleLiteral();
 
 		Iterator<Statement> selection = model.getStatements(null, null, literal1).iterator();
@@ -276,7 +276,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testGetStatements_IteratorModification() {
+	public void testGetStatements_IteratorModification() {
 		Model model = getNewEmptyModel();
 		model.add(uri1, RDFS.LABEL, uri2);
 		model.add(uri1, RDFS.LABEL, uri3);
@@ -295,7 +295,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testGetStatements_ConcurrentModificationOfModel() {
+	public void testGetStatements_ConcurrentModificationOfModel() {
 		Model model = getNewEmptyModel();
 		model.add(uri1, RDFS.LABEL, uri2);
 		model.add(uri1, RDFS.LABEL, uri3);
@@ -317,7 +317,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testGetStatements_AddToEmptyModel() {
+	public void testGetStatements_AddToEmptyModel() {
 		Model model = getNewEmptyModel();
 		Iterator<Statement> selection = model.getStatements(null, null, null).iterator();
 		assertThat(selection.hasNext()).isFalse();
@@ -333,7 +333,7 @@ public abstract class ModelTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#filter(Resource, IRI, Value, Resource...)}.
 	 */
 	@Test
-	public final void testFilterSingleLiteral() {
+	public void testFilterSingleLiteral() {
 		Model model = getNewModelObjectSingleLiteral();
 		Model filter1 = model.filter(null, null, literal1);
 		assertFalse(filter1.isEmpty());
@@ -342,7 +342,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testFilter_AddToEmptyFilteredModel() {
+	public void testFilter_AddToEmptyFilteredModel() {
 		Model model = getNewEmptyModel();
 		Model filter = model.filter(null, null, null);
 		assertTrue(filter.isEmpty());
@@ -353,7 +353,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testFilter_RemoveFromFilter() {
+	public void testFilter_RemoveFromFilter() {
 		Model model = getNewEmptyModel();
 		model.add(uri1, RDFS.LABEL, literal1, uri1);
 		Model filter = model.filter(uri1, RDFS.LABEL, literal1, uri1);
@@ -365,7 +365,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testFilter_AddToNonEmptyFilteredModel() {
+	public void testFilter_AddToNonEmptyFilteredModel() {
 		Model model = getNewModelObjectSingleLiteral();
 		Model filter = model.filter(null, null, literal1);
 		assertFalse(filter.isEmpty());
@@ -375,7 +375,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testFilter_AddToEmptyOriginalModel() {
+	public void testFilter_AddToEmptyOriginalModel() {
 		Model model = getNewEmptyModel();
 		Model filter = model.filter(null, null, null);
 		assertTrue(filter.isEmpty());
@@ -386,7 +386,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testFilter_RemoveFromOriginal() {
+	public void testFilter_RemoveFromOriginal() {
 		Model model = getNewEmptyModel();
 		model.add(uri1, RDFS.LABEL, literal1, uri1);
 		Model filter = model.filter(uri1, RDFS.LABEL, literal1, uri1);
@@ -398,7 +398,7 @@ public abstract class ModelTest {
 	}
 
 	@Test
-	public final void testFilter_AddToOriginalModel() {
+	public void testFilter_AddToOriginalModel() {
 		Model model = getNewModelObjectSingleLiteral();
 		Model filter = model.filter(null, null, literal1);
 		assertFalse(filter.isEmpty());
@@ -413,7 +413,7 @@ public abstract class ModelTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#contains(Resource, IRI, Value, Resource...)} .
 	 */
 	@Test
-	public final void testContainsSingleLiteral() {
+	public void testContainsSingleLiteral() {
 		Model model = getNewModelObjectSingleLiteral();
 		assertTrue(model.contains(null, null, literal1));
 		assertTrue(model.contains(null, null, literal1, (Resource) null));
@@ -423,7 +423,7 @@ public abstract class ModelTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#subjects()}.
 	 */
 	@Test
-	public final void testSubjects() {
+	public void testSubjects() {
 		Model m = getNewModelObjectDoubleLiteral();
 
 		final int modelSizeBefore = m.size();
@@ -444,7 +444,7 @@ public abstract class ModelTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#predicates()}.
 	 */
 	@Test
-	public final void testPredicates() {
+	public void testPredicates() {
 		Model m = getNewModelObjectDoubleLiteral();
 
 		final int modelSizeBefore = m.size();
@@ -465,7 +465,7 @@ public abstract class ModelTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#objects()}.
 	 */
 	@Test
-	public final void testObjects() {
+	public void testObjects() {
 		Model m = getNewModelObjectDoubleLiteral();
 
 		final int modelSizeBefore = m.size();
@@ -486,7 +486,7 @@ public abstract class ModelTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.Model#contexts()}.
 	 */
 	@Test
-	public final void testContexts() {
+	public void testContexts() {
 		Model m = getNewModelTwoContexts();
 
 		final int modelSizeBefore = m.size();


### PR DESCRIPTION
GitHub issue resolved: #2967  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added unit test that reproduces the bug
- added additional unit tests on SailSourceModel to have better coverage/compliance
- fixed by making sure private `sink` field is not directly referenced, but only via the `sink()` method

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

