### PR TITLE
setting timeout on task and bumping version

### DIFF
--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -1,11 +1,12 @@
-name: Add a new GitHub Project card linked to a GitHub issue to the specified project column
+name: Add new issue to Inbox
 on: [issues]
 jobs:
   github-actions-automate-projects:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: add-new-issues-to-repository-based-project-column
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+      uses: docker://takanabe/github-actions-automate-projects:v0.0.2
       if: github.event_name == 'issues' && github.event.action == 'opened'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- timeout to avoid long queue of "stuck" actions (like we saw after migrating several issue to discussion board)
- version bump because it might fix some relevant things


