### PR TITLE
GH-3160 disable flaky FedX test until we have time to hunt the cause

### DIFF
--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/ServiceTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/ServiceTests.java
@@ -35,6 +35,7 @@ import org.eclipse.rdf4j.repository.sparql.federation.SPARQLServiceResolver;
 import org.eclipse.rdf4j.repository.util.Repositories;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Sets;
@@ -366,6 +367,7 @@ public class ServiceTests extends SPARQLBaseTest {
 	}
 
 	@Test
+	@Disabled("test is flaky - see https://github.com/eclipse/rdf4j/issues/3160")
 	public void test11_errorHandling() throws Exception {
 
 		assumeSparqlEndpoint();


### PR DESCRIPTION
GitHub issue resolved: #3160  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- temporarily disable flaky test to avoid intermittent build failures
- we should not close the underlying issue until we have time to look a bit deeper at the underlying cause

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

