### PR TITLE
GH-3071 ensure bsa result iter returns result when assignment is UNDEF

### DIFF
--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -2513,6 +2513,19 @@ public abstract class ComplexSPARQLQueryTest {
 		assertThat(result).hasSize(2);
 	}
 
+	@Test
+	public void testValuesCartesianProduct() {
+		final String queryString = ""
+				+ "select ?x ?y where { "
+				+ "  values ?x { undef 67 } "
+				+ "  values ?y { undef 42 } "
+				+ "}";
+		final TupleQuery tupleQuery = conn.prepareTupleQuery(queryString);
+
+		List<BindingSet> bindingSets = QueryResults.asList(tupleQuery.evaluate());
+		assertThat(bindingSets).hasSize(4);
+	}
+
 	/**
 	 * See https://github.com/eclipse/rdf4j/issues/1267
 	 */


### PR DESCRIPTION
GitHub issue resolved: #3071 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- fix corner case of binding set assignment result processing when binding is UNDEF.
- added regresssion test
- some variable renaming and code cleanup 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

