### PR TITLE
Add Demo Project for RDF4J-Spring

### DIFF
--- a/site/content/documentation/programming/spring.md
+++ b/site/content/documentation/programming/spring.md
@@ -1,0 +1,643 @@
+---
+title: "Integration with Spring"
+weight: 6
+toc: true
+autonumbering: true
+---
+
+The {{< javadoc "rdf4j-spring" "spring/" >}} module allows for using an RDF4J repository as the data backend of a spring application.
+<!--more-->
+
+A self-contained demo application can be found at {{< javadoc "rdf4j-spring-demo" "spring/demo" >}}
+
+## Getting Started
+
+To use RDF as the data backend of a spring application built with maven, use these dependencies: 
+
+```$xml
+    <dependency>
+        <groupId>org.eclipse.rdf4j</groupId>
+        <artifactId>rdf4j-spring</artifactId>
+        <version>${rdf4j.version}</version>
+    </dependency>
+```  
+... setting the property `rdf4j.version` is set to the RDF4J version you want (minimum `4.0.0`).
+
+In order for the application to run, a repository has to be configured:
+
+To configure the application to access an existing repository, set the following configuration properties, e.g. in `application.properties`:
+```properties
+ rdf4j.spring.repository.remote.manager-url=http://localhost:7200
+ rdf4j.spring.repository.remote.name=myrepo
+```
+To use an in-memory repository (for example, for unit tests), use
+```properties
+rdf4j.spring.repository.inmemory.enabled=true
+```
+
+
+## Programming with RDF4J-Spring
+
+The main purpose of `rdf4j-spring` is to support accessing an RDF4J repository using the [DAO pattern](https://en.wikipedia.org/wiki/Data_access_object). 
+DAOs are subclasses of {{< javadoc "RDF4JDao" "spring/dao/RDF4JDao.html" >}} and use 
+the {{< javadoc "RDF4JTemplate" "/spring/support/RDF4JTemplate.html" >}} for accessing 
+the [RDF4J repository configured for the application]({{< relref "spring.md#configuring-a-repository" >}}). 
+
+### RDF4JTemplate
+
+The `RDF4JTemplate` is the class used to access a `Repository` in `rdf4j-spring`. A bean of this type is configured
+at start up and available for wiring into beans. The `RDF4JTemplate` accesses the `Repository` through a `RepositoryConnection` 
+that it obtains from a {{< javadoc "RepositoryConnectionFactory" "spring/support/connectionFactory/RepositoryConnectionFactory.html" >}}. 
+This indirection allows for using a connection pool, connect RDF4J to spring's transaction management, and provide 
+query logging to a file or exposing query statistics via JMX. These features can be enabled/disabled using 
+configuration properties (see [Configuration]({{< relref "spring.md#configuration" >}}))
+
+#### Wiring into a spring bean
+To use the `RDF4JTemplate` in a bean, define that bean in the spring application's configuration and wire the `RDF4JTemplate` in:
+```java
+@Configuration
+@Import(RDF4JConfig.class)
+public class MyAppConfig {
+	@Bean
+	public MyBeanClass getMyBean(@Autowired RDF4JTemplate template){
+        return new MyBeanClass(template);
+    }    
+}
+```
+```java
+public class MyBeanClass {
+
+	private RDF4JTemplate rdf4JTemplate;
+    
+    public MyBeanClass(RDF4JTemplate template){
+        this.rdf4jTemplate = template;
+    }
+}
+``` 
+ 
+#### Evaluating queries and executing updates 
+ 
+The RDF4JTemplate offers various ways to access the repository. 
+For example, to evaluate a `TupleQuery` using the `RDF4JTemplate` (in this case, counting all triples):
+
+```java
+int count = rdf4JTemplate
+				.tupleQuery("SELECT (count(?a) as ?cnt) WHERE { ?a ?b ?c }")
+				.evaluateAndConvert()
+				.toSingleton(bs -> TypeMappingUtils.toInt(QueryResultUtils.getValue(bs, "cnt")));
+``` 
+
+The query, provided through the `tupleQuery` method, is executed with the call to `evaluateAndConvert()`, which returns 
+a {{< javadoc "TupleQueryResultConverter" "spring/dao/support/operation/TupleQueryResultConverter.html" >}}. 
+The latter provides methods for converting the `TupleQueryResult` of the query into an object, an `Optional`, a `Map`, 
+`Set`, `List`, or `Stream`. In the example, we are just interested in the count as an `int` - one single object - so we use 
+the `toSingleton()` method and convert the value of the projection variable to an int. The conversion is done 
+using {{< javadoc "TypeMappingUtils" "spring/util/TypeMappingUtils.html" >}}; the 
+extraction of the variable's value from the `BindingSet bs` is done using 
+{{< javadoc "QueryResultUtils" "spring/util/QueryResultUtils.html" >}}.
+
+#### Pre-binding variables
+
+For binding variables before executing a query or update, use the {{< javadoc "OperationBuilder" "spring/dao/support/opbuilder/OperationBuilder.html" >}}
+returned by the `tupleQuery()`, `graphQuery`, or `update` methods. It provides various `withBinding()` methods following 
+the builder pattern, allowing for binding variables, as illustrated in the following example.
+```java
+Set<IRI> artists = rdf4JTemplate
+                    .tupleQuery("PREFIX ex: <http://example.org/>"
+				            + "SELECT distinct ?artist "
+				            + "WHERE { ?artist a ?type }")
+				    .withBinding("type", EX.Artist)
+				    .evaluateAndConvert()
+				    .toSet(bs -> QueryResultUtils.getIRI(bs, "artist"));
+```   
+
+#### Using the RepositoryConnection directly
+
+For using the {{< javadoc "RepostoryConnection" "repository/RepositoryConnection.html" >}} directly, 
+without the need to generate a result, the `consumeConnection()` method is used:
+
+```java 
+rdf4JTemplate.consumeConnection(con -> con.remove(EX.Picasso, RDF.TYPE, EX.Artist);
+```
+
+Alternatively, to generate a result, the `applyToConnection()` method is used:
+```java 
+boolean isPresent = rdf4JTemplate.applyToConnection(
+                        con -> con.hasStatement(EX.Picasso, RDF.TYPE, EX.Artist, true);
+```
+
+#### Using SPARQL queries/updates from external files
+
+For running queries or updates from external resources, the `[(tupleQuery|graphQuery|update)FromResource]` methods can be used.
+
+For example, the `sparql/construct-artists.rq` file on the classpath might contain this query:
+```sparql
+PREFIX ex: <http://example.org/>
+CONSTRUCT {?artist ?p ?o } WHERE { ?artist a ex:Artist; ?p ?o }
+```
+and could be evaluated using
+```java
+Model model = rdf4JTemplate.graphQueryFromResource(
+                        getClass(), 
+                        "classpath:sparql/construct-artists.rq")
+				        .evaluateAndConvert()
+				        .toModel();
+```
+
+The resource to be read is resolved by spring's [ResourceLoader](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/io/ResourceLoader.html), 
+which supports fully qualified URLs (e.g., `file://` URLs, relative paths and `classpath:` pseudo-URLs.) 
+
+### Implementing a DAO 
+
+Any spring bean that uses the `RDF4JTemplate` can be seen as a DAO and participates in transactionality, query logging, 
+caching, etc. However, `rdf4j-spring` provides a few base classes that provide frequently used functionality.
+
+#### RDF4JDao
+{{< javadoc "RDF4JDao" "spring/dao/RDF4JDao.html" >}} is a suitable base class for a general-purpose DAO. It provides 
+two functionalities to subclasses: 
+    
+* The `RDF4JTemplate` is automatically wired into the bean and it is available through `getRDF4JTemplate()`
+    
+* It provides a simple management facility for SPARQL query/update strings. This allows for SPARQL queries being
+generated only once (by String concatenation, read from a file, or built with the [SparqlBuilder](../../tutorials/sparqlbuilder)).
+The queries are prepared in the template method `prepareNamedSparqlSuppliers()`:  
+
+In the following example, we
+* create a DAO, extending `RDF4JDao`
+* annotate it with [`@Component`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/index.html?org/springframework/core/io/package-summary.html) 
+so it gets auto-detected during Spring's component scan
+* create an inner class, `QUERY_KEYS`, as a container for `String` constants we use for query keys
+* implement the {{< javadoc "prepareNamedSparqlSuppliers" "spring/support/RDF4JDao.html#prepareNamedSparqlSuppliers(org.eclipse.rdf4j.spring.dao.RDF4JDao.NamedSparqlSupplierPreparer)" >}} method and add one query
+* use the prepared query in a DAO method (`getArtistsWithoutPaintings()`). We access the prepared query with {{< javadoc "getNamedTupleQuery(String)" "spring/support/RDF4JDao.html#getNamedTupleQuery(java.lang.String)" >}}, passing the constant we defined in `QUERY_KEYS`.
+
+  
+```java
+
+@Component // make the DAO a spring component so it's auto-detected in the classpath scan
+public class ArtistDao extends RDF4JDao {
+    
+    // constructor, other methods etc
+
+    // recommended: encapsulate the keys for queries in an object
+    // so it's easier to find them when you need them
+	static abstract class QUERY_KEYS {
+		public static final String ARTISTS_WITHOUT_PAINTINGS = "artists-without-paintings";
+	}
+
+    // prepare the named queries, assigning each one of the keys
+	@Override
+	protected NamedSparqlSupplierPreparer prepareNamedSparqlSuppliers(NamedSparqlSupplierPreparer preparer) {
+		return preparer
+            .forKey(QUERY_KEYS.ARTISTS_WITHOUT_PAINTINGS)
+            .supplySparql(Queries.SELECT(
+                            ARTIST_ID)
+                            .where(
+                                ARTIST_ID.isA(iri(EX.Artist))
+                                .and(ARTIST_ID.has(iri(EX.creatorOf), Painting.PAINTING_ID).optional())
+                                .filter(not(bound(Painting.PAINTING_ID)))).getQueryString()
+            );
+	}
+
+    // use the named query with getNamedTupleQuery(String)
+	public Set<Artist> getArtistsWithoutPaintings(){
+		return getNamedTupleQuery(QUERY_KEYS.ARTISTS_WITHOUT_PAINTINGS)
+						.evaluateAndConvert()
+						.toStream()
+						.map(bs -> QueryResultUtils.getIRI(bs, ARTIST_ID))
+						.map(iri -> getById(iri))
+						.collect(Collectors.toSet());
+	}
+    
+    // ...
+
+}
+```
+#### SimpleRDF4JCRUDDao
+
+The {{< javadoc "SimpleRDF4JCRUDDao" "spring/dao/SimpleRDF4JCRUDDao.html" >}} is a suitable base class for a DAO for
+creating, reading, updating, and deleting one class of entities. It requires two type parameters, `ENTITY` and `ID`.
+It provides create, read, update, and delete functionality for the `ENTITY` class, using the `ID` class wherever the 
+entity's identifier is required. 
+
+Subclasses of `SimpleRDF4JCRUDDao` must implement a couple of template methods in order to customize the generic 
+behaviour for the specific entity and id classes.
+
+In the following, we use the entity {{< javadoc "Artist" "spring/demo/model/Artist.html">}} (as used in the demo 
+application) as an example. Note that we define public constants of type {{< javadoc "ExtendedVariable" "sparqlbuilder/core/ExtendedVariable.html" >}}, 
+one corresponding to each of the entity's fields.
+ 
+```java
+public class Artist {
+    // recommended pattern: use a public ExtendedVariable constant for each of the entities fields 
+    // for use in queries and result processing. 
+	public static final ExtendedVariable ARTIST_ID = new ExtendedVariable("artist_id"); 
+	public static final ExtendedVariable ARTIST_FIRST_NAME = new ExtendedVariable("artist_firstName");
+	public static final ExtendedVariable ARTIST_LAST_NAME = new ExtendedVariable("artist_lastName");
+	private IRI id;
+	private String firstName;
+	private String lastName;
+    // getter, setter, constructor, ...
+    // be sure to implement equals() and hashCode() for proper behaviour of collections!
+}
+``` 
+
+The {{< javadoc "ArtistDao" "spring/demo/dao/ArtistDao.html">}} is shown in the following code snippets.
+
+We recommend to use `@Component` for auto-detection. Implementing the constructor is required. 
+```java
+@Component // again, make it a component (see above) 
+public class ArtistDao extends SimpleRDF4JCRUDDao<Artist, IRI> {
+
+	public ArtistDao(RDF4JTemplate rdf4JTemplate) {
+		super(rdf4JTemplate);
+	}
+``` 
+
+The `populateIdBindings` method is called by the superclass to bind the id to variable(s) in a SPARQL query.
+```java
+	@Override
+	protected void populateIdBindings(MutableBindings bindingsBuilder, IRI iri) {
+		bindingsBuilder.add(ARTIST_ID, iri);
+	}
+```
+
+The `populateBindingsForUpdate` method is called by the superclass to bind all non-id variables when performing an update.
+```java
+	@Override
+	protected void populateBindingsForUpdate(MutableBindings bindingsBuilder, Artist artist) {
+		bindingsBuilder
+				.add(ARTIST_FIRST_NAME, artist.getFirstName())
+				.add(ARTIST_LAST_NAME, artist.getLastName());
+	}
+```
+
+The `mapSolution` method converts a query solution, i.e., a {{< javadoc "BindingSet" "query/BindingSet.html">}}, to an instance of the entity.
+```java
+	@Override
+	protected Artist mapSolution(BindingSet querySolution) {
+		Artist artist = new Artist();
+		artist.setId(QueryResultUtils.getIRI(querySolution, ARTIST_ID));
+		artist.setFirstName(QueryResultUtils.getString(querySolution, ARTIST_FIRST_NAME));
+		artist.setLastName(QueryResultUtils.getString(querySolution, ARTIST_LAST_NAME));
+		return artist;
+	}
+```
+
+The `getReadQuery` method provides the SPARQL string used to read one entity. Note that the variable names must be the 
+same ones used in `mapSolution(BindingSet)`. It may be cleaner to use the SparqlBuilder for generating this string.
+```java
+	@Override
+	protected String getReadQuery() {
+		return "prefix foaf: <http://xmlns.com/foaf/0.1/> "
+				+ "prefix ex: <http://example.org/> "
+				+ "SELECT ?artist_id ?artist_firstName ?artist_lastName where {"
+				+ "?artist_id a ex:Artist; "
+				+ "    foaf:firstName ?artist_firstName; "
+				+ "    foaf:surname ?artist_lastName ."
+				+ " } ";
+	}
+```
+
+The `getInsertSparql(ENTITY)` method provides the SPARQL string for inserting a new instance. This SPARQL operation
+will also be used for updates. If updates require a different operation from inserts, it must be provided by implementing
+`getUpdateSparql(ENTITY)`. 
+```java
+	@Override
+	protected NamedSparqlSupplier getInsertSparql(Artist artist) {
+		return NamedSparqlSupplier.of("insert", () -> Queries.INSERT(ARTIST_ID.isA(iri(EX.Artist))
+				.andHas(iri(FOAF.FIRST_NAME), ARTIST_FIRST_NAME)
+				.andHas(iri(FOAF.SURNAME), ARTIST_LAST_NAME))
+				.getQueryString());
+	}
+```
+
+The `getInputId(ENTITY)` method is used to generate the `id` of an entity to be inserted. Here, we use the `id` of the
+specified `artist` object; if it is null we generate a new `IRI` using `getRdf4JTemplate().getNewUUID()`.  
+```java
+	@Override
+	protected IRI getInputId(Artist artist) {
+		if (artist.getId() == null) {
+			return getRdf4JTemplate().getNewUUID();
+		}
+		return artist.getId();
+	}
+}
+```
+
+##### Composite Keys
+
+If the entity uses a composite key, a class implementing {{< javadoc "CompositeKey" "spring/dao/support/key/CompositeKey.html">}} 
+must be used for the `ID` type parameter. For a key consisting of two components, the {{< javadoc "CompositeKey2" "spring/dao/support/key/CompositeKey2.html">}}
+class is available. If more components are needed, the key class can be modeled after that one.
+
+##### RelationMapBuilder
+
+It is not uncommon for an application to read a relation present in the repository data into a `Map`. For example, we
+might want to group painting `id`s by artist `id`. The {{<javadoc "RelationMapBuilder" "spring/dao/support/RelationMapBuilder.html">}}
+provides the necesary functionality for such cases:
+
+```java
+RelationMapBuilder b = new RelationMapBuilder(getRDF4JTemplate(), EX.creatorOf);
+Map<IRI, Set<IRI>> paintingsByArtists = b.buildOneToMany();
+```  
+Additional Functionality:
+* The `constraints(GraphPattern)` method restricts the relation 
+* The `relationIsOptional()` method allows for the object to be missing, in which case an empty set is generated for the subject key.
+* The `useRelationObjectAsKey()` method flips the map such that the objects of the relation are used as keys and the subjects are aggregated.
+* The `buildOneToOne()` method returns a one to one mapping, which dies horribly if the data is not 1:1 
+
+#### RDF4JCRUDDao
+
+The {{< javadoc "RDF4JCRUDDao" "spring/dao/RDF4JCRUDDao.html" >}} is essentially the same as the `SimpleRDF4JCRUDDao`, 
+with the one difference that it has three type parameters, `ENTITY`, `INPUT`, and `ID`. The class thus allows different 
+classes for input and output: creation and updates use `INPUT`, e.g. `save(INPUT)`, reading methods use `ENTITY`, e.g.
+`ENTITY getById(ID)`. 
+
+
+### Service Layer
+
+Usually, the functionality offered by DAOs is rather narrow, e.g. CRUD methods for one entity class. They 
+are combined to provide a wider range of functionality in the *servcie layer*. The only thing one 
+needs to know when implementing the service layer with `rdf4j-spring` DAOs is that its methods need to participate
+in spring's transaction management. The most straightforward way to do this is to use the [`@Transactional`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/annotation/Transactional.html)
+method annotation, causing the service object to be wrapped with a proxy that takes care of transactionality. 
+ 
+The following code snippet, taken from the demo's {{< javadoc "ArtService" "spring/demo/service/ArtService.html">}} class, 
+shows part of a simple service.  
+ 
+```java
+@Component
+public class ArtService {
+	
+    @Autowired
+	private ArtistDao artistDao;
+
+	@Autowired
+	private PaintingDao paintingDao;
+
+	@Transactional
+	public Artist createArtist(String firstName, String lastName) {
+		Artist artist = new Artist();
+		artist.setFirstName(firstName);
+		artist.setLastName(lastName);
+		return artistDao.save(artist);
+	}
+
+	@Transactional
+	public Painting createPainting(String title, String technique, IRI artist) {
+		Painting painting = new Painting();
+		painting.setTitle(title);
+		painting.setTechnique(technique);
+		painting.setArtistId(artist);
+		return paintingDao.save(painting);
+	}
+
+	@Transactional
+	public List<Painting> getPaintings() {
+		return paintingDao.list();
+	}
+
+	@Transactional
+	public List<Artist> getArtists() {
+		return artistDao.list();
+	}
+
+	@Transactional
+	public Set<Artist> getArtistsWithoutPaintings(){
+		return artistDao.getArtistsWithoutPaintings();
+	}
+    
+    // ...
+
+}
+```   
+
+## Testing with Junit 5
+
+Testing an application built with `rdf4j-spring` can be done at the DAO layer as well as on the service layer. Generally,
+applications will have more than one test classes.
+
+The common approach is to have a configuration for tests that is shared by all tests, and this configuration prepares
+the spring context with all the required facilities. A minimal, shared test configuration is the following:
+
+```java
+@TestConfiguration
+@EnableTransactionManagement
+@ComponentScan("com.example.myapp.dao")
+public class TestConfig {
+
+    @Bean
+    DataInserter getDataInserter() {
+        return new DataInserter();
+    }
+    
+}
+``` 
+
+With this configuration, a test class can use the `dataInserter` bean to insert data into an inmemory repository before
+each test:
+
+```java
+@ExtendWith(SpringExtension.class)
+@Transactional
+@ContextConfiguration(
+		classes = {
+				RDF4JConfig.class,
+				TestConfig.class,
+		})
+@TestPropertySource("classpath:application.properties")
+@TestPropertySource(
+		properties = {
+				"rdf4j.spring.repository.inmemory.enabled=true",
+				"rdf4j.spring.repository.inmemory.use-shacl-sail=true",
+				"rdf4j.spring.tx.enabled=true",
+				"rdf4j.spring.resultcache.enabled=false",
+				"rdf4j.spring.operationcache.enabled=false",
+				"rdf4j.spring.pool.enabled=true",
+				"rdf4j.spring.pool.max-connections=2"
+		})
+@DirtiesContext
+public class ArtistDaoTests {
+
+    @Autowired
+    private ArtistDao artistDao;       
+
+	@BeforeAll
+	public static void insertTestData(
+			@Autowired DataInserter dataInserter,
+			@Value("classpath:/data/my-testdata.ttl") Resource dataFile) {
+		dataInserter.insertData(dataFile);
+	}
+    
+    @Test
+    public void testReadArtist(){
+         // ...          
+    }      
+
+}
+```
+
+### Testing against a local database
+ 
+The inmemory repository is likely to behave differently from any database used in production in some edge cases. It
+is recommended to test against a local installation of the database that is used in production in addition to testing
+against the inmemory repository. 
+
+With `rdf4j-spring` this is quite straightforward:
+1. install the database locally and create a repository for the tests
+2. provide a property file on the classpath with the necessary properties to connect to that repository 
+(`rdf4j.spring.repository.remote.*` properties)
+3. Create a subclass of your test class and provide the properties file through the `@TestPropertySource` annotation
+4. Use the `@Tag` annotation, so you can easily switch the test on or off using the configuration of your test environment 
+(most likely the Maven Surefire Plugin), as the local database installation will not be present in many build environments.
+
+Example:
+```java
+@Tag("requires-local-database")
+@TestPropertySource("classpath:/repository-localdb.properties")
+public class ArtistDaoDbTests extends ArtistDaoTests {
+// no code needed, the class is just created to run your ArtistDaoTests with a different configuration     
+}
+```
+   
+   
+ 
+## Debugging
+
+In addition to [query logging]({{< relref "spring.md#query-logging" >}}), if you need to get a close look at what's happening inside the `rdf4j-spring` code, 
+set the loglevel for `org.eclipse.rdf4j.spring` to `DEBUG`. Sometimes it may be required to look into what spring is doing. 
+In this case, set `org.springframework` to `DEBUG` or even `TRACE`.
+
+One way to do this is to provide a `logback.xml` file on the classpath, as can be found in the source at `rdf4j-spring/src/test/resources/logback.xml`.
+
+Another way to set the loglevel is to provide an application property starting with `logging.level.`, e.g.
+```properties
+logging.level.org.eclipse.rdf4j.spring=DEBUG
+```
+which can be provided in an `application.properties` (for details and other ways to do that, have a look at the documentation on [Externalied Configuration](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config) in Spring).
+
+ 
+
+## Configuration 
+
+`rdf4j-spring` makes use of the auto-configuration feature in Spring (configured in the source file `rdf4j-spring/META-INF/spring.factories`).
+That means that bean creation at start up is governed by configuration properties, all of which are prefixed by `rdf4j.spring.` 
+
+The following table shows all subsystems with their property prefixes, the packages they reside in, and the class holding their properties. 
+  
+| Subsystem | property prefix | package (links to reference) | Properties class |
+| --------- | ----------------| --------| -----------------|
+| [Repository]({{< relref "spring.md#repository" >}}) | `rdf4j.spring.repository.`| {{< javadoc "org.eclipse.rdf4j.spring.repository" "spring/repository/package-summary.html" >}} | {{< javadoc "RemoteRepositoryProperties" "spring/repository/remote/RemoteRepositoryProperties.html">}} and {{< javadoc "InMemoryRepositoryProperties" "spring/repository/inmemory/InMemoryRepositoryProperties.html">}} |
+| [Transaction management]({{< relref "spring.md#transaction-management" >}}) | `rdf4j.spring.tx.` | {{< javadoc "org.eclipse.rdf4j.spring.tx" "spring/tx/package-summary.html" >}} | {{< javadoc "TxProperties" "spring/tx/TxProperties.html">}} |
+| [Connection Pooling]({{< relref "spring.md#connection-pooling" >}}) | `rdf4j.spring.pool.` | {{< javadoc "org.eclipse.rdf4j.spring.pool" "spring/pool/package-summary.html" >}} | {{< javadoc "PoolProperties" "spring/pool/PoolProperties.html">}} | 
+| [Operation caching]({{< relref "spring.md#operation-caching" >}}) | `rdf4j.spring.operationcache.` | {{< javadoc "org.eclipse.rdf4j.spring.operationcache" "spring/operationcache/package-summary.html" >}} | {{< javadoc "OperationCacheProperties" "spring/operationcache/OperationCacheProperties.html">}} |      
+| [Operation logging]({{< relref "spring.md#operation-logging" >}}) | `rdf4j.spring.operationlog.` | {{< javadoc "org.eclipse.rdf4j.spring.operationlog" "spring/operationlog/package-summary.html" >}} | {{< javadoc "OperationLogProperties" "spring/operationlog/OperationLogProperties.html">}} and {{< javadoc "OperationLogJmxProperties" "spring/operationlog/log/jmx/OperationLogJmxProperties.html">}} |
+| [Query result caching]({{< relref "spring.md#query-result-caching" >}}) | `rdf4j.spring.resultcache.` | {{< javadoc "org.eclipse.rdf4j.spring.resultcache" "spring/resultcache/package-summary.html" >}} | {{< javadoc "ResultCacheProperties" "spring/resultcache/ResultCacheProperties.html">}} |         
+| [UUIDSource]({{< relref "spring.md#uuidsource" >}})| `rdf4j.spring.uuidsource.` |{{< javadoc "org.eclipse.rdf4j.spring.uuidsource" "spring/uuidsource/package-summary.html" >}} | {{< javadoc "SimpleUUIDSourceProperties" "spring/uuidsource/simple/SimpleUUIDSourceProperties.html">}}, {{< javadoc "NoveltyCheckingUUIDSourceProperties" "spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceProperties.html">}}, {{< javadoc "UUIDSequenceProperties" "spring/uuidsource/sequence/UUIDSequenceProperties.html">}}, and {{< javadoc "PredictableUUIDSourceProperties" "spring/uuidsource/predictable/PredictableUUIDSourceProperties.html">}}  | 
+
+These subsystems and their configuration are described in more detail below.
+
+### Repository
+
+As stated in the [Getting Started]({{< relref "spring.md#getting-started" >}}) section, to configure the application 
+to access an existing repository, set the following configuration properties, e.g. in `application.properties`:
+```properties
+ rdf4j.spring.repository.remote.manager-url=[manager-url]
+ rdf4j.spring.repository.remote.name=[name]
+```
+To use an in-memory repository (for example, for unit tests), use
+```properties
+rdf4j.spring.repository.inmemory.enabled=true
+```
+
+### Transaction management
+
+By default, `rdf4j-spring` connects with Spring's PlatformTransactionManager. To disable this connection, use 
+```properties
+rdf4j.spring.tx.enabled=false
+```
+
+### Connection Pooling
+
+Creating a `RepositoryConnection` has a certain overhead that many applications wish to avoid. `rdf4j-spring` allows for 
+pooling of such connections. Several configuration options, such as the maximum number of connections, are available
+(see {{< javadoc "PoolProperties" "spring/pool/PoolProperties.html" >}}).
+
+To enable, use
+```properties
+rdf4j.spring.pool.enabled=true
+``` 
+
+### Operation caching
+
+SPARQL operations (queries and updates) require some computation time to prepare from the SPARQL string they are based on.
+In `rdf4j-spring`, this process is hidden from clients and happens in the `RDF4JTemplate`. By default, operations 
+are not cached, and the same operation executed multiple times always has the overhead of parsing the SPARQL string and 
+generating the operation. If this feature is enabled, operations are cached per connection.
+ 
+Note: If [connection pooling]({{< relref "spring.md#connection-pooling" >}}) is enabled, it is possible that operations created in different threads will use different connections and will therefore
+all generate their own instance of the SPARQL operation, thus reducing the speedup incurred by operation caching.  
+
+To enable, use
+```properties
+rdf4j.spring.operationcache.enabled=true
+```
+
+### Operation logging 
+(aka Query logging)
+
+Two options are available for logging operations (queries and updates) sent to the repository:
+
+#### Operation logging via SLF4J
+Each operation is written to the logger `org.eclipse.rdf4j.spring.operationlog.log.slf4` with loglevel `DEBUG`.
+
+To enable, use
+````properties
+rdf4j.spring.operationlog.enabled=true
+````
+
+#### Operation logging via JMX
+
+Each operation is recorded (if identical operations are executed, statistics are aggregated) and exposed via JMX. 
+
+To enable, use
+```properties
+rdf4j.spring.operationlog.jmx.enabled=true
+``` 
+
+### Query result caching
+
+Applications that frequently execute the same queries might profit from result caching. If enabled, query results are 
+cached on a per-connection basis. By default, this cache is cleared at the end of the ongoing transaction. The performance
+impact of result caching is application-specific and is not unlikely to be negative. Measure carefully! 
+
+However, if the application is the only one using the `repository`, and therefore no updates are possible that the 
+application does not know about, the property `rdf4j.spring.resultcache.assumeNoOtherRepositoryClients=true` can be set. 
+In this case, results are copied to a global cache that all connections have access to, and which is only cleared when
+the application executes an update. 
+
+To enable result caching, use
+```properties
+rdf4j.spring.resultcache.enabled=true
+```
+### UUIDSource
+
+Using UUIDs as identifiers for entities is a common strategy for applications using an RDF store as their backend. Doing
+this requires a source of new, previously unused UUIDs for new entities created by the application. Conversely, in
+unit tests, it is sometimes required that the UUIDs are generated in a predictable manner, so that actual results
+can be compared with expected results containing generated UUIDs.
+
+The UUIDSource subsystem provides different implementations of the {{< javadoc "UUIDSource" "spring/support/UUIDSource.html">}} 
+interface. The configuration of this subsystem determines which implementation is wired into the `RDF4JTemplate` at
+start up and gets used by the application.
+
+In our opinion, the default implementation, {{< javadoc "DefaultUUIDSource" "spring/support/DefaultUUIDSource.html">}} 
+is sufficient for generating previously unused UUIDs. Collisions are possible but sufficiently unlikely, so using 
+any one of `noveltychecking`, `sequence`, and `simple` subsystems should not be necessary. 
+
+For using the `predictable` UUIDSource, which always produces the same sequence of UUIDs, use
+```properties
+rdf4j.spring.uuidsource.predictable.enabled=true
+```  
+
+ 

--- a/site/content/documentation/programming/spring.md
+++ b/site/content/documentation/programming/spring.md
@@ -418,11 +418,13 @@ Testing an application built with `rdf4j-spring` can be done at the DAO layer as
 applications will have more than one test classes.
 
 The common approach is to have a configuration for tests that is shared by all tests, and this configuration prepares
-the spring context with all the required facilities. A minimal, shared test configuration is the following:
+the spring context with all the required facilities. A minimal, shared test configuration is the following. Note that 
+it imports {{< javadoc "RDF4JTestConfig" "spring/test/RDF4JTestConfig.html">}}:
 
 ```java
 @TestConfiguration
 @EnableTransactionManagement
+@Import(RDF4JTestConfig.class)
 @ComponentScan("com.example.myapp.dao")
 public class TestConfig {
 
@@ -440,11 +442,7 @@ each test:
 ```java
 @ExtendWith(SpringExtension.class)
 @Transactional
-@ContextConfiguration(
-		classes = {
-				RDF4JConfig.class,
-				TestConfig.class,
-		})
+@ContextConfiguration(classes = { TestConfig.class })
 @TestPropertySource("classpath:application.properties")
 @TestPropertySource(
 		properties = {

--- a/site/content/documentation/programming/spring.md
+++ b/site/content/documentation/programming/spring.md
@@ -640,4 +640,8 @@ For using the `predictable` UUIDSource, which always produces the same sequence 
 rdf4j.spring.uuidsource.predictable.enabled=true
 ```  
 
- 
+## Acknowledgments
+
+The RDF4J-Spring module, the RDF4J-Spring-Demo, and this documentation have been developed in the project 
+'BIM-Interoperables Merkmalservice', funded by the Austrian Research Promotion Agency and Österreichische Bautechnik 
+Veranstaltungs GmbH.

--- a/spring-components/pom.xml
+++ b/spring-components/pom.xml
@@ -10,6 +10,7 @@
 	<modules>
 		<module>spring-boot-sparql-web</module>
 		<module>rdf4j-spring</module>
+		<module>rdf4j-spring-demo</module>
 	</modules>
 	<properties>
 		<spring.boot.version>2.4.12</spring.boot.version>

--- a/spring-components/rdf4j-spring-demo/README.md
+++ b/spring-components/rdf4j-spring-demo/README.md
@@ -1,0 +1,14 @@
+# RDF4J-Spring Demo
+
+Small demo application for `rdf4j-spring`. 
+
+The purpose of `rdf4j-spring` is to use an RDF4J repository as the data backend of a spring or spring boot application.
+
+To run the demo, do 
+
+```$bash
+mvn spring-boot:run
+```
+
+The program writes to stdout and exits. The class [ArtDemoCli](src/main/java/org/eclipse/rdf4j/spring.demo/ArtDemoCli.java) is a good starting point for looking at the code. 
+

--- a/spring-components/rdf4j-spring-demo/pom.xml
+++ b/spring-components/rdf4j-spring-demo/pom.xml
@@ -1,59 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.eclipse.rdf4j</groupId>
-    <artifactId>rdf4j-spring-demo</artifactId>
-    <name>RDF4J: Demo rdf4j-spring project</name>
-    <version>4.0.0-SNAPSHOT</version>
-    <description>Demo of a spring-boot project using an RDF4J repo as its backend</description>
-    <properties>
-        <spring.boot.version>2.4.3</spring.boot.version>
-    </properties>
-
-    <!-- explicitly NOT submodule of maven module in parent folder so as to show what a self-contained, minimal pom looks like -->
-    <dependencies>
-        <dependency>
-            <groupId>org.eclipse.rdf4j</groupId>
-            <artifactId>rdf4j-spring</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-
-    </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <fork>true</fork>
-                    <release>11</release>
-                    <encoding>utf8</encoding>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
-            </plugin>
-        </plugins>
-    </build>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.eclipse.rdf4j</groupId>
+	<artifactId>rdf4j-spring-demo</artifactId>
+	<name>RDF4J: RDF4J-Spring Demo</name>
+	<version>4.0.0-SNAPSHOT</version>
+	<description>Demo of a spring-boot project using an RDF4J repo as its backend</description>
+	<properties>
+		<spring.boot.version>2.4.3</spring.boot.version>
+	</properties>
+	<!-- explicitly NOT submodule of maven module in parent folder so as to show what a self-contained, minimal pom looks like -->
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-spring</artifactId>
+			<version>4.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring.boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<configuration>
+					<fork>true</fork>
+					<release>11</release>
+					<encoding>utf8</encoding>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring.boot.version}</version>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/spring-components/rdf4j-spring-demo/pom.xml
+++ b/spring-components/rdf4j-spring-demo/pom.xml
@@ -30,6 +30,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.vintage</groupId>
+					<artifactId>junit-vintage-engine</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-components/rdf4j-spring-demo/pom.xml
+++ b/spring-components/rdf4j-spring-demo/pom.xml
@@ -8,23 +8,23 @@
   ~ http://www.eclipse.org/org/documents/edl-v10.php.
   ~ ******************************************************************************
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.rdf4j</groupId>
 	<artifactId>rdf4j-spring-demo</artifactId>
-	<name>RDF4J: RDF4J-Spring Demo</name>
+	<name>RDF4J: Spring Demo</name>
 	<version>4.0.0-SNAPSHOT</version>
 	<description>Demo of a spring-boot project using an RDF4J repo as its backend</description>
-	<properties>
-		<spring.boot.version>2.4.3</spring.boot.version>
-	</properties>
-	<!-- explicitly NOT submodule of maven module in parent folder so as to show what a self-contained, minimal pom looks like -->
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-spring-components</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
+	</parent>
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-spring</artifactId>
-			<version>4.0.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-components/rdf4j-spring-demo/pom.xml
+++ b/spring-components/rdf4j-spring-demo/pom.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ ******************************************************************************
-  ~ Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
-  ~ All rights reserved. This program and the accompanying materials
-  ~ are made available under the terms of the Eclipse Distribution License v1.0
-  ~ which accompanies this distribution, and is available at
-  ~ http://www.eclipse.org/org/documents/edl-v10.php.
-  ~ ******************************************************************************
-  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.rdf4j</groupId>

--- a/spring-components/rdf4j-spring-demo/pom.xml
+++ b/spring-components/rdf4j-spring-demo/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.eclipse.rdf4j</groupId>
+    <artifactId>rdf4j-spring-demo</artifactId>
+    <name>RDF4J: Demo rdf4j-spring project</name>
+    <version>4.0.0-SNAPSHOT</version>
+    <description>Demo of a spring-boot project using an RDF4J repo as its backend</description>
+    <properties>
+        <spring.boot.version>2.4.3</spring.boot.version>
+    </properties>
+
+    <!-- explicitly NOT submodule of maven module in parent folder so as to show what a self-contained, minimal pom looks like -->
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-spring</artifactId>
+            <version>4.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <fork>true</fork>
+                    <release>11</release>
+                    <encoding>utf8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-components/rdf4j-spring-demo/pom.xml
+++ b/spring-components/rdf4j-spring-demo/pom.xml
@@ -1,4 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ ******************************************************************************
+  ~ Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Distribution License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/org/documents/edl-v10.php.
+  ~ ******************************************************************************
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.rdf4j</groupId>

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
@@ -1,0 +1,56 @@
+package org.eclipse.rdf4j.spring.demo;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.spring.demo.model.Artist;
+import org.eclipse.rdf4j.spring.demo.model.Painting;
+import org.eclipse.rdf4j.spring.demo.service.ArtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.Map;
+import java.util.Set;
+
+@SpringBootApplication
+public class ArtDemoCli implements CommandLineRunner {
+    @Autowired ArtService artService;
+
+    public static void main(String[] args) {
+        SpringApplication.run(ArtDemoCli.class, args).close();
+    }
+
+    @Override
+    public void run(String... args) {
+        System.out.println("\nData read from 'artists.ttl':");
+        Map<Artist, Set<Painting>> paintingsMap = artService.getPaintingsGroupedByArtist();
+        listPaintingsByArtist(paintingsMap);
+        System.out.println("\nNow adding some data...");
+        addPaintingWithArtist();
+        System.out.println("\nReloaded data:");
+        paintingsMap = artService.getPaintingsGroupedByArtist();
+        listPaintingsByArtist(paintingsMap);
+        System.out.println("\n");
+    }
+
+    private void addPaintingWithArtist() {
+        Artist a = new Artist();
+        a.setFirstName("Jan");
+        a.setLastName("Vermeer");
+        IRI artistId = artService.addArtist(a);
+        Painting p = new Painting();
+        p.setTitle("View of Delft");
+        p.setTechnique("oil on canvas");
+        p.setArtistId(artistId);
+        artService.addPainting(p);
+    }
+
+    private void listPaintingsByArtist(Map<Artist, Set<Painting>> paintingsMap) {
+        for (Artist a : paintingsMap.keySet()) {
+            System.out.println(String.format("%s %s", a.getFirstName(), a.getLastName()));
+            for (Painting p : paintingsMap.get(a)) {
+                System.out.println(String.format("\t%s (%s)", p.getTitle(), p.getTechnique()));
+            }
+        }
+    }
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
@@ -1,5 +1,8 @@
 package org.eclipse.rdf4j.spring.demo;
 
+import java.util.Map;
+import java.util.Set;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.spring.demo.model.Artist;
 import org.eclipse.rdf4j.spring.demo.model.Painting;
@@ -9,48 +12,46 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import java.util.Map;
-import java.util.Set;
-
 @SpringBootApplication
 public class ArtDemoCli implements CommandLineRunner {
-    @Autowired ArtService artService;
+	@Autowired
+	ArtService artService;
 
-    public static void main(String[] args) {
-        SpringApplication.run(ArtDemoCli.class, args).close();
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(ArtDemoCli.class, args).close();
+	}
 
-    @Override
-    public void run(String... args) {
-        System.out.println("\nData read from 'artists.ttl':");
-        Map<Artist, Set<Painting>> paintingsMap = artService.getPaintingsGroupedByArtist();
-        listPaintingsByArtist(paintingsMap);
-        System.out.println("\nNow adding some data...");
-        addPaintingWithArtist();
-        System.out.println("\nReloaded data:");
-        paintingsMap = artService.getPaintingsGroupedByArtist();
-        listPaintingsByArtist(paintingsMap);
-        System.out.println("\n");
-    }
+	@Override
+	public void run(String... args) {
+		System.out.println("\nData read from 'artists.ttl':");
+		Map<Artist, Set<Painting>> paintingsMap = artService.getPaintingsGroupedByArtist();
+		listPaintingsByArtist(paintingsMap);
+		System.out.println("\nNow adding some data...");
+		addPaintingWithArtist();
+		System.out.println("\nReloaded data:");
+		paintingsMap = artService.getPaintingsGroupedByArtist();
+		listPaintingsByArtist(paintingsMap);
+		System.out.println("\n");
+	}
 
-    private void addPaintingWithArtist() {
-        Artist a = new Artist();
-        a.setFirstName("Jan");
-        a.setLastName("Vermeer");
-        IRI artistId = artService.addArtist(a);
-        Painting p = new Painting();
-        p.setTitle("View of Delft");
-        p.setTechnique("oil on canvas");
-        p.setArtistId(artistId);
-        artService.addPainting(p);
-    }
+	private void addPaintingWithArtist() {
+		Artist a = new Artist();
+		a.setFirstName("Jan");
+		a.setLastName("Vermeer");
+		IRI artistId = artService.addArtist(a);
+		Painting p = new Painting();
+		p.setTitle("View of Delft");
+		p.setTechnique("oil on canvas");
+		p.setArtistId(artistId);
+		artService.addPainting(p);
+	}
 
-    private void listPaintingsByArtist(Map<Artist, Set<Painting>> paintingsMap) {
-        for (Artist a : paintingsMap.keySet()) {
-            System.out.println(String.format("%s %s", a.getFirstName(), a.getLastName()));
-            for (Painting p : paintingsMap.get(a)) {
-                System.out.println(String.format("\t%s (%s)", p.getTitle(), p.getTechnique()));
-            }
-        }
-    }
+	private void listPaintingsByArtist(Map<Artist, Set<Painting>> paintingsMap) {
+		for (Artist a : paintingsMap.keySet()) {
+			System.out.println(String.format("%s %s", a.getFirstName(), a.getLastName()));
+			for (Painting p : paintingsMap.get(a)) {
+				System.out.println(String.format("\t%s (%s)", p.getTitle(), p.getTechnique()));
+			}
+		}
+	}
 }

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
 package org.eclipse.rdf4j.spring.demo;
 
 import java.util.Map;

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
@@ -20,6 +20,17 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Command line interface for the demo. Takes no parameters. It outputs the content of the demo repository, then adds
+ * some data and outputs the content of the repository again.
+ *
+ * Accessing the repository is done via the {@link ArtService} class, which just encapsulates accesses to the
+ * {@link org.eclipse.rdf4j.spring.demo.dao.PaintingDao} and {@link org.eclipse.rdf4j.spring.demo.dao.ArtistDao}
+ * classes.
+ *
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
 @SpringBootApplication
 public class ArtDemoCli implements CommandLineRunner {
 	@Autowired

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoCli.java
@@ -51,6 +51,8 @@ public class ArtDemoCli implements CommandLineRunner {
 		paintingsMap = artService.getPaintingsGroupedByArtist();
 		listPaintingsByArtist(paintingsMap);
 		System.out.println("\n");
+		listArtistsWithoutPaintings();
+		System.out.println("\n");
 	}
 
 	private void addPaintingWithArtist() {
@@ -70,6 +72,18 @@ public class ArtDemoCli implements CommandLineRunner {
 			System.out.println(String.format("%s %s", a.getFirstName(), a.getLastName()));
 			for (Painting p : paintingsMap.get(a)) {
 				System.out.println(String.format("\t%s (%s)", p.getTitle(), p.getTechnique()));
+			}
+		}
+	}
+
+	private void listArtistsWithoutPaintings() {
+		System.out.println("Artists without paintings:");
+		Set<Artist> a = artService.getArtistsWithoutPaintings();
+		if (a.isEmpty()) {
+			System.out.println("\t[none]");
+		} else {
+			for (Artist artist : a) {
+				System.out.println(String.format("%s %s", artist.getFirstName(), artist.getLastName()));
 			}
 		}
 	}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
@@ -17,6 +17,25 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.*;
 import org.springframework.core.io.Resource;
 
+/**
+ * Spring config for the demo.
+ *
+ * Here is what it does:
+ *
+ * <ul>
+ * <li>it imports {@link RDF4JConfig} which interprets the config properties (in our example, they are in
+ * <code>application.properties</code>) and registers a number of beans.</li>
+ * <li>it scans the <code>org.eclipse.rdf4j.spring.demo.dao</code> package, finds the DAOs, registers them as beans and
+ * injects their dependencies</li>
+ * <li>it configures the 'data inserter' beans, which read data from the 'artists.ttl' file and adds them to the
+ * repository at startup</li>
+ * </ul>
+ *
+ * See {@link org.eclipse.rdf4j.spring Rdf4J-Spring} for an overview and more pointers.
+ *
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
 @Configuration
 @Import(RDF4JConfig.class)
 @ComponentScan(

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
 package org.eclipse.rdf4j.spring.demo;
 
 import org.eclipse.rdf4j.spring.RDF4JConfig;

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
@@ -1,0 +1,30 @@
+package org.eclipse.rdf4j.spring.demo;
+
+import org.eclipse.rdf4j.spring.RDF4JConfig;
+import org.eclipse.rdf4j.spring.dao.RDF4JDao;
+import org.eclipse.rdf4j.spring.demo.support.InitialDataInserter;
+import org.eclipse.rdf4j.spring.support.DataInserter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.*;
+import org.springframework.core.io.Resource;
+
+@Configuration
+@Import(RDF4JConfig.class)
+@ComponentScan(
+                value = "org.eclipse.rdf4j.spring.demo.dao",
+                includeFilters =
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RDF4JDao.class))
+public class ArtDemoConfig {
+    @Bean
+    public DataInserter getDataInserter() {
+        return new DataInserter();
+    }
+
+    @Bean
+    public InitialDataInserter getInitialDataInserter(
+                    @Autowired DataInserter dataInserter,
+                    @Value("classpath:/artists.ttl") Resource ttlFile) {
+        return new InitialDataInserter(dataInserter, ttlFile);
+    }
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/ArtDemoConfig.java
@@ -12,19 +12,17 @@ import org.springframework.core.io.Resource;
 @Configuration
 @Import(RDF4JConfig.class)
 @ComponentScan(
-                value = "org.eclipse.rdf4j.spring.demo.dao",
-                includeFilters =
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RDF4JDao.class))
+		value = "org.eclipse.rdf4j.spring.demo.dao", includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = RDF4JDao.class))
 public class ArtDemoConfig {
-    @Bean
-    public DataInserter getDataInserter() {
-        return new DataInserter();
-    }
+	@Bean
+	public DataInserter getDataInserter() {
+		return new DataInserter();
+	}
 
-    @Bean
-    public InitialDataInserter getInitialDataInserter(
-                    @Autowired DataInserter dataInserter,
-                    @Value("classpath:/artists.ttl") Resource ttlFile) {
-        return new InitialDataInserter(dataInserter, ttlFile);
-    }
+	@Bean
+	public InitialDataInserter getInitialDataInserter(
+			@Autowired DataInserter dataInserter,
+			@Value("classpath:/artists.ttl") Resource ttlFile) {
+		return new InitialDataInserter(dataInserter, ttlFile);
+	}
 }

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
@@ -1,0 +1,93 @@
+/*
+ * ******************************************************************************
+ *  * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Distribution License v1.0
+ *  * which accompanies this distribution, and is available at
+ *  * http://www.eclipse.org/org/documents/edl-v10.php.
+ *  ******************************************************************************
+ */
+
+package org.eclipse.rdf4j.spring.demo.dao;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
+import org.eclipse.rdf4j.spring.dao.SimpleRDF4JCRUDDao;
+import org.eclipse.rdf4j.spring.dao.support.bindingsBuilder.MutableBindings;
+import org.eclipse.rdf4j.spring.dao.support.sparql.NamedSparqlSupplier;
+import org.eclipse.rdf4j.spring.demo.model.Artist;
+import org.eclipse.rdf4j.spring.demo.model.EX;
+import org.eclipse.rdf4j.spring.support.RDF4JTemplate;
+import org.eclipse.rdf4j.spring.util.QueryResultUtils;
+import org.springframework.stereotype.Component;
+
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.eclipse.rdf4j.spring.demo.model.Artist.*;
+
+/**
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+@Component
+public class ArtistDao extends SimpleRDF4JCRUDDao<Artist, IRI> {
+
+	public ArtistDao(RDF4JTemplate rdf4JTemplate) {
+		super(rdf4JTemplate);
+	}
+
+	@Override
+	protected void populateIdBindings(MutableBindings bindingsBuilder, IRI iri) {
+		bindingsBuilder.add(ARTIST_ID, iri);
+	}
+
+	@Override
+	protected void populateBindingsForUpdate(MutableBindings bindingsBuilder, Artist artist) {
+		bindingsBuilder
+				.add(ARTIST_FIRST_NAME, artist.getFirstName())
+				.add(ARTIST_LAST_NAME, artist.getLastName());
+	}
+
+	@Override
+	protected NamedSparqlSupplierPreparer prepareNamedSparqlSuppliers(NamedSparqlSupplierPreparer preparer) {
+		return null;
+	}
+
+	@Override
+	protected Artist mapSolution(BindingSet querySolution) {
+		Artist artist = new Artist();
+		artist.setId(QueryResultUtils.getIRI(querySolution, ARTIST_ID));
+		artist.setFirstName(QueryResultUtils.getString(querySolution, ARTIST_FIRST_NAME));
+		artist.setLastName(QueryResultUtils.getString(querySolution, ARTIST_LAST_NAME));
+		return artist;
+	}
+
+	@Override
+	protected String getReadQuery() {
+		return "prefix foaf: <http://xmlns.com/foaf/0.1/> "
+				+ "prefix ex: <http://example.org/> "
+				+ "SELECT ?artist_id ?artist_firstName ?artist_lastName where {"
+				+ "?artist_id a ex:Artist; "
+				+ "    foaf:firstName ?artist_firstName; "
+				+ "    foaf:surname ?artist_lastName ."
+				+ " } ";
+	}
+
+	@Override
+	protected NamedSparqlSupplier getInsertSparql(Artist artist) {
+		return NamedSparqlSupplier.of("insert", () -> Queries.INSERT(ARTIST_ID.isA(iri(EX.Artist))
+				.andHas(iri(FOAF.FIRST_NAME), ARTIST_FIRST_NAME)
+				.andHas(iri(FOAF.SURNAME), ARTIST_LAST_NAME))
+				.getQueryString());
+	}
+
+	@Override
+	protected IRI getInputId(Artist artist) {
+		if (artist.getId() == null) {
+			return getRdf4JTemplate().getNewUUID();
+		}
+		return artist.getId();
+	}
+
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
@@ -10,6 +10,9 @@
 
 package org.eclipse.rdf4j.spring.demo.dao;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.eclipse.rdf4j.spring.demo.model.Artist.*;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -22,9 +25,6 @@ import org.eclipse.rdf4j.spring.demo.model.EX;
 import org.eclipse.rdf4j.spring.support.RDF4JTemplate;
 import org.eclipse.rdf4j.spring.util.QueryResultUtils;
 import org.springframework.stereotype.Component;
-
-import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.eclipse.rdf4j.spring.demo.model.Artist.*;
 
 /**
  * @since 4.0.0

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
@@ -25,6 +25,10 @@ import org.eclipse.rdf4j.spring.util.QueryResultUtils;
 import org.springframework.stereotype.Component;
 
 /**
+ * Class responsible for repository access for managing {@link Artist} entities.
+ *
+ * The class extends the {@link SimpleRDF4JCRUDDao}, providing capabilities for inserting and reading entities.
+ *
  * @since 4.0.0
  * @author Florian Kleedorfer
  */

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDao.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.demo.dao;
 

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
@@ -1,0 +1,97 @@
+/*
+ * ******************************************************************************
+ *  * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Distribution License v1.0
+ *  * which accompanies this distribution, and is available at
+ *  * http://www.eclipse.org/org/documents/edl-v10.php.
+ *  ******************************************************************************
+ */
+
+package org.eclipse.rdf4j.spring.demo.dao;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
+import org.eclipse.rdf4j.spring.dao.RDF4JDao;
+import org.eclipse.rdf4j.spring.dao.SimpleRDF4JCRUDDao;
+import org.eclipse.rdf4j.spring.dao.support.bindingsBuilder.MutableBindings;
+import org.eclipse.rdf4j.spring.dao.support.sparql.NamedSparqlSupplier;
+import org.eclipse.rdf4j.spring.demo.model.EX;
+import org.eclipse.rdf4j.spring.demo.model.Painting;
+import org.eclipse.rdf4j.spring.support.RDF4JTemplate;
+import org.eclipse.rdf4j.spring.util.QueryResultUtils;
+import org.springframework.stereotype.Component;
+
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.eclipse.rdf4j.spring.demo.model.Painting.*;
+
+/**
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+@Component
+public class PaintingDao extends SimpleRDF4JCRUDDao<Painting, IRI> {
+
+	public PaintingDao(RDF4JTemplate rdf4JTemplate) {
+		super(rdf4JTemplate);
+	}
+
+	@Override
+	protected void populateIdBindings(MutableBindings bindingsBuilder, IRI iri) {
+		bindingsBuilder.add(PAINTING_ID, iri);
+	}
+
+	@Override
+	protected RDF4JDao.NamedSparqlSupplierPreparer prepareNamedSparqlSuppliers(NamedSparqlSupplierPreparer preparer) {
+		return null;
+	}
+
+	@Override
+	protected Painting mapSolution(BindingSet querySolution) {
+		Painting painting = new Painting();
+		painting.setId(QueryResultUtils.getIRI(querySolution, PAINTING_ID));
+		painting.setTechnique(QueryResultUtils.getString(querySolution, PAINTING_TECHNIQUE));
+		painting.setTitle(QueryResultUtils.getString(querySolution, PAINTING_LABEL));
+		painting.setArtistId(QueryResultUtils.getIRI(querySolution, PAINTING_ARTIST_ID));
+		return painting;
+	}
+
+	@Override
+	protected String getReadQuery() {
+		return Queries.SELECT(PAINTING_ID, PAINTING_LABEL, PAINTING_TECHNIQUE, PAINTING_ARTIST_ID)
+				.where(
+						PAINTING_ID.isA(iri(EX.Painting))
+								.andHas(iri(EX.technique), PAINTING_TECHNIQUE)
+								.andHas(iri(RDFS.LABEL), PAINTING_LABEL),
+						PAINTING_ARTIST_ID.has(iri(EX.creatorOf), PAINTING_ID))
+				.getQueryString();
+	}
+
+	@Override
+	protected NamedSparqlSupplier getInsertSparql(Painting painting) {
+		return NamedSparqlSupplier.of("insert", () -> Queries.INSERT(
+				PAINTING_ID.isA(iri(EX.Painting))
+						.andHas(iri(EX.technique), PAINTING_TECHNIQUE)
+						.andHas(iri(RDFS.LABEL), PAINTING_LABEL),
+				PAINTING_ARTIST_ID.has(iri(EX.creatorOf), PAINTING_ID))
+				.getQueryString());
+	}
+
+	@Override
+	protected void populateBindingsForUpdate(MutableBindings bindingsBuilder, Painting painting) {
+		bindingsBuilder
+				.add(PAINTING_LABEL, painting.getTitle())
+				.add(PAINTING_TECHNIQUE, painting.getTechnique())
+				.add(PAINTING_ARTIST_ID, painting.getArtistId());
+	}
+
+	@Override
+	protected IRI getInputId(Painting painting) {
+		if (painting.getId() == null) {
+			return getRdf4JTemplate().getNewUUID();
+		}
+		return painting.getId();
+	}
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.spring.dao.RDF4JDao;
 import org.eclipse.rdf4j.spring.dao.SimpleRDF4JCRUDDao;
 import org.eclipse.rdf4j.spring.dao.support.bindingsBuilder.MutableBindings;
 import org.eclipse.rdf4j.spring.dao.support.sparql.NamedSparqlSupplier;
+import org.eclipse.rdf4j.spring.demo.model.Artist;
 import org.eclipse.rdf4j.spring.demo.model.EX;
 import org.eclipse.rdf4j.spring.demo.model.Painting;
 import org.eclipse.rdf4j.spring.support.RDF4JTemplate;
@@ -26,6 +27,10 @@ import org.eclipse.rdf4j.spring.util.QueryResultUtils;
 import org.springframework.stereotype.Component;
 
 /**
+ * Class responsible for repository access for managing {@link Painting} entities.
+ *
+ * The class extends the {@link SimpleRDF4JCRUDDao}, providing capabilities for inserting and reading entities.
+ *
  * @since 4.0.0
  * @author Florian Kleedorfer
  */

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.demo.dao;
 

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/dao/PaintingDao.java
@@ -10,6 +10,9 @@
 
 package org.eclipse.rdf4j.spring.demo.dao;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.eclipse.rdf4j.spring.demo.model.Painting.*;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -23,9 +26,6 @@ import org.eclipse.rdf4j.spring.demo.model.Painting;
 import org.eclipse.rdf4j.spring.support.RDF4JTemplate;
 import org.eclipse.rdf4j.spring.util.QueryResultUtils;
 import org.springframework.stereotype.Component;
-
-import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.eclipse.rdf4j.spring.demo.model.Painting.*;
 
 /**
  * @since 4.0.0

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Artist.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Artist.java
@@ -10,10 +10,10 @@
 
 package org.eclipse.rdf4j.spring.demo.model;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.core.ExtendedVariable;
-
-import java.util.Objects;
 
 /**
  * @since 4.0.0
@@ -51,7 +51,8 @@ public class Artist {
 		this.id = id;
 	}
 
-	@Override public boolean equals(Object o) {
+	@Override
+	public boolean equals(Object o) {
 		if (this == o)
 			return true;
 		if (o == null || getClass() != o.getClass())
@@ -60,7 +61,8 @@ public class Artist {
 		return Objects.equals(id, artist.id);
 	}
 
-	@Override public int hashCode() {
+	@Override
+	public int hashCode() {
 		return Objects.hash(id);
 	}
 }

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Artist.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Artist.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.demo.model;
 

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Artist.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Artist.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Artist.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Artist.java
@@ -1,0 +1,66 @@
+/*
+ * ******************************************************************************
+ *  * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Distribution License v1.0
+ *  * which accompanies this distribution, and is available at
+ *  * http://www.eclipse.org/org/documents/edl-v10.php.
+ *  ******************************************************************************
+ */
+
+package org.eclipse.rdf4j.spring.demo.model;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.sparqlbuilder.core.ExtendedVariable;
+
+import java.util.Objects;
+
+/**
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+public class Artist {
+	public static final ExtendedVariable ARTIST_ID = new ExtendedVariable("artist_id");
+	public static final ExtendedVariable ARTIST_FIRST_NAME = new ExtendedVariable("artist_firstName");
+	public static final ExtendedVariable ARTIST_LAST_NAME = new ExtendedVariable("artist_lastName");
+	private IRI id;
+	private String firstName;
+	private String lastName;
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public IRI getId() {
+		return id;
+	}
+
+	public void setId(IRI id) {
+		this.id = id;
+	}
+
+	@Override public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		Artist artist = (Artist) o;
+		return Objects.equals(id, artist.id);
+	}
+
+	@Override public int hashCode() {
+		return Objects.hash(id);
+	}
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.demo.model;
 

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
@@ -1,0 +1,40 @@
+/*
+ * ******************************************************************************
+ *  * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Distribution License v1.0
+ *  * which accompanies this distribution, and is available at
+ *  * http://www.eclipse.org/org/documents/edl-v10.php.
+ *  ******************************************************************************
+ */
+
+package org.eclipse.rdf4j.spring.demo.model;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+
+/**
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+public class EX {
+	private static final String base = "http://example.org/";
+	public static final IRI Artist = SimpleValueFactory.getInstance().createIRI(base, "Artist");
+	public static final IRI Gallery = SimpleValueFactory.getInstance().createIRI(base, "Gallery");
+	public static final IRI Painting = SimpleValueFactory.getInstance().createIRI(base, "Painting");
+	public static final IRI Picasso = SimpleValueFactory.getInstance().createIRI(base, "Picasso");
+	public static final IRI VanGogh = SimpleValueFactory.getInstance().createIRI(base, "VanGogh");
+	public static final IRI street = SimpleValueFactory.getInstance().createIRI(base, "street");
+	public static final IRI city = SimpleValueFactory.getInstance().createIRI(base, "city");
+	public static final IRI country = SimpleValueFactory.getInstance().createIRI(base, "country");
+	public static final IRI creatorOf = SimpleValueFactory.getInstance().createIRI(base, "creatorOf");
+	public static final IRI technique = SimpleValueFactory.getInstance().createIRI(base, "technique");
+	public static final IRI starryNight = SimpleValueFactory.getInstance().createIRI(base, "starryNight");
+	public static final IRI sunflowers = SimpleValueFactory.getInstance().createIRI(base, "sunflowers");
+	public static final IRI potatoEaters = SimpleValueFactory.getInstance().createIRI(base, "potatoEaters");
+	public static final IRI guernica = SimpleValueFactory.getInstance().createIRI(base, "guernica");
+
+	public static IRI of(String localName) {
+		return SimpleValueFactory.getInstance().createIRI(base, localName);
+	}
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
@@ -25,6 +25,7 @@ public class EX {
 	public static final IRI Painting = Values.iri(base, "Painting");
 	public static final IRI Picasso = Values.iri(base, "Picasso");
 	public static final IRI VanGogh = Values.iri(base, "VanGogh");
+	public static final IRI Rembrandt = Values.iri(base, "Rembrandt");
 	public static final IRI street = Values.iri(base, "street");
 	public static final IRI city = Values.iri(base, "city");
 	public static final IRI country = Values.iri(base, "country");

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/EX.java
@@ -9,30 +9,33 @@
 package org.eclipse.rdf4j.spring.demo.model;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Values;
 
 /**
  * @since 4.0.0
  * @author Florian Kleedorfer
  */
 public class EX {
-	private static final String base = "http://example.org/";
-	public static final IRI Artist = SimpleValueFactory.getInstance().createIRI(base, "Artist");
-	public static final IRI Gallery = SimpleValueFactory.getInstance().createIRI(base, "Gallery");
-	public static final IRI Painting = SimpleValueFactory.getInstance().createIRI(base, "Painting");
-	public static final IRI Picasso = SimpleValueFactory.getInstance().createIRI(base, "Picasso");
-	public static final IRI VanGogh = SimpleValueFactory.getInstance().createIRI(base, "VanGogh");
-	public static final IRI street = SimpleValueFactory.getInstance().createIRI(base, "street");
-	public static final IRI city = SimpleValueFactory.getInstance().createIRI(base, "city");
-	public static final IRI country = SimpleValueFactory.getInstance().createIRI(base, "country");
-	public static final IRI creatorOf = SimpleValueFactory.getInstance().createIRI(base, "creatorOf");
-	public static final IRI technique = SimpleValueFactory.getInstance().createIRI(base, "technique");
-	public static final IRI starryNight = SimpleValueFactory.getInstance().createIRI(base, "starryNight");
-	public static final IRI sunflowers = SimpleValueFactory.getInstance().createIRI(base, "sunflowers");
-	public static final IRI potatoEaters = SimpleValueFactory.getInstance().createIRI(base, "potatoEaters");
-	public static final IRI guernica = SimpleValueFactory.getInstance().createIRI(base, "guernica");
+	private static final Namespace base = new SimpleNamespace("ex", "http://example.org/");
+	public static final IRI Artist = Values.iri(base, "Artist");
+	public static final IRI Gallery = Values.iri(base, "Gallery");
+	public static final IRI Painting = Values.iri(base, "Painting");
+	public static final IRI Picasso = Values.iri(base, "Picasso");
+	public static final IRI VanGogh = Values.iri(base, "VanGogh");
+	public static final IRI street = Values.iri(base, "street");
+	public static final IRI city = Values.iri(base, "city");
+	public static final IRI country = Values.iri(base, "country");
+	public static final IRI creatorOf = Values.iri(base, "creatorOf");
+	public static final IRI technique = Values.iri(base, "technique");
+	public static final IRI starryNight = Values.iri(base, "starryNight");
+	public static final IRI sunflowers = Values.iri(base, "sunflowers");
+	public static final IRI potatoEaters = Values.iri(base, "potatoEaters");
+	public static final IRI guernica = Values.iri(base, "guernica");
 
 	public static IRI of(String localName) {
-		return SimpleValueFactory.getInstance().createIRI(base, localName);
+		return Values.iri(base, localName);
 	}
 }

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Painting.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Painting.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.demo.model;
 

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Painting.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Painting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Painting.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Painting.java
@@ -10,10 +10,10 @@
 
 package org.eclipse.rdf4j.spring.demo.model;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.core.ExtendedVariable;
-
-import java.util.Objects;
 
 /**
  * @since 4.0.0
@@ -62,7 +62,8 @@ public class Painting {
 		this.artistId = artistId;
 	}
 
-	@Override public boolean equals(Object o) {
+	@Override
+	public boolean equals(Object o) {
 		if (this == o)
 			return true;
 		if (o == null || getClass() != o.getClass())
@@ -71,7 +72,8 @@ public class Painting {
 		return Objects.equals(id, painting.id);
 	}
 
-	@Override public int hashCode() {
+	@Override
+	public int hashCode() {
 		return Objects.hash(id);
 	}
 }

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Painting.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/model/Painting.java
@@ -1,0 +1,77 @@
+/*
+ * ******************************************************************************
+ *  * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Distribution License v1.0
+ *  * which accompanies this distribution, and is available at
+ *  * http://www.eclipse.org/org/documents/edl-v10.php.
+ *  ******************************************************************************
+ */
+
+package org.eclipse.rdf4j.spring.demo.model;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.sparqlbuilder.core.ExtendedVariable;
+
+import java.util.Objects;
+
+/**
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+public class Painting {
+	public static final ExtendedVariable PAINTING_ID = new ExtendedVariable("painting_id");
+	public static final ExtendedVariable PAINTING_ARTIST_ID = new ExtendedVariable("painting_artist_id");
+	public static final ExtendedVariable PAINTING_TECHNIQUE = new ExtendedVariable("painting_technique");
+	public static final ExtendedVariable PAINTING_LABEL = new ExtendedVariable("painting_label");
+
+	private IRI id;
+	private String title;
+	private String technique;
+	private IRI artistId;
+
+	public IRI getId() {
+		return id;
+	}
+
+	public void setId(IRI id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getTechnique() {
+		return technique;
+	}
+
+	public void setTechnique(String technique) {
+		this.technique = technique;
+	}
+
+	public IRI getArtistId() {
+		return artistId;
+	}
+
+	public void setArtistId(IRI artistId) {
+		this.artistId = artistId;
+	}
+
+	@Override public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		Painting painting = (Painting) o;
+		return Objects.equals(id, painting.id);
+	}
+
+	@Override public int hashCode() {
+		return Objects.hash(id);
+	}
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
@@ -28,6 +28,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Uses {@link ArtistDao} and {@link PaintingDao} to query and manipulate the repository.
+ *
+ *
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
 @Component
 public class ArtService {
 	@Autowired

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
@@ -1,0 +1,87 @@
+/*
+ * ******************************************************************************
+ *  * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Distribution License v1.0
+ *  * which accompanies this distribution, and is available at
+ *  * http://www.eclipse.org/org/documents/edl-v10.php.
+ *  ******************************************************************************
+ */
+
+package org.eclipse.rdf4j.spring.demo.service;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.spring.demo.dao.ArtistDao;
+import org.eclipse.rdf4j.spring.demo.dao.PaintingDao;
+import org.eclipse.rdf4j.spring.demo.model.Artist;
+import org.eclipse.rdf4j.spring.demo.model.Painting;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.rdf4j.spring.demo.model.EX.Artist;
+import static org.eclipse.rdf4j.spring.demo.model.EX.Painting;
+
+@Component
+public class ArtService {
+	@Autowired
+	private ArtistDao artistDao;
+
+	@Autowired
+	private PaintingDao paintingDao;
+
+	@Transactional(propagation = Propagation.REQUIRED)
+	public Artist createArtist(String firstName, String lastName) {
+		Artist artist = new Artist();
+		artist.setFirstName(firstName);
+		artist.setLastName(lastName);
+		return artistDao.save(artist);
+	}
+
+	@Transactional(propagation = Propagation.REQUIRED)
+	public Painting createPainting(String title, String technique, IRI artist) {
+		Painting painting = new Painting();
+		painting.setTitle(title);
+		painting.setTechnique(technique);
+		painting.setArtistId(artist);
+		return paintingDao.save(painting);
+	}
+
+	@Transactional(propagation = Propagation.REQUIRED)
+	public List<Painting> getPaintings(){
+		return paintingDao.list();
+	}
+
+	@Transactional(propagation = Propagation.REQUIRED)
+	public List<Artist> getArtists(){
+		return artistDao.list();
+	}
+
+	@Transactional(propagation = Propagation.REQUIRED)
+	public Map<Artist, Set<Painting>> getPaintingsGroupedByArtist(){
+		List<Painting> paintings = paintingDao.list();
+		return paintings
+						.stream()
+						.collect(groupingBy(
+										p -> artistDao.getById(p.getArtistId()),
+										toSet()));
+	}
+
+	@Transactional(propagation = Propagation.REQUIRED)
+	public IRI addArtist(Artist artist){
+		return artistDao.saveAndReturnId(artist);
+	}
+
+	@Transactional(propagation = Propagation.REQUIRED)
+	public IRI addPainting(Painting painting) {
+		return paintingDao.saveAndReturnId(painting);
+	}
+
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.demo.service;
 

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
@@ -43,7 +43,7 @@ public class ArtService {
 	@Autowired
 	private PaintingDao paintingDao;
 
-	@Transactional(propagation = Propagation.REQUIRED)
+	@Transactional
 	public Artist createArtist(String firstName, String lastName) {
 		Artist artist = new Artist();
 		artist.setFirstName(firstName);
@@ -51,7 +51,7 @@ public class ArtService {
 		return artistDao.save(artist);
 	}
 
-	@Transactional(propagation = Propagation.REQUIRED)
+	@Transactional
 	public Painting createPainting(String title, String technique, IRI artist) {
 		Painting painting = new Painting();
 		painting.setTitle(title);
@@ -60,17 +60,22 @@ public class ArtService {
 		return paintingDao.save(painting);
 	}
 
-	@Transactional(propagation = Propagation.REQUIRED)
+	@Transactional
 	public List<Painting> getPaintings() {
 		return paintingDao.list();
 	}
 
-	@Transactional(propagation = Propagation.REQUIRED)
+	@Transactional
 	public List<Artist> getArtists() {
 		return artistDao.list();
 	}
 
-	@Transactional(propagation = Propagation.REQUIRED)
+	@Transactional
+	public Set<Artist> getArtistsWithoutPaintings() {
+		return artistDao.getArtistsWithoutPaintings();
+	}
+
+	@Transactional
 	public Map<Artist, Set<Painting>> getPaintingsGroupedByArtist() {
 		List<Painting> paintings = paintingDao.list();
 		return paintings
@@ -80,12 +85,12 @@ public class ArtService {
 						toSet()));
 	}
 
-	@Transactional(propagation = Propagation.REQUIRED)
+	@Transactional
 	public IRI addArtist(Artist artist) {
 		return artistDao.saveAndReturnId(artist);
 	}
 
-	@Transactional(propagation = Propagation.REQUIRED)
+	@Transactional
 	public IRI addPainting(Painting painting) {
 		return paintingDao.saveAndReturnId(painting);
 	}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/service/ArtService.java
@@ -10,6 +10,16 @@
 
 package org.eclipse.rdf4j.spring.demo.service;
 
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toSet;
+
+import static org.eclipse.rdf4j.spring.demo.model.EX.Artist;
+import static org.eclipse.rdf4j.spring.demo.model.EX.Painting;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.spring.demo.dao.ArtistDao;
 import org.eclipse.rdf4j.spring.demo.dao.PaintingDao;
@@ -19,15 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toSet;
-import static org.eclipse.rdf4j.spring.demo.model.EX.Artist;
-import static org.eclipse.rdf4j.spring.demo.model.EX.Painting;
 
 @Component
 public class ArtService {
@@ -55,27 +56,27 @@ public class ArtService {
 	}
 
 	@Transactional(propagation = Propagation.REQUIRED)
-	public List<Painting> getPaintings(){
+	public List<Painting> getPaintings() {
 		return paintingDao.list();
 	}
 
 	@Transactional(propagation = Propagation.REQUIRED)
-	public List<Artist> getArtists(){
+	public List<Artist> getArtists() {
 		return artistDao.list();
 	}
 
 	@Transactional(propagation = Propagation.REQUIRED)
-	public Map<Artist, Set<Painting>> getPaintingsGroupedByArtist(){
+	public Map<Artist, Set<Painting>> getPaintingsGroupedByArtist() {
 		List<Painting> paintings = paintingDao.list();
 		return paintings
-						.stream()
-						.collect(groupingBy(
-										p -> artistDao.getById(p.getArtistId()),
-										toSet()));
+				.stream()
+				.collect(groupingBy(
+						p -> artistDao.getById(p.getArtistId()),
+						toSet()));
 	}
 
 	@Transactional(propagation = Propagation.REQUIRED)
-	public IRI addArtist(Artist artist){
+	public IRI addArtist(Artist artist) {
 		return artistDao.saveAndReturnId(artist);
 	}
 

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
@@ -13,6 +13,12 @@ import javax.annotation.PostConstruct;
 import org.eclipse.rdf4j.spring.support.DataInserter;
 import org.springframework.core.io.Resource;
 
+/**
+ * Inserts data from the specified TTL file into the repository at startup.
+ * 
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
 public class InitialDataInserter {
 	DataInserter dataInserter;
 	Resource ttlFile;

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
@@ -1,21 +1,21 @@
 package org.eclipse.rdf4j.spring.demo.support;
 
+import javax.annotation.PostConstruct;
+
 import org.eclipse.rdf4j.spring.support.DataInserter;
 import org.springframework.core.io.Resource;
 
-import javax.annotation.PostConstruct;
-
 public class InitialDataInserter {
-    DataInserter dataInserter;
-    Resource ttlFile;
+	DataInserter dataInserter;
+	Resource ttlFile;
 
-    public InitialDataInserter(DataInserter dataInserter, Resource ttlFile) {
-        this.dataInserter = dataInserter;
-        this.ttlFile = ttlFile;
-    }
+	public InitialDataInserter(DataInserter dataInserter, Resource ttlFile) {
+		this.dataInserter = dataInserter;
+		this.ttlFile = ttlFile;
+	}
 
-    @PostConstruct
-    public void insertDemoData() {
-        this.dataInserter.insertData(ttlFile);
-    }
+	@PostConstruct
+	public void insertDemoData() {
+		this.dataInserter.insertData(ttlFile);
+	}
 }

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
@@ -1,0 +1,21 @@
+package org.eclipse.rdf4j.spring.demo.support;
+
+import org.eclipse.rdf4j.spring.support.DataInserter;
+import org.springframework.core.io.Resource;
+
+import javax.annotation.PostConstruct;
+
+public class InitialDataInserter {
+    DataInserter dataInserter;
+    Resource ttlFile;
+
+    public InitialDataInserter(DataInserter dataInserter, Resource ttlFile) {
+        this.dataInserter = dataInserter;
+        this.ttlFile = ttlFile;
+    }
+
+    @PostConstruct
+    public void insertDemoData() {
+        this.dataInserter.insertData(ttlFile);
+    }
+}

--- a/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
+++ b/spring-components/rdf4j-spring-demo/src/main/java/org/eclipse/rdf4j/spring/demo/support/InitialDataInserter.java
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
 package org.eclipse.rdf4j.spring.demo.support;
 
 import javax.annotation.PostConstruct;

--- a/spring-components/rdf4j-spring-demo/src/main/resources/application.properties
+++ b/spring-components/rdf4j-spring-demo/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+rdf4j.spring.repository.inmemory.enabled=true
+rdf4j.spring.pool.enabled=true
+rdf4j.spring.operationcache.enabled=false
+rdf4j.spring.operationlog.enabled=false
+rdf4j.spring.resultcache.enabled=false
+rdf4j.spring.tx.enabled=true

--- a/spring-components/rdf4j-spring-demo/src/main/resources/application.properties
+++ b/spring-components/rdf4j-spring-demo/src/main/resources/application.properties
@@ -1,3 +1,13 @@
+#
+# ******************************************************************************
+# Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Distribution License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+# ******************************************************************************
+#
+
 rdf4j.spring.repository.inmemory.enabled=true
 rdf4j.spring.pool.enabled=true
 rdf4j.spring.operationcache.enabled=false

--- a/spring-components/rdf4j-spring-demo/src/main/resources/application.properties
+++ b/spring-components/rdf4j-spring-demo/src/main/resources/application.properties
@@ -1,13 +1,3 @@
-#
-# ******************************************************************************
-# Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Distribution License v1.0
-# which accompanies this distribution, and is available at
-# http://www.eclipse.org/org/documents/edl-v10.php.
-# ******************************************************************************
-#
-
 rdf4j.spring.repository.inmemory.enabled=true
 rdf4j.spring.pool.enabled=true
 rdf4j.spring.operationcache.enabled=false

--- a/spring-components/rdf4j-spring-demo/src/main/resources/artists.ttl
+++ b/spring-components/rdf4j-spring-demo/src/main/resources/artists.ttl
@@ -32,3 +32,7 @@ ex:sunflowers a ex:Painting ;
 ex:potatoEaters a ex:Painting ;
                 ex:technique "oil on canvas";
                 rdfs:label "The Potato Eaters" .
+
+ex:Rembrandt a ex:Artist ;
+           foaf:firstName "Rembrandt Harmensz" ;
+           foaf:surname "van Rijn".

--- a/spring-components/rdf4j-spring-demo/src/main/resources/artists.ttl
+++ b/spring-components/rdf4j-spring-demo/src/main/resources/artists.ttl
@@ -1,0 +1,34 @@
+@prefix ex: <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:Picasso a ex:Artist ;
+           foaf:firstName "Pablo" ;
+           foaf:surname "Picasso";
+           ex:creatorOf ex:guernica ;
+           ex:homeAddress _:node1 .
+
+_:node1  ex:street "31 Art Gallery" ;
+         ex:city "Madrid" ;
+         ex:country "Spain" .
+
+ex:guernica a ex:Painting ;
+            rdfs:label "Guernica";
+            ex:technique "oil on canvas".
+
+ex:VanGogh a ex:Artist ;
+           foaf:firstName "Vincent" ;
+           foaf:surname "van Gogh";
+           ex:creatorOf ex:starryNight, ex:sunflowers, ex:potatoEaters .
+
+ex:starryNight a ex:Painting ;
+               ex:technique "oil on canvas";
+               rdfs:label "Starry Night" .
+
+ex:sunflowers a ex:Painting ;
+              ex:technique "oil on canvas";
+              rdfs:label "Sunflowers" .
+
+ex:potatoEaters a ex:Painting ;
+                ex:technique "oil on canvas";
+                rdfs:label "The Potato Eaters" .

--- a/spring-components/rdf4j-spring-demo/src/main/test/java/org/eclipse/rdf4j/spring/demo/TestConfig.java
+++ b/spring-components/rdf4j-spring-demo/src/main/test/java/org/eclipse/rdf4j/spring/demo/TestConfig.java
@@ -1,12 +1,10 @@
-/*
- * *****************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- * *****************************************************************************
- */
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.demo;
 

--- a/spring-components/rdf4j-spring-demo/src/main/test/java/org/eclipse/rdf4j/spring/demo/TestConfig.java
+++ b/spring-components/rdf4j-spring-demo/src/main/test/java/org/eclipse/rdf4j/spring/demo/TestConfig.java
@@ -1,0 +1,32 @@
+/*
+ * *****************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * *****************************************************************************
+ */
+
+package org.eclipse.rdf4j.spring.demo;
+
+import org.eclipse.rdf4j.spring.support.DataInserter;
+import org.eclipse.rdf4j.spring.test.RDF4JTestConfig;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@TestConfiguration
+@EnableTransactionManagement
+@Import(RDF4JTestConfig.class)
+@ComponentScan("org.eclipse.rdf4j.spring.demo.*")
+public class TestConfig {
+
+    @Bean
+    DataInserter getDataInserter() {
+        return new DataInserter();
+    }
+
+}

--- a/spring-components/rdf4j-spring-demo/src/main/test/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDaoTests.java
+++ b/spring-components/rdf4j-spring-demo/src/main/test/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDaoTests.java
@@ -1,0 +1,97 @@
+/*
+ * *****************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * *****************************************************************************
+ */
+
+package org.eclipse.rdf4j.spring.demo.dao;
+
+import org.eclipse.rdf4j.spring.RDF4JConfig;
+import org.eclipse.rdf4j.spring.demo.TestConfig;
+import org.eclipse.rdf4j.spring.demo.model.Artist;
+import org.eclipse.rdf4j.spring.demo.model.EX;
+import org.eclipse.rdf4j.spring.operationcache.OperationCacheConfig;
+import org.eclipse.rdf4j.spring.operationlog.OperationLogConfig;
+import org.eclipse.rdf4j.spring.operationlog.log.jmx.OperationLogJmxConfig;
+import org.eclipse.rdf4j.spring.pool.PoolConfig;
+import org.eclipse.rdf4j.spring.repository.inmemory.InMemoryRepositoryConfig;
+import org.eclipse.rdf4j.spring.repository.remote.RemoteRepositoryConfig;
+import org.eclipse.rdf4j.spring.resultcache.ResultCacheConfig;
+import org.eclipse.rdf4j.spring.support.DataInserter;
+import org.eclipse.rdf4j.spring.tx.TxConfig;
+import org.eclipse.rdf4j.spring.uuidsource.noveltychecking.NoveltyCheckingUUIDSourceConfig;
+import org.eclipse.rdf4j.spring.uuidsource.sequence.UUIDSequenceConfig;
+import org.eclipse.rdf4j.spring.uuidsource.simple.SimpleRepositoryUUIDSourceConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@ExtendWith(SpringExtension.class)
+@Transactional
+@ContextConfiguration(classes = {TestConfig.class})
+@TestPropertySource("classpath:application.properties")
+@TestPropertySource(
+                properties = {
+                                "rdf4j.spring.repository.inmemory.enabled=true",
+                                "rdf4j.spring.repository.inmemory.use-shacl-sail=true",
+                                "rdf4j.spring.tx.enabled=true",
+                                "rdf4j.spring.resultcache.enabled=false",
+                                "rdf4j.spring.operationcache.enabled=false",
+                                "rdf4j.spring.pool.enabled=true",
+                                "rdf4j.spring.pool.max-connections=2"
+                })
+@DirtiesContext
+public class ArtistDaoTests {
+
+    @Autowired
+    private ArtistDao artistDao;
+
+    @BeforeAll
+    public static void insertTestData(
+                    @Autowired DataInserter dataInserter,
+                    @Value("classpath:artists.ttl") Resource dataFile) {
+        dataInserter.insertData(dataFile);
+    }
+
+    @Test
+    public void testReadArtist(){
+        Artist a = artistDao.getById(EX.Picasso);
+        Assertions.assertEquals("Picasso", a.getLastName());
+        Assertions.assertEquals("Pablo", a.getFirstName());
+    }
+
+    @Test
+    public void testWriteArtist(){
+        Artist a = new Artist();
+        a.setFirstName("Salvador");
+        a.setLastName("Dalí");
+        Artist savedDali = artistDao.save(a);
+        Assertions.assertNotNull(savedDali.getId());
+        Artist reloadedDali = artistDao.getById(savedDali.getId());
+        Assertions.assertEquals(savedDali, reloadedDali);
+    }
+
+    @Test
+    public void testReadArtistWithoutPaintings(){
+        Set<Artist> withoutPaintings = artistDao.getArtistsWithoutPaintings();
+        Assertions.assertEquals(1, withoutPaintings.size());
+        Artist a = artistDao.getById(EX.Rembrandt);
+        Assertions.assertTrue(withoutPaintings.contains(a));
+    }
+
+}

--- a/spring-components/rdf4j-spring-demo/src/main/test/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDaoTests.java
+++ b/spring-components/rdf4j-spring-demo/src/main/test/java/org/eclipse/rdf4j/spring/demo/dao/ArtistDaoTests.java
@@ -1,12 +1,10 @@
-/*
- * *****************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- * *****************************************************************************
- */
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.demo.dao;
 

--- a/spring-components/rdf4j-spring/pom.xml
+++ b/spring-components/rdf4j-spring/pom.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ /*******************************************************************************
-  ~  * Copyright (c) 2021 Eclipse RDF4J contributors.
-  ~  * All rights reserved. This program and the accompanying materials
-  ~  * are made available under the terms of the Eclipse Distribution License v1.0
-  ~  * which accompanies this distribution, and is available at
-  ~  * http://www.eclipse.org/org/documents/edl-v10.php.
-  ~  *******************************************************************************/
-  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/RDF4JConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/RDF4JConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/RDF4JConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/RDF4JConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/RDF4JCRUDDao.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/RDF4JCRUDDao.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/RDF4JCRUDDao.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/RDF4JCRUDDao.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/RDF4JDao.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/RDF4JDao.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/RDF4JDao.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/RDF4JDao.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/SimpleRDF4JCRUDDao.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/SimpleRDF4JCRUDDao.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/SimpleRDF4JCRUDDao.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/SimpleRDF4JCRUDDao.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/IncorrectResultSetSizeException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/IncorrectResultSetSizeException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/IncorrectResultSetSizeException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/IncorrectResultSetSizeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/RDF4JDaoException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/RDF4JDaoException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/RDF4JDaoException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/RDF4JDaoException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/RDF4JSpringException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/RDF4JSpringException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/RDF4JSpringException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/RDF4JSpringException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/UnexpectedResultException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/UnexpectedResultException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/UnexpectedResultException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/UnexpectedResultException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/UnsupportedDataTypeException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/UnsupportedDataTypeException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/UnsupportedDataTypeException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/UnsupportedDataTypeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/mapper/ExceptionMapper.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/mapper/ExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/mapper/ExceptionMapper.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/exception/mapper/ExceptionMapper.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.exception.mapper;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/package-info.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  *

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/BindingSetMapper.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/BindingSetMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/BindingSetMapper.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/BindingSetMapper.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/MappingPostProcessor.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/MappingPostProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/MappingPostProcessor.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/MappingPostProcessor.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilder.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/TupleQueryResultMapper.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/TupleQueryResultMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/TupleQueryResultMapper.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/TupleQueryResultMapper.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/UpdateCallback.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/UpdateCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/UpdateCallback.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/UpdateCallback.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/UpdateWithModelBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/UpdateWithModelBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/UpdateWithModelBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/UpdateWithModelBuilder.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/bindingsBuilder/BindingsBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/bindingsBuilder/BindingsBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/bindingsBuilder/BindingsBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/bindingsBuilder/BindingsBuilder.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.bindingsBuilder;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/bindingsBuilder/MutableBindings.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/bindingsBuilder/MutableBindings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/bindingsBuilder/MutableBindings.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/bindingsBuilder/MutableBindings.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.bindingsBuilder;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/key/CompositeKey.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/key/CompositeKey.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.key;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/key/CompositeKey.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/key/CompositeKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/key/CompositeKey2.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/key/CompositeKey2.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.key;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/key/CompositeKey2.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/key/CompositeKey2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/GraphQueryEvaluationBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/GraphQueryEvaluationBuilder.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.opbuilder;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/GraphQueryEvaluationBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/GraphQueryEvaluationBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/OperationBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/OperationBuilder.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.opbuilder;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/OperationBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/OperationBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/TupleQueryEvaluationBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/TupleQueryEvaluationBuilder.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.opbuilder;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/TupleQueryEvaluationBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/TupleQueryEvaluationBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/UpdateExecutionBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/UpdateExecutionBuilder.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.opbuilder;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/UpdateExecutionBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/opbuilder/UpdateExecutionBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/GraphQueryResultConverter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/GraphQueryResultConverter.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.operation;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/GraphQueryResultConverter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/GraphQueryResultConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/OperationType.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/OperationType.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.operation;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/OperationType.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/OperationType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/OperationUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/OperationUtils.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.operation;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/OperationUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/OperationUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryEvaluator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryEvaluator.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.operation;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryEvaluator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverter.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.operation;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/sparql/NamedSparqlSupplier.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/sparql/NamedSparqlSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/sparql/NamedSparqlSupplier.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/sparql/NamedSparqlSupplier.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.sparql;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/sparql/PreparedSparqlManager.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/sparql/PreparedSparqlManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/sparql/PreparedSparqlManager.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/sparql/PreparedSparqlManager.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.sparql;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/CachingOperationInstantiator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/CachingOperationInstantiator.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/CachingOperationInstantiator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/CachingOperationInstantiator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/OperationCacheConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/OperationCacheConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/OperationCacheConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/OperationCacheConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/OperationCacheProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/OperationCacheProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/OperationCacheProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/OperationCacheProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationcache/package-info.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  *

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingGraphQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingGraphQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingGraphQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingGraphQuery.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingRepositoryConnection.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingRepositoryConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingRepositoryConnection.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingRepositoryConnection.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingRepositoryConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingRepositoryConnectionFactory.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingTupleQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingTupleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingTupleQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingTupleQuery.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingUpdate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingUpdate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingUpdate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/LoggingUpdate.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/OperationLogConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/OperationLogConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/OperationLogConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/OperationLogConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/OperationLogProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/OperationLogProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/OperationLogProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/OperationLogProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationExecutionStats.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationExecutionStats.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationExecutionStats.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationExecutionStats.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationExecutionStatsConsumer.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationExecutionStatsConsumer.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationExecutionStatsConsumer.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationExecutionStatsConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationLog.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationLog.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationLog.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/OperationLog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/PseudoOperation.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/PseudoOperation.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/PseudoOperation.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/PseudoOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/AggregatedOperationStats.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/AggregatedOperationStats.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log.jmx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/AggregatedOperationStats.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/AggregatedOperationStats.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationLogJmxConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationLogJmxConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log.jmx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationLogJmxConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationLogJmxConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationLogJmxProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationLogJmxProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log.jmx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationLogJmxProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationLogJmxProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationStatsBean.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationStatsBean.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log.jmx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationStatsBean.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationStatsBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationStatsMXBean.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationStatsMXBean.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log.jmx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationStatsMXBean.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/jmx/OperationStatsMXBean.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/slf4j/DebuggingOperationExecutionStatsConsumer.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/slf4j/DebuggingOperationExecutionStatsConsumer.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.operationlog.log.slf4j;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/slf4j/DebuggingOperationExecutionStatsConsumer.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/log/slf4j/DebuggingOperationExecutionStatsConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/operationlog/package-info.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  *

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/package-info.java
@@ -42,6 +42,7 @@
  * }
  * </pre>
  *
+ * <p>
  * For more information on the subsystems, please refer to their package-infos:
  *
  * <ul>
@@ -52,6 +53,12 @@
  * <li>{@link org.eclipse.rdf4j.spring.resultcache Rdf4J-Spring ResultCache}
  * <li>{@link org.eclipse.rdf4j.spring.tx Rdf4J-Spring Tx}
  * </ul>
+ * </p>
+ *
+ * <p>
+ * This software has been developed in the project 'BIM-Interoperables Merkmalservice', funded by the Austrian Research
+ * Promotion Agency and Österreichische Bautechnik Veranstaltungs GmbH.
+ * </p>
  *
  * @since 4.0.0
  * @author Florian Kleedorfer

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/package-info.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  *

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PoolConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PoolConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.pool;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PoolConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PoolConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PoolProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PoolProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.pool;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PoolProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PoolProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledConnectionObjectFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledConnectionObjectFactory.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.pool;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledConnectionObjectFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledConnectionObjectFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledRepositoryConnection.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledRepositoryConnection.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.pool;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledRepositoryConnection.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledRepositoryConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledRepositoryConnectionFactory.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.pool;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/PooledRepositoryConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/pool/package-info.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  *

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/inmemory/InMemoryRepositoryConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/inmemory/InMemoryRepositoryConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/inmemory/InMemoryRepositoryConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/inmemory/InMemoryRepositoryConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.repository.inmemory;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/inmemory/InMemoryRepositoryProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/inmemory/InMemoryRepositoryProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/inmemory/InMemoryRepositoryProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/inmemory/InMemoryRepositoryProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.repository.inmemory;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/package-info.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  *
@@ -20,7 +18,6 @@
  * To configure a remote repostitory, use
  *
  * <ul>
- * <li><code>rdf4j.spring.repository.remote.enabled=true</code>
  * <li><code>rdf4j.spring.repository.remote.manager-url=[manager-url]</code>
  * <li><code>rdf4j.spring.repository.remote.name=[name]</code>
  * </ul>

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.repository.remote;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.repository.remote;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachedGraphQueryResult.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachedGraphQueryResult.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachedGraphQueryResult.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachedGraphQueryResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachedTupleQueryResult.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachedTupleQueryResult.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachedTupleQueryResult.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachedTupleQueryResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachingRepositoryConnection.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachingRepositoryConnection.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachingRepositoryConnection.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachingRepositoryConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachingRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachingRepositoryConnectionFactory.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachingRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/CachingRepositoryConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/Clearable.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/Clearable.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/Clearable.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/Clearable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ClearableAwareUpdate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ClearableAwareUpdate.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ClearableAwareUpdate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ClearableAwareUpdate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/LRUResultCache.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/LRUResultCache.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/LRUResultCache.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/LRUResultCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCache.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCache.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCache.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCacheConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCacheConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCacheConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCacheConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCacheProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCacheProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCacheProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCacheProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCachingGraphQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCachingGraphQuery.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCachingGraphQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCachingGraphQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCachingTupleQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCachingTupleQuery.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCachingTupleQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ResultCachingTupleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ReusableGraphQueryResult.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ReusableGraphQueryResult.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ReusableGraphQueryResult.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ReusableGraphQueryResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ReusableTupleQueryResult.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ReusableTupleQueryResult.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ReusableTupleQueryResult.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ReusableTupleQueryResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ThrowableRecorder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ThrowableRecorder.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.resultcache;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ThrowableRecorder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/ThrowableRecorder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/package-info.java
@@ -1,12 +1,10 @@
-/*
-* ******************************************************************************
-*  * Copyright (c) 2021 Eclipse RDF4J contributors.
-*  * All rights reserved. This program and the accompanying materials
-*  * are made available under the terms of the Eclipse Distribution License v1.0
-*  * which accompanies this distribution, and is available at
-*  * http://www.eclipse.org/org/documents/edl-v10.php.
-*  ******************************************************************************
-*/
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  *

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/resultcache/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/ConfigurationException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/ConfigurationException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/ConfigurationException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/ConfigurationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DataInserter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DataInserter.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DataInserter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DataInserter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DefaultUUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DefaultUUIDSource.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DefaultUUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DefaultUUIDSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DirectOperationInstantiator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DirectOperationInstantiator.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DirectOperationInstantiator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/DirectOperationInstantiator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/OperationInstantiator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/OperationInstantiator.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/OperationInstantiator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/OperationInstantiator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/RDF4JTemplate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/RDF4JTemplate.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/RDF4JTemplate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/RDF4JTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/UUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/UUIDSource.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/UUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/UUIDSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/DelegatingRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/DelegatingRepositoryConnectionFactory.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support.connectionfactory;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/DelegatingRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/DelegatingRepositoryConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/DirectRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/DirectRepositoryConnectionFactory.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support.connectionfactory;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/DirectRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/DirectRepositoryConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/RepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/RepositoryConnectionFactory.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support.connectionfactory;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/RepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/connectionfactory/RepositoryConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingGraphQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingGraphQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingGraphQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingGraphQuery.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support.query;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingIterator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingIterator.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingIterator.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support.query;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingTupleQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingTupleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingTupleQuery.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingTupleQuery.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support.query;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingUpdate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingUpdate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingUpdate.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/support/query/DelegatingUpdate.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support.query;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/test/RDF4JTestConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/test/RDF4JTestConfig.java
@@ -1,0 +1,61 @@
+/******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * *****************************************************************************/
+
+package org.eclipse.rdf4j.spring.test;
+
+import org.eclipse.rdf4j.spring.RDF4JConfig;
+import org.eclipse.rdf4j.spring.operationcache.OperationCacheConfig;
+import org.eclipse.rdf4j.spring.operationlog.OperationLogConfig;
+import org.eclipse.rdf4j.spring.operationlog.log.jmx.OperationLogJmxConfig;
+import org.eclipse.rdf4j.spring.pool.PoolConfig;
+import org.eclipse.rdf4j.spring.repository.inmemory.InMemoryRepositoryConfig;
+import org.eclipse.rdf4j.spring.repository.remote.RemoteRepositoryConfig;
+import org.eclipse.rdf4j.spring.resultcache.ResultCacheConfig;
+import org.eclipse.rdf4j.spring.tx.TxConfig;
+import org.eclipse.rdf4j.spring.uuidsource.noveltychecking.NoveltyCheckingUUIDSourceConfig;
+import org.eclipse.rdf4j.spring.uuidsource.predictable.PredictableUUIDSource;
+import org.eclipse.rdf4j.spring.uuidsource.predictable.PredictableUUIDSourceConfig;
+import org.eclipse.rdf4j.spring.uuidsource.sequence.UUIDSequenceConfig;
+import org.eclipse.rdf4j.spring.uuidsource.simple.SimpleRepositoryUUIDSourceConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Spring configuration for use in unit tests. Imports the configurations of all subsystems that are autoconfigured when
+ * used outside of tests. Test configurations should import this configuration:
+ *
+ * <pre>
+ * 	&#64TestConfiguration
+ * 	&#64Import(RDF4JTestConfig.class)
+ * 	&#64ComponentScan(basePackages = "com.example.myapp.*")
+ *  	public class TestConfig {
+ * 			// application-specific configuration
+ *   	}
+ * </pre>
+ *
+ * @author Florian Kleedorfer
+ * @since 4.0.0
+ */
+@Configuration
+@Import({
+		RDF4JConfig.class,
+		InMemoryRepositoryConfig.class,
+		RemoteRepositoryConfig.class,
+		PoolConfig.class,
+		ResultCacheConfig.class,
+		OperationCacheConfig.class,
+		OperationLogConfig.class,
+		OperationLogJmxConfig.class,
+		TxConfig.class,
+		UUIDSequenceConfig.class,
+		NoveltyCheckingUUIDSourceConfig.class,
+		SimpleRepositoryUUIDSourceConfig.class,
+		PredictableUUIDSourceConfig.class
+})
+public class RDF4JTestConfig {
+}

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/test/RDF4JTestConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/test/RDF4JTestConfig.java
@@ -1,10 +1,10 @@
-/******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- * *****************************************************************************/
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.test;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/IsolationLevelAdapter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/IsolationLevelAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/IsolationLevelAdapter.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/IsolationLevelAdapter.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/RDF4JRepositoryTransactionManager.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/RDF4JRepositoryTransactionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/RDF4JRepositoryTransactionManager.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/RDF4JRepositoryTransactionManager.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionObject.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionObject.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionObject.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionalRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionalRepositoryConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionalRepositoryConnectionFactory.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionalRepositoryConnectionFactory.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TxConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TxConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TxConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TxConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TxProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TxProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TxProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TxProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/CommitException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/CommitException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/CommitException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/CommitException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/ConnectionClosedException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/ConnectionClosedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/ConnectionClosedException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/ConnectionClosedException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/NoTransactionException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/NoTransactionException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/NoTransactionException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/NoTransactionException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RDF4JTransactionException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RDF4JTransactionException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RDF4JTransactionException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RDF4JTransactionException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RepositoryConnectionPoolException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RepositoryConnectionPoolException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RepositoryConnectionPoolException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RepositoryConnectionPoolException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RollbackException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RollbackException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RollbackException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/RollbackException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/TransactionInactiveException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/TransactionInactiveException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/TransactionInactiveException.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/exception/TransactionInactiveException.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.tx.exception;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/package-info.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  *

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/ObjectMapUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/ObjectMapUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/ObjectMapUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/ObjectMapUtils.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.util;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/QueryResultUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/QueryResultUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/QueryResultUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/QueryResultUtils.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.util;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/RepositoryConnectionWrappingUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/RepositoryConnectionWrappingUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/RepositoryConnectionWrappingUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/RepositoryConnectionWrappingUtils.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.util;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/TypeMappingUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/TypeMappingUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/TypeMappingUtils.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/util/TypeMappingUtils.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.util;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSource.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.noveltychecking;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.noveltychecking;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.noveltychecking;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/noveltychecking/NoveltyCheckingUUIDSourceProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/package-info.java
@@ -7,12 +7,15 @@
  *******************************************************************************/
 
 /**
- * This package contains three different approaches for obtaining UUIDs from a
+ * This package contains different approaches for generating UUIDs. One of them always generates the same sequence of
+ * UUIDs after bean initialization, which is useful for tests. Three of them obtain them from a
  * {@link org.eclipse.rdf4j.repository.Repository Repository}, guaranteeing their uniqueness. Due to the <b>very, very,
- * very</b> low probability of a collision, it is recommended not to use any of these and instead rely on the
- * {@link org.eclipse.rdf4j.spring.support.DefaultUUIDSource DefaultUUIDSource}.
+ * very</b> low probability of a collision, it is recommended not to use any of the latter and instead rely on the one
+ * instantiated by default, {@link org.eclipse.rdf4j.spring.support.DefaultUUIDSource DefaultUUIDSource}.
  *
  * <ol>
+ * <li>{@link org.eclipse.rdf4j.spring.uuidsource.predictable.PredictableUUIDSource PredictableUUIDSource}: Always
+ * generate the same sequence of UUIDs.</li>
  * <li>{@link org.eclipse.rdf4j.spring.uuidsource.noveltychecking.NoveltyCheckingUUIDSource NoveltyCheckingUUIDSource}:
  * Generate a {@link java.util.UUID UUID} locally using {@link java.util.UUID#randomUUID() UUID.randomUUID()} and then
  * ask the repository if the UUID is unique. Enable with

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/package-info.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 /**
  * This package contains three different approaches for obtaining UUIDs from a

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/package-info.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSource.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.spring.uuidsource.predictable;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.spring.support.UUIDSource;
+
+/**
+ * UUID source that generates the same sequence of UUIDs by counting up a <code>long</code> counter and using that as
+ * the value for generating a UUID. Useful for unit tests as newly generated entities will receive the same UUIDs each
+ * time the tests are executed.
+ *
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+public class PredictableUUIDSource implements UUIDSource {
+
+	private final AtomicLong counter = new AtomicLong(0);
+
+	public PredictableUUIDSource() {
+	}
+
+	@Override
+	public IRI nextUUID() {
+		long value = counter.incrementAndGet();
+		return toURNUUID(UUID.nameUUIDFromBytes(Long.toString(value).getBytes()).toString());
+	}
+
+}

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSourceConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSourceConfig.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.spring.uuidsource.predictable;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+@Configuration
+@EnableConfigurationProperties(PredictableUUIDSourceProperties.class)
+@ConditionalOnProperty(prefix = "rdf4j.spring.uuidsource.predictable", name = "enabled")
+public class PredictableUUIDSourceConfig {
+	@Bean
+	public PredictableUUIDSource getUUIDSource() {
+		return new PredictableUUIDSource();
+	}
+}

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSourceConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSourceConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSourceProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSourceProperties.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.spring.uuidsource.predictable;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+@ConfigurationProperties(prefix = "rdf4j.spring.uuidsource.predictable")
+public class PredictableUUIDSourceProperties {
+
+	private boolean enabled;
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+}

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSourceProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/predictable/PredictableUUIDSourceProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequence.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequence.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequence.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequence.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.sequence;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequenceConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequenceConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequenceConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequenceConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.sequence;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequenceProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequenceProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequenceProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/sequence/UUIDSequenceProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.sequence;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSource.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSource.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.simple;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSourceConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSourceConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSourceConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSourceConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.simple;
 

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSourceProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSourceProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSourceProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/uuidsource/simple/SimpleRepositoryUUIDSourceProperties.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.uuidsource.simple;
 

--- a/spring-components/rdf4j-spring/src/main/resources/META-INF/spring.factories
+++ b/spring-components/rdf4j-spring/src/main/resources/META-INF/spring.factories
@@ -10,4 +10,5 @@ org.eclipse.rdf4j.spring.resultcache.ResultCacheConfig,\
 org.eclipse.rdf4j.spring.tx.TxConfig,\
 org.eclipse.rdf4j.spring.uuidsource.noveltychecking.NoveltyCheckingUUIDSourceConfig,\
 org.eclipse.rdf4j.spring.uuidsource.sequence.UUIDSequenceConfig,\
-org.eclipse.rdf4j.spring.uuidsource.simple.SimpleRepositoryUUIDSourceConfig
+org.eclipse.rdf4j.spring.uuidsource.simple.SimpleRepositoryUUIDSourceConfig,\
+org.eclipse.rdf4j.spring.uuidsource.predictable.PredictableUUIDSourceConfig

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/BasicTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/BasicTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/BasicTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/BasicTests.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/RDF4JSpringTestBase.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/RDF4JSpringTestBase.java
@@ -37,22 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @ExtendWith(SpringExtension.class)
 @Transactional
-@ContextConfiguration(
-		classes = {
-				RDF4JConfig.class,
-				TestConfig.class,
-				InMemoryRepositoryConfig.class,
-				RemoteRepositoryConfig.class,
-				PoolConfig.class,
-				ResultCacheConfig.class,
-				OperationCacheConfig.class,
-				OperationLogConfig.class,
-				OperationLogJmxConfig.class,
-				TxConfig.class,
-				UUIDSequenceConfig.class,
-				NoveltyCheckingUUIDSourceConfig.class,
-				SimpleRepositoryUUIDSourceConfig.class
-		})
+@ContextConfiguration(classes = { TestConfig.class })
 @TestPropertySource("classpath:application.properties")
 @TestPropertySource(
 		properties = {

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/RDF4JSpringTestBase.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/RDF4JSpringTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/RDF4JSpringTestBase.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/RDF4JSpringTestBase.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/TestConfig.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/TestConfig.java
@@ -9,9 +9,11 @@
 package org.eclipse.rdf4j.spring;
 
 import org.eclipse.rdf4j.spring.support.DataInserter;
+import org.eclipse.rdf4j.spring.test.RDF4JTestConfig;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  */
 @TestConfiguration
 @EnableTransactionManagement
+@Import(RDF4JTestConfig.class)
 @ComponentScan(basePackages = "org.eclipse.rdf4j.spring.domain")
 public class TestConfig {
 	@Bean

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/TestConfig.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/TestConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/TestConfig.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/TestConfig.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/RDF4JCrudDaoTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/RDF4JCrudDaoTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/RDF4JCrudDaoTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/RDF4JCrudDaoTests.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/ServiceLayerTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/ServiceLayerTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/ServiceLayerTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/ServiceLayerTests.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverterTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverterTests.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.dao.support.operation;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverterTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/operation/TupleQueryResultConverterTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/dao/ArtistDao.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/dao/ArtistDao.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/dao/ArtistDao.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/dao/ArtistDao.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.domain.dao;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/dao/PaintingDao.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/dao/PaintingDao.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/dao/PaintingDao.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/dao/PaintingDao.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.domain.dao;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/Artist.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/Artist.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.domain.model;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/Artist.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/Artist.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/EX.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/EX.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.domain.model;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/EX.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/EX.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/Painting.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/Painting.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.domain.model;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/Painting.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/model/Painting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/service/ArtService.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/service/ArtService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/service/ArtService.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/domain/service/ArtService.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.domain.service;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTests.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationCache.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationCache.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationCache.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationLog.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationLog.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationLog.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationLog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationLogViaJMX.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationLogViaJMX.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationLogViaJMX.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithOperationLogViaJMX.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithResultCache.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithResultCache.java
@@ -1,12 +1,10 @@
-/*
- * ******************************************************************************
- *  * Copyright (c) 2021 Eclipse RDF4J contributors.
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Distribution License v1.0
- *  * which accompanies this distribution, and is available at
- *  * http://www.eclipse.org/org/documents/edl-v10.php.
- *  ******************************************************************************
- */
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.spring.support;
 

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithResultCache.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/support/RDF4JTemplateTestsWithResultCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
Related Issue: #3387 

Add folder `spring-components/rdf4j-spring-demo` containing a maven project that uses `rdf4j-spring`.

The `rdf4j-spring-demo` project is explicitly **not a maven submodule** of `rdf4j-spring-components` so the pom is self-contained, which makes it clearer to users how to start their own `rdf4j-spring` project.

As discussed in #3387, I am not sure that this is the best place for this demo project, but I think it is the best place I can put it without changes to the rdf4j folder/project structure.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

