### PR TITLE
GH-3178 rdf4j-users archived, made Github Discussion more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the main code repository for the Eclipse RDF4J project.
 [![main status](https://github.com/eclipse/rdf4j/workflows/main%20status/badge.svg)](https://github.com/eclipse/rdf4j/actions?query=workflow%3A%22main+status%22)
 [![develop status](https://github.com/eclipse/rdf4j/workflows/develop%20status/badge.svg)](https://github.com/eclipse/rdf4j/actions?query=workflow%3A%22develop+status%22) [![Join the chat at https://gitter.im/eclipse/rdf4j](https://badges.gitter.im/eclipse/rdf4j.svg)](https://gitter.im/eclipse/rdf4j?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Visit the [project website](https://rdf4j.org/) for news, documentation, and downloadable releases.
+Visit the [project website](https://rdf4j.org/) for news, documentation, and downloadable releases. For support questions, comments, and any ideas for improvements you'd like to discuss, please use our [discussion forum](https://github.com/eclipse/rdf4j/discussions). If you have found a bug or have a very specific feature/improvement request, you can also use our [issue tracker](https://github.com/eclipse/rdf4j/issues) to report it.
 
 ## Installation and usage
 

--- a/site/content/support.md
+++ b/site/content/support.md
@@ -2,16 +2,17 @@
 title: "Support"
 ---
 
-## Ask about or discuss RDF4J 
+## Ask about or discuss RDF4J
 
-[![Gitter](https://badges.gitter.im/eclipse/rdf4j.svg)](https://gitter.im/eclipse/rdf4j?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) you can find us on Gitter!
 
 **[RDF4J Github Discussions](https://github.com/eclipse/rdf4j/discussions)** is the best place to ask questions, propose new ideas or discuss other issues related to RDF4J.
 
-We also have a [Google group]( https://groups.google.com/d/forum/rdf4j-users) called **rdf4j-users**. You can [browse through the group messages](https://groups.google.com/d/forum/rdf4j-users) without joining, but you’ll need to join the group to be able to post.
+You can also find us on [Gitter](https://gitter.im/eclipse/rdf4j?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge), if you prefer an instant messaging style of communication. However, we make no promises that any of the RDF4J developers will be online at any given time.
+
+We previously used a Google group called rdf4j-users. This group has now been archived. You can still [browse the archive](https://groups.google.com/d/forum/rdf4j-users), but no new posts will be accepted.
 
 The RDF4J development team uses the [rdf4j-dev@eclipse.org mailinglist](https://dev.eclipse.org/mailman/listinfo/rdf4j-dev) to discuss development progress.
 
 ## Reporting bugs and requests for improvement
 
-If you think you’ve found a bug in RDF4J, or wish to log a request for a new feature or improvement, please use the [RDF4J issue tracker](https://github.com/eclipse/rdf4j/issues). Before you add your new issue, though, please have a look around to see if it’s not already there. 
+If you think you’ve found a bug in RDF4J, or wish to log a request for a new feature or improvement, please use the [RDF4J issue tracker](https://github.com/eclipse/rdf4j/issues). Before you add your new issue, though, please have a look around to see if it’s not already there.


### PR DESCRIPTION
GitHub issue resolved: #3178  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- adapted website support page to make Github Discussions the preferred comms channel, and make it clear that rdf4j-users is no longer used.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

