### PR TITLE
GH-3166 GlobalValidationExecutionLogging should log before iterator is created

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -448,13 +448,15 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 							before = System.currentTimeMillis();
 						}
 
+						if (GlobalValidationExecutionLogging.loggingEnabled) {
+							logger.info("Start execution of plan:\n{}\n", shapePlanNodeTuple.getShape().toString());
+						}
+
 						try (CloseableIteration<? extends ValidationTuple, SailException> iterator = planNode
 								.iterator()) {
-							if (GlobalValidationExecutionLogging.loggingEnabled) {
-								logger.info("Start execution of plan:\n{}\n", shapePlanNodeTuple.getShape().toString());
-							}
 
 							ValidationResultIterator validationResults;
+
 							try {
 								validationResults = new ValidationResultIterator(iterator,
 										sail.getEffectiveValidationResultsLimitPerConstraint());


### PR DESCRIPTION


GitHub issue resolved: #3166 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

