### PR TITLE
GH-3217 Union and Unique plan nodes can return the provided node if they are redundant

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/NodeShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/NodeShape.java
@@ -175,10 +175,10 @@ public class NodeShape extends Shape implements ConstraintComponent, Identifiabl
 			}
 
 			if (scope == Scope.propertyShape) {
-				validationPlanNode = new Unique(new ShiftToPropertyShape(validationPlanNode), true);
+				validationPlanNode = Unique.getInstance(new ShiftToPropertyShape(validationPlanNode), true);
 			}
 
-			union = new UnionNode(union,
+			union = UnionNode.getInstance(union,
 					validationPlanNode);
 		}
 
@@ -204,19 +204,19 @@ public class NodeShape extends Shape implements ConstraintComponent, Identifiabl
 		PlanNode planNode = constraintComponents.stream()
 				.map(c -> c.getAllTargetsPlan(connectionsGroup, Scope.nodeShape))
 				.distinct()
-				.reduce(UnionNode::new)
+				.reduce(UnionNode::getInstanceDedupe)
 				.orElse(EmptyNode.getInstance());
 
-		planNode = new UnionNode(planNode,
+		planNode = UnionNode.getInstanceDedupe(planNode,
 				getTargetChain()
 						.getEffectiveTarget("_target", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 						.getPlanNode(connectionsGroup, Scope.nodeShape, true, null));
 
 		if (scope == Scope.propertyShape) {
-			planNode = new Unique(new ShiftToPropertyShape(planNode), true);
+			planNode = Unique.getInstance(new ShiftToPropertyShape(planNode), true);
 		}
 
-		planNode = new Unique(planNode, false);
+		planNode = Unique.getInstance(planNode, false);
 
 		return planNode;
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
@@ -187,12 +187,12 @@ public class PropertyShape extends Shape implements ConstraintComponent, Identif
 //
 //				PlanNode allTargetsPlan = getAllLocalTargetsPlan(connectionsGroup, negatePlan);
 //
-//				Unique invalid = new Unique(planNode);
+//				Unique invalid = Unique.getInstance(planNode);
 //
 //				PlanNode discardedLeft = new InnerJoin(allTargetsPlan, invalid)
 //						.getDiscardedLeft(BufferedPlanNode.class);
 //
-//				ret = new UnionNode(ret, discardedLeft);
+//				ret = UnionNode.getInstance(ret, discardedLeft);
 //
 //			}
 //
@@ -218,12 +218,12 @@ public class PropertyShape extends Shape implements ConstraintComponent, Identif
 			}
 
 			if (scope == Scope.propertyShape) {
-				validationPlanNode = new Unique(new TargetChainPopper(validationPlanNode), true);
+				validationPlanNode = Unique.getInstance(new TargetChainPopper(validationPlanNode), true);
 			} else {
-				validationPlanNode = new Unique(new ShiftToNodeShape(validationPlanNode), true);
+				validationPlanNode = Unique.getInstance(new ShiftToNodeShape(validationPlanNode), true);
 			}
 
-			union = new UnionNode(union, validationPlanNode);
+			union = UnionNode.getInstance(union, validationPlanNode);
 		}
 
 		return union;
@@ -234,22 +234,22 @@ public class PropertyShape extends Shape implements ConstraintComponent, Identif
 		PlanNode planNode = constraintComponents.stream()
 				.map(c -> c.getAllTargetsPlan(connectionsGroup, Scope.propertyShape))
 				.distinct()
-				.reduce(UnionNode::new)
+				.reduce(UnionNode::getInstanceDedupe)
 				.orElse(EmptyNode.getInstance());
 
-		planNode = new UnionNode(planNode,
+		planNode = UnionNode.getInstanceDedupe(planNode,
 				getTargetChain()
 						.getEffectiveTarget("_target", Scope.propertyShape,
 								connectionsGroup.getRdfsSubClassOfReasoner())
 						.getPlanNode(connectionsGroup, Scope.propertyShape, true, null));
 
 		if (scope == Scope.propertyShape) {
-			planNode = new Unique(new TargetChainPopper(planNode), true);
+			planNode = Unique.getInstance(new TargetChainPopper(planNode), true);
 		} else {
 			planNode = new ShiftToNodeShape(planNode);
 		}
 
-		planNode = new Unique(planNode, false);
+		planNode = Unique.getInstance(planNode, false);
 
 		return planNode;
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AndConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AndConstraintComponent.java
@@ -96,10 +96,10 @@ public class AndConstraintComponent extends LogicalOperatorConstraintComponent {
 		PlanNode planNode = and.stream()
 				.map(a -> a.generateTransactionalValidationPlan(connectionsGroup, logValidationPlans,
 						overrideTargetNode, scope))
-				.reduce(UnionNode::new)
+				.reduce(UnionNode::getInstance)
 				.orElse(EmptyNode.getInstance());
 
-		return new Unique(planNode, false);
+		return Unique.getInstance(planNode, false);
 
 	}
 
@@ -108,10 +108,10 @@ public class AndConstraintComponent extends LogicalOperatorConstraintComponent {
 		PlanNode planNode = and.stream()
 				.map(c -> c.getAllTargetsPlan(connectionsGroup, scope))
 				.distinct()
-				.reduce(UnionNode::new)
+				.reduce(UnionNode::getInstanceDedupe)
 				.orElse(EmptyNode.getInstance());
 
-		planNode = new Unique(planNode, false);
+		planNode = Unique.getInstance(planNode, false);
 
 		return planNode;
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
@@ -75,7 +75,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 				PlanNode addedByPath = path.getAdded(connectionsGroup, null);
 
 				addedByPath = target.getTargetFilter(connectionsGroup,
-						new Unique(new TrimToTarget(addedByPath), false));
+						Unique.getInstance(new TrimToTarget(addedByPath), false));
 
 				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
 						null);
@@ -95,12 +95,12 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 									connectionsGroup.getRdfsSubClassOfReasoner())
 							.getTargetFilter(connectionsGroup, deletedTypes);
 
-					addedTargets = new UnionNode(addedTargets,
+					addedTargets = UnionNode.getInstance(addedTargets,
 							new TrimToTarget(new ShiftToPropertyShape(deletedTypes)));
 				}
 
-				addedTargets = new UnionNode(addedByPath, addedTargets);
-				addedTargets = new Unique(addedTargets, false);
+				addedTargets = UnionNode.getInstance(addedByPath, addedTargets);
+				addedTargets = Unique.getInstance(addedTargets, false);
 			}
 
 			PlanNode joined = new BulkedExternalInnerJoin(
@@ -150,7 +150,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 					deletedTypes = getTargetChain()
 							.getEffectiveTarget("target_", scope, connectionsGroup.getRdfsSubClassOfReasoner())
 							.extend(deletedTypes, connectionsGroup, scope, EffectiveTarget.Extend.left, false, null);
-					addedTargets = new UnionNode(addedTargets, new TrimToTarget(deletedTypes));
+					addedTargets = UnionNode.getInstance(addedTargets, new TrimToTarget(deletedTypes));
 				}
 			}
 
@@ -186,7 +186,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 						.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 						.extend(deletedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false,
 								null);
-				allTargetsPlan = new UnionNode(allTargetsPlan, deletedTypes);
+				allTargetsPlan = UnionNode.getInstanceDedupe(allTargetsPlan, deletedTypes);
 			}
 
 			// added type statements that match clazz could affect sh:not
@@ -200,10 +200,10 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 						.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 						.extend(addedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false,
 								null);
-				allTargetsPlan = new UnionNode(allTargetsPlan, addedTypes);
+				allTargetsPlan = UnionNode.getInstanceDedupe(allTargetsPlan, addedTypes);
 			}
 
-			return new Unique(new TrimToTarget(new ShiftToPropertyShape(allTargetsPlan)), false);
+			return Unique.getInstance(new TrimToTarget(new ShiftToPropertyShape(allTargetsPlan)), false);
 		}
 		PlanNode allTargetsPlan = EmptyNode.getInstance();
 
@@ -217,7 +217,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 			deletedTypes = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 					.extend(deletedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false, null);
-			allTargetsPlan = new UnionNode(allTargetsPlan, deletedTypes);
+			allTargetsPlan = UnionNode.getInstanceDedupe(allTargetsPlan, deletedTypes);
 
 		}
 
@@ -231,11 +231,11 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 			addedTypes = getTargetChain()
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 					.extend(addedTypes, connectionsGroup, Scope.nodeShape, EffectiveTarget.Extend.left, false, null);
-			allTargetsPlan = new UnionNode(allTargetsPlan, addedTypes);
+			allTargetsPlan = UnionNode.getInstanceDedupe(allTargetsPlan, addedTypes);
 
 		}
 
-		return new Unique(allTargetsPlan, false);
+		return Unique.getInstance(allTargetsPlan, false);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
@@ -90,12 +90,12 @@ public class DashHasValueInConstraintComponent extends AbstractConstraintCompone
 				PlanNode addedByPath = path.getAdded(connectionsGroup, null);
 
 				addedByPath = target.getTargetFilter(connectionsGroup,
-						new Unique(new TrimToTarget(addedByPath), false));
+						Unique.getInstance(new TrimToTarget(addedByPath), false));
 				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
 						null);
 
-				addedTargets = new UnionNode(addedByPath, addedTargets);
-				addedTargets = new Unique(addedTargets, false);
+				addedTargets = UnionNode.getInstance(addedByPath, addedTargets);
+				addedTargets = Unique.getInstance(addedTargets, false);
 			}
 
 			PlanNode joined = new BulkedExternalLeftOuterJoin(
@@ -112,7 +112,7 @@ public class DashHasValueInConstraintComponent extends AbstractConstraintCompone
 				return group.stream().map(ValidationTuple::getValue).noneMatch(hasValueIn::contains);
 			});
 
-			return new Unique(new TrimToTarget(invalidTargets), false);
+			return Unique.getInstance(new TrimToTarget(invalidTargets), false);
 
 		} else if (scope == Scope.nodeShape) {
 
@@ -144,7 +144,7 @@ public class DashHasValueInConstraintComponent extends AbstractConstraintCompone
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
-			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
+			return Unique.getInstance(new ShiftToPropertyShape(allTargetsPlan), true);
 		}
 		return EmptyNode.getInstance();
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/HasValueConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/HasValueConstraintComponent.java
@@ -80,12 +80,12 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 				PlanNode addedByPath = path.getAdded(connectionsGroup, null);
 
 				addedByPath = target.getTargetFilter(connectionsGroup,
-						new Unique(new TrimToTarget(addedByPath), false));
+						Unique.getInstance(new TrimToTarget(addedByPath), false));
 				addedByPath = target.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
 						null);
 
-				addedTargets = new UnionNode(addedByPath, addedTargets);
-				addedTargets = new Unique(addedTargets, false);
+				addedTargets = UnionNode.getInstance(addedByPath, addedTargets);
+				addedTargets = Unique.getInstance(addedTargets, false);
 			}
 
 			PlanNode joined = new BulkedExternalLeftOuterJoin(
@@ -102,7 +102,7 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 				return group.stream().map(ValidationTuple::getValue).noneMatch(v -> hasValue.equals(v));
 			});
 
-			return new Unique(new TrimToTarget(invalidTargets), false);
+			return Unique.getInstance(new TrimToTarget(invalidTargets), false);
 
 		} else if (scope == Scope.nodeShape) {
 
@@ -134,7 +134,7 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
-			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
+			return Unique.getInstance(new ShiftToPropertyShape(allTargetsPlan), true);
 		}
 		return EmptyNode.getInstance();
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
@@ -72,7 +72,7 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 		}
 
 		PlanNode relevantTargetsWithPath = new BulkedExternalLeftOuterJoin(
-				new Unique(new TrimToTarget(target), false),
+				Unique.getInstance(new TrimToTarget(target), false),
 				connectionsGroup.getBaseConnection(),
 				getTargetChain().getPath()
 						.get()
@@ -85,7 +85,7 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 
 		PlanNode groupByCount = new GroupByCountFilter(relevantTargetsWithPath, count -> count < minCount);
 
-		return new Unique(new TrimToTarget(groupByCount), false);
+		return Unique.getInstance(new TrimToTarget(groupByCount), false);
 
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/NotConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/NotConstraintComponent.java
@@ -94,7 +94,7 @@ public class NotConstraintComponent extends AbstractConstraintComponent {
 				scope
 		);
 
-		PlanNode invalid = new Unique(planNode, false);
+		PlanNode invalid = Unique.getInstance(planNode, false);
 
 		PlanNode allTargetsPlan;
 		if (overrideTargetNode != null) {
@@ -103,7 +103,7 @@ public class NotConstraintComponent extends AbstractConstraintComponent {
 						.getEffectiveTarget("_target", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 						.extend(planNodeProvider.getPlanNode(), connectionsGroup, Scope.nodeShape,
 								EffectiveTarget.Extend.right, false, null);
-				allTargetsPlan = new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
+				allTargetsPlan = Unique.getInstance(new ShiftToPropertyShape(allTargetsPlan), true);
 			} else {
 				allTargetsPlan = getTargetChain()
 						.getEffectiveTarget("_target", scope, connectionsGroup.getRdfsSubClassOfReasoner())
@@ -132,7 +132,7 @@ public class NotConstraintComponent extends AbstractConstraintComponent {
 	 * PlanNode planNode = not.generateTransactionalValidationPlan(connectionsGroup, logValidationPlans, targetProvider,
 	 * negateChildren, false, scope);
 	 *
-	 * PlanNode invalid = new Unique(planNode);
+	 * PlanNode invalid = Unique.getInstance(planNode);
 	 *
 	 * PlanNode discardedLeft = new NotValuesIn(allTargetsPlan, invalid);
 	 *
@@ -151,7 +151,7 @@ public class NotConstraintComponent extends AbstractConstraintComponent {
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
-			allTargets = new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
+			allTargets = Unique.getInstance(new ShiftToPropertyShape(allTargetsPlan), true);
 		} else {
 			allTargets = getTargetChain()
 					.getEffectiveTarget("target_", scope, connectionsGroup.getRdfsSubClassOfReasoner())
@@ -161,7 +161,7 @@ public class NotConstraintComponent extends AbstractConstraintComponent {
 
 		PlanNode notTargets = not.getAllTargetsPlan(connectionsGroup, scope);
 
-		return new Unique(new UnionNode(allTargets, notTargets), false);
+		return Unique.getInstance(UnionNode.getInstanceDedupe(allTargets, notTargets), false);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/OrConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/OrConstraintComponent.java
@@ -117,7 +117,7 @@ public class OrConstraintComponent extends LogicalOperatorConstraintComponent {
 				.reduce((a, b) -> new EqualsJoinValue(a, b, false))
 				.orElse(EmptyNode.getInstance());
 
-		PlanNode invalid = new Unique(orPlanNodes, false);
+		PlanNode invalid = Unique.getInstance(orPlanNodes, false);
 
 		return invalid;
 	}
@@ -131,7 +131,7 @@ public class OrConstraintComponent extends LogicalOperatorConstraintComponent {
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
-			allTargets = new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
+			allTargets = Unique.getInstance(new ShiftToPropertyShape(allTargetsPlan), true);
 		} else {
 			allTargets = getTargetChain()
 					.getEffectiveTarget("target_", scope, connectionsGroup.getRdfsSubClassOfReasoner())
@@ -142,11 +142,10 @@ public class OrConstraintComponent extends LogicalOperatorConstraintComponent {
 		PlanNode planNode = or.stream()
 				.map(or -> or.getAllTargetsPlan(connectionsGroup, scope))
 				.distinct()
-				.reduce(UnionNode::new)
+				.reduce(UnionNode::getInstanceDedupe)
 				.orElse(EmptyNode.getInstance());
 
-		Unique unique = new Unique(new UnionNode(allTargets, planNode), false);
-		return unique;
+		return Unique.getInstance(UnionNode.getInstanceDedupe(allTargets, planNode), false);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
@@ -129,7 +129,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 		planNode = new LeftOuterJoin(target, planNode);
 
 		GroupByCountFilter groupByCountFilter = new GroupByCountFilter(planNode, count -> count > qualifiedMaxCount);
-		return new Unique(new TrimToTarget(groupByCountFilter), false);
+		return Unique.getInstance(new TrimToTarget(groupByCountFilter), false);
 
 	}
 
@@ -149,7 +149,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 								false, null);
 			}
 
-			target = new Unique(new TrimToTarget(target), false);
+			target = Unique.getInstance(new TrimToTarget(target), false);
 
 			PlanNode relevantTargetsWithPath = new BulkedExternalLeftOuterJoin(
 					target,
@@ -178,7 +178,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 				scope
 		);
 
-		PlanNode invalid = new Unique(planNode, false);
+		PlanNode invalid = Unique.getInstance(planNode, false);
 
 		PlanNode allTargetsPlan = getAllTargetsPlan(connectionsGroup, scope);
 
@@ -189,7 +189,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 							false, null);
 		}
 
-		allTargetsPlan = new Unique(new TrimToTarget(allTargetsPlan), false);
+		allTargetsPlan = Unique.getInstance(new TrimToTarget(allTargetsPlan), false);
 
 		allTargetsPlan = new BulkedExternalLeftOuterJoin(
 				allTargetsPlan,
@@ -219,8 +219,7 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 
 		PlanNode subTargets = qualifiedValueShape.getAllTargetsPlan(connectionsGroup, scope);
 
-		PlanNode unique = new Unique(new TrimToTarget(new UnionNode(allTargets, subTargets)), false);
-		return unique;
+		return Unique.getInstance(new TrimToTarget(UnionNode.getInstanceDedupe(allTargets, subTargets)), false);
 
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/SimpleAbstractConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/SimpleAbstractConstraintComponent.java
@@ -159,7 +159,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 					PlanNode allTargets = effectiveTarget.getAllTargets(connectionsGroup, scope);
 					allTargets = getFilterAttacherWithNegation(negatePlan, allTargets);
 
-					return new Unique(allTargets, true);
+					return Unique.getInstance(allTargets, true);
 				} else {
 					return effectiveTarget.extend(overrideTargetPlanNode, connectionsGroup, scope,
 							EffectiveTarget.Extend.right,
@@ -184,7 +184,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 
 					allTargets = getFilterAttacherWithNegation(negatePlan, allTargets);
 
-					return new Unique(allTargets, true);
+					return Unique.getInstance(allTargets, true);
 
 				} else {
 
@@ -232,7 +232,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 			typeFilterPlan = effectiveTarget.extend(typeFilterPlan, connectionsGroup, scope,
 					EffectiveTarget.Extend.left, true, null);
 
-			top = new UnionNode(top, typeFilterPlan);
+			top = UnionNode.getInstance(top, typeFilterPlan);
 
 			PlanNode bulkedExternalInnerJoin = new BulkedExternalInnerJoin(
 					effectiveTarget.getPlanNode(connectionsGroup, scope, false, null),
@@ -245,7 +245,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 					connectionsGroup.getPreviousStateConnection(),
 					b -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true));
 
-			top = new UnionNode(top, bulkedExternalInnerJoin);
+			top = UnionNode.getInstance(top, bulkedExternalInnerJoin);
 
 			return getFilterAttacherWithNegation(negatePlan, top);
 
@@ -297,7 +297,7 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
-			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
+			return Unique.getInstance(new ShiftToPropertyShape(allTargetsPlan), true);
 		}
 		return EmptyNode.getInstance();
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/UniqueLangConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/UniqueLangConstraintComponent.java
@@ -128,7 +128,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 			);
 
 			PlanNode nonUniqueTargetLang = new NonUniqueTargetLang(relevantTargetsWithPath);
-			return new Unique(new TrimToTarget(nonUniqueTargetLang), false);
+			return Unique.getInstance(new TrimToTarget(nonUniqueTargetLang), false);
 		}
 
 		if (connectionsGroup.getStats().isBaseSailEmpty()) {
@@ -139,7 +139,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 			PlanNode innerJoin = new InnerJoin(addedTargets, addedByPath).getJoined(UnBufferedPlanNode.class);
 
 			PlanNode nonUniqueTargetLang = new NonUniqueTargetLang(innerJoin);
-			return new Unique(new TrimToTarget(nonUniqueTargetLang), false);
+			return Unique.getInstance(new TrimToTarget(nonUniqueTargetLang), false);
 		}
 
 		PlanNode addedTargets = effectiveTarget.getPlanNode(connectionsGroup, scope, false, null);
@@ -147,16 +147,16 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 		PlanNode addedByPath = path.get().getAdded(connectionsGroup, null);
 
 		addedByPath = effectiveTarget.getTargetFilter(connectionsGroup,
-				new Unique(new TrimToTarget(addedByPath), false));
+				Unique.getInstance(new TrimToTarget(addedByPath), false));
 
 		addedByPath = effectiveTarget.extend(addedByPath, connectionsGroup, scope, EffectiveTarget.Extend.left, false,
 				null);
 
-		PlanNode mergeNode = new UnionNode(addedTargets, addedByPath);
+		PlanNode mergeNode = UnionNode.getInstance(addedTargets, addedByPath);
 
 		mergeNode = new TrimToTarget(mergeNode);
 
-		PlanNode allRelevantTargets = new Unique(mergeNode, false);
+		PlanNode allRelevantTargets = Unique.getInstance(mergeNode, false);
 
 		PlanNode relevantTargetsWithPath = new BulkedExternalInnerJoin(
 				allRelevantTargets,
@@ -171,7 +171,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 
 		PlanNode nonUniqueTargetLang = new NonUniqueTargetLang(relevantTargetsWithPath);
 
-		return new Unique(new TrimToTarget(nonUniqueTargetLang), false);
+		return Unique.getInstance(new TrimToTarget(nonUniqueTargetLang), false);
 
 	}
 
@@ -182,7 +182,7 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 					.getEffectiveTarget("target_", Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner())
 					.getPlanNode(connectionsGroup, Scope.nodeShape, true, null);
 
-			return new Unique(new ShiftToPropertyShape(allTargetsPlan), true);
+			return Unique.getInstance(new ShiftToPropertyShape(allTargetsPlan), true);
 		}
 		return EmptyNode.getInstance();
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/PlanNodeHelper.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/PlanNodeHelper.java
@@ -10,7 +10,11 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 public class PlanNodeHelper {
 
 	public static PlanNode handleSorting(PlanNode child, PlanNode parent) {
-		if (child.requiresSorted()) {
+		return handleSorting(child.requiresSorted(), parent);
+	}
+
+	public static PlanNode handleSorting(boolean requiresSorted, PlanNode parent) {
+		if (requiresSorted) {
 			if (!parent.producesSorted()) {
 				parent = new Sort(parent);
 			}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
@@ -37,7 +37,7 @@ public class Unique implements PlanNode {
 	private boolean printed = false;
 	private ValidationExecutionLogger validationExecutionLogger;
 
-	public Unique(PlanNode parent, boolean compress) {
+	private Unique(PlanNode parent, boolean compress) {
 //		this.stackTrace = Thread.currentThread().getStackTrace();
 		parent = PlanNodeHelper.handleSorting(this, parent);
 
@@ -53,6 +53,12 @@ public class Unique implements PlanNode {
 
 		this.parent = parent;
 		this.compress = compress;
+	}
+
+	public static PlanNode getInstance(PlanNode parent, boolean compress) {
+		if (parent == EmptyNode.getInstance())
+			return parent;
+		return new Unique(parent, compress);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/DashAllObjects.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/DashAllObjects.java
@@ -49,7 +49,7 @@ public class DashAllObjects extends Target {
 	private PlanNode getAddedRemovedInner(ConnectionsGroup connectionsGroup, ConstraintComponent.Scope scope,
 			SailConnection connection) {
 
-		return new Unique(new UnorderedSelect(connection, null,
+		return Unique.getInstance(new UnorderedSelect(connection, null,
 				null, null, UnorderedSelect.Mapper.ObjectScopedMapper.getFunction(scope)), false);
 
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/DashAllSubjects.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/DashAllSubjects.java
@@ -47,7 +47,7 @@ public class DashAllSubjects extends Target {
 	private PlanNode getAddedRemovedInner(ConnectionsGroup connectionsGroup, ConstraintComponent.Scope scope,
 			SailConnection connection) {
 
-		return new Unique(new UnorderedSelect(connection, null,
+		return Unique.getInstance(new UnorderedSelect(connection, null,
 				null, null, UnorderedSelect.Mapper.SubjectScopedMapper.getFunction(scope)), false);
 
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/EffectiveTarget.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/EffectiveTarget.java
@@ -91,7 +91,8 @@ public class EffectiveTarget {
 				parent = filter.apply(parent);
 			}
 
-			return connectionsGroup.getCachedNodeFor(getTargetFilter(connectionsGroup, new Unique(parent, false)));
+			return connectionsGroup
+					.getCachedNodeFor(getTargetFilter(connectionsGroup, Unique.getInstance(parent, false)));
 		} else {
 
 			PlanNode parent = new BindSelect(connectionsGroup.getBaseConnection(), query, vars, source, varNames, scope,
@@ -100,11 +101,11 @@ public class EffectiveTarget {
 			if (filter != null) {
 				parent = connectionsGroup.getCachedNodeFor(parent);
 				parent = filter.apply(parent);
-				parent = new Unique(parent, true);
+				parent = Unique.getInstance(parent, true);
 				return parent;
 			} else {
 				return connectionsGroup.getCachedNodeFor(
-						new Unique(parent, true));
+						Unique.getInstance(parent, true));
 			}
 
 		}
@@ -225,9 +226,9 @@ public class EffectiveTarget {
 			}
 
 			if (filter != null) {
-				return connectionsGroup.getCachedNodeFor(new Unique(filter.apply(targetChainRetriever), true));
+				return connectionsGroup.getCachedNodeFor(Unique.getInstance(filter.apply(targetChainRetriever), true));
 			} else {
-				return connectionsGroup.getCachedNodeFor(new Unique(targetChainRetriever, true));
+				return connectionsGroup.getCachedNodeFor(Unique.getInstance(targetChainRetriever, true));
 			}
 
 		}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/RSXTargetShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/RSXTargetShape.java
@@ -80,7 +80,7 @@ public class RSXTargetShape extends Target {
 
 		List<StatementMatcher.Variable> vars = Collections.singletonList(object);
 
-		return new Unique(new TargetChainRetriever(
+		return Unique.getInstance(new TargetChainRetriever(
 				connectionsGroup,
 				statementMatchers,
 				statementMatchers,

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetClass.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetClass.java
@@ -58,7 +58,7 @@ public class TargetClass extends Target {
 					"?a", b -> new ValidationTuple(b.getValue("a"), scope, false));
 		}
 
-		return new Unique(planNode, false);
+		return Unique.getInstance(planNode, false);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetObjectsOf.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetObjectsOf.java
@@ -53,10 +53,10 @@ public class TargetObjectsOf extends Target {
 		PlanNode planNode = targetObjectsOf.stream()
 				.map(predicate -> (PlanNode) new UnorderedSelect(connection, null,
 						predicate, null, UnorderedSelect.Mapper.ObjectScopedMapper.getFunction(scope)))
-				.reduce(UnionNode::new)
+				.reduce(UnionNode::getInstance)
 				.orElse(EmptyNode.getInstance());
 
-		return new Unique(planNode, false);
+		return Unique.getInstance(planNode, false);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetSubjectsOf.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetSubjectsOf.java
@@ -53,10 +53,10 @@ public class TargetSubjectsOf extends Target {
 		PlanNode planNode = targetSubjectsOf.stream()
 				.map(predicate -> (PlanNode) new UnorderedSelect(connection, null,
 						predicate, null, UnorderedSelect.Mapper.SubjectScopedMapper.getFunction(scope)))
-				.reduce(UnionNode::new)
+				.reduce(UnionNode::getInstance)
 				.orElse(EmptyNode.getInstance());
 
-		return new Unique(planNode, false);
+		return Unique.getInstance(planNode, false);
 	}
 
 	@Override

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UniqueTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UniqueTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
+import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.Unique;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ValidationTuple;
 import org.eclipse.rdf4j.sail.shacl.mock.MockConsumePlanNode;
@@ -79,7 +80,7 @@ public class UniqueTest {
 				Arrays.asList("a", "a", "2")
 		);
 
-		Unique unique = new Unique(input, true);
+		PlanNode unique = Unique.getInstance(input, true);
 
 		List<ValidationTuple> tuples = new MockConsumePlanNode(unique).asList();
 
@@ -88,7 +89,7 @@ public class UniqueTest {
 	}
 
 	private void runTest(MockInputPlanNode input, boolean compress) {
-		Unique unique = new Unique(input, compress);
+		PlanNode unique = Unique.getInstance(input, compress);
 
 		List<ValidationTuple> tuples = new MockConsumePlanNode(unique).asList();
 


### PR DESCRIPTION
GitHub issue resolved: #GH-3217 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - use getInstance methods instead of constructors
 - check input so that for 
     - Unique we can return the provided node if the is already unique
     - UnionNode we can return the provided node if the effective node count is 1
 - also (because it was hard to untangle from this code) GH-3218 optimize QualifiedMinCount to better handle bulk validation

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

