### PR TITLE
GH-3106: fix large joins in FedX engine

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/PhaserHandlingParallelExecutor.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/PhaserHandlingParallelExecutor.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.evaluation.join;
+
+import java.util.concurrent.Phaser;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelExecutor;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+
+/**
+ * A delegating {@link ParallelExecutor} which arrives and de-registers on the phaser on completion of a task.
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+class PhaserHandlingParallelExecutor implements ParallelExecutor<BindingSet> {
+
+	private final ParallelExecutor<BindingSet> delegate;
+	private final Phaser phaser;
+
+	public PhaserHandlingParallelExecutor(ParallelExecutor<BindingSet> delegate, Phaser phaser) {
+		super();
+		this.delegate = delegate;
+		this.phaser = phaser;
+	}
+
+	@Override
+	public void addResult(CloseableIteration<BindingSet, QueryEvaluationException> res) {
+		delegate.addResult(res);
+	}
+
+	@Override
+	public void toss(Exception e) {
+		phaser.arriveAndDeregister();
+		delegate.toss(e);
+	}
+
+	@Override
+	public void done() {
+		phaser.arriveAndDeregister();
+		delegate.done();
+	}
+
+	@Override
+	public boolean isFinished() {
+		return delegate.isFinished();
+	}
+
+	@Override
+	public QueryInfo getQueryInfo() {
+		return delegate.getQueryInfo();
+	}
+
+	@Override
+	public void run() {
+		delegate.run();
+	}
+}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/LargeJoinTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/LargeJoinTest.java
@@ -1,0 +1,130 @@
+package org.eclipse.rdf4j.federated;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.federated.FedXWithLocalRepositoryManagerTest.TestLocalRepositoryManager;
+import org.eclipse.rdf4j.federated.repository.FedXRepository;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
+import org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class LargeJoinTest extends FedXBaseTest {
+
+	@TempDir
+	Path tempDir;
+
+	private TestLocalRepositoryManager repoManager;
+
+	@BeforeEach
+	public void before() throws Exception {
+		File baseDir = new File(tempDir.toFile(), "data");
+		repoManager = new TestLocalRepositoryManager(baseDir);
+		repoManager.init();
+	}
+
+	@AfterEach
+	public void after() throws Exception {
+		repoManager.shutDown();
+	}
+
+	@Override
+	protected FederationContext federationContext() {
+		throw new UnsupportedOperationException("Not available in this context.");
+	}
+
+	@Test
+	@Disabled
+	public void testWithLocalRepositoryManager() throws Exception {
+
+		addNativeStore("repo1");
+		addNativeStore("repo2");
+
+		try (RepositoryConnection conn = repoManager.getRepository("repo1").getConnection()) {
+			for (int i = 0; i < 100000; i++) {
+				conn.add(Values.iri("http://example.com/p" + i), RDF.TYPE, FOAF.PERSON);
+			}
+
+			Assertions.assertEquals(100000, conn.size());
+		}
+
+		try (RepositoryConnection conn = repoManager.getRepository("repo2").getConnection()) {
+			for (int i = 0; i < 100000; i += 1000) {
+				conn.add(Values.iri("http://example.com/p" + i), RDFS.LABEL, Values.literal("p" + i));
+			}
+
+			Assertions.assertEquals(100, conn.size());
+		}
+
+		FedXRepository repo = FedXFactory.newFederation()
+				.withResolvableEndpoint("repo1")
+				.withResolvableEndpoint("repo2")
+				.withRepositoryResolver(repoManager)
+				.create();
+		try {
+
+			repo.init();
+			try (RepositoryConnection conn = repo.getConnection()) {
+				TupleQuery tq = conn
+						.prepareTupleQuery(
+								"PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+										+ "SELECT * WHERE {\n"
+										+ "    SERVICE <http://repo1> {\n"
+										+ "      ?person a <http://xmlns.com/foaf/0.1/Person>\n"
+										+ "    }\n"
+										+ "    OPTIONAL {\n"
+										+ "       SERVICE <http://repo2> {\n"
+										+ "          ?person rdfs:label ?label .\n"
+										+ "       }\n"
+										+ "    }\n"
+										+ "}");
+
+				List<BindingSet> res = Iterations.asList(tq.evaluate());
+				Assertions.assertEquals(100000, res.size());
+				List<BindingSet> personsWithName = res.stream()
+						.filter(bs -> bs.hasBinding("label"))
+						.collect(Collectors.toList());
+				Assertions.assertEquals(100, personsWithName.size());
+			}
+
+		} finally {
+			repo.shutDown();
+		}
+
+	}
+
+	protected void addNativeStore(String repoId) throws Exception {
+
+		RepositoryImplConfig implConfig = new SailRepositoryConfig(new NativeStoreConfig());
+		RepositoryConfig config = new RepositoryConfig(repoId, implConfig);
+		repoManager.addRepositoryConfig(config);
+	}
+
+	protected void addData(String repoId, Iterable<Statement> model) {
+
+		Repository repo = repoManager.getRepository(repoId);
+
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.add(model);
+		}
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #3106 

In the concurrency facilities of FedX we make use of the Java Phaser.
This is limited to 65535 registered parties.

In case of large joins (see the example test case) we were seeing errors
that the the phaser has reached limits.

This is now avoided by using tiering of phasers as suggested by the
Phaser javadocs. Note that we pass on a delegate executor control now to
call the arrive and deregister on the correct phaser instance.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

