### PR TITLE
GH-2922 rename to RDF-star, SPARQL-star, Turtle-star, and TriG-star

### DIFF
--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
@@ -125,7 +125,7 @@ public class SPARQLProtocolSessionTest {
 		SPARQLStarResultsXMLWriter handler = Mockito.spy(new SPARQLStarResultsXMLWriter(out));
 		sparqlSession.sendTupleQuery(QueryLanguage.SPARQL, "SELECT * WHERE { ?s ?p ?o}", null, null, true, -1, handler);
 
-		// SPARQL* XML sink should accept SPARQL/XML data and pass directly to OutputStream
+		// SPARQL-star XML sink should accept SPARQL/XML data and pass directly to OutputStream
 		verify(handler, never()).startQueryResult(anyList());
 
 		// check that the OutputStream received content in XML format

--- a/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/ProtocolTest.java
+++ b/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/ProtocolTest.java
@@ -133,7 +133,7 @@ public class ProtocolTest {
 		assertEquals(vf.createBNode("bnode1"), Protocol.decodeContext("_:bnode1", vf));
 		assertEquals(vf.createIRI("urn:test"), Protocol.decodeContext("<urn:test>", vf));
 
-		// RDF* triples are resources but they can't be used as context values
+		// RDF-star triples are resources but they can't be used as context values
 		try {
 			Protocol.decodeContext("<<<urn:a> <urn:b> <urn:c>>>", SimpleValueFactory.getInstance());
 			fail("Must fail with exception");

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/Triple.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/Triple.java
@@ -10,17 +10,18 @@ package org.eclipse.rdf4j.model;
 import org.eclipse.rdf4j.common.annotation.Experimental;
 
 /**
- * An RDF* embedded triple. Embedded triples have a subject, predicate and object. Unlike {@link Statement}, a triple
- * never has an associated context.
+ * An RDF-star embedded triple. Embedded triples have a subject, predicate and object. Unlike {@link Statement}, a
+ * triple never has an associated context.
  * <p>
  * Additional utility functionality for working with {@code Triple} objects is available in the
- * {@code org.eclipse.rdf4j.model.util.Statements} utility class.
+ * {@link org.eclipse.rdf4j.model.util.Statements} and {@link org.eclipse.rdf4j.model.util.Values} utility classes.
  *
  * @author Pavel Mihaylov
  *
  * @implNote In order to ensure interoperability of concrete classes implementing this interface,
  *           {@link #equals(Object)} and {@link #hashCode()} methods must be implemented exactly as described in their
  *           specs.
+ * @see <a href="https://w3c.github.io/rdf-star/cg-spec/">RDF-star and SPARQL-star Draft Community Group Report</a>
  */
 @Experimental
 public interface Triple extends Resource {

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -310,7 +310,7 @@ public interface ValueFactory {
 	}
 
 	/**
-	 * Creates a new RDF* triple with the supplied subject, predicate and object.
+	 * Creates a new RDF-star triple with the supplied subject, predicate and object.
 	 *
 	 * @param subject   The statement's subject.
 	 * @param predicate The statement's predicate.

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/LexicalValueComparator.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/LexicalValueComparator.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
- * A lexical rdf term Comparator, this class does not compare numerically and is therefore a bit faster than a SPARQL
+ * A lexical RDF Term Comparator, this class does not compare numerically and is therefore a bit faster than a SPARQL
  * compliant comparator.
  *
  * @author james
@@ -84,7 +84,7 @@ public class LexicalValueComparator implements Serializable, Comparator<Value> {
 			return 1;
 		}
 
-		// 5. RDF* triples
+		// 5. RDF-star triples
 		return compareTriples((Triple) o1, (Triple) o2);
 	}
 

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Models.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Models.java
@@ -823,8 +823,8 @@ public class Models {
 	}
 
 	/**
-	 * Converts the supplied RDF* model to RDF reification statements. The converted statements are sent to the supplied
-	 * consumer function.
+	 * Converts the supplied RDF-star model to RDF reification statements. The converted statements are sent to the
+	 * supplied consumer function.
 	 * <p>
 	 * The supplied value factory is used to create all new statements.
 	 *
@@ -838,8 +838,8 @@ public class Models {
 	}
 
 	/**
-	 * Converts the supplied RDF* model to RDF reification statements. The converted statements are sent to the supplied
-	 * consumer function.
+	 * Converts the supplied RDF-star model to RDF reification statements. The converted statements are sent to the
+	 * supplied consumer function.
 	 *
 	 * @param model    the {@link Model} to convert.
 	 * @param consumer the {@link Consumer} function for the produced statements.
@@ -850,13 +850,13 @@ public class Models {
 	}
 
 	/**
-	 * Converts the statements in supplied RDF* model to a new RDF model using reificiation.
+	 * Converts the statements in supplied RDF-star model to a new RDF model using reificiation.
 	 * <p>
 	 * The supplied value factory is used to create all new statements.
 	 *
 	 * @param vf    the {@link ValueFactory} to use for creating statements.
 	 * @param model the {@link Model} to convert.
-	 * @return a new {@link Model} with RDF* statements converted to reified triples.
+	 * @return a new {@link Model} with RDF-star statements converted to reified triples.
 	 */
 	@Experimental
 	public static Model convertRDFStarToReification(ValueFactory vf, Model model) {
@@ -866,14 +866,14 @@ public class Models {
 	}
 
 	/**
-	 * Converts the statements in supplied RDF* model to a new RDF model using reificiation.
+	 * Converts the statements in supplied RDF-star model to a new RDF model using reificiation.
 	 * <p>
 	 * The supplied value factory is used to create all new statements.
 	 *
 	 * @param vf           the {@link ValueFactory} to use for creating statements.
 	 * @param model        the {@link Model} to convert.
 	 * @param modelFactory the {@link ModelFactory} used to create the new output {@link Model}.
-	 * @return a new {@link Model} with RDF* statements converted to reified triples.
+	 * @return a new {@link Model} with RDF-star statements converted to reified triples.
 	 */
 	@Experimental
 	public static Model convertRDFStarToReification(ValueFactory vf, Model model, ModelFactory modelFactory) {
@@ -883,10 +883,10 @@ public class Models {
 	}
 
 	/**
-	 * Converts the statements in the supplied RDF* model to a new RDF model using reification.
+	 * Converts the statements in the supplied RDF-star model to a new RDF model using reification.
 	 *
 	 * @param model the {@link Model} to convert.
-	 * @return a new {@link Model} with RDF* statements converted to reified triples.
+	 * @return a new {@link Model} with RDF-star statements converted to reified triples.
 	 */
 	@Experimental
 	public static Model convertRDFStarToReification(Model model) {
@@ -894,8 +894,8 @@ public class Models {
 	}
 
 	/**
-	 * Converts the supplied RDF reification model to RDF* statements. The converted statements are sent to the supplied
-	 * consumer function.
+	 * Converts the supplied RDF reification model to RDF-star statements. The converted statements are sent to the
+	 * supplied consumer function.
 	 * <p>
 	 * The supplied value factory is used to create all new statements.
 	 *
@@ -957,8 +957,8 @@ public class Models {
 	}
 
 	/**
-	 * Converts the supplied RDF reification model to RDF* statements. The converted statements are sent to the supplied
-	 * consumer function.
+	 * Converts the supplied RDF reification model to RDF-star statements. The converted statements are sent to the
+	 * supplied consumer function.
 	 *
 	 * @param model    the {@link Model} to convert.
 	 * @param consumer the {@link Consumer} function for the produced statements.
@@ -969,14 +969,14 @@ public class Models {
 	}
 
 	/**
-	 * Converts the statements in supplied RDF reification model to a new RDF* model.
+	 * Converts the statements in supplied RDF reification model to a new RDF-star model.
 	 * <p>
 	 * The supplied value factory is used to create all new statements.
 	 *
 	 * @param vf           the {@link ValueFactory} to use for creating statements.
 	 * @param model        the {@link Model} to convert.
 	 * @param modelFactory the {@link ModelFactory} to use for creating a new Model object for the output.
-	 * @return a new {@link Model} with reification statements converted to RDF* {@link Triple}s.
+	 * @return a new {@link Model} with reification statements converted to RDF-star {@link Triple}s.
 	 */
 	@Experimental
 	public static Model convertReificationToRDFStar(ValueFactory vf, Model model, ModelFactory modelFactory) {
@@ -986,13 +986,13 @@ public class Models {
 	}
 
 	/**
-	 * Converts the statements in supplied RDF reification model to a new RDF* model.
+	 * Converts the statements in supplied RDF reification model to a new RDF-star model.
 	 * <p>
 	 * The supplied value factory is used to create all new statements.
 	 *
 	 * @param vf    the {@link ValueFactory} to use for creating statements.
 	 * @param model the {@link Model} to convert.
-	 * @return a new {@link Model} with reification statements converted to RDF* {@link Triple}s.
+	 * @return a new {@link Model} with reification statements converted to RDF-star {@link Triple}s.
 	 */
 	@Experimental
 	public static Model convertReificationToRDFStar(ValueFactory vf, Model model) {
@@ -1000,10 +1000,10 @@ public class Models {
 	}
 
 	/**
-	 * Converts the supplied RDF reification model to a new RDF* model.
+	 * Converts the supplied RDF reification model to a new RDF-star model.
 	 *
 	 * @param model the {@link Model} to convert.
-	 * @return a new {@link Model} with reification statements converted to RDF* {@link Triple}s.
+	 * @return a new {@link Model} with reification statements converted to RDF-star {@link Triple}s.
 	 */
 	@Experimental
 	public static Model convertReificationToRDFStar(Model model) {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
@@ -26,8 +26,8 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 
 /**
- * Utility methods for working with {@link Statement} objects, including conversion to/from {@link Triple RDF* triple
- * objects}.
+ * Utility methods for working with {@link Statement} objects, including conversion to/from {@link Triple RDF-star
+ * triple objects}.
  *
  * @author Jeen Broekstra
  */
@@ -123,10 +123,10 @@ public class Statements {
 	}
 
 	/**
-	 * Create an {@link Triple RDF* triple} from the supplied {@link Statement}
+	 * Create an {@link Triple RDF-star triple} from the supplied {@link Statement}
 	 *
-	 * @param statement a statement to convert to an RDF* triple
-	 * @return an {@link Triple RDF* triple} with the same subject, predicate and object as the input statement.
+	 * @param statement a statement to convert to an RDF-star triple
+	 * @return an {@link Triple RDF-star triple} with the same subject, predicate and object as the input statement.
 	 * @since 3.4.0
 	 * @deprecated since 3.5.0 - use {@link Values#triple(Statement)} instead
 	 */
@@ -136,11 +136,11 @@ public class Statements {
 	}
 
 	/**
-	 * Create an {@link Triple RDF* triple} from the supplied {@link Statement}
+	 * Create an {@link Triple RDF-star triple} from the supplied {@link Statement}
 	 *
 	 * @param vf        the {@link ValueFactory} to use for creating the {@link Triple} object.
-	 * @param statement a statement to convert to an RDF* triple
-	 * @return an {@link Triple RDF* triple} with the same subject, predicate and object as the input statement.
+	 * @param statement a statement to convert to an RDF-star triple
+	 * @return an {@link Triple RDF-star triple} with the same subject, predicate and object as the input statement.
 	 * @since 3.4.0
 	 * 
 	 * @deprecated since 3.5.0 - use {@link Values#triple(ValueFactory, Statement)} instead
@@ -151,40 +151,81 @@ public class Statements {
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF* triple}
+	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple}
 	 *
-	 * @param triple an RDF* triple to convert to a {@link Statement}.
+	 * @param triple an RDF-star triple to convert to a {@link Statement}.
+	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and no context.
+	 * @since 3.4.0
+	 * @deprecated Use {@link #statement(Triple)} instead
+	 */
+	public static Statement toStatement(Triple triple) {
+		return statement(triple);
+	}
+
+	/**
+	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple}
+	 *
+	 * @param triple an RDF-star triple to convert to a {@link Statement}.
 	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and no context.
 	 * @since 3.4.0
 	 */
-	public static Statement toStatement(Triple triple) {
+	public static Statement statement(Triple triple) {
 		return toStatement(triple, null);
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF* triple} and context.
+	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple} and context.
 	 *
-	 * @param triple  an RDF* triple to convert to a {@link Statement}.
+	 * @param triple  an RDF-star triple to convert to a {@link Statement}.
+	 * @param context the context to assign to the {@link Statement}.
+	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and having the
+	 *         supplied context.
+	 * @since 3.7.0
+	 */
+	public static Statement statement(Triple triple, Resource context) {
+		return statement(SimpleValueFactory.getInstance(), triple, context);
+	}
+
+	/**
+	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple} and context.
+	 *
+	 * @param triple  an RDF-star triple to convert to a {@link Statement}.
 	 * @param context the context to assign to the {@link Statement}.
 	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and having the
 	 *         supplied context.
 	 * @since 3.4.0
+	 * @deprecated since 3.7.0 - use {@link #statement(Triple, Resource)} instead
 	 */
 	public static Statement toStatement(Triple triple, Resource context) {
-		return toStatement(SimpleValueFactory.getInstance(), triple, context);
+		return statement(SimpleValueFactory.getInstance(), triple, context);
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF* triple} and context.
+	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple} and context.
 	 *
 	 * @param vf      the {@link ValueFactory} to use for creating the {@link Statement} object.
-	 * @param triple  an RDF* triple to convert to a {@link Statement}.
+	 * @param triple  an RDF-star triple to convert to a {@link Statement}.
 	 * @param context the context to assign to the {@link Statement}. May be null to indicate no context.
 	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and having the
 	 *         supplied context.
 	 * @since 3.4.0
+	 * @deprecated Use {@link #statement(ValueFactory,Triple,Resource)} instead
 	 */
 	public static Statement toStatement(ValueFactory vf, Triple triple, Resource context) {
+		return statement(vf, triple, context);
+	}
+
+	/**
+	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple} and context.
+	 *
+	 * @param vf      the {@link ValueFactory} to use for creating the {@link Statement} object.
+	 * @param triple  an RDF-star triple to convert to a {@link Statement}.
+	 * @param context the context to assign to the {@link Statement}. May be null to indicate no context.
+	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and having the
+	 *         supplied context.
+	 * @since 3.7.0
+	 */
+	public static Statement statement(ValueFactory vf, Triple triple, Resource context) {
 		return vf.createStatement(triple.getSubject(), triple.getPredicate(), triple.getObject(), context);
 	}
 
@@ -242,8 +283,8 @@ public class Statements {
 	}
 
 	/**
-	 * Converts the supplied RDF* statement to RDF reification statements, and sends the resultant statements to the
-	 * supplied consumer. If the supplied statement is not RDF* it will be sent to the consumer as is.
+	 * Converts the supplied RDF-star statement to RDF reification statements, and sends the resultant statements to the
+	 * supplied consumer. If the supplied statement is not RDF-star it will be sent to the consumer as is.
 	 * <p>
 	 * The statements needed to represent reification will use blank nodes.
 	 *
@@ -256,8 +297,8 @@ public class Statements {
 	}
 
 	/**
-	 * Converts the supplied RDF* statement to RDF reification statements, and sends the resultant statements to the
-	 * supplied consumer. If the supplied statement is not RDF* it will be sent to the consumer as is.
+	 * Converts the supplied RDF-star statement to RDF reification statements, and sends the resultant statements to the
+	 * supplied consumer. If the supplied statement is not RDF-star it will be sent to the consumer as is.
 	 * <p>
 	 * The statements needed to represent reification will use blank nodes.
 	 * <p>
@@ -273,8 +314,8 @@ public class Statements {
 	}
 
 	/**
-	 * Converts the supplied RDF* statement to RDF reification statements, and sends the resultant statements to the
-	 * supplied consumer. If the supplied statement is not RDF* it will be sent to the consumer as is.
+	 * Converts the supplied RDF-star statement to RDF reification statements, and sends the resultant statements to the
+	 * supplied consumer. If the supplied statement is not RDF-star it will be sent to the consumer as is.
 	 * <p>
 	 * The supplied value factory is used to create all new statements.
 	 * <p>
@@ -305,7 +346,7 @@ public class Statements {
 	}
 
 	/**
-	 * Converts the supplied RDF* triple to a series of RDF reification statements and sends the statements to the
+	 * Converts the supplied RDF-star triple to a series of RDF reification statements and sends the statements to the
 	 * supplied consumer. The subject of the created statements is returned.
 	 * <p>
 	 * The supplied value factory is used to create all new statements.

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
@@ -644,7 +644,7 @@ public class Values {
 	/* triple factory methods */
 
 	/**
-	 * Creates a new {@link Triple RDF* embedded triple} with the supplied subject, predicate, and object.
+	 * Creates a new {@link Triple RDF-star embedded triple} with the supplied subject, predicate, and object.
 	 *
 	 * @param subject   the Triple subject
 	 * @param predicate the Triple predicate
@@ -659,7 +659,7 @@ public class Values {
 	}
 
 	/**
-	 * Creates a new {@link Triple RDF* embedded triple} with the supplied subject, predicate, and object.
+	 * Creates a new {@link Triple RDF-star embedded triple} with the supplied subject, predicate, and object.
 	 * 
 	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Triple}
 	 * @param subject   the Triple subject
@@ -679,7 +679,7 @@ public class Values {
 	}
 
 	/**
-	 * Creates a new {@link Triple RDF* embedded triple} using the subject, predicate and object from the supplied
+	 * Creates a new {@link Triple RDF-star embedded triple} using the subject, predicate and object from the supplied
 	 * {@link Statement}.
 	 *
 	 * @param statement the {@link Statement} from which to construct a {@link Triple}
@@ -694,7 +694,7 @@ public class Values {
 	}
 
 	/**
-	 * Creates a new {@link Triple RDF* embedded triple} using the subject, predicate and object from the supplied
+	 * Creates a new {@link Triple RDF-star embedded triple} using the subject, predicate and object from the supplied
 	 * {@link Statement}.
 	 * 
 	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Triple}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelsTest.java
@@ -459,21 +459,21 @@ public class ModelsTest {
 		Model referenceRDFStarModel = RDFStarTestHelper.createRDFStarModel();
 
 		Model rdfStarModel1 = Models.convertReificationToRDFStar(VF, reificationModel);
-		assertTrue("RDF reification conversion to RDF* with explicit VF, model-to-model",
+		assertTrue("RDF reification conversion to RDF-star with explicit VF, model-to-model",
 				Models.isomorphic(rdfStarModel1, referenceRDFStarModel));
 
 		Model rdfStarModel2 = Models.convertReificationToRDFStar(reificationModel);
-		assertTrue("RDF reification conversion to RDF* with implicit VF, model-to-model",
+		assertTrue("RDF reification conversion to RDF-star with implicit VF, model-to-model",
 				Models.isomorphic(rdfStarModel2, referenceRDFStarModel));
 
 		Model rdfStarModel3 = new TreeModel();
 		Models.convertReificationToRDFStar(VF, reificationModel, (Consumer<Statement>) rdfStarModel3::add);
-		assertTrue("RDF reification conversion to RDF* with explicit VF, model-to-consumer",
+		assertTrue("RDF reification conversion to RDF-star with explicit VF, model-to-consumer",
 				Models.isomorphic(rdfStarModel3, referenceRDFStarModel));
 
 		Model rdfStarModel4 = new TreeModel();
 		Models.convertReificationToRDFStar(reificationModel, rdfStarModel4::add);
-		assertTrue("RDF reification conversion to RDF* with implicit VF, model-to-consumer",
+		assertTrue("RDF reification conversion to RDF-star with implicit VF, model-to-consumer",
 				Models.isomorphic(rdfStarModel4, referenceRDFStarModel));
 	}
 
@@ -484,21 +484,21 @@ public class ModelsTest {
 		Model incompleteReificationModel = RDFStarTestHelper.createIncompleteRDFReificationModel();
 
 		Model rdfStarModel1 = Models.convertReificationToRDFStar(VF, incompleteReificationModel);
-		assertTrue("Incomplete RDF reification conversion to RDF* with explicit VF, model-to-model",
+		assertTrue("Incomplete RDF reification conversion to RDF-star with explicit VF, model-to-model",
 				Models.isomorphic(rdfStarModel1, incompleteReificationModel));
 
 		Model rdfStarModel2 = Models.convertReificationToRDFStar(incompleteReificationModel);
-		assertTrue("Incomplete RDF reification conversion to RDF* with implicit VF, model-to-model",
+		assertTrue("Incomplete RDF reification conversion to RDF-star with implicit VF, model-to-model",
 				Models.isomorphic(rdfStarModel2, incompleteReificationModel));
 
 		Model rdfStarModel3 = new TreeModel();
 		Models.convertReificationToRDFStar(VF, incompleteReificationModel, (Consumer<Statement>) rdfStarModel3::add);
-		assertTrue("Incomplete RDF reification conversion to RDF* with explicit VF, model-to-consumer",
+		assertTrue("Incomplete RDF reification conversion to RDF-star with explicit VF, model-to-consumer",
 				Models.isomorphic(rdfStarModel3, incompleteReificationModel));
 
 		Model rdfStarModel4 = new TreeModel();
 		Models.convertReificationToRDFStar(incompleteReificationModel, rdfStarModel4::add);
-		assertTrue("Incomplete RDF reification conversion to RDF* with implicit VF, model-to-consumer",
+		assertTrue("Incomplete RDF reification conversion to RDF-star with implicit VF, model-to-consumer",
 				Models.isomorphic(rdfStarModel4, incompleteReificationModel));
 	}
 
@@ -508,21 +508,21 @@ public class ModelsTest {
 		Model referenceModel = RDFStarTestHelper.createRDFReificationModel();
 
 		Model reificationModel1 = Models.convertRDFStarToReification(VF, rdfStarModel);
-		assertTrue("RDF* conversion to reification with explicit VF, model-to-model",
+		assertTrue("RDF-star conversion to reification with explicit VF, model-to-model",
 				Models.isomorphic(reificationModel1, referenceModel));
 
 		Model reificationModel2 = Models.convertRDFStarToReification(rdfStarModel);
-		assertTrue("RDF* conversion to reification with implicit VF, model-to-model",
+		assertTrue("RDF-star conversion to reification with implicit VF, model-to-model",
 				Models.isomorphic(reificationModel2, referenceModel));
 
 		Model reificationModel3 = new TreeModel();
 		Models.convertRDFStarToReification(VF, rdfStarModel, (Consumer<Statement>) reificationModel3::add);
-		assertTrue("RDF* conversion to reification with explicit VF, model-to-consumer",
+		assertTrue("RDF-star conversion to reification with explicit VF, model-to-consumer",
 				Models.isomorphic(reificationModel3, referenceModel));
 
 		Model reificationModel4 = new TreeModel();
 		Models.convertRDFStarToReification(rdfStarModel, reificationModel4::add);
-		assertTrue("RDF* conversion to reification with explicit VF, model-to-consumer",
+		assertTrue("RDF-star conversion to reification with explicit VF, model-to-consumer",
 				Models.isomorphic(reificationModel4, referenceModel));
 	}
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/StatementsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/StatementsTest.java
@@ -89,18 +89,18 @@ public class StatementsTest {
 
 		Model convertedModel1 = new LinkedHashModel();
 		rdfStarModel.forEach((s) -> Statements.convertRDFStarToReification(s, convertedModel1::add));
-		assertTrue("RDF* conversion to reification with implicit VF",
+		assertTrue("RDF-star conversion to reification with implicit VF",
 				Models.isomorphic(reifiedModel, convertedModel1));
 
 		Model convertedModel2 = new LinkedHashModel();
 		rdfStarModel.forEach((s) -> Statements.convertRDFStarToReification(vf, s, convertedModel2::add));
-		assertTrue("RDF* conversion to reification with explicit VF",
+		assertTrue("RDF-star conversion to reification with explicit VF",
 				Models.isomorphic(reifiedModel, convertedModel2));
 
 		Model convertedModel3 = new LinkedHashModel();
 		rdfStarModel.forEach((s) -> Statements.convertRDFStarToReification(vf, (t) -> vf.createBNode(t.stringValue()),
 				s, convertedModel3::add));
-		assertTrue("RDF* conversion to reification with explicit VF and custom BNode mapping",
+		assertTrue("RDF-star conversion to reification with explicit VF and custom BNode mapping",
 				Models.isomorphic(reifiedModel, convertedModel3));
 	}
 
@@ -126,7 +126,7 @@ public class StatementsTest {
 	}
 
 	@Test
-	public void testToStatement() {
+	public void testStatement() {
 
 		Resource context = vf.createIRI("http://example.org/context");
 		Triple t1 = vf.createTriple(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
@@ -135,11 +135,11 @@ public class StatementsTest {
 		Statement st1 = vf.createStatement(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
 				vf.createLiteral("data"));
 
-		assertThat(Statements.toStatement(t1)).isEqualTo(st1);
+		assertThat(Statements.statement(t1)).isEqualTo(st1);
 	}
 
 	@Test
-	public void testToStatement_Context() {
+	public void testStatement_Context() {
 
 		Resource context = vf.createIRI("http://example.org/context");
 		Triple t1 = vf.createTriple(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
@@ -148,17 +148,17 @@ public class StatementsTest {
 		Statement st1 = vf.createStatement(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
 				vf.createLiteral("data"), context);
 
-		assertThat(Statements.toStatement(t1, context)).isEqualTo(st1);
+		assertThat(Statements.statement(t1, context)).isEqualTo(st1);
 	}
 
 	@Test
-	public void testToStatement_NullContext() {
+	public void testStatement_NullContext() {
 		Triple t1 = vf.createTriple(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
 				vf.createLiteral("data"));
 
 		Statement st1 = vf.createStatement(vf.createIRI("http://example.com/1"), vf.createIRI("http://example.com/2"),
 				vf.createLiteral("data"), null);
 
-		assertThat(Statements.toStatement(t1, null)).isEqualTo(st1);
+		assertThat(Statements.statement(t1, null)).isEqualTo(st1);
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/IsTripleFunction.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/IsTripleFunction.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
 /**
- * Function that return "true"^^xsd:boolean if its argument is RDF* Triple otherwise return "false"^^xsd:boolean the
+ * Function that return "true"^^xsd:boolean if its argument is RDF-star Triple otherwise return "false"^^xsd:boolean the
  * function's IRI uses RDF namespace to match the other functions in the package
  *
  * @author damyan.ognyanov

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/StatementFunction.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/StatementFunction.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
 /**
- * Function constructing RDF* Triple from its 3 arguments reused the IRI of rdf:Statement as name
+ * Function constructing RDF-star Triple from its 3 arguments reused the IRI of rdf:Statement as name
  *
  * @author damyan.ognyanov
  *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TripleObjectFunction.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TripleObjectFunction.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
 /**
- * Function returning the object component of RDF* Triple reused the IRI of rdf:object as name
+ * Function returning the object component of RDF-star Triple reused the IRI of rdf:object as name
  *
  * @author damyan.ognyanov
  *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TriplePredicateFunction.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TriplePredicateFunction.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
 /**
- * Function returning the predicate component of RDF* Triple reused the IRI of rdf:predicate as name
+ * Function returning the predicate component of RDF-star Triple reused the IRI of rdf:predicate as name
  *
  * @author damyan.ognyanov
  *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TripleSubjectFunction.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TripleSubjectFunction.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
 /**
- * Function returning the subject component of RDF* Triple reused the IRI of rdf:subject as name
+ * Function returning the subject component of RDF-star Triple reused the IRI of rdf:subject as name
  *
  * @author damyan.ognyanov
  *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/ValueComparator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/ValueComparator.java
@@ -86,7 +86,7 @@ public class ValueComparator implements Comparator<Value> {
 			return 1;
 		}
 
-		// 5. RDF* triples
+		// 5. RDF-star triples
 		return compareTriples((Triple) o1, (Triple) o2);
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStrategyWithRDFStarTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStrategyWithRDFStarTest.java
@@ -50,7 +50,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class EvaluationStrategyWithRDFStarTest {
 
-	@Parameters(name = "RDF*={0}")
+	@Parameters(name = "RDF-star={0}")
 	public static Object[] params() {
 		return new Object[] { false, true };
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/TripleRef.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/TripleRef.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/** Triple lookup reference. Allow retrieval of RDF* triples **/
+/** Triple lookup reference. Allow retrieval of RDF-star triples **/
 public class TripleRef extends AbstractQueryModelNode implements TupleExpr {
 
 	private org.eclipse.rdf4j.query.algebra.Var exprVar;

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateDataBlockParser.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateDataBlockParser.java
@@ -27,7 +27,7 @@ import org.eclipse.rdf4j.rio.turtle.TurtleUtil;
  * <li>it introduces the 'GRAPH' keyword in front of each named graph identifier
  * <li>it does not allow the occurrence of blank nodes.
  * <li>it does not require curly braces around the default graph.
- * <li>it adds support for RDF* triples (from TriG*).</li>
+ * <li>it adds support for RDF-star triples (from TriG-star).</li>
  * </ul>
  *
  * @author Jeen Broekstra

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractQueryResultWriter.java
@@ -53,7 +53,8 @@ public abstract class AbstractQueryResultWriter implements QueryResultWriter, Si
 
 	@Override
 	public void startQueryResult(List<String> bindingNames) throws TupleQueryResultHandlerException {
-		// Formats without native RDF* support obey the ENCODE_RDF_STAR setting and may encode RDF* triples to IRIs
+		// Formats without native RDF-star support obey the ENCODE_RDF_STAR setting and may encode RDF-star triples to
+		// IRIs
 		encodeRDFStar = this instanceof TupleQueryResultWriter
 				&& !((TupleQueryResultWriter) this).getTupleQueryResultFormat().supportsRDFStar()
 				&& getWriterConfig().get(BasicWriterSettings.ENCODE_RDF_STAR);
@@ -70,7 +71,7 @@ public abstract class AbstractQueryResultWriter implements QueryResultWriter, Si
 
 	/**
 	 * Extending classes must implement this method instead of overriding {@link #handleSolution(BindingSet)} in order
-	 * to benefit from automatic handling of RDF* encoding.
+	 * to benefit from automatic handling of RDF-star encoding.
 	 *
 	 * @param bindings the solution to handle
 	 * @throws TupleQueryResultHandlerException

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/BooleanQueryResultFormat.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/BooleanQueryResultFormat.java
@@ -38,8 +38,8 @@ public class BooleanQueryResultFormat extends QueryResultFormat {
 	 * SPARQL Query Results JSON Format.
 	 */
 	public static final BooleanQueryResultFormat JSON = new BooleanQueryResultFormat("SPARQL/JSON",
-			// Note: The MIME type for SPARQL* JSON is handled by this format in order to handle BooleanQueryResult
-			// when SPARQL* JSON is requested.
+			// Note: The MIME type for SPARQL-star JSON is handled by this format in order to handle BooleanQueryResult
+			// when SPARQL-star JSON is requested.
 			Arrays.asList("application/sparql-results+json", "application/json",
 					"application/x-sparqlstar-results+json"),
 			StandardCharsets.UTF_8, Arrays.asList("srj", "json"), SPARQL_RESULTS_JSON_URI);

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/RDFStarDecodingQueryResultHandler.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/RDFStarDecodingQueryResultHandler.java
@@ -18,8 +18,8 @@ import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
 import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
 
 /**
- * A {@link QueryResultHandler} that delegates all results to another handler and processes RDF* triples encoded as
- * special IRIs back to RDF* triple values.
+ * A {@link QueryResultHandler} that delegates all results to another handler and processes RDF-star triples encoded as
+ * special IRIs back to RDF-star triple values.
  *
  * @author Pavel Mihaylov
  */

--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormat.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormat.java
@@ -29,12 +29,12 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 *-----------*/
 
 	/**
-	 * Indicates that RDF* triples can be serialized natively for this format.
+	 * Indicates that RDF-star triples can be serialized natively for this format.
 	 */
 	private static final boolean SUPPORTS_RDF_STAR = true;
 
 	/**
-	 * Indicates that RDF* triples will NOT be serialized natively for this format.
+	 * Indicates that RDF-star triples will NOT be serialized natively for this format.
 	 */
 	private static final boolean NO_RDF_STAR = false;
 
@@ -46,10 +46,10 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 			Arrays.asList("srx", "xml"), SPARQL_RESULTS_XML_URI, NO_RDF_STAR);
 
 	/**
-	 * SPARQL* Query Results XML Format (like SPARQL/XML but with native RDF* support).
+	 * SPARQL-star Query Results XML Format (like SPARQL/XML but with native RDF-star support).
 	 */
 	@Experimental
-	public static final TupleQueryResultFormat SPARQL_STAR = new TupleQueryResultFormat("SPARQL*/XML",
+	public static final TupleQueryResultFormat SPARQL_STAR = new TupleQueryResultFormat("SPARQL-star/XML",
 			Arrays.asList("application/x-sparqlstar-results+xml"), StandardCharsets.UTF_8,
 			Arrays.asList("srxs"), null, SUPPORTS_RDF_STAR);
 
@@ -67,10 +67,10 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 			Arrays.asList("srj", "json"), SPARQL_RESULTS_JSON_URI, NO_RDF_STAR);
 
 	/**
-	 * SPARQL* Query Results JSON Format (like SPARQL JSON but with RDF* support).
+	 * SPARQL-star Query Results JSON Format (like SPARQL JSON but with RDF-star support).
 	 */
 	@Experimental
-	public static final TupleQueryResultFormat JSON_STAR = new TupleQueryResultFormat("SPARQL*/JSON",
+	public static final TupleQueryResultFormat JSON_STAR = new TupleQueryResultFormat("SPARQL-star/JSON",
 			Arrays.asList("application/x-sparqlstar-results+json"), StandardCharsets.UTF_8,
 			Arrays.asList("srjs"), null, SUPPORTS_RDF_STAR);
 
@@ -88,9 +88,9 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 			SPARQL_RESULTS_TSV_URI, NO_RDF_STAR);
 
 	/**
-	 * SPARQL* Query Results TSV Format (like SPARQL TSV but with RDF* support).
+	 * SPARQL-star Query Results TSV Format (like SPARQL TSV but with RDF-star support).
 	 */
-	public static final TupleQueryResultFormat TSV_STAR = new TupleQueryResultFormat("SPARQL*/TSV",
+	public static final TupleQueryResultFormat TSV_STAR = new TupleQueryResultFormat("SPARQL-star/TSV",
 			Arrays.asList("text/x-tab-separated-values-star", "application/x-sparqlstar-results+tsv"),
 			StandardCharsets.UTF_8, Arrays.asList("tsvs"), null, SUPPORTS_RDF_STAR);
 
@@ -99,7 +99,7 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 *-----------*/
 
 	/**
-	 * Flag indicating whether the TupleQueryResultFormat can encode RDF* triples natively.
+	 * Flag indicating whether the TupleQueryResultFormat can encode RDF-star triples natively.
 	 */
 	private final boolean supportsRDFStar;
 
@@ -126,8 +126,8 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 * @param mimeType        The MIME type of the format, e.g. <tt>application/sparql-results+xml</tt> for the
 	 *                        SPARQL/XML format.
 	 * @param fileExt         The (default) file extension for the format, e.g. <tt>srx</tt> for SPARQL/XML.
-	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively
-	 *                        and <tt>false</tt> otherwise.
+	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF-star triples
+	 *                        natively and <tt>false</tt> otherwise.
 	 * @since 3.2.0
 	 */
 	public TupleQueryResultFormat(String name, String mimeType, String fileExt, boolean supportsRDFStar) {
@@ -155,8 +155,8 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 *                        SPARQL/XML format.
 	 * @param charset         The default character encoding of the format. Specify <tt>null</tt> if not applicable.
 	 * @param fileExt         The (default) file extension for the format, e.g. <tt>srx</tt> for SPARQL/XML.
-	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively
-	 *                        and <tt>false</tt> otherwise.
+	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF-star triples
+	 *                        natively and <tt>false</tt> otherwise.
 	 * @since 3.2.0
 	 */
 	public TupleQueryResultFormat(String name, String mimeType, Charset charset, String fileExt,
@@ -191,8 +191,8 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 * @param charset         The default character encoding of the format. Specify <tt>null</tt> if not applicable.
 	 * @param fileExtensions  The format's file extensions, e.g. <tt>srx</tt> for SPARQL/XML files. The first item in
 	 *                        the list is interpreted as the default file extension for the format.
-	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively
-	 *                        and <tt>false</tt> otherwise.
+	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF-star triples
+	 *                        natively and <tt>false</tt> otherwise.
 	 * @since 3.2.0
 	 */
 	public TupleQueryResultFormat(String name, Collection<String> mimeTypes, Charset charset,
@@ -232,8 +232,8 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 *                        the list is interpreted as the default file extension for the format.
 	 * @param standardURI     The standard URI that has been assigned to this format by a standards organisation or null
 	 *                        if it does not currently have a standard URI.
-	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively
-	 *                        and <tt>false</tt> otherwise.
+	 * @param supportsRDFStar <tt>True</tt> if the TupleQueryResultFormat supports the encoding of RDF-star triples
+	 *                        natively and <tt>false</tt> otherwise.
 	 * @since 3.2.0
 	 */
 	public TupleQueryResultFormat(String name, Collection<String> mimeTypes, Charset charset,
@@ -247,7 +247,7 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	 *---------*/
 
 	/**
-	 * Return <tt>true</tt> if the TupleQueryResultFormat supports the encoding of RDF* triples natively.
+	 * Return <tt>true</tt> if the TupleQueryResultFormat supports the encoding of RDF-star triples natively.
 	 *
 	 * @since 3.2.0
 	 */

--- a/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultConstants.java
+++ b/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultConstants.java
@@ -61,7 +61,7 @@ import java.io.DataOutput;
  * <li><tt>EMPTY_ROW</tt> (byte value: 9):<br>
  * This indicates a row with zero values.
  * <li><tt>TRIPLE</tt> (byte value: 10):<br>
- * This indicates an RDF* triple value. It is followed by the subject, predicate and object values of the triple.
+ * This indicates an RDF-star triple value. It is followed by the subject, predicate and object values of the triple.
  * <li><tt>ERROR</tt> (byte value: 126):<br>
  * This record indicates a error. The type of error is indicates by the byte directly following the record type marker:
  * <tt>1</tt> for a malformed query error, <tt>2</tt> for a query evaluation error. The error type byte is followed by

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
@@ -343,7 +343,7 @@ public abstract class AbstractSPARQLJSONParser extends AbstractQueryResultParser
 			if (TYPE.equals(fieldName)) {
 				type = jp.nextTextValue();
 				if (TRIPLE_STARDOG.equals(type)) {
-					// Stardog RDF* serialization dialect does not wrap the triple in a value object
+					// Stardog RDF-star serialization dialect does not wrap the triple in a value object
 					triple = parseStardogTripleValue(jp, type);
 					// avoid reading away the next end-of-object token by jumping out of the loop.
 					break;

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONConstants.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONConstants.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 
 /**
- * Constants for the SPARQL* JSON format. The format is handles {@link org.eclipse.rdf4j.query.TupleQueryResult} only.
+ * Constants for the SPARQL-star JSON format. The format handles {@link org.eclipse.rdf4j.query.TupleQueryResult} only.
  * For Boolean results, the SPARQL JSON format is used.
  * <p>
  * The format introduces a new type, triple, whose value is an object consisting of three elements:
@@ -41,12 +41,13 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
  * 			"o" : {
  * 				"type" : "uri",
  * 				"value" : "urn:b"
- *        }
+ *          }
  *        }
  *  }
  * </pre>
  *
  * @author Pavel Mihaylov
+ * @see <a href="https://w3c.github.io/rdf-star/cg-spec/">RDF-star and SPARQL-star Draft Community Group Report</a>
  */
 final class SPARQLStarResultsJSONConstants {
 	static TupleQueryResultFormat QUERY_RESULT_FORMAT = TupleQueryResultFormat.JSON_STAR;

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONParser.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONParser.java
@@ -11,8 +11,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 
 /**
- * Parser for SPARQL* JSON results. This is equivalent to the SPARQL JSON parser with the addition of support for RDF*
- * triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF* extension.
+ * Parser for SPARQL-star JSON results. This is equivalent to the SPARQL JSON parser with the addition of support for
+ * RDF-star triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF-star extension.
  *
  * @author Pavel Mihaylov
  */

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarResultsJSONWriter.java
@@ -14,12 +14,12 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 
 /**
- * Writer for SPARQL* JSON results. This is equivalent to the SPARQL JSON writer with the addition of support for RDF*
- * triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF* extension.
+ * Writer for SPARQL-star JSON results. This is equivalent to the SPARQL JSON writer with the addition of support for
+ * RDF-star triples. See {@link SPARQLStarResultsJSONConstants} for a description of the RDF-star extension.
  *
  * @author Pavel Mihaylov
- * @implNote the actual {@link SPARQLResultsJSONWriter} itself already supports writing RDF* triples according to the
- *           extension. This subclass functions as an anchor point for the custom
+ * @implNote the actual {@link SPARQLResultsJSONWriter} itself already supports writing RDF-star triples according to
+ *           the extension. This subclass functions as an anchor point for the custom
  *           {@link TupleQueryResultFormat#JSON_STAR} content type.
  */
 public class SPARQLStarResultsJSONWriter extends SPARQLResultsJSONWriter implements TupleQueryResultWriter {
@@ -39,7 +39,7 @@ public class SPARQLStarResultsJSONWriter extends SPARQLResultsJSONWriter impleme
 
 	@Override
 	public boolean acceptsFileFormat(FileFormat format) {
-		// since SPARQL*/JSON is a superset of regular SPARQL/JSON, this Sink also accepts regular SPARQL/JSON
+		// since SPARQL-star/JSON is a superset of regular SPARQL/JSON, this Sink also accepts regular SPARQL/JSON
 		// serialization
 		return super.acceptsFileFormat(format) || TupleQueryResultFormat.JSON.equals(format);
 	}

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsSAXParser.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsSAXParser.java
@@ -82,7 +82,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 	private QueryResultHandler handler;
 
 	/**
-	 * stack for handling nested RDF* triples
+	 * stack for handling nested RDF-star triples
 	 */
 	private Deque<TripleContainer> tripleStack = new ArrayDeque<>();
 
@@ -201,7 +201,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 		case S_TAG:
 			currentTriple = tripleStack.peek();
 			if (currentTriple.getSubject() != null) {
-				throw new SAXException("RDF* triple subject defined twice");
+				throw new SAXException("RDF-star triple subject defined twice");
 			}
 			if (currentValue instanceof Resource) {
 				currentTriple.setSubject((Resource) currentValue);
@@ -213,7 +213,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 		case P_TAG:
 			currentTriple = tripleStack.peek();
 			if (currentTriple.getPredicate() != null) {
-				throw new SAXException("RDF* triple predicate defined twice");
+				throw new SAXException("RDF-star triple predicate defined twice");
 			}
 			if (currentValue instanceof IRI) {
 				currentTriple.setPredicate((IRI) currentValue);
@@ -225,7 +225,7 @@ class SPARQLResultsSAXParser extends SimpleSAXAdapter {
 		case O_TAG:
 			currentTriple = tripleStack.peek();
 			if (currentTriple.getObject() != null) {
-				throw new SAXException("RDF* triple object defined twice");
+				throw new SAXException("RDF-star triple object defined twice");
 			}
 			currentTriple.setObject(currentValue);
 			break;

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsXMLConstants.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLResultsXMLConstants.java
@@ -58,7 +58,7 @@ interface SPARQLResultsXMLConstants {
 
 	public static final String QNAME = "q:qname";
 
-	/* tag constants for serialization of RDF* values in results */
+	/* tag constants for serialization of RDF-star values in results */
 
 	public static final String TRIPLE_TAG = "triple";
 

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarResultsXMLParser.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarResultsXMLParser.java
@@ -12,11 +12,12 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 
 /**
- * Parser for reading tuple query results formatted as SPARQL Results Documents, extended with support for RDF* triples
+ * Parser for reading tuple query results formatted as SPARQL Results Documents, extended with support for RDF-star
+ * triples
  *
  * @author Jeen Broekstra
- * @implNote the base class {@link SPARQLResultsXMLParser} already has full support for processing extended RDF* syntax.
- *           This class purely exists as a hook for the custom content type for
+ * @implNote the base class {@link SPARQLResultsXMLParser} already has full support for processing extended RDF-star
+ *           syntax. This class purely exists as a hook for the custom content type for
  *           {@link TupleQueryResultFormat#SPARQL_STAR}.
  */
 @Experimental

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarResultsXMLWriter.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarResultsXMLWriter.java
@@ -19,8 +19,8 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
  * <a href="http://www.w3.org/TR/rdf-sparql-XMLres/">SPARQL Query Results XML Format</a>.
  *
  * @author Jeen Broekstra
- * @implNote the base class {@link SPARQLResultsXMLWriter} already has full support for writing extended RDF* syntax.
- *           This class purely exists as a hook for the custom content type for
+ * @implNote the base class {@link SPARQLResultsXMLWriter} already has full support for writing extended RDF-star
+ *           syntax. This class purely exists as a hook for the custom content type for
  *           {@link TupleQueryResultFormat#SPARQL_STAR}.
  */
 @Experimental

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVParser.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVParser.java
@@ -10,9 +10,9 @@ package org.eclipse.rdf4j.query.resultio.text.tsv;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 
 /**
- * Parser for SPARQL* TSV results. This is equivalent to the SPARQL TSV parser with the addition of support for RDF*
- * triples. Serialized triples must be in Turtle* fashion with the notable exception that any embedded literals may not
- * use the triple quotes notation (as regular literals in SPARQL TSV).
+ * Parser for SPARQL-star TSV results. This is equivalent to the SPARQL TSV parser with the addition of support for
+ * RDF-star triples. Serialized triples must be in Turtle-star fashion with the notable exception that any embedded
+ * literals may not use the triple quotes notation (as regular literals in SPARQL TSV).
  *
  * @author Pavel Mihaylov
  * @author Jeen Broekstra

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarResultsTSVWriter.java
@@ -12,9 +12,9 @@ import java.io.OutputStream;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 
 /**
- * Writer for SPARQL* TSV results. This is equivalent to the SPARQL TSV writer with the addition of support for RDF*
- * triples. Triples will be serialized in Turtle* fashion with the notable exception that any embedded literals will not
- * use the triple quotes notation (as regular literals in SPARQL TSV).
+ * Writer for SPARQL-star TSV results. This is equivalent to the SPARQL TSV writer with the addition of support for
+ * RDF-star triples. Triples will be serialized in Turtle-star fashion with the notable exception that any embedded
+ * literals will not use the triple quotes notation (as regular literals in SPARQL TSV).
  *
  * @author Pavel Mihaylov
  */

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleQueryResultWriterTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleQueryResultWriterTest.java
@@ -32,13 +32,13 @@ public class SPARQLCSVTupleQueryResultWriterTest extends AbstractTupleQueryResul
 	}
 
 	@Override
-	@Ignore("pending implementation of RDF* extensions for the csv format")
+	@Ignore("pending implementation of RDF-star extensions for the csv format")
 	@Test
 	public void testRDFStarHandling_NoEncoding() throws Exception {
 	}
 
 	@Override
-	@Ignore("pending implementation of RDF* extensions for the csv format")
+	@Ignore("pending implementation of RDF-star extensions for the csv format")
 	@Test
 	public void testRDFStarHandling_DeepNesting() throws Exception {
 	}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
@@ -56,12 +56,12 @@ public class RDFFormat extends FileFormat {
 	public static final boolean NO_CONTEXTS = false;
 
 	/**
-	 * Indicates that RDF* triples can be serialized natively for this format.
+	 * Indicates that RDF-star triples can be serialized natively for this format.
 	 */
 	public static final boolean SUPPORTS_RDF_STAR = true;
 
 	/**
-	 * Indicates that RDF* triples will NOT be serialized natively for this format.
+	 * Indicates that RDF-star triples will NOT be serialized natively for this format.
 	 */
 	public static final boolean NO_RDF_STAR = false;
 
@@ -111,16 +111,17 @@ public class RDFFormat extends FileFormat {
 			NO_CONTEXTS, NO_RDF_STAR);
 
 	/**
-	 * The Turtle* (TurtleStar) file format, a Turtle-based RDF serialization format that supports RDF* triples.
+	 * The Turtle-star file format, a Turtle-based RDF serialization format that supports RDF-star triples.
 	 * <p>
-	 * The file extension <code>.ttls</code> is recommended for Turtle* documents. The media type is
+	 * The file extension <code>.ttls</code> is recommended for Turtle-star documents. The media type is
 	 * <code>application/x-turtlestar</code> and the encoding is UTF-8.
 	 * </p>
 	 *
 	 * @see <a href="https://arxiv.org/pdf/1406.3399.pdf">Foundations of an Alternative Approach to Reification in
 	 *      RDF</a>
+	 * @see <a href="https://w3c.github.io/rdf-star/cg-spec/">RDF-star and SPARQL-star Draft Community Group Report</a>
 	 */
-	public static final RDFFormat TURTLESTAR = new RDFFormat("Turtle*",
+	public static final RDFFormat TURTLESTAR = new RDFFormat("Turtle-star",
 			Arrays.asList("text/x-turtlestar", "application/x-turtlestar"), StandardCharsets.UTF_8,
 			Arrays.asList("ttls"), SUPPORTS_NAMESPACES, NO_CONTEXTS, SUPPORTS_RDF_STAR);
 
@@ -168,17 +169,18 @@ public class RDFFormat extends FileFormat {
 			SUPPORTS_CONTEXTS, NO_RDF_STAR);
 
 	/**
-	 * The TriG* (TriGStar) file format, a TriG-based RDF serialization format that supports RDF* triples. This builds
-	 * upon the idea for the Turtle* format but adds support for named graphs.
+	 * The TriG-star file format, a TriG-based RDF serialization format that supports RDF-star triples. This builds upon
+	 * the idea for the Turtle-star format but adds support for named graphs.
 	 * <p>
-	 * The file extension <code>.trigs</code> is recommended for TriG* documents. The media type is
+	 * The file extension <code>.trigs</code> is recommended for TriG-star documents. The media type is
 	 * <code>application/x-trigstar</code> and the encoding is UTF-8.
 	 * </p>
 	 *
 	 * @see <a href="https://arxiv.org/pdf/1406.3399.pdf">Foundations of an Alternative Approach to Reification in
 	 *      RDF</a>
+	 * @see <a href="https://w3c.github.io/rdf-star/cg-spec/">RDF-star and SPARQL-star Draft Community Group Report</a>
 	 */
-	public static final RDFFormat TRIGSTAR = new RDFFormat("TriG*", "application/x-trigstar",
+	public static final RDFFormat TRIGSTAR = new RDFFormat("TriG-star", "application/x-trigstar",
 			StandardCharsets.UTF_8, "trigs", SUPPORTS_NAMESPACES, SUPPORTS_CONTEXTS, SUPPORTS_RDF_STAR);
 
 	/**
@@ -353,7 +355,7 @@ public class RDFFormat extends FileFormat {
 	private final boolean supportsContexts;
 
 	/**
-	 * Flag indicating whether the RDFFormat can encode RDF* triples natively.
+	 * Flag indicating whether the RDFFormat can encode RDF-star triples natively.
 	 */
 	private final boolean supportsRDFStar;
 
@@ -404,7 +406,7 @@ public class RDFFormat extends FileFormat {
 	 *                           and <tt>false</tt> otherwise.
 	 * @param supportsContexts   <tt>True</tt> if the RDFFormat supports the encoding of contexts/named graphs and
 	 *                           <tt>false</tt> otherwise.
-	 * @param supportsRDFStar    <tt>True</tt> if the RDFFormat supports the encoding of RDF* triples natively and
+	 * @param supportsRDFStar    <tt>True</tt> if the RDFFormat supports the encoding of RDF-star triples natively and
 	 *                           <tt>false</tt> otherwise.
 	 */
 	public RDFFormat(String name, String mimeType, Charset charset, String fileExtension, boolean supportsNamespaces,
@@ -449,7 +451,7 @@ public class RDFFormat extends FileFormat {
 	 *                           and <tt>false</tt> otherwise.
 	 * @param supportsContexts   <tt>True</tt> if the RDFFormat supports the encoding of contexts/named graphs and
 	 *                           <tt>false</tt> otherwise.
-	 * @param supportsRDFStar    <tt>True</tt> if the RDFFormat supports the encoding of RDF* triples natively and
+	 * @param supportsRDFStar    <tt>True</tt> if the RDFFormat supports the encoding of RDF-star triples natively and
 	 *                           <tt>false</tt> otherwise.
 	 */
 	public RDFFormat(String name, String mimeType, Charset charset, Collection<String> fileExtensions,
@@ -496,7 +498,7 @@ public class RDFFormat extends FileFormat {
 	 *                           and <tt>false</tt> otherwise.
 	 * @param supportsContexts   <tt>True</tt> if the RDFFormat supports the encoding of contexts/named graphs and
 	 *                           <tt>false</tt> otherwise.
-	 * @param supportsRDFStar    <tt>True</tt> if the RDFFormat supports the encoding of RDF* triples natively and
+	 * @param supportsRDFStar    <tt>True</tt> if the RDFFormat supports the encoding of RDF-star triples natively and
 	 *                           <tt>false</tt> otherwise.
 	 */
 	public RDFFormat(String name, Collection<String> mimeTypes, Charset charset, Collection<String> fileExtensions,
@@ -547,7 +549,7 @@ public class RDFFormat extends FileFormat {
 	 *                           and <tt>false</tt> otherwise.
 	 * @param supportsContexts   <tt>True</tt> if the RDFFormat supports the encoding of contexts/named graphs and
 	 *                           <tt>false</tt> otherwise.
-	 * @param supportsRDFStar    <tt>True</tt> if the RDFFormat supports the encoding of RDF* triples natively and
+	 * @param supportsRDFStar    <tt>True</tt> if the RDFFormat supports the encoding of RDF-star triples natively and
 	 *                           <tt>false</tt> otherwise.
 	 */
 	public RDFFormat(String name, Collection<String> mimeTypes, Charset charset, Collection<String> fileExtensions,
@@ -579,7 +581,7 @@ public class RDFFormat extends FileFormat {
 	}
 
 	/**
-	 * Return <tt>true</tt> if the RDFFormat supports the encoding of RDF* triples natively.
+	 * Return <tt>true</tt> if the RDFFormat supports the encoding of RDF-star triples natively.
 	 */
 	public boolean supportsRDFStar() {
 		return supportsRDFStar;

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFWriter.java
@@ -91,11 +91,11 @@ public abstract class AbstractRDFWriter implements RDFWriter, Sink {
 
 		statementConsumer = this::consumeStatement;
 		if (getWriterConfig().get(BasicWriterSettings.CONVERT_RDF_STAR_TO_REIFICATION)) {
-			// All writers can convert RDF* to reification on request
+			// All writers can convert RDF-star to reification on request
 			statementConsumer = this::handleStatementConvertRDFStar;
 		} else if (!getRDFFormat().supportsRDFStar() && getWriterConfig().get(BasicWriterSettings.ENCODE_RDF_STAR)) {
-			// By default non-RDF* writers encode RDF* to special RDF IRIs
-			// (all parsers, including RDF* will convert back the encoded IRIs)
+			// By default non-RDF-star writers encode RDF-star to special RDF IRIs
+			// (all parsers, including RDF-star will convert back the encoded IRIs)
 			statementConsumer = this::handleStatementEncodeRDFStar;
 		}
 	}
@@ -110,7 +110,7 @@ public abstract class AbstractRDFWriter implements RDFWriter, Sink {
 	 * Consume a statement.
 	 *
 	 * Extending classes must override this method instead of overriding {@link #handleStatement(Statement)} in order to
-	 * benefit from automatic handling of RDF* conversion or encoding.
+	 * benefit from automatic handling of RDF-star conversion or encoding.
 	 *
 	 * @param st the statement to consume.
 	 */

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -215,11 +215,11 @@ public class BasicParserSettings {
 			Namespaces.DEFAULT_RDF4J);
 
 	/**
-	 * Boolean setting for parser to determine whether it should process RDF* triples encoded as RDF-compatible special
-	 * IRIs back to RDF* values. These IRIs start with urn:rdf4j:triple: followed by the base64-encoding of the
-	 * N-Triples serialization of the RDF* triple value.
+	 * Boolean setting for parser to determine whether it should process RDF-star triples encoded as RDF-compatible
+	 * special IRIs back to RDF-star values. These IRIs start with urn:rdf4j:triple: followed by the base64-encoding of
+	 * the N-Triples serialization of the RDF-star triple value.
 	 * <p>
-	 * Parsers that support RDF* natively will honour this setting too.
+	 * Parsers that support RDF-star natively will honour this setting too.
 	 * <p>
 	 * Defaults to true.
 	 * <p>
@@ -227,7 +227,7 @@ public class BasicParserSettings {
 	 */
 	public static final RioSetting<Boolean> PROCESS_ENCODED_RDF_STAR = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.process_encoded_rdf_star",
-			"Converts RDF* triples encoded as RDF-compatible IRIs back to triple values", Boolean.TRUE);
+			"Converts RDF-star triples encoded as RDF-compatible IRIs back to triple values", Boolean.TRUE);
 
 	static {
 		List<DatatypeHandler> defaultDatatypeHandlers = new ArrayList<>(5);

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicWriterSettings.java
@@ -89,21 +89,22 @@ public class BasicWriterSettings {
 			"org.eclipse.rdf4j.rio.base_directive", "Serialize base directive", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for writer to determine whether it should convert RDF* statements to standard RDF reification.
+	 * Boolean setting for writer to determine whether it should convert RDF-star statements to standard RDF
+	 * reification.
 	 * <p>
 	 * Defaults to false
 	 * <p>
 	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.convert_rdf_star}.
 	 */
 	public static final RioSetting<Boolean> CONVERT_RDF_STAR_TO_REIFICATION = new BooleanRioSetting(
-			"org.eclipse.rdf4j.rio.convert_rdf_star", "Convert RDF* statements to RDF reification", Boolean.FALSE);
+			"org.eclipse.rdf4j.rio.convert_rdf_star", "Convert RDF-star statements to RDF reification", Boolean.FALSE);
 
 	/**
-	 * Boolean setting for writer to determine whether it should encode RDF* triple values to RDF-compatible special
+	 * Boolean setting for writer to determine whether it should encode RDF-star triple values to RDF-compatible special
 	 * IRIs. These IRIs start with urn:rdf4j:triple: followed by the base64-encoding of the N-Triples serialization of
-	 * the RDF* triple value.
+	 * the RDF-star triple value.
 	 * <p>
-	 * Writers that support RDF* natively will ignore this setting and always serialize RDF* triples.
+	 * Writers that support RDF-star natively will ignore this setting and always serialize RDF-star triples.
 	 * <p>
 	 * Defaults to true.
 	 * <p>
@@ -111,7 +112,7 @@ public class BasicWriterSettings {
 	 */
 	public static final RioSetting<Boolean> ENCODE_RDF_STAR = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.encode_rdf_star",
-			"Encodes RDF* triples to special IRIs for compatibility with RDF", Boolean.TRUE);
+			"Encodes RDF-star triples to special IRIs for compatibility with RDF", Boolean.TRUE);
 
 	/**
 	 * Private default constructor.

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesUtil.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesUtil.java
@@ -116,7 +116,7 @@ public class NTriplesUtil {
 	public static IRI parseURI(String nTriplesURI, ValueFactory valueFactory) throws IllegalArgumentException {
 		if (nTriplesURI.startsWith("<") && nTriplesURI.endsWith(">")) {
 			String uri = nTriplesURI.substring(1, nTriplesURI.length() - 1);
-			// Disambiguate with RDF* triple
+			// Disambiguate with RDF-star triple
 			if (!uri.startsWith("<")) {
 				uri = unescapeString(uri);
 				return valueFactory.createIRI(uri);
@@ -186,10 +186,10 @@ public class NTriplesUtil {
 	}
 
 	/**
-	 * Parses an RDF* triple (non-standard N-Triples), creates an object for it using the supplied ValueFactory and
+	 * Parses an RDF-star triple (non-standard N-Triples), creates an object for it using the supplied ValueFactory and
 	 * returns this object.
 	 *
-	 * @param nTriplesTriple The RDF* triple to parse.
+	 * @param nTriplesTriple The RDF-star triple to parse.
 	 * @param valueFactory   The ValueFactory to use for creating the object.
 	 * @return An object representing the parsed triple.
 	 * @throws IllegalArgumentException If the supplied triple could not be parsed correctly.
@@ -203,10 +203,10 @@ public class NTriplesUtil {
 	}
 
 	/**
-	 * Parses an RDF* triple (non-standard N-Triples), creates an object for it using the supplied ValueFactory and
+	 * Parses an RDF-star triple (non-standard N-Triples), creates an object for it using the supplied ValueFactory and
 	 * returns an object that contains the parsed triple and the length of the parsed text.
 	 *
-	 * @param nTriplesTriple The RDF* triple to parse.
+	 * @param nTriplesTriple The RDF-star triple to parse.
 	 * @param valueFactory   The ValueFactory to use for creating the object.
 	 * @return An object representing the parsed triple and the length of the matching text.
 	 * @throws IllegalArgumentException If the supplied triple could not be parsed correctly.
@@ -576,7 +576,7 @@ public class NTriplesUtil {
 	}
 
 	/**
-	 * Creates an N-Triples (non-standard) string for the supplied RDF* triple.
+	 * Creates an N-Triples (non-standard) string for the supplied RDF-star triple.
 	 *
 	 * @param triple
 	 * @return string

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarDecodingValueFactory.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarDecodingValueFactory.java
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 
 /**
  * A {@link ValueFactory} that will delegate everything to another {@link ValueFactory} and create statements whose
- * subject and object will be converted from RDF* triples encoded as special IRIs back to RDF* values.
+ * subject and object will be converted from RDF-star triples encoded as special IRIs back to RDF-star values.
  * <p>
  * All other values in the subject and object position will be used as is.
  */

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarEncodingStatement.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarEncodingStatement.java
@@ -15,8 +15,8 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 
 /**
- * Represents a {@link Statement} whose subject or object may be an RDF* triple that will be encoded as a special IRI
- * value on {@link #getSubject()} and {@link #getObject()}.
+ * Represents a {@link Statement} whose subject or object may be an RDF-star triple that will be encoded as a special
+ * IRI value on {@link #getSubject()} and {@link #getObject()}.
  *
  * @author Pavel Mihaylov
  */

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarUtil.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarUtil.java
@@ -17,27 +17,27 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
- * Utility methods for RDF* triples.
+ * Utility methods for RDF-star triples.
  *
  * @author Pavel Mihaylov
  */
 public class RDFStarUtil {
 	/**
-	 * IRI prefix for RDF* triples encoded as IRIs.
+	 * IRI prefix for RDF-star triples encoded as IRIs.
 	 */
 	public static final String TRIPLE_PREFIX = "urn:rdf4j:triple:";
 
 	private static ValueFactory VF = SimpleValueFactory.getInstance();
 
 	/**
-	 * Converts the supplied value from RDF* to an RDF-compatible representation.
+	 * Converts the supplied value from RDF-star to an RDF-compatible representation.
 	 * <p>
-	 * RDF* triples are encoded as IRIs that start with {@link #TRIPLE_PREFIX}, followed by the base64 encoding of the
-	 * N-Triples serialization of the triple.
+	 * RDF-star triples are encoded as IRIs that start with {@link #TRIPLE_PREFIX}, followed by the base64 encoding of
+	 * the N-Triples serialization of the triple.
 	 * <p>
-	 * All other RDF* values are valid in RDF as well and remain unchanged.
+	 * All other RDF-star values are valid in RDF as well and remain unchanged.
 	 *
-	 * @param value a RDF* {@link Value} to encode.
+	 * @param value a RDF-star {@link Value} to encode.
 	 * @param <T>
 	 * @return the RDF-compatible encoded value, if a {@link Triple} was supplied, or the supplied value otherwise.
 	 */
@@ -48,16 +48,16 @@ public class RDFStarUtil {
 	}
 
 	/**
-	 * Converts the supplied value from an RDF-compatible representation to an RDF* value.
+	 * Converts the supplied value from an RDF-compatible representation to an RDF-star value.
 	 * <p>
 	 * See {@link #toRDFEncodedValue(Value)}.
 	 *
-	 * @param encodedValue an RDF {@link Value} to convert to RDF*.
+	 * @param encodedValue an RDF {@link Value} to convert to RDF-star.
 	 * @param <T>
-	 * @return the decoded RDF* triple, if a {@link Triple} encoded as {@link IRI} was supplied, or the supplied value
-	 *         otherwise.
-	 * @throws IllegalArgumentException if the supplied value looked like an RDF* triple encoded as an IRI but it could
-	 *                                  not be decoded successfully.
+	 * @return the decoded RDF-star triple, if a {@link Triple} encoded as {@link IRI} was supplied, or the supplied
+	 *         value otherwise.
+	 * @throws IllegalArgumentException if the supplied value looked like an RDF-star triple encoded as an IRI but it
+	 *                                  could not be decoded successfully.
 	 */
 	public static <T extends Value> T fromRDFEncodedValue(T encodedValue) {
 		try {
@@ -66,15 +66,15 @@ public class RDFStarUtil {
 							encodedValue.stringValue().substring(TRIPLE_PREFIX.length())), VF)
 					: encodedValue;
 		} catch (IllegalArgumentException e) {
-			throw new IllegalArgumentException("Invalid RDF* encoded triple: " + encodedValue);
+			throw new IllegalArgumentException("Invalid RDF-star encoded triple: " + encodedValue);
 		}
 	}
 
 	/**
-	 * Checks if the supplied {@link Value} represents an RDF* triple encoded as an IRI.
+	 * Checks if the supplied {@link Value} represents an RDF-star triple encoded as an IRI.
 	 *
 	 * @param value the value to check.
-	 * @return True if the value is an RDF* triple encoded as an IRI, false otherwise.
+	 * @return True if the value is an RDF-star triple encoded as an IRI, false otherwise.
 	 */
 	public static boolean isEncodedTriple(Value value) {
 		return value instanceof IRI && value.stringValue().startsWith(TRIPLE_PREFIX);

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TurtleParserSettings.java
@@ -29,7 +29,7 @@ public class TurtleParserSettings {
 			"Allows case-insensitive directives to be recognised", Boolean.FALSE);
 
 	/**
-	 * Allows the regular Turtle parser to accept data using the non-standard Turtle* extension.
+	 * Allows the regular Turtle parser to accept data using the non-standard Turtle-star extension.
 	 * <p>
 	 * Defaults to true.
 	 * <p>
@@ -39,7 +39,7 @@ public class TurtleParserSettings {
 	 */
 	public static final RioSetting<Boolean> ACCEPT_TURTLESTAR = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.turtle.accept_turtlestar",
-			"Allow processing of Turtle* data by the standard Turtle parser",
+			"Allow processing of Turtle-star data by the standard Turtle parser",
 			Boolean.TRUE);
 
 }

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
@@ -933,7 +933,7 @@ public abstract class AbstractParserHandlingTest {
 				vf.createIRI("urn:f"));
 		expectedModel.add(vf.createStatement(t3, vf.createIRI("urn:same"), t3));
 
-		// Default: formats with RDF* support handle it natively and non-RDF* use a compatibility encoding
+		// Default: formats with RDF-star support handle it natively and non-RDF-star use a compatibility encoding
 		InputStream input1 = serialize(expectedModel);
 		testParser.parse(input1, BASE_URI);
 		assertErrorListener(0, 0, 0);
@@ -942,8 +942,8 @@ public abstract class AbstractParserHandlingTest {
 		testListener.reset();
 		testStatements.clear();
 
-		// Turn off compatibility on parsing: formats with RDF* support will produce RDF* triples,
-		// non-RDF* formats will produce IRIs of the kind urn:rdf4j:triple:xxx
+		// Turn off compatibility on parsing: formats with RDF-star support will produce RDF-star triples,
+		// non-RDF-star formats will produce IRIs of the kind urn:rdf4j:triple:xxx
 		InputStream input2 = serialize(expectedModel);
 		testParser.getParserConfig().set(BasicParserSettings.PROCESS_ENCODED_RDF_STAR, false);
 		testParser.parse(input2, BASE_URI);

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -757,7 +757,7 @@ public abstract class RDFWriterTest {
 			IRI pred = potentialPredicates.get(prng.nextInt(potentialPredicates.size()));
 			while (obj instanceof Triple && pred.equals(RDF.TYPE)) {
 				// Avoid statements "x rdf:type <<triple>>" as those use the shorter syntax in RDFXMLPrettyWriter
-				// and the writer produces invalid XML in that case. Even though the RDF* triples are encoded as
+				// and the writer produces invalid XML in that case. Even though the RDF-star triples are encoded as
 				// valid IRIs, XML has limitations on what characters may form an XML tag name and thus a limitation
 				// on what IRIs may be used in predicates (predicates are XML tags) or the short form of rdf:type
 				// (where the type is also an XML tag).
@@ -1848,8 +1848,8 @@ public abstract class RDFWriterTest {
 		rdfParser.setRDFHandler(new StatementCollector(parsedOutput));
 		rdfParser.parse(inputReader, "");
 
-		// 1 non-RDF* statement
-		// 1 RDF* statement whose conversion yields 20 additional statements:
+		// 1 non-RDF-star statement
+		// 1 RDF-star statement whose conversion yields 20 additional statements:
 		// 4 for triple3
 		// 4 for triple6
 		// 4 for triple2 (contained in triple6)

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RDFStarUtilTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RDFStarUtilTest.java
@@ -108,7 +108,7 @@ public class RDFStarUtilTest {
 				RDFStarUtil.fromRDFEncodedValue(invalidValue);
 				fail("Must fail because of invalid value");
 			} catch (IllegalArgumentException e) {
-				assertTrue(e.getMessage().startsWith("Invalid RDF* encoded triple"));
+				assertTrue(e.getMessage().startsWith("Invalid RDF-star encoded triple"));
 			}
 		}
 	}

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFParser.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFParser.java
@@ -256,7 +256,7 @@ public class BinaryRDFParser extends AbstractRDFParser {
 			}
 		}
 
-		reportFatalError("Invalid RDF* triple value");
+		reportFatalError("Invalid RDF-star triple value");
 		return null;
 	}
 

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParser.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParser.java
@@ -21,20 +21,20 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.trig.TriGParser;
 
 /**
- * RDF parser for TriG* (an extension of TriG that adds RDF* support).
+ * RDF parser for TriG-star (an extension of TriG that adds RDF-star support).
  *
  * @author Pavel Mihaylov
  */
 public class TriGStarParser extends TriGParser {
 	/**
-	 * Creates a new TriGStarParser that will use a {@link SimpleValueFactory} to create RDF* model objects.
+	 * Creates a new TriGStarParser that will use a {@link SimpleValueFactory} to create RDF-star model objects.
 	 */
 	public TriGStarParser() {
 		super();
 	}
 
 	/**
-	 * Creates a new TriGStarParser that will use the supplied ValueFactory to create RDF* model objects.
+	 * Creates a new TriGStarParser that will use the supplied ValueFactory to create RDF-star model objects.
 	 *
 	 * @param valueFactory A ValueFactory.
 	 */

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserFactory.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserFactory.java
@@ -12,7 +12,7 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFParserFactory;
 
 /**
- * An {@link RDFParserFactory} for TriG* parsers.
+ * An {@link RDFParserFactory} for TriG-star parsers.
  *
  * @author Pavel Mihaylov
  */

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriter.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriter.java
@@ -18,7 +18,8 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.trig.TriGWriter;
 
 /**
- * An extension of {@link TriGWriter} that writes RDF* documents in the TriG* format by including the RDF* triples.
+ * An extension of {@link TriGWriter} that writes RDF-star documents in the TriG-star format by including the RDF-star
+ * triples.
  *
  * @author Pavel Mihaylov
  */
@@ -26,7 +27,7 @@ public class TriGStarWriter extends TriGWriter {
 	/**
 	 * Creates a new TriGStarWriter that will write to the supplied OutputStream.
 	 *
-	 * @param out The OutputStream to write the TriG* document to.
+	 * @param out The OutputStream to write the TriG-star document to.
 	 */
 	public TriGStarWriter(OutputStream out) {
 		super(out);
@@ -35,7 +36,7 @@ public class TriGStarWriter extends TriGWriter {
 	/**
 	 * Creates a new TriGStarWriter that will write to the supplied OutputStream using the supplied base IRI.
 	 *
-	 * @param out     The OutputStream to write the TriG* document to.
+	 * @param out     The OutputStream to write the TriG-star document to.
 	 * @param baseIRI The base IRI to use.
 	 */
 	public TriGStarWriter(OutputStream out, ParsedIRI baseIRI) {
@@ -45,7 +46,7 @@ public class TriGStarWriter extends TriGWriter {
 	/**
 	 * Creates a new TriGStarWriter that will write to the supplied Writer.
 	 *
-	 * @param writer The Writer to write the TriG* document to.
+	 * @param writer The Writer to write the TriG-star document to.
 	 */
 	public TriGStarWriter(Writer writer) {
 		super(writer);
@@ -54,7 +55,7 @@ public class TriGStarWriter extends TriGWriter {
 	/**
 	 * Creates a new TriGStarWriter that will write to the supplied Writer using the supplied base IRI.
 	 *
-	 * @param writer  The Writer to write the TriG* document to.
+	 * @param writer  The Writer to write the TriG-star document to.
 	 * @param baseIRI The base IRI to use.
 	 */
 	public TriGStarWriter(Writer writer, ParsedIRI baseIRI) {
@@ -68,7 +69,7 @@ public class TriGStarWriter extends TriGWriter {
 
 	@Override
 	public boolean acceptsFileFormat(FileFormat format) {
-		// since TriG* is a superset of regular TriG, this Sink also accepts regular TriG
+		// since TriG-star is a superset of regular TriG, this Sink also accepts regular TriG
 		// serialization
 		return super.acceptsFileFormat(format) || RDFFormat.TRIG.equals(format);
 	}

--- a/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterFactory.java
+++ b/core/rio/trig/src/main/java/org/eclipse/rdf4j/rio/trigstar/TriGStarWriterFactory.java
@@ -17,7 +17,7 @@ import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
 
 /**
- * An {@link RDFWriterFactory} for TriG* writers.
+ * An {@link RDFWriterFactory} for TriG-star writers.
  *
  * @author Pavel Mihaylov
  */

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -1331,9 +1331,9 @@ public class TurtleParser extends AbstractRDFParser {
 
 	/**
 	 * Peeks at the next two Unicode code points without advancing the reader and returns true if they indicate the
-	 * start of an RDF* triple value. Such values start with '<<'.
+	 * start of an RDF-star triple value. Such values start with '<<'.
 	 *
-	 * @return true if the next code points indicate the beginning of an RDF* triple value, false otherwise
+	 * @return true if the next code points indicate the beginning of an RDF-star triple value, false otherwise
 	 * @throws IOException
 	 */
 	protected boolean peekIsTripleValue() throws IOException {
@@ -1346,9 +1346,9 @@ public class TurtleParser extends AbstractRDFParser {
 	}
 
 	/**
-	 * Parser an RDF* triple value and returns it.
+	 * Parser an RDF-star triple value and returns it.
 	 *
-	 * @return An RDF* triple.
+	 * @return An RDF-star triple.
 	 * @throws IOException
 	 */
 	protected Triple parseTripleValue() throws IOException {
@@ -1368,13 +1368,13 @@ public class TurtleParser extends AbstractRDFParser {
 					verifyCharacterOrFail(readCodePoint(), ">");
 					return valueFactory.createTriple((Resource) subject, (IRI) predicate, object);
 				} else {
-					reportFatalError("Missing object in RDF* triple");
+					reportFatalError("Missing object in RDF-star triple");
 				}
 			} else {
-				reportFatalError("Illegal predicate value in RDF* triple: " + predicate);
+				reportFatalError("Illegal predicate value in RDF-star triple: " + predicate);
 			}
 		} else {
-			reportFatalError("Illegal subject val in RDF* triple: " + subject);
+			reportFatalError("Illegal subject val in RDF-star triple: " + subject);
 		}
 
 		return null;

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -615,7 +615,7 @@ public class TurtleWriter extends AbstractRDFWriter implements RDFWriter, CharSi
 	}
 
 	protected void writeTriple(Triple triple, boolean canShorten) throws IOException {
-		throw new IOException(getRDFFormat().getName() + " does not support RDF* triples");
+		throw new IOException(getRDFFormat().getName() + " does not support RDF-star triples");
 	}
 
 	protected void writeTripleRDFStar(Triple triple, boolean canShorten) throws IOException {

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParser.java
@@ -18,20 +18,20 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.turtle.TurtleParser;
 
 /**
- * RDF parser for Turtle* (an extension of Turtle that adds RDF* support).
+ * RDF parser for Turtle-star (an extension of Turtle that adds RDF-star support).
  *
  * @author Pavel Mihaylov
  */
 public class TurtleStarParser extends TurtleParser {
 	/**
-	 * Creates a new TurtleStarParser that will use a {@link SimpleValueFactory} to create RDF* model objects.
+	 * Creates a new TurtleStarParser that will use a {@link SimpleValueFactory} to create RDF-star model objects.
 	 */
 	public TurtleStarParser() {
 		super();
 	}
 
 	/**
-	 * Creates a new TurtleStarParser that will use the supplied ValueFactory to create RDF* model objects.
+	 * Creates a new TurtleStarParser that will use the supplied ValueFactory to create RDF-star model objects.
 	 *
 	 * @param valueFactory A ValueFactory.
 	 */

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserFactory.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserFactory.java
@@ -12,7 +12,7 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFParserFactory;
 
 /**
- * An {@link RDFParserFactory} for Turtle* parsers.
+ * An {@link RDFParserFactory} for Turtle-star parsers.
  *
  * @author Pavel Mihaylov
  */

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriter.java
@@ -18,7 +18,8 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.turtle.TurtleWriter;
 
 /**
- * An extension of {@link TurtleWriter} that writes RDF* documents in the Turtle* format by including the RDF* triples.
+ * An extension of {@link TurtleWriter} that writes RDF-star documents in the Turtle-star format by including the
+ * RDF-star triples.
  *
  * @author Pavel Mihaylov
  */
@@ -68,7 +69,7 @@ public class TurtleStarWriter extends TurtleWriter {
 
 	@Override
 	public boolean acceptsFileFormat(FileFormat format) {
-		// since Turtle* is a superset of regular Turtle, this Sink also accepts regular Turtle
+		// since Turtle-star is a superset of regular Turtle, this Sink also accepts regular Turtle
 		// serialization
 		return super.acceptsFileFormat(format) || RDFFormat.TURTLE.equals(format);
 	}

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterFactory.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarWriterFactory.java
@@ -17,7 +17,7 @@ import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RDFWriterFactory;
 
 /**
- * An {@link RDFWriterFactory} for Turtle* writers.
+ * An {@link RDFWriterFactory} for Turtle-star writers.
  *
  * @author Pavel Mihaylov
  */

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
@@ -510,7 +510,7 @@ public class TurtleParserTest {
 	}
 
 	/**
-	 * Extend standard Turtle parser to also accept RDF* data (see GH-2511)
+	 * Extend standard Turtle parser to also accept RDF-star data (see GH-2511)
 	 *
 	 */
 	@Test

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
@@ -113,7 +113,7 @@ public class TurtleStarParserTest {
 		try (InputStream in = this.getClass().getResourceAsStream("/test-rdfstar.ttls")) {
 			parser.parse(in, baseURI);
 		} catch (RDFParseException e) {
-			fail("parser setting should have no influence on TurtleStarParser handling of RDF* data");
+			fail("parser setting should have no influence on TurtleStarParser handling of RDF-star data");
 		}
 	}
 

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDataset.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDataset.java
@@ -77,18 +77,18 @@ public interface SailDataset extends SailClosable {
 			Resource... contexts) throws SailException;
 
 	/**
-	 * Gets all RDF* triples that have a specific subject, predicate and/or object. All three parameters may be null to
-	 * indicate wildcards.
+	 * Gets all RDF-star triples that have a specific subject, predicate and/or object. All three parameters may be null
+	 * to indicate wildcards.
 	 *
 	 * @param subj A Resource specifying the subject, or <tt>null</tt> for a wildcard.
 	 * @param pred A IRI specifying the predicate, or <tt>null</tt> for a wildcard.
 	 * @param obj  A Value specifying the object, or <tt>null</tt> for a wildcard.
 	 * @return An iterator over the relevant triples.
-	 * @throws SailException If the triple source failed to get the RDF* triples.
+	 * @throws SailException If the triple source failed to get the RDF-star triples.
 	 */
 	default CloseableIteration<? extends Triple, SailException> getTriples(Resource subj, IRI pred, Value obj)
 			throws SailException {
-		throw new SailException("RDF* triple retrieval not supported by this store");
+		throw new SailException("RDF-star triple retrieval not supported by this store");
 	}
 
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetTripleSource.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailDatasetTripleSource.java
@@ -87,7 +87,7 @@ class SailDatasetTripleSource implements TripleSource, RDFStarTripleSource {
 			Value obj) throws QueryEvaluationException {
 		try {
 			// In contrast to statement retrieval (which gets de-duplicated later on when handling things like
-			// projections and conversions) we need to make sure we de-duplicate the RDF* triples here.
+			// projections and conversions) we need to make sure we de-duplicate the RDF-star triples here.
 			return new DistinctIteration<>(new TriplesIteration(dataset.getTriples(subj, pred, obj)));
 		} catch (SailException e) {
 			throw new QueryEvaluationException(e);

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemTriple.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemTriple.java
@@ -172,7 +172,7 @@ public class MemTriple implements Triple, MemResource {
 
 	@Override
 	public void addContextStatement(MemStatement st) {
-		throw new UnsupportedOperationException("RDF* triples can not be used as context identifier");
+		throw new UnsupportedOperationException("RDF-star triples can not be used as context identifier");
 	}
 
 	@Override

--- a/site/content/documentation/programming/rdfstar.md
+++ b/site/content/documentation/programming/rdfstar.md
@@ -1,62 +1,58 @@
 ---
-title: "RDF* and SPARQL*"
+title: "RDF-star and SPARQL-star"
 toc: true
 weight: 9
 autonumbering: true
 ---
-(new in RDF4J 3.2)
-
-RDF4J has (experimental) support for RDF\* and SPARQL\*.
+RDF4J has (experimental) support for RDF-star and SPARQL-star.
 <!--more-->
 
-RDF\*
-and its companion SPARQL\* are proposed extensions to the RDF and SPARQL standards (see [Olaf
-Hartig's position paper](https://blog.liu.se/olafhartig/2019/01/10/position-statement-rdf-star-and-sparql-star/) )
-to provide a more convenient way to annotate RDF statements and to query such
-annotations. In essence, RDF\* attempts to bridge the gap between the RDF world
-and the Property Graph world.
+RDF-star and its companion SPARQL-star are proposed extensions to the RDF and
+SPARQL standards (see [RDF-star W3C Community
+Group](https://w3c.github.io/rdf-star/)) to provide a more convenient way to
+annotate RDF statements and to query such annotations. In essence, RDF-star
+attempts to bridge the gap between the RDF world and the Property Graph world.
 
-RDF4J support for these extensions currently (3.2.0) covers:
+RDF4J support for these extensions currently covers:
 
- - reading and writing RDF\* data in a variety of syntax formats (including Turtle\* and TriG*)
- - converting between an RDF\* Model using annotations and a regular RDF Model (translating the annotations to regular RDF reification)
- - persisting RDF\* data in the Memory Memory Store and querying with SPARQL\*, regular SPARQL and / or API calls
- - adding extension hooks for third-party triplestores that implement the SAIL API to allow persistence and querying of RDF\* annotations
+ - reading and writing RDF-star data in a variety of syntax formats (including Turtle-star and TriG-star)
+ - converting between an RDF-star Model using annotations and a regular RDF Model (translating the annotations to regular RDF reification)
+ - persisting RDF-star data in the Memory Memory Store and querying with SPARQL-star, regular SPARQL and / or API calls
+ - adding extension hooks for third-party triplestores that implement the SAIL API to allow persistence and querying of RDF-star annotations
 
 Note: these features are currently in the experimental/beta stage. While we'll do our best to not make breaking changes in future releases unless necessary, we make no guarantees.
 
-## The RDF\* data model in RDF4J
+## The RDF-star data model in RDF4J
 
-To support RDF\* annotations, the core RDF model in RDF4J has been extended with a new type of Resource: the {{< javadoc "Triple" "model/Triple.html" >}} (not to be confused with the pre-existing {{< javadoc "Statement" "model/Statement.html" >}}, which is the representation of a "regular" RDF statement).
+To support RDF-star annotations, the core RDF model in RDF4J has been extended with a new type of Resource: the {{< javadoc "Triple" "model/Triple.html" >}} (not to be confused with the pre-existing {{< javadoc "Statement" "model/Statement.html" >}}, which is the representation of a "regular" RDF statement).
 
-You can create `Triple` objects using a `ValueFactory`, and then use them as the subject (or object) of another statement, for example:
+You can create `Triple` objects using a `ValueFactory` or through the static `Values` factory methods, and then use them as the subject (or object) of another statement, for example:
 
 ```java
-IRI bob = valueFactory.createIRI("http://example.org/bob");
-Triple bobsAge = valueFactory.createTriple(bob, FOAF.AGE, valueFactory.createLiteral(23));
+IRI bob = Values.iri("http://example.org/bob");
+Triple bobsAge = Values.triple(bob, FOAF.AGE, Values.literal(23));
 
-IRI certainty = valueFactory.createIRI("http://example.org/certainty");
-Statement aboutBobsAge = valueFactory.createStatement(bobsAge, certainty, valueFactory.createLiteral(0.9));
+IRI certainty = Values.iri("http://example.org/certainty");
+Statement aboutBobsAge = Statements.statement(bobsAge, certainty, Values.literal(0.9), null);
 ```
 
-The {{< javadoc "Statements" "model/util/Statements.html" >}}  utility class offers several functions to easily transform Statements into Triples, vice versa:
-
+The {{< javadoc "Statements" "model/util/Statements.html" >}} and {{< javadoc "Values" "model/util/Values.html" >}}   utility classes offers several functions to easily transform Statements into Triples, vice versa:
 
 ```java
-IRI bob = valueFactory.createIRI("http://example.org/bob");
-Triple bobsAge = valueFactory.createTriple(bob, FOAF.AGE, valueFactory.createLiteral(23));
+IRI bob = Values.iri("http://example.org/bob");
+Triple bobsAge = Values.triple(bob, FOAF.AGE, valueFactory.createLiteral(23));
 
 Statement ageStatement = Statements.toStatement(bobsAge);
-Triple backToTriple = Statements.toTriple(ageStatement);
+Triple backToTriple = Values.triple(ageStatement);
 ```
 
-## Reading and writing RDF\* data
+## Reading and writing RDF-star data
 
-RDF4J currently provides several Rio parser/writers for RDF\*-enabled syntax formats: the Turtle\* format, and the TriG\* format. As the names suggest, both are extended versions of existing RDF format (Turtle and TriG, respectively). In addition, RDF4J's [binary RDF format](/documentation/reference/rdf4j-binary/) parser has also been extended to be able to read and write RDF\* data.
+RDF4J currently provides several Rio parser/writers for RDF-star enabled syntax formats: the Turtle-star format, and the TriG-star format. As the names suggest, both are extended versions of existing RDF format (Turtle and TriG, respectively). In addition, RDF4J's [binary RDF format](/documentation/reference/rdf4j-binary/) parser has also been extended to be able to read and write RDF-star data.
 
-### Reading / writing a Turtle\* file
+### Reading / writing a Turtle-star file
 
-A Turtle\* file that contains an annotation with a certainty score, on a statement saying "Bob's age is 23", would look like this:
+A Turtle-star file that contains an annotation with a certainty score, on a statement saying "Bob's age is 23", would look like this:
 
 ```turtle
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
@@ -65,22 +61,22 @@ A Turtle\* file that contains an annotation with a certainty score, on a stateme
 <<ex:bob foaf:age 23>> ex:certainty 0.9 .
 ```
 
-If we wish to read this data into an RDF4J Model object, we can do so using the Rio Turtle\* parser:
+If we wish to read this data into an RDF4J Model object, we can do so using the Rio Turtle-star parser:
 
 ```java
 Model model = Rio.parse(new FileInputStream("/path/to/file.ttls"), "", RDFFORMAT.TURTLESTAR);
 ```
 
-Similarly, Rio can be used to write RDF\* models to file:
+Similarly, Rio can be used to write RDF-star models to file:
 ```java
 Rio.write(model, new FileOuputStream("/path/to/file.ttls"), "", RDFFORMAT.TURTLESTAR);
 ```
 
-## Storing and retrieving RDF\* in a Repository
+## Storing and retrieving RDF-star in a Repository
 
-Note: not every store can handle RDF\* data. Attempting to upload an RDF\* model directly to a Repository that does not support it will result in errors.
+Note: not every store can handle RDF-star data. Attempting to upload an RDF-star model directly to a Repository that does not support it will result in errors.
 
-The RDF4J MemoryStore accepts RDF\* data. You can add the RDF\* model we created above directly to an in-memory Repository:
+The RDF4J MemoryStore accepts RDF-star data. You can add the RDF-star model we created above directly to an in-memory Repository:
 
 ```java
 try(RepositoryConnection conn = repo.getConnection()) {
@@ -113,9 +109,9 @@ try(RepositoryConnection conn = repo.getConnection()) {
 }
 ```
 
-### SPARQL query results containing RDF\*
+### SPARQL query results containing RDF-star
 
-When querying a store that contains RDF\* data, even regular SPARQL queries may include RDF\* triples as a result. To make it possible to serialize such query results (e.g. for network transfer), the SPARQL/JSON, SPARQL/XML, Binary and TSV query result formats have all been extended to handle RDF\* triples as possible value bindings.
+When querying a store that contains RDF-star data, even regular SPARQL queries may include RDF-star triples as a result. To make it possible to serialize such query results (e.g. for network transfer), the SPARQL/JSON, SPARQL/XML, Binary and TSV query result formats have all been extended to handle RDF-star triples as possible value bindings.
 
 #### Extended SPARQL JSON format
 
@@ -135,15 +131,15 @@ The default [SPARQL 1.1 Query Results JSON format](https://www.w3.org/TR/sparql1
       { "a" : {
           "type" : "triple",
           "value" : {
-            "s" : {
+            "subject" : {
               "type" : "uri",
               "value" : "http://example.org/bob"
             },
-            "p" : {
+            "predicate" : {
               "type" : "uri",
               "value" : "http://xmlns.com/foaf/0.1/age"
             },
-            "o" : {
+            "object" : {
               "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
               "type" : "literal",
               "value" : "23"
@@ -165,7 +161,7 @@ The default [SPARQL 1.1 Query Results JSON format](https://www.w3.org/TR/sparql1
 }
 ```
 
-RDF4J introduces a new, custom content type `application/x-sparqlstar-results+json` to specifically request this extended content. By default, if a client requests the standard content type (`application/sparql-results+json` or `application/json`), the response serializer will instead "compress" the RDF\* triple into a single IRI, using Base64 encoding:
+RDF4J introduces a new, custom content type `application/x-sparqlstar-results+json` to specifically request this extended content. By default, if a client requests the standard content type (`application/sparql-results+json` or `application/json`), the response serializer will instead "compress" the RDF-star triple into a single IRI, using Base64 encoding:
 
 ```json
 {
@@ -199,7 +195,7 @@ RDF4J introduces a new, custom content type `application/x-sparqlstar-results+js
 
 This ensures that by default, an RDF4J-based endpoint will always use standards-compliant serialization to avoid breaking clients that have not yet been updated.
 
-It is possible to override this behavior by explicitly configuring the writer to _not_ encode RDF\* triples. Setting the {{< javadoc "BasicWriterSetting ENCODE_RDF_STAR" "rio/helpers/BasicWriterSettings.html" >}} to `false` will ensure that even when requesting the standard content type, the serializer will use the extended syntax.
+It is possible to override this behavior by explicitly configuring the writer to _not_ encode RDF-star triples. Setting the {{< javadoc "BasicWriterSetting ENCODE_RDF_STAR" "rio/helpers/BasicWriterSettings.html" >}} to `false` will ensure that even when requesting the standard content type, the serializer will use the extended syntax.
 
 #### Extended SPARQL XML format
 
@@ -208,34 +204,34 @@ The default [SPARQL Query Results XML format](https://www.w3.org/TR/rdf-sparql-X
 ```xml
 <?xml version='1.0' encoding='UTF-8'?>
 <sparql xmlns='http://www.w3.org/2005/sparql-results#'>
-	<head>
-		<variable name='a'/>
-		<variable name='b'/>
-		<variable name='c'/>
-	</head>
-	<results>
-		<result>
-			<binding name='a'>
-				<triple>
-					<subject>
-						<uri>http://example.org/bob</uri>
-					</subject>
-					<predicate>
-						<uri>http://xmlns.com/foaf/0.1/age</uri>
-					</predicate>
-					<object>
-						<literal datatype='http://www.w3.org/2001/XMLSchema#integer'>23</literal>
-					</object>
-				</triple>
-			</binding>
-			<binding name='b'>
-				<uri>http://example.org/certainty</uri>
-			</binding>
-			<binding name='c'>
-				<literal datatype='http://www.w3.org/2001/XMLSchema#decimal'>0.9</literal>
-			</binding>
-		</result>
-	</results>
+  <head>
+    <variable name='a'/>
+    <variable name='b'/>
+    <variable name='c'/>
+  </head>
+  <results>
+    <result>
+      <binding name='a'>
+        <triple>
+          <subject>
+            <uri>http://example.org/bob</uri>
+          </subject>
+          <predicate>
+            <uri>http://xmlns.com/foaf/0.1/age</uri>
+          </predicate>
+          <object>
+            <literal datatype='http://www.w3.org/2001/XMLSchema#integer'>23</literal>
+          </object>
+        </triple>
+      </binding>
+      <binding name='b'>
+        <uri>http://example.org/certainty</uri>
+      </binding>
+      <binding name='c'>
+        <literal datatype='http://www.w3.org/2001/XMLSchema#decimal'>0.9</literal>
+      </binding>
+    </result>
+  </results>
 </sparql>
 ```
 
@@ -250,11 +246,11 @@ The [SPARQL 1.1 Query Results TSV format](https://www.w3.org/TR/sparql11-results
 <<<http://example.org/bob> <http://xmlns.com/foaf/0.1/age> 23>>	<http://example.org/certainty>	0.9
 ```
 
-### SPARQL\* queries
+### SPARQL-star queries
 
-The SPARQL engine in RDF4J has been extended to allow for SPARQL\* queries. Executing a SPARQL\* query relies on the underlying store supporting RDF\* data storage.
+The SPARQL engine in RDF4J has been extended to allow for SPARQL-star queries. Executing a SPARQL-star query relies on the underlying store supporting RDF-star data storage.
 
-SPARQL\* allows accessing the RDF\* triple patterns directly in the query. For example, after you have uploaded the above simple RDF\* model to a MemoryStore, you can execute a query like this:
+SPARQL-star allows accessing the RDF-star triple patterns directly in the query. For example, after you have uploaded the above simple RDF-star model to a MemoryStore, you can execute a query like this:
 
 ```sparql
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -269,9 +265,9 @@ The result will be:
     ?p      ?a     ?c
     ex:bob  23     0.9
 
-## Converting RDF\* to regular RDF and back
+## Converting RDF-star to regular RDF and back
 
-RDF4J offers functions to convert between RDF\* data and regular RDF. In the converted regular RDF, the RDF\* triple is replaced with a reified statement using the [RDF Reification vocabulary](https://www.w3.org/wiki/RdfReification). For example:
+RDF4J offers functions to convert between RDF-star data and regular RDF. In the converted regular RDF, the RDF-star triple is replaced with a reified statement using the [RDF Reification vocabulary](https://www.w3.org/wiki/RdfReification). For example:
 
 
 ```turtle
@@ -288,10 +284,10 @@ _:node1 a rdf:Statement;
         ex:certainty 0.9 .
 ```
 
-You can find the the conversion functions in the {{< javadoc "Models" "model/util/Models.html" >}} utility class. There are several variants, but the simplest form just takes a `Model` containing RDF\* data and creates a new `Model` containing the same data, but with all RDF\* annotation converted to reified statements:
+You can find the the conversion functions in the {{< javadoc "Models" "model/util/Models.html" >}} utility class. There are several variants, but the simplest form just takes a `Model` containing RDF-star data and creates a new `Model` containing the same data, but with all RDF-star annotation converted to reified statements:
 
 ```java
-Model rdfStarModel; // model containing RDF\* annotations
+Model rdfStarModel; // model containing RDF-star annotations
 Model convertedModel = Models.convertRDFStarToReification(rdfStarModel);
 ```
 
@@ -302,14 +298,5 @@ Model reificiationModel; // model containing RDF reification statements
 Model rdfStarModel = Models.convertReificiationtoRDFStar(reificiationModel);
 ```
 
-Note: since the RDF\* functionality is currently in experimental stage, it is possible that the names or precise signatures of these functions will be changed in a future release.
-
-## Property Graphs (PG) vs Separate Assertions (SA)
-
-In the [current discussions around RDF\*](https://lists.w3.org/Archives/Public/public-rdf-star/), two "modes" for working with RDF\* have been identified. Simply put, these two modes are:
-
-1. Property Graph (PG) mode - in this mode, when an RDF\* triple is annotated and added, the associated "ground" statement is automatically assumed to also exist. In this mode, asserting `<<ex:bob foaf:age 23>> ex:certainty 0.9 .` implicitly also asserts the statement `ex:bob foaf:age 23.`.
-2. Separate Assertions (SA) mode - in this mode, RDF\* annotation are seen as separate from the statements which they annotate. In this mode, asserting `<<ex:bob foaf:age 23>> ex:certainty 0.9` does not automatically imply that the statement `ex:bob foaf:age 23` is present - the ground fact and the annotation are seen as independent entities, and either one can exist without the other.
-
-Although RDF4J makes no assumptions about the mode used at the level of its core interfaces, the default implementations in RDF4J's own triplestore implementations currently work only in SA mode.
+Note: since the RDF-star functionality is currently in experimental stage, it is possible that the names or precise signatures of these functions will be changed in a future release.
 

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractTupleQueryResultWriterTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/query/resultio/AbstractTupleQueryResultWriterTest.java
@@ -63,8 +63,8 @@ public abstract class AbstractTupleQueryResultWriterTest {
 		BindingSet actual = collector.getBindingSets().get(0);
 
 		if (writer.getTupleQueryResultFormat().supportsRDFStar()) {
-			// natively-supporting RDF* writers should ignore the encoding setting and just always use their extended
-			// format
+			// natively-supporting RDF-star writers should ignore the encoding setting and just always use their
+			// extended format
 			assertThat(actual.getValue("t")).isInstanceOf(Triple.class);
 		} else {
 			assertThat(actual.getValue("t")).isInstanceOf(IRI.class);

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 /**
- * Test cases for RDF* support in the Repository.
+ * Test cases for RDF-star support in the Repository.
  *
  * @author Jeen Broekstra
  *
@@ -126,7 +126,7 @@ public abstract class RDFStarSupportTest {
 
 		try {
 			testCon.add(RDF.ALT, RDF.TYPE, RDF.ALT, rdfStarTriple);
-			fail("RDF* triple value should not be allowed by store as context identifier");
+			fail("RDF-star triple value should not be allowed by store as context identifier");
 		} catch (UnsupportedOperationException e) {
 			// fall through, expected behavior
 			testCon.rollback();


### PR DESCRIPTION
GitHub issue resolved: #2922 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- renamed all occurrences in code to new acronyms
- updated documentation accordingly
- did some minor API cleanup for RDF-star support while at it

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

