### PR TITLE
GH-3170: fix typos

### DIFF
--- a/site/content/documentation/programming/lucene.md
+++ b/site/content/documentation/programming/lucene.md
@@ -75,12 +75,12 @@ results.forEach(res -> {
 
 ## SearchIndex implementations
 
-The LuceneSail can currently be used with five SearchIndex implementations:
+The LuceneSail can currently be used with three SearchIndex implementations:
 
 |                   |  SearchIndex implementation                 | Maven module                          |
 |------------------ |---------------------------------------------|---------------------|
-| Apachce Lucence 6 | `org.eclipse.rdf4j.sail.lucene.LuceneIndex` | `rdf4j-sail-lucene` |
-| ElasticSearch     | `org.eclipse.rdf4j.sail.elasticSearch.ElasticSearchIndex` | `rdf4j-sail-elasticsearch` |
+| Apache Lucene     | `org.eclipse.rdf4j.sail.lucene.LuceneIndex` | `rdf4j-sail-lucene` |
+| ElasticSearch     | `org.eclipse.rdf4j.sail.elasticsearch.ElasticsearchIndex` | `rdf4j-sail-elasticsearch` |
 | Apache Solr       | `org.eclipse.rdf4j.sail.solr.SolrIndex`     | `rdf4j-sail-solr`   |
 
 Each SearchIndex implementation can easily be extended if you need to add extra features or store/access data with a different schema.


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #3170 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- 'three' instead of 'five'
- 'Apachce Lucence' to 'Apache Lucene' <!-- short description of your change goes here -->
- correct casing of ElasticsearchIndex

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

