### PR TITLE
GH-3131: fix FedX resource leaks in error / cancel cases

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -68,6 +68,8 @@ public class FedXConfig {
 
 	private String prefixDeclarations = null;
 
+	private int consumingIterationMax = 1000;
+
 	/* factory like setters */
 
 	/**
@@ -506,5 +508,28 @@ public class FedXConfig {
 	 */
 	public Optional<TaskWrapper> getTaskWrapper() {
 		return Optional.ofNullable(taskWrapper);
+	}
+
+	/**
+	 * Set the max number of results to be consumed by {@link ConsumingIteration}. See
+	 * {@link #getConsumingIterationMax()}.
+	 *
+	 * <p>
+	 * Can only be set before federation initialization.
+	 * </p>
+	 *
+	 * @param max
+	 * @return the current config
+	 */
+	public FedXConfig withConsumingIterationMax(int max) {
+		this.consumingIterationMax = max;
+		return this;
+	}
+
+	/**
+	 * Returns the max number of results to be consumed by {@link ConsumingIteration}
+	 */
+	public int getConsumingIterationMax() {
+		return consumingIterationMax;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/StatementSourcePattern.java
@@ -55,11 +55,12 @@ public class StatementSourcePattern extends FedXStatementPattern {
 	public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(BindingSet bindings)
 			throws QueryEvaluationException {
 
+		WorkerUnionBase<BindingSet> union = null;
 		try {
 
 			AtomicBoolean isEvaluated = new AtomicBoolean(false); // is filter evaluated in prepared query
 			String preparedQuery = null; // used for some triple sources
-			WorkerUnionBase<BindingSet> union = federationContext.getManager().createWorkerUnion(queryInfo);
+			union = federationContext.getManager().createWorkerUnion(queryInfo);
 
 			for (StatementSource source : statementSources) {
 
@@ -113,7 +114,11 @@ public class StatementSourcePattern extends FedXStatementPattern {
 			}
 
 		} catch (RepositoryException | MalformedQueryException e) {
+			union.close();
 			throw new QueryEvaluationException(e);
+		} catch (Throwable t) {
+			union.close();
+			throw t;
 		}
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -449,10 +449,18 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 
 		ControlledWorkerScheduler<BindingSet> joinScheduler = federationContext.getManager().getJoinScheduler();
 
-		for (int i = 1, n = join.getNumberOfArguments(); i < n; i++) {
+		boolean completed = false;
+		try {
+			for (int i = 1, n = join.getNumberOfArguments(); i < n; i++) {
 
-			result = executeJoin(joinScheduler, result, join.getArg(i), join.getJoinVariables(i), bindings,
-					join.getQueryInfo());
+				result = executeJoin(joinScheduler, result, join.getArg(i), join.getJoinVariables(i), bindings,
+						join.getQueryInfo());
+			}
+			completed = true;
+		} finally {
+			if (!completed) {
+				result.close();
+			}
 		}
 		return result;
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
@@ -87,6 +87,7 @@ public class SparqlFederationEvalStrategy extends FederationEvalStrategy {
 				result = new BoundJoinVALUESConversionIteration(result, bindings); // apply conversion
 				result = new FilteringIteration(filterExpr, result, this); // apply filter
 				if (!result.hasNext()) {
+					result.close();
 					return new EmptyIteration<>();
 				}
 			} else {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
@@ -156,7 +156,7 @@ public abstract class TripleSourceBase implements TripleSource {
 				res = new InsertBindingsIteration(res, bindings);
 			}
 
-			resultHolder.set(new ConsumingIteration(res));
+			resultHolder.set(new ConsumingIteration(res, federationContext.getConfig().getConsumingIterationMax()));
 
 		});
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelServiceExecutor.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelServiceExecutor.java
@@ -155,8 +155,7 @@ public class ParallelServiceExecutor extends LookAheadIteration<BindingSet, Quer
 	private class ParallelServiceTask extends ParallelTaskBase<BindingSet> {
 
 		@Override
-		public CloseableIteration<BindingSet, QueryEvaluationException> performTask()
-				throws Exception {
+		protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 
 			// Note: in order two avoid deadlocks we consume the SERVICE result.
 			// This is basically required to avoid processing background tuple

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/CloseDependentConnectionIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/CloseDependentConnectionIteration.java
@@ -38,20 +38,30 @@ public class CloseDependentConnectionIteration<T>
 
 	@Override
 	public boolean hasNext() throws QueryEvaluationException {
-		boolean res = inner.hasNext();
-		if (!res) {
-			try {
-				dependentConn.close();
-			} catch (Throwable ignore) {
-				log.trace("Failed to close dependent connection:", ignore);
+		try {
+			boolean res = inner.hasNext();
+			if (!res) {
+				try {
+					dependentConn.close();
+				} catch (Throwable ignore) {
+					log.trace("Failed to close dependent connection:", ignore);
+				}
 			}
+			return res;
+		} catch (Throwable t) {
+			dependentConn.close();
+			throw t;
 		}
-		return res;
 	}
 
 	@Override
 	public T next() throws QueryEvaluationException {
-		return inner.next();
+		try {
+			return inner.next();
+		} catch (Throwable t) {
+			dependentConn.close();
+			throw t;
+		}
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/ConsumingIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/ConsumingIteration.java
@@ -30,12 +30,6 @@ import com.google.common.collect.Lists;
  */
 public class ConsumingIteration implements CloseableIteration<BindingSet, QueryEvaluationException> {
 
-	/**
-	 * Maximum number of bindings that are consumed at construction time. Remaining items, if any are consumed from the
-	 * iterator itself
-	 */
-	private static final int max = 1000; // TODO make configurable
-
 	private final List<BindingSet> consumed = Lists.newArrayList();
 
 	private final CloseableIteration<BindingSet, QueryEvaluationException> innerIter;
@@ -45,7 +39,12 @@ public class ConsumingIteration implements CloseableIteration<BindingSet, QueryE
 	 */
 	private int currentIndex = 0;
 
-	public ConsumingIteration(CloseableIteration<BindingSet, QueryEvaluationException> iter)
+	/**
+	 * @param iter iteration to be consumed
+	 * @param max  the number of results to be consumed.
+	 * @throws QueryEvaluationException
+	 */
+	public ConsumingIteration(CloseableIteration<BindingSet, QueryEvaluationException> iter, int max)
 			throws QueryEvaluationException {
 
 		innerIter = iter;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/ConsumingIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/ConsumingIteration.java
@@ -50,13 +50,21 @@ public class ConsumingIteration implements CloseableIteration<BindingSet, QueryE
 
 		innerIter = iter;
 
-		while (consumed.size() < max && iter.hasNext()) {
-			consumed.add(iter.next());
+		boolean completed = false;
+		try {
+			while (consumed.size() < max && iter.hasNext()) {
+				consumed.add(iter.next());
+			}
+			if (!iter.hasNext()) {
+				iter.close();
+			}
+			completed = true;
+		} finally {
+			if (!completed) {
+				iter.close();
+			}
 		}
 
-		if (!iter.hasNext()) {
-			iter.close();
-		}
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerBoundJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerBoundJoin.java
@@ -71,7 +71,7 @@ public class ControlledWorkerBoundJoin extends ControlledWorkerJoin {
 		Phaser currentPhaser = phaser;
 
 		// first item is always sent in a non-bound way
-		if (!closed && leftIter.hasNext()) {
+		if (!isClosed() && leftIter.hasNext()) {
 			BindingSet b = leftIter.next();
 			totalBindings++;
 			if (expr instanceof StatementTupleExpr) {
@@ -95,7 +95,7 @@ public class ControlledWorkerBoundJoin extends ControlledWorkerJoin {
 
 		int nBindings;
 		List<BindingSet> bindings = null;
-		while (!closed && leftIter.hasNext()) {
+		while (!isClosed() && leftIter.hasNext()) {
 
 			// create a new phaser if there are more than 10000 parties
 			// note: a phaser supports only up to 65535 registered parties
@@ -122,7 +122,7 @@ public class ControlledWorkerBoundJoin extends ControlledWorkerJoin {
 			bindings = new ArrayList<>(nBindings);
 
 			int count = 0;
-			while (count < nBindings && leftIter.hasNext()) {
+			while (!isClosed() && count < nBindings && leftIter.hasNext()) {
 				bindings.add(leftIter.next());
 				count++;
 			}
@@ -133,6 +133,8 @@ public class ControlledWorkerBoundJoin extends ControlledWorkerJoin {
 			scheduler.schedule(taskCreator.getTask(new PhaserHandlingParallelExecutor(this, currentPhaser), bindings));
 		}
 
+		leftIter.close();
+
 		scheduler.informFinish(this);
 
 		if (log.isDebugEnabled()) {
@@ -140,6 +142,16 @@ public class ControlledWorkerBoundJoin extends ControlledWorkerJoin {
 		}
 
 		phaser.awaitAdvanceInterruptibly(phaser.arrive(), queryInfo.getMaxRemainingTimeMS(), TimeUnit.MILLISECONDS);
+	}
+
+	@Override
+	public void handleClose() throws QueryEvaluationException {
+		try {
+			super.handleClose();
+		} finally {
+			// signal the phaser to close (if currently being blocked)
+			phaser.forceTermination();
+		}
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerJoin.java
@@ -53,7 +53,7 @@ public class ControlledWorkerJoin extends JoinExecutorBase<BindingSet> {
 		int totalBindings = 0; // the total number of bindings
 
 		Phaser currentPhaser = phaser;
-		while (!closed && leftIter.hasNext()) {
+		while (!isClosed() && leftIter.hasNext()) {
 			totalBindings++;
 			// create a new phaser if there are more than 10000 parties
 			// note: a phaser supports only up to 65535 registered parties
@@ -66,6 +66,8 @@ public class ControlledWorkerJoin extends JoinExecutorBase<BindingSet> {
 			scheduler.schedule(task);
 		}
 
+		leftIter.close();
+
 		scheduler.informFinish(this);
 
 		if (log.isDebugEnabled()) {
@@ -75,5 +77,15 @@ public class ControlledWorkerJoin extends JoinExecutorBase<BindingSet> {
 		// wait until all tasks are executed
 		phaser.awaitAdvanceInterruptibly(phaser.arrive(), queryInfo.getMaxRemainingTimeMS(), TimeUnit.MILLISECONDS);
 
+	}
+
+	@Override
+	public void handleClose() throws QueryEvaluationException {
+		try {
+			super.handleClose();
+		} finally {
+			// signal the phaser to close (if currently being blocked)
+			phaser.forceTermination();
+		}
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoin.java
@@ -56,7 +56,7 @@ public class HashJoin extends JoinExecutorBase<BindingSet> {
 		try (LazyMutableClosableIteration rightArgIter = new LazyMutableClosableIteration(
 				strategy.evaluate(rightArg, bindings))) {
 
-			while (!closed && leftIter.hasNext()) {
+			while (!isClosed() && leftIter.hasNext()) {
 
 				int blockSizeL = 10;
 				if (totalBindingsLeft > 20) {
@@ -69,7 +69,7 @@ public class HashJoin extends JoinExecutorBase<BindingSet> {
 				}
 
 				int blockSizeR = 10;
-				while (!closed && rightArgIter.hasNext()) {
+				while (!isClosed() && rightArgIter.hasNext()) {
 					if (totalBindingsRight > 20) {
 						blockSizeR = 100;
 					}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelBoundJoinTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelBoundJoinTask.java
@@ -40,7 +40,7 @@ public class ParallelBoundJoinTask extends ParallelTaskBase<BindingSet> {
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 		return strategy.evaluateBoundJoinStatementPattern(expr, bindings);
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelCheckJoinTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelCheckJoinTask.java
@@ -39,7 +39,7 @@ public class ParallelCheckJoinTask extends ParallelTaskBase<BindingSet> {
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 		return strategy.evaluateGroupedCheck(expr, bindings);
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelJoinTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelJoinTask.java
@@ -36,7 +36,7 @@ public class ParallelJoinTask extends ParallelTaskBase<BindingSet> {
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 		return strategy.evaluate(expr, bindings);
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelLeftJoinTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelLeftJoinTask.java
@@ -46,7 +46,7 @@ public class ParallelLeftJoinTask extends ParallelTaskBase<BindingSet> {
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 
 		return new FedXLeftJoinIteration(strategy, join, leftBindings);
 
@@ -92,6 +92,7 @@ public class ParallelLeftJoinTask extends ParallelTaskBase<BindingSet> {
 				rightIter = strategy.evaluate(join.getRightArg(), leftBindings);
 
 				if (!rightIter.hasNext() && !exhausted.getAndSet(true)) {
+					rightIter.close();
 					return leftBindings;
 				}
 			}
@@ -123,6 +124,9 @@ public class ParallelLeftJoinTask extends ParallelTaskBase<BindingSet> {
 					return leftBindings;
 				}
 			}
+
+			// proactively close
+			rightIter.close();
 
 			return null;
 		}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelServiceJoinTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelServiceJoinTask.java
@@ -41,7 +41,7 @@ public class ParallelServiceJoinTask extends ParallelTaskBase<BindingSet> {
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 
 		// Note: in order two avoid deadlocks we consume the SERVICE result.
 		// This is basically required to avoid processing background tuple

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousBoundJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousBoundJoin.java
@@ -59,19 +59,19 @@ public class SynchronousBoundJoin extends SynchronousJoin {
 		// first item is always sent in a non-bound way
 
 		boolean hasFreeVars = true;
-		if (!closed && leftIter.hasNext()) {
+		if (!isClosed() && leftIter.hasNext()) {
 			BindingSet b = leftIter.next();
 			totalBindings++;
 			hasFreeVars = stmt.hasFreeVarsFor(b);
 			if (!hasFreeVars) {
 				stmt = new CheckStatementPattern(stmt, queryInfo);
 			}
-			rightQueue.put(strategy.evaluate(stmt, b));
+			addResult(strategy.evaluate(stmt, b));
 		}
 
 		int nBindings;
 		List<BindingSet> bindings = null;
-		while (!closed && leftIter.hasNext()) {
+		while (!isClosed() && leftIter.hasNext()) {
 
 			/*
 			 * XXX idea:
@@ -91,13 +91,14 @@ public class SynchronousBoundJoin extends SynchronousJoin {
 			bindings = new ArrayList<>(nBindings);
 
 			int count = 0;
-			while (count < nBindings && leftIter.hasNext()) {
+			while (!isClosed() && count < nBindings && leftIter.hasNext()) {
 				bindings.add(leftIter.next());
 				count++;
 			}
 
 			totalBindings += count;
-
+			if (isClosed())
+				return;
 			if (hasFreeVars) {
 				addResult(strategy.evaluateBoundJoinStatementPattern(stmt, bindings));
 			} else {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousJoin.java
@@ -33,7 +33,7 @@ public class SynchronousJoin extends JoinExecutorBase<BindingSet> {
 
 		int totalBindings = 0;
 
-		while (!closed && leftIter.hasNext()) {
+		while (!isClosed() && leftIter.hasNext()) {
 			rightQueue.put(strategy.evaluate(rightArg, leftIter.next()));
 			totalBindings++;
 		}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelGetStatementsTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelGetStatementsTask.java
@@ -56,8 +56,7 @@ public class ParallelGetStatementsTask extends ParallelTaskBase<Statement> {
 	}
 
 	@Override
-	public CloseableIteration<Statement, QueryEvaluationException> performTask()
-			throws Exception {
+	protected CloseableIteration<Statement, QueryEvaluationException> performTaskInternal() throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
 		return tripleSource.getStatements(subj, pred, obj, queryInfo, contexts);
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelPreparedAlgebraUnionTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelPreparedAlgebraUnionTask.java
@@ -44,7 +44,7 @@ public class ParallelPreparedAlgebraUnionTask extends ParallelTaskBase<BindingSe
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
 		return tripleSource.getStatements(preparedQuery, bindings, filterExpr, queryInfo);
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelPreparedUnionTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelPreparedUnionTask.java
@@ -43,7 +43,7 @@ public class ParallelPreparedUnionTask extends ParallelTaskBase<BindingSet> {
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
 		return tripleSource.getStatements(preparedQuery, bindings, filterExpr, queryInfo);
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelUnionOperatorTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelUnionOperatorTask.java
@@ -42,8 +42,7 @@ public class ParallelUnionOperatorTask extends ParallelTaskBase<BindingSet> {
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask()
-			throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 		return strategy.evaluate(expr, bindings);
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelUnionTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ParallelUnionTask.java
@@ -44,7 +44,7 @@ public class ParallelUnionTask extends ParallelTaskBase<BindingSet> {
 	}
 
 	@Override
-	public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+	protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 		TripleSource tripleSource = endpoint.getTripleSource();
 		return tripleSource.getStatements(stmt, bindings, filterExpr, queryInfo);
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/SynchronousWorkerUnion.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/SynchronousWorkerUnion.java
@@ -26,6 +26,12 @@ public class SynchronousWorkerUnion<T> extends WorkerUnionBase<T> {
 	@Override
 	protected void union() throws Exception {
 		for (ParallelTask<T> task : tasks) {
+			try {
+				task.getQueryInfo().registerScheduledTask(task);
+			} catch (Throwable e) {
+				task.cancel();
+				throw e;
+			}
 			addResult(task.performTask());
 		}
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
@@ -314,7 +314,7 @@ public class SourceSelection {
 		}
 
 		@Override
-		public CloseableIteration<BindingSet, QueryEvaluationException> performTask() throws Exception {
+		protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 			try {
 				TripleSource t = endpoint.getTripleSource();
 				boolean hasResults = false;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
@@ -162,6 +162,7 @@ public class QueryInfo {
 	 */
 	public synchronized void registerScheduledTask(ParallelTask<?> task) throws QueryEvaluationException {
 		if (done) {
+			task.cancel();
 			throw new QueryEvaluationException("Query is aborted or closed, cannot accept new tasks");
 		}
 		scheduledSubtasks.add(task);


### PR DESCRIPTION
GitHub issue resolved: #3131 

This change adds robustness to FedX in special error and cancelling
cases, e.g. when the query is only partially consumed. Before we have
seen situations where there were resource leaks and blocked threads.

Summary of changes:

* ParallleTaskBase has now performTaskInternal to remember the reference
to the closable iteration. Upon cancel() the closable iteration is also
closed. Subclasses of ParallelTaskBase now override performTaskInternal
* Scheduler classes that make use of a phaser (e.g.
ControlledWorkerJoin) now explicitly force termination of the phaser
upon close. This potentially unblocks running threads
* Close dependent connection now also handles unexpected error cases
(e.g. interrupts)
* Generally more safe-guards are added and inner iterations are closed
as early as possible

Note: MediumConcurrencyTest now has a helper method for executing queries partially. If this is used, the canceling case can be simulated due to partial consumption of query results.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

