### PR TITLE
GH-3008 inline VALUES clause values if possible

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInliner.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInliner.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+
+/**
+ * Optimizes a query model by inlining {@link BindingSetAssignment} values where possible.
+ *
+ * @author Jeen Broekstra
+ */
+public class BindingSetAssignmentInliner implements QueryOptimizer {
+
+	@Override
+	public void optimize(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings) {
+		BindingSetAssignmentVisitor visitor = new BindingSetAssignmentVisitor();
+		tupleExpr.visit(visitor);
+	}
+
+	private static class BindingSetAssignmentVisitor extends AbstractQueryModelVisitor<RuntimeException> {
+
+		private BindingSet bindingSet;
+
+		@Override
+		public void meet(BindingSetAssignment bsa) {
+			List<BindingSet> bindingSets = new ArrayList<>();
+			bsa.getBindingSets().forEach(bindingSets::add);
+
+			if (bindingSets.size() == 1) {
+				bindingSet = bindingSets.get(0);
+			}
+			super.meet(bsa);
+		}
+
+		@Override
+		public void meet(Var var) {
+			if (bindingSet != null && bindingSet.hasBinding(var.getName())) {
+				var.setValue(bindingSet.getValue(var.getName()));
+			}
+		}
+
+		@Override
+		public void meetOther(QueryModelNode node) throws RuntimeException {
+			// reset if we encounter a scope change (e.g. a subquery)
+			if (node instanceof AbstractQueryModelNode) {
+				if (((AbstractQueryModelNode) node).isVariableScopeChange()) {
+					bindingSet = null;
+				}
+			}
+			super.meetOther(node);
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInliner.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInliner.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.LeftJoin;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
@@ -53,6 +54,14 @@ public class BindingSetAssignmentInliner implements QueryOptimizer {
 			if (bindingSet != null && bindingSet.hasBinding(var.getName())) {
 				var.setValue(bindingSet.getValue(var.getName()));
 			}
+		}
+
+		@Override
+		public void meet(LeftJoin leftJoin) {
+			leftJoin.getLeftArg().visit(this);
+			// we can not pre-bind values for the optional part of the left-join
+			bindingSet = null;
+			leftJoin.getRightArg().visit(this);
 		}
 
 		@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInliner.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInliner.java
@@ -8,12 +8,14 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.LeftJoin;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
@@ -40,11 +42,10 @@ public class BindingSetAssignmentInliner implements QueryOptimizer {
 
 		@Override
 		public void meet(BindingSetAssignment bsa) {
-			List<BindingSet> bindingSets = new ArrayList<>();
-			bsa.getBindingSets().forEach(bindingSets::add);
-
-			if (bindingSets.size() == 1) {
-				bindingSet = bindingSets.get(0);
+			Iterator<BindingSet> iter = bsa.getBindingSets().iterator();
+			BindingSet firstBindingSet = iter.next();
+			if (!iter.hasNext()) {
+				bindingSet = firstBindingSet;
 			}
 			super.meet(bsa);
 		}
@@ -57,6 +58,12 @@ public class BindingSetAssignmentInliner implements QueryOptimizer {
 		}
 
 		@Override
+		public void meet(Filter node) throws RuntimeException {
+			// TODO Auto-generated method stub
+			super.meet(node);
+		}
+
+		@Override
 		public void meet(LeftJoin leftJoin) {
 			leftJoin.getLeftArg().visit(this);
 			// we can not pre-bind values for the optional part of the left-join
@@ -65,14 +72,14 @@ public class BindingSetAssignmentInliner implements QueryOptimizer {
 		}
 
 		@Override
-		public void meetOther(QueryModelNode node) throws RuntimeException {
-			// reset if we encounter a scope change (e.g. a subquery)
+		protected void meetNode(QueryModelNode node) throws RuntimeException {
+			// reset if we encounter a scope change (e.g. a subquery or a union)
 			if (node instanceof AbstractQueryModelNode) {
 				if (((AbstractQueryModelNode) node).isVariableScopeChange()) {
 					bindingSet = null;
 				}
 			}
-			super.meetOther(node);
+			super.meetNode(node);
 		}
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
@@ -46,6 +46,7 @@ public class StandardQueryOptimizerPipeline implements QueryOptimizerPipeline {
 	public Iterable<QueryOptimizer> getOptimizers() {
 		return Arrays.asList(
 				new BindingAssigner(),
+				new BindingSetAssignmentInliner(),
 				new ConstantOptimizer(strategy),
 				new RegexAsStringFunctionOptimizer(tripleSource.getValueFactory()),
 				new CompareOptimizer(),

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInlinerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInlinerTest.java
@@ -1,0 +1,61 @@
+/******************************************************************************* 
+ * Copyright (c) 2021 Eclipse RDF4J contributors. 
+ * All rights reserved. This program and the accompanying materials 
+ * are made available under the terms of the Eclipse Distribution License v1.0 
+ * which accompanies this distribution, and is available at 
+ * http://www.eclipse.org/org/documents/edl-v10.php. 
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
+import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.Projection;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.query.impl.SimpleDataset;
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeen
+ */
+public class BindingSetAssignmentInlinerTest extends QueryOptimizerTest {
+
+	@Test
+	public void testOptimizeAssignsVars() {
+		String query = "select * \n"
+				+ "where { values ?z { <urn:z1> } \n"
+				+ "        ?x <urn:pred1> ?y ; \n"
+				+ "           (<urn:pred2>/<urn:pred3>)* ?z . \n"
+				+ "}";
+
+		ParsedTupleQuery parsedQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL, query, null);
+
+		QueryOptimizer optimizer = getOptimizer();
+		optimizer.optimize(parsedQuery.getTupleExpr(), new SimpleDataset(), EmptyBindingSet.getInstance());
+
+		TupleExpr optimizedTree = parsedQuery.getTupleExpr();
+		assertThat(optimizedTree).isInstanceOf(Projection.class);
+
+		Projection projection = (Projection) optimizedTree;
+
+		Join join = (Join) projection.getArg();
+		assertThat(join.getRightArg()).isInstanceOf(ArbitraryLengthPath.class);
+
+		ArbitraryLengthPath path = (ArbitraryLengthPath) join.getRightArg();
+		assertThat(path.getObjectVar().getName()).isEqualTo("z");
+		assertThat(path.getObjectVar().getValue()).isEqualTo(iri("urn:z1"));
+	}
+
+	@Override
+	public QueryOptimizer getOptimizer() {
+		return new BindingSetAssignmentInliner();
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #3008 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- special-case fix for VALUES clause with a single value for a variable: inline where possible
- added regression test


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

