### PR TITLE
GH-3102 favour BindingSetAssignment if it binds variables in the query

### DIFF
--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizerEmptyStatisticsTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizerEmptyStatisticsTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+
+/**
+ * Tests to monitor QueryJoinOptimizer behaviour when cardinalities are below 1.
+ *
+ */
+public class QueryJoinOptimizerEmptyStatisticsTest extends QueryJoinOptimizerTest {
+
+	@Override
+	public QueryJoinOptimizer getOptimizer() {
+		return new QueryJoinOptimizer(new EvaluationStatistics() {
+			@Override
+			protected CardinalityCalculator createCardinalityCalculator() {
+				return cardinalityCalculator;
+			}
+
+			final CardinalityCalculator cardinalityCalculator = new CardinalityCalculator() {
+				@Override
+				protected double getCardinality(StatementPattern sp) {
+					double value = 0.1;
+					if (sp.getSubjectVar() == null || !sp.getSubjectVar().hasValue()) {
+						value += 0.1;
+					}
+					if (sp.getPredicateVar() == null || !sp.getPredicateVar().hasValue()) {
+						value += 0.1;
+					}
+					if (sp.getObjectVar() == null || !sp.getObjectVar().hasValue()) {
+						value += 0.1;
+					}
+					if (sp.getContextVar() == null || !sp.getContextVar().hasValue()) {
+						value += 0.1;
+					}
+					return value;
+				}
+			};
+		});
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizerTest.java
@@ -122,6 +122,29 @@ public class QueryJoinOptimizerTest extends QueryOptimizerTest {
 				.isInstanceOf(Extension.class);
 	}
 
+	@Test
+	public void testValues() throws RDF4JException {
+		String query = String.join("\n", "",
+				"prefix ex: <ex:> ",
+				"select * where {",
+				"	values ?x {ex:a ex:b ex:c ex:d ex:e ex:f ex:g}",
+				"	?b a ?x. ",
+				"}"
+		);
+
+		String expectedQuery = String.join("\n", "",
+				"prefix ex: <ex:> ",
+				"select * where {",
+				"	values ?x {ex:a ex:b ex:c ex:d ex:e ex:f ex:g}",
+				"	{",
+				"		?b a ?x. ",
+				"	}",
+				"}"
+		);
+
+		testOptimizer(expectedQuery, query);
+	}
+
 	@Override
 	public QueryJoinOptimizer getOptimizer() {
 		return new QueryJoinOptimizer();
@@ -137,7 +160,7 @@ public class QueryJoinOptimizerTest extends QueryOptimizerTest {
 		}
 	}
 
-	private void testOptimizer(String expectedQuery, String actualQuery)
+	void testOptimizer(String expectedQuery, String actualQuery)
 			throws MalformedQueryException, UnsupportedQueryLanguageException {
 		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, actualQuery, null);
 		QueryJoinOptimizer opt = getOptimizer();


### PR DESCRIPTION
Signed-off-by: Håvard Ottestad <hmottestad@gmail.com>


GitHub issue resolved: #3102  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- cherry-pick of fix for GH-3102 to include in the upcomgin 3.7.3 patch release

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

