### PR TITLE
GH-3005 reinstate snapshot repo def but as a profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,25 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>use-sonatype-snapshots</id>
+			<activation>
+				<!-- active on all Java 8 and higher builds by default -->
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<repositories>
+				<repository>
+					<releases>
+						<enabled>false</enabled>
+					</releases>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+					<id>oss-sonatype-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+				</repository>
+			</repositories>
+		</profile>
+		<profile>
 			<id>formatting</id>
 			<activation>
 				<!-- active on all Java 8 and higher builds by default -->
@@ -990,21 +1009,6 @@
 			</extension>
 		</extensions>
 	</build>
-	<!--
-	See: GH-3005 and https://www.eclipse.org/lists/rdf4j-dev/msg01815.html
-		<repositories>
-			<repository>
-				<releases>
-					<enabled>false</enabled>
-				</releases>
-				<snapshots>
-					<enabled>true</enabled>
-				</snapshots>
-				<id>oss-sonatype-snapshots</id>
-				<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-			</repository>
-		</repositories>
-		-->
 	<scm>
 		<connection>scm:git:git://github.com:eclipse/rdf4j.git</connection>
 		<developerConnection>scm:git:git@github.com:eclipse/rdf4j.git</developerConnection>


### PR DESCRIPTION
GitHub issue resolved: #3005  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added snapshot repo def again by default for ease of use
- can be locally disabled if necessary by setting `-P-use-sonatype-snapshots`


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

