### PR TITLE
GH-3372 maven-javadoc-plugin 3.x uses different config flags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
 								</goals>
 							</execution>
 						</executions>
-						<configuration>
-							<encoding>utf8</encoding>
-							<source>11</source>
-							<additionalparam>${javadoc.opts}</additionalparam>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -193,11 +188,6 @@
 								</configuration>
 							</execution>
 						</executions>
-						<configuration>
-							<encoding>utf8</encoding>
-							<source>11</source>
-							<additionalparam>${javadoc.opts}</additionalparam>
-						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -229,15 +219,6 @@
 					</plugin>
 				</plugins>
 			</build>
-		</profile>
-		<profile>
-			<id>doclint-disable</id>
-			<activation>
-				<jdk>[11,)</jdk>
-			</activation>
-			<properties>
-				<javadoc.opts>-Xdoclint:none -html5 -tag implNote:a:"Implementation Note"</javadoc.opts>
-			</properties>
 		</profile>
 		<profile>
 			<id>use-sonatype-snapshots</id>
@@ -746,8 +727,12 @@
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>3.3.1</version>
 					<configuration>
+						<encoding>utf8</encoding>
 						<source>11</source>
-						<additionalparam>${javadoc.opts}</additionalparam>
+						<doclint>none</doclint>
+						<additionalOptions>
+							<additionalOption>-html5</additionalOption>
+						</additionalOptions>
 						<additionalJOption>${additional.j.option}</additionalJOption>
 						<additionalDependencies>
 							<additionalDependency>


### PR DESCRIPTION
GitHub issue resolved: #3372  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- tweaked javadoc plugin config to conform to changes that were made in its supported options since 3.0

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

