### PR TITLE
GH-3377: fix FedX filter optimizations for ExclusiveGroups

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveGroup.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveGroup.java
@@ -64,6 +64,8 @@ public class ExclusiveGroup extends AbstractQueryModelNode
 		ownedEndpoint = queryInfo.getFederationContext().getEndpointManager().getEndpoint(owner.getEndpointID());
 
 		strategy = queryInfo.getFederationContext().getStrategy();
+
+		ownedNodes.forEach(node -> node.setParentNode(this));
 	}
 
 	/**
@@ -86,6 +88,9 @@ public class ExclusiveGroup extends AbstractQueryModelNode
 		if (boundFilters != null) {
 			BoundFiltersNode.visit(visitor, boundFilters);
 		}
+		if (filterExpr != null) {
+			filterExpr.visit(visitor);
+		}
 	}
 
 	@Override
@@ -96,12 +101,16 @@ public class ExclusiveGroup extends AbstractQueryModelNode
 
 	@Override
 	public Set<String> getAssuredBindingNames() {
-		return Collections.emptySet();
+		Set<String> res = new HashSet<>();
+		owned.forEach(e -> res.addAll(e.getAssuredBindingNames()));
+		return res;
 	}
 
 	@Override
 	public Set<String> getBindingNames() {
-		return Collections.emptySet();
+		Set<String> res = new HashSet<>();
+		owned.forEach(e -> res.addAll(e.getBindingNames()));
+		return res;
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/FilterOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/FilterOptimizer.java
@@ -329,7 +329,9 @@ public class FilterOptimizer extends AbstractQueryModelVisitor<OptimizationExcep
 		}
 
 		public boolean shouldAddFilter(FilterTuple filterTuple) {
-			if (hasUnionParent(filterTuple)) {
+			if (filterTuple.getParentNode() instanceof ExclusiveGroup) {
+				return false;
+			} else if (hasUnionParent(filterTuple)) {
 				return true;
 			} else if (added > 0) {
 				// only push filter if it has not been applied to another statement

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FilterTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/FilterTests.java
@@ -85,4 +85,12 @@ public class FilterTests extends SPARQLBaseTest {
 					Sets.newHashSet(iri("http://namespace1.org/", "Person_1")));
 		}
 	}
+
+	@Test
+	public void testFilter_ExclusiveGroup_Regex() throws Exception {
+		prepareTest(Arrays.asList("/tests/data/data1.ttl", "/tests/data/data3.ttl"));
+
+		execute("/tests/filter/query07.rq", "/tests/filter/query07.srx", false);
+		evaluateQueryPlan("/tests/filter/query07.rq", "/tests/filter/query07.qp");
+	}
 }

--- a/tools/federation/src/test/resources/tests/filter/query07.qp
+++ b/tools/federation/src/test/resources/tests/filter/query07.qp
@@ -1,0 +1,28 @@
+QueryRoot
+   Distinct
+      Projection
+         ProjectionElemList
+            ProjectionElem "person"
+         NJoin
+            ExclusiveGroup
+               ExclusiveStatement
+                  Var (name=person)
+                  Var (name=_const_23b7c3b6_uri, value=http://xmlns.com/foaf/0.1/name, anonymous)
+                  Var (name=name)
+                  StatementSource (id=endpoint1, type=REMOTE)
+               ExclusiveStatement
+                  Var (name=person)
+                  Var (name=_const_8d89de74_uri, value=http://xmlns.com/foaf/0.1/age, anonymous)
+                  Var (name=age)
+                  StatementSource (id=endpoint1, type=REMOTE)
+               FilterExpr
+                  Regex
+                     Var (name=name)
+                     ValueConstant (value="Person1")
+                     ValueConstant (value="i")
+            StatementSourcePattern
+               Var (name=person)
+               Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)
+               Var (name=type)
+               StatementSource (id=endpoint1, type=REMOTE)
+               StatementSource (id=endpoint2, type=REMOTE)

--- a/tools/federation/src/test/resources/tests/filter/query07.rq
+++ b/tools/federation/src/test/resources/tests/filter/query07.rq
@@ -1,0 +1,7 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT DISTINCT ?person WHERE { 
+	?person foaf:name ?name .
+	?person foaf:age ?age . 
+	FILTER(REGEX(?name, "Person1", "i"))
+	?person a ?type .
+}

--- a/tools/federation/src/test/resources/tests/filter/query07.srx
+++ b/tools/federation/src/test/resources/tests/filter/query07.srx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="person"/>
+  </head>
+  <results>
+    <result>
+      <binding name="person"><uri>http://namespace1.org/Person_1</uri></binding>
+    </result>
+  </results>
+</sparql>
+


### PR DESCRIPTION
GitHub issue resolved: #3377 


Briefly describe the changes proposed in this PR:

- do not push filter expressions into exclusive statements, as they have
to be handled on the exclusive group
- fix parent assignment for exclusive statements when adding them to the
group
- fix computation of scope binding names in exclusive groups by
collecting the bindings produced by the individual statements

Covered with a unit test that checks evaluation and the produced query
plan

Signed-off-by: Andreas Schwarte <aschwarte10@gmail.com>


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

