### PR TITLE
GH-3048 transaction writer with rdfstar

### DIFF
--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionSAXParser.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionSAXParser.java
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.impl.SimpleBinding;
 import org.eclipse.rdf4j.query.impl.SimpleDataset;
+import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
 import org.xml.sax.SAXException;
 
 /**
@@ -76,7 +77,10 @@ class TransactionSAXParser extends SimpleSAXAdapter {
 
 	@Override
 	public void startTag(String tagName, Map<String, String> atts, String text) throws SAXException {
-		if (TransactionXMLConstants.URI_TAG.equals(tagName)) {
+		if (TransactionXMLConstants.TRIPLE_TAG.equals(tagName)) {
+			// fixes GH-3048
+			parsedValues.add(RDFStarUtil.fromRDFEncodedValue(valueFactory.createIRI(text)));
+		} else if (TransactionXMLConstants.URI_TAG.equals(tagName)) {
 			parsedValues.add(valueFactory.createIRI(text));
 		} else if (TransactionXMLConstants.BNODE_TAG.equals(tagName)) {
 			parsedValues.add(valueFactory.createBNode(text));

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriter.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriter.java
@@ -28,10 +28,12 @@ import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
 
 /**
  * Serializes of an RDF transaction.
@@ -250,6 +252,8 @@ public class TransactionWriter {
 			serialize((IRI) resource, xmlWriter);
 		} else if (resource instanceof BNode) {
 			serialize((BNode) resource, xmlWriter);
+		} else if (resource instanceof Triple) {
+			serialize((Triple) resource, xmlWriter);
 		} else if (resource == null) {
 			serializeNull(xmlWriter);
 		} else {
@@ -303,5 +307,14 @@ public class TransactionWriter {
 
 	protected void serializeNull(XMLWriter xmlWriter) throws IOException {
 		xmlWriter.emptyElement(TransactionXMLConstants.NULL_TAG);
+	}
+
+	protected void serialize(Triple triple, XMLWriter xmlWriter) throws IOException {
+		if (triple != null) {
+			Value convertBase64 = RDFStarUtil.toRDFEncodedValue(triple);
+			xmlWriter.textElement(TransactionXMLConstants.TRIPLE_TAG, convertBase64.stringValue());
+		} else {
+			serializeNull(xmlWriter);
+		}
 	}
 }

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionXMLConstants.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionXMLConstants.java
@@ -27,6 +27,8 @@ interface TransactionXMLConstants {
 
 	public static final String NULL_TAG = "null";
 
+	public static final String TRIPLE_TAG = "triple";
+
 	public static final String URI_TAG = "uri";
 
 	public static final String BNODE_TAG = "bnode";


### PR DESCRIPTION
GitHub issue resolved: #3048

Briefly describe the changes proposed in this PR:

 - persist Triple resources as base64 encoded IRI using new "triple" tag
 - parse the newly introduced tag and decode the Triple from it's base64 encoded value
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

