### PR TITLE
GH-3011 fix handling of cyclic paths in construct queries

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -786,14 +786,15 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		// Retrieve all StatementPatterns from the construct expression
 		List<StatementPattern> statementPatterns = StatementPatternCollector.process(constructExpr);
 
-		if (constructExpr instanceof Filter) {
+		SameTermCollector collector = new SameTermCollector();
+		constructExpr.visit(collector);
+		if (!collector.getCollectedSameTerms().isEmpty()) {
 			// sameTerm filters in construct (this can happen when there's a
-			// cyclic
-			// path defined, see SES-1685 and SES-2104)
+			// cyclic path defined, see SES-1685 and SES-2104)
 
 			// we remove the sameTerm filters by simply replacing all mapped
 			// variable occurrences
-			Set<SameTerm> sameTermConstraints = getSameTermConstraints((Filter) constructExpr);
+			Set<SameTerm> sameTermConstraints = collector.getCollectedSameTerms();
 			statementPatterns = replaceSameTermVars(statementPatterns, sameTermConstraints);
 		}
 
@@ -897,13 +898,6 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			}
 		}
 		return statementPatterns;
-	}
-
-	private Set<SameTerm> getSameTermConstraints(Filter filter) throws VisitorException {
-		final SameTermCollector collector = new SameTermCollector();
-		filter.visit(collector);
-
-		return collector.getCollectedSameTerms();
 	}
 
 	@Override


### PR DESCRIPTION
GitHub issue resolved: #3011  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- handling of SameTerm constraints introduced for cyclic paths extended to deal with more complex expressions
- added  compliance testcase

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

