### PR TITLE
GH-3404-Error parsing JSON-LD data with the default base URI from StatementsController

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/StatementsController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/StatementsController.java
@@ -377,9 +377,9 @@ public class StatementsController extends AbstractController {
 		final boolean preserveNodeIds = ProtocolUtil.parseBooleanParam(request, Protocol.PRESERVE_BNODE_ID_PARAM_NAME,
 				false);
 
-		if (baseURI == null) {
-			baseURI = vf.createIRI("foo:bar");
-			logger.info("no base URI specified, using dummy '{}'", baseURI);
+		String baseURIString = null;
+		if (baseURI != null) {
+			baseURIString = baseURI.toString();
 		}
 
 		InputStream in = request.getInputStream();
@@ -393,7 +393,7 @@ public class StatementsController extends AbstractController {
 			if (replaceCurrent) {
 				repositoryCon.clear(contexts);
 			}
-			repositoryCon.add(in, baseURI.toString(), rdfFormat, contexts);
+			repositoryCon.add(in, baseURIString, rdfFormat, contexts);
 
 			repositoryCon.commit();
 


### PR DESCRIPTION
GH-3404-Error parsing JSON-LD data with the default base URI from StatementsController

GitHub issue resolved: 3404

Briefly describe the changes proposed in this PR:

Remove the default 'foo:bar' base URI in order to prevent error when data is parsed with JSONLDParser 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

