### PR TITLE
GH-3407 sail level query optimizers

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/MapBindingSet.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/MapBindingSet.java
@@ -48,7 +48,7 @@ public class MapBindingSet extends AbstractBindingSet {
 	 * @param value The binding's value.
 	 */
 	public void addBinding(String name, Value value) {
-		addBinding(new SimpleBinding(name, value));
+		addBinding(new SimpleMutableBinding(name, value));
 	}
 
 	/**

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/SimpleMutableBinding.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/SimpleMutableBinding.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.query.impl;
+
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Binding;
+
+/**
+ * An implementation of the {@link Binding} interface that allows the value of the binding to be updated.
+ *
+ * @author Håvard Ottestad
+ */
+public class SimpleMutableBinding implements Binding {
+
+	private static final long serialVersionUID = -8257254838478873398L;
+
+	private final String name;
+
+	private Value value;
+
+	/**
+	 * Creates a binding object with the supplied name and value.
+	 *
+	 * @param name  The binding's name.
+	 * @param value The binding's value.
+	 */
+	public SimpleMutableBinding(String name, Value value) {
+		assert name != null : "name must not be null";
+		assert value != null : "value must not be null";
+
+		this.name = name;
+		this.value = value;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public Value getValue() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof Binding) {
+			Binding other = (Binding) o;
+
+			return name.equals(other.getName()) && value.equals(other.getValue());
+		}
+
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode() ^ value.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return name + "=" + value.toString();
+	}
+
+	public void setValue(Value value) {
+		assert value != null : "value must not be null";
+		this.value = value;
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategy.java
@@ -50,6 +50,14 @@ public interface EvaluationStrategy extends FederatedServiceResolver {
 	void setOptimizerPipeline(QueryOptimizerPipeline pipeline);
 
 	/**
+	 * Get the {@link QueryOptimizerPipeline}.
+	 *
+	 * @see #optimize(TupleExpr, EvaluationStatistics, BindingSet)
+	 * @since 4.0
+	 */
+	QueryOptimizerPipeline getOptimizerPipeline();
+
+	/**
 	 * Execute the {@link QueryOptimizerPipeline} on the given {@link TupleExpr} to optimize its execution plan.
 	 *
 	 * @param expr                 the {@link TupleExpr} to optimize.

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.query.Dataset;
@@ -81,4 +83,10 @@ public interface EvaluationStrategyFactory {
 		// no-op for backwards compatibility
 	}
 
+	void addOptimizer(QueryOptimizerFunctionalInterface queryOptimizerFunctionalInterface,
+			boolean beforeOtherQueryOptimizers);
+
+	List<QueryOptimizerFunctionalInterface> getQueryOptimizersPre();
+
+	List<QueryOptimizerFunctionalInterface> getQueryOptimizersPost();
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizerFunctionalInterface.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizerFunctionalInterface.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.query.algebra.evaluation;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
+
+public interface QueryOptimizerFunctionalInterface {
+
+	QueryOptimizer getOptimizer(EvaluationStrategy strategy, TripleSource tripleSource,
+			EvaluationStatistics evaluationStatistics);
+
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
@@ -7,9 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerFunctionalInterface;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
 
 /**
@@ -25,6 +29,8 @@ public abstract class AbstractEvaluationStrategyFactory implements EvaluationStr
 	private boolean trackResultSize;
 
 	private QueryOptimizerPipeline pipeline;
+	private final List<QueryOptimizerFunctionalInterface> queryOptimizersPre = new ArrayList<>();
+	private final List<QueryOptimizerFunctionalInterface> queryOptimizersPost = new ArrayList<>();
 
 	@Override
 	public void setQuerySolutionCacheThreshold(long threshold) {
@@ -54,5 +60,23 @@ public abstract class AbstractEvaluationStrategyFactory implements EvaluationStr
 	@Override
 	public void setTrackResultSize(boolean trackResultSize) {
 		this.trackResultSize = trackResultSize;
+	}
+
+	@Override
+	public void addOptimizer(QueryOptimizerFunctionalInterface queryOptimizerFunctionalInterface,
+			boolean beforeOtherQueryOptimizers) {
+		if (beforeOtherQueryOptimizers) {
+			queryOptimizersPre.add(queryOptimizerFunctionalInterface);
+		} else {
+			queryOptimizersPost.add(queryOptimizerFunctionalInterface);
+		}
+	}
+
+	public List<QueryOptimizerFunctionalInterface> getQueryOptimizersPre() {
+		return Collections.unmodifiableList(queryOptimizersPre);
+	}
+
+	public List<QueryOptimizerFunctionalInterface> getQueryOptimizersPost() {
+		return Collections.unmodifiableList(queryOptimizersPost);
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -255,6 +255,11 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 		this.pipeline = pipeline;
 	}
 
+	@Override
+	public QueryOptimizerPipeline getOptimizerPipeline() {
+		return pipeline;
+	}
+
 	/**
 	 * Execute the {@link QueryOptimizerPipeline} on the given {@link TupleExpr} to optimize its execution plan.
 	 *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
@@ -8,7 +8,9 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -51,19 +53,43 @@ public class StrictEvaluationStrategyFactory extends AbstractEvaluationStrategyF
 				getQuerySolutionCacheThreshold(), evaluationStatistics, isTrackResultSize());
 		getOptimizerPipeline().ifPresent(strategy::setOptimizerPipeline);
 
-		QueryOptimizerPipeline optimizerPipeline = strategy.getOptimizerPipeline();
+		if (!getQueryOptimizersPre().isEmpty() || !getQueryOptimizersPost().isEmpty()) {
 
-		List<QueryOptimizer> collect = Stream.concat(
-				getQueryOptimizersPre().stream().map(i -> i.getOptimizer(strategy, tripleSource, evaluationStatistics)),
-				Stream.concat(
-						StreamSupport.stream(optimizerPipeline.getOptimizers().spliterator(), false),
-						getQueryOptimizersPost().stream()
-								.map(i -> i.getOptimizer(strategy, tripleSource, evaluationStatistics))
-				)
-		)
-				.collect(Collectors.toList());
+			Iterable<QueryOptimizer> optimizers = strategy.getOptimizerPipeline().getOptimizers();
+			List<QueryOptimizer> queryOptimizersPre = getQueryOptimizersPre().stream()
+					.map(i -> i.getOptimizer(strategy, tripleSource, evaluationStatistics))
+					.collect(Collectors.toList());
+			List<QueryOptimizer> queryOptimizersPost = getQueryOptimizersPost().stream()
+					.map(i -> i.getOptimizer(strategy, tripleSource, evaluationStatistics))
+					.collect(Collectors.toList());
 
-		strategy.setOptimizerPipeline(() -> collect);
+			strategy.setOptimizerPipeline(() -> () -> new Iterator<>() {
+
+				final Iterator<QueryOptimizer> preIterator = queryOptimizersPre.iterator();
+				final Iterator<QueryOptimizer> iterator = optimizers.iterator();
+				final Iterator<QueryOptimizer> postIterator = queryOptimizersPost.iterator();
+
+				@Override
+				public boolean hasNext() {
+					return preIterator.hasNext() || iterator.hasNext() || postIterator.hasNext();
+				}
+
+				@Override
+				public QueryOptimizer next() {
+					if (preIterator.hasNext()) {
+						return preIterator.next();
+					}
+					if (iterator.hasNext()) {
+						return iterator.next();
+					}
+					if (postIterator.hasNext()) {
+						return postIterator.next();
+					}
+					throw new NoSuchElementException();
+				}
+			});
+
+		}
 
 		return strategy;
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/OrderComparatorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/OrderComparatorTest.java
@@ -74,6 +74,11 @@ public class OrderComparatorTest {
 		}
 
 		@Override
+		public QueryOptimizerPipeline getOptimizerPipeline() {
+			return null;
+		}
+
+		@Override
 		public TupleExpr optimize(TupleExpr expr, EvaluationStatistics evaluationStatistics, BindingSet bindings) {
 			// TODO Auto-generated method stub
 			return null;

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactory.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactory.java
@@ -102,14 +102,14 @@ public class MemValueFactory extends AbstractValueFactory {
 	 * See getMemValue() for description.
 	 */
 	public MemResource getMemResource(Resource resource) {
-		if (resource instanceof IRI) {
-			return getMemURI((IRI) resource);
-		} else if (resource instanceof BNode) {
-			return getMemBNode((BNode) resource);
-		} else if (resource instanceof Triple) {
-			return getMemTriple((Triple) resource);
-		} else if (resource == null) {
+		if (resource == null) {
 			return null;
+		} else if (resource.isIRI()) {
+			return getMemURI((IRI) resource);
+		} else if (resource.isBNode()) {
+			return getMemBNode((BNode) resource);
+		} else if (resource.isTriple()) {
+			return getMemTriple((Triple) resource);
 		} else {
 			throw new IllegalArgumentException("resource is not a URI or BNode: " + resource);
 		}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SimpleBindingSet.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/SimpleBindingSet.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.AbstractBindingSet;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.impl.SimpleBinding;
+import org.eclipse.rdf4j.query.impl.SimpleMutableBinding;
 
 /**
  * A simple binding set tuned for the use case that the ShaclSail has.
@@ -34,7 +35,7 @@ class SimpleBindingSet extends AbstractBindingSet {
 		this.bindingNamesSet = Collections.unmodifiableSet(bindingNamesSet);
 
 		for (int i = 0; i < varNamesList.size(); i++) {
-			bindings[i] = new SimpleBinding(varNamesList.get(i), values.get(i));
+			bindings[i] = new SimpleMutableBinding(varNamesList.get(i), values.get(i));
 		}
 
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/SailSourceEvaluationStrategyFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/endpoint/provider/SailSourceEvaluationStrategyFactory.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.endpoint.provider;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -20,6 +21,7 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerFunctionalInterface;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
@@ -75,6 +77,22 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
 		return new SailSourceEvaluationStrategy(delegateStrategy, dataset);
 	}
 
+	@Override
+	public void addOptimizer(QueryOptimizerFunctionalInterface queryOptimizerFunctionalInterface,
+			boolean beforeOtherQueryOptimizers) {
+		delegate.addOptimizer(queryOptimizerFunctionalInterface, beforeOtherQueryOptimizers);
+	}
+
+	@Override
+	public List<QueryOptimizerFunctionalInterface> getQueryOptimizersPre() {
+		return delegate.getQueryOptimizersPre();
+	}
+
+	@Override
+	public List<QueryOptimizerFunctionalInterface> getQueryOptimizersPost() {
+		return delegate.getQueryOptimizersPost();
+	}
+
 	/**
 	 * {@link EvaluationStrategy} that can handle {@link PrecompiledQueryNode} without prior optimization. All other
 	 * {@link TupleExpr} are handled in the respective delegate.
@@ -101,6 +119,11 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
 		@Override
 		public void setOptimizerPipeline(QueryOptimizerPipeline pipeline) {
 			delegate.setOptimizerPipeline(pipeline);
+		}
+
+		@Override
+		public QueryOptimizerPipeline getOptimizerPipeline() {
+			return delegate.getOptimizerPipeline();
 		}
 
 		@Override
@@ -134,6 +157,16 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
 		public boolean isTrue(ValueExpr expr, BindingSet bindings)
 				throws ValueExprEvaluationException, QueryEvaluationException {
 			return delegate.isTrue(expr, bindings);
+		}
+
+		@Override
+		public void setTrackResultSize(boolean trackResultSize) {
+			delegate.setTrackResultSize(trackResultSize);
+		}
+
+		@Override
+		public void setTrackTime(boolean trackTime) {
+			delegate.setTrackTime(trackTime);
 		}
 
 		protected TupleExpr optimizePreparedQuery(PrecompiledQueryNode preparedQuery, BindingSet bindings) {


### PR DESCRIPTION
GitHub issue resolved: #3407 <!-- add a Github issue number here, e.g #123. -->

### Briefly describe the changes proposed in this PR:

Add functionality to the `EvaluationStrategyFactory` in order to inject new optimisers at runtime.

This functionality should consist of:
 - a functional interface (supplier) that is provided with `EvaluationStrategy strategy, TripleSource tripleSource, EvaluationStatistics evaluationStatistics` in order to instantiate a `QueryOptimizer`
 - methods on the `EvaluationStrategyFactory` to add instances of the above mentioned interface (with the ability to specify if the new `QueryOptimizer` should be inserted at the beginning or end of the current pipeline)
 - getters for the above
 - getter for the pipeline in `EvaluationStrategy`


Create a `Value` optimiser for the MemoryStore to swap out values in the query with the "interned" value from the `MemValueFactory`.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

