### PR TITLE
GH-3252-NDJSONLDParser-uses-platform-encoding-to-convert-chars-to-bytes

### DIFF
--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParser.java
@@ -68,7 +68,8 @@ public class NDJSONLDParser extends JSONLDParser implements RDFParser {
 			String line;
 			while ((line = bufferedReader.readLine()) != null) {
 				if (!line.isEmpty()) {
-					JsonParser nextParser = factory.createParser(new ByteArrayInputStream(line.getBytes()));
+					JsonParser nextParser = factory
+							.createParser(new ByteArrayInputStream(line.getBytes(StandardCharsets.UTF_8)));
 					Object singleJSONLD = JsonUtils.fromJsonParser(nextParser);
 					if (singleJSONLD instanceof List) {
 						arrayOfJSONLD.addAll((List) singleJSONLD);


### PR DESCRIPTION



GitHub issue resolved: # GH-3252

Briefly describe the changes proposed in this PR:
- Added UTF-8 encoding at getJSONObject method so to not use the default platform encoding


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

