### PR TITLE
GH-3029 limit transaction size for transactional validation in ShaclSail

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/NotifyingSailConnectionBase.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/NotifyingSailConnectionBase.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.helpers;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
@@ -22,24 +22,13 @@ import org.eclipse.rdf4j.sail.SailConnectionListener;
  */
 public abstract class NotifyingSailConnectionBase extends AbstractSailConnection implements NotifyingSailConnection {
 
-	/*-----------*
-	 * Variables *
-	 *-----------*/
-
-	private List<SailConnectionListener> listeners;
-
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
+	// Use of a CopyOnWriteArrayList allows us to remove a listener from within a call to `listener.statementAdded(st)`
+	// or `listener.statementRemoved(st)`
+	private final List<SailConnectionListener> listeners = new CopyOnWriteArrayList<>();
 
 	public NotifyingSailConnectionBase(AbstractSail sailBase) {
 		super(sailBase);
-		listeners = new ArrayList<>(0);
 	}
-
-	/*---------*
-	 * Methods *
-	 *---------*/
 
 	@Override
 	public void addConnectionListener(SailConnectionListener listener) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -205,8 +205,10 @@ public class ShaclSail extends NotifyingSailWrapper {
 	private boolean eclipseRdf4jShaclExtensions = ShaclSailConfig.ECLIPSE_RDF4J_SHACL_EXTENSIONS_DEFAULT;
 	private boolean dashDataShapes = ShaclSailConfig.DASH_DATA_SHAPES_DEFAULT;
 
-	private long validationResultsLimitTotal = -1;
-	private long validationResultsLimitPerConstraint = -1;
+	private long validationResultsLimitTotal = ShaclSailConfig.VALIDATION_RESULTS_LIMIT_TOTAL_DEFAULT;
+	private long validationResultsLimitPerConstraint = ShaclSailConfig.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT_DEFAULT;
+
+	private long transactionalValidationLimit = ShaclSailConfig.TRANSACTIONAL_VALIDATION_LIMIT_DEFAULT;
 
 	// SHACL Vocabulary from W3C - https://www.w3.org/ns/shacl.ttl
 	private final static SchemaCachingRDFSInferencer shaclVocabulary;
@@ -957,6 +959,14 @@ public class ShaclSail extends NotifyingSailWrapper {
 	@Override
 	public IsolationLevel getDefaultIsolationLevel() {
 		return super.getDefaultIsolationLevel();
+	}
+
+	public long getTransactionalValidationLimit() {
+		return transactionalValidationLimit;
+	}
+
+	public void setTransactionalValidationLimit(long transactionalValidationLimit) {
+		this.transactionalValidationLimit = transactionalValidationLimit;
 	}
 
 	boolean hasShapes() {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -37,6 +37,7 @@ import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.UpdateContext;
 import org.eclipse.rdf4j.sail.helpers.NotifyingSailConnectionWrapper;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail.TransactionSettings.ValidationApproach;
 import org.eclipse.rdf4j.sail.shacl.ast.Shape;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.EmptyNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
@@ -126,15 +127,6 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 		currentIsolationLevel = level;
 
-		Settings localTransactionSettings = getLocalTransactionSettings();
-
-		transactionSettings = getDefaultSettings(sail);
-		transactionSettings.applyTransactionSettings(localTransactionSettings);
-
-		assert transactionSettings.parallelValidation != null;
-		assert transactionSettings.cacheSelectedNodes != null;
-		assert transactionSettings.validationApproach != null;
-
 		assert addedStatements == null;
 		assert removedStatements == null;
 
@@ -152,9 +144,19 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 		stats.setEmptyBeforeTransaction(isEmpty());
 
+		transactionSettings = getDefaultSettings(sail);
+
+		if (stats.wasEmptyBeforeTransaction() && !shouldUseSerializableValidation()) {
+			transactionSettings.switchToBulkValidation();
+		}
+
+		transactionSettings.applyTransactionSettings(getLocalTransactionSettings());
+
+		assert transactionSettings.parallelValidation != null;
+		assert transactionSettings.cacheSelectedNodes != null;
+		assert transactionSettings.validationApproach != null;
+
 		if (isBulkValidation() || !isValidationEnabled()) {
-			removeConnectionListener(this);
-		} else if (stats.wasEmptyBeforeTransaction()) {
 			removeConnectionListener(this);
 		} else {
 			addConnectionListener(this);
@@ -173,8 +175,8 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		Arrays.stream(transactionSettingsRaw)
 				.filter(Objects::nonNull)
 				.forEach(setting -> {
-					if (setting instanceof ShaclSail.TransactionSettings.ValidationApproach) {
-						localTransactionSettings.validationApproach = (ShaclSail.TransactionSettings.ValidationApproach) setting;
+					if (setting instanceof ValidationApproach) {
+						localTransactionSettings.validationApproach = (ValidationApproach) setting;
 					}
 					if (setting instanceof ShaclSail.TransactionSettings.PerformanceHint) {
 						switch (((ShaclSail.TransactionSettings.PerformanceHint) setting)) {
@@ -205,7 +207,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 	}
 
 	boolean isValidationEnabled() {
-		return transactionSettings.getValidationApproach() != ShaclSail.TransactionSettings.ValidationApproach.Disabled;
+		return transactionSettings.getValidationApproach() != ValidationApproach.Disabled;
 	}
 
 	@Override
@@ -556,78 +558,49 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			before = System.currentTimeMillis();
 		}
 
-		if (stats.wasEmptyBeforeTransaction()) {
+		Stream.of(addedStatementsSet, removedStatementsSet)
+				.parallel()
+				.forEach(set -> {
+					Set<Statement> otherSet;
+					Sail repository;
+					if (set == addedStatementsSet) {
+						otherSet = removedStatementsSet;
 
-			flush();
+						if (addedStatements != null && addedStatements != sail.getBaseSail()) {
+							addedStatements.shutDown();
+						}
 
-			if ((rdfsSubClassOfReasoner == null || rdfsSubClassOfReasoner.isEmpty())
-					&& sail.getBaseSail() instanceof MemoryStore && this.getIsolationLevel() == IsolationLevels.NONE) {
-				addedStatements = sail.getBaseSail();
-				removedStatements = getNewMemorySail();
-			} else {
-				addedStatements = getNewMemorySail();
-				removedStatements = getNewMemorySail();
+						addedStatements = getNewMemorySail();
+						repository = addedStatements;
 
-				try (Stream<? extends Statement> stream = getStatements(null, null, null, false).stream()) {
-					try (SailConnection connection = addedStatements.getConnection()) {
+						set.forEach(stats::added);
+
+					} else {
+						otherSet = addedStatementsSet;
+
+						if (removedStatements != null) {
+							removedStatements.shutDown();
+							removedStatements = null;
+						}
+
+						removedStatements = getNewMemorySail();
+						repository = removedStatements;
+
+						set.forEach(stats::removed);
+					}
+
+					try (SailConnection connection = repository.getConnection()) {
 						connection.begin(IsolationLevels.NONE);
-						stream
+						set.stream()
+								.filter(statement -> !otherSet.contains(statement))
 								.flatMap(statement -> rdfsSubClassOfReasoner == null ? Stream.of(statement)
 										: rdfsSubClassOfReasoner.forwardChain(statement))
 								.forEach(statement -> connection.addStatement(statement.getSubject(),
 										statement.getPredicate(), statement.getObject(), statement.getContext()));
 						connection.commit();
 					}
-				}
-			}
 
-		} else {
-
-			Stream.of(addedStatementsSet, removedStatementsSet)
-					.parallel()
-					.forEach(set -> {
-						Set<Statement> otherSet;
-						Sail repository;
-						if (set == addedStatementsSet) {
-							otherSet = removedStatementsSet;
-
-							if (addedStatements != null && addedStatements != sail.getBaseSail()) {
-								addedStatements.shutDown();
-							}
-
-							addedStatements = getNewMemorySail();
-							repository = addedStatements;
-
-							set.forEach(stats::added);
-
-						} else {
-							otherSet = addedStatementsSet;
-
-							if (removedStatements != null) {
-								removedStatements.shutDown();
-								removedStatements = null;
-							}
-
-							removedStatements = getNewMemorySail();
-							repository = removedStatements;
-
-							set.forEach(stats::removed);
-						}
-
-						try (SailConnection connection = repository.getConnection()) {
-							connection.begin(IsolationLevels.NONE);
-							set.stream()
-									.filter(statement -> !otherSet.contains(statement))
-									.flatMap(statement -> rdfsSubClassOfReasoner == null ? Stream.of(statement)
-											: rdfsSubClassOfReasoner.forwardChain(statement))
-									.forEach(statement -> connection.addStatement(statement.getSubject(),
-											statement.getPredicate(), statement.getObject(), statement.getContext()));
-							connection.commit();
-						}
-
-					});
-
-		}
+				});
 
 		if (sail.isPerformanceLogging()) {
 			logger.info("fillAddedAndRemovedStatementRepositories() took {} ms", System.currentTimeMillis() - before);
@@ -698,9 +671,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 			// Serializable validation uses synchronized validation (with locking) to allow a transaction to run in
 			// SNAPSHOT isolation but validate as if it was using SERIALIZABLE isolation
-			boolean useSerializableValidation = sail.isSerializableValidation() &&
-					currentIsolationLevel == IsolationLevels.SNAPSHOT &&
-					!isBulkValidation();
+			boolean useSerializableValidation = shouldUseSerializableValidation() && !isBulkValidation();
 
 			if (useSerializableValidation) {
 				if (!(writeLock != null && writeLock.isActive())) {
@@ -730,17 +701,13 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 				return;
 			}
 
-			stats.setEmptyIncludingCurrentTransaction(isEmpty());
-
 			if (!isShapeRefreshNeeded && !isBulkValidation() && addedStatementsSet.isEmpty()
 					&& removedStatementsSet.isEmpty()) {
-				// on the first transaction we can elect to not use the statements tracking mechanism and instead use
-				// the underlying sail as the "added" source
-				if (!(stats.wasEmptyBeforeTransaction() && !stats.isEmptyIncludingCurrentTransaction())) {
-					logger.debug("Nothing has changed, nothing to validate.");
-					return;
-				}
+				logger.debug("Nothing has changed, nothing to validate.");
+				return;
 			}
+
+			stats.setEmptyIncludingCurrentTransaction(isEmpty());
 
 			List<Shape> shapesBeforeRefresh = sail.getCurrentShapes();
 			List<Shape> shapesAfterRefresh;
@@ -821,8 +788,12 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 	}
 
+	private boolean shouldUseSerializableValidation() {
+		return sail.isSerializableValidation() && currentIsolationLevel == IsolationLevels.SNAPSHOT;
+	}
+
 	private boolean isBulkValidation() {
-		return transactionSettings.getValidationApproach() == ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+		return transactionSettings.getValidationApproach() == ValidationApproach.Bulk;
 	}
 
 	private ValidationReport serializableValidation(List<Shape> shapesAfterRefresh) {
@@ -851,7 +822,6 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 					try (SailConnection connection = removedStatements.getConnection()) {
 						SailConnection baseConnection = connectionsGroup.getBaseConnection();
 						ConnectionHelper.transferStatements(connection, baseConnection::removeStatements);
-
 					}
 
 					serializableConnection.flush();
@@ -901,13 +871,18 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 	private void checkTransactionalValidationLimit() {
 		if ((addedStatementsSet.size() + removedStatementsSet.size()) > sail.getTransactionalValidationLimit()) {
-			logger.debug("Transaction size limit exceeded, reverting to bulk validation.");
-			removeConnectionListener(this);
-			Settings bulkValidation = getLocalTransactionSettings();
-			bulkValidation.validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Bulk;
-			getTransactionSettings().applyTransactionSettings(bulkValidation);
-			removedStatementsSet.clear();
-			addedStatementsSet.clear();
+			if (shouldUseSerializableValidation()) {
+				logger.debug(
+						"Transaction size limit exceeded, could not switch to bulk validation because serializable validation is enabled.");
+			} else {
+				logger.debug("Transaction size limit exceeded, reverting to bulk validation.");
+				removeConnectionListener(this);
+				Settings bulkValidation = getLocalTransactionSettings();
+				bulkValidation.validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+				getTransactionSettings().applyTransactionSettings(bulkValidation);
+				removedStatementsSet.clear();
+				addedStatementsSet.clear();
+			}
 		}
 	}
 
@@ -949,10 +924,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			throw new IllegalStateException("No active transaction!");
 		}
 
-		prepareValidation();
-		ValidationReport validate = validate(sail.getCurrentShapes(), true);
-
-		return new ShaclSailValidationException(validate).getValidationReport();
+		return validate(sail.getShapes(shapesRepoConnection), true);
 	}
 
 	Settings getTransactionSettings() {
@@ -961,7 +933,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 	public static class Settings {
 
-		private ShaclSail.TransactionSettings.ValidationApproach validationApproach;
+		private ValidationApproach validationApproach;
 		private Boolean cacheSelectedNodes;
 		private Boolean parallelValidation;
 		private IsolationLevel isolationLevel;
@@ -973,15 +945,15 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 				IsolationLevel isolationLevel) {
 			this.cacheSelectedNodes = cacheSelectNodes;
 			if (!validationEnabled) {
-				validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Disabled;
+				validationApproach = ValidationApproach.Disabled;
 			} else {
-				this.validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Auto;
+				this.validationApproach = ValidationApproach.Auto;
 			}
 			this.parallelValidation = parallelValidation;
 			this.isolationLevel = isolationLevel;
 		}
 
-		public ShaclSail.TransactionSettings.ValidationApproach getValidationApproach() {
+		public ValidationApproach getValidationApproach() {
 			return validationApproach;
 		}
 
@@ -997,14 +969,14 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			return isolationLevel;
 		}
 
-		static ShaclSail.TransactionSettings.ValidationApproach getMostSignificantValidationApproach(
-				ShaclSail.TransactionSettings.ValidationApproach base,
-				ShaclSail.TransactionSettings.ValidationApproach overriding) {
+		static ValidationApproach getMostSignificantValidationApproach(
+				ValidationApproach base,
+				ValidationApproach overriding) {
 			if (base == null && overriding == null) {
-				return ShaclSail.TransactionSettings.ValidationApproach.Auto;
+				return ValidationApproach.Auto;
 			}
 
-			return ShaclSail.TransactionSettings.ValidationApproach.getHighestPriority(base, overriding);
+			return ValidationApproach.getHighestPriority(base, overriding);
 
 		}
 
@@ -1015,7 +987,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 					transactionSettingsLocal.validationApproach);
 
 			// apply restrictions first
-			if (validationApproach == ShaclSail.TransactionSettings.ValidationApproach.Bulk) {
+			if (validationApproach == ValidationApproach.Bulk) {
 				cacheSelectedNodes = false;
 				parallelValidation = false;
 			}
@@ -1049,6 +1021,17 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 					", parallelValidation=" + parallelValidation +
 					", isolationLevel=" + isolationLevel +
 					'}';
+		}
+
+		public void switchToBulkValidation() {
+			ValidationApproach newValidationApproach = getMostSignificantValidationApproach(validationApproach,
+					ValidationApproach.Bulk);
+
+			if (newValidationApproach != this.validationApproach) {
+				this.validationApproach = newValidationApproach;
+				parallelValidation = false;
+				cacheSelectedNodes = false;
+			}
 		}
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/Stats.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/Stats.java
@@ -18,10 +18,10 @@ import org.eclipse.rdf4j.model.Statement;
 @InternalUseOnly
 public class Stats {
 
-	private boolean emptyBeforeTransaction;
+	private Boolean emptyBeforeTransaction;
 	private boolean hasAdded;
 	private boolean hasRemoved;
-	private boolean emptyIncludingCurrentTransaction;
+	private Boolean emptyIncludingCurrentTransaction;
 
 	public void added(Statement statement) {
 		hasAdded = true;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/Shape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/Shape.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,6 +26,7 @@ import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.vocabulary.DASH;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.RSX;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -558,15 +560,18 @@ abstract public class Shape implements ConstraintComponent, Identifiable, Export
 		Model statements = toModel(new DynamicModel(new LinkedHashModelFactory()));
 		statements.setNamespace(SHACL.NS);
 		statements.setNamespace(XSD.NS);
+		statements.setNamespace(RSX.NS);
+		statements.setNamespace(RDFS.NS);
+		statements.setNamespace(RDF.NS);
 		WriterConfig writerConfig = new WriterConfig();
 		writerConfig.set(BasicWriterSettings.PRETTY_PRINT, true);
 		writerConfig.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
 
 		StringWriter stringWriter = new StringWriter();
 		Rio.write(statements, stringWriter, RDFFormat.TURTLE, writerConfig);
+
 		return stringWriter.toString()
-				.replace("@prefix sh: <http://www.w3.org/ns/shacl#> .", "")
-				.replace("@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .", "")
+				.replaceAll("(?m)^(@prefix)(.*)(\\.)$", "") // remove all lines that are prefix declarations
 				.trim();
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
@@ -53,6 +53,7 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	public static final boolean DASH_DATA_SHAPES_DEFAULT = false;
 	public final static long VALIDATION_RESULTS_LIMIT_TOTAL_DEFAULT = 1_000_000;
 	public final static long VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT_DEFAULT = 1_000;
+	public final static long TRANSACTIONAL_VALIDATION_LIMIT_DEFAULT = 500_000;
 
 	private boolean parallelValidation = PARALLEL_VALIDATION_DEFAULT;
 	private boolean undefinedTargetValidatesAllSubjects = UNDEFINED_TARGET_VALIDATES_ALL_SUBJECTS_DEFAULT;
@@ -69,6 +70,7 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	private boolean dashDataShapes = DASH_DATA_SHAPES_DEFAULT;
 	private long validationResultsLimitTotal = VALIDATION_RESULTS_LIMIT_TOTAL_DEFAULT;
 	private long validationResultsLimitPerConstraint = VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT_DEFAULT;
+	private long transactionalValidationLimit = TRANSACTIONAL_VALIDATION_LIMIT_DEFAULT;
 
 	public ShaclSailConfig() {
 		super(ShaclSailFactory.SAIL_TYPE);
@@ -206,6 +208,14 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 		this.validationResultsLimitPerConstraint = validationResultsLimitPerConstraint;
 	}
 
+	public long getTransactionalValidationLimit() {
+		return transactionalValidationLimit;
+	}
+
+	public void setTransactionalValidationLimit(long transactionalValidationLimit) {
+		this.transactionalValidationLimit = transactionalValidationLimit;
+	}
+
 	@Override
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
@@ -231,6 +241,9 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 				literal(getValidationResultsLimitTotal()));
 		m.add(implNode, ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT,
 				literal(getValidationResultsLimitPerConstraint()));
+
+		m.add(implNode, ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT,
+				literal(getTransactionalValidationLimit()));
 		return implNode;
 	}
 
@@ -284,6 +297,10 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 			Models.objectLiteral(
 					m.getStatements(implNode, ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT, null))
 					.ifPresent(l -> setValidationResultsLimitPerConstraint(l.longValue()));
+
+			Models.objectLiteral(
+					m.getStatements(implNode, ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT, null))
+					.ifPresent(l -> setTransactionalValidationLimit(l.longValue()));
 
 		} catch (IllegalArgumentException e) {
 			throw new SailConfigException("error parsing Sail configuration", e);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
@@ -62,6 +62,7 @@ public class ShaclSailSchema {
 
 	public final static IRI VALIDATION_RESULTS_LIMIT_TOTAL = create("validationResultsLimitTotal");
 	public final static IRI VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT = create("validationResultsLimitPerConstraint");
+	public final static IRI TRANSACTIONAL_VALIDATION_LIMIT = create("transactionalValidationLimit");
 
 	private static IRI create(String localName) {
 		return iri(NAMESPACE, localName);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -936,6 +936,8 @@ abstract public class AbstractShaclTest {
 					}
 				}
 
+				// testing that bulk validation always validates all the data by committing the transaction with
+				// validation disabled and then running an empty transaction with bulk validation
 				shaclSailConnection.commit();
 
 				shaclSailConnection.begin(ValidationApproach.Bulk);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ExtendedFeaturesetTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ExtendedFeaturesetTest.java
@@ -35,8 +35,8 @@ public class ExtendedFeaturesetTest {
 	@Test
 	public void testDashIsDisabledByDefault() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("test-cases/class/allSubjects/shacl.ttl",
-				false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("test-cases/class/allSubjects/shacl.ttl"
+		);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.begin();
@@ -49,8 +49,8 @@ public class ExtendedFeaturesetTest {
 	@Test(expected = ShaclSailValidationException.class)
 	public void testThatDashCanBeEnabled() throws Throwable {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("test-cases/class/allSubjects/shacl.ttl",
-				false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("test-cases/class/allSubjects/shacl.ttl"
+		);
 		((ShaclSail) shaclRepository.getSail()).setDashDataShapes(true);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
@@ -69,7 +69,7 @@ public class ExtendedFeaturesetTest {
 	public void testTargetShapeIsDisabledByDefault() throws Exception {
 
 		SailRepository shaclRepository = Utils
-				.getInitializedShaclRepository("test-cases/class/simpleTargetShape/shacl.ttl", false);
+				.getInitializedShaclRepository("test-cases/class/simpleTargetShape/shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.begin();
@@ -85,7 +85,7 @@ public class ExtendedFeaturesetTest {
 	public void testThatTargetShapesCanBeEnabled() throws Throwable {
 
 		SailRepository shaclRepository = Utils
-				.getInitializedShaclRepository("test-cases/class/simpleTargetShape/shacl.ttl", false);
+				.getInitializedShaclRepository("test-cases/class/simpleTargetShape/shacl.ttl");
 
 		((ShaclSail) shaclRepository.getSail()).setDashDataShapes(true);
 		((ShaclSail) shaclRepository.getSail()).setEclipseRdf4jShaclExtensions(true);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/NoChangeTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/NoChangeTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.shacl;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class NoChangeTest {
+
+	@Test
+	public void testSkippingValidationWhenThereAreNoChanges() throws IOException {
+
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+		shaclSail.init();
+
+		Model shapes;
+		try (InputStream stream = NoShapesTest.class.getClassLoader().getResourceAsStream("shacl.ttl")) {
+			shapes = Rio.parse(stream, RDFFormat.TURTLE);
+		}
+
+		try (SailConnection connection = shaclSail.getConnection()) {
+
+			connection.begin();
+			shapes.forEach(s -> connection.addStatement(s.getSubject(), s.getPredicate(), s.getObject(),
+					RDF4J.SHACL_SHAPE_GRAPH));
+			connection.addStatement(RDF.TYPE, RDF.TYPE, RDFS.RESOURCE);
+			connection.addStatement(RDF.TYPE, RDFS.LABEL, RDFS.RESOURCE);
+			connection.commit();
+		}
+
+		try (SailConnection connection = shaclSail.getConnection()) {
+			ShaclSailConnection connectionSpy = Mockito.spy((ShaclSailConnection) connection);
+			connectionSpy.begin();
+			connectionSpy.commit();
+			verify(connectionSpy, never()).prepareValidation();
+		}
+
+		shaclSail.shutDown();
+
+	}
+
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/PrepareCommitTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/PrepareCommitTest.java
@@ -212,7 +212,7 @@ public class PrepareCommitTest {
 
 	@Test
 	public void testAutomaticRollbackRepository() throws IOException {
-		SailRepository shaclSail = Utils.getInitializedShaclRepository("shacl.ttl", false);
+		SailRepository shaclSail = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		boolean exception = false;
 		BNode bNode = SimpleValueFactory.getInstance().createBNode();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ReduceNumberOfPlansTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ReduceNumberOfPlansTest.java
@@ -36,6 +36,8 @@ public class ReduceNumberOfPlansTest {
 		shaclSail.init();
 		Utils.loadShapeData(shaclSail, "reduceNumberOfPlansTest/shacl.ttl");
 
+		addDummyData(shaclSail);
+
 		try (ShaclSailConnection connection = (ShaclSailConnection) shaclSail.getConnection()) {
 			connection.begin();
 
@@ -81,6 +83,8 @@ public class ReduceNumberOfPlansTest {
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 		shaclSail.init();
 		Utils.loadShapeData(shaclSail, "reduceNumberOfPlansTest/shacl.ttl");
+
+		addDummyData(shaclSail);
 
 		try (ShaclSailConnection connection = (ShaclSailConnection) shaclSail.getConnection()) {
 
@@ -142,6 +146,14 @@ public class ReduceNumberOfPlansTest {
 			shaclSail.shutDown();
 		}
 
+	}
+
+	private void addDummyData(ShaclSail shaclSail) {
+		try (ShaclSailConnection connection = (ShaclSailConnection) shaclSail.getConnection()) {
+			connection.begin();
+			connection.addStatement(RDF.TYPE, RDF.TYPE, RDF.PROPERTY);
+			connection.commit();
+		}
 	}
 
 	private void refreshAddedRemovedStatements(ShaclSailConnection connection) {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SerializableTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SerializableTest.java
@@ -33,7 +33,7 @@ public class SerializableTest {
 	@Test
 	public void testMaxCountSnapshot() throws IOException, InterruptedException {
 		for (int i = 0; i < 10; i++) {
-			SailRepository repo = Utils.getInitializedShaclRepository("shaclMax.ttl", false);
+			SailRepository repo = Utils.getInitializedShaclRepository("shaclMax.ttl");
 
 			Sail sail = repo.getSail();
 //			((ShaclSail) sail).setGlobalLogValidationExecution(true);
@@ -59,7 +59,7 @@ public class SerializableTest {
 	@Test
 	public void testMaxCountSerializable() throws IOException, InterruptedException {
 
-		SailRepository repo = Utils.getInitializedShaclRepository("shaclMax.ttl", false);
+		SailRepository repo = Utils.getInitializedShaclRepository("shaclMax.ttl");
 
 		multithreadedMaxCountViolation(IsolationLevels.SERIALIZABLE, repo);
 
@@ -80,7 +80,7 @@ public class SerializableTest {
 	@Test
 	public void testMaxCount2Serializable() throws IOException, InterruptedException {
 
-		SailRepository repo = Utils.getInitializedShaclRepository("shaclMax.ttl", false);
+		SailRepository repo = Utils.getInitializedShaclRepository("shaclMax.ttl");
 
 		multithreadedMaxCount2Violation(IsolationLevels.SERIALIZABLE, repo);
 
@@ -101,7 +101,7 @@ public class SerializableTest {
 	@Test
 	public void testMaxCount2Snapshot() throws IOException, InterruptedException {
 
-		SailRepository repo = Utils.getInitializedShaclRepository("shaclMax.ttl", false);
+		SailRepository repo = Utils.getInitializedShaclRepository("shaclMax.ttl");
 
 		multithreadedMaxCount2Violation(IsolationLevels.SNAPSHOT, repo);
 
@@ -123,7 +123,7 @@ public class SerializableTest {
 	public void serializableParallelValidation() throws Throwable {
 
 		SailRepository repo = Utils
-				.getInitializedShaclRepository("test-cases/complex/targetShapeAndQualifiedShape/shacl.ttl", false);
+				.getInitializedShaclRepository("test-cases/complex/targetShapeAndQualifiedShape/shacl.ttl");
 
 		ShaclSail sail = (ShaclSail) repo.getSail();
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TempTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TempTest.java
@@ -43,7 +43,7 @@ public class TempTest {
 	@Test
 	public void a() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl", false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -81,7 +81,7 @@ public class TempTest {
 
 	@Test
 	public void b() throws Exception {
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl", false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -109,7 +109,7 @@ public class TempTest {
 
 	@Test(expected = RepositoryException.class)
 	public void maxCount() throws Exception {
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclMax.ttl", false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclMax.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -143,7 +143,7 @@ public class TempTest {
 	@Test
 	public void minCount() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl", false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -169,7 +169,7 @@ public class TempTest {
 	@Test
 	public void leftOuterJoin() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl", false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -207,7 +207,7 @@ public class TempTest {
 	@Test(expected = RepositoryException.class)
 	public void testShapeWithoutTargetClassRemove() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -229,7 +229,7 @@ public class TempTest {
 	@Test(expected = RepositoryException.class)
 	public void testShapeWithoutTargetClassAdd() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -250,7 +250,7 @@ public class TempTest {
 	@Test
 	public void testShapeWithoutTargetClassValid() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl");
 
 		((ShaclSail) shaclRepository.getSail()).setUndefinedTargetValidatesAllSubjects(true);
 
@@ -282,7 +282,7 @@ public class TempTest {
 	@Test(expected = ShaclSailValidationException.class)
 	public void testUndefinedTargetClassValidatesAllSubjects() throws Throwable {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -339,7 +339,7 @@ public class TempTest {
 	@Test(expected = ShaclSailValidationException.class)
 	public void testUndefinedTargetClassValidatesAllSubjects2() throws Throwable {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -391,7 +391,7 @@ public class TempTest {
 	@Test
 	public void testUndefinedTargetClassValidatesAllSubjects3() throws Throwable {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl", false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacleNoTargetClass.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TrackAddedStatementsTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TrackAddedStatementsTest.java
@@ -35,9 +35,8 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testCleanup() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -56,9 +55,8 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testTransactions() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -81,9 +79,8 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testRollback() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -114,9 +111,7 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testTrandactionRollbackCleanup() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -146,9 +141,7 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testValidationFailedCausesRollback() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -176,9 +169,7 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testCleanupOnClose() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		SailRepositoryConnection connection = shaclRepository.getConnection();
 		connection.begin();
@@ -201,9 +192,8 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testAddRemoveAddRemove() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
@@ -233,9 +223,10 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testAdd() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
+
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.begin();
@@ -267,12 +258,17 @@ public class TrackAddedStatementsTest {
 		}
 	}
 
+	private void addDummyData(SailRepository shaclRepository) {
+		try (SailRepositoryConnection connection1 = shaclRepository.getConnection()) {
+			connection1.add(RDF.TYPE, RDF.TYPE, RDF.PROPERTY);
+		}
+	}
+
 	@Test
 	public void testAddRemove() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.begin();
@@ -304,9 +300,8 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testRemove() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
@@ -336,9 +331,8 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testRemoveWithoutAdding() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 
@@ -364,9 +358,8 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testSingleRemove() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
@@ -393,9 +386,8 @@ public class TrackAddedStatementsTest {
 	@Test
 	public void testSingleAdd() throws Exception {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl", false);
-		((ShaclSail) shaclRepository.getSail()).setIgnoreNoShapesLoadedException(true);
-		shaclRepository.init();
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("empty.ttl");
+		addDummyData(shaclRepository);
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.begin();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionSettingsTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionSettingsTest.java
@@ -46,6 +46,8 @@ public class TransactionSettingsTest {
 		shaclSail.setCacheSelectNodes(true);
 
 		SailRepository sailRepository = new SailRepository(shaclSail);
+		addDummyData(sailRepository);
+
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
 			connection.begin(Bulk);
@@ -72,6 +74,8 @@ public class TransactionSettingsTest {
 		shaclSail.setCacheSelectNodes(true);
 
 		SailRepository sailRepository = new SailRepository(shaclSail);
+		addDummyData(sailRepository);
+
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
 			connection.begin(Bulk, ParallelValidation);
@@ -97,9 +101,37 @@ public class TransactionSettingsTest {
 		shaclSail.setCacheSelectNodes(true);
 
 		SailRepository sailRepository = new SailRepository(shaclSail);
+		addDummyData(sailRepository);
+
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
 			connection.begin(Bulk, ParallelValidation, CacheEnabled);
+
+			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
+			ShaclSailConnection.Settings transactionSettings = sailConnection.getTransactionSettings();
+
+			assertSame(transactionSettings.getValidationApproach(), Bulk);
+			assertTrue(transactionSettings.isCacheSelectNodes());
+			assertTrue(transactionSettings.isParallelValidation());
+
+			connection.commit();
+
+		} finally {
+			sailRepository.shutDown();
+		}
+	}
+
+	@Test
+	public void testParallelCacheEmptyRepo() {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+		shaclSail.setParallelValidation(true);
+		shaclSail.setCacheSelectNodes(true);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin(ParallelValidation, CacheEnabled);
 
 			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
 			ShaclSailConnection.Settings transactionSettings = sailConnection.getTransactionSettings();
@@ -122,6 +154,8 @@ public class TransactionSettingsTest {
 		shaclSail.setCacheSelectNodes(true);
 
 		SailRepository sailRepository = new SailRepository(shaclSail);
+		addDummyData(sailRepository);
+
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
 			connection.begin();
@@ -145,6 +179,8 @@ public class TransactionSettingsTest {
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 
 		SailRepository sailRepository = new SailRepository(shaclSail);
+		addDummyData(sailRepository);
+
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
 			connection.begin();
@@ -170,6 +206,9 @@ public class TransactionSettingsTest {
 		shaclSail.setCacheSelectNodes(true);
 
 		SailRepository sailRepository = new SailRepository(shaclSail);
+
+		addDummyData(sailRepository);
+
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
 			connection.begin(CacheDisabled, SerialValidation);
@@ -190,12 +229,20 @@ public class TransactionSettingsTest {
 
 	}
 
+	private void addDummyData(SailRepository sailRepository) {
+		try (SailRepositoryConnection connection1 = sailRepository.getConnection()) {
+			connection1.add(RDF.TYPE, RDF.TYPE, RDF.PROPERTY);
+		}
+	}
+
 	@Test
 	public void testSerializableParallelValidation() {
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 		shaclSail.setParallelValidation(true);
 
 		SailRepository sailRepository = new SailRepository(shaclSail);
+		addDummyData(sailRepository);
+
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
 			connection.begin(IsolationLevels.SERIALIZABLE, ParallelValidation);
@@ -238,6 +285,7 @@ public class TransactionSettingsTest {
 	public void testValid() throws Exception {
 
 		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
+		addDummyData(repository);
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 
@@ -261,6 +309,7 @@ public class TransactionSettingsTest {
 	public void testInvalid() throws Throwable {
 
 		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
+		addDummyData(repository);
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 
@@ -286,6 +335,7 @@ public class TransactionSettingsTest {
 	public void testInvalidSnapshot() throws Throwable {
 
 		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
+		addDummyData(repository);
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 
@@ -312,6 +362,7 @@ public class TransactionSettingsTest {
 	public void testInvalidRollsBackCorrectly() {
 
 		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
+		addDummyData(repository);
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 
@@ -345,6 +396,7 @@ public class TransactionSettingsTest {
 	public void testValidationDisabled() throws Throwable {
 
 		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
+		addDummyData(repository);
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 
@@ -378,6 +430,7 @@ public class TransactionSettingsTest {
 	public void testValidationDisabledSnapshotSerializableValidation() throws Throwable {
 
 		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
+		addDummyData(repository);
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 
@@ -411,6 +464,7 @@ public class TransactionSettingsTest {
 	public void testDisabledValidationBulk() throws Throwable {
 
 		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
+		addDummyData(repository);
 
 		((ShaclSail) repository.getSail()).disableValidation();
 
@@ -435,7 +489,35 @@ public class TransactionSettingsTest {
 	public void testDisabledValidationAuto() throws Throwable {
 
 		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
+		addDummyData(repository);
 
+		((ShaclSail) repository.getSail()).disableValidation();
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+
+			connection.begin(Auto);
+
+			try (InputStream shapesData = Utils.class.getClassLoader().getResourceAsStream("shacl.ttl")) {
+				connection.add(shapesData, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+			}
+
+			connection.commit();
+
+			connection.begin(Auto);
+
+			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
+
+			connection.commit();
+
+		} finally {
+			repository.shutDown();
+		}
+	}
+
+	@Test
+	public void testDisabledValidationAutoEmptyRepo() throws Throwable {
+
+		SailRepository repository = new SailRepository(new ShaclSail(new MemoryStore()));
 		((ShaclSail) repository.getSail()).disableValidation();
 
 		try (RepositoryConnection connection = repository.getConnection()) {
@@ -465,6 +547,7 @@ public class TransactionSettingsTest {
 		ShaclSail sail = new ShaclSail(new MemoryStore());
 		ShaclSail spy = Mockito.spy(sail);
 		SailRepository repository = new SailRepository(spy);
+		addDummyData(repository);
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionValidationLimitTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionValidationLimitTest.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+/**
+ * @author Håvard Ottestad
+ */
+public class TransactionValidationLimitTest {
+
+	@AfterClass
+	public static void afterClass() {
+		GlobalValidationExecutionLogging.loggingEnabled = false;
+	}
+
+	@Test
+	public void testFailoverToBulkValidationSingleConnection() throws Exception {
+
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
+
+		((ShaclSail) shaclRepository.getSail()).setTransactionalValidationLimit(3);
+
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+			ShaclSailConnection shaclSailConnection = (ShaclSailConnection) connection.getSailConnection();
+
+			connection.begin();
+			connection.add(RDFS.CLASS, RDFS.LABEL, connection.getValueFactory().createLiteral("a"));
+			connection.commit();
+
+			connection.begin(ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled,
+					ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation);
+			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
+			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral("a"));
+			connection.add(RDFS.CLASS, RDF.TYPE, RDFS.RESOURCE);
+
+			assertEquals(ShaclSail.TransactionSettings.ValidationApproach.Auto,
+					shaclSailConnection.getTransactionSettings().getValidationApproach(),
+					"Auto is the default validation approach so should still be the case since we haven't hit the transaction size limit yet.");
+
+			connection.add(RDFS.CLASS, RDFS.LABEL, connection.getValueFactory().createLiteral("4th statement"));
+
+			assertEquals(ShaclSail.TransactionSettings.ValidationApproach.Bulk,
+					shaclSailConnection.getTransactionSettings().getValidationApproach(),
+					"We have added more than 3 statements so the validation approach should have switched to Bulk.");
+			assertTrue(shaclSailConnection.getTransactionSettings().isCacheSelectNodes(),
+					"Bulk validation should by default disable caching select nodes, but the local transaction settings should override this.");
+			assertTrue(shaclSailConnection.getTransactionSettings().isParallelValidation(),
+					"Bulk validation should by default disable parallel validation, but the local transaction settings should override this.");
+
+			connection.add(RDFS.CLASS, RDFS.LABEL, connection.getValueFactory().createLiteral("5th statement"));
+			connection.commit();
+
+		} finally {
+			shaclRepository.shutDown();
+		}
+
+	}
+
+	@Test
+	public void testFailoverToBulkValidationNewConnection() throws Exception {
+
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
+
+		((ShaclSail) shaclRepository.getSail()).setTransactionalValidationLimit(3);
+
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+
+			connection.begin();
+			connection.add(RDFS.CLASS, RDFS.LABEL, connection.getValueFactory().createLiteral("a"));
+			connection.commit();
+		}
+
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+			ShaclSailConnection shaclSailConnection = (ShaclSailConnection) connection.getSailConnection();
+
+			connection.begin();
+			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
+			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral("a"));
+			connection.add(RDFS.CLASS, RDF.TYPE, RDFS.RESOURCE);
+
+			assertEquals(ShaclSail.TransactionSettings.ValidationApproach.Auto,
+					shaclSailConnection.getTransactionSettings().getValidationApproach(),
+					"Auto is the default validation approach so should still be the case since we haven't hit the transaction size limit yet.");
+
+			connection.add(RDFS.CLASS, RDFS.LABEL, connection.getValueFactory().createLiteral("4th statement"));
+
+			assertEquals(ShaclSail.TransactionSettings.ValidationApproach.Bulk,
+					shaclSailConnection.getTransactionSettings().getValidationApproach(),
+					"We have added more than 3 statements so the validation approach should have switched to Bulk.");
+			assertFalse(shaclSailConnection.getTransactionSettings().isCacheSelectNodes(),
+					"Bulk validation should by default disable caching select nodes.");
+			assertFalse(shaclSailConnection.getTransactionSettings().isParallelValidation(),
+					"Bulk validation should by default disable parallel validation.");
+
+			connection.add(RDFS.CLASS, RDFS.LABEL, connection.getValueFactory().createLiteral("5th statement"));
+			connection.commit();
+
+		} finally {
+			shaclRepository.shutDown();
+		}
+
+	}
+
+	@Test
+	public void testFailoverToBulkValidationTriggersValidation() throws Exception {
+
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
+
+		((ShaclSail) shaclRepository.getSail()).setTransactionalValidationLimit(3);
+
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+			ShaclSailConnection shaclSailConnection = (ShaclSailConnection) connection.getSailConnection();
+
+			connection.begin();
+			connection.add(RDFS.CLASS, RDFS.COMMENT, connection.getValueFactory().createLiteral("a"));
+			connection.commit();
+
+			connection.begin(ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled,
+					ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation);
+			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
+			connection.add(RDFS.RESOURCE, RDFS.LABEL, connection.getValueFactory().createLiteral("a"));
+			connection.add(RDFS.CLASS, RDF.TYPE, RDFS.RESOURCE);
+			connection.add(RDFS.CLASS, RDFS.COMMENT, connection.getValueFactory().createLiteral("4th statement"));
+			connection.add(RDFS.CLASS, RDFS.COMMENT, connection.getValueFactory().createLiteral("5th statement"));
+
+			assertThrows(ShaclSailValidationException.class, () -> {
+				try {
+					connection.commit();
+				} catch (RepositoryException repositoryException) {
+					throw repositoryException.getCause();
+				}
+			});
+
+		} finally {
+			shaclRepository.shutDown();
+		}
+
+	}
+
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionValidationLimitTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionValidationLimitTest.java
@@ -155,4 +155,30 @@ public class TransactionValidationLimitTest {
 
 	}
 
+	@Test
+	public void testBulkValidationForEmptySail() throws Exception {
+
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shacl.ttl");
+
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+			ShaclSailConnection shaclSailConnection = (ShaclSailConnection) connection.getSailConnection();
+
+			connection.begin(ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled);
+
+			assertEquals(ShaclSail.TransactionSettings.ValidationApproach.Bulk,
+					shaclSailConnection.getTransactionSettings().getValidationApproach(),
+					"Empty sail should use bulk validation");
+			assertTrue(shaclSailConnection.getTransactionSettings().isCacheSelectNodes(),
+					"Bulk validation should by default disable caching select nodes, but the local transaction settings should override this.");
+			assertFalse(shaclSailConnection.getTransactionSettings().isParallelValidation(),
+					"Bulk validation should by default disable parallel validation.");
+
+			connection.commit();
+
+		} finally {
+			shaclRepository.shutDown();
+		}
+
+	}
+
 }

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionalIsolationTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionalIsolationTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
@@ -26,6 +27,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
 import org.junit.jupiter.api.Disabled;
@@ -275,7 +277,6 @@ public class TransactionalIsolationTest {
 		shaclSail.setSerializableValidation(true);
 
 		SailRepository sailRepository = new SailRepository(shaclSail);
-		sailRepository.init();
 
 		SailRepositoryConnection connection1 = sailRepository.getConnection();
 		SailRepositoryConnection connection2 = sailRepository.getConnection();
@@ -412,6 +413,66 @@ public class TransactionalIsolationTest {
 				"        ] ."));
 
 		connection2.add(shaclRules, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+
+		connection1.commit();
+
+		try {
+			connection2.commit();
+		} catch (Throwable ignored) {
+		}
+
+		connection2.close();
+		connection1.close();
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+			connection.begin();
+			ValidationReport validationReport = ((ShaclSailConnection) connection.getSailConnection()).revalidate();
+
+			assertTrue(validationReport.conforms());
+
+			connection.commit();
+		}
+
+		sailRepository.shutDown();
+
+	}
+
+	@Test
+	public void testIsolation5() throws Throwable {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+
+		shaclSail.setSerializableValidation(true);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+			StringReader shaclRules = new StringReader(String.join("\n", "",
+					"@prefix ex: <http://example.com/ns#> .",
+					"@prefix sh: <http://www.w3.org/ns/shacl#> .",
+					"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
+					"@prefix foaf: <http://xmlns.com/foaf/0.1/>.",
+
+					"ex:PersonShape",
+					"        a sh:NodeShape  ;",
+					"        sh:targetClass ex:Person ;",
+					"        sh:property [",
+					"                sh:path ex:age ;",
+					"                sh:minCount 1 ;",
+					"        ] ."));
+
+			connection.add(shaclRules, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+			add(connection, "ex:steve ex:age 1 .");
+		}
+
+		SailRepositoryConnection connection1 = sailRepository.getConnection();
+		SailRepositoryConnection connection2 = sailRepository.getConnection();
+
+		connection1.begin(IsolationLevels.SNAPSHOT);
+		addInTransaction(connection1, "ex:steve a ex:Person .");
+
+		connection2.begin(IsolationLevels.SNAPSHOT);
+
+		removeInTransaction(connection2, "ex:steve ex:age 1 .");
 
 		connection1.commit();
 
@@ -868,6 +929,60 @@ public class TransactionalIsolationTest {
 		}
 	}
 
+	@Test
+	public void testSerializableValidationAndTransactionalValidationLimit() throws Throwable {
+		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
+
+		shaclSail.setSerializableValidation(true);
+		shaclSail.setTransactionalValidationLimit(0);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+
+		SailRepositoryConnection connection1 = sailRepository.getConnection();
+		SailRepositoryConnection connection2 = sailRepository.getConnection();
+
+		connection2.begin(IsolationLevels.SNAPSHOT);
+
+		StringReader shaclRules = new StringReader(String.join("\n", "",
+				"@prefix ex: <http://example.com/ns#> .",
+				"@prefix sh: <http://www.w3.org/ns/shacl#> .",
+				"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
+				"@prefix foaf: <http://xmlns.com/foaf/0.1/>.",
+
+				"ex:PersonShape",
+				"        a sh:NodeShape  ;",
+				"        sh:targetClass ex:Person ;",
+				"        sh:property [",
+				"                sh:path ex:age ;",
+				"                sh:minCount 1 ;",
+				"        ] ."));
+
+		connection2.add(shaclRules, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+		addInTransaction(connection2, "ex:steve ex:age 1 .");
+
+		connection1.begin(IsolationLevels.SNAPSHOT);
+
+		addInTransaction(connection1, "ex:steve a ex:Person .");
+
+		connection2.commit();
+		connection1.commit();
+
+		connection2.close();
+		connection1.close();
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+			connection.begin();
+			ValidationReport validationReport = ((ShaclSailConnection) connection.getSailConnection()).revalidate();
+
+			assertTrue(validationReport.conforms());
+
+			connection.commit();
+		}
+
+		sailRepository.shutDown();
+
+	}
+
 	private void add(SailRepositoryConnection connection, String data) throws IOException {
 		data = String.join("\n", "",
 				"@prefix ex: <http://example.com/ns#> .",
@@ -894,6 +1009,23 @@ public class TransactionalIsolationTest {
 
 		try {
 			connection.add(stringReader, "", RDFFormat.TURTLE);
+		} catch (IOException e) {
+			throw new IllegalStateException();
+		}
+	}
+
+	private void removeInTransaction(SailRepositoryConnection connection, String data) {
+		data = String.join("\n", "",
+				"@prefix ex: <http://example.com/ns#> .",
+				"@prefix foaf: <http://xmlns.com/foaf/0.1/>.",
+				"@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
+				data);
+
+		StringReader stringReader = new StringReader(data);
+
+		try {
+			Model parse = Rio.parse(stringReader, RDFFormat.TURTLE);
+			connection.remove(parse);
 		} catch (IOException e) {
 			throw new IllegalStateException();
 		}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TruncatedValidationReportTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TruncatedValidationReportTest.java
@@ -44,7 +44,7 @@ public class TruncatedValidationReportTest {
 
 	@Test
 	public void testTotal() throws IOException {
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitTotal(10);
@@ -65,7 +65,7 @@ public class TruncatedValidationReportTest {
 	@Test
 	public void testPerConstraint() throws IOException {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitPerConstraint(10);
@@ -88,7 +88,7 @@ public class TruncatedValidationReportTest {
 	@Test
 	public void testPerConstraint2() throws IOException {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitPerConstraint(10);
@@ -113,7 +113,7 @@ public class TruncatedValidationReportTest {
 	@Test
 	public void testZeroTotal() throws IOException {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitTotal(0);
@@ -135,7 +135,7 @@ public class TruncatedValidationReportTest {
 	@Test
 	public void testZeroPerConstraint() throws IOException {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitPerConstraint(0);
@@ -157,7 +157,7 @@ public class TruncatedValidationReportTest {
 	@Test
 	public void testTotalAndPerConstraint() throws IOException {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitTotal(20);
@@ -181,7 +181,7 @@ public class TruncatedValidationReportTest {
 	@Test
 	public void testTotalAndPerConstraint2() throws IOException {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitTotal(20);
@@ -204,7 +204,7 @@ public class TruncatedValidationReportTest {
 	@Test
 	public void testNoLimit() throws IOException {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ValidationReport validationReport = getValidationReport(shaclRepository);
 		shaclRepository.shutDown();
@@ -226,7 +226,7 @@ public class TruncatedValidationReportTest {
 	@Test
 	public void testLimitIsEqualToSize() throws IOException {
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitTotal(NUMBER_OF_FAILURES * 2);
@@ -251,7 +251,7 @@ public class TruncatedValidationReportTest {
 
 	@Test
 	public void testRevalidate() throws IOException {
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl", true);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclRepository.getSail();
 		sail.setValidationResultsLimitPerConstraint(15);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TruncatedValidationReportTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TruncatedValidationReportTest.java
@@ -206,6 +206,9 @@ public class TruncatedValidationReportTest {
 
 		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
 
+		((ShaclSail) shaclRepository.getSail()).setValidationResultsLimitPerConstraint(-1);
+		((ShaclSail) shaclRepository.getSail()).setValidationResultsLimitTotal(-1);
+
 		ValidationReport validationReport = getValidationReport(shaclRepository);
 		shaclRepository.shutDown();
 
@@ -220,6 +223,28 @@ public class TruncatedValidationReportTest {
 		assertEquals(NUMBER_OF_FAILURES,
 				collect.get(SourceConstraintComponent.DatatypeConstraintComponent).longValue());
 		assertEquals(NUMBER_OF_FAILURES * 2, total);
+
+	}
+
+	@Test
+	public void testDefaultLimit() throws IOException {
+
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("shaclDatatypeAndMinCount.ttl");
+
+		ValidationReport validationReport = getValidationReport(shaclRepository);
+		shaclRepository.shutDown();
+
+		Map<SourceConstraintComponent, Long> collect = validationReport.getValidationResult()
+				.stream()
+				.collect(Collectors.groupingBy(ValidationResult::getSourceConstraintComponent, Collectors.counting()));
+		long total = collect.values().stream().mapToLong(l -> l).sum();
+
+		assertTrue(validationReport.isTruncated());
+		assertEquals(1000,
+				collect.get(SourceConstraintComponent.MinCountConstraintComponent).longValue());
+		assertEquals(1000,
+				collect.get(SourceConstraintComponent.DatatypeConstraintComponent).longValue());
+		assertEquals(2000, total);
 
 	}
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UnknownShapesTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UnknownShapesTest.java
@@ -38,7 +38,7 @@ public class UnknownShapesTest {
 		MyAppender newAppender = new MyAppender();
 		root.addAppender(newAppender);
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("unknownProperties.ttl", false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("unknownProperties.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.begin();
@@ -71,7 +71,7 @@ public class UnknownShapesTest {
 		MyAppender newAppender = new MyAppender();
 		root.addAppender(newAppender);
 
-		SailRepository shaclRepository = Utils.getInitializedShaclRepository("complexPath.ttl", false);
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("complexPath.ttl");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			connection.begin();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/Utils.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/Utils.java
@@ -85,6 +85,12 @@ public class Utils {
 		return repo;
 	}
 
+	public static SailRepository getInitializedShaclRepository(String shapeData) throws IOException {
+		SailRepository repo = new SailRepository(new ShaclSail(new MemoryStore()));
+		Utils.loadShapeData(repo, shapeData);
+		return repo;
+	}
+
 	public static ShaclSail getInitializedShaclSail(String shapeData) throws IOException {
 		ShaclSail sail = new ShaclSail(new MemoryStore());
 		Utils.loadShapeData(sail, shapeData);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/Utils.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/Utils.java
@@ -76,15 +76,6 @@ public class Utils {
 		}
 	}
 
-	public static SailRepository getInitializedShaclRepository(String shapeData,
-			boolean undefinedTargetClassValidatesAllSubjects) throws IOException {
-		ShaclSail sail = new ShaclSail(new MemoryStore());
-		sail.setUndefinedTargetValidatesAllSubjects(undefinedTargetClassValidatesAllSubjects);
-		SailRepository repo = new SailRepository(sail);
-		Utils.loadShapeData(repo, shapeData);
-		return repo;
-	}
-
 	public static SailRepository getInitializedShaclRepository(String shapeData) throws IOException {
 		SailRepository repo = new SailRepository(new ShaclSail(new MemoryStore()));
 		Utils.loadShapeData(repo, shapeData);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
@@ -36,7 +36,7 @@ public class ValidationReportTest {
 
 	@Test
 	public void simpleFirstTest() throws IOException {
-		SailRepository shaclSail = Utils.getInitializedShaclRepository("shacl.ttl", false);
+		SailRepository shaclSail = Utils.getInitializedShaclRepository("shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclSail.getConnection()) {
 
@@ -97,7 +97,7 @@ public class ValidationReportTest {
 
 	@Test
 	public void withoutPathTest() throws IOException {
-		SailRepository shaclSail = Utils.getInitializedShaclRepository("shaclValidateTarget.ttl", false);
+		SailRepository shaclSail = Utils.getInitializedShaclRepository("shaclValidateTarget.ttl");
 
 		try (SailRepositoryConnection connection = shaclSail.getConnection()) {
 
@@ -151,7 +151,7 @@ public class ValidationReportTest {
 	@Test
 	public void nestedLogicalOrSupport() throws IOException {
 
-		SailRepository shaclSail = Utils.getInitializedShaclRepository("test-cases/or/datatype/shacl.ttl", false);
+		SailRepository shaclSail = Utils.getInitializedShaclRepository("test-cases/or/datatype/shacl.ttl");
 
 		try (SailRepositoryConnection connection = shaclSail.getConnection()) {
 
@@ -214,7 +214,7 @@ public class ValidationReportTest {
 	@Test
 	public void testHasValueIn() throws IOException {
 
-		SailRepository shaclSail = Utils.getInitializedShaclRepository("test-cases/hasValueIn/simple/shacl.ttl", false);
+		SailRepository shaclSail = Utils.getInitializedShaclRepository("test-cases/hasValueIn/simple/shacl.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclSail.getSail();
 		sail.setDashDataShapes(true);
@@ -273,7 +273,7 @@ public class ValidationReportTest {
 	@Test
 	public void testHasValue() throws IOException {
 
-		SailRepository shaclSail = Utils.getInitializedShaclRepository("test-cases/hasValue/simple/shacl.ttl", false);
+		SailRepository shaclSail = Utils.getInitializedShaclRepository("test-cases/hasValue/simple/shacl.ttl");
 
 		ShaclSail sail = (ShaclSail) shaclSail.getSail();
 		sail.setDashDataShapes(true);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ClassBenchmarkEmpty.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ClassBenchmarkEmpty.java
@@ -84,11 +84,6 @@ public class ClassBenchmarkEmpty {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclClassBenchmark.ttl"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -103,11 +98,6 @@ public class ClassBenchmarkEmpty {
 	public void shaclBulk() throws Exception {
 
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclClassBenchmark.ttl"));
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
@@ -128,10 +118,6 @@ public class ClassBenchmarkEmpty {
 		repository.init();
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -149,10 +135,6 @@ public class ClassBenchmarkEmpty {
 
 		repository.init();
 
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexLargeBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexLargeBenchmark.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.IOUtils;
 import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -232,6 +233,7 @@ public class ComplexLargeBenchmark {
 			((ShaclSail) repository.getSail()).setParallelValidation(false);
 			((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
 //			((ShaclSail) repository.getSail()).setPerformanceLogging(true);
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE);
@@ -258,6 +260,7 @@ public class ComplexLargeBenchmark {
 			((ShaclSail) repository.getSail()).setParallelValidation(true);
 			((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
 //			((ShaclSail) repository.getSail()).setPerformanceLogging(true);
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE);
@@ -284,6 +287,7 @@ public class ComplexLargeBenchmark {
 			((ShaclSail) repository.getSail()).setParallelValidation(true);
 			((ShaclSail) repository.getSail()).setCacheSelectNodes(false);
 //			((ShaclSail) repository.getSail()).setPerformanceLogging(true);
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE);
@@ -306,7 +310,10 @@ public class ComplexLargeBenchmark {
 
 		try {
 			SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+
 			((ShaclSail) repository.getSail()).disableValidation();
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
+
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE);
 				SimpleValueFactory vf = SimpleValueFactory.getInstance();
@@ -340,7 +347,10 @@ public class ComplexLargeBenchmark {
 
 		try {
 			SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+
 			((ShaclSail) repository.getSail()).disableValidation();
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
+
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE);
 				SimpleValueFactory vf = SimpleValueFactory.getInstance();
@@ -377,6 +387,7 @@ public class ComplexLargeBenchmark {
 
 			((ShaclSail) repository.getSail()).setParallelValidation(true);
 			((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			((ShaclSail) repository.getSail()).disableValidation();
 
@@ -412,6 +423,7 @@ public class ComplexLargeBenchmark {
 
 			((ShaclSail) repository.getSail()).setParallelValidation(false);
 			((ShaclSail) repository.getSail()).setCacheSelectNodes(false);
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			((ShaclSail) repository.getSail()).disableValidation();
 
@@ -447,6 +459,7 @@ public class ComplexLargeBenchmark {
 
 			((ShaclSail) repository.getSail()).setParallelValidation(true);
 			((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Bulk);
@@ -472,11 +485,43 @@ public class ComplexLargeBenchmark {
 
 			((ShaclSail) repository.getSail()).setParallelValidation(false);
 			((ShaclSail) repository.getSail()).setCacheSelectNodes(false);
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE,
 						ShaclSail.TransactionSettings.ValidationApproach.Bulk,
 						ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation,
+						ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled);
+				try (InputStream resourceAsStream = getData()) {
+					connection.add(resourceAsStream, "", RDFFormat.TURTLE);
+				}
+				connection.commit();
+			}
+
+			repository.shutDown();
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
+
+	@Benchmark
+	public void noPreloadingTransactionalValidationLimit() {
+
+		try {
+			SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(600000);
+
+			try (SailRepositoryConnection connection = repository.getConnection()) {
+				connection.begin(IsolationLevels.NONE);
+				connection.add(RDF.TYPE, RDF.TYPE, RDF.PROPERTY);
+				connection.commit();
+			}
+
+			try (SailRepositoryConnection connection = repository.getConnection()) {
+				connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation,
 						ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled);
 				try (InputStream resourceAsStream = getData()) {
 					connection.add(resourceAsStream, "", RDFFormat.TURTLE);
@@ -504,6 +549,7 @@ public class ComplexLargeBenchmark {
 
 			((ShaclSail) repository.getSail()).setParallelValidation(true);
 			((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			((ShaclSail) repository.getSail()).disableValidation();
 
@@ -539,6 +585,7 @@ public class ComplexLargeBenchmark {
 
 		((ShaclSail) repository.getSail()).setParallelValidation(true);
 		((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
+		((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 
@@ -555,6 +602,7 @@ public class ComplexLargeBenchmark {
 
 		((ShaclSail) repository.getSail()).setParallelValidation(true);
 		((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
+		((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 
@@ -571,6 +619,7 @@ public class ComplexLargeBenchmark {
 
 		((ShaclSail) repository.getSail()).setParallelValidation(false);
 		((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
+		((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 
@@ -587,6 +636,7 @@ public class ComplexLargeBenchmark {
 
 		((ShaclSail) repository.getSail()).setParallelValidation(false);
 		((ShaclSail) repository.getSail()).setCacheSelectNodes(true);
+		((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 
@@ -604,6 +654,7 @@ public class ComplexLargeBenchmark {
 		try {
 			SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
 			((ShaclSail) repository.getSail()).disableValidation();
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE);
@@ -628,6 +679,7 @@ public class ComplexLargeBenchmark {
 
 		try {
 			SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+			((ShaclSail) repository.getSail()).setTransactionalValidationLimit(1000000);
 
 			try (SailRepositoryConnection connection = repository.getConnection()) {
 				connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Disabled);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/MaxCountBenchmarkEmpty.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/MaxCountBenchmarkEmpty.java
@@ -81,11 +81,6 @@ public class MaxCountBenchmarkEmpty {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclMaxCountBenchmark.ttl"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -100,11 +95,6 @@ public class MaxCountBenchmarkEmpty {
 	public void shaclBulk() throws Exception {
 
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclMaxCountBenchmark.ttl"));
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
@@ -125,10 +115,6 @@ public class MaxCountBenchmarkEmpty {
 		repository.init();
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -146,10 +132,6 @@ public class MaxCountBenchmarkEmpty {
 
 		repository.init();
 
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
@@ -172,10 +154,6 @@ public class MaxCountBenchmarkEmpty {
 
 		repository.init();
 
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/MinCountBenchmarkEmpty.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/MinCountBenchmarkEmpty.java
@@ -82,11 +82,6 @@ public class MinCountBenchmarkEmpty {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shacl.ttl"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -103,11 +98,6 @@ public class MinCountBenchmarkEmpty {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shacl.ttl"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
 			for (List<Statement> statements : allStatements) {
 				connection.add(statements);
@@ -122,11 +112,6 @@ public class MinCountBenchmarkEmpty {
 	public void shaclClear() throws Exception {
 
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shacl.ttl"));
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
@@ -150,10 +135,6 @@ public class MinCountBenchmarkEmpty {
 		repository.init();
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -171,10 +152,6 @@ public class MinCountBenchmarkEmpty {
 
 		repository.init();
 
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
@@ -197,11 +174,6 @@ public class MinCountBenchmarkEmpty {
 	public void shaclMinCountZero() throws Exception {
 
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclMinCountZero.ttl"));
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/MinCountPrefilledVsEmptyBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/MinCountPrefilledVsEmptyBenchmark.java
@@ -126,11 +126,6 @@ public class MinCountPrefilledVsEmptyBenchmark {
 		SailRepository repository = new SailRepository(shaclRepo);
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
@@ -172,9 +172,9 @@ public class NativeStoreBenchmark {
 
 		File file = Files.newTemporaryFolder();
 
-		NotifyingSail shaclSail = new NativeStore(file, "spoc,ospc,psoc");
+		NotifyingSail nativeStore = new NativeStore(file, "spoc,ospc,psoc");
 
-		SailRepository sailRepository = new SailRepository(shaclSail);
+		SailRepository sailRepository = new SailRepository(nativeStore);
 		sailRepository.init();
 
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NotClassBenchmarkEmpty.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NotClassBenchmarkEmpty.java
@@ -103,11 +103,6 @@ public class NotClassBenchmarkEmpty {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclNotClassBenchmark.ttl"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -125,11 +120,6 @@ public class NotClassBenchmarkEmpty {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclNotClassBenchmark.ttl"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
 			for (List<Statement> statements : allStatements) {
 				connection.add(statements);
@@ -144,11 +134,6 @@ public class NotClassBenchmarkEmpty {
 	public void shaclWithoutAnimals() throws Exception {
 
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclNotClassBenchmark.ttl"));
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatementsWithoutAnimals) {
@@ -169,10 +154,6 @@ public class NotClassBenchmarkEmpty {
 		repository.init();
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -190,10 +171,6 @@ public class NotClassBenchmarkEmpty {
 
 		repository.init();
 
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
@@ -219,10 +196,6 @@ public class NotClassBenchmarkEmpty {
 
 		repository.init();
 
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatementsWithoutAnimals) {
 				connection.begin();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NotMaxCountBenchmarkEmpty.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NotMaxCountBenchmarkEmpty.java
@@ -79,11 +79,6 @@ public class NotMaxCountBenchmarkEmpty {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclNotMaxCountBenchmark.ttl"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();
 				connection.add(statements);
@@ -98,11 +93,6 @@ public class NotMaxCountBenchmarkEmpty {
 	public void shaclBulk() throws Exception {
 
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("shaclNotMaxCountBenchmark.ttl"));
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
@@ -122,10 +112,6 @@ public class NotMaxCountBenchmarkEmpty {
 
 		repository.init();
 
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin();
-			connection.commit();
-		}
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			for (List<Statement> statements : allStatements) {
 				connection.begin();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ParallelBenchmark.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ParallelBenchmark.java
@@ -96,7 +96,7 @@ public class ParallelBenchmark {
 
 	@Benchmark
 	public void shaclSnapshotWithoutSerializableValidation(Blackhole blackhole) throws Exception {
-		SailRepository repository = Utils.getInitializedShaclRepository("shaclDatatype.ttl", false);
+		SailRepository repository = Utils.getInitializedShaclRepository("shaclDatatype.ttl");
 		((ShaclSail) repository.getSail()).setSerializableValidation(false);
 
 		runBenchmark(IsolationLevels.SNAPSHOT, repository, true, false, blackhole);
@@ -104,7 +104,7 @@ public class ParallelBenchmark {
 
 	@Benchmark
 	public void shaclSnapshotWithoutSerializableValidationMixedReadWrite(Blackhole blackhole) throws Exception {
-		SailRepository repository = Utils.getInitializedShaclRepository("shaclDatatype.ttl", false);
+		SailRepository repository = Utils.getInitializedShaclRepository("shaclDatatype.ttl");
 		((ShaclSail) repository.getSail()).setSerializableValidation(false);
 
 		runBenchmark(IsolationLevels.SNAPSHOT, repository, true, true, blackhole);

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PARALLEL_VALID
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PERFORMANCE_LOGGING;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.RDFS_SUB_CLASS_REASONING;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.SERIALIZABLE_VALIDATION;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.UNDEFINED_TARGET_VALIDATES_ALL_SUBJECTS;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_ENABLED;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT;
@@ -61,6 +62,7 @@ public class ShaclSailConfigTest {
 		assertThat(shaclSailConfig.isDashDataShapes()).isFalse();
 		assertThat(shaclSailConfig.getValidationResultsLimitTotal()).isEqualTo(1000000);
 		assertThat(shaclSailConfig.getValidationResultsLimitPerConstraint()).isEqualTo(1000);
+		assertThat(shaclSailConfig.getTransactionalValidationLimit()).isEqualTo(500000);
 
 	}
 
@@ -87,6 +89,7 @@ public class ShaclSailConfigTest {
 
 		mb.add(VALIDATION_RESULTS_LIMIT_TOTAL, 100);
 		mb.add(VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT, 3);
+		mb.add(TRANSACTIONAL_VALIDATION_LIMIT, 9);
 
 		shaclSailConfig.parse(mb.build(), implNode);
 
@@ -105,6 +108,7 @@ public class ShaclSailConfigTest {
 		assertThat(shaclSailConfig.isDashDataShapes()).isTrue();
 		assertThat(shaclSailConfig.getValidationResultsLimitTotal()).isEqualTo(100);
 		assertThat(shaclSailConfig.getValidationResultsLimitPerConstraint()).isEqualTo(3);
+		assertThat(shaclSailConfig.getTransactionalValidationLimit()).isEqualTo(9);
 
 	}
 
@@ -155,6 +159,7 @@ public class ShaclSailConfigTest {
 		assertTrue(m.contains(node, DASH_DATA_SHAPES, null));
 		assertTrue(m.contains(node, VALIDATION_RESULTS_LIMIT_TOTAL, null));
 		assertTrue(m.contains(node, VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT, null));
+		assertTrue(m.contains(node, TRANSACTIONAL_VALIDATION_LIMIT, null));
 
 	}
 

--- a/site/content/documentation/programming/shacl.md
+++ b/site/content/documentation/programming/shacl.md
@@ -281,8 +281,6 @@ validated, and for each of those shapes only the least amount of data is retriev
 
 Parallel validation further increases performance and is enabled by default. This can be disabled with `setParallelValidation(false)`.
 
-The initial commit to an empty ShaclSail is further optimized if the underlying sail is a MemoryStore.
-
 Some workloads will not fit in memory and need to be validated while stored on disk. This can be achieved by using a
 NativeStore and using the new transaction settings introduced in 3.3.0.
 
@@ -340,6 +338,18 @@ try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
 sailRepository.shutDown();
 ```
+
+### Automatic bulk validation
+Large transactions will take up significant amounts of memory because the transactional validation needs to analyze the transactional 
+changes in order to decide what needs to be validated. Very large transactions could exceed the amount of memory available and cause the 
+JVM to crash.
+
+As of 4.0.0 transactions can automatically be switched to bulk validation if they exceed a set limit. 
+
+- `setTransactionalValidationLimit(1000)` will make transactions switch to bulk validation if the transaction size is more than 1000 statements. Default is 500 000.
+   - `<http://rdf4j.org/config/sail/shacl#transactionalValidationLimit>`
+
+Automatic bulk validation is not compatible with serializable validation.
 
 ## Reasoning
 By default the ShaclSail supports the simple rdfs:subClassOf reasoning required by the W3C recommendation. There is no


### PR DESCRIPTION
GitHub issue resolved: #3029  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

 - NotifyingSailConnectionBase allows listeners to be removed while the transaction is ongoing
 - ShaclSailConnection removes itself as a listener once a certain number of statements has been reached
 - Limit is configurable by users on a sail basis
     - Name: TransactionalValidationLimit

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

