### PR TITLE
GH-3010 improve binary rdf format

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BinaryRDFWriterSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BinaryRDFWriterSettings.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.rio.helpers;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.rdf4j.rio.RioSetting;
+
+/**
+ * WriterSettings for the binary RDF writer.
+ *
+ * @author Frens Jan Rumph
+ */
+public class BinaryRDFWriterSettings {
+
+	/**
+	 * Setting for the binary RDF format to use.
+	 * <p>
+	 * Defaults to {@code 2}.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.binary.format_version}
+	 */
+	public static final RioSetting<Long> VERSION = new LongRioSetting(
+			"org.eclipse.rdf4j.rio.binary.format_version", "Binary RDF format", 2L);
+
+	/**
+	 * Setting for the number of statements to consider while analyzing duplicate RDF terms. Terms that occur twice or
+	 * more within the buffer of statements are written out (starting from the second occurrence) as identifiers.
+	 * <p>
+	 * Defaults to {@code 8192}.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.binary.buffer_size}
+	 */
+	public static final RioSetting<Long> BUFFER_SIZE = new LongRioSetting(
+			"org.eclipse.rdf4j.rio.binary.buffer_size", "Buffer size", 8192L);
+
+	/**
+	 * Setting for the character set to use for encoding strings (only applicable to version 2 of the binary RDF
+	 * format).
+	 * <p>
+	 * Defaults to {@code "UTF-8"}.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.binary.charset}
+	 */
+	public static final RioSetting<String> CHARSET = new StringRioSetting(
+			"org.eclipse.rdf4j.rio.binary.charset", "Charset", StandardCharsets.UTF_8.name());
+
+	/**
+	 * Setting for whether to recycle IDs while writing binary RDF files. (only applicable to version 2 of the binary
+	 * RDF format).
+	 * <p>
+	 * If enabled (the default), once an RDF term is no longer referenced in the buffer of statements (see also
+	 * {@link #BUFFER_SIZE}), the ID of that term can be reused and any in memory reference to that term is released. If
+	 * disabled, once an RDF term is assigned an ID it is never released and an in-memory reference to that term is
+	 * maintained in memory. Note that disabling this setting <i>may</i> decrease file size, but also <i>may</i> result
+	 * in an {@link OutOfMemoryError} because heap memory used is for every term that is ever assigned an ID.
+	 * </p>
+	 * <p>
+	 * Defaults to {@code true}.
+	 * <p>
+	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.binary.recycle_ids}
+	 */
+	public static final RioSetting<Boolean> RECYCLE_IDS = new BooleanRioSetting(
+			"org.eclipse.rdf4j.rio.binary.recycle_ids", "Charset", true);
+
+	/**
+	 * Private constructor
+	 */
+	private BinaryRDFWriterSettings() {
+	}
+
+}

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFConstants.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFConstants.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.binary;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 class BinaryRDFConstants {
 
 	/**
@@ -14,10 +17,11 @@ class BinaryRDFConstants {
 	 */
 	static final byte[] MAGIC_NUMBER = new byte[] { 'B', 'R', 'D', 'F' };
 
-	/**
-	 * The version number of the current format.
-	 */
-	static final int FORMAT_VERSION = 1;
+	static final Charset V1_STRING_CHARSET = StandardCharsets.UTF_16BE;
+
+	static final int FORMAT_V1 = 1;
+
+	static final int FORMAT_V2 = 2;
 
 	/* RECORD TYPES */
 

--- a/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
+++ b/core/rio/binary/src/main/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriter.java
@@ -5,17 +5,21 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
+
 package org.eclipse.rdf4j.rio.binary;
 
+import static org.eclipse.rdf4j.common.io.IOUtil.writeVarInt;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.BNODE_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.COMMENT;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.DATATYPE_LITERAL_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.END_OF_DATA;
-import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.FORMAT_VERSION;
+import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.FORMAT_V1;
+import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.FORMAT_V2;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.LANG_LITERAL_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.MAGIC_NUMBER;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.NAMESPACE_DECL;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.NULL_VALUE;
+import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.PLAIN_LITERAL_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.STATEMENT;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.TRIPLE_VALUE;
 import static org.eclipse.rdf4j.rio.binary.BinaryRDFConstants.URI_VALUE;
@@ -25,12 +29,16 @@ import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
 
 import org.eclipse.rdf4j.common.io.ByteSink;
 import org.eclipse.rdf4j.model.BNode;
@@ -39,43 +47,64 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
+import org.eclipse.rdf4j.rio.helpers.BinaryRDFWriterSettings;
 
 /**
+ * A {@link RDFWriter} for the binary RDF format.
+ * 
  * @author Arjohn Kampman
+ * @author Frens Jan Rumph
  */
 public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter, ByteSink {
 
-	private final BlockingQueue<Statement> statementQueue;
+	private final Queue<Statement> statementQueue;
 
-	private final Map<Value, AtomicInteger> valueFreq;
+	private int bufferSize;
 
-	private final Map<Value, Integer> valueIdentifiers;
+	private final Map<Value, ValueMeta> valueMeta;
 
-	private final AtomicInteger maxValueId = new AtomicInteger(-1);
+	private int nextId = 0;
+
+	private final Queue<Integer> idPool;
 
 	private final DataOutputStream out;
 
-	private byte[] buf;
+	private int formatVersion;
+	private Charset charset;
+	private boolean recycleIds;
 
 	public BinaryRDFWriter(OutputStream out) {
-		this(out, 100);
+		this(out, 8192);
 	}
 
 	public BinaryRDFWriter(OutputStream out, int bufferSize) {
 		this.out = new DataOutputStream(new BufferedOutputStream(out));
-		this.statementQueue = new ArrayBlockingQueue<>(bufferSize);
-		this.valueFreq = new HashMap<>(3 * bufferSize);
-		this.valueIdentifiers = new LinkedHashMap<>(bufferSize);
+		this.statementQueue = new ArrayDeque<>(bufferSize);
+		this.valueMeta = new HashMap<>(bufferSize * 3);
+		this.idPool = new ArrayDeque<>(bufferSize);
+		this.bufferSize = bufferSize;
 	}
 
 	@Override
 	public RDFFormat getRDFFormat() {
 		return RDFFormat.BINARY;
+	}
+
+	@Override
+	public Collection<RioSetting<?>> getSupportedSettings() {
+		Set<RioSetting<?>> result = new HashSet<>(super.getSupportedSettings());
+		result.add(BinaryRDFWriterSettings.VERSION);
+		result.add(BinaryRDFWriterSettings.BUFFER_SIZE);
+		result.add(BinaryRDFWriterSettings.CHARSET);
+		result.add(BinaryRDFWriterSettings.RECYCLE_IDS);
+		return result;
 	}
 
 	@Override
@@ -86,12 +115,40 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter, Byt
 	@Override
 	public void startRDF() throws RDFHandlerException {
 		super.startRDF();
+
+		handleWriterConfig();
+
 		try {
 			out.write(MAGIC_NUMBER);
-			out.writeInt(FORMAT_VERSION);
+			out.writeInt(formatVersion);
+
+			if (formatVersion != FORMAT_V1) {
+				byte[] charsetBytes = charset.toString().getBytes(charset);
+				writeInt(charsetBytes.length);
+				out.write(charsetBytes);
+			}
 		} catch (IOException e) {
 			throw new RDFHandlerException(e);
 		}
+	}
+
+	private void handleWriterConfig() {
+		WriterConfig config = getWriterConfig();
+
+		formatVersion = Math.toIntExact(config.get(BinaryRDFWriterSettings.VERSION));
+		if (formatVersion == FORMAT_V1) {
+			charset = StandardCharsets.UTF_16BE;
+		} else if (formatVersion == FORMAT_V2) {
+			charset = Charset.forName(config.get(BinaryRDFWriterSettings.CHARSET));
+		} else {
+			throw new IllegalArgumentException("Unsupported binary RDF version: " + formatVersion);
+		}
+
+		if (config.isSet(BinaryRDFWriterSettings.BUFFER_SIZE)) {
+			bufferSize = Math.toIntExact(config.get(BinaryRDFWriterSettings.BUFFER_SIZE));
+		}
+
+		recycleIds = config.get(BinaryRDFWriterSettings.RECYCLE_IDS);
 	}
 
 	@Override
@@ -139,7 +196,7 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter, Byt
 		incValueFreq(st.getObject());
 		incValueFreq(st.getContext());
 
-		if (statementQueue.remainingCapacity() > 0) {
+		if (statementQueue.size() < bufferSize) {
 			// postpone statement writing until queue is filled
 			return;
 		}
@@ -155,90 +212,71 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter, Byt
 	/** Writes the first statement from the statement queue */
 	private void writeStatement() throws RDFHandlerException, IOException {
 		Statement st = statementQueue.remove();
-		int subjId = getValueId(st.getSubject());
-		int predId = getValueId(st.getPredicate());
-		int objId = getValueId(st.getObject());
-		int contextId = getValueId(st.getContext());
-
-		decValueFreq(st.getSubject());
-		decValueFreq(st.getPredicate());
-		decValueFreq(st.getObject());
-		decValueFreq(st.getContext());
 
 		out.writeByte(STATEMENT);
-		writeValueOrId(st.getSubject(), subjId);
-		writeValueOrId(st.getPredicate(), predId);
-		writeValueOrId(st.getObject(), objId);
-		writeValueOrId(st.getContext(), contextId);
+		writeValueOrId(st.getSubject());
+		writeValueOrId(st.getPredicate());
+		writeValueOrId(st.getObject());
+		writeValueOrId(st.getContext());
 	}
 
 	private void incValueFreq(Value v) {
-		if (v != null) {
-			AtomicInteger freq = valueFreq.get(v);
-			if (freq != null) {
-				freq.incrementAndGet();
-			} else {
-				valueFreq.put(v, new AtomicInteger(1));
-			}
-		}
-	}
-
-	private void decValueFreq(Value v) {
-		if (v != null) {
-			AtomicInteger freq = valueFreq.get(v);
-			if (freq != null) {
-				int newFreq = freq.decrementAndGet();
-				if (newFreq == 0) {
-					valueFreq.remove(v);
-				}
-			}
-		}
-	}
-
-	private int getValueId(Value v) throws IOException, RDFHandlerException {
 		if (v == null) {
-			return -1;
+			return;
 		}
-		Integer id = valueIdentifiers.get(v);
-		if (id == null) {
-			// Assign an id if valueFreq >= 2
-			AtomicInteger freq = valueFreq.get(v);
-			if (freq != null && freq.get() >= 2) {
-				id = assignValueId(v);
+
+		ValueMeta meta = valueMeta.get(v);
+		if (meta == null) {
+			valueMeta.put(v, new ValueMeta(1));
+		} else {
+			meta.frequency++;
+			if (meta.frequency == 2 && !meta.hasId()) {
+				assignId(v, meta);
 			}
 		}
-		if (id != null) {
-			return id.intValue();
-		}
-		return -1;
 	}
 
-	private Integer assignValueId(Value v) throws IOException, RDFHandlerException {
-		// Check if a previous value can be overwritten
-		Integer id = null;
-		/*
-		 * FIXME: This loop is very slow for large datasets for (Value key : valueIdentifiers.keySet()) { if
-		 * (!valueFreq.containsKey(key)) { id = valueIdentifiers.remove(key); break; } }
-		 */
+	private void assignId(Value v, ValueMeta meta) {
+		Integer id = idPool.poll();
 		if (id == null) {
-			// no previous value could be overwritten
-			id = maxValueId.incrementAndGet();
+			id = nextId++; // get then increment
 		}
-		out.writeByte(BinaryRDFConstants.VALUE_DECL);
-		out.writeInt(id);
-		writeValue(v);
-		valueIdentifiers.put(v, id);
-		return id;
+
+		meta.id = id;
+
+		try {
+			out.writeByte(BinaryRDFConstants.VALUE_DECL);
+			writeInt(id);
+			writeValue(v);
+		} catch (IOException e) {
+			throw new RDFHandlerException(e);
+		}
 	}
 
-	private void writeValueOrId(Value value, int id) throws RDFHandlerException, IOException {
+	private void writeValueOrId(Value value) throws RDFHandlerException, IOException {
 		if (value == null) {
 			out.writeByte(NULL_VALUE);
-		} else if (id >= 0) {
-			out.writeByte(VALUE_REF);
-			out.writeInt(id);
 		} else {
-			writeValue(value);
+			ValueMeta meta = valueMeta.get(value);
+
+			if (meta.hasId()) {
+				out.writeByte(VALUE_REF);
+				writeInt(meta.id);
+			} else {
+				writeValue(value);
+			}
+
+			meta.frequency--;
+
+			if (meta.frequency == 0) {
+				if (!meta.hasId()) {
+					valueMeta.remove(value);
+				} else if (recycleIds) {
+					valueMeta.remove(value);
+					idPool.add(meta.id);
+				}
+				// else keep value and id
+			}
 		}
 	}
 
@@ -269,11 +307,15 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter, Byt
 	private void writeLiteral(Literal literal) throws IOException {
 		String label = literal.getLabel();
 		IRI datatype = literal.getDatatype();
+		Optional<String> language = literal.getLanguage();
 
-		if (Literals.isLanguageLiteral(literal)) {
+		if (language.isPresent()) {
 			out.writeByte(LANG_LITERAL_VALUE);
 			writeString(label);
-			writeString(literal.getLanguage().get());
+			writeString(language.get());
+		} else if (datatype.equals(XSD.STRING)) {
+			out.writeByte(PLAIN_LITERAL_VALUE);
+			writeString(label);
 		} else {
 			out.writeByte(DATATYPE_LITERAL_VALUE);
 			writeString(label);
@@ -289,19 +331,41 @@ public class BinaryRDFWriter extends AbstractRDFWriter implements RDFWriter, Byt
 	}
 
 	private void writeString(String s) throws IOException {
-		int strLen = s.length();
-		out.writeInt(strLen);
-		int stringBytes = strLen << 1;
-		if (buf == null || buf.length < stringBytes) {
-			buf = new byte[stringBytes << 1];
+		byte[] bytes = s.getBytes(charset);
+
+		if (formatVersion == FORMAT_V1) {
+			writeInt(s.length());
+		} else {
+			writeInt(bytes.length);
 		}
-		int pos = 0;
-		for (int i = 0; i < strLen; i++) {
-			char v = s.charAt(i);
-			buf[pos++] = (byte) ((v >>> 8) & 0xFF);
-			buf[pos++] = (byte) ((v >>> 0) & 0xFF);
+
+		out.write(bytes);
+	}
+
+	private void writeInt(int i) throws IOException {
+		if (formatVersion == FORMAT_V1) {
+			out.writeInt(i);
+		} else {
+			writeVarInt(out, i);
 		}
-		out.write(buf, 0, stringBytes);
+	}
+
+	/**
+	 * Holds the frequency of a value within the current {@link #statementQueue} as well as an identifier if any has
+	 * been assigned.
+	 */
+	private static class ValueMeta {
+
+		private long frequency;
+		private int id = -1;
+
+		public ValueMeta(long frequency) {
+			this.frequency = frequency;
+		}
+
+		private boolean hasId() {
+			return id != -1;
+		}
 	}
 
 }

--- a/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
+++ b/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BinaryRDFWriterSettings;
 
 /**
  * @author Arjohn Kampman
@@ -35,7 +36,12 @@ public class BinaryRDFWriterBackgroundTest extends RDFWriterTest {
 
 	@Override
 	protected RioSetting<?>[] getExpectedSupportedSettings() {
-		return new RioSetting[] {};
+		return new RioSetting[] {
+				BinaryRDFWriterSettings.VERSION,
+				BinaryRDFWriterSettings.BUFFER_SIZE,
+				BinaryRDFWriterSettings.CHARSET,
+				BinaryRDFWriterSettings.RECYCLE_IDS
+		};
 	}
 
 }

--- a/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterTest.java
+++ b/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.rio.binary;
 
 import org.eclipse.rdf4j.rio.RDFWriterTest;
 import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.helpers.BinaryRDFWriterSettings;
 
 /**
  * @author Arjohn Kampman
@@ -21,6 +22,11 @@ public class BinaryRDFWriterTest extends RDFWriterTest {
 
 	@Override
 	protected RioSetting<?>[] getExpectedSupportedSettings() {
-		return new RioSetting[] {};
+		return new RioSetting[] {
+				BinaryRDFWriterSettings.VERSION,
+				BinaryRDFWriterSettings.BUFFER_SIZE,
+				BinaryRDFWriterSettings.CHARSET,
+				BinaryRDFWriterSettings.RECYCLE_IDS
+		};
 	}
 }

--- a/core/util/pom.xml
+++ b/core/util/pom.xml
@@ -31,6 +31,16 @@
 			<version>${jmhVersion}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/util/src/test/java/org/eclipse/rdf4j/common/io/IOUtilTest.java
+++ b/core/util/src/test/java/org/eclipse/rdf4j/common/io/IOUtilTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.common.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+class IOUtilTest {
+
+	@Test
+	void shouldWriteVarInt() throws IOException {
+		// test some basic numbers
+		shouldWriteVarInt(0);
+		shouldWriteVarInt(1);
+		shouldWriteVarInt(2);
+		shouldWriteVarInt(Integer.MAX_VALUE);
+
+		// test all numbers up to 1048576
+		for (int i = 0; i < 1024 * 1024; i++) {
+			shouldWriteVarInt(i);
+		}
+
+		// test random positive integers
+		Random rng = new Random();
+		for (int i = 2; i < 10_000; i++) {
+			shouldWriteVarInt(rng.nextInt(Integer.MAX_VALUE));
+		}
+	}
+
+	private void shouldWriteVarInt(int value) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		IOUtil.writeVarInt(out, value);
+		byte[] bytes = out.toByteArray();
+
+		ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+		int read = IOUtil.readVarInt(in);
+
+		assertThat(value).isEqualTo(read);
+	}
+
+	@Test
+	void shouldRejectWritingNegativeVarInt() {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		assertThatThrownBy(() -> IOUtil.writeVarInt(out, -1))
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> IOUtil.writeVarInt(out, Integer.MIN_VALUE))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void shouldThrowEOFException() {
+		// the single byte in this array indicates that more bytes should follow in the varint format, but none will
+		ByteArrayInputStream in = new ByteArrayInputStream(new byte[] { -2 });
+
+		assertThatThrownBy(() -> IOUtil.readVarInt(in))
+				.isInstanceOf(EOFException.class);
+	}
+
+}

--- a/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/rio/RDFSizeBenchmarks.java
+++ b/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/rio/RDFSizeBenchmarks.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.benchmark.rio;
+
+import static java.nio.charset.StandardCharsets.UTF_16;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static org.apache.commons.io.output.NullOutputStream.NULL_OUTPUT_STREAM;
+import static org.eclipse.rdf4j.rio.helpers.BasicParserSettings.VERIFY_LANGUAGE_TAGS;
+import static org.eclipse.rdf4j.rio.helpers.BasicParserSettings.VERIFY_RELATIVE_URIS;
+import static org.eclipse.rdf4j.rio.helpers.BasicParserSettings.VERIFY_URI_SYNTAX;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.commons.io.output.CountingOutputStream;
+import org.eclipse.rdf4j.rio.ParserConfig;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.binary.BinaryRDFWriter;
+
+/**
+ * <p>This class benchmarks {@link RDFWriter}s in terms of output size given a number of datasets (see
+ * {@link RDFTestDataset}. The output of the benchmark is the output size in megabytes, the time for parsing the input
+ * dataset (!) and writing the output and a description of the writer used for each of the datasets.</p>
+ * <p>Please note that the datasets from {@link RDFTestDataset} are fairly large files</p>
+ * 
+ * @author Frens Jan Rumph
+ */
+public class RDFSizeBenchmarks {
+
+	public static void main(String[] args) throws IOException {
+		List<File> datasets = List.of(
+				RDFTestDataset.SWDF.download(),
+				RDFTestDataset.LEXVO.download(),
+				RDFTestDataset.DATAGOVBE.download(),
+				RDFTestDataset.FISHMARK.download(),
+				RDFTestDataset.SP2BENCH.download(),
+				RDFTestDataset.GENE2GO.download(),
+				RDFTestDataset.BSBM.download()
+		);
+
+		Map<String, Function<OutputStream, RDFWriter>> writers = new LinkedHashMap<>();
+		writers.put("binary, default settings", out -> new BinaryRDFWriter(out));
+		writers.put("binary, buffer size = 8k", out -> new BinaryRDFWriter(out, 8 * 1024));
+
+		for (File dataset : datasets) {
+			for (Map.Entry<String, Function<OutputStream, RDFWriter>> writer : writers.entrySet()) {
+				System.gc();
+				reportSize(dataset, writer.getKey(), writer.getValue());
+			}
+		}
+	}
+
+	private static void reportSize(File path, String description, Function<OutputStream, RDFWriter> writer)
+			throws IOException {
+		String fileName = path.getName();
+		RDFFormat format = Rio.getParserFormatForFileName(fileName)
+				.orElseThrow(() -> new IllegalArgumentException("No format available for " + fileName));
+		InputStream is = new BufferedInputStream(new FileInputStream(path));
+		reportSize(fileName, is, description, format, writer);
+	}
+
+	private static void reportSize(String dataset, InputStream is, String description, RDFFormat format,
+			Function<OutputStream, RDFWriter> writerConstructor) throws IOException {
+
+		CountingOutputStream os = new CountingOutputStream(NULL_OUTPUT_STREAM);
+		RDFWriter writer = writerConstructor.apply(os);
+
+		RDFParser parser = Rio.createParser(format);
+		parser.setRDFHandler(writer);
+		// Verification of datasets is disabled because of encoding issues in the input data and it's not a critical
+		// part of the benchmarking.
+		parser.setParserConfig(new ParserConfig()
+				.set(VERIFY_LANGUAGE_TAGS, false)
+				.set(VERIFY_RELATIVE_URIS, false)
+				.set(VERIFY_URI_SYNTAX, false));
+
+		Instant start = Instant.now();
+		try {
+			parser.parse(is);
+		} finally {
+			is.close();
+		}
+		Instant end = Instant.now();
+		Duration duration = Duration.between(start, end);
+
+		long size = os.getByteCount();
+		System.out.printf(
+				"%20s %8.2f MB in %-14s - %s%n",
+				dataset,
+				size / 1024 / 1024f,
+				duration,
+				description
+		);
+	}
+
+}

--- a/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/rio/RDFTestDataset.java
+++ b/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/rio/RDFTestDataset.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.benchmark.rio;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.eclipse.rdf4j.common.io.IOUtil;
+
+/**
+ * This enum holds locations for RDF files from the web. It allows downloading these into a a temporary location in
+ * {@code {java.io.tmpdir}/rdf4j-benchmark-datasets/{filename} }. Please note
+ *
+ * @author Frens Jan Rumph
+ */
+public enum RDFTestDataset {
+
+	/**
+	 * <p>
+	 * A dump of the <a href="http://wifo5-03.informatik.uni-mannheim.de/bizer/berlinsparqlbenchmark/">Berlin SPARQL
+	 * Benchmark</a> made available by the <a href="https://project-hobbit.eu">HOBBIT project</a>.
+	 * </p>
+	 * <p>
+	 * 25 GB extracted.
+	 * </p>
+	 */
+	BSBM("bsbm.nt", "dataset.nt",
+			"https://hobbitdata.informatik.uni-leipzig.de/benchmarks-data/datasets-dumps/bsbm-dump.zip"),
+	/**
+	 * <p>
+	 * A dump of the <a href="http://owl.cs.manchester.ac.uk/publications/supporting-material/fishmark/">FishMark</a>
+	 * benchmark made available by the <a href="https://project-hobbit.eu">HOBBIT project</a>.
+	 * </p>
+	 * <p>
+	 * 1.8 GB extracted
+	 * </p>
+	 */
+	FISHMARK("fishmark.nt", "fishmark-size1.nt",
+			"https://hobbitdata.informatik.uni-leipzig.de/benchmarks-data/datasets-dumps/fishmark-dump.zip"),
+
+	/**
+	 * <p>
+	 * A dump of the
+	 * <a href="http://borneo.informatik.uni-freiburg.de/content/publikationen/papers/sp2b.pdf">SP2Bench</a> benchmark
+	 * made available by the <a href="https://project-hobbit.eu">HOBBIT project</a>.
+	 * </p>
+	 * <p>
+	 * 2.7 GB extracted
+	 * </p>
+	 */
+	SP2BENCH("sp2b.n3", "sp2b.n3",
+			"https://hobbitdata.informatik.uni-leipzig.de/benchmarks-data/datasets-dumps/sp2bench-dump.zip"),
+
+	/**
+	 * <p>
+	 * A dump of the Semantic Web Dog Food dataset made available by the <a href="https://project-hobbit.eu">HOBBIT
+	 * project</a>.
+	 * </p>
+	 * <p>
+	 * 49 MB extracted
+	 * </p>
+	 */
+	SWDF("swdf.nt", "SWDF.nt",
+			"https://hobbitdata.informatik.uni-leipzig.de/benchmarks-data/datasets-dumps/swdf-dump.zip"),
+
+	/**
+	 * <p>
+	 * A dump of the gene database of National Center for Biotechnology Information made available by the
+	 * <a href="https://bio2rdf.org">Bio2RDF project</a>.
+	 * </p>
+	 * <p>
+	 * 5.6 GB extracted
+	 * </p>
+	 */
+	GENE2GO("gene2go.nq",
+			"https://download.bio2rdf.org/files/release/3/ncbigene/gene2go.nq.gz"),
+
+	/**
+	 * <p>
+	 * A dump of the <a href="http://www.lexvo.org/">Lexvo.org</a> data.
+	 * </p>
+	 * <p>
+	 * 67 MB extracted
+	 * </p>
+	 */
+	LEXVO("lexvo_latest.rdf",
+			"http://www.lexvo.org/resources/lexvo_latest.rdf.gz"),
+
+	/**
+	 * <p>
+	 * A Data Catalogue Vocabulary file from <a href="https://github.com/Fedict/dcat">Federal Public Service Policy and
+	 * Support DG Digital Transformation</a>'s github repository.
+	 * </p>
+	 * <p>
+	 * 139 MB extracted
+	 * </p>
+	 */
+	DATAGOVBE("datagovbe.nt",
+			"https://github.com/Fedict/dcat/raw/master/all/datagovbe.nt.gz");
+
+	/**
+	 * Name of the target file.
+	 */
+	private final String fileName;
+
+	/**
+	 * Name of the file to extract from the archive; {@code null} if the file is not part of a multi file archive (e.g.
+	 * ZIP file).
+	 */
+	private final String archiveEntryName;
+
+	/**
+	 * The {@link URL} to download the file from.
+	 */
+	private final URL url;
+
+	RDFTestDataset(String fileName, String url) {
+		this(fileName, null, url);
+	}
+
+	RDFTestDataset(String fileName, String archiveEntryName, String url) {
+		this.archiveEntryName = archiveEntryName;
+		this.fileName = fileName;
+		try {
+			this.url = new URL(url);
+		} catch (MalformedURLException e) {
+			throw new RuntimeException("Statically defiled URL " + url + " is unexpectedly malformed", e);
+		}
+	}
+
+	/**
+	 * Download the dataset file to {@code {java.io.tmpdir}/rdf4j-benchmark-datasets/{fileName}}.
+	 * 
+	 * @return The {@link File} to which the dataset was downloaded and extracted.
+	 */
+	public File download() {
+		File downloadDir = new File(System.getProperty("java.io.tmpdir"), "rdf4j-benchmark-datasets");
+
+		File dataFile = new File(downloadDir, fileName);
+		if (dataFile.exists()) {
+			return dataFile;
+		}
+
+		try {
+			Files.createDirectories(downloadDir.toPath());
+			File downloadFile = new File(downloadDir, Paths.get(url.getPath()).getFileName().toString());
+
+			if (!downloadFile.exists()) {
+				downloadTo(downloadFile);
+			}
+
+			if (!downloadFile.equals(dataFile)) {
+				extract(downloadFile, dataFile);
+				downloadFile.delete();
+			}
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+
+		return dataFile;
+	}
+
+	private void downloadTo(File downloadFile) throws IOException {
+		System.out.println("Downloading " + url);
+		try (InputStream is = new BufferedInputStream(url.openStream())) {
+			IOUtil.transfer(is, downloadFile);
+		}
+	}
+
+	private void extract(File downloadFile, File dataFile) throws IOException {
+		String downloadFileName = downloadFile.getName();
+		if (downloadFileName.endsWith(".zip")) {
+			extractFromZip(downloadFile, dataFile);
+		} else if (downloadFileName.endsWith(".gz")) {
+			extractFromGzip(downloadFile, dataFile);
+		}
+	}
+
+	private void extractFromZip(File downloadFile, File dataFile) throws IOException {
+		System.out.println("Extracting " + archiveEntryName + " from " + downloadFile + " to " + dataFile.getName());
+		try (ZipFile zf = new ZipFile(downloadFile)) {
+			ZipEntry entry = zf.getEntry(archiveEntryName);
+
+			try (InputStream in = zf.getInputStream(entry)) {
+				IOUtil.writeStream(in, dataFile);
+			}
+		}
+	}
+
+	private void extractFromGzip(File downloadFile, File dataFile) throws IOException {
+		System.out.println("Extracting " + downloadFile + " to " + dataFile.getName());
+		GZIPInputStream in = new GZIPInputStream(new FileInputStream(downloadFile));
+		IOUtil.writeStream(in, dataFile);
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #3010

Briefly describe the changes proposed in this PR:

Added a parser and writer second version of the binary RDF format with backwards compatibility with version 1. Notable changes in this version are the default use of UTF-8, variable length integers for string lengths and value identifiers and a larger default statement queue.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
----