### PR TITLE
GH-3083 run jdk 11 build for main branch to enable sync with develop

### DIFF
--- a/.github/workflows/main-status.yml
+++ b/.github/workflows/main-status.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest    
     strategy:
       matrix:
-        jdk: [1.8, 15]
+        jdk: [1.8, 11, 15]
 
     steps:
     - uses: actions/checkout@v1
@@ -27,6 +27,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-jdk${{ matrix.jdk }}-maven-
     - name: Build
-      run: mvn -B -T 2 clean install -Pquick,\!formatting 
+      run: mvn -B -T 2 clean install -Pquick,-formatting 
     - name: Run all tests
-      run: mvn -B verify -P\!skipSlowTests,\!formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true
+      run: mvn -B verify -P-skipSlowTests,-formatting -Dmaven.javadoc.skip=true -Djapicmp.skip -Denforcer.skip=true -Danimal.sniffer.skip=true


### PR DESCRIPTION
GitHub issue resolved: #3083  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added jdk 11 to the matrix build so that required job for merging into develop is run, unblocking PR #3082 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

