### PR TITLE
GH-3088 various optimizations for sh:or

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/ListBindingSet.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/ListBindingSet.java
@@ -28,6 +28,7 @@ public class ListBindingSet extends AbstractBindingSet {
 	private static final long serialVersionUID = -2907809218835403743L;
 
 	private final List<String> bindingNames;
+	private Set<String> bindingNamesSetCache;
 
 	private final List<? extends Value> values;
 
@@ -60,7 +61,10 @@ public class ListBindingSet extends AbstractBindingSet {
 
 	@Override
 	public Set<String> getBindingNames() {
-		return new LinkedHashSet<>(bindingNames);
+		if (bindingNamesSetCache == null) {
+			bindingNamesSetCache = new LinkedHashSet<>(bindingNames);
+		}
+		return bindingNamesSetCache;
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/NodeShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/NodeShape.java
@@ -210,7 +210,7 @@ public class NodeShape extends Shape implements ConstraintComponent, Identifiabl
 		planNode = new UnionNode(planNode,
 				getTargetChain()
 						.getEffectiveTarget("_target", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-						.getPlanNode(connectionsGroup, Scope.nodeShape, true));
+						.getPlanNode(connectionsGroup, Scope.nodeShape, true, null));
 
 		if (scope == Scope.propertyShape) {
 			planNode = new Unique(new ShiftToPropertyShape(planNode), true);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/NodeShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/NodeShape.java
@@ -7,11 +7,9 @@
  ******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.ast;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
@@ -159,10 +157,10 @@ public class NodeShape extends Shape implements ConstraintComponent, Identifiabl
 			Scope scope) {
 
 		if (isDeactivated()) {
-			return new EmptyNode();
+			return EmptyNode.getInstance();
 		}
 
-		PlanNode union = new EmptyNode();
+		PlanNode union = EmptyNode.getInstance();
 
 		for (ConstraintComponent constraintComponent : constraintComponents) {
 			PlanNode validationPlanNode = constraintComponent
@@ -205,8 +203,9 @@ public class NodeShape extends Shape implements ConstraintComponent, Identifiabl
 
 		PlanNode planNode = constraintComponents.stream()
 				.map(c -> c.getAllTargetsPlan(connectionsGroup, Scope.nodeShape))
+				.distinct()
 				.reduce(UnionNode::new)
-				.orElse(new EmptyNode());
+				.orElse(EmptyNode.getInstance());
 
 		planNode = new UnionNode(planNode,
 				getTargetChain()
@@ -236,11 +235,12 @@ public class NodeShape extends Shape implements ConstraintComponent, Identifiabl
 	@Override
 	public SparqlFragment buildSparqlValidNodes_rsx_targetShape(StatementMatcher.Variable subject,
 			StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 
 		List<SparqlFragment> sparqlFragments = constraintComponents.stream()
 				.map(shape -> shape.buildSparqlValidNodes_rsx_targetShape(subject, object, rdfsSubClassOfReasoner,
-						Scope.nodeShape))
+						Scope.nodeShape, stableRandomVariableProvider))
 				.collect(Collectors.toList());
 
 		if (SparqlFragment.isFilterCondition(sparqlFragments)) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
@@ -7,12 +7,9 @@
  ******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.ast;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
@@ -173,15 +170,15 @@ public class PropertyShape extends Shape implements ConstraintComponent, Identif
 			Scope scope) {
 
 		if (isDeactivated()) {
-			return new EmptyNode();
+			return EmptyNode.getInstance();
 		}
 
-		PlanNode union = new EmptyNode();
+		PlanNode union = EmptyNode.getInstance();
 
 //		if (negatePlan) {
 //			assert overrideTargetNode == null : "Negated property shape with override target is not supported at the moment!";
 //
-//			PlanNode ret = new EmptyNode();
+//			PlanNode ret = EmptyNode.getInstance();
 //
 //			for (ConstraintComponent constraintComponent : constraintComponents) {
 //				PlanNode planNode = constraintComponent.generateTransactionalValidationPlan(connectionsGroup,
@@ -236,8 +233,9 @@ public class PropertyShape extends Shape implements ConstraintComponent, Identif
 	public PlanNode getAllTargetsPlan(ConnectionsGroup connectionsGroup, Scope scope) {
 		PlanNode planNode = constraintComponents.stream()
 				.map(c -> c.getAllTargetsPlan(connectionsGroup, Scope.propertyShape))
+				.distinct()
 				.reduce(UnionNode::new)
-				.orElse(new EmptyNode());
+				.orElse(EmptyNode.getInstance());
 
 		planNode = new UnionNode(planNode,
 				getTargetChain()
@@ -282,11 +280,13 @@ public class PropertyShape extends Shape implements ConstraintComponent, Identif
 	@Override
 	public SparqlFragment buildSparqlValidNodes_rsx_targetShape(StatementMatcher.Variable subject,
 			StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 
 		List<SparqlFragment> sparqlFragments = constraintComponents.stream()
 				.map(shape -> shape.buildSparqlValidNodes_rsx_targetShape(object,
-						StatementMatcher.Variable.getRandomInstance(), rdfsSubClassOfReasoner, Scope.propertyShape))
+						stableRandomVariableProvider.next(), rdfsSubClassOfReasoner, Scope.propertyShape,
+						stableRandomVariableProvider))
 				.collect(Collectors.toList());
 
 		if (SparqlFragment.isFilterCondition(sparqlFragments)) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
@@ -241,7 +241,7 @@ public class PropertyShape extends Shape implements ConstraintComponent, Identif
 				getTargetChain()
 						.getEffectiveTarget("_target", Scope.propertyShape,
 								connectionsGroup.getRdfsSubClassOfReasoner())
-						.getPlanNode(connectionsGroup, Scope.propertyShape, true));
+						.getPlanNode(connectionsGroup, Scope.propertyShape, true, null));
 
 		if (scope == Scope.propertyShape) {
 			planNode = new Unique(new TargetChainPopper(planNode), true);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ShaclAstLists.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ShaclAstLists.java
@@ -26,13 +26,13 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 /**
  * Internal utility methods for the SHACL AST to quickly convert between java collections and RDF collections. These
  * utilities are not meant for general use as they make several simplifying assumptions for performance reasons:
- * 
+ *
  * <ul>
  * <li>they add type coercion
  * <Li>they rely on the use of "stable" identifiers for blank nodes, so that duplicates can be quickly detected and
  * discarded
  * </ul>
- * 
+ *
  * @apiNote This feature is for internal use only: its existence, signature or behavior may change without warning from
  *          one release to the next.
  */

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ShaclProperties.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ShaclProperties.java
@@ -49,7 +49,7 @@ public class ShaclProperties {
 	private Long minCount;
 	private Long maxCount;
 
-	private Resource datatype;
+	private IRI datatype;
 	private Resource in;
 	private final List<Value> hasValue = new ArrayList<>();
 	private final List<Resource> hasValueIn = new ArrayList<>();
@@ -148,7 +148,7 @@ public class ShaclProperties {
 					if (datatype != null) {
 						throw new IllegalStateException(predicate + " already populated");
 					}
-					datatype = (Resource) object;
+					datatype = (IRI) object;
 					break;
 				case "http://www.w3.org/ns/shacl#minCount":
 					if (minCount != null) {
@@ -335,7 +335,7 @@ public class ShaclProperties {
 		return maxCount;
 	}
 
-	public Resource getDatatype() {
+	public IRI getDatatype() {
 		return datatype;
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/Shape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/Shape.java
@@ -23,7 +23,6 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.DynamicModel;
 import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
-import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.DASH;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RSX;
@@ -396,7 +395,7 @@ abstract public class Shape implements ConstraintComponent, Identifiable, Export
 				return Shape.this.generateTransactionalValidationPlan(connectionsGroup, logValidationPlans, null,
 						Scope.none);
 			} else {
-				return new EmptyNode();
+				return EmptyNode.getInstance();
 			}
 
 		} else {
@@ -430,7 +429,8 @@ abstract public class Shape implements ConstraintComponent, Identifiable, Export
 	 */
 	public SparqlFragment buildSparqlValidNodes_rsx_targetShape(StatementMatcher.Variable subject,
 			StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		throw new UnsupportedOperationException(this.getClass().getSimpleName());
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/StatementMatcher.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/StatementMatcher.java
@@ -170,6 +170,24 @@ public class StatementMatcher {
 		return Objects.hash(subjectName, subjectValue, predicateName, predicateValue, objectName, objectValue);
 	}
 
+	public static class StableRandomVariableProvider {
+		private static final String BASE = UUID.randomUUID().toString().replace("-", "") + "_"; // We just need a random
+																								// base that isn't used
+																								// elsewhere in the
+																								// ShaclSail, but we
+																								// don't want it to be
+																								// stable so we can
+																								// compare the SPARQL
+																								// queries where these
+																								// variables are used
+		private int counter = 0;
+
+		public Variable next() {
+			return new Variable(BASE + counter++);
+		}
+
+	}
+
 	public static class Variable {
 		String name;
 		Value value;
@@ -199,8 +217,11 @@ public class StatementMatcher {
 			return name == null && value == null;
 		}
 
-		public static Variable getRandomInstance() {
-			return new Variable(UUID.randomUUID().toString().replace("-", ""));
+		public String asSparqlVariable() {
+			if (value != null)
+				throw new IllegalStateException(
+						"Can not produce SPARQL variable for variables that have fixed values!");
+			return "?" + name.replace("-", "__");
 		}
 
 		@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/StatementMatcher.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/StatementMatcher.java
@@ -171,15 +171,11 @@ public class StatementMatcher {
 	}
 
 	public static class StableRandomVariableProvider {
-		private static final String BASE = UUID.randomUUID().toString().replace("-", "") + "_"; // We just need a random
-																								// base that isn't used
-																								// elsewhere in the
-																								// ShaclSail, but we
-																								// don't want it to be
-																								// stable so we can
-																								// compare the SPARQL
-																								// queries where these
-																								// variables are used
+
+		// We just need a random base that isn't used elsewhere in the ShaclSail, but we don't want it to be stable so
+		// we can compare the SPARQL queries where these variables are used
+		private static final String BASE = UUID.randomUUID().toString().replace("-", "") + "_";
+
 		private int counter = 0;
 
 		public Variable next() {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/Targetable.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/Targetable.java
@@ -17,6 +17,7 @@ public interface Targetable {
 			RdfsSubClassOfReasoner rdfsSubClassOfReasoner);
 
 	String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner);
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider);
 
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ValidationQuery.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/ValidationQuery.java
@@ -223,7 +223,7 @@ public class ValidationQuery {
 
 		@Override
 		public PlanNode getValidationPlan(SailConnection baseConnection) {
-			return new EmptyNode();
+			return EmptyNode.getInstance();
 		}
 
 		@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AbstractConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AbstractConstraintComponent.java
@@ -1,7 +1,5 @@
 package org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents;
 
-import java.util.UUID;
-
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.RdfsSubClassOfReasoner;
@@ -60,7 +58,7 @@ public abstract class AbstractConstraintComponent implements ConstraintComponent
 			boolean logValidationPlans, PlanNodeProvider overrideTargetNode,
 			Scope scope) {
 		logger.error("Transactional validation for {} has not been implemented", getConstraintComponent());
-		return new EmptyNode();
+		return EmptyNode.getInstance();
 	}
 
 	@Override
@@ -87,12 +85,9 @@ public abstract class AbstractConstraintComponent implements ConstraintComponent
 	@Override
 	public SparqlFragment buildSparqlValidNodes_rsx_targetShape(StatementMatcher.Variable subject,
 			StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		throw new UnsupportedOperationException(this.getClass().getSimpleName());
-	}
-
-	static String randomSparqlVariable() {
-		return "?" + UUID.randomUUID().toString().replace("-", "");
 	}
 
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AndConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AndConstraintComponent.java
@@ -23,7 +23,6 @@ import org.eclipse.rdf4j.sail.shacl.ast.Shape;
 import org.eclipse.rdf4j.sail.shacl.ast.SparqlFragment;
 import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
 import org.eclipse.rdf4j.sail.shacl.ast.ValidationQuery;
-import org.eclipse.rdf4j.sail.shacl.ast.paths.Path;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.EmptyNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNodeProvider;
@@ -98,7 +97,7 @@ public class AndConstraintComponent extends LogicalOperatorConstraintComponent {
 				.map(a -> a.generateTransactionalValidationPlan(connectionsGroup, logValidationPlans,
 						overrideTargetNode, scope))
 				.reduce(UnionNode::new)
-				.orElse(new EmptyNode());
+				.orElse(EmptyNode.getInstance());
 
 		return new Unique(planNode, false);
 
@@ -108,8 +107,9 @@ public class AndConstraintComponent extends LogicalOperatorConstraintComponent {
 	public PlanNode getAllTargetsPlan(ConnectionsGroup connectionsGroup, Scope scope) {
 		PlanNode planNode = and.stream()
 				.map(c -> c.getAllTargetsPlan(connectionsGroup, scope))
+				.distinct()
 				.reduce(UnionNode::new)
-				.orElse(new EmptyNode());
+				.orElse(EmptyNode.getInstance());
 
 		planNode = new Unique(planNode, false);
 
@@ -135,9 +135,11 @@ public class AndConstraintComponent extends LogicalOperatorConstraintComponent {
 	@Override
 	public SparqlFragment buildSparqlValidNodes_rsx_targetShape(StatementMatcher.Variable subject,
 			StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner, Scope scope,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 
-		return buildSparqlValidNodes_rsx_targetShape_inner(subject, object, rdfsSubClassOfReasoner, scope, and,
+		return buildSparqlValidNodes_rsx_targetShape_inner(subject, object, rdfsSubClassOfReasoner, scope,
+				stableRandomVariableProvider, and,
 				getTargetChain(),
 				SparqlFragment::join, SparqlFragment::and);
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
@@ -2,7 +2,6 @@ package org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -56,6 +55,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 	@Override
 	public PlanNode generateTransactionalValidationPlan(ConnectionsGroup connectionsGroup, boolean logValidationPlans,
 			PlanNodeProvider overrideTargetNode, Scope scope) {
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
 		EffectiveTarget target = getTargetChain().getEffectiveTarget("_target", scope,
 				connectionsGroup.getRdfsSubClassOfReasoner());
@@ -106,7 +106,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 					addedTargets,
 					connectionsGroup.getBaseConnection(),
 					path.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
-							connectionsGroup.getRdfsSubClassOfReasoner()),
+							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 					false,
 					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)
@@ -196,7 +196,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 
 			return new Unique(new TrimToTarget(new ShiftToPropertyShape(allTargetsPlan)), false);
 		}
-		PlanNode allTargetsPlan = new EmptyNode();
+		PlanNode allTargetsPlan = EmptyNode.getInstance();
 
 		// removed type statements that match clazz could affect sh:or
 		if (connectionsGroup.getStats().hasRemoved()) {
@@ -241,6 +241,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 			boolean logValidationPlans, boolean negatePlan, boolean negateChildren, Scope scope) {
 
 		String targetVarPrefix = "target_";
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
 		EffectiveTarget effectiveTarget = getTargetChain().getEffectiveTarget(targetVarPrefix, scope,
 				connectionsGroup.getRdfsSubClassOfReasoner());
@@ -261,7 +262,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 
 			String pathQuery = getTargetChain().getPath()
 					.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
-							connectionsGroup.getRdfsSubClassOfReasoner()))
+							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider))
 					.orElseThrow(IllegalStateException::new);
 
 			query += pathQuery;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
@@ -68,16 +68,17 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 			if (overrideTargetNode != null) {
 				addedTargets = overrideTargetNode.getPlanNode();
 				addedTargets = target.extend(addedTargets, connectionsGroup, scope, EffectiveTarget.Extend.right,
-						false);
+						false, null);
 
 			} else {
-				addedTargets = target.getPlanNode(connectionsGroup, scope, false);
+				addedTargets = target.getPlanNode(connectionsGroup, scope, false, null);
 				PlanNode addedByPath = path.getAdded(connectionsGroup, null);
 
 				addedByPath = target.getTargetFilter(connectionsGroup,
 						new Unique(new TrimToTarget(addedByPath), false));
 
-				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false);
+				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
+						null);
 
 				if (connectionsGroup.getStats().hasRemoved()) {
 					PlanNode deletedTypes = new UnorderedSelect(connectionsGroup.getRemovedStatements(), null, RDF.TYPE,
@@ -87,7 +88,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 							.getEffectiveTarget("target_", Scope.nodeShape,
 									connectionsGroup.getRdfsSubClassOfReasoner())
 							.extend(deletedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left,
-									false);
+									false, null);
 
 					deletedTypes = getTargetChain()
 							.getEffectiveTarget("target_", Scope.nodeShape,
@@ -130,9 +131,9 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 			if (overrideTargetNode != null) {
 				addedTargets = overrideTargetNode.getPlanNode();
 				addedTargets = target.extend(addedTargets, connectionsGroup, scope, EffectiveTarget.Extend.right,
-						false);
+						false, null);
 			} else {
-				addedTargets = target.getPlanNode(connectionsGroup, scope, false);
+				addedTargets = target.getPlanNode(connectionsGroup, scope, false, null);
 
 				if (connectionsGroup.getStats().hasRemoved()) {
 					PlanNode deletedTypes = new UnorderedSelect(connectionsGroup.getRemovedStatements(), null, RDF.TYPE,
@@ -142,7 +143,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 							.getTargetFilter(connectionsGroup, deletedTypes);
 					deletedTypes = getTargetChain()
 							.getEffectiveTarget("target_", scope, connectionsGroup.getRdfsSubClassOfReasoner())
-							.extend(deletedTypes, connectionsGroup, scope, EffectiveTarget.Extend.left, false);
+							.extend(deletedTypes, connectionsGroup, scope, EffectiveTarget.Extend.left, false, null);
 					addedTargets = new UnionNode(addedTargets, new TrimToTarget(deletedTypes));
 				}
 			}
@@ -166,7 +167,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 		if (scope == Scope.propertyShape) {
 			PlanNode allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, Scope.nodeShape, true);
+					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
 			// removed type statements that match clazz could affect sh:or
 			if (connectionsGroup.getStats().hasRemoved()) {
@@ -177,7 +178,8 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 						.getTargetFilter(connectionsGroup, deletedTypes);
 				deletedTypes = getTargetChain()
 						.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-						.extend(deletedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false);
+						.extend(deletedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false,
+								null);
 				allTargetsPlan = new UnionNode(allTargetsPlan, deletedTypes);
 			}
 
@@ -190,7 +192,8 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 						.getTargetFilter(connectionsGroup, addedTypes);
 				addedTypes = getTargetChain()
 						.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-						.extend(addedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false);
+						.extend(addedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false,
+								null);
 				allTargetsPlan = new UnionNode(allTargetsPlan, addedTypes);
 			}
 
@@ -207,7 +210,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 					.getTargetFilter(connectionsGroup, deletedTypes);
 			deletedTypes = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.extend(deletedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false);
+					.extend(deletedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false, null);
 			allTargetsPlan = new UnionNode(allTargetsPlan, deletedTypes);
 
 		}
@@ -221,7 +224,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 					.getTargetFilter(connectionsGroup, addedTypes);
 			addedTypes = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.extend(addedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false);
+					.extend(addedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false, null);
 			allTargetsPlan = new UnionNode(allTargetsPlan, addedTypes);
 
 		}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ConstraintComponent.java
@@ -1,8 +1,5 @@
 package org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents;
 
-import java.util.Set;
-import java.util.stream.Stream;
-
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.RdfsSubClassOfReasoner;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -51,7 +48,7 @@ public interface ConstraintComponent extends Exportable, TargetChainInterface {
 	SparqlFragment buildSparqlValidNodes_rsx_targetShape(StatementMatcher.Variable subject,
 			StatementMatcher.Variable object,
 			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
-			Scope scope);
+			Scope scope, StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider);
 
 	enum Scope {
 		none,

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
@@ -84,14 +84,15 @@ public class DashHasValueInConstraintComponent extends AbstractConstraintCompone
 				addedTargets = overrideTargetNode.getPlanNode();
 
 				addedTargets = target.extend(addedTargets, connectionsGroup, scope, EffectiveTarget.Extend.right,
-						false);
+						false, null);
 			} else {
-				addedTargets = target.getPlanNode(connectionsGroup, scope, true);
+				addedTargets = target.getPlanNode(connectionsGroup, scope, true, null);
 				PlanNode addedByPath = path.getAdded(connectionsGroup, null);
 
 				addedByPath = target.getTargetFilter(connectionsGroup,
 						new Unique(new TrimToTarget(addedByPath), false));
-				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false);
+				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
+						null);
 
 				addedTargets = new UnionNode(addedByPath, addedTargets);
 				addedTargets = new Unique(addedTargets, false);
@@ -120,9 +121,9 @@ public class DashHasValueInConstraintComponent extends AbstractConstraintCompone
 			if (overrideTargetNode != null) {
 				addedTargets = overrideTargetNode.getPlanNode();
 				addedTargets = target.extend(addedTargets, connectionsGroup, scope, EffectiveTarget.Extend.right,
-						false);
+						false, null);
 			} else {
-				addedTargets = target.getPlanNode(connectionsGroup, scope, false);
+				addedTargets = target.getPlanNode(connectionsGroup, scope, false, null);
 			}
 
 			PlanNode falseNode = new ValueInFilter(addedTargets, hasValueIn)
@@ -141,7 +142,7 @@ public class DashHasValueInConstraintComponent extends AbstractConstraintCompone
 		if (scope == Scope.propertyShape) {
 			PlanNode allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, Scope.nodeShape, true);
+					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
 			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DatatypeConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DatatypeConstraintComponent.java
@@ -8,16 +8,15 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.DatatypeFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
 
 public class DatatypeConstraintComponent extends SimpleAbstractConstraintComponent {
 
-	Resource datatype;
+	IRI datatype;
 
-	public DatatypeConstraintComponent(Resource datatype) {
+	public DatatypeConstraintComponent(IRI datatype) {
 		this.datatype = datatype;
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/HasValueConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/HasValueConstraintComponent.java
@@ -73,15 +73,16 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 			if (overrideTargetNode != null) {
 				addedTargets = overrideTargetNode.getPlanNode();
 				addedTargets = target.extend(addedTargets, connectionsGroup, scope, EffectiveTarget.Extend.right,
-						false);
+						false, null);
 
 			} else {
-				addedTargets = target.getPlanNode(connectionsGroup, scope, true);
+				addedTargets = target.getPlanNode(connectionsGroup, scope, true, null);
 				PlanNode addedByPath = path.getAdded(connectionsGroup, null);
 
 				addedByPath = target.getTargetFilter(connectionsGroup,
 						new Unique(new TrimToTarget(addedByPath), false));
-				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false);
+				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
+						null);
 
 				addedTargets = new UnionNode(addedByPath, addedTargets);
 				addedTargets = new Unique(addedTargets, false);
@@ -110,9 +111,9 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 			if (overrideTargetNode != null) {
 				addedTargets = overrideTargetNode.getPlanNode();
 				addedTargets = target.extend(addedTargets, connectionsGroup, scope, EffectiveTarget.Extend.right,
-						false);
+						false, null);
 			} else {
-				addedTargets = target.getPlanNode(connectionsGroup, scope, false);
+				addedTargets = target.getPlanNode(connectionsGroup, scope, false, null);
 			}
 
 			PlanNode falseNode = new ValueInFilter(addedTargets, new HashSet<>(Collections.singletonList(hasValue)))
@@ -131,7 +132,7 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 		if (scope == Scope.propertyShape) {
 			PlanNode allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, Scope.nodeShape, true);
+					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
 			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/InConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/InConstraintComponent.java
@@ -14,7 +14,6 @@ import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ast.ShaclAstLists;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ValueInFilter;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/LanguageInConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/LanguageInConstraintComponent.java
@@ -18,7 +18,6 @@ import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ast.ShaclAstLists;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.LanguageInFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxCountConstraintComponent.java
@@ -3,7 +3,6 @@ package org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents;
 import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -55,6 +54,8 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 	public PlanNode generateTransactionalValidationPlan(ConnectionsGroup connectionsGroup, boolean logValidationPlans,
 			PlanNodeProvider overrideTargetNode, Scope scope) {
 
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
+
 		EffectiveTarget effectiveTarget = getTargetChain().getEffectiveTarget("_target", scope,
 				connectionsGroup.getRdfsSubClassOfReasoner());
 		Optional<Path> path = getTargetChain().getPath();
@@ -83,7 +84,7 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 				getTargetChain().getPath()
 						.get()
 						.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
-								connectionsGroup.getRdfsSubClassOfReasoner()),
+								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 				false,
 				null,
 				(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)
@@ -104,7 +105,7 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 
 			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		}
-		return new EmptyNode();
+		return EmptyNode.getInstance();
 	}
 
 	@Override
@@ -117,6 +118,7 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 			boolean logValidationPlans, boolean negatePlan, boolean negateChildren, Scope scope) {
 
 		String targetVarPrefix = "target_";
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
 		EffectiveTarget effectiveTarget = getTargetChain().getEffectiveTarget(targetVarPrefix, scope,
 				connectionsGroup.getRdfsSubClassOfReasoner());
@@ -127,7 +129,7 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 
 			String pathQuery = getTargetChain().getPath()
 					.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
-							connectionsGroup.getRdfsSubClassOfReasoner()))
+							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider))
 					.orElseThrow(IllegalStateException::new);
 
 			query += pathQuery;
@@ -142,7 +144,7 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 
 				String pathQuery = getTargetChain().getPath()
 						.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
-								connectionsGroup.getRdfsSubClassOfReasoner()))
+								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider))
 						.orElseThrow(IllegalStateException::new);
 
 				paths.append(pathQuery).append("\n");

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxCountConstraintComponent.java
@@ -60,20 +60,21 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 				connectionsGroup.getRdfsSubClassOfReasoner());
 		Optional<Path> path = getTargetChain().getPath();
 
-		PlanNode addedTargets = effectiveTarget.getPlanNode(connectionsGroup, scope, false);
+		PlanNode addedTargets = effectiveTarget.getPlanNode(connectionsGroup, scope, false, null);
 
 		PlanNode addedByPath = path.get().getAdded(connectionsGroup, null);
 
 		addedByPath = effectiveTarget.getTargetFilter(connectionsGroup,
 				new Unique(new TrimToTarget(addedByPath), false));
 
-		addedByPath = effectiveTarget.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false);
+		addedByPath = effectiveTarget.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
+				null);
 
 		PlanNode mergeNode = new UnionNode(addedTargets, addedByPath);
 
 		if (overrideTargetNode != null) {
 			mergeNode = effectiveTarget.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope,
-					EffectiveTarget.Extend.right, false);
+					EffectiveTarget.Extend.right, false, null);
 		}
 
 		mergeNode = new Unique(new TrimToTarget(mergeNode), false);
@@ -101,7 +102,7 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 		if (scope == Scope.propertyShape) {
 			PlanNode allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, Scope.nodeShape, true);
+					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
 			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxExclusiveConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxExclusiveConstraintComponent.java
@@ -10,7 +10,6 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.query.algebra.Compare;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxInclusiveConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxInclusiveConstraintComponent.java
@@ -10,7 +10,6 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.query.algebra.Compare;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxLengthConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxLengthConstraintComponent.java
@@ -11,7 +11,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.MaxLengthFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
@@ -56,12 +56,12 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 
 		PlanNode target = getTargetChain()
 				.getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
-				.getPlanNode(connectionsGroup, scope, true);
+				.getPlanNode(connectionsGroup, scope, true, null);
 
 		if (overrideTargetNode != null) {
 			target = getTargetChain().getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 					.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
-							false);
+							false, null);
 		} else {
 			// we can assume that we are not doing bulk validation, so it is worth checking our added statements before
 			// we go to the base sail

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinExclusiveConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinExclusiveConstraintComponent.java
@@ -10,7 +10,6 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.query.algebra.Compare;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinInclusiveConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinInclusiveConstraintComponent.java
@@ -10,7 +10,6 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.query.algebra.Compare;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinLengthConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinLengthConstraintComponent.java
@@ -11,7 +11,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.MinLengthFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/NodeKindConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/NodeKindConstraintComponent.java
@@ -8,7 +8,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.NodeKindFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/NotConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/NotConstraintComponent.java
@@ -102,13 +102,13 @@ public class NotConstraintComponent extends AbstractConstraintComponent {
 				allTargetsPlan = getTargetChain()
 						.getEffectiveTarget("_target", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 						.extend(planNodeProvider.getPlanNode(), connectionsGroup, Scope.nodeShape,
-								EffectiveTarget.Extend.right, false);
+								EffectiveTarget.Extend.right, false, null);
 				allTargetsPlan = new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 			} else {
 				allTargetsPlan = getTargetChain()
 						.getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 						.extend(planNodeProvider.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
-								false);
+								false, null);
 			}
 
 		} else {
@@ -149,13 +149,13 @@ public class NotConstraintComponent extends AbstractConstraintComponent {
 		if (scope == Scope.propertyShape) {
 			PlanNode allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, Scope.nodeShape, true);
+					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
 			allTargets = new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		} else {
 			allTargets = getTargetChain()
 					.getEffectiveTarget("target_", scope, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, scope, true);
+					.getPlanNode(connectionsGroup, scope, true, null);
 
 		}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/OrConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/OrConstraintComponent.java
@@ -129,13 +129,13 @@ public class OrConstraintComponent extends LogicalOperatorConstraintComponent {
 		if (scope == Scope.propertyShape) {
 			PlanNode allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, Scope.nodeShape, true);
+					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
 			allTargets = new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		} else {
 			allTargets = getTargetChain()
 					.getEffectiveTarget("target_", scope, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, scope, true);
+					.getPlanNode(connectionsGroup, scope, true, null);
 
 		}
 
@@ -145,7 +145,8 @@ public class OrConstraintComponent extends LogicalOperatorConstraintComponent {
 				.reduce(UnionNode::new)
 				.orElse(EmptyNode.getInstance());
 
-		return new Unique(new UnionNode(allTargets, planNode), false);
+		Unique unique = new Unique(new UnionNode(allTargets, planNode), false);
+		return unique;
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/PatternConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/PatternConstraintComponent.java
@@ -10,7 +10,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.ast.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.FilterPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PatternFilter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
@@ -119,7 +119,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 		if (overrideTargetNode != null) {
 			target = getTargetChain().getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 					.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
-							false);
+							false, null);
 		} else {
 			target = getAllTargetsPlan(connectionsGroup, scope);
 		}
@@ -146,7 +146,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 				target = getTargetChain()
 						.getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 						.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
-								false);
+								false, null);
 			}
 
 			target = new Unique(new TrimToTarget(target), false);
@@ -186,7 +186,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 			allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 					.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
-							false);
+							false, null);
 		}
 
 		allTargetsPlan = new Unique(new TrimToTarget(allTargetsPlan), false);
@@ -215,7 +215,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 
 		PlanNode allTargets = getTargetChain()
 				.getEffectiveTarget("target_", Scope.propertyShape, connectionsGroup.getRdfsSubClassOfReasoner())
-				.getPlanNode(connectionsGroup, Scope.propertyShape, true);
+				.getPlanNode(connectionsGroup, Scope.propertyShape, true, null);
 
 		PlanNode subTargets = qualifiedValueShape.getAllTargetsPlan(connectionsGroup, scope);
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
@@ -136,7 +136,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 	public PlanNode negated(ConnectionsGroup connectionsGroup, boolean logValidationPlans,
 			PlanNodeProvider overrideTargetNode, Scope scope) {
 
-		// if (scope == Scope.nodeShape) {
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
 		PlanNodeProvider planNodeProvider = () -> {
 
@@ -158,7 +158,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 							.get()
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 									new StatementMatcher.Variable("c"),
-									connectionsGroup.getRdfsSubClassOfReasoner()),
+									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 					false,
 					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)
@@ -197,7 +197,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 				getTargetChain().getPath()
 						.get()
 						.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
-								connectionsGroup.getRdfsSubClassOfReasoner()),
+								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 				false,
 				null,
 				(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMinCountConstraintComponent.java
@@ -129,7 +129,7 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 	public PlanNode negated(ConnectionsGroup connectionsGroup, boolean logValidationPlans,
 			PlanNodeProvider overrideTargetNode, Scope scope) {
 
-		// if (scope == Scope.nodeShape) {
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
 		PlanNodeProvider planNodeProvider = () -> {
 
@@ -151,7 +151,7 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 							.get()
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 									new StatementMatcher.Variable("c"),
-									connectionsGroup.getRdfsSubClassOfReasoner()),
+									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 					false,
 					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)
@@ -190,7 +190,7 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 				getTargetChain().getPath()
 						.get()
 						.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
-								connectionsGroup.getRdfsSubClassOfReasoner()),
+								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 				false,
 				null,
 				(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMinCountConstraintComponent.java
@@ -112,7 +112,7 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 		if (overrideTargetNode != null) {
 			target = getTargetChain().getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 					.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
-							false);
+							false, null);
 		} else {
 			target = getAllTargetsPlan(connectionsGroup, scope);
 		}
@@ -139,7 +139,7 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 				target = getTargetChain()
 						.getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 						.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
-								false);
+								false, null);
 			}
 
 			target = new Unique(new TrimToTarget(target), false);
@@ -179,7 +179,7 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 			allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 					.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope, EffectiveTarget.Extend.right,
-							false);
+							false, null);
 		}
 
 		allTargetsPlan = new Unique(new TrimToTarget(allTargetsPlan), false);
@@ -208,7 +208,7 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 
 		PlanNode allTargets = getTargetChain()
 				.getEffectiveTarget("target_", Scope.propertyShape, connectionsGroup.getRdfsSubClassOfReasoner())
-				.getPlanNode(connectionsGroup, Scope.propertyShape, true);
+				.getPlanNode(connectionsGroup, Scope.propertyShape, true, null);
 
 		PlanNode subTargets = qualifiedValueShape.getAllTargetsPlan(connectionsGroup, scope);
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/SimpleAbstractConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/SimpleAbstractConstraintComponent.java
@@ -79,6 +79,8 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 	public ValidationQuery generateSparqlValidationQuery(ConnectionsGroup connectionsGroup,
 			boolean logValidationPlans, boolean negatePlan, boolean negateChildren, Scope scope) {
 
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
+
 		String targetVarPrefix = "target_";
 
 		EffectiveTarget effectiveTarget = targetChain.getEffectiveTarget(targetVarPrefix, scope,
@@ -98,7 +100,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 
 			String pathQuery = targetChain.getPath()
 					.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value,
-							connectionsGroup.getRdfsSubClassOfReasoner()))
+							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider))
 					.orElseThrow(IllegalStateException::new);
 
 			query += pathQuery;
@@ -140,6 +142,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 			PlanNodeProvider overrideTargetNode, Function<PlanNode, FilterPlanNode> filterAttacher, Scope scope) {
 
 		boolean negatePlan = false;
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
 		EffectiveTarget effectiveTarget = targetChain.getEffectiveTarget("target_", scope,
 				connectionsGroup.getRdfsSubClassOfReasoner());
@@ -164,7 +167,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 						path.get()
 								.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 										new StatementMatcher.Variable("c"),
-										connectionsGroup.getRdfsSubClassOfReasoner()),
+										connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 						false, null,
 						(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true));
 			}
@@ -227,7 +230,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 					path.get()
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 									new StatementMatcher.Variable("c"),
-									connectionsGroup.getRdfsSubClassOfReasoner()),
+									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 					true,
 					connectionsGroup.getPreviousStateConnection(),
 					b -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true));
@@ -281,7 +284,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 
 			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		}
-		return new EmptyNode();
+		return EmptyNode.getInstance();
 	}
 
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/UniqueLangConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/UniqueLangConstraintComponent.java
@@ -113,7 +113,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 		if (overrideTargetNode != null) {
 
 			PlanNode targets = effectiveTarget.extend(overrideTargetNode.getPlanNode(), connectionsGroup, scope,
-					EffectiveTarget.Extend.right, false);
+					EffectiveTarget.Extend.right, false, null);
 
 			PlanNode relevantTargetsWithPath = new BulkedExternalInnerJoin(
 					targets,
@@ -132,7 +132,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 		}
 
 		if (connectionsGroup.getStats().isBaseSailEmpty()) {
-			PlanNode addedTargets = effectiveTarget.getPlanNode(connectionsGroup, scope, false);
+			PlanNode addedTargets = effectiveTarget.getPlanNode(connectionsGroup, scope, false, null);
 
 			PlanNode addedByPath = path.get().getAdded(connectionsGroup, null);
 
@@ -142,14 +142,15 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 			return new Unique(new TrimToTarget(nonUniqueTargetLang), false);
 		}
 
-		PlanNode addedTargets = effectiveTarget.getPlanNode(connectionsGroup, scope, false);
+		PlanNode addedTargets = effectiveTarget.getPlanNode(connectionsGroup, scope, false, null);
 
 		PlanNode addedByPath = path.get().getAdded(connectionsGroup, null);
 
 		addedByPath = effectiveTarget.getTargetFilter(connectionsGroup,
 				new Unique(new TrimToTarget(addedByPath), false));
 
-		addedByPath = effectiveTarget.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false);
+		addedByPath = effectiveTarget.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
+				null);
 
 		PlanNode mergeNode = new UnionNode(addedTargets, addedByPath);
 
@@ -179,7 +180,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 		if (scope == Scope.propertyShape) {
 			PlanNode allTargetsPlan = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
-					.getPlanNode(connectionsGroup, Scope.nodeShape, true);
+					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
 			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/UniqueLangConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/UniqueLangConstraintComponent.java
@@ -9,7 +9,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.query.algebra.Str;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
@@ -48,6 +47,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 	@Override
 	public ValidationQuery generateSparqlValidationQuery(ConnectionsGroup connectionsGroup,
 			boolean logValidationPlans, boolean negatePlan, boolean negateChildren, Scope scope) {
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
 		String targetVarPrefix = "target_";
 
@@ -59,7 +59,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 
 		String pathQuery1 = getTargetChain().getPath()
 				.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value1,
-						connectionsGroup.getRdfsSubClassOfReasoner()))
+						connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider))
 				.orElseThrow(IllegalStateException::new);
 
 		query += pathQuery1;
@@ -68,7 +68,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 
 		String pathQuery2 = getTargetChain().getPath()
 				.map(p -> p.getTargetQueryFragment(effectiveTarget.getTargetVar(), value2,
-						connectionsGroup.getRdfsSubClassOfReasoner()))
+						connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider))
 				.orElseThrow(IllegalStateException::new);
 
 		query += String.join("\n", "",
@@ -104,6 +104,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 		EffectiveTarget effectiveTarget = getTargetChain().getEffectiveTarget("target_", Scope.propertyShape,
 				connectionsGroup.getRdfsSubClassOfReasoner());
 		Optional<Path> path = getTargetChain().getPath();
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
 		if (!path.isPresent() || scope != Scope.propertyShape) {
 			throw new IllegalStateException("UniqueLang only operates on paths");
@@ -120,7 +121,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 					path.get()
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 									new StatementMatcher.Variable("c"),
-									connectionsGroup.getRdfsSubClassOfReasoner()),
+									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 					false,
 					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)
@@ -161,7 +162,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 				connectionsGroup.getBaseConnection(),
 				path.get()
 						.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
-								connectionsGroup.getRdfsSubClassOfReasoner()),
+								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 				false,
 				null,
 				(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)
@@ -182,7 +183,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 
 			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
 		}
-		return new EmptyNode();
+		return EmptyNode.getInstance();
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/AlternativePath.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/AlternativePath.java
@@ -55,7 +55,8 @@ public class AlternativePath extends Path {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		throw new ShaclUnsupportedException();
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/InversePath.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/InversePath.java
@@ -68,9 +68,11 @@ public class InversePath extends Path {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 
-		return inversePath.getTargetQueryFragment(object, subject, rdfsSubClassOfReasoner);
+		return inversePath.getTargetQueryFragment(object, subject, rdfsSubClassOfReasoner,
+				stableRandomVariableProvider);
 
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/OneOrMorePath.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/OneOrMorePath.java
@@ -55,7 +55,8 @@ public class OneOrMorePath extends Path {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		throw new ShaclUnsupportedException();
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/SequencePath.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/SequencePath.java
@@ -68,7 +68,8 @@ public class SequencePath extends Path {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		throw new ShaclUnsupportedException();
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/SimplePath.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/SimplePath.java
@@ -62,7 +62,8 @@ public class SimplePath extends Path {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 
 		return "?" + subject.getName() + " <" + predicate + "> ?" + object.getName() + " .";
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/ZeroOrMorePath.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/ZeroOrMorePath.java
@@ -55,7 +55,8 @@ public class ZeroOrMorePath extends Path {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		throw new ShaclUnsupportedException();
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/ZeroOrOnePath.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/paths/ZeroOrOnePath.java
@@ -55,7 +55,8 @@ public class ZeroOrOnePath extends Path {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		throw new ShaclUnsupportedException();
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AbstractBulkJoinPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AbstractBulkJoinPlanNode.java
@@ -21,7 +21,6 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
-import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserFactory;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AbstractBulkJoinPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AbstractBulkJoinPlanNode.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -121,7 +122,8 @@ public abstract class AbstractBulkJoinPlanNode implements PlanNode {
 
 				})
 				.map(ValidationTuple::getActiveTarget)
-				.map(r -> new ListBindingSet(Collections.singletonList("a"), Collections.singletonList(r)))
+				.map(r -> new SimpleBindingSet(Collections.singleton("a"), Collections.singletonList("a"),
+						Collections.singletonList(r)))
 				.collect(Collectors.toList());
 	}
 
@@ -133,5 +135,22 @@ public abstract class AbstractBulkJoinPlanNode implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		AbstractBulkJoinPlanNode that = (AbstractBulkJoinPlanNode) o;
+		return mapper.equals(that.mapper);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(mapper);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AllTargetsPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AllTargetsPlanNode.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
+import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
+import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.ConstraintComponent;
+import org.eclipse.rdf4j.sail.shacl.ast.targets.EffectiveTarget;
+
+/**
+ * Used for adding a custom log statement to tuples as they pass through. Should only be used for debugging.
+ */
+public class AllTargetsPlanNode implements PlanNode {
+
+	private final Select select;
+	private StackTraceElement[] stackTrace;
+	private boolean printed;
+	private ValidationExecutionLogger validationExecutionLogger;
+
+	public AllTargetsPlanNode(ConnectionsGroup connectionsGroup,
+			ArrayDeque<EffectiveTarget.EffectiveTargetObject> chain, List<StatementMatcher.Variable> vars,
+			ConstraintComponent.Scope scope) {
+		String query = chain.stream()
+				.map(EffectiveTarget.EffectiveTargetObject::getQueryFragment)
+				.reduce((a, b) -> a + "\n" + b)
+				.orElse("");
+
+		List<String> varNames = vars.stream().map(StatementMatcher.Variable::getName).collect(Collectors.toList());
+
+		this.select = new Select(connectionsGroup.getBaseConnection(), query, null,
+				new AllTargetsBindingSetMapper(varNames, scope, false));
+
+	}
+
+	@Override
+	public CloseableIteration<? extends ValidationTuple, SailException> iterator() {
+
+		return new LoggingCloseableIteration(this, validationExecutionLogger) {
+
+			final CloseableIteration<? extends ValidationTuple, SailException> iterator = select.iterator();
+
+			@Override
+			public void close() throws SailException {
+				iterator.close();
+			}
+
+			@Override
+			protected ValidationTuple loggingNext() throws SailException {
+				return iterator.next();
+			}
+
+			@Override
+			protected boolean localHasNext() throws SailException {
+				return iterator.hasNext();
+			}
+		};
+
+	}
+
+	@Override
+	public int depth() {
+		return select.depth() + 1;
+	}
+
+	@Override
+	public void getPlanAsGraphvizDot(StringBuilder stringBuilder) {
+		if (printed) {
+			return;
+		}
+		printed = true;
+		stringBuilder.append(getId() + " [label=\"" + StringEscapeUtils.escapeJava(this.toString()) + "\"];")
+				.append("\n");
+		stringBuilder.append(select.getId() + " -> " + getId()).append("\n");
+		select.getPlanAsGraphvizDot(stringBuilder);
+	}
+
+	@Override
+	public String getId() {
+		return System.identityHashCode(this) + "";
+	}
+
+	@Override
+	public String toString() {
+		return "AllTargetsPlanNode";
+	}
+
+	@Override
+	public void receiveLogger(ValidationExecutionLogger validationExecutionLogger) {
+		this.validationExecutionLogger = validationExecutionLogger;
+		select.receiveLogger(validationExecutionLogger);
+	}
+
+	@Override
+	public boolean producesSorted() {
+		return false;
+	}
+
+	@Override
+	public boolean requiresSorted() {
+		return false;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		AllTargetsPlanNode that = (AllTargetsPlanNode) o;
+		return select.equals(that.select);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(select);
+	}
+
+	static class AllTargetsBindingSetMapper implements Function<BindingSet, ValidationTuple> {
+		List<String> varNames;
+		ConstraintComponent.Scope scope;
+		boolean hasValue;
+
+		public AllTargetsBindingSetMapper(List<String> varNames, ConstraintComponent.Scope scope, boolean hasValue) {
+			this.varNames = varNames;
+			this.scope = scope;
+			this.hasValue = hasValue;
+		}
+
+		@Override
+		public ValidationTuple apply(BindingSet b) {
+			return new ValidationTuple(b, varNames, scope, false);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			AllTargetsBindingSetMapper that = (AllTargetsBindingSetMapper) o;
+			return hasValue == that.hasValue &&
+					varNames.equals(that.varNames) &&
+					scope == that.scope;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(varNames, scope, hasValue, AllTargetsBindingSetMapper.class);
+		}
+	}
+
+}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AllTargetsPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AllTargetsPlanNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -23,7 +23,7 @@ import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.ConstraintComponent
 import org.eclipse.rdf4j.sail.shacl.ast.targets.EffectiveTarget;
 
 /**
- * Used for adding a custom log statement to tuples as they pass through. Should only be used for debugging.
+ * Used to signal bulk validation. This plan node should only be used from EffectiveTarget#getAllTargets
  */
 public class AllTargetsPlanNode implements PlanNode {
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BindSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BindSelect.java
@@ -27,7 +27,6 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
-import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserFactory;
 import org.eclipse.rdf4j.query.parser.QueryParserRegistry;
@@ -215,7 +214,7 @@ public class BindSelect implements PlanNode {
 					updateQuery(parsedQuery, bindingSets, targetChainSize);
 
 					bindingSet = connection.evaluate(parsedQuery.getTupleExpr(), parsedQuery.getDataset(),
-							new EmptyBindingSet(), true);
+							EmptyBindingSet.getInstance(), true);
 				}
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BindSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BindSelect.java
@@ -11,6 +11,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import static java.util.stream.Collectors.toCollection;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -25,7 +26,7 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
-import org.eclipse.rdf4j.query.impl.ListBindingSet;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserFactory;
@@ -177,6 +178,8 @@ public class BindSelect implements PlanNode {
 								.collect(Collectors.toList());
 					}
 
+					Set<String> varNamesSet = new HashSet<>(varNames);
+
 					List<BindingSet> bindingSets = bulk
 							.stream()
 							.filter(t -> {
@@ -190,8 +193,8 @@ public class BindSelect implements PlanNode {
 
 								return temp == targetChainSize;
 							})
-							.map(t -> new ListBindingSet(varNames,
-									new ArrayList<>(t.getTargetChain(includePropertyShapeValues))))
+							.map(t -> new SimpleBindingSet(varNamesSet, varNames,
+									t.getTargetChain(includePropertyShapeValues)))
 							.collect(Collectors.toList());
 
 					bulk = bulk
@@ -212,7 +215,7 @@ public class BindSelect implements PlanNode {
 					updateQuery(parsedQuery, bindingSets, targetChainSize);
 
 					bindingSet = connection.evaluate(parsedQuery.getTupleExpr(), parsedQuery.getDataset(),
-							new MapBindingSet(), true);
+							new EmptyBindingSet(), true);
 				}
 			}
 
@@ -392,4 +395,5 @@ public class BindSelect implements PlanNode {
 				", scope=" + scope +
 				'}';
 	}
+
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BufferedPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BufferedPlanNode.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.ArrayDeque;
+import java.util.Objects;
 import java.util.Queue;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -30,7 +31,7 @@ public class BufferedPlanNode<T extends MultiStreamPlanNode & PlanNode> implemen
 
 	BufferedPlanNode(T parent, String name) {
 		this.parent = parent;
-		this.name = name;
+		this.name = Objects.requireNonNull(name);
 	}
 
 	@Override
@@ -144,5 +145,22 @@ public class BufferedPlanNode<T extends MultiStreamPlanNode & PlanNode> implemen
 	@Override
 	public boolean requiresSorted() {
 		return parent.requiresSorted();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		BufferedPlanNode<?> that = (BufferedPlanNode<?>) o;
+		return parent.equals(that.parent) && name.equals(that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parent, name);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BufferedSplitter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BufferedSplitter.java
@@ -167,6 +167,22 @@ public class BufferedSplitter implements PlanNodeProvider {
 			return bufferedSplitter.parent.requiresSorted();
 		}
 
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			BufferedSplitterPlaneNode that = (BufferedSplitterPlaneNode) o;
+			return bufferedSplitter.equals(that.bufferedSplitter);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(bufferedSplitter);
+		}
 	}
 
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalInnerJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalInnerJoin.java
@@ -9,6 +9,7 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.ArrayDeque;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -209,5 +210,28 @@ public class BulkedExternalInnerJoin extends AbstractBulkJoinPlanNode {
 	public void receiveLogger(ValidationExecutionLogger validationExecutionLogger) {
 		this.validationExecutionLogger = validationExecutionLogger;
 		leftNode.receiveLogger(validationExecutionLogger);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		BulkedExternalInnerJoin that = (BulkedExternalInnerJoin) o;
+		return skipBasedOnPreviousConnection == that.skipBasedOnPreviousConnection && connection.equals(that.connection)
+				&& leftNode.equals(that.leftNode)
+				&& Objects.equals(previousStateConnection, that.previousStateConnection) && query.equals(that.query);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), connection, leftNode, skipBasedOnPreviousConnection,
+				previousStateConnection, query);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalLeftOuterJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalLeftOuterJoin.java
@@ -9,6 +9,7 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.ArrayDeque;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -191,5 +192,28 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 	public void receiveLogger(ValidationExecutionLogger validationExecutionLogger) {
 		this.validationExecutionLogger = validationExecutionLogger;
 		leftNode.receiveLogger(validationExecutionLogger);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		BulkedExternalLeftOuterJoin that = (BulkedExternalLeftOuterJoin) o;
+		return skipBasedOnPreviousConnection == that.skipBasedOnPreviousConnection && connection.equals(that.connection)
+				&& leftNode.equals(that.leftNode)
+				&& Objects.equals(previousStateConnection, that.previousStateConnection) && query.equals(that.query);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), connection, leftNode, skipBasedOnPreviousConnection,
+				previousStateConnection, query);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DatatypeFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DatatypeFilter.java
@@ -11,6 +11,8 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -38,5 +40,25 @@ public class DatatypeFilter extends FilterPlanNode {
 	@Override
 	public String toString() {
 		return "DatatypeFilter{" + "datatype=" + Formatter.prefix(datatype) + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		DatatypeFilter that = (DatatypeFilter) o;
+		return datatype.equals(that.datatype);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), datatype);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DatatypeFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DatatypeFilter.java
@@ -8,22 +8,26 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.Resource;
-
 import java.util.Objects;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.SimpleLiteral;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
  * @author Håvard Ottestad
  */
 public class DatatypeFilter extends FilterPlanNode {
 
-	private final Resource datatype;
+	private final IRI datatype;
+	private final XSD.Datatype xsdDatatype;
 	private StackTraceElement[] stackTrace;
 
-	public DatatypeFilter(PlanNode parent, Resource datatype) {
+	public DatatypeFilter(PlanNode parent, IRI datatype) {
 		super(parent);
 		this.datatype = datatype;
+		this.xsdDatatype = XSD.Datatype.from(datatype).orElse(null);
 //		stackTrace = Thread.currentThread().getStackTrace();
 	}
 
@@ -34,7 +38,11 @@ public class DatatypeFilter extends FilterPlanNode {
 		}
 
 		Literal literal = (Literal) t.getValue();
-		return literal.getDatatype() == datatype || literal.getDatatype().equals(datatype);
+		if (xsdDatatype != null && literal instanceof SimpleLiteral) {
+			return xsdDatatype == ((SimpleLiteral) literal).getXsdDatatype().orElse(null);
+		} else {
+			return literal.getDatatype() == datatype || literal.getDatatype().equals(datatype);
+		}
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DebugPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DebugPlanNode.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.apache.commons.text.StringEscapeUtils;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DebugPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/DebugPlanNode.java
@@ -7,8 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
-import java.util.Arrays;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.apache.commons.text.StringEscapeUtils;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EmptyNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EmptyNode.java
@@ -17,8 +17,13 @@ public class EmptyNode implements PlanNode {
 
 	private boolean printed = false;
 
-	public EmptyNode() {
+	static final private EmptyNode instance = new EmptyNode();
 
+	private EmptyNode() {
+	}
+
+	public static EmptyNode getInstance() {
+		return instance;
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EqualsJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EqualsJoin.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
+
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
@@ -162,5 +164,22 @@ public class EqualsJoin implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		EqualsJoin that = (EqualsJoin) o;
+		return useAsFilter == that.useAsFilter && left.equals(that.left) && right.equals(that.right);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(left, right, useAsFilter);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EqualsJoinValue.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EqualsJoinValue.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
+
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
@@ -167,5 +169,22 @@ public class EqualsJoinValue implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		EqualsJoinValue that = (EqualsJoinValue) o;
+		return useAsFilter == that.useAsFilter && left.equals(that.left) && right.equals(that.right);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(left, right, useAsFilter);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByQuery.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByQuery.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -21,6 +22,7 @@ import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserFactory;
 import org.eclipse.rdf4j.query.parser.QueryParserRegistry;
 import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStoreConnection;
 import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,5 +86,39 @@ public class ExternalFilterByQuery extends FilterPlanNode {
 				", queryString=" + queryString.replace("\n", "\t") +
 				", queryVariable='" + queryVariable.toString().replace("\n", "  ") + '\'' +
 				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		ExternalFilterByQuery that = (ExternalFilterByQuery) o;
+
+		if (connection instanceof MemoryStoreConnection && that.connection instanceof MemoryStoreConnection) {
+			return ((MemoryStoreConnection) connection).getSail()
+					.equals(((MemoryStoreConnection) that.connection).getSail())
+					&& queryVariable.equals(that.queryVariable) && filterOn.equals(that.filterOn)
+					&& queryString.equals(that.queryString);
+		}
+
+		return connection.equals(that.connection) && queryVariable.equals(that.queryVariable)
+				&& filterOn.equals(that.filterOn) && queryString.equals(that.queryString);
+	}
+
+	@Override
+	public int hashCode() {
+		if (connection instanceof MemoryStoreConnection) {
+			return Objects.hash(super.hashCode(), ((MemoryStoreConnection) connection).getSail(), queryVariable,
+					filterOn, queryString);
+		}
+
+		return Objects.hash(super.hashCode(), connection, queryVariable, filterOn, queryString);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/FilterPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/FilterPlanNode.java
@@ -253,4 +253,5 @@ public abstract class FilterPlanNode implements MultiStreamPlanNode, PlanNode {
 	public int hashCode() {
 		return Objects.hash(parent);
 	}
+
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/GroupByCountFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/GroupByCountFilter.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -141,5 +142,22 @@ public class GroupByCountFilter implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		GroupByCountFilter that = (GroupByCountFilter) o;
+		return filter.equals(that.filter) && parent.equals(that.parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(filter, parent);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/GroupByFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/GroupByFilter.java
@@ -11,6 +11,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -146,5 +147,22 @@ public class GroupByFilter implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		GroupByFilter that = (GroupByFilter) o;
+		return filter.equals(that.filter) && parent.equals(that.parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(filter, parent);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/InnerJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/InnerJoin.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
@@ -441,6 +442,23 @@ public class InnerJoin implements MultiStreamPlanNode, PlanNode {
 
 		public boolean wasRecentlyPushed() {
 			return recentlyPushed;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			NotifyingPushablePlanNode that = (NotifyingPushablePlanNode) o;
+			return delegate.equals(that.delegate);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(delegate);
 		}
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LanguageInFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LanguageInFilter.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -66,5 +67,25 @@ public class LanguageInFilter extends FilterPlanNode {
 				"languageRanges=" + Arrays.toString(languageRanges.toArray()) +
 				", lowerCaseLanguageIn=" + Arrays.toString(lowerCaseLanguageIn.toArray()) +
 				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		LanguageInFilter that = (LanguageInFilter) o;
+		return languageRanges.equals(that.languageRanges) && lowerCaseLanguageIn.equals(that.lowerCaseLanguageIn);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), languageRanges, lowerCaseLanguageIn);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LeftOuterJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LeftOuterJoin.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
+
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
@@ -176,5 +178,22 @@ public class LeftOuterJoin implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		LeftOuterJoin that = (LeftOuterJoin) o;
+		return left.equals(that.left) && right.equals(that.right);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(left, right);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LiteralComparatorFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LiteralComparatorFilter.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.algebra.Compare;
@@ -48,5 +50,25 @@ public class LiteralComparatorFilter extends FilterPlanNode {
 				"compareTo=" + compareTo +
 				", compareOp=" + compareOp +
 				'}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		LiteralComparatorFilter that = (LiteralComparatorFilter) o;
+		return compareTo.equals(that.compareTo) && compareOp == that.compareOp;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), compareTo, compareOp);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/MaxLengthFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/MaxLengthFilter.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.model.Value;
 
 /**
@@ -32,5 +34,25 @@ public class MaxLengthFilter extends FilterPlanNode {
 	@Override
 	public String toString() {
 		return "MaxLengthFilter{" + "maxLength=" + maxLength + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MaxLengthFilter that = (MaxLengthFilter) o;
+		return maxLength == that.maxLength;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), maxLength);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/MinLengthFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/MinLengthFilter.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.model.Value;
 
 /**
@@ -32,5 +34,25 @@ public class MinLengthFilter extends FilterPlanNode {
 	@Override
 	public String toString() {
 		return "MinLengthFilter{" + "minLength=" + minLength + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MinLengthFilter that = (MinLengthFilter) o;
+		return minLength == that.minLength;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), minLength);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NodeKindFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NodeKindFilter.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.NodeKindConstraintComponent;
 
@@ -54,5 +56,25 @@ public class NodeKindFilter extends FilterPlanNode {
 	@Override
 	public String toString() {
 		return "NodeKindFilter{" + "nodeKind=" + nodeKind + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		NodeKindFilter that = (NodeKindFilter) o;
+		return nodeKind == that.nodeKind;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), nodeKind);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NonUniqueTargetLang.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NonUniqueTargetLang.java
@@ -9,6 +9,7 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -89,6 +90,22 @@ public class NonUniqueTargetLang implements PlanNode {
 		return true;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		NonUniqueTargetLang that = (NonUniqueTargetLang) o;
+		return parent.equals(that.parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parent);
+	}
 }
 
 class OnlyNonUnique extends LoggingCloseableIteration {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NotValuesIn.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NotValuesIn.java
@@ -9,6 +9,7 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -130,5 +131,22 @@ public class NotValuesIn implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		NotValuesIn that = (NotValuesIn) o;
+		return parent.equals(that.parent) && notIn.equals(that.notIn);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parent, notIn);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/PatternFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/PatternFilter.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.eclipse.rdf4j.model.Value;
@@ -72,5 +73,25 @@ public class PatternFilter extends FilterPlanNode {
 	@Override
 	public String toString() {
 		return "PatternFilter{" + "pattern=" + pattern + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		PatternFilter that = (PatternFilter) o;
+		return pattern.equals(that.pattern);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), pattern);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ShiftToNodeShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ShiftToNodeShape.java
@@ -11,6 +11,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -25,8 +26,6 @@ public class ShiftToNodeShape implements PlanNode {
 	PlanNode parent;
 	private boolean printed = false;
 	private ValidationExecutionLogger validationExecutionLogger;
-
-	boolean keepPath = false;
 
 	public ShiftToNodeShape(PlanNode parent) {
 		parent = PlanNodeHelper.handleSorting(this, parent);
@@ -93,7 +92,7 @@ public class ShiftToNodeShape implements PlanNode {
 
 	@Override
 	public String toString() {
-		return "TrimToTarget";
+		return "ShiftToNodeShape";
 	}
 
 	@Override
@@ -115,5 +114,22 @@ public class ShiftToNodeShape implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return false;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ShiftToNodeShape that = (ShiftToNodeShape) o;
+		return parent.equals(that.parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parent);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ShiftToPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ShiftToPropertyShape.java
@@ -11,6 +11,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -90,7 +91,7 @@ public class ShiftToPropertyShape implements PlanNode {
 
 	@Override
 	public String toString() {
-		return "ShiftTarget";
+		return "ShiftToPropertyShape";
 	}
 
 	@Override
@@ -112,5 +113,22 @@ public class ShiftToPropertyShape implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return false;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ShiftToPropertyShape that = (ShiftToPropertyShape) o;
+		return parent.equals(that.parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parent);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SimpleBindingSet.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SimpleBindingSet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * .Copyright (c) 2021 Eclipse RDF4J contributors.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -61,20 +61,14 @@ class SimpleBindingSet extends AbstractBindingSet {
 
 	@Override
 	public boolean hasBinding(String bindingName) {
-		for (Binding binding : bindings) {
-			if (binding.getName().equals(bindingName)) {
-				return true;
-			}
-		}
-		return false;
+		return bindingNamesSet.contains(bindingName);
 	}
 
 	@Override
 	public Value getValue(String bindingName) {
-		for (Binding binding : bindings) {
-			if (binding.getName().equals(bindingName)) {
-				return binding.getValue();
-			}
+		Binding binding = getBinding(bindingName);
+		if (binding != null) {
+			return binding.getValue();
 		}
 		return null;
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SimpleBindingSet.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SimpleBindingSet.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * .Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.AbstractBindingSet;
+import org.eclipse.rdf4j.query.Binding;
+import org.eclipse.rdf4j.query.impl.SimpleBinding;
+
+/**
+ * A simple binding set tuned for the use case that the ShaclSail has.
+ */
+class SimpleBindingSet extends AbstractBindingSet {
+
+	private final Binding[] bindings;
+	private final Set<String> bindingNamesSet;
+
+	public SimpleBindingSet(Set<String> bindingNamesSet, List<String> varNamesList, List<Value> values) {
+
+		assert varNamesList.size() == values.size();
+		this.bindings = new Binding[varNamesList.size()];
+		this.bindingNamesSet = Collections.unmodifiableSet(bindingNamesSet);
+
+		for (int i = 0; i < varNamesList.size(); i++) {
+			bindings[i] = new SimpleBinding(varNamesList.get(i), values.get(i));
+		}
+
+	}
+
+	@Override
+	public Iterator<Binding> iterator() {
+		return Arrays.asList(bindings).iterator();
+	}
+
+	@Override
+	public Set<String> getBindingNames() {
+		return bindingNamesSet;
+	}
+
+	@Override
+	public Binding getBinding(String bindingName) {
+		for (Binding binding : bindings) {
+			if (binding.getName().equals(bindingName)) {
+				return binding;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public boolean hasBinding(String bindingName) {
+		for (Binding binding : bindings) {
+			if (binding.getName().equals(bindingName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public Value getValue(String bindingName) {
+		for (Binding binding : bindings) {
+			if (binding.getName().equals(bindingName)) {
+				return binding.getValue();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public int size() {
+		return bindings.length;
+	}
+}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SingleCloseablePlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SingleCloseablePlanNode.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -98,5 +99,22 @@ public class SingleCloseablePlanNode implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return false;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SingleCloseablePlanNode that = (SingleCloseablePlanNode) o;
+		return parent.equals(that.parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parent);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Sort.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Sort.java
@@ -32,6 +32,7 @@ public class Sort implements PlanNode {
 
 	@Override
 	public CloseableIteration<? extends ValidationTuple, SailException> iterator() {
+
 		return new LoggingCloseableIteration(this, validationExecutionLogger) {
 
 			final CloseableIteration<? extends ValidationTuple, SailException> iterator = parent.iterator();
@@ -157,7 +158,7 @@ public class Sort implements PlanNode {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(parent, Sort.class);
+		return Objects.hash(parent);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/TargetChainPopper.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/TargetChainPopper.java
@@ -11,6 +11,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -121,5 +122,22 @@ public class TargetChainPopper implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return false;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TargetChainPopper that = (TargetChainPopper) o;
+		return parent.equals(that.parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parent);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnBufferedPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnBufferedPlanNode.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
+
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
@@ -29,7 +31,7 @@ public class UnBufferedPlanNode<T extends PlanNode & MultiStreamPlanNode> implem
 
 	UnBufferedPlanNode(T parent, String name) {
 		this.parent = parent;
-		this.name = name;
+		this.name = Objects.requireNonNull(name);
 	}
 
 	@Override
@@ -141,5 +143,22 @@ public class UnBufferedPlanNode<T extends PlanNode & MultiStreamPlanNode> implem
 	@Override
 	public boolean requiresSorted() {
 		return parent.producesSorted();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		UnBufferedPlanNode<?> that = (UnBufferedPlanNode<?>) o;
+		return parent.equals(that.parent) && name.equals(that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(parent, name);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnionNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnionNode.java
@@ -9,7 +9,6 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnionNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnionNode.java
@@ -9,8 +9,11 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -21,22 +24,55 @@ import org.eclipse.rdf4j.sail.SailException;
  */
 public class UnionNode implements PlanNode {
 
+	private final HashSet<PlanNode> nodesSet;
 	private StackTraceElement[] stackTrace;
 	private final PlanNode[] nodes;
 	private boolean printed = false;
 	private ValidationExecutionLogger validationExecutionLogger;
 
 	public UnionNode(PlanNode... nodes) {
-		for (int i = 0; i < nodes.length; i++) {
-			nodes[i] = PlanNodeHelper.handleSorting(this, nodes[i]);
-		}
 
-		this.nodes = nodes;
+		this.nodes = Arrays.stream(nodes)
+				.filter(n -> !(n instanceof EmptyNode))
+				.flatMap(n -> {
+					if (n instanceof UnionNode) {
+						return Arrays.stream(((UnionNode) n).nodes);
+					}
+					return Stream.of(n);
+				})
+				.map(n -> PlanNodeHelper.handleSorting(this, n))
+				.toArray(PlanNode[]::new);
+
+		this.nodesSet = new HashSet<>(Arrays.asList(this.nodes));
+
 		// this.stackTrace = Thread.currentThread().getStackTrace();
 	}
 
 	@Override
 	public CloseableIteration<? extends ValidationTuple, SailException> iterator() {
+
+		if (nodes.length == 1) {
+			return new LoggingCloseableIteration(this, validationExecutionLogger) {
+
+				final CloseableIteration<? extends ValidationTuple, SailException> iterator = nodes[0].iterator();
+
+				@Override
+				public void close() throws SailException {
+					iterator.close();
+				}
+
+				@Override
+				protected ValidationTuple loggingNext() throws SailException {
+					return iterator.next();
+				}
+
+				@Override
+				protected boolean localHasNext() throws SailException {
+					return iterator.hasNext();
+				}
+			};
+		}
+
 		return new LoggingCloseableIteration(this, validationExecutionLogger) {
 
 			final List<CloseableIteration<? extends ValidationTuple, SailException>> iterators = Arrays.stream(nodes)
@@ -163,5 +199,27 @@ public class UnionNode implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		UnionNode unionNode = (UnionNode) o;
+		if (nodes.length != unionNode.nodes.length) {
+			return false;
+		}
+
+		return nodesSet.equals(unionNode.nodesSet);
+
+	}
+
+	@Override
+	public int hashCode() {
+		return nodes.length + nodesSet.hashCode();
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
@@ -41,6 +41,16 @@ public class Unique implements PlanNode {
 //		this.stackTrace = Thread.currentThread().getStackTrace();
 		parent = PlanNodeHelper.handleSorting(this, parent);
 
+		if (parent instanceof Unique) {
+			Unique parentUnique = ((Unique) parent);
+
+			parent = parentUnique.parent;
+
+			if (!compress) {
+				compress = parentUnique.compress;
+			}
+		}
+
 		this.parent = parent;
 		this.compress = compress;
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
@@ -221,7 +221,7 @@ public class Unique implements PlanNode {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(parent, Unique.class);
+		return Objects.hash(parent);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnorderedSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnorderedSelect.java
@@ -165,11 +165,10 @@ public class UnorderedSelect implements PlanNode {
 		// added/removed connections are always newly minted per plan node, so we instead need to compare the underlying
 		// sail
 		if (connection instanceof MemoryStoreConnection) {
-			return Objects.hash(((MemoryStoreConnection) connection).getSail(), subject, predicate, object, mapper,
-					UnorderedSelect.class);
+			return Objects.hash(((MemoryStoreConnection) connection).getSail(), subject, predicate, object, mapper);
 		}
 
-		return Objects.hash(connection, subject, predicate, object, mapper, UnorderedSelect.class);
+		return Objects.hash(connection, subject, predicate, object, mapper);
 	}
 
 	public static class Mapper {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValidationReportNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValidationReportNode.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -97,5 +98,22 @@ public class ValidationReportNode implements PlanNode {
 	@Override
 	public boolean requiresSorted() {
 		return false;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ValidationReportNode that = (ValidationReportNode) o;
+		return validationResultFunction.equals(that.validationResultFunction) && parent.equals(that.parent);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(validationResultFunction, parent);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValueInFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValueInFilter.java
@@ -9,6 +9,7 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.Value;
@@ -34,5 +35,25 @@ public class ValueInFilter extends FilterPlanNode {
 	public String toString() {
 		return "ValueInFilter{" + "valueSet=" + Arrays.toString(valueSet.stream().map(Formatter::prefix).toArray())
 				+ '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		ValueInFilter that = (ValueInFilter) o;
+		return valueSet.equals(that.valueSet);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), valueSet);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/DashAllObjects.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/DashAllObjects.java
@@ -1,7 +1,6 @@
 package org.eclipse.rdf4j.sail.shacl.ast.targets;
 
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -57,8 +56,8 @@ public class DashAllObjects extends Target {
 
 	@Override
 	public String getQueryFragment(String subjectVariable, String objectVariable,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
-		String tempVar = "?" + UUID.randomUUID().toString().replace("-", "");
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 
 //		return targetObjectsOf.stream()
 //			.map(target -> "\n{ BIND(<" + target + "> as " + tempVar + ") \n " + objectVariable + " "
@@ -93,11 +92,12 @@ public class DashAllObjects extends Target {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		assert (subject == null);
 
-		String tempVar1 = "?" + UUID.randomUUID().toString().replace("-", "");
-		String tempVar2 = "?" + UUID.randomUUID().toString().replace("-", "");
+		String tempVar1 = stableRandomVariableProvider.next().asSparqlVariable();
+		String tempVar2 = stableRandomVariableProvider.next().asSparqlVariable();
 
 		return tempVar1 + " " + tempVar2 + " ?" + object.getName() + " .";
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/DashAllSubjects.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/DashAllSubjects.java
@@ -1,7 +1,6 @@
 package org.eclipse.rdf4j.sail.shacl.ast.targets;
 
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -55,8 +54,8 @@ public class DashAllSubjects extends Target {
 
 	@Override
 	public String getQueryFragment(String subjectVariable, String objectVariable,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
-		String tempVar = "?" + UUID.randomUUID().toString().replace("-", "");
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 
 //		return targetObjectsOf.stream()
 //			.map(target -> "\n{ BIND(<" + target + "> as " + tempVar + ") \n " + objectVariable + " "
@@ -91,11 +90,12 @@ public class DashAllSubjects extends Target {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		assert (subject == null);
 
-		String tempVar1 = "?" + UUID.randomUUID().toString().replace("-", "");
-		String tempVar2 = "?" + UUID.randomUUID().toString().replace("-", "");
+		String tempVar1 = stableRandomVariableProvider.next().asSparqlVariable();
+		String tempVar2 = stableRandomVariableProvider.next().asSparqlVariable();
 
 		return " ?" + object.getName() + " " + tempVar1 + " " + tempVar2 + " .";
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/EffectiveTarget.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/EffectiveTarget.java
@@ -38,13 +38,15 @@ public class EffectiveTarget {
 
 		EffectiveTargetObject previous = null;
 
+		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
+
 		for (Targetable targetable : chain) {
 			EffectiveTargetObject effectiveTargetObject = new EffectiveTargetObject(
 					new StatementMatcher.Variable(targetVarPrefix + String.format("%010d", index++)),
 					targetable,
 					previous,
-					rdfsSubClassOfReasoner
-			);
+					rdfsSubClassOfReasoner,
+					stableRandomVariableProvider);
 			previous = effectiveTargetObject;
 			this.chain.addLast(effectiveTargetObject);
 		}
@@ -54,8 +56,8 @@ public class EffectiveTarget {
 					new StatementMatcher.Variable(targetVarPrefix + String.format("%010d", index)),
 					optional,
 					previous,
-					rdfsSubClassOfReasoner
-			);
+					rdfsSubClassOfReasoner,
+					stableRandomVariableProvider);
 		} else {
 			this.optional = null;
 		}
@@ -271,17 +273,20 @@ public class EffectiveTarget {
 
 	static class EffectiveTargetObject {
 
-		final StatementMatcher.Variable var;
-		final Targetable target;
-		final EffectiveTargetObject prev;
-		final RdfsSubClassOfReasoner rdfsSubClassOfReasoner;
+		private final StatementMatcher.Variable var;
+		private final Targetable target;
+		private final EffectiveTargetObject prev;
+		private final RdfsSubClassOfReasoner rdfsSubClassOfReasoner;
+		private final StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider;
 
 		public EffectiveTargetObject(StatementMatcher.Variable var, Targetable target, EffectiveTargetObject prev,
-				RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+				RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+				StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 			this.var = var;
 			this.target = target;
 			this.prev = prev;
 			this.rdfsSubClassOfReasoner = rdfsSubClassOfReasoner;
+			this.stableRandomVariableProvider = stableRandomVariableProvider;
 		}
 
 		public Stream<StatementMatcher> getStatementMatcher() {
@@ -294,9 +299,10 @@ public class EffectiveTarget {
 
 		public String getQueryFragment() {
 			if (prev == null) {
-				return target.getTargetQueryFragment(null, var, rdfsSubClassOfReasoner);
+				return target.getTargetQueryFragment(null, var, rdfsSubClassOfReasoner, stableRandomVariableProvider);
 			} else {
-				return target.getTargetQueryFragment(prev.var, var, rdfsSubClassOfReasoner);
+				return target.getTargetQueryFragment(prev.var, var, rdfsSubClassOfReasoner,
+						stableRandomVariableProvider);
 			}
 		}
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/EffectiveTarget.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/EffectiveTarget.java
@@ -8,7 +8,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.RdfsSubClassOfReasoner;
 import org.eclipse.rdf4j.sail.shacl.ast.ShaclUnsupportedException;
@@ -19,7 +18,6 @@ import org.eclipse.rdf4j.sail.shacl.ast.planNodes.AllTargetsPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.BindSelect;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ExternalFilterByQuery;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
-import org.eclipse.rdf4j.sail.shacl.ast.planNodes.Select;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.TupleMapper;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.UnBufferedPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.Unique;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/RSXTargetShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/RSXTargetShape.java
@@ -71,7 +71,8 @@ public class RSXTargetShape extends Target {
 		StatementMatcher.Variable object = new StatementMatcher.Variable("temp1");
 
 		SparqlFragment sparqlFragment = this.targetShape.buildSparqlValidNodes_rsx_targetShape(null, object,
-				connectionsGroup.getRdfsSubClassOfReasoner(), null);
+				connectionsGroup.getRdfsSubClassOfReasoner(), null,
+				new StatementMatcher.StableRandomVariableProvider());
 
 		List<StatementMatcher> statementMatchers = sparqlFragment.getStatementMatchers();
 
@@ -92,7 +93,8 @@ public class RSXTargetShape extends Target {
 
 	@Override
 	public String getQueryFragment(String subjectVariable, String objectVariable,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 
 		throw new UnsupportedOperationException(this.getClass().getSimpleName());
 
@@ -100,8 +102,9 @@ public class RSXTargetShape extends Target {
 
 	@Override
 	public PlanNode getTargetFilter(ConnectionsGroup connectionsGroup, PlanNode parent) {
+
 		String query = getTargetQueryFragment(null, new StatementMatcher.Variable("temp1"),
-				connectionsGroup.getRdfsSubClassOfReasoner());
+				connectionsGroup.getRdfsSubClassOfReasoner(), new StatementMatcher.StableRandomVariableProvider());
 
 		// TODO: this is a slow way to solve this problem! We should use bulk operations.
 		return new ExternalFilterByQuery(connectionsGroup.getBaseConnection(), parent, query,
@@ -116,17 +119,22 @@ public class RSXTargetShape extends Target {
 			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
 		assert (subject == null);
 
-		return this.targetShape.buildSparqlValidNodes_rsx_targetShape(subject, object, rdfsSubClassOfReasoner, null)
+		return this.targetShape
+				.buildSparqlValidNodes_rsx_targetShape(subject, object, rdfsSubClassOfReasoner, null,
+						new StatementMatcher.StableRandomVariableProvider())
 				.getStatementMatchers()
 				.stream();
 	}
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		assert (subject == null);
 
-		return this.targetShape.buildSparqlValidNodes_rsx_targetShape(subject, object, rdfsSubClassOfReasoner, null)
+		return this.targetShape
+				.buildSparqlValidNodes_rsx_targetShape(subject, object, rdfsSubClassOfReasoner, null,
+						new StatementMatcher.StableRandomVariableProvider())
 				.getFragment();
 
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/Target.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/Target.java
@@ -4,6 +4,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sail.shacl.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.RdfsSubClassOfReasoner;
 import org.eclipse.rdf4j.sail.shacl.ast.Exportable;
+import org.eclipse.rdf4j.sail.shacl.ast.StatementMatcher;
 import org.eclipse.rdf4j.sail.shacl.ast.Targetable;
 import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.ConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
@@ -15,7 +16,8 @@ public abstract class Target implements Exportable, Targetable {
 	public abstract PlanNode getAdded(ConnectionsGroup connectionsGroup, ConstraintComponent.Scope scope);
 
 	public abstract String getQueryFragment(String subjectVariable, String objectVariable,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner);
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider);
 
 	public abstract PlanNode getTargetFilter(ConnectionsGroup connectionsGroup, PlanNode parent);
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetClass.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetClass.java
@@ -52,7 +52,8 @@ public class TargetClass extends Target {
 			planNode = new UnorderedSelect(connection, null, RDF.TYPE, clazz,
 					UnorderedSelect.Mapper.SubjectScopedMapper.getFunction(scope));
 		} else {
-			planNode = new Select(connection, getQueryFragment("?a", "?c", null),
+			planNode = new Select(connection,
+					getQueryFragment("?a", "?c", null, new StatementMatcher.StableRandomVariableProvider()),
 					"?a", b -> new ValidationTuple(b.getValue("a"), scope, false));
 		}
 
@@ -61,7 +62,8 @@ public class TargetClass extends Target {
 
 	@Override
 	public String getQueryFragment(String subjectVariable, String objectVariable,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		Set<Resource> targets = targetClass;
 
 		if (rdfsSubClassOfReasoner != null) {
@@ -113,7 +115,8 @@ public class TargetClass extends Target {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		assert (subject == null);
 
 		List<Resource> targetClass = this.targetClass

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetNode.java
@@ -40,7 +40,8 @@ public class TargetNode extends Target {
 
 	@Override
 	public String getQueryFragment(String subjectVariable, String objectVariable,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		StringBuilder sb = new StringBuilder();
 		sb.append("VALUES ( ").append(subjectVariable).append(" ) {\n");
 
@@ -93,7 +94,8 @@ public class TargetNode extends Target {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		assert subject == null;
 
 		StringBuilder sb = new StringBuilder();

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetObjectsOf.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetObjectsOf.java
@@ -2,7 +2,6 @@ package org.eclipse.rdf4j.sail.shacl.ast.targets;
 
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -55,15 +54,16 @@ public class TargetObjectsOf extends Target {
 				.map(predicate -> (PlanNode) new UnorderedSelect(connection, null,
 						predicate, null, UnorderedSelect.Mapper.ObjectScopedMapper.getFunction(scope)))
 				.reduce(UnionNode::new)
-				.orElse(new EmptyNode());
+				.orElse(EmptyNode.getInstance());
 
 		return new Unique(planNode, false);
 	}
 
 	@Override
 	public String getQueryFragment(String subjectVariable, String objectVariable,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
-		String tempVar = "?" + UUID.randomUUID().toString().replace("-", "");
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
+		String tempVar = stableRandomVariableProvider.next().asSparqlVariable();
 
 		return targetObjectsOf.stream()
 				.map(target -> "\n{ BIND(<" + target + "> as " + tempVar + ") \n " + objectVariable + " "
@@ -96,10 +96,11 @@ public class TargetObjectsOf extends Target {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		assert (subject == null);
 
-		String tempVar = "?" + UUID.randomUUID().toString().replace("-", "");
+		String tempVar = stableRandomVariableProvider.next().asSparqlVariable();
 
 		if (targetObjectsOf.size() == 1) {
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetSubjectsOf.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetSubjectsOf.java
@@ -2,7 +2,6 @@ package org.eclipse.rdf4j.sail.shacl.ast.targets;
 
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -55,15 +54,16 @@ public class TargetSubjectsOf extends Target {
 				.map(predicate -> (PlanNode) new UnorderedSelect(connection, null,
 						predicate, null, UnorderedSelect.Mapper.SubjectScopedMapper.getFunction(scope)))
 				.reduce(UnionNode::new)
-				.orElse(new EmptyNode());
+				.orElse(EmptyNode.getInstance());
 
 		return new Unique(planNode, false);
 	}
 
 	@Override
 	public String getQueryFragment(String subjectVariable, String objectVariable,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
-		String tempVar = "?" + UUID.randomUUID().toString().replace("-", "");
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
+		String tempVar = stableRandomVariableProvider.next().asSparqlVariable();
 
 		return targetSubjectsOf.stream()
 				.map(target -> "\n{ BIND(<" + target + "> as " + tempVar + ") \n " + subjectVariable + " "
@@ -96,10 +96,11 @@ public class TargetSubjectsOf extends Target {
 
 	@Override
 	public String getTargetQueryFragment(StatementMatcher.Variable subject, StatementMatcher.Variable object,
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
+			RdfsSubClassOfReasoner rdfsSubClassOfReasoner,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		assert (subject == null);
 
-		String tempVar = "?" + UUID.randomUUID().toString().replace("-", "");
+		String tempVar = stableRandomVariableProvider.next().asSparqlVariable();
 
 		if (targetSubjectsOf.size() == 1) {
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/OrDatatypeBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/OrDatatypeBenchmark.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.benchmark;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.shacl.GlobalValidationExecutionLogging;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
+import org.eclipse.rdf4j.sail.shacl.Utils;
+import org.eclipse.rdf4j.sail.shacl.testimp.TestNotifyingSail;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 20)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xmx64M", "-XX:+UseSerialGC" })
+//@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G", "-XX:+UseSerialGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=5s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class OrDatatypeBenchmark {
+	{
+		GlobalValidationExecutionLogging.loggingEnabled = false;
+	}
+
+	private List<List<Statement>> allStatements;
+
+	@Setup(Level.Iteration)
+	public void setUp() throws InterruptedException {
+		Logger root = (Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName());
+		root.setLevel(ch.qos.logback.classic.Level.WARN);
+		System.setProperty("org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation", "true");
+
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+
+		Random random = new Random(490343534);
+
+		allStatements = BenchmarkConfigs.generateStatements(((statements, i, j) -> {
+
+			IRI iri = vf.createIRI("http://example.com/" + i + "_" + j);
+			statements.add(vf.createStatement(iri, RDF.TYPE, RDFS.RESOURCE));
+
+			if (random.nextBoolean()) {
+				statements.add(vf.createStatement(iri, RDFS.LABEL, vf.createLiteral(i + "1")));
+			}
+			if (random.nextBoolean()) {
+				statements.add(vf.createStatement(iri, RDFS.LABEL, vf.createLiteral(i + "2")));
+				statements.add(vf.createStatement(iri, RDFS.LABEL, vf.createLiteral(i + "3")));
+				statements.add(vf.createStatement(iri, RDFS.LABEL, vf.createLiteral(i + "4")));
+				statements.add(vf.createStatement(iri, RDFS.LABEL, vf.createLiteral(i + "1", "en")));
+				statements.add(vf.createStatement(iri, RDFS.LABEL, vf.createLiteral(i + "2", "no")));
+			}
+			if (random.nextBoolean()) {
+				statements.add(vf.createStatement(iri, RDFS.LABEL, vf.createLiteral(i + "3", "se")));
+				statements.add(vf.createStatement(iri, RDFS.LABEL, vf.createLiteral(i + "4", "dk")));
+			}
+
+			if (random.nextBoolean()) {
+				statements.add(vf.createStatement(iri, RDFS.COMMENT, vf.createLiteral(i + "8", "en")));
+				statements.add(vf.createStatement(iri, RDFS.COMMENT, vf.createLiteral(i + "9", "no")));
+			} else if (random.nextBoolean()) {
+				statements.add(vf.createStatement(iri, RDFS.COMMENT, vf.createLiteral(i + "5")));
+				statements.add(vf.createStatement(iri, RDFS.COMMENT, vf.createLiteral(i + "6")));
+				statements.add(vf.createStatement(iri, RDFS.COMMENT, vf.createLiteral(i + "7")));
+			}
+
+		}));
+
+		System.gc();
+		Thread.sleep(100);
+	}
+
+	@Benchmark
+	public void shacl() throws Exception {
+
+		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclOrDatatype.ttl"));
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			for (List<Statement> statements : allStatements) {
+				connection.begin(IsolationLevels.SNAPSHOT);
+				connection.add(statements);
+				connection.commit();
+			}
+		}
+
+		repository.shutDown();
+
+	}
+
+	public static void main(String[] args) throws Exception {
+		OrDatatypeBenchmark orDatatypeBenchmark = new OrDatatypeBenchmark();
+		orDatatypeBenchmark.setUp();
+		orDatatypeBenchmark.shacl();
+	}
+
+	@Benchmark
+	public void shaclBulk() throws Exception {
+
+		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclOrDatatype.ttl"));
+
+		((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
+			for (List<Statement> statements : allStatements) {
+				connection.add(statements);
+			}
+			connection.commit();
+
+		}
+
+		repository.shutDown();
+
+	}
+
+	@Benchmark
+	public void noShacl() {
+
+		SailRepository repository = new SailRepository(new TestNotifyingSail(new MemoryStore()));
+
+		repository.init();
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			for (List<Statement> statements : allStatements) {
+				connection.begin(IsolationLevels.SNAPSHOT);
+				connection.add(statements);
+				connection.commit();
+			}
+		}
+
+//		repository.shutDown();
+
+	}
+
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/OrDatatypeBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/OrDatatypeBenchmark.java
@@ -161,7 +161,7 @@ public class OrDatatypeBenchmark {
 			}
 		}
 
-//		repository.shutDown();
+		repository.shutDown();
 
 	}
 

--- a/core/sail/shacl/src/test/resources/shaclOrDatatype.ttl
+++ b/core/sail/shacl/src/test/resources/shaclOrDatatype.ttl
@@ -1,0 +1,22 @@
+@base <http://example.com/ns> .
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+ex:OrShape
+	a sh:NodeShape  ;
+	sh:targetClass rdfs:Resource ;
+	sh:property [
+		sh:path rdfs:label ;
+		sh:or( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ]  )
+
+	] ;
+	sh:or( [sh:path rdfs:comment ; sh:datatype xsd:string ] [sh:path rdfs:comment ; sh:datatype rdf:langString ]  )
+	 .
+
+
+


### PR DESCRIPTION
GitHub issue resolved: #3088 
GitHub issue resolved: #3097 
GitHub issue resolved: #3098 
GitHub issue resolved: #3099 
GitHub issue resolved: #3100 
GitHub issue resolved: #3101 

Briefly describe the changes proposed in this PR:


 - Implement .equals and .hashCode for all plan nodes so that we can more easily reduce duplicates. We also add some code that simplifies nested unions, which also makes it easier to deduplicate. Deduplication makes sh:or faster since we can reduce the number of plan nodes used to calculate the relevant targets for a transaction. #3088 
 - Related to #3088 is performance or sh:or during bulk validation. The problem boils down to skipping the target extension phase by being able to detect when we are using bulk validation and retrieving all the targets directly. We introduce a new plan node to signal bulk validation and also add some support for filtering data earlier. #3098 
 - Similar to the simplification of nested unions, we can also simplify nested Unique (distinct) plan nodes #3099
 - The new XSD enum support allows us to optimise the DatatypeFilter plan node #3100 
 - The ListBindingSet mints a new hash set every time the getBindingNames method is called, this is now cached on the first call. #3097 
 - Even with the optimisations in #3097 it was still better to be able to provide the binding names as a set, so we introduced a new binding set with this support (in the ShaclSail code base) #3101 
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

