### PR TITLE
wip: GH-3131 FedX cancel tasks. configurable ConsumingIteration parameter

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -68,6 +68,8 @@ public class FedXConfig {
 
 	private String prefixDeclarations = null;
 
+	private int consumingIterationMax = 1000;
+
 	/* factory like setters */
 
 	/**
@@ -506,5 +508,28 @@ public class FedXConfig {
 	 */
 	public Optional<TaskWrapper> getTaskWrapper() {
 		return Optional.ofNullable(taskWrapper);
+	}
+
+	/**
+	 * Set the max number of results to be consumed by {@link ConsumingIteration}. See
+	 * {@link #getConscumingIterationMax()}.
+	 *
+	 * <p>
+	 * Can only be set before federation initialization.
+	 * </p>
+	 *
+	 * @param max
+	 * @return the current config
+	 */
+	public FedXConfig withConsumingIterationMax(int max) {
+		this.consumingIterationMax = max;
+		return this;
+	}
+
+	/**
+	 * Returns the max number of results to be consumed by {@link ConsumingIteration}
+	 */
+	public int getConscumingIterationMax() {
+		return consumingIterationMax;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
@@ -156,7 +156,7 @@ public abstract class TripleSourceBase implements TripleSource {
 				res = new InsertBindingsIteration(res, bindings);
 			}
 
-			resultHolder.set(new ConsumingIteration(res));
+			resultHolder.set(new ConsumingIteration(res, federationContext.getConfig().getConscumingIterationMax()));
 
 		});
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelExecutorBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelExecutorBase.java
@@ -97,7 +97,10 @@ public abstract class ParallelExecutorBase<T> extends LookAheadIteration<T, Quer
 		}
 
 		try {
-			rightQueue.put(res);
+			if (!closed)
+				rightQueue.put(res);
+			else
+				res.close();
 		} catch (InterruptedException e) {
 			throw new RuntimeException("Error adding element to right queue", e);
 		}
@@ -153,6 +156,7 @@ public abstract class ParallelExecutorBase<T> extends LookAheadIteration<T, Quer
 	@Override
 	public void handleClose() throws QueryEvaluationException {
 
+		closed = true;
 		try {
 			rightQueue.close();
 		} finally {
@@ -162,7 +166,6 @@ public abstract class ParallelExecutorBase<T> extends LookAheadIteration<T, Quer
 				rightIter = null;
 			}
 		}
-		closed = true;
 		super.handleClose();
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/CloseDependentConnectionIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/CloseDependentConnectionIteration.java
@@ -38,20 +38,30 @@ public class CloseDependentConnectionIteration<T>
 
 	@Override
 	public boolean hasNext() throws QueryEvaluationException {
-		boolean res = inner.hasNext();
-		if (!res) {
-			try {
-				dependentConn.close();
-			} catch (Throwable ignore) {
-				log.trace("Failed to close dependent connection:", ignore);
+		try {
+			boolean res = inner.hasNext();
+			if (!res) {
+				try {
+					dependentConn.close();
+				} catch (Throwable ignore) {
+					log.trace("Failed to close dependent connection:", ignore);
+				}
 			}
+			return res;
+		} catch (Throwable t) {
+			dependentConn.close();
+			throw t;
 		}
-		return res;
 	}
 
 	@Override
 	public T next() throws QueryEvaluationException {
-		return inner.next();
+		try {
+			return inner.next();
+		} catch (Throwable t) {
+			dependentConn.close();
+			throw t;
+		}
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/ConsumingIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/ConsumingIteration.java
@@ -30,12 +30,6 @@ import com.google.common.collect.Lists;
  */
 public class ConsumingIteration implements CloseableIteration<BindingSet, QueryEvaluationException> {
 
-	/**
-	 * Maximum number of bindings that are consumed at construction time. Remaining items, if any are consumed from the
-	 * iterator itself
-	 */
-	private static final int max = 1000; // TODO make configurable
-
 	private final List<BindingSet> consumed = Lists.newArrayList();
 
 	private final CloseableIteration<BindingSet, QueryEvaluationException> innerIter;
@@ -45,7 +39,12 @@ public class ConsumingIteration implements CloseableIteration<BindingSet, QueryE
 	 */
 	private int currentIndex = 0;
 
-	public ConsumingIteration(CloseableIteration<BindingSet, QueryEvaluationException> iter)
+	/**
+	 * @param iter iteration to be consumed
+	 * @param max  the number of results to be consumed.
+	 * @throws QueryEvaluationException
+	 */
+	public ConsumingIteration(CloseableIteration<BindingSet, QueryEvaluationException> iter, int max)
 			throws QueryEvaluationException {
 
 		innerIter = iter;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousBoundJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousBoundJoin.java
@@ -91,13 +91,14 @@ public class SynchronousBoundJoin extends SynchronousJoin {
 			bindings = new ArrayList<>(nBindings);
 
 			int count = 0;
-			while (count < nBindings && leftIter.hasNext()) {
+			while (!closed && count < nBindings && leftIter.hasNext()) {
 				bindings.add(leftIter.next());
 				count++;
 			}
 
 			totalBindings += count;
-
+			if (closed)
+				return;
 			if (hasFreeVars) {
 				addResult(strategy.evaluateBoundJoinStatementPattern(stmt, bindings));
 			} else {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelGetStatementsTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelGetStatementsTask.java
@@ -35,6 +35,7 @@ public class ParallelGetStatementsTask extends ParallelTaskBase<Statement> {
 	protected final Value obj;
 	protected final QueryInfo queryInfo;
 	protected Resource[] contexts;
+	private CloseableIteration<Statement, QueryEvaluationException> res;
 
 	public ParallelGetStatementsTask(ParallelExecutor<Statement> unionControl,
 			Endpoint endpoint,
@@ -59,6 +60,17 @@ public class ParallelGetStatementsTask extends ParallelTaskBase<Statement> {
 	public CloseableIteration<Statement, QueryEvaluationException> performTask()
 			throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
-		return tripleSource.getStatements(subj, pred, obj, queryInfo, contexts);
+		res = tripleSource.getStatements(subj, pred, obj, queryInfo, contexts);
+		return res;
+	}
+
+	@Override
+	public void cancel() {
+		// TODO Auto-generated method stub
+		super.cancel();
+		if (res != null) {
+			res.close();
+			res = null;
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: damyan.ognyanov <damyan.ognyanov@ontotext.com>


GitHub issue resolved: #3131

Briefly describe the changes proposed in this PR:

 - address issues with connection leaks when tasks are being canceled
 - add new configuration parameter that specify number of results collected by ConsumingIteration initially

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

