### PR TITLE
GH-2992 remove orphan references to removed serql parser

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -65,11 +65,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
-				<artifactId>rdf4j-queryparser-serql</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-queryparser-sparql</artifactId>
 				<version>${project.version}</version>
 			</dependency>

--- a/compliance/geosparql/pom.xml
+++ b/compliance/geosparql/pom.xml
@@ -20,12 +20,6 @@
 			<artifactId>rdf4j-queryalgebra-geosparql</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/client/pom.xml
+++ b/core/client/pom.xml
@@ -53,11 +53,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-queryparser-sparql</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -52,12 +52,6 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-sail-api</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/core/repository/sail/pom.xml
+++ b/core/repository/sail/pom.xml
@@ -67,12 +67,6 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/sail/elasticsearch-store/pom.xml
+++ b/core/sail/elasticsearch-store/pom.xml
@@ -84,12 +84,6 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-sail-extensible-store</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/core/sail/extensible-store/pom.xml
+++ b/core/sail/extensible-store/pom.xml
@@ -49,12 +49,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>

--- a/core/sail/inferencer/pom.xml
+++ b/core/sail/inferencer/pom.xml
@@ -32,12 +32,6 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-rio-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/core/sail/lucene-api/pom.xml
+++ b/core/sail/lucene-api/pom.xml
@@ -38,12 +38,6 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-queryparser</artifactId>
 			<version>${lucene.version}</version>

--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -71,12 +71,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.locationtech.jts</groupId>
 			<artifactId>jts-core</artifactId>
 		</dependency>

--- a/core/sail/memory/pom.xml
+++ b/core/sail/memory/pom.xml
@@ -70,12 +70,6 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-repository-manager</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/core/sail/nativerdf/pom.xml
+++ b/core/sail/nativerdf/pom.xml
@@ -74,12 +74,6 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-rio-nquads</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/core/sail/shacl/pom.xml
+++ b/core/sail/shacl/pom.xml
@@ -46,12 +46,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
 			<version>${jmhVersion}</version>

--- a/core/storage/pom.xml
+++ b/core/storage/pom.xml
@@ -268,11 +268,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
-			<artifactId>rdf4j-lucene-spin</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-spin</artifactId>
 			<version>${project.version}</version>
 			<exclusions>

--- a/core/storage/pom.xml
+++ b/core/storage/pom.xml
@@ -188,10 +188,6 @@
 				</exclusion>
 				<exclusion>
 					<groupId>org.eclipse.rdf4j</groupId>
-					<artifactId>rdf4j-queryparser-serql</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.eclipse.rdf4j</groupId>
 					<artifactId>rdf4j-repository-api</artifactId>
 				</exclusion>
 				<exclusion>

--- a/testsuites/lucene/pom.xml
+++ b/testsuites/lucene/pom.xml
@@ -22,11 +22,6 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-sail-memory</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/testsuites/rio/pom.xml
+++ b/testsuites/rio/pom.xml
@@ -12,12 +12,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-repository-sail</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/testsuites/sail/pom.xml
+++ b/testsuites/sail/pom.xml
@@ -46,12 +46,6 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>rdf4j-queryparser-serql</artifactId>
-			<version>${project.version}</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-rio-ntriples</artifactId>
 			<version>${project.version}</version>
 			<scope>runtime</scope>


### PR DESCRIPTION
GitHub issue resolved: GH-2992  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- remove leftover dependencies on serql parser
- rewrote test case that was overlooked earlier
- also removed a dangling reference to the lucene-spin sail (see GH-1706)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

