### PR TITLE
GH-1706 remove left overs from lucene spin sail

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -280,11 +280,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-lucene-spin</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-spin</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION


GitHub issue resolved: #1706 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - removed some left over references that cause build to fail if you don't have the lucene spin snapshot build
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

