### PR TITLE
GH-3199 issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: File a bug report
+labels: [ "🐞 bug", "triage" ]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to fill out this bug report!
+    - type: textarea
+      attributes:
+        label: Current Behavior
+        description: A concise description of what you're experiencing.
+      validations:
+        required: true
+    - type: textarea
+      attributes:
+        label: Expected Behavior
+        description: A concise description of what you expected to happen.
+      validations:
+        required: true
+    - type: textarea
+      attributes:
+        label: Steps To Reproduce
+        description: Steps to reproduce the behavior.
+        placeholder: |
+          1. In this environment...
+          2. With this config...
+          3. Run '...' (include code example if possible)
+          4. See error...
+        validations:
+          required: false
+    - type: dropdown
+      id: version
+      attributes:
+        label: Version
+        description: What version of RDF4J are you using?
+        options:
+        - 3.7.1
+        - 3.7.0
+        - 3.6.3
+        - 3.6.2
+        - 3.6.1
+        - 3.6.0
+        - 3.5.1
+        - 3.5.0
+        - older (please specify in a comment)
+      validations:
+        required: true
+    - type: textarea
+      attributes:
+        label: Anything else?
+        description: |
+          Links? References? Anything that will give us more context about the issue you are encountering!
+
+          Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      validations:
+        required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-labels: [ "🐞 bug", "triage" ]
+labels: [ "🐞 bug" ]
 body:
     - type: markdown
       attributes:
@@ -29,23 +29,25 @@ body:
           4. See error...
         validations:
           required: false
-    - type: dropdown
+    - type: input
       id: version
       attributes:
         label: Version
         description: What version of RDF4J are you using?
-        options:
-        - 3.7.1
-        - 3.7.0
-        - 3.6.3
-        - 3.6.2
-        - 3.6.1
-        - 3.6.0
-        - 3.5.1
-        - 3.5.0
-        - older (please specify in a comment)
+        placeholder: "eg. 3.7.1"
       validations:
         required: true
+    - type: dropdown
+      id: contributor
+      attributes:
+        label: Are you interested in contributing a solution yourself?
+        description: We welcome your bug report, but please keep in mind that we're a small team, with limited capacity. Let us know if you would like to get involved in actually contributing a fix yourself. We'd be overjoyed to help you get started.
+        options:
+            - Yes
+            - No
+            - Perhaps?
+        validations:
+            required: false
     - type: textarea
       attributes:
         label: Anything else?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+contact_links:
+  - name: RDF4J Discussion Forum
+    url: https://github.com/eclipse/rdf4j/discussions
+    about: Please ask questions or discuss ideas, possible improvements, and so on here.
+  - name: Report a security vulnerability
+    url: https://www.eclipse.org/security/
+    about: Please report possible security vulnerabilities directly to the Eclipse Security Team.
+

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest an idea for improving RDF4J
+labels: [ "📶 enhancement", "triage" ]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to let us know your suggestion.
+    - type: textarea
+      attributes:
+        label: Problem description
+        description: Provide a concise description of the problem your improvement will address.
+        placeholder: "Performing task X would be a lot easier if RDF4J could do..." 
+      validations:
+        required: true
+    - type: textarea
+      attributes:
+        label: Preferred solution
+        description: Provide a clear and concise description of what you want to happen.
+      validations:
+        required: false
+    - type: textarea
+      attributes:
+        label: Alternatives you've considered
+        description: Let us know about other solutions you have tried or researched.
+        validations:
+          required: false
+    - type: textarea
+      attributes:
+        label: Anything else?
+        description: |
+          Links? References? Anything that will give us more context about your proposal! 
+
+          Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+      validations:
+        required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for improving RDF4J
-labels: [ "📶 enhancement", "triage" ]
+labels: [ "📶 enhancement" ]
 body:
     - type: markdown
       attributes:
@@ -10,7 +10,7 @@ body:
       attributes:
         label: Problem description
         description: Provide a concise description of the problem your improvement will address.
-        placeholder: "Performing task X would be a lot easier if RDF4J could do..." 
+        placeholder: "Performing task X would be a lot easier if RDF4J could do..."
       validations:
         required: true
     - type: textarea
@@ -19,6 +19,17 @@ body:
         description: Provide a clear and concise description of what you want to happen.
       validations:
         required: false
+    - type: dropdown
+      id: contributor
+      attributes:
+        label: Are you interested in contributing a solution yourself?
+        description: We welcome your feature request, but please keep in mind that we're a small team, with limited capacity. Let us know if you would like to get involved in actually contributing a fix yourself. We'd be overjoyed to help you get started.
+        options:
+            - Yes
+            - No
+            - Perhaps?
+        validations:
+            required: false
     - type: textarea
       attributes:
         label: Alternatives you've considered
@@ -29,7 +40,7 @@ body:
       attributes:
         label: Anything else?
         description: |
-          Links? References? Anything that will give us more context about your proposal! 
+          Links? References? Anything that will give us more context about your proposal!
 
           Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
       validations:

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: add-new-issues-to-repository-based-project-column
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+      uses: docker://takanabe/github-actions-automate-projects:v0.0.2
       if: github.event_name == 'issues' && github.event.action == 'opened'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: add-new-issues-to-repository-based-project-column
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.2
+      uses: docker://takanabe/github-actions-automate-projects:latest
       if: github.event_name == 'issues' && github.event.action == 'opened'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub issue resolved: #3199  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- adds issue templates with forms for bug reports and feature requests
- adds an obvious direct link to the discussion forum for questions, comments, etc.
- still possible to create a "blank" new issue if none of the templates fit (e.g. for our own internal tasks).
- bumped version of the new-issue github action (hopefully fixes the problems I ran into earlier, but this is as yet untested)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

