### PR TITLE
GH-2978 explicit disabling/enabling of pass-through for SPARQL endpoints

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -183,6 +183,8 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 
 	private Map<String, String> additionalHttpHeaders = Collections.emptyMap();
 
+	private boolean passThroughEnabled = true;
+
 	public SPARQLProtocolSession(HttpClient client, ExecutorService executor) {
 		this.httpClient = client;
 		this.httpContext = new HttpClientContext();
@@ -879,6 +881,9 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	 */
 	private boolean passThrough(HttpResponse response, FileFormat responseFormat, Sink sink)
 			throws IOException {
+		if (!isPassThroughEnabled()) {
+			return false;
+		}
 		if (sink.acceptsFileFormat(responseFormat)) {
 			InputStream in = response.getEntity().getContent();
 			if (sink instanceof CharSink) {
@@ -1243,5 +1248,25 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	 */
 	protected HttpContext getHttpContext() {
 		return this.httpContext;
+	}
+
+	/**
+	 * Indicates if direct pass-through of the endpoint result to the supplied {@link Sink} is enabled.
+	 * 
+	 * @return the passThroughEnabled setting.
+	 */
+	public boolean isPassThroughEnabled() {
+		return passThroughEnabled;
+	}
+
+	/**
+	 * Configure direct pass-through of the endpoint result to the supplied {@link Sink}.
+	 * <p>
+	 * If not explicitly configured, the setting defaults to {@code true}.
+	 * 
+	 * @param passThroughEnabled the passThroughEnabled to set.
+	 */
+	public void setPassThroughEnabled(boolean passThroughEnabled) {
+		this.passThroughEnabled = passThroughEnabled;
 	}
 }

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSessionTest.java
@@ -133,6 +133,25 @@ public class SPARQLProtocolSessionTest {
 	}
 
 	@Test
+	public void testTupleQuery_Passthrough_ConfiguredFalse() throws Exception {
+		stubFor(post(urlEqualTo("/rdf4j-server/repositories/test"))
+				.willReturn(aResponse().withStatus(200)
+						.withHeader("Content-Type", TupleQueryResultFormat.SPARQL.getDefaultMIMEType())
+						.withBodyFile("repository-list.xml")));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		SPARQLStarResultsXMLWriter handler = Mockito.spy(new SPARQLStarResultsXMLWriter(out));
+		sparqlSession.setPassThroughEnabled(false);
+		sparqlSession.sendTupleQuery(QueryLanguage.SPARQL, "SELECT * WHERE { ?s ?p ?o}", null, null, true, -1, handler);
+
+		// If not passed through, the QueryResultWriter methods should have been invoked
+		verify(handler, times(1)).startQueryResult(anyList());
+
+		// check that the OutputStream received content in XML format
+		assertThat(out.toString()).startsWith("<");
+	}
+
+	@Test
 	public void getContentTypeSerialisationTest() {
 		{
 			HttpResponse httpResponse = withContentType("application/shacl-validation-report+n-quads");

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
@@ -7,10 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql.config;
 
+import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
@@ -28,15 +30,31 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/sparql#";
 
+	/**
+	 * Configuration setting for the SPARQL query endpoint. Required.
+	 */
 	public static final IRI QUERY_ENDPOINT = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#query-endpoint");
 
+	/**
+	 * Configuration setting for the SPARQL update endpoint. Optional.
+	 */
 	public static final IRI UPDATE_ENDPOINT = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#update-endpoint");
+
+	/**
+	 * Configuration setting for enabling/disabling direct result pass-through. Optional.
+	 * 
+	 * @see SPARQLProtocolSession#isPassThroughEnabled()
+	 */
+	public static final IRI PASS_THROUGH_ENABLED = vf
+			.createIRI("http://www.openrdf.org/config/repository/sparql#pass-through-enabled");
 
 	private String queryEndpointUrl;
 
 	private String updateEndpointUrl;
+
+	private Boolean passThroughEnabled;
 
 	public SPARQLRepositoryConfig() {
 		super(SPARQLRepositoryFactory.REPOSITORY_TYPE);
@@ -87,6 +105,9 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 		if (getUpdateEndpointUrl() != null) {
 			m.add(implNode, UPDATE_ENDPOINT, vf.createIRI(getUpdateEndpointUrl()));
 		}
+		if (getPassThroughEnabled() != null) {
+			m.add(implNode, PASS_THROUGH_ENABLED, BooleanLiteral.valueOf(getPassThroughEnabled()));
+		}
 
 		return implNode;
 	}
@@ -100,8 +121,24 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 					.ifPresent(iri -> setQueryEndpointUrl(iri.stringValue()));
 			Models.objectIRI(m.getStatements(implNode, UPDATE_ENDPOINT, null))
 					.ifPresent(iri -> setUpdateEndpointUrl(iri.stringValue()));
+			Models.objectLiteral(m.getStatements(implNode, PASS_THROUGH_ENABLED, null))
+					.ifPresent(lit -> setPassThroughEnabled(lit.booleanValue()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);
 		}
+	}
+
+	/**
+	 * @return the passThroughEnabled
+	 */
+	public Boolean getPassThroughEnabled() {
+		return passThroughEnabled;
+	}
+
+	/**
+	 * @param passThroughEnabled the passThroughEnabled to set
+	 */
+	public void setPassThroughEnabled(Boolean passThroughEnabled) {
+		this.passThroughEnabled = passThroughEnabled;
 	}
 }

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryFactory.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryFactory.java
@@ -42,6 +42,9 @@ public class SPARQLRepositoryFactory implements RepositoryFactory {
 			} else {
 				result = new SPARQLRepository(httpConfig.getQueryEndpointUrl());
 			}
+			if (httpConfig.getPassThroughEnabled() != null) {
+				result.setPassThroughEnabled(httpConfig.getPassThroughEnabled());
+			}
 		} else {
 			throw new RepositoryConfigException("Invalid configuration class: " + config.getClass());
 		}

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositoryTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositoryTest.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,15 +16,15 @@ import org.eclipse.rdf4j.http.client.HttpClientSessionManager;
 import org.eclipse.rdf4j.http.client.RDF4JProtocolSession;
 import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SPARQLRepositoryTest {
 
 	String endpointUrl = "http://example.org/sparql";
 	TupleQueryResultFormat customPreferred = TupleQueryResultFormat.CSV;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 	}
 
@@ -54,6 +61,20 @@ public class SPARQLRepositoryTest {
 			}
 		});
 
-		assertThat(rep.createHTTPClient().getPreferredTupleQueryResultFormat()).isEqualTo(customPreferred);
+		assertThat(rep.createSPARQLProtocolSession().getPreferredTupleQueryResultFormat()).isEqualTo(customPreferred);
+	}
+
+	public void testPassThroughEnabled() throws Exception {
+		SPARQLRepository rep = new SPARQLRepository(endpointUrl);
+		assertThat(rep.getPassThroughEnabled()).isNull();
+		assertThat(rep.createSPARQLProtocolSession()).isNotNull();
+
+		rep.setPassThroughEnabled(true);
+		assertThat(rep.getPassThroughEnabled()).isTrue();
+		assertThat(rep.createSPARQLProtocolSession().isPassThroughEnabled()).isTrue();
+
+		rep.setPassThroughEnabled(false);
+		assertThat(rep.getPassThroughEnabled()).isFalse();
+		assertThat(rep.createSPARQLProtocolSession().isPassThroughEnabled()).isFalse();
 	}
 }

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfigTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfigTest.java
@@ -1,9 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.util.Values.bnode;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 
-import org.junit.Test;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link SPARQLRepositoryConfig}.
@@ -19,16 +33,49 @@ public class SPARQLRepositoryConfigTest {
 	@Test
 	public void testConstructorWithSPARQLEndpoint() {
 		SPARQLRepositoryConfig config = new SPARQLRepositoryConfig(QUERY_ENDPOINT_URL);
-		assertEquals(QUERY_ENDPOINT_URL, config.getQueryEndpointUrl());
-		assertNull(config.getUpdateEndpointUrl());
-		assertEquals(SPARQLRepositoryFactory.REPOSITORY_TYPE, config.getType());
+		assertThat(config.getQueryEndpointUrl()).isEqualTo(QUERY_ENDPOINT_URL);
+		assertThat(config.getUpdateEndpointUrl()).isNull();
+		assertThat(config.getType()).isEqualTo(SPARQLRepositoryFactory.REPOSITORY_TYPE);
 	}
 
 	@Test
 	public void testConstructorWithQueryAndUpdateEndpoints() {
 		SPARQLRepositoryConfig config = new SPARQLRepositoryConfig(QUERY_ENDPOINT_URL, UPDATE_ENDPOINT_URL);
-		assertEquals(QUERY_ENDPOINT_URL, config.getQueryEndpointUrl());
-		assertEquals(UPDATE_ENDPOINT_URL, config.getUpdateEndpointUrl());
-		assertEquals(SPARQLRepositoryFactory.REPOSITORY_TYPE, config.getType());
+
+		assertThat(config.getQueryEndpointUrl()).isEqualTo(QUERY_ENDPOINT_URL);
+		assertThat(config.getUpdateEndpointUrl()).isEqualTo(UPDATE_ENDPOINT_URL);
+		assertThat(config.getType()).isEqualTo(SPARQLRepositoryFactory.REPOSITORY_TYPE);
+	}
+
+	@Test
+	public void testPassThroughEnabled() {
+		SPARQLRepositoryConfig config = new SPARQLRepositoryConfig(QUERY_ENDPOINT_URL);
+
+		assertThat(config.getPassThroughEnabled()).isNull();
+		config.setPassThroughEnabled(true);
+		assertThat(config.getPassThroughEnabled()).isTrue();
+		config.setPassThroughEnabled(false);
+		assertThat(config.getPassThroughEnabled()).isFalse();
+	}
+
+	@Test
+	public void testParse() {
+		Model m = new LinkedHashModel();
+		BNode implNode = bnode();
+		m.add(implNode, RepositoryConfigSchema.REPOSITORYTYPE, literal(SPARQLRepositoryFactory.REPOSITORY_TYPE));
+		m.add(implNode, SPARQLRepositoryConfig.QUERY_ENDPOINT, iri(QUERY_ENDPOINT_URL));
+		m.add(implNode, SPARQLRepositoryConfig.UPDATE_ENDPOINT, iri(UPDATE_ENDPOINT_URL));
+
+		SPARQLRepositoryConfig config = new SPARQLRepositoryConfig();
+		config.parse(m, implNode);
+
+		assertThat(config.getQueryEndpointUrl()).isEqualTo(QUERY_ENDPOINT_URL);
+		assertThat(config.getUpdateEndpointUrl()).isEqualTo(UPDATE_ENDPOINT_URL);
+		assertThat(config.getPassThroughEnabled()).isNull();
+
+		m.add(implNode, SPARQLRepositoryConfig.PASS_THROUGH_ENABLED, BooleanLiteral.FALSE);
+
+		config.parse(m, implNode);
+		assertThat(config.getPassThroughEnabled()).isFalse();
 	}
 }

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryFactoryTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryFactoryTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.sparql.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
+import org.junit.jupiter.api.Test;
+
+public class SPARQLRepositoryFactoryTest {
+
+	private final String queryEndpointUrl = "http://example.org/sparql";
+
+	private SPARQLRepositoryFactory factory = new SPARQLRepositoryFactory();
+
+	@Test
+	public void testGetRepository() {
+		SPARQLRepositoryConfig config = new SPARQLRepositoryConfig(queryEndpointUrl);
+
+		SPARQLRepository rep = factory.getRepository(config);
+		assertThat(rep.getPassThroughEnabled()).isNull();
+
+		config.setPassThroughEnabled(false);
+		rep = factory.getRepository(config);
+		assertThat(rep.getPassThroughEnabled()).isFalse();
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #2978 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- allow disabling passthrough in SPARQLProtocolSession
- add configuration option in SPARQLRepository(Config)
- added/updated unit tests

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

