### PR TITLE
GH-3056 add link to new Github Discussions support forum

### DIFF
--- a/site/content/support.md
+++ b/site/content/support.md
@@ -2,14 +2,16 @@
 title: "Support"
 ---
 
+## Ask about or discuss RDF4J 
+
 [![Gitter](https://badges.gitter.im/eclipse/rdf4j.svg)](https://gitter.im/eclipse/rdf4j?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) you can find us on Gitter!
 
-## Mailing List / Forum
+**[RDF4J Github Discussions](https://github.com/eclipse/rdf4j/discussions)** is the best place to ask questions, propose new ideas or discuss other issues related to RDF4J.
 
-There is an active RDF4J community that uses the **[rdf4j-users Google group]( https://groups.google.com/d/forum/rdf4j-users)** to communicate. You can [browse through the group messages](https://groups.google.com/d/forum/rdf4j-users) without joining, but you’ll need to join the group to be able to post.
+We also have a [Google group]( https://groups.google.com/d/forum/rdf4j-users) called **rdf4j-users**. You can [browse through the group messages](https://groups.google.com/d/forum/rdf4j-users) without joining, but you’ll need to join the group to be able to post.
 
 The RDF4J development team uses the [rdf4j-dev@eclipse.org mailinglist](https://dev.eclipse.org/mailman/listinfo/rdf4j-dev) to discuss development progress.
 
 ## Reporting bugs and requests for improvement
 
-If you think you’ve found a bug in rdf4j, or wish to log a request for a new feature or improvement, please use the [rdf4j issue tracker](https://github.com/eclipse/rdf4j/issues). Before you add your new issue, though, please have a look around to see if it’s not already there.
+If you think you’ve found a bug in RDF4J, or wish to log a request for a new feature or improvement, please use the [RDF4J issue tracker](https://github.com/eclipse/rdf4j/issues). Before you add your new issue, though, please have a look around to see if it’s not already there. 


### PR DESCRIPTION
GitHub issue resolved: #3056 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- add link to new Github Discussions forum on support page
- de-emphasize google group (a little)

