### PR TITLE
GH-3116 fix aggregated javadoc layout for HTML5 features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 							</execution>
 						</executions>
 						<configuration>
-							<source>8</source>
+							<source>11</source>
 						</configuration>
 					</plugin>
 					<plugin>
@@ -158,44 +158,33 @@
 									<goal>aggregate</goal>
 								</goals>
 								<configuration>
-									<doctitle>Eclipse RDF4J ${project.version} API</doctitle>
-									<windowtitle>Eclipse RDF4J ${project.version} API</windowtitle>
+									<overview>src/main/javadoc/overview.html</overview>
+									<windowtitle>Eclipse RDF4J ${project.version}</windowtitle>
+									<doctitle>Eclipse RDF4J version ${project.version} API specification</doctitle>
 									<groups>
 										<group>
 											<title>RDF Model API</title>
 											<packages>org.eclipse.rdf4j.model*</packages>
 										</group>
 										<group>
-											<title>Repository API: database and SPARQL endpoint access</title>
+											<title>Repository API</title>
 											<packages>org.eclipse.rdf4j.repository*</packages>
 										</group>
 										<group>
-											<title>Rio: RDF Parsers and Writers</title>
+											<title>Rio: RDF Parsers/Writers</title>
 											<packages>org.eclipse.rdf4j.rio*</packages>
-										</group>
-										<group>
-											<title>Query API and query parsers</title>
-											<packages>org.eclipse.rdf4j.query:org.eclipse.rdf4j.query.impl:org.eclipse.rdf4j.query.algebra*:org.eclipse.rdf4j.query.parser*</packages>
 										</group>
 										<group>
 											<title>Query Result Parsers and Writers</title>
 											<packages>org.eclipse.rdf4j.query.resultio*</packages>
 										</group>
 										<group>
-											<title>SPARQLBuilder</title>
-											<packages>org.eclipse.rdf4j.sparqlbuilder*</packages>
-										</group>
-										<group>
-											<title>Storage And Inference Layer (SAIL) SPI</title>
+											<title>SAIL API</title>
 											<packages>org.eclipse.rdf4j.sail*</packages>
-										</group>
-										<group>
-											<title>RDF4J REST Client and Protocol</title>
-											<packages>org.eclipse.rdf4j.http*</packages>
 										</group>
 									</groups>
 									<links>
-										<link>http://docs.oracle.com/javase/8/docs/api/</link>
+										<link>http://docs.oracle.com/javase/11/docs/api/</link>
 									</links>
 									<excludePackageNames>*.ast:*.AST:*.benchmark</excludePackageNames>
 								</configuration>
@@ -245,7 +234,6 @@
 			</activation>
 			<properties>
 				<javadoc.opts>-Xdoclint:none -html5</javadoc.opts>
-				<additional.j.option>--no-module-directories</additional.j.option>
 			</properties>
 		</profile>
 		<profile>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  <body>
+    <p>Eclipse RDF4J&trade; is a modular Java framework for working with RDF, SPARQL, SHACL, and related languages and tools. This is the reference Javadoc for its core APIs and utility classes.
+    <ul>
+      <li>The <a href="https://rdf4j.org/documentation/programming/model/">RDF Model API</a> provides the basic building blocks for manipulating RDF data in Java.</li>
+      <li>The <a href="https://rdf4j.org/documentation/programming/repository/">Repository API</a> is the central access point for RDF4J-compatible RDF databases (a.k.a. triplestores), as well as for SPARQL endpoints.</li>
+      <li><a href="https://rdf4j.org/documentation/programming/rio/">Rio</a> is RDF4J's RDF Parser/Writer toolkit.</li>
+      <li>The <a href="https://rdf4j.org/documentation/reference/sail/">SAIL API</a> is a collection of interfaces designed for low-level transactional access to RDF data.</li>
+    </ul>
+    <p>For more information, including tutorials on every aspect of the framework, see the <a href="https://rdf4j.org/documentation">RDF4J Documentation</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
GitHub issue resolved: #3116  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- fewer groups to make horizontal "tab" layout work better
- added general overview text with pointers to more comprehensive documentation

Screenshot of new Javadoc overview page (Firefox on desktop):

![Screenshot from 2021-07-24 14-41-51](https://user-images.githubusercontent.com/728776/126857573-15eadb3f-4fdc-4be9-bb57-a903eae3f7c9.png)


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

