### PR TITLE
GH-3228 ValidationTuple uses array instead of list

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValuesBackedNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ValuesBackedNode.java
@@ -39,7 +39,7 @@ public class ValuesBackedNode implements PlanNode {
 	public ValuesBackedNode(SortedSet<Value> values, ConstraintComponent.Scope scope) {
 
 		this.tuples = values.stream()
-				.map(c -> new ValidationTuple(Collections.singletonList(c), scope, false))
+				.map(c -> new ValidationTuple(c, scope, false))
 				.collect(Collectors.toList());
 
 		this.values = values;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetChainRetriever.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetChainRetriever.java
@@ -1,14 +1,16 @@
 package org.eclipse.rdf4j.sail.shacl.ast.targets;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -121,8 +123,9 @@ public class TargetChainRetriever implements PlanNode {
 						currentStatementMatcher = statementPatternIterator.next();
 						connection = connectionsGroup.getAddedStatements();
 					} else {
-						if (!connectionsGroup.getStats().hasRemoved())
+						if (!connectionsGroup.getStats().hasRemoved()) {
 							break;
+						}
 						currentStatementMatcher = removedStatementIterator.next();
 						connection = connectionsGroup.getRemovedStatements();
 					}
@@ -201,13 +204,16 @@ public class TargetChainRetriever implements PlanNode {
 				if (results.hasNext()) {
 					BindingSet nextBinding = results.next();
 
-					List<Value> collect = nextBinding.getBindingNames()
-							.stream()
-							.sorted()
-							.map(nextBinding::getValue)
-							.collect(Collectors.toList());
+					if (nextBinding.size() == 1) {
+						next = new ValidationTuple(nextBinding.iterator().next().getValue(), scope, false);
+					} else {
+						Value[] values = StreamSupport.stream(nextBinding.spliterator(), false)
+								.sorted(Comparator.comparing(Binding::getName))
+								.map(Binding::getValue)
+								.toArray(Value[]::new);
+						next = new ValidationTuple(values, scope, false);
 
-					next = new ValidationTuple(collect, scope, false);
+					}
 
 				}
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ValidationTupleBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ValidationTupleBenchmark.java
@@ -8,7 +8,12 @@
 
 package org.eclipse.rdf4j.sail.shacl.benchmark;
 
-import ch.qos.logback.classic.Logger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -30,22 +35,19 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
+import ch.qos.logback.classic.Logger;
 
 /**
+ * Test how many validation tuples we can keep in memory.
+ *
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 2)
-@BenchmarkMode({Mode.AverageTime})
-@Fork(value = 1, jvmArgs = {"-Xms512M", "-Xmx512M", "-XX:+UseG1GC"})
+@Warmup(iterations = 0)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms512M", "-Xmx512M", "-XX:+UseG1GC" })
 //@Fork(value = 1, jvmArgs = {"-Xms512M", "-Xmx512M", "-XX:+UseG1GC", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
-@Measurement(iterations = 2)
+@Measurement(iterations = 1)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ValidationTupleBenchmark {
 
@@ -61,13 +63,13 @@ public class ValidationTupleBenchmark {
 	public void setUp() throws InterruptedException {
 		Thread.sleep(100);
 		((Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName()))
-			.setLevel(ch.qos.logback.classic.Level.ERROR);
+				.setLevel(ch.qos.logback.classic.Level.ERROR);
 		((Logger) LoggerFactory.getLogger(ShaclSail.class.getName())).setLevel(ch.qos.logback.classic.Level.ERROR);
 		System.setProperty("org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation", "true");
 	}
 
 	@Benchmark
-	public int randomData() throws IOException {
+	public int randomData() {
 
 		int size = 670_000;
 
@@ -77,25 +79,23 @@ public class ValidationTupleBenchmark {
 
 		ArrayList<Object> objects = new ArrayList<>(size);
 
-		for(int i = 0; i< size; i++){
+		for (int i = 0; i < size; i++) {
 			List<Value> values = Arrays.asList(
-				vf.createIRI(NS1 + r.nextInt(size *1000)),
-				vf.createIRI(NS2 + r.nextInt(size *1000)),
-				vf.createIRI(NS3 + r.nextInt(size *1000)),
-				vf.createLiteral(NS3 + r.nextInt(size *1000)),
-				vf.createLiteral(r.nextInt(size *1000))
-
+					vf.createIRI(NS1 + r.nextInt(size * 1000)),
+					vf.createIRI(NS2 + r.nextInt(size * 1000)),
+					vf.createIRI(NS3 + r.nextInt(size * 1000)),
+					vf.createLiteral(NS3 + r.nextInt(size * 1000)),
+					vf.createLiteral(r.nextInt(size * 1000))
 			);
 
-			ValidationTuple validationTuple = new ValidationTuple(values, ConstraintComponent.Scope.propertyShape, true);
+			ValidationTuple validationTuple = new ValidationTuple(values, ConstraintComponent.Scope.propertyShape,
+					true);
 			objects.add(validationTuple);
 
 		}
 
 		return objects.size();
 
-
 	}
-
 
 }

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ValidationTupleBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ValidationTupleBenchmark.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.benchmark;
+
+import ch.qos.logback.classic.Logger;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sail.shacl.GlobalValidationExecutionLogging;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
+import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.ConstraintComponent;
+import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ValidationTuple;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@BenchmarkMode({Mode.AverageTime})
+@Fork(value = 1, jvmArgs = {"-Xms512M", "-Xmx512M", "-XX:+UseG1GC"})
+//@Fork(value = 1, jvmArgs = {"-Xms512M", "-Xmx512M", "-XX:+UseG1GC", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Measurement(iterations = 2)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ValidationTupleBenchmark {
+
+	private static final String NS1 = "http://example.com/fkewjfowejiofiew/fjewifoweifjwe/jfiewjifjewofiwe/";
+	private static final String NS2 = "http://example.com/jiu98u89/fjewifoweifjwe/jfiewjifjewofiwe/";
+	private static final String NS3 = "http://example.com/fkewjfowejiofiew/556r6fuig7t87/jfiewjifjewofiwe/";
+
+	{
+		GlobalValidationExecutionLogging.loggingEnabled = false;
+	}
+
+	@Setup(Level.Trial)
+	public void setUp() throws InterruptedException {
+		Thread.sleep(100);
+		((Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName()))
+			.setLevel(ch.qos.logback.classic.Level.ERROR);
+		((Logger) LoggerFactory.getLogger(ShaclSail.class.getName())).setLevel(ch.qos.logback.classic.Level.ERROR);
+		System.setProperty("org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation", "true");
+	}
+
+	@Benchmark
+	public int randomData() throws IOException {
+
+		int size = 670_000;
+
+		ValueFactory vf = SimpleValueFactory.getInstance();
+
+		Random r = new Random(5637248);
+
+		ArrayList<Object> objects = new ArrayList<>(size);
+
+		for(int i = 0; i< size; i++){
+			List<Value> values = Arrays.asList(
+				vf.createIRI(NS1 + r.nextInt(size *1000)),
+				vf.createIRI(NS2 + r.nextInt(size *1000)),
+				vf.createIRI(NS3 + r.nextInt(size *1000)),
+				vf.createLiteral(NS3 + r.nextInt(size *1000)),
+				vf.createLiteral(r.nextInt(size *1000))
+
+			);
+
+			ValidationTuple validationTuple = new ValidationTuple(values, ConstraintComponent.Scope.propertyShape, true);
+			objects.add(validationTuple);
+
+		}
+
+		return objects.size();
+
+
+	}
+
+
+}


### PR DESCRIPTION
GitHub issue resolved: #3228  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - The chain is the most used structure in the ValidationTuple. It's similar to a binding set. Using an array instead of a list reduces the amount of memory we use.
 - Fixed some empty set and empty list usage elsewhere in the ValidationTuple code too
 - Also added benchmark

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

