### PR TITLE
GH-2392: added lucene-backward-codecs + documentation

### DIFF
--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -50,7 +50,6 @@
 			<artifactId>lucene-backward-codecs</artifactId>
 			<version>${lucene.version}</version>
 			<scope>runtime</scope>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/site/content/release-notes/4.0.0.md
+++ b/site/content/release-notes/4.0.0.md
@@ -26,6 +26,32 @@ The LuceneSpinSail component, which was first marked deprecated in release 3.0.3
 
 The parser for the SeRQL query language, as well as all related code and tool options, has been removed from RDF4J. If you still have SeRQL queries in your project, you will need to rewrite them into SPARQL syntax before upgrading ([GH-2992](https://github.com/eclipse/rdf4j/issues/2992)).
 
+### Lucene libraries upgraded
+
+The Lucene (full-text search) libraries have been upgraded from 7.7 to 8.5.
+This affects projects storing the full-text index to disk (using the `LuceneSail.LUCENE_DIR_KEY`).
+
+Projects upgrading from RDF4J 3.x (Lucene 7.7) to RDF4J 4.0 (Lucene 8.5) should include the `lucene-backwards-codec` 8.5 jar to continue using the existing Lucene 7.7 indexes.
+
+It is recommended to reindex the data / upgrade the Lucene index stored in the `LuceneSail.LUCENE_DIR_KEY` directory,
+after which the `lucene-backwards-codec` jar can be removed:
+- either programmatically, using the [reindex() method](https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/sail/lucene/LuceneSail.html#reindex())
+- or via the [Lucene index upgrade tool](https://lucene.apache.org/core/8_5_0/core/org/apache/lucene/index/IndexUpgrader.html) which is part of the `lucene-core` jar
+
+Both options may require shutting down the application(s) using the indexed data, it is recommended to back up the index directory before reindexing.
+
+The RDF4J SDK contains both the `lucene-core` and `lucene-backwards-codec` jars.
+
+### Solr client libraries upgraded
+
+The Solr client libraries have been upgraded from 7.7 to 8.4.
+New clients should still be able to work correctly with older Solr servers without code changes, but this cannot be guaranteed.
+
+### ElasticSearch client libraries upgraded
+
+The ElasticSearch client libraries have been upgraded from 6.8 to 7.8.
+New clients should still be able to work correctly with older ElasticSearch servers without code changes, but this cannot be guaranteed.
+
 ### rdf4j-util module split up
 
 The `rdf4j-util` module has been split up into 8 separate modules, to allow for greater flexibility in our dependency tree and potential smaller footprints. The 8 new modules are as follows:
@@ -75,7 +101,6 @@ The following methods were removed from `org.eclipse.rdf4j.common.text.StringUti
 - `getAllAfter(String, char)`
 - `getAllBefore(String, char)`
 - `isGarbageText(String)`
-
 
 ## Acknowledgements
 


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #2392  <!-- add a Github issue number here, e.g #123. -->
- always add lucene-backward-codecs jar as runtime dependency
- added documentation on upgrading lucene index
- mention upgrade from Solr and ElasticSearch

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

