### PR TITLE
revert version change for project automation github action 

### DIFF
--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -6,7 +6,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: add-new-issues-to-repository-based-project-column
-      uses: docker://takanabe/github-actions-automate-projects:v0.0.2
+      uses: docker://takanabe/github-actions-automate-projects:v0.0.1
       if: github.event_name == 'issues' && github.event.action == 'opened'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
rolling back version bump on project automation github action: it can't seem to pull the docker image. 