### PR TITLE
GH-2959 use junit4 rule for temporary dirs

### DIFF
--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/NativeStoreCustomInferencingTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/NativeStoreCustomInferencingTest.java
@@ -29,7 +29,7 @@ public class NativeStoreCustomInferencingTest extends CustomGraphQueryInferencer
 	@Override
 	protected NotifyingSail newSail() {
 		try {
-			return new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
+			return new NativeStore(tempDir.newFolder(), "spoc,posc");
 		} catch (IOException e) {
 			fail(e.getMessage());
 			throw new AssertionError(e);

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/NativeStoreInferencingTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/NativeStoreInferencingTest.java
@@ -24,7 +24,7 @@ public class NativeStoreInferencingTest extends InferencingTest {
 	@Override
 	protected Sail createSail() {
 		try {
-			NotifyingSail sailStack = new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
+			NotifyingSail sailStack = new NativeStore(tempDir.newFolder(), "spoc,posc");
 			sailStack = new SchemaCachingRDFSInferencer(sailStack);
 			return sailStack;
 		} catch (IOException e) {

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/RDFSchemaNativeRepositoryConnectionTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/RDFSchemaNativeRepositoryConnectionTest.java
@@ -7,19 +7,19 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.inferencer.fc;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.IsolationLevel;
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.RDFSchemaRepositoryConnectionTest;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class RDFSchemaNativeRepositoryConnectionTest extends RDFSchemaRepositoryConnectionTest {
-
-	private File dataDir;
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
 
 	public RDFSchemaNativeRepositoryConnectionTest(IsolationLevel level) {
 		super(level);
@@ -27,16 +27,6 @@ public class RDFSchemaNativeRepositoryConnectionTest extends RDFSchemaRepository
 
 	@Override
 	protected Repository createRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new ForwardChainingRDFSInferencer(new NativeStore(dataDir, "spoc")));
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
+		return new SailRepository(new ForwardChainingRDFSInferencer(new NativeStore(tempDir.newFolder(), "spoc")));
 	}
 }

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerNativeIsolationLevelTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerNativeIsolationLevelTest.java
@@ -35,7 +35,7 @@ public class SchemaCachingRDFSInferencerNativeIsolationLevelTest extends SailIso
 	@Override
 	protected NotifyingSail createSail() throws SailException {
 		try {
-			return new SchemaCachingRDFSInferencer(new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc"));
+			return new SchemaCachingRDFSInferencer(new NativeStore(tempDir.newFolder(), "spoc,posc"));
 		} catch (IOException e) {
 			throw new AssertionError(e);
 		}

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerNativeRepositoryConnectionTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerNativeRepositoryConnectionTest.java
@@ -9,12 +9,10 @@ package org.eclipse.rdf4j.sail.inferencer.fc;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.IsolationLevel;
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -24,11 +22,13 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class SchemaCachingRDFSInferencerNativeRepositoryConnectionTest extends RDFSchemaRepositoryConnectionTest {
-
-	private File dataDir;
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
 
 	public SchemaCachingRDFSInferencerNativeRepositoryConnectionTest(IsolationLevel level) {
 		super(level);
@@ -36,19 +36,10 @@ public class SchemaCachingRDFSInferencerNativeRepositoryConnectionTest extends R
 
 	@Override
 	protected Repository createRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		SchemaCachingRDFSInferencer sail = new SchemaCachingRDFSInferencer(new NativeStore(dataDir, "spoc"), true);
+		SchemaCachingRDFSInferencer sail = new SchemaCachingRDFSInferencer(new NativeStore(tempDir.newFolder(), "spoc"),
+				true);
 		sail.setAddInferredStatementsToDefaultContext(false);
 		return new SailRepository(sail);
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
 	}
 
 	@Override

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
@@ -18,9 +18,9 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-
-import com.google.common.io.Files;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * Unit tests for {@link ContextStore}
@@ -37,20 +37,22 @@ public class ContextStoreTest {
 	private Resource g1 = vf.createIRI("http://example.org/g1");
 	private Resource g2 = vf.createBNode();
 
-	private File dir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	private File dataDir;
 
 	/**
 	 * @throws java.lang.Exception
 	 */
 	@Before
 	public void setUp() throws Exception {
-		dir = Files.createTempDir();
+		dataDir = tmpDir.newFolder();
 		NativeSailStore sailStore = mock(NativeSailStore.class);
 
 		when(sailStore.getValueFactory()).thenReturn(SimpleValueFactory.getInstance());
 		when(sailStore.getContexts()).thenReturn(new EmptyIteration<>());
 
-		subject = new ContextStore(sailStore, dir);
+		subject = new ContextStore(sailStore, dataDir);
 	}
 
 	@Test
@@ -113,7 +115,7 @@ public class ContextStoreTest {
 
 	@Test
 	public void testSync() throws Exception {
-		File datafile = new File(dir, "contexts.dat");
+		File datafile = new File(dataDir, "contexts.dat");
 		assertThat(datafile.exists());
 		long size = datafile.length();
 		assertThat(size).isEqualTo(8L); // empty contexts file is 8 bytes

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/DefaultIndexTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/DefaultIndexTest.java
@@ -15,13 +15,17 @@ import java.io.InputStream;
 import java.util.Properties;
 
 import org.eclipse.rdf4j.common.io.FileUtil;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class DefaultIndexTest {
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Test
 	public void testDefaultIndex() throws Exception {
-		File dir = FileUtil.createTempDir("nativerdf");
+		File dir = tmpDir.newFolder();
 		TripleStore store = new TripleStore(dir, null);
 		store.close();
 		// check that the triple store used the default index
@@ -31,7 +35,7 @@ public class DefaultIndexTest {
 
 	@Test
 	public void testExistingIndex() throws Exception {
-		File dir = FileUtil.createTempDir("nativerdf");
+		File dir = tmpDir.newFolder();
 		// set a non-default index
 		TripleStore store = new TripleStore(dir, "spoc,opsc");
 		store.close();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/LimitedSizeNativeStoreConnectionTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/LimitedSizeNativeStoreConnectionTest.java
@@ -12,11 +12,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.IsolationLevel;
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -28,11 +26,13 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnectionTest;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class LimitedSizeNativeStoreConnectionTest extends RepositoryConnectionTest {
-
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	public LimitedSizeNativeStoreConnectionTest(IsolationLevel level) {
 		super(level);
@@ -40,17 +40,7 @@ public class LimitedSizeNativeStoreConnectionTest extends RepositoryConnectionTe
 
 	@Override
 	protected Repository createRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new LimitedSizeNativeStore(dataDir, "spoc"));
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
+		return new SailRepository(new LimitedSizeNativeStore(tmpDir.newFolder(), "spoc"));
 	}
 
 	@Test

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/LongMultithreadedTransactions.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/LongMultithreadedTransactions.java
@@ -1,12 +1,8 @@
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.apache.commons.io.FileUtils;
-import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -16,31 +12,17 @@ import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.sail.SailConnection;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class LongMultithreadedTransactions {
-
-	File file;
-
-	@After
-	public void after() {
-		try {
-			FileUtils.deleteDirectory(file);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@Before
-	public void before() {
-		file = Files.newTemporaryFolder();
-	}
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	NotifyingSail getBaseSail() {
-		return new NativeStore(file);
+		return new NativeStore(tmpDir.getRoot());
 	}
 
 	@Test

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeCascadeValueExceptionTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeCascadeValueExceptionTest.java
@@ -7,30 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.CascadeValueExceptionTest;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class NativeCascadeValueExceptionTest extends CascadeValueExceptionTest {
-
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new NativeStore(dataDir, "spoc"));
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
+		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeGraphQueryResultTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeGraphQueryResultTest.java
@@ -7,30 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.GraphQueryResultTest;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class NativeGraphQueryResultTest extends GraphQueryResultTest {
-
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new NativeStore(dataDir, "spoc"));
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
+		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSparqlOrderByTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSparqlOrderByTest.java
@@ -7,31 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.SparqlOrderByTest;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class NativeSparqlOrderByTest extends SparqlOrderByTest {
-
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new NativeStore(dataDir, "spoc"));
+		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
 	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
-	}
-
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSparqlRegexTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSparqlRegexTest.java
@@ -7,30 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.SparqlRegexTest;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class NativeSparqlRegexTest extends SparqlRegexTest {
-
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new NativeStore(dataDir, "spoc"));
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
+		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConcurrencyTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConcurrencyTest.java
@@ -34,7 +34,7 @@ public class NativeStoreConcurrencyTest extends SailConcurrencyTest {
 	@Override
 	protected NotifyingSail createSail() throws SailException {
 		try {
-			return new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
+			return new NativeStore(tempDir.newFolder(), "spoc,posc");
 		} catch (IOException e) {
 			throw new AssertionError(e);
 		}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnectionTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnectionTest.java
@@ -9,22 +9,22 @@ package org.eclipse.rdf4j.sail.nativerdf;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.IsolationLevel;
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnectionTest;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class NativeStoreConnectionTest extends RepositoryConnectionTest {
-
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	public NativeStoreConnectionTest(IsolationLevel level) {
 		super(level);
@@ -32,17 +32,7 @@ public class NativeStoreConnectionTest extends RepositoryConnectionTest {
 
 	@Override
 	protected Repository createRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new NativeStore(dataDir, "spoc"));
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
+		return new SailRepository(new NativeStore(tmpDir.newFolder(), "spoc"));
 	}
 
 	@Test

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConsistencyIT.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConsistencyIT.java
@@ -60,7 +60,7 @@ public class NativeStoreConsistencyIT {
 		IRI oldContext = vf.createIRI("http://example.org/oldContext");
 		IRI newContext = vf.createIRI("http://example.org/newContext");
 
-		File dataDir = tempDir.newFolder("nativestore-consistency");
+		File dataDir = tempDir.newFolder();
 
 		Repository repo = new SailRepository(new NativeStore(dataDir, "spoc,psoc"));
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreContextTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreContextTest.java
@@ -34,7 +34,7 @@ public class NativeStoreContextTest extends RDFNotifyingStoreTest {
 	@Override
 	protected NotifyingSail createSail() throws SailException {
 		try {
-			NotifyingSail sail = new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
+			NotifyingSail sail = new NativeStore(tempDir.newFolder(), "spoc,posc");
 			sail.init();
 			return sail;
 		} catch (IOException e) {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreDirLockTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreDirLockTest.java
@@ -24,7 +24,7 @@ public class NativeStoreDirLockTest {
 
 	@Test
 	public void testLocking() throws Exception {
-		File dataDir = tempDir.newFolder("nativestore");
+		File dataDir = tempDir.newFolder();
 		NativeStore sail = new NativeStore(dataDir, "spoc,posc");
 		sail.initialize();
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreInterruptTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreInterruptTest.java
@@ -35,7 +35,7 @@ public class NativeStoreInterruptTest extends SailInterruptTest {
 	@Override
 	protected NotifyingSail createSail() throws SailException {
 		try {
-			return new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
+			return new NativeStore(tempDir.newFolder(), "spoc,posc");
 		} catch (IOException e) {
 			throw new AssertionError(e);
 		}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreIsolationLevelTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreIsolationLevelTest.java
@@ -34,7 +34,7 @@ public class NativeStoreIsolationLevelTest extends SailIsolationLevelTest {
 	@Override
 	protected NotifyingSail createSail() throws SailException {
 		try {
-			return new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
+			return new NativeStore(tempDir.newFolder(), "spoc,posc");
 		} catch (IOException e) {
 			throw new AssertionError(e);
 		}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreRepositoryTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreRepositoryTest.java
@@ -7,31 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryTest;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class NativeStoreRepositoryTest extends RepositoryTest {
-
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Override
 	protected Repository createRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new NativeStore(dataDir, "spoc"));
+		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
 	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
-	}
-
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTest.java
@@ -35,6 +35,7 @@ public class NativeStoreTest extends RDFNotifyingStoreTest {
 
 	@Rule
 	public TemporaryFolder tempDir = new TemporaryFolder();
+	private File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -43,7 +44,8 @@ public class NativeStoreTest extends RDFNotifyingStoreTest {
 	@Override
 	protected NotifyingSail createSail() throws SailException {
 		try {
-			NotifyingSail sail = new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
+			dataDir = tempDir.newFolder();
+			NotifyingSail sail = new NativeStore(dataDir, "spoc,posc");
 			sail.init();
 			return sail;
 		} catch (IOException e) {
@@ -75,7 +77,7 @@ public class NativeStoreTest extends RDFNotifyingStoreTest {
 		con.close();
 		sail.shutDown();
 
-		File contextFile = new File(tempDir.getRoot(), "/nativestore/contexts.dat");
+		File contextFile = new File(dataDir, "/contexts.dat");
 		Files.delete(contextFile);
 
 		sail.init();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeTupleQueryResultTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeTupleQueryResultTest.java
@@ -7,30 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.TupleQueryResultTest;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 public class NativeTupleQueryResultTest extends TupleQueryResultTest {
-
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new NativeStore(dataDir, "spoc"));
-	}
-
-	@Override
-	public void tearDown() throws Exception {
-		try {
-			super.tearDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
+		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreMemoryOverflow.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreMemoryOverflow.java
@@ -9,12 +9,10 @@ package org.eclipse.rdf4j.sail.nativerdf;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.common.iteration.Iteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Statement;
@@ -25,7 +23,9 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -41,7 +41,8 @@ public class TestNativeStoreMemoryOverflow {
 		return IsolationLevels.values();
 	}
 
-	private File dataDir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	private Repository testRepository;
 
@@ -70,19 +71,14 @@ public class TestNativeStoreMemoryOverflow {
 	}
 
 	private Repository createRepository() throws IOException {
-		dataDir = FileUtil.createTempDir("nativestore");
-		return new SailRepository(new NativeStore(dataDir, "spoc"));
+		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		try {
-			testCon2.close();
-			testCon.close();
-			testRepository.shutDown();
-		} finally {
-			FileUtil.deleteDir(dataDir);
-		}
+		testCon2.close();
+		testCon.close();
+		testRepository.shutDown();
 	}
 
 	@Test

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreUpgrade.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreUpgrade.java
@@ -20,7 +20,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -28,9 +27,9 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @author James Leigh
@@ -41,21 +40,12 @@ public class TestNativeStoreUpgrade {
 
 	private static final String ZIP_2_7_15_INCONSISTENT = "/nativerdf-inconsistent-2.7.15.zip";
 
-	private File dataDir;
-
-	@Before
-	public void setUp() throws Exception {
-		dataDir = FileUtil.createTempDir("nativestore");
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		FileUtil.deleteDir(dataDir);
-		dataDir = null;
-	}
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Test
 	public void testDevel() throws IOException, SailException {
+		File dataDir = tmpDir.getRoot();
 		NativeStore store = new NativeStore(dataDir);
 		try {
 			store.initialize();
@@ -75,6 +65,7 @@ public class TestNativeStoreUpgrade {
 
 	@Test
 	public void test2715() throws IOException, SailException {
+		File dataDir = tmpDir.getRoot();
 		extractZipResource(ZIP_2_7_15, dataDir);
 		assertFalse(new File(dataDir, "nativerdf.ver").exists());
 		assertValue(dataDir);
@@ -83,6 +74,7 @@ public class TestNativeStoreUpgrade {
 
 	@Test
 	public void test2715Inconsistent() throws IOException, SailException {
+		File dataDir = tmpDir.getRoot();
 		extractZipResource(ZIP_2_7_15_INCONSISTENT, dataDir);
 		assertFalse(new File(dataDir, "nativerdf.ver").exists());
 		NativeStore store = new NativeStore(dataDir);

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
@@ -12,33 +12,22 @@ import static org.junit.Assert.assertNull;
 
 import java.io.File;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.sail.nativerdf.TxnStatusFile.TxnStatus;
 import org.eclipse.rdf4j.sail.nativerdf.btree.RecordIterator;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * An extension of RDFStoreTest for testing the class {@link NativeStore}.
  */
 public class TripleStoreRecoveryTest {
-
-	private File dataDir;
-
-	@Before
-	public void setUp() throws Exception {
-		dataDir = FileUtil.createTempDir("nativestore");
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		FileUtil.deleteDir(dataDir);
-		dataDir = null;
-	}
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Test
 	public void testRollbackRecovery() throws Exception {
+		File dataDir = tmpDir.getRoot();
 		TripleStore tripleStore = new TripleStore(dataDir, "spoc");
 		try {
 			tripleStore.startTransaction();
@@ -61,6 +50,7 @@ public class TripleStoreRecoveryTest {
 
 	@Test
 	public void testCommitRecovery() throws Exception {
+		File dataDir = tmpDir.getRoot();
 		TripleStore tripleStore = new TripleStore(dataDir, "spoc");
 		try {
 			tripleStore.startTransaction();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
@@ -15,9 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Resource;
@@ -27,6 +25,8 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -57,7 +57,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 public class QueryBenchmark {
 
 	private SailRepository repository;
-	private File file;
+
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
 
 	private static final String query1;
 	private static final String query2;
@@ -92,7 +94,7 @@ public class QueryBenchmark {
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException {
 
-		file = Files.newTemporaryFolder();
+		File file = tempDir.newFolder();
 
 		repository = new SailRepository(new NativeStore(file, "spoc,ospc,psoc"));
 
@@ -119,8 +121,6 @@ public class QueryBenchmark {
 	public void afterClass() throws IOException {
 
 		repository.shutDown();
-		FileUtils.deleteDirectory(file);
-
 	}
 
 	@Benchmark

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTreeBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTreeBenchmark.java
@@ -7,15 +7,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf.btree;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Random;
 
 import org.eclipse.rdf4j.common.io.ByteArrayUtil;
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Arjohn Kampman
@@ -28,7 +28,8 @@ public class BTreeBenchmark {
 	 * Variables *
 	 *-----------*/
 
-	private File dir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	private BTree btree;
 
@@ -38,14 +39,12 @@ public class BTreeBenchmark {
 
 	@Before
 	public void setUp() throws Exception {
-		dir = FileUtil.createTempDir("btree");
-		btree = new BTree(dir, "test", 4096, 8);
+		btree = new BTree(tmpDir.newFolder(), "test", 4096, 8);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		btree.delete();
-		FileUtil.deleteDir(dir);
 	}
 
 	@Test

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTreeTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTreeTest.java
@@ -7,15 +7,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf.btree;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Arjohn Kampman
@@ -45,7 +45,8 @@ public class BTreeTest {
 	 * Variables *
 	 *-----------*/
 
-	private File dir;
+	@Rule
+	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	private BTree btree;
 
@@ -55,14 +56,12 @@ public class BTreeTest {
 
 	@Before
 	public void setUp() throws Exception {
-		dir = FileUtil.createTempDir("btree");
-		btree = new BTree(dir, "test", 85, 1);
+		btree = new BTree(tmpDir.newFolder(), "test", 85, 1);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		btree.delete();
-		FileUtil.deleteDir(dir);
 	}
 
 	@Test

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/NativeStoreTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/NativeStoreTest.java
@@ -8,38 +8,38 @@
 package org.eclipse.rdf4j.sail.shacl;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 
-import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class NativeStoreTest {
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
 
 	@Test
 	public void testEmpty() throws IOException {
 
-		File file = Files.newTemporaryFolder();
+		File file = tempDir.newFolder();
 
 		SailRepository shaclSail = new SailRepository(new ShaclSail(new NativeStore(file)));
 		shaclSail.init();
 
 		shaclSail.shutDown();
-
-		delete(file);
 	}
 
 	@Test(expected = ShaclSailValidationException.class)
 	public void testPersistedShapes() throws Throwable {
 
-		File file = Files.newTemporaryFolder();
+		File file = tempDir.newFolder();
 
 		SailRepository shaclSail = new SailRepository(new ShaclSail(new NativeStore(file)));
 		shaclSail.init();
@@ -73,7 +73,6 @@ public class NativeStoreTest {
 		finally {
 			shaclSail.shutDown();
 		}
-		delete(file);
 	}
 
 	private void addShapes(SailRepository shaclSail) throws IOException {
@@ -96,16 +95,4 @@ public class NativeStoreTest {
 
 		}
 	}
-
-	void delete(File f) throws IOException {
-		if (f.isDirectory()) {
-			for (File c : f.listFiles()) {
-				delete(c);
-			}
-		}
-		if (!f.delete()) {
-			throw new FileNotFoundException("Failed to delete file: " + f);
-		}
-	}
-
 }

--- a/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/QueryOrderBenchmark.java
+++ b/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/QueryOrderBenchmark.java
@@ -3,7 +3,6 @@ package org.eclipse.rdf4j.benchmark;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -15,7 +14,9 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -45,8 +46,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class QueryOrderBenchmark {
-
-	private File tempDir;
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
+	private File dataDir;
 
 	private Repository repository;
 
@@ -64,10 +66,8 @@ public class QueryOrderBenchmark {
 	@Setup
 	@Before
 	public void setup() throws Exception {
-		tempDir = File.createTempFile("nativestore", "");
-		tempDir.delete();
-		tempDir.mkdirs();
-		NativeStore sail = new NativeStore(tempDir, "spoc,posc");
+		dataDir = tempDir.newFolder();
+		NativeStore sail = new NativeStore(dataDir, "spoc,posc");
 		sail.setIterationCacheSyncThreshold(syncThreshold);
 		repository = new SailRepository(sail);
 		initialize();
@@ -95,7 +95,6 @@ public class QueryOrderBenchmark {
 	public void tearDown() throws Exception {
 		conn.close();
 		repository.shutDown();
-		FileUtil.deleteDir(tempDir);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #2959  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- use a junit4 rule to create temp dirs (instead of relying on custom ways to achieve the same thing) that should be removed after the test
- use random temp dirs, instead of fixed onces (e.g. "nativestore"): this should help running tests in parallel (though currently all tests are performed in series), otherwise different tests may end up using the same subdirectory

Not using junit5 (yet), because it looks like some tests inherit from other junit4 tests outside their own package.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

