### PR TITLE
GH-3127: bump version + remove deprecated methods

### DIFF
--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/SPARQLResultsXSVMappingStrategy.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/SPARQLResultsXSVMappingStrategy.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.text;
 
-import java.beans.PropertyDescriptor;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -19,7 +18,6 @@ import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.BindingSet;
 
-import com.opencsv.bean.BeanField;
 import com.opencsv.bean.MappingStrategy;
 
 /**
@@ -44,39 +42,9 @@ abstract public class SPARQLResultsXSVMappingStrategy implements MappingStrategy
 		return bindingNames;
 	}
 
-	@Deprecated
-	@Override
-	public PropertyDescriptor findDescriptor(int col) {
-		return null;
-	}
-
-	@Deprecated
-	@Override
-	public BeanField<BindingSet> findField(int col) {
-		return null;
-	}
-
-	@Deprecated
-	@Override
-	public int findMaxFieldIndex() {
-		return 0;
-	}
-
-	@Deprecated
-	@Override
-	public BindingSet createBean() {
-		return null;
-	}
-
 	@Override
 	public String[] generateHeader(BindingSet bean) {
 		throw new UnsupportedOperationException(WRITING_UNSUPPORTED);
-	}
-
-	@Deprecated
-	@Override
-	public Integer getColumnIndex(String name) {
-		return null;
 	}
 
 	@Override
@@ -109,17 +77,6 @@ abstract public class SPARQLResultsXSVMappingStrategy implements MappingStrategy
 
 		return dataType != null ? valueFactory.createLiteral(valueString, dataType)
 				: valueFactory.createLiteral(valueString);
-	}
-
-	@Deprecated
-	@Override
-	public BindingSet populateNewBeanWithIntrospection(String[] line) {
-		throw new UnsupportedOperationException("Please use populateNewBean() instead.");
-	}
-
-	@Deprecated
-	@Override
-	public void verifyLineLength(int numberOfFields) {
 	}
 
 	@Override

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVMappingStrategy.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVMappingStrategy.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.resultio.text.SPARQLResultsXSVMappingStrategy;
 
 import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 
 /**
  * Implements a {@link com.opencsv.bean.MappingStrategy} to allow opencsv to work in parallel. This is where the input
@@ -34,8 +35,11 @@ public class SPARQLResultsCSVMappingStrategy extends SPARQLResultsXSVMappingStra
 
 	@Override
 	public void captureHeader(CSVReader reader) throws IOException {
-		// header is mandatory in SPARQL CSV
-		bindingNames = Arrays.asList(reader.readNext());
+		try {
+			bindingNames = Arrays.asList(reader.readNext());
+		} catch (CsvValidationException ex) {
+			throw new IOException(ex);
+		}
 	}
 
 	@Override

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVReader.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLResultsTSVReader.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.Reader;
 
 import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 
 /**
  * This reader respects the TSV semantics of RDF4J and does absolutely no processing except for splitting the line on
@@ -24,6 +25,15 @@ public class SPARQLResultsTSVReader extends CSVReader {
 	@Override
 	public String[] readNext() throws IOException {
 		String line = getNextLine();
-		return line == null ? null : validateResult(line.split("\t", -1));
+		if (line == null) {
+			return null;
+		}
+		String[] fields = line.split("\t", -1);
+		try {
+			validateResult(fields, linesRead);
+		} catch (CsvValidationException ex) {
+			throw new IOException(ex);
+		}
+		return fields;
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
 			<dependency>
 				<groupId>com.opencsv</groupId>
 				<artifactId>opencsv</artifactId>
-				<version>4.6</version>
+				<version>5.3</version>
 			</dependency>
 			<!-- Apache Commons -->
 			<dependency>


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #3127  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- remove deprecated methods
- bump version to opencsv 5.3
- use switch statement instead of nested ifs

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

