### PR TITLE
GH-3356 Add complexQuery benchmark to memory store as in native store…

### DIFF
--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
@@ -122,12 +122,26 @@ public class QueryBenchmark {
 	}
 
 	@Benchmark
-	public List<BindingSet> groupByQuery() {
+	public long groupByQuery() {
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			return Iterations.asList(connection
+			return connection
 					.prepareTupleQuery(query1)
-					.evaluate());
+					.evaluate()
+					.stream()
+					.count();
+		}
+	}
+
+	@Benchmark
+	public long complexQuery() {
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query4)
+					.evaluate()
+					.stream()
+					.count();
 		}
 	}
 


### PR DESCRIPTION
… Benchmark


GitHub issue resolved: #GH-3356

Briefly describe the changes proposed in this PR:

Reduce unfortunate differences between nativerdf/memory store QueryBenchmark file.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

