### PR TITLE
GH-3154 fix null pointer exception when disabling the ShaclSail RDFS reasoner 

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
@@ -114,7 +114,13 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 			);
 
 			RdfsSubClassOfReasoner rdfsSubClassOfReasoner = connectionsGroup.getRdfsSubClassOfReasoner();
-			Set<Resource> clazzForwardChained = rdfsSubClassOfReasoner.backwardsChain(clazz);
+			Set<Resource> clazzForwardChained;
+
+			if (rdfsSubClassOfReasoner != null) {
+				clazzForwardChained = rdfsSubClassOfReasoner.backwardsChain(clazz);
+			} else {
+				clazzForwardChained = Collections.singleton(clazz);
+			}
 
 			// filter by type against the base sail
 			PlanNode falseNode = new ExternalPredicateObjectFilter(
@@ -279,7 +285,15 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 	}
 
 	private String getFilter(ConnectionsGroup connectionsGroup, StatementMatcher.Variable target) {
-		Set<Resource> allClasses = connectionsGroup.getRdfsSubClassOfReasoner().backwardsChain(clazz);
+
+		RdfsSubClassOfReasoner rdfsSubClassOfReasoner = connectionsGroup.getRdfsSubClassOfReasoner();
+		Set<Resource> allClasses;
+
+		if (rdfsSubClassOfReasoner != null) {
+			allClasses = rdfsSubClassOfReasoner.backwardsChain(clazz);
+		} else {
+			allClasses = Collections.singleton(clazz);
+		}
 
 		String condition = allClasses.stream()
 				.map(c -> "EXISTS{?" + target.getName() + " a <" + c.stringValue() + ">}")

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetClass.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetClass.java
@@ -1,5 +1,6 @@
 package org.eclipse.rdf4j.sail.shacl.ast.targets;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -104,13 +105,19 @@ public class TargetClass extends Target {
 			RdfsSubClassOfReasoner rdfsSubClassOfReasoner) {
 		assert (subject == null);
 
-		return targetClass
-				.stream()
-				.map(rdfsSubClassOfReasoner::backwardsChain)
-				.flatMap(Collection::stream)
-				.distinct()
+		Stream<Resource> stream = targetClass.stream();
+
+		if (rdfsSubClassOfReasoner != null) {
+			stream = stream
+					.map(rdfsSubClassOfReasoner::backwardsChain)
+					.flatMap(Collection::stream)
+					.distinct();
+		}
+
+		return stream
 				.map(t -> new StatementMatcher(object, new StatementMatcher.Variable(RDF.TYPE),
 						new StatementMatcher.Variable(t)));
+
 	}
 
 	@Override
@@ -119,13 +126,18 @@ public class TargetClass extends Target {
 			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		assert (subject == null);
 
-		List<Resource> targetClass = this.targetClass
-				.stream()
-				.map(rdfsSubClassOfReasoner::backwardsChain)
-				.flatMap(Collection::stream)
+		Collection<Resource> targetClass;
 
-				.distinct()
-				.collect(Collectors.toList());
+		if (rdfsSubClassOfReasoner != null) {
+			targetClass = this.targetClass
+					.stream()
+					.map(rdfsSubClassOfReasoner::backwardsChain)
+					.flatMap(Collection::stream)
+					.distinct()
+					.collect(Collectors.toList());
+		} else {
+			targetClass = this.targetClass;
+		}
 
 		if (targetClass.size() == 1) {
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -335,7 +335,7 @@ abstract public class AbstractShaclTest {
 		return ret;
 	}
 
-	static void runTestCase(String shaclPath, String dataPath, ExpectedResult expectedResult,
+	void runTestCase(String shaclPath, String dataPath, ExpectedResult expectedResult,
 			IsolationLevel isolationLevel, boolean preloadWithDummyData) {
 
 		if (!dataPath.endsWith("/")) {
@@ -816,7 +816,7 @@ abstract public class AbstractShaclTest {
 		return s;
 	}
 
-	static void runTestCaseSingleTransaction(String shaclPath, String dataPath, ExpectedResult expectedResult,
+	void runTestCaseSingleTransaction(String shaclPath, String dataPath, ExpectedResult expectedResult,
 			IsolationLevel isolationLevel) {
 
 		if (!dataPath.endsWith("/")) {
@@ -895,7 +895,7 @@ abstract public class AbstractShaclTest {
 
 	}
 
-	static void runTestCaseRevalidate(String shaclPath, String dataPath, ExpectedResult expectedResult,
+	void runTestCaseRevalidate(String shaclPath, String dataPath, ExpectedResult expectedResult,
 			IsolationLevel isolationLevel) {
 
 		if (!dataPath.endsWith("/")) {
@@ -966,7 +966,7 @@ abstract public class AbstractShaclTest {
 
 	}
 
-	static void runParsingTest(String shaclPath, String dataPath, ExpectedResult expectedResult) {
+	void runParsingTest(String shaclPath, String dataPath, ExpectedResult expectedResult) {
 		if (!dataPath.endsWith("/")) {
 			dataPath = dataPath + "/";
 		}
@@ -1053,7 +1053,7 @@ abstract public class AbstractShaclTest {
 		printResults(validationReport);
 	}
 
-	private static SailRepository getShaclSail() {
+	SailRepository getShaclSail() {
 
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 		SailRepository repository = new SailRepository(shaclSail);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTestWithoutRdfsReasoner.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTestWithoutRdfsReasoner.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl;
+
+import org.eclipse.rdf4j.IsolationLevel;
+import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * When the RDFS reasoner is disabled it makes ConnectionsGroup.getRdfsSubClassOfReasoner() return null. This could lead
+ * to null pointer exceptions if some code assumes that it will never be null!
+ *
+ * @author Håvard Ottestad
+ */
+@RunWith(Parameterized.class)
+@Tag("slow")
+public class ShaclTestWithoutRdfsReasoner extends AbstractShaclTest {
+
+	public ShaclTestWithoutRdfsReasoner(String testCasePath, String path, ExpectedResult expectedResult,
+			IsolationLevel isolationLevel) {
+		super(testCasePath, path, expectedResult, isolationLevel);
+	}
+
+	@Test
+	public void test() {
+		if (ignoredTest(testCasePath)) {
+			return;
+		}
+		runWithAutomaticLogging(() -> runTestCase(testCasePath, path, expectedResult, isolationLevel, false));
+	}
+
+	@Test
+	public void testRevalidation() {
+		if (ignoredTest(testCasePath)) {
+			return;
+		}
+		runWithAutomaticLogging(() -> runTestCaseRevalidate(testCasePath, path, expectedResult, isolationLevel));
+	}
+
+	// Since we have disabled the RDFS reasoner we can't run the tests that require reasoning
+	private static boolean ignoredTest(String testCasePath) {
+		return testCasePath.contains("/subclass");
+	}
+
+	private void runWithAutomaticLogging(Runnable r) {
+		try {
+			r.run();
+		} catch (Throwable t) {
+			fullLogging = true;
+			System.out.println("\n##############################################");
+			System.out.println("###### Re-running test with full logging #####");
+			System.out.println("##############################################\n");
+
+			r.run();
+		} finally {
+			fullLogging = false;
+		}
+	}
+
+	SailRepository getShaclSail() {
+
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+		SailRepository repository = new SailRepository(shaclSail);
+
+		shaclSail.setLogValidationPlans(fullLogging);
+		shaclSail.setCacheSelectNodes(true);
+		shaclSail.setParallelValidation(false);
+		shaclSail.setLogValidationViolations(fullLogging);
+		shaclSail.setGlobalLogValidationExecution(fullLogging);
+		shaclSail.setEclipseRdf4jShaclExtensions(true);
+		shaclSail.setDashDataShapes(true);
+		shaclSail.setRdfsSubClassReasoning(false);
+
+		System.setProperty("org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation", "true");
+
+		repository.init();
+
+		return repository;
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #3154 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - add tests
 - check if null before using reasoner


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

