### PR TITLE
GH-3117 Fix FedX syntax error on literal with new lines and language tags

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
@@ -889,19 +889,19 @@ public class QueryStringUtil {
 	 * @return the string builder
 	 */
 	protected static StringBuilder appendLiteral(StringBuilder sb, Literal lit) {
-		sb.append('"');
+		sb.append("'''");
 		sb.append(lit.getLabel().replace("\"", "\\\""));
-		sb.append('"');
+		sb.append("'''");
 
 		if (lit.getLanguage().isPresent()) {
 			sb.append('@');
-			sb.append(lit.getLanguage());
-		}
-
-		if (lit.getDatatype() != null) {
-			sb.append("^^<");
-			sb.append(lit.getDatatype().stringValue());
-			sb.append('>');
+			sb.append(lit.getLanguage().get());
+		} else {
+			if (lit.getDatatype() != null) {
+				sb.append("^^<");
+				sb.append(lit.getDatatype().stringValue());
+				sb.append('>');
+			}
 		}
 		return sb;
 	}

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
@@ -99,6 +99,27 @@ public class BasicTests extends SPARQLBaseTest {
 	}
 
 	@Test
+	public void testQuotes() throws Exception {
+		/* test query with new line in literal */
+		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint3.ttl"));
+		execute("/tests/basic/query_quotes.rq", "/tests/basic/query_quotes.srx", false);
+	}
+
+	@Test
+	public void testQuotesDatatype() throws Exception {
+		/* test query with new line in triple quotes and datatype */
+		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint3.ttl"));
+		execute("/tests/basic/query_quotes_datatype.rq", "/tests/basic/query_quotes_datatype.srx", false);
+	}
+
+	@Test
+	public void testLanguageTag() throws Exception {
+		/* test query with a language tag */
+		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint4.ttl"));
+		execute("/tests/basic/query_lang.rq", "/tests/basic/query_lang.srx", false);
+	}
+
+	@Test
 	public void testBindClause() throws Exception {
 
 		/* test query with bind clause */

--- a/tools/federation/src/test/resources/tests/basic/data01endpoint3.ttl
+++ b/tools/federation/src/test/resources/tests/basic/data01endpoint3.ttl
@@ -1,0 +1,8 @@
+@prefix : <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+:a foaf:interest '''SPARQL 1.1 Basic
+Federated Query''' .
+
+:b foaf:interest '''SPARQL 1.1 Basic
+Federated Query'''^^:someType .

--- a/tools/federation/src/test/resources/tests/basic/data01endpoint4.ttl
+++ b/tools/federation/src/test/resources/tests/basic/data01endpoint4.ttl
@@ -1,0 +1,3 @@
+@prefix : <http://example.org/> .
+
+:c :p  "string"@en .

--- a/tools/federation/src/test/resources/tests/basic/query_lang.rq
+++ b/tools/federation/src/test/resources/tests/basic/query_lang.rq
@@ -1,0 +1,4 @@
+PREFIX : <http://example.org/>
+SELECT ?s
+{ ?s :p "string"@en
+}

--- a/tools/federation/src/test/resources/tests/basic/query_lang.srx
+++ b/tools/federation/src/test/resources/tests/basic/query_lang.srx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="s"/>
+  </head>
+  <results>
+    <result>
+      <binding name="s"><uri>http://example.org/c</uri></binding>
+    </result>
+  </results>
+</sparql>
+

--- a/tools/federation/src/test/resources/tests/basic/query_quotes.rq
+++ b/tools/federation/src/test/resources/tests/basic/query_quotes.rq
@@ -1,0 +1,5 @@
+PREFIX : <http://example.org/ns#>
+SELECT ?s
+{ ?s ?p '''SPARQL 1.1 Basic
+Federated Query'''
+}

--- a/tools/federation/src/test/resources/tests/basic/query_quotes.srx
+++ b/tools/federation/src/test/resources/tests/basic/query_quotes.srx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="s"/>
+    <variable name="interest"/>
+  </head>
+  <results>
+    <result>
+      <binding name="s"><uri>http://example.org/a</uri></binding>
+    </result>
+  </results>
+</sparql>
+

--- a/tools/federation/src/test/resources/tests/basic/query_quotes_datatype.rq
+++ b/tools/federation/src/test/resources/tests/basic/query_quotes_datatype.rq
@@ -1,0 +1,5 @@
+PREFIX : <http://example.org/>
+SELECT ?s
+{ ?s ?p '''SPARQL 1.1 Basic
+Federated Query'''^^:someType
+}

--- a/tools/federation/src/test/resources/tests/basic/query_quotes_datatype.srx
+++ b/tools/federation/src/test/resources/tests/basic/query_quotes_datatype.srx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="s"/>
+    <variable name="interest"/>
+  </head>
+  <results>
+    <result>
+      <binding name="s"><uri>http://example.org/b</uri></binding>
+    </result>
+  </results>
+</sparql>
+


### PR DESCRIPTION
GitHub issue resolved: #3117 
Fix FedX ASK queries generated that fail with syntax errors. Use triple quotes to handle literals with new lines and get language tag properly.
