### PR TITLE
GH-3199 remove security vulnerability bit

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,3 @@ contact_links:
   - name: RDF4J Discussion Forum
     url: https://github.com/eclipse/rdf4j/discussions
     about: Please ask questions or discuss ideas, possible improvements, and so on here.
-  - name: Report a security vulnerability
-    url: https://www.eclipse.org/security/
-    about: Please report possible security vulnerabilities directly to the Eclipse Security Team.
-


### PR DESCRIPTION
apparently Github already automatically adds that anyway.


GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

