### PR TITLE
GH-3322 optimize union clauses to inject vars when we can

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
@@ -53,6 +53,7 @@ public class StandardQueryOptimizerPipeline implements QueryOptimizerPipeline {
 				new ConjunctiveConstraintSplitter(),
 				new DisjunctiveConstraintOptimizer(),
 				new SameTermFilterOptimizer(),
+				new UnionScopeChangeOptimizer(),
 				new QueryModelNormalizer(),
 				new QueryJoinOptimizer(evaluationStatistics),
 				new IterativeEvaluationOptimizer(),

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/UnionScopeChangeOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/UnionScopeChangeOptimizer.java
@@ -11,6 +11,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Extension;
+import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Union;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
@@ -58,6 +59,19 @@ public class UnionScopeChangeOptimizer implements QueryOptimizer {
 	private static class UnionArgChecker extends AbstractQueryModelVisitor<RuntimeException> {
 
 		boolean containsBindOrValues = false;
+
+		@Override
+		public void meet(Union union) {
+			if (!union.isVariableScopeChange()) {
+				super.meet(union);
+			}
+		}
+
+		@Override
+		public void meet(Projection subselect) {
+			// do not check deeper in the tree
+			return;
+		}
 
 		@Override
 		public void meet(Extension node) throws RuntimeException {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/UnionScopeChangeOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/UnionScopeChangeOptimizer.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.Extension;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.Union;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+
+/**
+ * Inspect Union clauses to check if scope change can be avoided (allowing injection of pre-bound vars into union
+ * arguments).
+ *
+ * @author Jeen Broekstra
+ */
+public class UnionScopeChangeOptimizer implements QueryOptimizer {
+
+	@Override
+	public void optimize(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings) {
+		tupleExpr.visit(new UnionScopeChangeFixer());
+	}
+
+	private static class UnionScopeChangeFixer extends AbstractQueryModelVisitor<RuntimeException> {
+
+		@Override
+		public void meet(Union union) {
+			super.meet(union);
+			if (union.isVariableScopeChange()) {
+				UnionArgChecker checker = new UnionArgChecker();
+				union.getLeftArg().visit(checker);
+				if (checker.containsBindOrValues) {
+					return;
+				}
+
+				checker.containsBindOrValues = false;
+				union.getRightArg().visit(checker);
+
+				if (checker.containsBindOrValues) {
+					return;
+				}
+
+				// Neither argument of the union contains a BIND or VALUES clause, we can safely ignore scope change
+				// for binding injection
+				union.setVariableScopeChange(false);
+			}
+		}
+	}
+
+	private static class UnionArgChecker extends AbstractQueryModelVisitor<RuntimeException> {
+
+		boolean containsBindOrValues = false;
+
+		@Override
+		public void meet(Extension node) throws RuntimeException {
+			containsBindOrValues = true;
+		}
+
+		@Override
+		public void meet(BindingSetAssignment bsa) {
+			containsBindOrValues = true;
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/UnionScopeChangeOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/UnionScopeChangeOptimizerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Extension;
+import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.SingletonSet;
 import org.eclipse.rdf4j.query.algebra.Union;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
@@ -56,6 +57,61 @@ public class UnionScopeChangeOptimizerTest extends QueryOptimizerTest {
 			subject.optimize(union, null, null);
 			assertThat(union.isVariableScopeChange()).isTrue();
 		}
+	}
+
+	@Test
+	public void fixesScopeChangeOnSubselect1() {
+		union.setLeftArg(new Projection(new Extension(new SingletonSet())));
+		union.setRightArg(new SingletonSet());
+
+		subject.optimize(union, null, null);
+		assertThat(union.isVariableScopeChange()).isFalse();
+	}
+
+	@Test
+	public void fixesScopeChangeOnSubselect2() {
+		union.setLeftArg(new SingletonSet());
+		union.setRightArg(new Projection(new Extension(new SingletonSet())));
+
+		subject.optimize(union, null, null);
+		assertThat(union.isVariableScopeChange()).isFalse();
+	}
+
+	@Test
+	public void fixesScopeChangeOnNestedUnion() {
+		Union nestedUnion = new Union();
+		nestedUnion.setVariableScopeChange(true);
+		nestedUnion.setLeftArg(new Extension(new SingletonSet()));
+		nestedUnion.setRightArg(new SingletonSet());
+		{
+			union.setLeftArg(nestedUnion);
+			union.setRightArg(new SingletonSet());
+
+			subject.optimize(union, null, null);
+			assertThat(union.isVariableScopeChange()).isFalse();
+		}
+
+		{
+			union.setLeftArg(new SingletonSet());
+			union.setRightArg(nestedUnion);
+
+			subject.optimize(union, null, null);
+			assertThat(union.isVariableScopeChange()).isFalse();
+		}
+
+	}
+
+	public void keepsScopeChangeOnNestedPathAlternative() {
+		Union nestedUnion = new Union();
+		nestedUnion.setVariableScopeChange(false);
+		nestedUnion.setLeftArg(new Extension(new SingletonSet()));
+		nestedUnion.setRightArg(new SingletonSet());
+
+		union.setLeftArg(new SingletonSet());
+		union.setRightArg(nestedUnion);
+
+		subject.optimize(union, null, null);
+		assertThat(union.isVariableScopeChange()).isTrue();
 	}
 
 	@Test

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/UnionScopeChangeOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/UnionScopeChangeOptimizerTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.Extension;
+import org.eclipse.rdf4j.query.algebra.SingletonSet;
+import org.eclipse.rdf4j.query.algebra.Union;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UnionScopeChangeOptimizerTest extends QueryOptimizerTest {
+
+	private UnionScopeChangeOptimizer subject;
+	private Union union;
+
+	@BeforeEach
+	public void setup() throws Exception {
+		subject = getOptimizer();
+		union = new Union();
+		union.setVariableScopeChange(true);
+
+	}
+
+	@Test
+	public void fixesScopeChange() {
+		union.setRightArg(new SingletonSet());
+		union.setLeftArg(new SingletonSet());
+
+		subject.optimize(union, null, null);
+		assertThat(union.isVariableScopeChange()).isFalse();
+	}
+
+	@Test
+	public void keepsScopeChangeOnBindClauseArg() {
+		{
+			union.setLeftArg(new Extension(new SingletonSet()));
+			union.setRightArg(new SingletonSet());
+
+			subject.optimize(union, null, null);
+			assertThat(union.isVariableScopeChange()).isTrue();
+		}
+
+		{
+			union.setLeftArg(new SingletonSet());
+			union.setRightArg(new Extension(new SingletonSet()));
+
+			subject.optimize(union, null, null);
+			assertThat(union.isVariableScopeChange()).isTrue();
+		}
+	}
+
+	@Test
+	public void keepsScopeChangeOnValuesClauseArg() {
+		{
+			union.setLeftArg(new BindingSetAssignment());
+			union.setRightArg(new SingletonSet());
+
+			subject.optimize(union, null, null);
+			assertThat(union.isVariableScopeChange()).isTrue();
+		}
+
+		{
+			union.setLeftArg(new SingletonSet());
+			union.setRightArg(new BindingSetAssignment());
+
+			subject.optimize(union, null, null);
+			assertThat(union.isVariableScopeChange()).isTrue();
+		}
+	}
+
+	@Override
+	public UnionScopeChangeOptimizer getOptimizer() {
+		return new UnionScopeChangeOptimizer();
+	}
+
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -632,51 +632,44 @@ public class QueryPlanRetrievalTest {
 			Query query = connection.prepareTupleQuery(UNION_QUERY);
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
-			String expected = "Projection (resultSizeActual=0)\n" +
-					"╠══ProjectionElemList\n" +
-					"║     ProjectionElem \"a\"\n" +
-					"╚══Join (HashJoinIteration) (resultSizeActual=0)\n" +
-					"   ├──StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"   │     Var (name=a)\n" +
-					"   │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
-					+
-					"   │     Var (name=type)\n" +
-					"   └──Union (new scope) (resultSizeActual=24)\n" +
-					"      ╠══Join (HashJoinIteration) (resultSizeActual=12)\n" +
-					"      ║  ├──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=12)\n" +
-					"      ║  │     Var (name=a)\n" +
-					"      ║  │     Var (name=b)\n" +
-					"      ║  │     Var (name=c2)\n" +
-					"      ║  └──Union (new scope) (resultSizeActual=96)\n" +
-					"      ║     ╠══Join (JoinIterator) (resultSizeActual=48)\n" +
-					"      ║     ║  ├──StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n"
-					+
-					"      ║     ║  │     Var (name=c2)\n" +
-					"      ║     ║  │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
-					+
-					"      ║     ║  │     Var (name=type1)\n" +
-					"      ║     ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=48)\n"
-					+
-					"      ║     ║        Var (name=a)\n" +
-					"      ║     ║        Var (name=b)\n" +
-					"      ║     ║        Var (name=c)\n" +
-					"      ║     ╚══Join (JoinIterator) (resultSizeActual=48)\n" +
-					"      ║        ├──StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n"
-					+
-					"      ║        │     Var (name=c2)\n" +
-					"      ║        │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
-					+
-					"      ║        │     Var (name=type2)\n" +
-					"      ║        └──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=48)\n"
-					+
-					"      ║              Var (name=a)\n" +
-					"      ║              Var (name=b)\n" +
-					"      ║              Var (name=c)\n" +
-					"      ╚══StatementPattern (new scope) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=12)\n"
-					+
-					"            Var (name=type)\n" +
-					"            Var (name=d)\n" +
-					"            Var (name=c)\n";
+			String expected = "Projection (resultSizeActual=24)\n"
+					+ "╠══ProjectionElemList\n"
+					+ "║     ProjectionElem \"a\"\n"
+					+ "╚══Join (JoinIterator) (resultSizeActual=24)\n"
+					+ "   ├──StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n"
+					+ "   │     Var (name=a)\n"
+					+ "   │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+ "   │     Var (name=type)\n"
+					+ "   └──Union (resultSizeActual=24)\n"
+					+ "      ╠══Join (JoinIterator) (resultSizeActual=20)\n"
+					+ "      ║  ├──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=6)\n"
+					+ "      ║  │     Var (name=a)\n"
+					+ "      ║  │     Var (name=b)\n"
+					+ "      ║  │     Var (name=c2)\n"
+					+ "      ║  └──Union (resultSizeActual=20)\n"
+					+ "      ║     ╠══Join (JoinIterator) (resultSizeActual=10)\n"
+					+ "      ║     ║  ├──StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n"
+					+ "      ║     ║  │     Var (name=c2)\n"
+					+ "      ║     ║  │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+ "      ║     ║  │     Var (name=type1)\n"
+					+ "      ║     ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=10)\n"
+					+ "      ║     ║        Var (name=a)\n"
+					+ "      ║     ║        Var (name=b)\n"
+					+ "      ║     ║        Var (name=c)\n"
+					+ "      ║     ╚══Join (JoinIterator) (resultSizeActual=10)\n"
+					+ "      ║        ├──StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n"
+					+ "      ║        │     Var (name=c2)\n"
+					+ "      ║        │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+ "      ║        │     Var (name=type2)\n"
+					+ "      ║        └──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=10)\n"
+					+ "      ║              Var (name=a)\n"
+					+ "      ║              Var (name=b)\n"
+					+ "      ║              Var (name=c)\n"
+					+ "      ╚══StatementPattern (new scope) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
+					+ "            Var (name=type)\n"
+					+ "            Var (name=d)\n"
+					+ "            Var (name=c)\n";
+
 			Assert.assertEquals(expected, actual);
 
 		}


### PR DESCRIPTION


GitHub issue resolved: #3322  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- add new optimizer that switches scope change off for unions when possible: only should not be allowed when BIND or VALUES clauses are inside one of the union arguments
- this optimization allows us to use interleaved joining when combining VALUES clauses with unions in the majority of practical cases, which is much more efficient.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

