### PR TITLE
GH-3219 close iterators when exhausted

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ConnectionsGroup.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ConnectionsGroup.java
@@ -83,6 +83,8 @@ public class ConnectionsGroup implements Closeable {
 		for (SailConnection sailConnection : connectionsToClose) {
 			sailConnection.close();
 		}
+
+		nodeCache.clear();
 	}
 
 	public SailConnection getBaseConnection() {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AllTargetsPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AllTargetsPlanNode.java
@@ -55,7 +55,7 @@ public class AllTargetsPlanNode implements PlanNode {
 			final CloseableIteration<? extends ValidationTuple, SailException> iterator = select.iterator();
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				iterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BindSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BindSelect.java
@@ -219,8 +219,10 @@ public class BindSelect implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				try {
+					bulk = null;
+					parsedQuery = null;
 					assert !iterator.hasNext();
 					iterator.close();
 				} finally {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalInnerJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalInnerJoin.java
@@ -139,7 +139,7 @@ public class BulkedExternalInnerJoin extends AbstractBulkJoinPlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				leftNodeIterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalLeftOuterJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalLeftOuterJoin.java
@@ -83,7 +83,7 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				leftNodeIterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EqualsJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EqualsJoin.java
@@ -97,7 +97,7 @@ public class EqualsJoin implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				leftIterator.close();
 				rightIterator.close();
 			}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EqualsJoinValue.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/EqualsJoinValue.java
@@ -102,7 +102,7 @@ public class EqualsJoinValue implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				leftIterator.close();
 				rightIterator.close();
 			}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByPredicate.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByPredicate.java
@@ -92,7 +92,7 @@ public class ExternalFilterByPredicate implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				parentIterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/GroupByCountFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/GroupByCountFilter.java
@@ -76,7 +76,7 @@ public class GroupByCountFilter implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				parentIterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/GroupByFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/GroupByFilter.java
@@ -81,7 +81,8 @@ public class GroupByFilter implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
+				group.clear();
 				parentIterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/InnerJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/InnerJoin.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
@@ -36,7 +37,6 @@ public class InnerJoin implements MultiStreamPlanNode, PlanNode {
 	private NotifyingPushablePlanNode joined;
 	private NotifyingPushablePlanNode discardedLeft;
 	private NotifyingPushablePlanNode discardedRight;
-	private ValidationExecutionLogger validationExecutionLogger;
 
 	public InnerJoin(PlanNode left, PlanNode right) {
 		left = PlanNodeHelper.handleSorting(this, left);
@@ -359,16 +359,9 @@ public class InnerJoin implements MultiStreamPlanNode, PlanNode {
 
 	@Override
 	public void receiveLogger(ValidationExecutionLogger validationExecutionLogger) {
-		this.validationExecutionLogger = validationExecutionLogger;
-
-		PlanNode[] planNodes = { joined, discardedLeft, discardedRight, left, right };
-
-		for (PlanNode planNode : planNodes) {
-			if (planNode != null) {
-				planNode.receiveLogger(validationExecutionLogger);
-			}
-		}
-
+		Stream.of(joined, discardedLeft, discardedRight, left, right)
+				.filter(Objects::nonNull)
+				.forEach(p -> p.receiveLogger(validationExecutionLogger));
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LeftOuterJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/LeftOuterJoin.java
@@ -110,7 +110,7 @@ public class LeftOuterJoin implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				leftIterator.close();
 				rightIterator.close();
 			}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NonUniqueTargetLang.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NonUniqueTargetLang.java
@@ -159,7 +159,7 @@ class OnlyNonUnique extends LoggingCloseableIteration {
 	}
 
 	@Override
-	public void close() throws SailException {
+	public void localClose() throws SailException {
 		parentIterator.close();
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NotValuesIn.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/NotValuesIn.java
@@ -77,7 +77,7 @@ public class NotValuesIn implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 
 				parentIterator.close();
 			}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/PlanNodeHelper.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/PlanNodeHelper.java
@@ -10,7 +10,11 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 public class PlanNodeHelper {
 
 	public static PlanNode handleSorting(PlanNode child, PlanNode parent) {
-		if (child.requiresSorted()) {
+		return handleSorting(child.requiresSorted(), parent);
+	}
+
+	public static PlanNode handleSorting(boolean requiresSorted, PlanNode parent) {
+		if (requiresSorted) {
 			if (!parent.producesSorted()) {
 				parent = new Sort(parent);
 			}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Select.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Select.java
@@ -88,7 +88,7 @@ public class Select implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				if (bindingSet != null) {
 					bindingSet.close();
 				}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SetFilterNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SetFilterNode.java
@@ -55,7 +55,7 @@ public class SetFilterNode implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				iterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ShiftToNodeShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ShiftToNodeShape.java
@@ -52,8 +52,9 @@ public class ShiftToNodeShape implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				parentIterator.close();
+				iterator = Collections.emptyIterator();
 			}
 
 			@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ShiftToPropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ShiftToPropertyShape.java
@@ -51,8 +51,9 @@ public class ShiftToPropertyShape implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				parentIterator.close();
+				iterator = Collections.emptyIterator();
 			}
 
 			@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Sort.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Sort.java
@@ -44,7 +44,7 @@ public class Sort implements PlanNode {
 			boolean closed = false;
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				if (closed) {
 					throw new IllegalStateException("Already closed");
 				}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SparqlTargetSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SparqlTargetSelect.java
@@ -74,7 +74,7 @@ public class SparqlTargetSelect implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				bindingSet.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/TargetChainPopper.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/TargetChainPopper.java
@@ -59,8 +59,9 @@ public class TargetChainPopper implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				parentIterator.close();
+				iterator = Collections.emptyIterator();
 			}
 
 			@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/TrimToTarget.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/TrimToTarget.java
@@ -28,7 +28,7 @@ public class TrimToTarget implements PlanNode {
 			final CloseableIteration<? extends ValidationTuple, SailException> parentIterator = parent.iterator();
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				parentIterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/TupleMapper.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/TupleMapper.java
@@ -34,7 +34,7 @@ public class TupleMapper implements PlanNode {
 			final CloseableIteration<? extends ValidationTuple, SailException> parentIterator = parent.iterator();
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				parentIterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnionNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnionNode.java
@@ -56,7 +56,7 @@ public class UnionNode implements PlanNode {
 				final CloseableIteration<? extends ValidationTuple, SailException> iterator = nodes[0].iterator();
 
 				@Override
-				public void close() throws SailException {
+				public void localClose() throws SailException {
 					iterator.close();
 				}
 
@@ -126,7 +126,7 @@ public class UnionNode implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				iterators.forEach(CloseableIteration::close);
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
@@ -155,9 +155,11 @@ public class Unique implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				targetAndValueDedupeSet = null;
 				parentIterator.close();
+				next = null;
+				previous = null;
 			}
 
 			@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnorderedSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnorderedSelect.java
@@ -58,7 +58,7 @@ public class UnorderedSelect implements PlanNode {
 					predicate, object, true);
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				statements.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValidationReportNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValidationReportNode.java
@@ -38,7 +38,7 @@ public class ValidationReportNode implements PlanNode {
 			private final CloseableIteration<? extends ValidationTuple, SailException> iterator = parent.iterator();
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 				iterator.close();
 			}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValuesBackedNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValuesBackedNode.java
@@ -53,7 +53,7 @@ public class ValuesBackedNode implements PlanNode {
 			final Iterator<ValidationTuple> iterator = tuples.iterator();
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 			}
 
 			@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetChainRetriever.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetChainRetriever.java
@@ -214,7 +214,7 @@ public class TargetChainRetriever implements PlanNode {
 			}
 
 			@Override
-			public void close() throws SailException {
+			public void localClose() throws SailException {
 
 				try {
 					if (statements != null) {


### PR DESCRIPTION
GitHub issue resolved: #3219 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - iterators that use the logging iterator will now get closed when they have no more elements
 - closing elements as early as possible frees up resources, especially in the Sort plan node
 - also found some other resources that could be nulled/cleared when the iterator is closed

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

