### PR TITLE
GH-3212 SailConnectionWrapper should implement hasStatement(...)

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
@@ -112,6 +112,12 @@ public class SailConnectionWrapper implements SailConnection, FederatedServiceRe
 	}
 
 	@Override
+	public boolean hasStatement(Resource subj, IRI pred, Value obj, boolean includeInferred, Resource... contexts)
+			throws SailException {
+		return wrappedCon.hasStatement(subj, pred, obj, includeInferred, contexts);
+	}
+
+	@Override
 	public long size(Resource... contexts) throws SailException {
 		return wrappedCon.size(contexts);
 	}

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/inferencer/InferencerConnectionWrapper.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/inferencer/InferencerConnectionWrapper.java
@@ -115,6 +115,13 @@ public class InferencerConnectionWrapper extends NotifyingSailConnectionWrapper 
 		return super.getContextIDs();
 	}
 
+	@Override
+	public boolean hasStatement(Resource subj, IRI pred, Value obj, boolean includeInferred, Resource... contexts)
+			throws SailException {
+		flushUpdates();
+		return super.hasStatement(subj, pred, obj, includeInferred, contexts);
+	}
+
 	/**
 	 * Calls {@link #flushUpdates()} before forwarding the call to the wrapped connection.
 	 */


### PR DESCRIPTION
GitHub issue resolved: #3212 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - delegate hasStatement to wrapped connection

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

