### PR TITLE
GH-3227 don't compress tuples if we only have one tuple but there are…

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Unique.java
@@ -111,6 +111,8 @@ public class Unique implements PlanNode {
 
 						if (tuples.isEmpty()) {
 							next = temp;
+						} else if (tuples.size() == 1 && tuples.contains(temp)) {
+							next = temp;
 						} else {
 							tuples.add(temp);
 							next = new ValidationTuple(temp, tuples);


### PR DESCRIPTION
GitHub issue resolved: #3227 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - We already have a check for this, but it doesn't account for when we have duplicates. So now we account for that too.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

