### PR TITLE
GH-3216 VerySimpleRdfsBackwardsChainingConnection handles larger inferred sets

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
@@ -113,19 +113,10 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true)
 			);
 
-			RdfsSubClassOfReasoner rdfsSubClassOfReasoner = connectionsGroup.getRdfsSubClassOfReasoner();
-			Set<Resource> clazzForwardChained;
-
-			if (rdfsSubClassOfReasoner != null) {
-				clazzForwardChained = rdfsSubClassOfReasoner.backwardsChain(clazz);
-			} else {
-				clazzForwardChained = Collections.singleton(clazz);
-			}
-
 			// filter by type against the base sail
 			PlanNode falseNode = new ExternalPredicateObjectFilter(
 					connectionsGroup.getBaseConnection(),
-					RDF.TYPE, clazzForwardChained,
+					RDF.TYPE, Collections.singleton(clazz),
 					joined, false, ExternalPredicateObjectFilter.FilterOn.value);
 
 			return falseNode;

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/QualifiedValueShapeBenchmarkEmpty.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/QualifiedValueShapeBenchmarkEmpty.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.benchmark;
+
+import static ch.qos.logback.classic.Level.WARN;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.shacl.GlobalValidationExecutionLogging;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
+import org.eclipse.rdf4j.sail.shacl.Utils;
+import org.eclipse.rdf4j.sail.shacl.ast.Shape;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xmx256M", "-XX:+UseSerialGC" })
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class QualifiedValueShapeBenchmarkEmpty {
+	{
+		GlobalValidationExecutionLogging.loggingEnabled = false;
+	}
+
+	private List<List<Statement>> allStatements;
+
+	public static void main(String[] args) throws Exception {
+		QualifiedValueShapeBenchmarkEmpty rdfsReasonerBenchmarkEmpty = new QualifiedValueShapeBenchmarkEmpty();
+		rdfsReasonerBenchmarkEmpty.setUp();
+		while (true) {
+			rdfsReasonerBenchmarkEmpty.shaclBulk();
+			System.out.println(".");
+		}
+	}
+
+	@Setup(Level.Trial)
+	public void setUp() throws InterruptedException {
+		((Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName())).setLevel(WARN);
+		((Logger) LoggerFactory.getLogger(Shape.class.getName())).setLevel(WARN);
+
+		System.setProperty("org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation", "true");
+
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+
+		allStatements = BenchmarkConfigs.generateStatements(((statements, i, j) -> {
+			IRI iri = vf.createIRI("http://example.com/" + i + "_" + j);
+
+			statements.add(vf.createStatement(iri, RDF.TYPE, FOAF.PERSON));
+			for (int k = 0; k < 10; k++) {
+				IRI friend = vf.createIRI("http://example.com/friend" + i + "_" + j + "_" + k);
+				statements.add(vf.createStatement(iri, FOAF.KNOWS, friend));
+				statements.add(vf.createStatement(friend, RDF.TYPE, FOAF.PERSON));
+				statements.add(vf.createStatement(friend, FOAF.KNOWS, friend));
+			}
+
+		}));
+
+		System.gc();
+		Thread.sleep(100);
+	}
+
+	@Benchmark
+	public void shacl() throws Exception {
+
+		SailRepository repository = new SailRepository(
+				Utils.getInitializedShaclSail("shaclQualifiedShapeBenchmark.ttl"));
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			for (List<Statement> statements : allStatements) {
+				connection.begin();
+				connection.add(statements);
+				connection.commit();
+			}
+		}
+		repository.shutDown();
+
+	}
+
+	@Benchmark
+	public void shaclBulk() throws Exception {
+
+		SailRepository repository = new SailRepository(
+				Utils.getInitializedShaclSail("shaclQualifiedShapeBenchmark.ttl"));
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
+			for (List<Statement> statements : allStatements) {
+				connection.add(statements);
+			}
+			connection.commit();
+		}
+		repository.shutDown();
+
+	}
+
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/RdfsReasonerBenchmarkEmpty.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/RdfsReasonerBenchmarkEmpty.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.benchmark;
+
+import static ch.qos.logback.classic.Level.WARN;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.shacl.GlobalValidationExecutionLogging;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
+import org.eclipse.rdf4j.sail.shacl.Utils;
+import org.eclipse.rdf4j.sail.shacl.ast.Shape;
+import org.eclipse.rdf4j.sail.shacl.testimp.TestNotifyingSail;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xmx64M", "-XX:+UseSerialGC" })
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class RdfsReasonerBenchmarkEmpty {
+	{
+		GlobalValidationExecutionLogging.loggingEnabled = false;
+	}
+
+	private List<List<Statement>> allStatements;
+
+//	public static void main(String[] args) throws Exception {
+//		RdfsReasonerBenchmarkEmpty rdfsReasonerBenchmarkEmpty = new RdfsReasonerBenchmarkEmpty();
+//		rdfsReasonerBenchmarkEmpty.setUp();
+//		while (true) {
+//			rdfsReasonerBenchmarkEmpty.shaclBulk();
+//			System.out.println(".");
+//		}
+//	}
+
+	@Setup(Level.Trial)
+	public void setUp() throws InterruptedException {
+		((Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName())).setLevel(WARN);
+		((Logger) LoggerFactory.getLogger(Shape.class.getName())).setLevel(WARN);
+
+		System.setProperty("org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation", "false");
+
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+
+		allStatements = BenchmarkConfigs.generateStatements(((statements, i, j) -> {
+			IRI iri = vf.createIRI("http://example.com/" + i + "_" + j);
+			IRI friend = vf.createIRI("http://example.com/friend" + i + "_" + j);
+
+			statements.add(vf.createStatement(iri, RDF.TYPE, FOAF.PERSON));
+			statements.add(vf.createStatement(iri, FOAF.KNOWS, friend));
+			statements.add(vf.createStatement(friend, RDF.TYPE, FOAF.PERSON));
+			statements.add(vf.createStatement(friend, FOAF.KNOWS, friend));
+
+		}));
+
+		System.gc();
+		Thread.sleep(100);
+	}
+
+	@Benchmark
+	public void shacl() throws Exception {
+
+		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclRdfsBenchmark.ttl"));
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			for (List<Statement> statements : allStatements) {
+				connection.begin();
+				connection.add(statements);
+				connection.commit();
+			}
+		}
+		repository.shutDown();
+
+	}
+
+	@Benchmark
+	public void shaclBulk() throws Exception {
+
+		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclRdfsBenchmark.ttl"));
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
+			for (List<Statement> statements : allStatements) {
+				connection.add(statements);
+			}
+			connection.commit();
+		}
+		repository.shutDown();
+
+	}
+
+}

--- a/core/sail/shacl/src/test/resources/shaclQualifiedShapeBenchmark.ttl
+++ b/core/sail/shacl/src/test/resources/shaclQualifiedShapeBenchmark.ttl
@@ -1,0 +1,33 @@
+@base <http://example.com/ns> .
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+ex:PersonShape
+	a sh:NodeShape  ;
+	sh:targetClass ex:Class8 ;
+	sh:property ex:PersonShapeProperty  .
+
+
+ex:PersonShapeProperty
+        sh:path foaf:knows ;
+        sh:qualifiedValueShape [
+                sh:class ex:Class10
+        ];
+        sh:qualifiedMinCount 1  .
+
+
+foaf:Person rdfs:subClassOf ex:Class1 .
+ex:Class1 rdfs:subClassOf ex:Class2 .
+ex:Class2 rdfs:subClassOf ex:Class3 .
+ex:Class3 rdfs:subClassOf ex:Class4 .
+ex:Class4 rdfs:subClassOf ex:Class5 .
+ex:Class5 rdfs:subClassOf ex:Class6 .
+ex:Class6 rdfs:subClassOf ex:Class7 .
+ex:Class7 rdfs:subClassOf ex:Class8 .
+ex:Class8 rdfs:subClassOf ex:Class9 .
+ex:Class9 rdfs:subClassOf ex:Class10 .

--- a/core/sail/shacl/src/test/resources/shaclRdfsBenchmark.ttl
+++ b/core/sail/shacl/src/test/resources/shaclRdfsBenchmark.ttl
@@ -1,0 +1,30 @@
+@base <http://example.com/ns> .
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+ex:PersonShape
+	a sh:NodeShape  ;
+	sh:targetClass ex:Class8 ;
+	sh:property ex:PersonShapeProperty  .
+
+
+ex:PersonShapeProperty
+        sh:path foaf:knows ;
+        sh:class ex:Class10 .
+
+
+foaf:Person rdfs:subClassOf ex:Class1 .
+ex:Class1 rdfs:subClassOf ex:Class2 .
+ex:Class2 rdfs:subClassOf ex:Class3 .
+ex:Class3 rdfs:subClassOf ex:Class4 .
+ex:Class4 rdfs:subClassOf ex:Class5 .
+ex:Class5 rdfs:subClassOf ex:Class6 .
+ex:Class6 rdfs:subClassOf ex:Class7 .
+ex:Class7 rdfs:subClassOf ex:Class8 .
+ex:Class8 rdfs:subClassOf ex:Class9 .
+ex:Class9 rdfs:subClassOf ex:Class10 .


### PR DESCRIPTION
GitHub issue resolved: #3216 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

 - some simplification to return earlier
 - check size of inferred set and if it is above 10 then we use getStatements to get the actual rdf:type(s) and check them against the inferred set

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

