### PR TITLE
GH-2988 Add eclipse annotation processor files to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 **/.settings
 bin
 **/bin
+**/.factorypath
 
 # Eclipse Plug-In Settings
 .pmd


### PR DESCRIPTION
Signed-off-by: Jerven bolleman <jerven.bolleman@sib.swiss>

GitHub issue resolved: #2988

Briefly describe the changes proposed in this PR:

Add one line to the .gitignore to make it more difficult to accidentally check these files in.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

