### PR TITLE
GH-3038 run _only_ tests marked as slow in slow-tests CI job

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check formatting
       run: mvn -B formatter:validate impsort:check xml-format:xml-check
     - name: Test
-      run: mvn -B clean test -P\!formatting -DskipITs -Dmaven.javadoc.skip=true
+      run: mvn -B clean test -P-formatting -DskipITs -Dmaven.javadoc.skip=true
     - name: Print test failures
       if: failure()
       run: ./scripts/printTestResults.sh
@@ -53,9 +53,9 @@ jobs:
     - name: Check formatting
       run: mvn -B formatter:validate impsort:check xml-format:xml-check
     - name: Build
-      run: mvn -B -T 2 clean install -Pquick,\!formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true
+      run: mvn -B -T 2 clean install -Pquick,-formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true
     - name: Verify
-      run: mvn -B verify -PskipUnitTests,\!formatting -Dmaven.javadoc.skip=true -Denforcer.skip=true -Danimal.sniffer.skip=true
+      run: mvn -B verify -PskipUnitTests,-formatting -Dmaven.javadoc.skip=true -Denforcer.skip=true -Danimal.sniffer.skip=true
     - name: Print test failures
       if: failure()
       run: ./scripts/printTestResults.sh
@@ -84,9 +84,9 @@ jobs:
     - name: Check formatting
       run: mvn -B formatter:validate impsort:check xml-format:xml-check
     - name: Build
-      run: mvn -B -T 2 clean install -Pquick,\!formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true
+      run: mvn -B -T 2 clean install -Pquick,-formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true
     - name: Verify
-      run: mvn -B verify -P\!skipSlowTests,\!formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true
+      run: mvn -B verify -PslowTestsOnly,-skipSlowTests,-formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true
     - name: Print test failures
       if: failure()
       run: ./scripts/printTestResults.sh

--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -49,6 +49,27 @@
 			</build>
 		</profile>
 		<profile>
+			<id>slowTestsOnly</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<groups>slow</groups>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<configuration>
+							<groups>slow</groups>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>skipSlowTests</id>
 			<activation>
 				<!-- active on all Java 8 and higher builds by default -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,27 @@
 	<description>Core modules for RDF4J</description>
 	<profiles>
 		<profile>
+			<id>slowTestsOnly</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<groups>slow</groups>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<configuration>
+							<groups>slow</groups>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>skipSlowTests</id>
 			<activation>
 				<!-- active on all Java 8 and higher builds by default -->

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
 		<guava.version>30.1.1-jre</guava.version>
 		<jmhVersion>1.21</jmhVersion>
 		<servlet.version>3.1.0</servlet.version>
-		<junit.version>5.7.1</junit.version>
+		<junit.version>5.7.2</junit.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
GitHub issue resolved: #3038 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- introduced new 'slowTestsOnly' profile, to be activated by the slow-tests CI job
- adjusted pr-verify CI job
- update to JUnit 5.7.2 (necessary to avoid NPE in modules that contain no slow tests)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

