### PR TITLE
GH-3091 do not inline values when part of right arg of leftjoin

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInliner.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInliner.java
@@ -7,9 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
@@ -67,8 +65,6 @@ public class BindingSetAssignmentInliner implements QueryOptimizer {
 		public void meet(LeftJoin leftJoin) {
 			leftJoin.getLeftArg().visit(this);
 			// we can not pre-bind values for the optional part of the left-join
-			bindingSet = null;
-			leftJoin.getRightArg().visit(this);
 		}
 
 		@Override

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInlinerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/BindingSetAssignmentInlinerTest.java
@@ -12,8 +12,11 @@ import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
+import org.eclipse.rdf4j.query.algebra.Bound;
 import org.eclipse.rdf4j.query.algebra.Difference;
 import org.eclipse.rdf4j.query.algebra.Exists;
+import org.eclipse.rdf4j.query.algebra.Extension;
+import org.eclipse.rdf4j.query.algebra.ExtensionElem;
 import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.LeftJoin;
@@ -117,6 +120,42 @@ public class BindingSetAssignmentInlinerTest extends QueryOptimizerTest {
 		Var o2 = ((StatementPattern) optional.getRightArg()).getObjectVar();
 		assertThat(o2.getName()).isEqualTo("o2");
 		assertThat(o2.getValue()).isNull();
+	}
+
+	/**
+	 * @see https://github.com/eclipse/rdf4j/issues/3091
+	 */
+	@Test
+	public void testOptimize_LeftJoinWithValuesInScope() {
+		String query = "SELECT ?datasetBound {\n"
+				+ "  OPTIONAL {\n"
+				+ "    VALUES(?dataset ?uriSpace) {\n"
+				+ "       (<http://example.org/void.ttl#FOAF> \"http://xmlns.com/foaf/0.1/\")  \n"
+				+ "    }\n"
+				+ "    FILTER(STRSTARTS(STR(<http://example.com>), ?uriSpace))\n"
+				+ "  }\n"
+				+ "  BIND(BOUND(?dataset) as ?datasetBound)\n"
+				+ "}";
+
+		ParsedTupleQuery parsedQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL, query, null);
+
+		QueryOptimizer optimizer = getOptimizer();
+		optimizer.optimize(parsedQuery.getTupleExpr(), new SimpleDataset(), EmptyBindingSet.getInstance());
+
+		TupleExpr optimizedTree = parsedQuery.getTupleExpr();
+
+		assertThat(optimizedTree).isInstanceOf(Projection.class);
+		Projection projection = (Projection) optimizedTree;
+
+		Extension extension = (Extension) projection.getArg();
+		assertThat(extension.getArg()).isInstanceOf(LeftJoin.class);
+		ExtensionElem elem = extension.getElements().iterator().next();
+		Bound bound = (Bound) elem.getExpr();
+
+		Var datasetVar = bound.getArg();
+		assertThat(datasetVar.getName()).isEqualTo("dataset");
+		assertThat(datasetVar.getValue()).isNull();
+
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #3091 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- avoid inlining values clause assignment inside an optional clause
- added regression test

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

