### PR TITLE
GH-3347 make LOAD_EXTERNAL_DTD compulsory so default is set to false

### DIFF
--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLReaderBasedParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/XMLReaderBasedParser.java
@@ -23,10 +23,8 @@ public abstract class XMLReaderBasedParser extends AbstractRDFParser {
 
 	private final static Set<RioSetting<Boolean>> compulsoryXmlFeatureSettings = new HashSet<>(
 			Arrays.asList(XMLParserSettings.SECURE_PROCESSING, XMLParserSettings.DISALLOW_DOCTYPE_DECL,
-					XMLParserSettings.EXTERNAL_GENERAL_ENTITIES, XMLParserSettings.EXTERNAL_PARAMETER_ENTITIES));
-
-	private final static Set<RioSetting<Boolean>> optionalXmlFeatureSettings = new HashSet<>(
-			Arrays.asList(XMLParserSettings.LOAD_EXTERNAL_DTD));
+					XMLParserSettings.EXTERNAL_GENERAL_ENTITIES, XMLParserSettings.EXTERNAL_PARAMETER_ENTITIES,
+					XMLParserSettings.LOAD_EXTERNAL_DTD));
 
 	protected XMLReaderBasedParser(ValueFactory f) {
 		super(f);
@@ -81,7 +79,7 @@ public abstract class XMLReaderBasedParser extends AbstractRDFParser {
 	 *         {@link XMLReader#setFeature(String, boolean)}.
 	 */
 	public Collection<RioSetting<Boolean>> getOptionalXmlFeatureSettings() {
-		return Collections.unmodifiableSet(optionalXmlFeatureSettings);
+		return Collections.<RioSetting<Boolean>>emptyList();
 	}
 
 	/**

--- a/core/rio/trix/src/test/resources/org/eclipse/rdf4j/rio/trix/trix-xxe-external-dtd.trix
+++ b/core/rio/trix/src/test/resources/org/eclipse/rdf4j/rio/trix/trix-xxe-external-dtd.trix
@@ -1,0 +1,10 @@
+<!DOCTYPE TriX SYSTEM "non-existent.dtd">
+<TriX>
+    <graph>
+        <triple>
+            <uri>http://example.org/Bob</uri>
+            <uri>http://example.org/name</uri>
+            <plainLiteral>&xxe;</plainLiteral>
+        </triple>
+    </graph>
+</TriX>


### PR DESCRIPTION
GitHub issue resolved: #3347 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- make LOAD_EXTERNAL_DTD a compulsory XML feature setting so that its default value (`false`) is explicitly configured on the SAX reader
- added regression tests

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

