### PR TITLE
GH-3329 ensure ping threads are closed when RDF4JProtocolSession exits

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
@@ -213,6 +213,7 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 				ping.cancel(false);
 				ping = null;
 			}
+			pingScheduler.shutdownNow();
 		}
 	}
 

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
@@ -532,6 +532,8 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 		}
 	}
 
+	// This is currently disabled because the implementation of removeData in RDF4JProtocolSession
+	// relies on an active transaction. See https://github.com/eclipse/rdf4j/issues/3336
 	/*
 	 * @Override public void remove(Resource subject, URI predicate, Value object, Resource... contexts) throws
 	 * RepositoryException { if (!isActive()) { // operation is not part of a transaction - just send directly


### PR DESCRIPTION
GitHub issue resolved: #3329  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- RDF4JProtocolSession.close now forces a shutdown on its internal ping thread scheduler

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

