### PR TITLE
GH-3251 remove lingering references to SeRQL

### DIFF
--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
@@ -32,7 +32,7 @@ public abstract class Protocol {
 		GET,
 		/** retrieving repository size */
 		SIZE,
-		/** SPARQL or SeRQL query */
+		/** SPARQL query */
 		QUERY,
 		/** SPARQL Update */
 		UPDATE,

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/Operation.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/Operation.java
@@ -11,8 +11,8 @@ import org.eclipse.rdf4j.model.Value;
 
 /**
  * An operation (e.g. a query or an update) on a repository that can be formulated in one of the supported query
- * languages (for example SeRQL or SPARQL). It allows one to predefine bindings in the operation to be able to reuse the
- * same operation with different bindings.
+ * languages (for example SPARQL). It allows one to predefine bindings in the operation to be able to reuse the same
+ * operation with different bindings.
  *
  * @author Jeen
  */

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/Query.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/Query.java
@@ -12,8 +12,8 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.query.explanation.Explanation;
 
 /**
- * A query on a repository that can be formulated in one of the supported query languages (for example SeRQL or SPARQL).
- * It allows one to predefine bindings in the query to be able to reuse the same query with different bindings.
+ * A query on a repository that can be formulated in one of the supported query languages (for example SPARQL). It
+ * allows one to predefine bindings in the query to be able to reuse the same query with different bindings.
  *
  * @author Arjohn Kampman
  * @author jeen

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResultHandler.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResultHandler.java
@@ -56,8 +56,8 @@ public interface QueryResultHandler {
 
 	/**
 	 * Indicates the start of a sequence of Solutions. The supplied bindingNames are an indication of the values that
-	 * are in the Solutions. For example, a SeRQL query like <tt>select X, Y from {X} P {Y} </tt> will have binding
-	 * names <tt>X</tt> and <tt>Y</tt>.
+	 * are in the Solutions. For example, a SPARQL query like <tt>select ?X ?Y where { ?X ?P ?Y } </tt> will have
+	 * binding names <tt>X</tt> and <tt>Y</tt>.
 	 *
 	 * @param bindingNames An ordered set of binding names.
 	 * @throws TupleQueryResultHandlerException If there was an error during the starting of the query result handler.

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/BaseTupleExprRenderer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/BaseTupleExprRenderer.java
@@ -116,7 +116,7 @@ public abstract class BaseTupleExprRenderer extends AbstractQueryModelVisitor<Ex
 	 * Render the ParsedQuery as a query string
 	 *
 	 * @param theQuery the parsed query to render
-	 * @return the query object rendered in the serql syntax
+	 * @return the query object rendered in the query language syntax
 	 * @throws Exception if there is an error while rendering
 	 */
 	public String render(ParsedQuery theQuery) throws Exception {
@@ -127,7 +127,7 @@ public abstract class BaseTupleExprRenderer extends AbstractQueryModelVisitor<Ex
 	 * Render the TupleExpr as a query or query fragment depending on what kind of TupleExpr it is
 	 *
 	 * @param theExpr the expression to render
-	 * @return the TupleExpr rendered in the serql syntax
+	 * @return the TupleExpr rendered in the query language syntax
 	 * @throws Exception if there is an error while rendering
 	 */
 	public abstract String render(TupleExpr theExpr) throws Exception;

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/RenderUtils.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/RenderUtils.java
@@ -17,7 +17,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
 
 /**
- * Utility methods for rendering (parts of) SeRQL and SPARQL query strings.
+ * Utility methods for rendering (parts of) SPARQL query strings.
  *
  * @author Michael Grove
  */
@@ -27,18 +27,6 @@ public final class RenderUtils {
 	 * No instances
 	 */
 	private RenderUtils() {
-	}
-
-	/**
-	 * Return the query string rendering of the {@link org.eclipse.rdf4j.model.Value}
-	 *
-	 * @param theValue the value to render
-	 * @return the value rendered in its query string representation
-	 * @deprecated Use {@link #toSPARQL(Value)} instead.
-	 */
-	@Deprecated
-	public static String getSPARQLQueryString(Value theValue) {
-		return toSPARQL(theValue);
 	}
 
 	/**
@@ -79,47 +67,6 @@ public final class RenderUtils {
 		}
 
 		return builder;
-	}
-
-	/**
-	 * Return the query string rendering of the {@link Value}
-	 *
-	 * @param theValue the value to render
-	 * @return the value rendered in its query string representation
-	 * @deprecated Use {{@link #toSeRQL(Value)} instead.
-	 */
-	@Deprecated
-	public static String getSerqlQueryString(Value theValue) {
-		return toSeRQL(theValue);
-	}
-
-	/**
-	 * Return the query string rendering of the {@link Value}
-	 *
-	 * @param theValue the value to render
-	 * @return the value rendered in its query string representation
-	 */
-	public static String toSeRQL(Value theValue) {
-		StringBuilder aBuffer = new StringBuilder();
-
-		if (theValue instanceof IRI) {
-			IRI aURI = (IRI) theValue;
-			aBuffer.append("<").append(aURI.toString()).append(">");
-		} else if (theValue instanceof BNode) {
-			aBuffer.append("_:").append(((BNode) theValue).getID());
-		} else if (theValue instanceof Literal) {
-			Literal aLit = (Literal) theValue;
-
-			aBuffer.append("\"").append(escape(aLit.getLabel())).append("\"");
-
-			if (Literals.isLanguageLiteral(aLit)) {
-				aBuffer.append("@").append(aLit.getLanguage());
-			} else {
-				aBuffer.append("^^<").append(aLit.getDatatype().toString()).append(">");
-			}
-		}
-
-		return aBuffer.toString();
 	}
 
 	/**

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/package-info.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/package-info.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 /**
  * This package contains classes for working with RDF4J query objects. It includes utilities for rendering, building,
- * modifying, and executing SPARQL & SeRQL queries. This functionality was contributed to RDF4J by Michael Grove of
+ * modifying, and executing SPARQL queries. This functionality was contributed to RDF4J by Michael Grove of
  * <a href="http://www.clarkparsia.com/">Clark & Parsia, LLC</a>.
  */
 package org.eclipse.rdf4j.queryrender;

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SPARQLQueryRenderer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SPARQLQueryRenderer.java
@@ -95,25 +95,6 @@ public class SPARQLQueryRenderer implements QueryRenderer {
 						}
 
 						aQuery.append("?" + aElem.getSourceName());
-
-						// SPARQL does not support this, its an artifact of copy and
-						// paste from the serql stuff
-						// aQuery.append(mRenderer.getExtensions().containsKey(aElem.getSourceName())
-						// ?
-						// mRenderer.renderValueExpr(mRenderer.getExtensions().get(aElem.getSourceName()))
-						// : "?"+aElem.getSourceName());
-						//
-						// if (!aElem.getSourceName().equals(aElem.getTargetName()) ||
-						// (mRenderer.getExtensions().containsKey(aElem.getTargetName())
-						// &&
-						// !mRenderer.getExtensions().containsKey(aElem.getSourceName())))
-						// {
-						// aQuery.append(" as
-						// ").append(mRenderer.getExtensions().containsKey(aElem.getTargetName())
-						// ?
-						// mRenderer.renderValueExpr(mRenderer.getExtensions().get(aElem.getTargetName()))
-						// : aElem.getTargetName());
-						// }
 					}
 				}
 			}

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SparqlTupleExprRenderer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SparqlTupleExprRenderer.java
@@ -12,10 +12,7 @@ import java.util.Map;
 
 import org.eclipse.rdf4j.query.algebra.And;
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
-import org.eclipse.rdf4j.query.algebra.BNodeGenerator;
-import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Bound;
-import org.eclipse.rdf4j.query.algebra.Coalesce;
 import org.eclipse.rdf4j.query.algebra.Compare;
 import org.eclipse.rdf4j.query.algebra.Datatype;
 import org.eclipse.rdf4j.query.algebra.Difference;
@@ -108,7 +105,7 @@ public final class SparqlTupleExprRenderer extends BaseTupleExprRenderer {
 		if (aContext != null) {
 			mJoinBuffer.append(indent()).append("GRAPH ");
 			if (aContext.hasValue()) {
-				mJoinBuffer.append(RenderUtils.getSPARQLQueryString(aContext.getValue()));
+				mJoinBuffer.append(RenderUtils.toSPARQL(aContext.getValue()));
 			} else {
 				mJoinBuffer.append("?").append(aContext.getName());
 			}

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SparqlValueExprRenderer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SparqlValueExprRenderer.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.queryrender.sparql;
 import org.eclipse.rdf4j.query.algebra.And;
 import org.eclipse.rdf4j.query.algebra.BNodeGenerator;
 import org.eclipse.rdf4j.query.algebra.BinaryValueOperator;
-import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Bound;
 import org.eclipse.rdf4j.query.algebra.Compare;
 import org.eclipse.rdf4j.query.algebra.CompareAll;
@@ -101,7 +100,7 @@ final class SparqlValueExprRenderer extends AbstractQueryModelVisitor<Exception>
 		if (theVar.isAnonymous() && !theVar.hasValue()) {
 			mBuffer.append("?").append(BaseTupleExprRenderer.scrubVarName(theVar.getName()));
 		} else if (theVar.hasValue()) {
-			mBuffer.append(RenderUtils.getSPARQLQueryString(theVar.getValue()));
+			mBuffer.append(RenderUtils.toSPARQL(theVar.getValue()));
 		} else {
 			mBuffer.append("?").append(theVar.getName());
 		}
@@ -192,7 +191,7 @@ final class SparqlValueExprRenderer extends AbstractQueryModelVisitor<Exception>
 	 */
 	@Override
 	public void meet(ValueConstant theVal) throws Exception {
-		mBuffer.append(RenderUtils.getSPARQLQueryString(theVal.getValue()));
+		mBuffer.append(RenderUtils.toSPARQL(theVal.getValue()));
 	}
 
 	/**

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/CustomGraphQueryInferencer.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/CustomGraphQueryInferencer.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A forward-chaining inferencer that infers new statements using a SPARQL or SeRQL graph query.
+ * A forward-chaining inferencer that infers new statements using a SPARQL graph query.
  *
  * @author Dale Visser
  */

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerConfig.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerConfig.java
@@ -41,12 +41,11 @@ import org.eclipse.rdf4j.sail.config.SailImplConfig;
  */
 public final class CustomGraphQueryInferencerConfig extends AbstractDelegatingSailImplConfig {
 
-	public static final Pattern SPARQL_PATTERN, SERQL_PATTERN;
+	public static final Pattern SPARQL_PATTERN;
 
 	static {
 		int flags = Pattern.CASE_INSENSITIVE | Pattern.DOTALL;
 		SPARQL_PATTERN = Pattern.compile("^(.*construct\\s+)(\\{.*\\}\\s*)where.*$", flags);
-		SERQL_PATTERN = Pattern.compile("^\\s*construct(\\s+.*)from\\s+.*(\\s+using\\s+namespace.*)$", flags);
 	}
 
 	private QueryLanguage language;

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -89,15 +89,8 @@ import org.slf4j.LoggerFactory;
  * </pre>
  *
  * <h2>Asking full-text queries</h2> Text queries are expressed using the virtual properties of the LuceneSail. An
- * example query looks like this (SERQL): <code>
- * SELECT Subject, Score, Snippet
- * FROM {Subject} <http://www.openrdf.org/contrib/lucenesail#matches> {}
- * <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> {<http://www.openrdf.org/contrib/lucenesail#LuceneQuery>};
- * <http://www.openrdf.org/contrib/lucenesail#query> {"my Lucene query"};
- * <http://www.openrdf.org/contrib/lucenesail#score> {Score};
- * <http://www.openrdf.org/contrib/lucenesail#snippet> {Snippet}</code>
- *
- * In SPARQL: <code>
+ * example query looks like this in SPARQL: <code>
+ * <pre>
  * SELECT ?subject ?score ?snippet ?resource WHERE {
  * ?subject <http://www.openrdf.org/contrib/lucenesail#matches> [
  *      a <http://www.openrdf.org/contrib/lucenesail#LuceneQuery> ;
@@ -107,6 +100,7 @@ import org.slf4j.LoggerFactory;
  *      <http://www.openrdf.org/contrib/lucenesail#resource> ?resource
  *   ]
  * }
+ * </pre>
  * </code> When defining queries, these properties <b>type and query are mandatory</b>. Also, the <b>matches relation is
  * mandatory</b>. When one of these misses, the query will not be executed as expected. The failure behavior can be
  * configured, setting the Sail property "incompletequeryfail" to true will throw a SailException when such patterns are

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/AbstractGenericLuceneTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/AbstractGenericLuceneTest.java
@@ -118,9 +118,6 @@ public abstract class AbstractGenericLuceneTest {
 	public void setUp() throws Exception {
 		// set logging, uncomment this to get better logging for debugging
 		// org.apache.log4j.BasicConfigurator.configure();
-		// TODO: disable logging for org.eclipse.rdf4j.query.parser.serql.SeRQLParser,
-		// which is not possible
-		// to configure using just the Logger
 
 		// setup a LuceneSail
 		MemoryStore memoryStore = new MemoryStore();

--- a/site/content/documentation/reference/rest-api.md
+++ b/site/content/documentation/reference/rest-api.md
@@ -125,7 +125,7 @@ Queries on a specific repository with ID `<ID>` can be evaluated by sending requ
 Parameters:
 
 - `query`: The query to evaluate.
-- `queryLn` (optional): Specifies the query language that is used for the query. Acceptable values are strings denoting the query languages supported by the server, i.e. “serql” for SeRQL queries and “sparql” for SPARQL queries. If not specified, the server assumes the query is a SPARQL query.
+- `queryLn` (optional): Specifies the query language that is used for the query. Acceptable values are strings denoting the query languages supported by the server. If not specified, the server assumes the query is a SPARQL query.
 - `infer` (optional): Specifies whether inferred statements should be included in the query evaluation. Inferred statements are included by default. Specifying any value other than “true” (ignoring case) restricts the query evluation to explicit statements only.
 - `$<varname>` (optional): specifies variable bindings. Variables appearing in the query can be bound to a specific value outside the actual query using this option. The value should be an N-Triples encoded RDF value.
 - `timeout` (optional): specifies a maximum query execution time, in whole seconds. The value should be an integer. A setting of 0 or a negative number indicates unlimited query time (the default).
@@ -139,11 +139,11 @@ Request headers:
 - `Content-Type`: specifies the mediatype of a POST request body. Possible values are “application/x-www-form-urlencoded” (for a SPARQL query or update encoded as a form parameter), “application/sparql-query” (for an unencoded SPARQL query string) or “application/sparql-update” (for an unencoded SPARQL update string).
 
 ### Request examples
-#### Evaluate a SeRQL-select query on repository “mem-ref”
+#### Evaluate a SPARQL select query on repository “mem-ref”
 
 Request:
 
-    GET /rdf4j-server/repositories/mem-rdf?query=select%20%3Cfoo:bar%3E&queryLn=serql HTTP/1.1
+    GET /rdf4j-server/repositories/mem-rdf?query=select%20%2A%20%7B%7D&queryLn=sparql HTTP/1.1
     Host: localhost
     Accept: application/sparql-results+xml, */*;q=0.5
 
@@ -155,16 +155,12 @@ Response:
     <?xml version='1.0' encoding='UTF-8'?>
     <sparql xmlns='http://www.w3.org/2005/sparql-results#'>
       <head>
-             <variable name='&lt;foo:bar&gt;'/>
       </head>
-      <results ordered='false' distinct='false'>
-             <result>
-                    <binding name='&lt;foo:bar&gt;'>
-                      <uri>foo:bar</uri>
-                    </binding>
-             </result>
+      <results>
       </results>
     </sparql>
+
+(note that in this example the query result is empty)
 
 #### Evaluate a SPARQL-construct query on repository “mem-rdf” using a POST request
 
@@ -888,12 +884,12 @@ Response:
 
 ### The QUERY operation
 
-The `QUERY` operation executes a SPARQL or SeRQL query on the repository as part of the current transaction, and returns the result as an RDF document.
+The `QUERY` operation executes a SPARQL query on the repository as part of the current transaction, and returns the result as an RDF document.
 
 Parameters:
 
 - `query`: The query to evaluate.
-- `queryLn` (optional): Specifies the query language that is used for the query. Acceptable values are strings denoting the query languages supported by the server, i.e. `serql` for SeRQL queries and `sparql` for SPARQL queries. If not specified, the server assumes the query is a SPARQL query.
+- `queryLn` (optional): Specifies the query language that is used for the query. Acceptable values are strings denoting the query languages supported by the server, e.g. `sparql` for SPARQL queries. If not specified, the server assumes the query is a SPARQL query.
 - `infer` (optional): Specifies whether inferred statements should be included in the query evaluation. Inferred statements are included by default. Specifying any value other than `true` (ignoring case) restricts the query evaluation to explicit statements only.
 
 Request Headers:

--- a/site/content/documentation/tools/server-workbench.md
+++ b/site/content/documentation/tools/server-workbench.md
@@ -345,9 +345,9 @@ By using the “Results per page” setting and the “Previous …” and “Ne
 
 ### Querying a Repository
 
-Clicking on “Query” on the sidebar menu brings you to Workbench’s querying interface. Here, you may enter queries in the SPARQL or SeRQL query languages, save them for future access, and execute them against your repository.
+Clicking on “Query” on the sidebar menu brings you to Workbench’s querying interface. Here, you may enter queries in the SPARQL language, save them for future access, and execute them against your repository.
 
-If you have executed queries previously, the query text area will show the most recently executed query. If not, it will be pre-populated with a prefix header (SPARQL) or footer (SeRQL) containing all the defined namespaces for the repository. The “Clear” button below the text area gives you the option to restore this pre-populated state for the currently selected query language.
+If you have executed queries previously, the query text area will show the most recently executed query. If not, it will be pre-populated with a prefix header containing all the defined namespaces for the repository. The “Clear” button below the text area gives you the option to restore this pre-populated state for the currently selected query language.
 
 The two other action buttons are “Save Query” and “Execute”:
 
@@ -369,7 +369,7 @@ The query name is displayed as a clickable link that will execute the query, fol
 
 The query metadata fields, aside from query name and user, are:
 
-- Query Language: either SPARQL or SeRQL
+- Query Language: SPARQL
 - Include Inferred Statements: whether to use any inferencing defined on the repository to expand the result set
 - Rows per page: How many results to display per page at first
 - Shared: whether this query is visible to users other than the one that saved it, restricted to always be true for the “anonymous” user

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailTest.java
@@ -107,9 +107,6 @@ public abstract class AbstractLuceneSailTest {
 	public void setUp() throws Exception {
 		// set logging, uncomment this to get better logging for debugging
 		// org.apache.log4j.BasicConfigurator.configure();
-		// TODO: disable logging for org.eclipse.rdf4j.query.parser.serql.SeRQLParser,
-		// which is not possible
-		// to configure using just the Logger
 
 		// setup a LuceneSail
 		MemoryStore memoryStore = new MemoryStore();

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -246,7 +246,6 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	}
 
 	/**
-	 * Parse and evaluate a SERQL or SPARQL query. Check if query is multi-line or to be read from input file, and check
 	 * if results are to be written to an output file.
 	 *
 	 * @param queryLn   query language
@@ -366,7 +365,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	}
 
 	/**
-	 * Evaluate a SPARQL or SERQL query that has already been parsed
+	 * Evaluate a SPARQL query that has already been parsed
 	 *
 	 * @param queryLn query language
 	 * @param query   parsed query
@@ -407,7 +406,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	}
 
 	/**
-	 * Add namespace prefixes to SPARQL or SERQL query
+	 * Add namespace prefixes to SPARQL query
 	 *
 	 * @param queryString query string
 	 * @return query string with prefixes

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/command/TupleAndGraphQueryEvaluator.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/command/TupleAndGraphQueryEvaluator.java
@@ -91,8 +91,8 @@ public class TupleAndGraphQueryEvaluator {
 	}
 
 	/**
-	 * Evaluate SPARQL or SERQL tuple query and send the output to a writer. If writer is null, the console will be used
-	 * for output.
+	 * Evaluate SPARQL tuple query and send the output to a writer. If writer is null, the console will be used for
+	 * output.
 	 *
 	 * @param queryLn     query language
 	 * @param queryString query string
@@ -138,7 +138,7 @@ public class TupleAndGraphQueryEvaluator {
 	}
 
 	/**
-	 * Evaluate SPARQL or SERQL graph query
+	 * Evaluate SPARQL graph query
 	 *
 	 * @param queryLn     query language
 	 * @param queryString query string
@@ -178,7 +178,7 @@ public class TupleAndGraphQueryEvaluator {
 	}
 
 	/**
-	 * Evaluate a boolean SPARQL or SERQL query
+	 * Evaluate a boolean SPARQL query
 	 *
 	 * @param queryLn     query language
 	 * @param queryString query string
@@ -208,7 +208,7 @@ public class TupleAndGraphQueryEvaluator {
 	}
 
 	/**
-	 * Execute a SPARQL or SERQL update
+	 * Execute a SPARQL update
 	 *
 	 * @param queryLn     query language
 	 * @param queryString query string

--- a/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/util/QueryStorage.java
+++ b/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/util/QueryStorage.java
@@ -118,8 +118,9 @@ public class QueryStorage {
 	 * @throws RepositoryException if there is an issue creating the object to access the repository
 	 * @throws IOException
 	 */
-	protected QueryStorage(final AppConfiguration appConfig) throws RepositoryException, IOException {
+	private QueryStorage(final AppConfiguration appConfig) throws RepositoryException, IOException {
 		queries = new SailRepository(new NativeStore(new File(appConfig.getDataDir(), "queries")));
+		queries.init();
 	}
 
 	public void shutdown() {

--- a/tools/workbench/src/main/webapp/transformations/query.xsl
+++ b/tools/workbench/src/main/webapp/transformations/query.xsl
@@ -121,26 +121,6 @@
             </xsl:for-each>
         };
         </script>
-		<pre id="SeRQL-namespaces" style="display:none">
-			`
-			<xsl:text>
-USING NAMESPACE</xsl:text>
-			<xsl:for-each
-				select="document(//sparql:link[@href='namespaces']/@href)//sparql:results/sparql:result">
-				<xsl:text>
-</xsl:text>
-				<xsl:choose>
-					<xsl:when test="following-sibling::sparql:result">
-						<xsl:value-of
-							select="concat(sparql:binding[@name='prefix']/sparql:literal, ' = &lt;', sparql:binding[@name='namespace']/sparql:literal, '&gt;,')" />
-					</xsl:when>
-					<xsl:otherwise>
-						<xsl:value-of
-							select="concat(sparql:binding[@name='prefix']/sparql:literal, ' = &lt;', sparql:binding[@name='namespace']/sparql:literal, '&gt;')" />
-					</xsl:otherwise>
-				</xsl:choose>
-			</xsl:for-each>
-		</pre>
 		<script src="../../scripts/codemirror.4.5.0.min.js" type="text/javascript"></script>
 		<script src="../../scripts/yasqe.min.js" type="text/javascript"></script>
 		<script src="../../scripts/yasqeHelper.js" type="text/javascript"></script>


### PR DESCRIPTION
GitHub issue resolved: #3251 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- removed code comments and obsolete methods referencing SeRQL
- tested/modified workbench to verify removal of SeRQL introduces no errors in query page or saved query functionality.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

