### PR TITLE
AbstractCloseableIteration is not thread safe so stop having volatile and synchronized code inside it.

### DIFF
--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/AbstractCloseableIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/AbstractCloseableIteration.java
@@ -11,6 +11,8 @@ package org.eclipse.rdf4j.common.iteration;
 /**
  * Base class for {@link CloseableIteration}s offering common functionality. This class keeps track of whether the
  * iteration has been closed and handles multiple calls to {@link #close()} by ignoring all but the first call.
+ * 
+ * Instances of this class is not safe to be accessed from multiple threads at the same time.
  */
 public abstract class AbstractCloseableIteration<E, X extends Exception> implements CloseableIteration<E, X> {
 
@@ -21,8 +23,7 @@ public abstract class AbstractCloseableIteration<E, X extends Exception> impleme
 	/**
 	 * Flag indicating whether this iteration has been closed.
 	 */
-	private volatile boolean closed = false;
-	private final Object MONITOR_FOR_CLOSED = new Object();
+	private boolean closed = false;
 
 	/*---------*
 	 * Methods *
@@ -42,26 +43,9 @@ public abstract class AbstractCloseableIteration<E, X extends Exception> impleme
 	 */
 	@Override
 	public final void close() throws X {
-		// this code is used because AtomicBoolean is slow for our usecase
 		if (!closed) {
-
-			// closedInThisCall will be true if we actually end up setting closed = true within this method call
-			boolean closedInThisCall = false;
-
-			// We synchronize here on _MONITOR_FOR_CLOSED_ so that we eliminate any race conditions then we read the
-			// variable again, since it could have been modified since last we checked it. Do not synchronize on _this_
-			// since it causes contention with subclasses that might also use synchronization. See issue
-			// https://github.com/eclipse/rdf4j/issues/2774.
-			synchronized (MONITOR_FOR_CLOSED) {
-				if (!closed) {
-					closed = true;
-					closedInThisCall = true;
-				}
-			}
-
-			if (closedInThisCall) {
-				handleClose();
-			}
+			closed = true;
+			handleClose();
 		}
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #GH-3042
Briefly describe the changes proposed in this PR:

AbstractCloseableIteration is not thread safe so stop having volatile and synchronized code inside it. 
Do note that it is not thread safe.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

