### PR TITLE
GH-2921 parse simple Turtle-star annotations

### DIFF
--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -29,6 +29,7 @@ import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -70,6 +71,8 @@ public class TurtleParser extends AbstractRDFParser {
 	private int lineNumber = 1;
 
 	private final StringBuilder parsingBuilder = new StringBuilder();
+
+	private Statement lastStatement;
 
 	/*--------------*
 	 * Constructors *
@@ -366,6 +369,9 @@ public class TurtleParser extends AbstractRDFParser {
 	protected void parseObjectList() throws IOException, RDFParseException, RDFHandlerException {
 		parseObject();
 
+		if (skipWSC() == '{') {
+			parseAnnotation();
+		}
 		while (skipWSC() == ',') {
 			readCodePoint();
 			skipWSC();
@@ -1099,9 +1105,9 @@ public class TurtleParser extends AbstractRDFParser {
 
 	protected void reportStatement(Resource subj, IRI pred, Value obj) throws RDFParseException, RDFHandlerException {
 		if (subj != null && pred != null && obj != null) {
-			Statement st = createStatement(subj, pred, obj);
+			lastStatement = createStatement(subj, pred, obj);
 			if (rdfHandler != null) {
-				rdfHandler.handleStatement(st);
+				rdfHandler.handleStatement(lastStatement);
 			}
 		}
 	}
@@ -1379,4 +1385,15 @@ public class TurtleParser extends AbstractRDFParser {
 
 		return null;
 	}
+
+	protected void parseAnnotation() throws IOException {
+		verifyCharacterOrFail(readCodePoint(), "{");
+		verifyCharacterOrFail(readCodePoint(), "|");
+		skipWSC();
+		subject = Values.triple(lastStatement);
+		parsePredicateObjectList();
+		verifyCharacterOrFail(readCodePoint(), "|");
+		verifyCharacterOrFail(readCodePoint(), "}");
+	}
+
 }

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
@@ -162,7 +162,7 @@ public class TurtleStarParserTest {
 	}
 
 	@Test
-	public void testTripleMultipleAnnotation() throws IOException {
+	public void testTripleMultipleAnnotationSameObject() throws IOException {
 		IRI example = iri("http://example.com/Example");
 		IRI a = iri("urn:a"), b = iri("urn:b"), c = iri("urn:c"), d = iri("urn:d");
 		Literal foo = literal("foo"), bar = literal("bar");
@@ -180,6 +180,29 @@ public class TurtleStarParserTest {
 			assertThat(stmts).contains(statement(Values.triple(annotatedSt), c, bar, null));
 			assertThat(stmts).contains(statement(Values.triple(annotatedSt), d, foo, null));
 			assertThat(stmts).contains(statement(example, d, a, null));
+		}
+	}
+
+	@Test
+	public void testTripleMultipleAnnotationMultipleObjects() throws IOException {
+		IRI example = iri("http://example.com/Example");
+		IRI a = iri("urn:a"), b = iri("urn:b"), c = iri("urn:c"), d = iri("urn:d");
+		Literal foo = literal("foo"), bar = literal("bar");
+		String data = "@prefix ex: <http://example.com/>.\n"
+				+ "ex:Example  <urn:a> <urn:b> {| <urn:c> \"foo\" |}, <urn:d> {| <urn:c> \"bar\" |}."
+				+ "ex:Example <urn:d> <urn:a> .";
+
+		Statement annotatedSt1 = statement(example, a, b, null), annotatedSt2 = statement(example, a, d, null);
+		try (Reader r = new StringReader(data)) {
+			parser.parse(r, baseURI);
+			Collection<Statement> stmts = statementCollector.getStatements();
+
+			assertThat(stmts).contains(annotatedSt1);
+			assertThat(stmts).contains(statement(Values.triple(annotatedSt1), c, foo, null));
+			assertThat(stmts).contains(statement(Values.triple(annotatedSt2), c, bar, null));
+			assertThat(stmts).contains(statement(example, d, a, null));
+			assertThat(stmts).doesNotContain(statement(Values.triple(annotatedSt1), c, bar, null));
+
 		}
 	}
 

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
@@ -7,6 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtlestar;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.rdf4j.model.util.Statements.statement;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -23,6 +28,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -138,4 +144,53 @@ public class TurtleStarParserTest {
 			assertEquals("Illegal datatype value: <<urn:a urn:b urn:c>> [line 2]", e.getMessage());
 		}
 	}
+
+	@Test
+	public void testTripleAnnotation() throws IOException {
+		IRI example = iri("http://example.com/Example");
+		IRI a = iri("urn:a"), b = iri("urn:b"), c = iri("urn:c");
+		Literal foo = literal("foo");
+		String data = "@prefix ex: <http://example.com/>.\nex:Example  <urn:a> <urn:b> {| <urn:c> \"foo\" |}.";
+		Statement st = statement(example, a, b, null);
+		try (Reader r = new StringReader(data)) {
+			parser.parse(r, baseURI);
+			Collection<Statement> stmts = statementCollector.getStatements();
+
+			assertThat(stmts).contains(st);
+			assertThat(stmts).contains(statement(Values.triple(st), c, foo, null));
+		}
+	}
+
+	@Test
+	public void testTripleMultipleAnnotation() throws IOException {
+		IRI example = iri("http://example.com/Example");
+		IRI a = iri("urn:a"), b = iri("urn:b"), c = iri("urn:c"), d = iri("urn:d");
+		Literal foo = literal("foo"), bar = literal("bar");
+		String data = "@prefix ex: <http://example.com/>.\n"
+				+ "ex:Example  <urn:a> <urn:b> {| <urn:c> \"foo\", \"bar\"; <urn:d> \"foo\" |}."
+				+ "ex:Example <urn:d> <urn:a> .";
+
+		Statement annotatedSt = statement(example, a, b, null);
+		try (Reader r = new StringReader(data)) {
+			parser.parse(r, baseURI);
+			Collection<Statement> stmts = statementCollector.getStatements();
+
+			assertThat(stmts).contains(annotatedSt);
+			assertThat(stmts).contains(statement(Values.triple(annotatedSt), c, foo, null));
+			assertThat(stmts).contains(statement(Values.triple(annotatedSt), c, bar, null));
+			assertThat(stmts).contains(statement(Values.triple(annotatedSt), d, foo, null));
+			assertThat(stmts).contains(statement(example, d, a, null));
+		}
+	}
+
+	@Test
+	public void testMalformedTripleAnnotation() throws IOException {
+		String data = "@prefix ex: <http://example.com/>.\nex:Example  <urn:a> <urn:b> {| <urn:c> \"foo\"  }.";
+		try (Reader r = new StringReader(data)) {
+			assertThatThrownBy(() -> parser.parse(r, baseURI))
+					.isInstanceOf(RDFParseException.class)
+					.hasMessageContaining("Expected '|', found '}'");
+		}
+	}
+
 }


### PR DESCRIPTION
GitHub issue resolved: #2921 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- add support annotation-style Turtle-star 
- test coverage 
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

