### PR TITLE
GH-1841 ntripleparser deprecated settings

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/ParserConfig.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/ParserConfig.java
@@ -62,9 +62,9 @@ public class ParserConfig extends RioConfig implements Serializable {
 		// parser to attempt to recover.
 		if (!stopAtFirstError) {
 			Set<RioSetting<?>> nonFatalErrors = new HashSet<>();
-			nonFatalErrors.add(TriXParserSettings.FAIL_ON_TRIX_INVALID_STATEMENT);
-			nonFatalErrors.add(TriXParserSettings.FAIL_ON_TRIX_MISSING_DATATYPE);
-			nonFatalErrors.add(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+			nonFatalErrors.add(TriXParserSettings.FAIL_ON_INVALID_STATEMENT);
+			nonFatalErrors.add(TriXParserSettings.FAIL_ON_MISSING_DATATYPE);
+			nonFatalErrors.add(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 			if (verifyData) {
 				nonFatalErrors.add(BasicParserSettings.VERIFY_RELATIVE_URIS);
 				if (datatypeHandling == DatatypeHandling.IGNORE) {

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -250,14 +250,14 @@ public abstract class AbstractRDFParser implements RDFParser {
 	@Deprecated
 	@Override
 	public void setStopAtFirstError(boolean stopAtFirstError) {
-		getParserConfig().set(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES, stopAtFirstError);
+		getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, stopAtFirstError);
 		if (!stopAtFirstError) {
-			getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+			getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 		} else {
 			// TODO: Add a ParserConfig.removeNonFatalError function to avoid
 			// this
 			Set<RioSetting<?>> set = new HashSet<>(getParserConfig().getNonFatalErrors());
-			set.remove(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+			set.remove(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 			getParserConfig().setNonFatalErrors(set);
 		}
 	}
@@ -291,16 +291,6 @@ public abstract class AbstractRDFParser implements RDFParser {
 				this.parserConfig.set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, false);
 			}
 		}
-	}
-
-	/**
-	 * @deprecated Use {@link BasicParserSettings#VERIFY_DATATYPE_VALUES} and
-	 *             {@link BasicParserSettings#FAIL_ON_UNKNOWN_DATATYPES} and
-	 *             {@link BasicParserSettings#NORMALIZE_DATATYPE_VALUES} instead.
-	 */
-	@Deprecated
-	public DatatypeHandling datatypeHandling() {
-		return this.parserConfig.datatypeHandling();
 	}
 
 	/**

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/NTriplesParserSettings.java
@@ -30,19 +30,6 @@ public class NTriplesParserSettings {
 			"org.eclipse.rdf4j.rio.ntriples.fail_on_invalid_lines", "Fail on N-Triples invalid lines", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for parser to determine whether syntactically invalid lines in N-Triples and N-Quads documents
-	 * generate a parse error.
-	 * <p>
-	 * Defaults to true.
-	 * <p>
-	 * Can be overridden by setting system property {@code org.eclipse.rdf4j.rio.ntriples.fail_on_invalid_lines}
-	 *
-	 * @deprecated use {@link #FAIL_ON_INVALID_LINES} instead.
-	 */
-	@Deprecated
-	public static final RioSetting<Boolean> FAIL_ON_NTRIPLES_INVALID_LINES = FAIL_ON_INVALID_LINES;
-
-	/**
 	 * Private constructor
 	 */
 	private NTriplesParserSettings() {

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TriXParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/TriXParserSettings.java
@@ -29,12 +29,6 @@ public class TriXParserSettings {
 			"org.eclipse.rdf4j.rio.trix.fail_on_missing_datatype", "Fail on TriX missing datatype", Boolean.TRUE);
 
 	/**
-	 * @deprecated use {@link #FAIL_ON_MISSING_DATATYPE} instead.
-	 */
-	@Deprecated
-	public static final RioSetting<Boolean> FAIL_ON_TRIX_MISSING_DATATYPE = FAIL_ON_MISSING_DATATYPE;
-
-	/**
 	 * Boolean setting for parser to determine whether the TriX parser should treat invalid statements as an error.
 	 * <p>
 	 * Defaults to true.
@@ -43,12 +37,6 @@ public class TriXParserSettings {
 	 */
 	public static final RioSetting<Boolean> FAIL_ON_INVALID_STATEMENT = new BooleanRioSetting(
 			"org.eclipse.rdf4j.rio.trix.fail_on_invalid_statement", "Fail on TriX invalid statement", Boolean.TRUE);
-
-	/**
-	 * @deprecated use {@link #FAIL_ON_INVALID_STATEMENT} instead
-	 */
-	@Deprecated
-	public static final RioSetting<Boolean> FAIL_ON_TRIX_INVALID_STATEMENT = FAIL_ON_INVALID_STATEMENT;
 
 	/**
 	 * Private constructor

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/ParserConfigTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/ParserConfigTest.java
@@ -220,7 +220,7 @@ public class ParserConfigTest {
 
 		assertTrue(testConfig.stopAtFirstError());
 
-		testConfig.addNonFatalError(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+		testConfig.addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 
 		assertFalse(testConfig.stopAtFirstError());
 	}
@@ -237,20 +237,6 @@ public class ParserConfigTest {
 		testConfig.set(BasicParserSettings.PRESERVE_BNODE_IDS, true);
 
 		assertTrue(testConfig.isPreserveBNodeIDs());
-	}
-
-	/**
-	 * Test method for {@link org.eclipse.rdf4j.rio.ParserConfig#datatypeHandling()}.
-	 */
-	@Test
-	public final void testDatatypeHandling() {
-		ParserConfig testConfig = new ParserConfig();
-
-		try {
-			testConfig.datatypeHandling();
-			fail("Did not receive expected exception");
-		} catch (Exception e) {
-		}
 	}
 
 	/**

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
@@ -544,7 +544,7 @@ public abstract class AbstractNQuadsParserUnitTest {
 						// error.
 						"<http://s1> <http://p1> <http://o1> <http://g1> .\n").getBytes());
 
-		parser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES, false);
+		parser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, false);
 
 		try {
 			parser.parse(bais, "http://test.base.uri");
@@ -566,8 +566,8 @@ public abstract class AbstractNQuadsParserUnitTest {
 		final TestRDFHandler rdfHandler = new TestRDFHandler();
 		parser.setRDFHandler(rdfHandler);
 
-		parser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES, false);
-		parser.getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+		parser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, false);
+		parser.getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 
 		parser.parse(bais, "http://base-uri");
 		rdfHandler.assertHandler(2);

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 		String data = "invalid nt";
 
 		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES, Boolean.TRUE);
+		ntriplesParser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, Boolean.TRUE);
 
 		Model model = new LinkedHashModel();
 		ntriplesParser.setRDFHandler(new StatementCollector(model));
@@ -99,7 +99,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 		String data = "invalid nt";
 
 		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES);
+		ntriplesParser.getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 
 		Model model = new LinkedHashModel();
 		ntriplesParser.setRDFHandler(new StatementCollector(model));
@@ -117,7 +117,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 		String data = "invalid nt";
 
 		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_NTRIPLES_INVALID_LINES, false);
+		ntriplesParser.getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, false);
 
 		Model model = new LinkedHashModel();
 		ntriplesParser.setRDFHandler(new StatementCollector(model));

--- a/site/content/release-notes/4.0.0.md
+++ b/site/content/release-notes/4.0.0.md
@@ -49,6 +49,18 @@ Projects that directly reference the `RDF4JException` class will need to update 
 
 Projects that directly reference the `RDF4JConfigException` class will need to update their imports.
 
+### Deprecated RIO parser settings removed
+
+The following deprecated settings were removed from `org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings`:
+
+- `FAIL_ON_NTRIPLES_INVALID_LINES` (use `FAIL_ON_INVALID_LINES` instead)
+
+The following deprecated settings were removed from `org.eclipse.rdf4j.rio.helpers.TriXParserSettings`:
+
+- `FAIL_ON_TRIX_MISSING_DATATYPE` (use `FAIL_ON_MISSING_DATATYPE` instead)
+- `FAIL_ON_TRIX_INVALID_STATEMENT` (use `FAIL_ON_INVALID_STATEMENT` instead)
+
+
 ### Removed utility methods
 
 The following methods were removed from `org.eclipse.rdf4j.common.io.FileUtil`


### PR DESCRIPTION
GitHub issue resolved: #1841 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- remove deprecated NTriples and TrixParserSettings
- use their respective replacements in tests etc
- remove deprecated datatypeHandling method

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

