### PR TITLE
GH-3153 better error handling/reporting on PUT repo config operations

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/RepositoryController.java
@@ -64,6 +64,7 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.repository.manager.SystemRepository;
@@ -167,8 +168,15 @@ public class RepositoryController extends AbstractController {
 								.orElseThrow(() -> new HTTPException(HttpStatus.SC_BAD_REQUEST,
 										"unrecognized content type " + request.getContentType())));
 				RepositoryConfig config = RepositoryConfigUtil.getRepositoryConfig(model, repId);
+				if (config == null) {
+					throw new RepositoryConfigException("could not read repository config from supplied data");
+				}
 				repositoryManager.addRepositoryConfig(config);
 				return new ModelAndView(EmptySuccessView.getInstance());
+			} catch (RepositoryConfigException e) {
+				ErrorInfo errorInfo = new ErrorInfo(ErrorType.MALFORMED_DATA,
+						"Supplied repository configuration is invalid: " + e.getMessage());
+				throw new ClientHTTPException(HttpStatus.SC_BAD_REQUEST, errorInfo.toString());
 			} catch (RDF4JException e) {
 				logger.error("error while attempting to create/configure repository '" + repId + "'", e);
 				throw new ServerHTTPException("Repository create error: " + e.getMessage(), e);


### PR DESCRIPTION
GitHub issue resolved: #3153  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- check for missing config data in RepositoryController and return an explicit /  helpful error (400 Bad Request)
- also catch other config validation errors  and also return a 400 error with useful message in body

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

