### PR TITLE
GH-3072 handle values clause after optional join correctly

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
@@ -499,8 +499,8 @@ public class QueryResults extends Iterations {
 	}
 
 	/**
-	 * Check whether two {@link BindingSet}s are compatible.Two binding sets are compatible if they have equal values
-	 * for each binding name that occurs in both binding sets.
+	 * Check whether two {@link BindingSet}s are compatible. Two binding sets are compatible if they have equal values
+	 * for each variable that is bound in both binding sets.
 	 *
 	 * @param bs1
 	 * @param bs2
@@ -513,6 +513,11 @@ public class QueryResults extends Iterations {
 		for (String bindingName : sharedBindings) {
 			Value value1 = bs1.getValue(bindingName);
 			Value value2 = bs2.getValue(bindingName);
+
+			if (value1 == null || value2 == null) {
+				// variable is unbound in one set, therefore compatible.
+				continue;
+			}
 
 			if (!value1.equals(value2)) {
 				return false;

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/QueryResultsTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/QueryResultsTest.java
@@ -7,9 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,8 +31,8 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.impl.MutableTupleQueryResult;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Arjohn Kampman
@@ -75,7 +76,7 @@ public class QueryResultsTest {
 
 	private IRI q = VF.createIRI("urn:q");
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		tqr1 = new MutableTupleQueryResult(twoBindingNames);
 		tqr2 = new MutableTupleQueryResult(twoBindingNames);
@@ -180,6 +181,41 @@ public class QueryResultsTest {
 			BindingSet result = filtered.next();
 			assertFalse(processed.contains(result));
 			processed.add(result);
+		}
+	}
+
+	@Test
+	public void testBindingSetsCompatible() {
+		{
+			BindingSet a = new ListBindingSet(twoBindingNames, foo, lit1);
+			BindingSet b = new ListBindingSet(twoBindingNames, foo, lit2);
+
+			assertThat(QueryResults.bindingSetsCompatible(a, b)).isFalse();
+		}
+		{
+			BindingSet a = new ListBindingSet(twoBindingNames, foo, lit1);
+			BindingSet b = new ListBindingSet(twoBindingNames, foo, lit1);
+
+			assertThat(QueryResults.bindingSetsCompatible(a, b)).isTrue();
+		}
+		{
+			BindingSet a = new ListBindingSet(twoBindingNames, null, lit1);
+			BindingSet b = new ListBindingSet(twoBindingNames, null, lit2);
+
+			assertThat(QueryResults.bindingSetsCompatible(a, b)).isFalse();
+		}
+		{
+			BindingSet a = new ListBindingSet(twoBindingNames, null, lit1);
+			BindingSet b = new ListBindingSet(twoBindingNames, null, lit1);
+
+			assertThat(QueryResults.bindingSetsCompatible(a, b)).isTrue();
+		}
+		{
+			BindingSet a = new ListBindingSet(twoBindingNames, foo, lit1);
+			BindingSet b = new ListBindingSet(twoBindingNames, null, lit1);
+
+			assertThat(QueryResults.bindingSetsCompatible(a, b)).isTrue();
+			assertThat(QueryResults.bindingSetsCompatible(b, a)).isTrue();
 		}
 	}
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -1151,6 +1151,33 @@ public abstract class ComplexSPARQLQueryTest {
 	}
 
 	/**
+	 * See https://github.com/eclipse/rdf4j/issues/3072
+	 * 
+	 */
+	@Test
+	public void testValuesAfterOptional() throws Exception {
+		String data = "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . \n"
+				+ "@prefix :     <urn:ex:> . \n"
+				+ ":r1 a rdfs:Resource . \n"
+				+ ":r2 a rdfs:Resource ; rdfs:label \"a label\" . \n";
+
+		String query = ""
+				+ "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n"
+				+ "prefix :     <urn:ex:> \n"
+				+ "\n"
+				+ "select ?resource ?label where { \n"
+				+ "  ?resource a rdfs:Resource . \n"
+				+ "  optional { ?resource rdfs:label ?label } \n"
+				+ "  values ?label { undef } \n"
+				+ "}";
+
+		conn.add(new StringReader(data), RDFFormat.TURTLE);
+
+		List<BindingSet> result = QueryResults.asList(conn.prepareTupleQuery(query).evaluate());
+		assertThat(result).hasSize(2);
+	}
+
+	/**
 	 * See https://github.com/eclipse/rdf4j/issues/1978
 	 */
 	@Test

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -2513,6 +2513,19 @@ public abstract class ComplexSPARQLQueryTest {
 		assertThat(result).hasSize(2);
 	}
 
+	@Test
+	public void testValuesCartesianProduct() {
+		final String queryString = ""
+				+ "select ?x ?y where { "
+				+ "  values ?x { undef 67 } "
+				+ "  values ?y { undef 42 } "
+				+ "}";
+		final TupleQuery tupleQuery = conn.prepareTupleQuery(queryString);
+
+		List<BindingSet> bindingSets = QueryResults.asList(tupleQuery.evaluate());
+		assertThat(bindingSets).hasSize(4);
+	}
+
 	/**
 	 * See https://github.com/eclipse/rdf4j/issues/1267
 	 */


### PR DESCRIPTION
GitHub issue resolved: #3072  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- handle case of unbound variables in compatibility check: guard against NPE and continue processing
- added regression test

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

