### PR TITLE
GH-3226 return a new AllTargetsPlanNode instead of extending

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/EffectiveTarget.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/EffectiveTarget.java
@@ -74,6 +74,14 @@ public class EffectiveTarget {
 	public PlanNode extend(PlanNode source, ConnectionsGroup connectionsGroup, ConstraintComponent.Scope scope,
 			Extend direction, boolean includePropertyShapeValues, Function<PlanNode, PlanNode> filter) {
 
+		if (source instanceof AllTargetsPlanNode && !includePropertyShapeValues) {
+			PlanNode allTargets = getAllTargets(connectionsGroup, scope);
+			if (filter != null) {
+				allTargets = filter.apply(allTargets);
+			}
+			return allTargets;
+		}
+
 		String query = getQuery(includePropertyShapeValues);
 		List<StatementMatcher.Variable> vars = getVars();
 		if (includePropertyShapeValues) {


### PR DESCRIPTION
GitHub issue resolved: #3226 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

AllTargetsPlanNode is used to signal bulk validation. The .extend(...) method is aimed at supporting sh:or and sh:not in particular. When using the target override feature (designed to support sh:or and sh:not) we don't need to extend the overriding targets if they are actually "all" targets. So the presence of the AllTargetsPlanNode means that we can just return a new one based on the current effective target chain.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

