### PR TITLE
Fixes GH-3053 Correct handling of zero-or-one case with sub-select.

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -1545,7 +1545,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 				pelist.addElement(pe);
 			}
 
-			return new Distinct(new Projection(zeroOne, pelist));
+			return new Distinct(new Projection(zeroOne, pelist, false));
 		}
 
 		// nothing to modify

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
@@ -7,9 +7,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory;
 
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
+import org.eclipse.rdf4j.query.parser.QueryParserUtil;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.RDFNotifyingStoreTest;
 import org.eclipse.rdf4j.sail.SailException;
+import org.junit.Test;
 
 /**
  * An extension of RDFStoreTest for testing the class <tt>org.eclipse.rdf4j.sesame.sail.memory.MemoryStore</tt>.
@@ -25,4 +37,33 @@ public class MemoryStoreTest extends RDFNotifyingStoreTest {
 		NotifyingSail sail = new MemoryStore();
 		return sail;
 	}
+
+	/**
+	 * reproduces GH-3053
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testZeroOrOnePropPathNonExisting() throws Exception {
+		ParsedTupleQuery tupleQuery = (ParsedTupleQuery) QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL,
+				"SELECT ?resource WHERE {\n" +
+						"    <http://unexisting_resource> (^(<http://predicate_a>)*) / <http://predicate_b>? ?resource\n"
+						+
+						"}",
+				"http://base.org/");
+		CloseableIteration<? extends BindingSet, QueryEvaluationException> res = con.evaluate(tupleQuery.getTupleExpr(),
+				null, EmptyBindingSet.getInstance(), false);
+		assertTrue("expect a result", res.hasNext());
+		int count = 0;
+		while (res.hasNext()) {
+			BindingSet bs = res.next();
+			Value v = bs.getValue("resource");
+			assertTrue("expect non-null value", v != null);
+			assertTrue("expect IRI", v instanceof IRI);
+			assertTrue("expect <http://unexisting_resource>", "http://unexisting_resource".equals(v.stringValue()));
+			count++;
+		}
+		assertTrue("expect single solution", count == 1);
+	}
+
 }


### PR DESCRIPTION
- make sure the projection is not a sub-select using proper consturctor in `TupleExprBuilder`
- added test cases.

Signed-off-by: damyan.ognyanov <damyan.ognyanov@ontotext.com>


GitHub issue resolved: #3053

Briefly describe the changes proposed in this PR:

make use of `subselect` argument of constructor so the external bound vars are visible

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

