### PR TITLE
GH-2046 use JDK 11 as the minimal java version

### DIFF
--- a/.github/workflows/develop-status.yml
+++ b/.github/workflows/develop-status.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest    
     strategy:
       matrix:
-        jdk: [1.8, 15]
+        jdk: [11, 15]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/main-status.yml
+++ b/.github/workflows/main-status.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest    
     strategy:
       matrix:
-        jdk: [1.8, 15]
+        jdk: [11, 15]
 
     steps:
     - uses: actions/checkout@v1
@@ -27,6 +27,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-
     - name: Build
-      run: mvn -B -T 2 clean install -Pquick,\!formatting 
+      run: mvn -B -T 2 clean install -Pquick,-formatting 
     - name: Run all tests
-      run: mvn -B verify -P\!skipSlowTests,\!formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true
+      run: mvn -B verify -P-skipSlowTests,-formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [1.8, 15]
+        jdk: [11, 15]
     steps:
     - uses: actions/checkout@v1
     - name: Set up JDK
@@ -42,14 +42,14 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-jdk1.8-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-jdk11-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-jdk1.8-maven-
+          ${{ runner.os }}-jdk11-maven-
     - name: Check formatting
       run: mvn -B formatter:validate impsort:check xml-format:xml-check
     - name: Build
@@ -73,14 +73,14 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache local Maven repository
       uses: actions/cache@v2
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-jdk1.8-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-jdk11-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-jdk1.8-maven-
+          ${{ runner.os }}-jdk11-maven-
     - name: Check formatting
       run: mvn -B formatter:validate impsort:check xml-format:xml-check
     - name: Build

--- a/pom.xml
+++ b/pom.xml
@@ -684,8 +684,8 @@
 					<version>3.7.0</version>
 					<configuration>
 						<fork>true</fork>
-						<source>1.8</source>
-						<target>1.8</target>
+						<source>11</source>
+						<target>11</target>
 						<encoding>utf8</encoding>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
GitHub issue resolved: #2046  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- update maven compiler settings to use Java 11
- update all github action configs to use Java 11

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

