### PR TITLE
GH-3410 improve MemStatementsIterator

### DIFF
--- a/core/common/io/src/main/java/org/eclipse/rdf4j/common/lang/ObjectUtil.java
+++ b/core/common/io/src/main/java/org/eclipse/rdf4j/common/lang/ObjectUtil.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.common.lang;
 
+import java.util.Objects;
+
 /**
  * Generic utility methods related to objects.
  *
@@ -24,8 +26,9 @@ public class ObjectUtil {
 	 *         objects are equal according to the {@link Object#equals} method of the first object; <var>false</var> in
 	 *         all other situations.
 	 */
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	public static boolean nullEquals(Object o1, Object o2) {
-		return o1 == o2 || o1 != null && o2 != null && o1.equals(o2);
+		return Objects.equals(o1, o2);
 	}
 
 	/**

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/CloseableIteratorIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/CloseableIteratorIteration.java
@@ -21,7 +21,7 @@ public class CloseableIteratorIteration<E, X extends Exception> extends Abstract
 	 * Variables *
 	 *-----------*/
 
-	private volatile Iterator<? extends E> iter;
+	private Iterator<? extends E> iter;
 
 	/*--------------*
 	 * Constructors *

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/LookAheadIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/LookAheadIteration.java
@@ -21,7 +21,7 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 	 * Variables *
 	 *-----------*/
 
-	private volatile E nextElement;
+	private E nextElement;
 
 	/*--------------*
 	 * Constructors *
@@ -46,11 +46,8 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 		if (isClosed()) {
 			return false;
 		}
-		boolean result = (lookAhead() != null);
-		if (!result) {
-			close();
-		}
-		return result;
+
+		return lookAhead() != null;
 	}
 
 	@Override
@@ -64,7 +61,6 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 			nextElement = null;
 			return result;
 		} else {
-			close();
 			throw new NoSuchElementException();
 		}
 	}
@@ -76,15 +72,14 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 	 * @throws X If there is an issue getting the next element or closing the iteration.
 	 */
 	private E lookAhead() throws X {
-		E checkElement = nextElement;
-		if (checkElement == null && !isClosed()) {
-			checkElement = nextElement = getNextElement();
+		if (nextElement == null) {
+			nextElement = getNextElement();
 
-			if (checkElement == null) {
+			if (nextElement == null) {
 				close();
 			}
 		}
-		return checkElement;
+		return nextElement;
 	}
 
 	/**

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/operations/RemoveNamespaceOperation.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/operations/RemoveNamespaceOperation.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.http.protocol.transaction.operations;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.eclipse.rdf4j.common.lang.ObjectUtil;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -52,7 +53,7 @@ public class RemoveNamespaceOperation implements TransactionOperation, Serializa
 	public boolean equals(Object other) {
 		if (other instanceof RemoveNamespaceOperation) {
 			RemoveNamespaceOperation o = (RemoveNamespaceOperation) other;
-			return ObjectUtil.nullEquals(getPrefix(), o.getPrefix());
+			return Objects.equals(getPrefix(), o.getPrefix());
 		}
 
 		return false;

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/operations/SetNamespaceOperation.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/operations/SetNamespaceOperation.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.http.protocol.transaction.operations;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.eclipse.rdf4j.common.lang.ObjectUtil;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -63,7 +64,7 @@ public class SetNamespaceOperation implements TransactionOperation, Serializable
 	public boolean equals(Object other) {
 		if (other instanceof SetNamespaceOperation) {
 			SetNamespaceOperation o = (SetNamespaceOperation) other;
-			return ObjectUtil.nullEquals(getPrefix(), o.getPrefix()) && ObjectUtil.nullEquals(getName(), o.getName());
+			return Objects.equals(getPrefix(), o.getPrefix()) && Objects.equals(getName(), o.getName());
 		}
 
 		return false;

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/operations/StatementOperation.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/operations/StatementOperation.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.protocol.transaction.operations;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.common.lang.ObjectUtil;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
@@ -59,9 +61,9 @@ public abstract class StatementOperation extends ContextOperation {
 		if (other instanceof StatementOperation) {
 			StatementOperation o = (StatementOperation) other;
 
-			return ObjectUtil.nullEquals(getSubject(), o.getSubject())
-					&& ObjectUtil.nullEquals(getPredicate(), o.getPredicate())
-					&& ObjectUtil.nullEquals(getObject(), o.getObject()) && super.equals(other);
+			return Objects.equals(getSubject(), o.getSubject())
+					&& Objects.equals(getPredicate(), o.getPredicate())
+					&& Objects.equals(getObject(), o.getObject()) && super.equals(other);
 		}
 
 		return false;

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractStatement.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractStatement.java
@@ -54,42 +54,4 @@ public abstract class AbstractStatement implements Statement {
 				+ ")";
 	}
 
-	static class GenericStatement extends AbstractStatement {
-
-		private static final long serialVersionUID = -4116676621136121342L;
-
-		private Resource subject;
-		private IRI predicate;
-		private Value object;
-		private Resource context;
-
-		GenericStatement(Resource subject, IRI predicate, Value object, Resource context) {
-			this.subject = subject;
-			this.predicate = predicate;
-			this.object = object;
-			this.context = context;
-		}
-
-		@Override
-		public Resource getSubject() {
-			return subject;
-		}
-
-		@Override
-		public IRI getPredicate() {
-			return predicate;
-		}
-
-		@Override
-		public Value getObject() {
-			return object;
-		}
-
-		@Override
-		public Resource getContext() {
-			return context;
-		}
-
-	}
-
 }

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
@@ -41,7 +41,6 @@ import org.eclipse.rdf4j.model.base.AbstractLiteral.TaggedLiteral;
 import org.eclipse.rdf4j.model.base.AbstractLiteral.TemporalAccessorLiteral;
 import org.eclipse.rdf4j.model.base.AbstractLiteral.TemporalAmountLiteral;
 import org.eclipse.rdf4j.model.base.AbstractLiteral.TypedLiteral;
-import org.eclipse.rdf4j.model.base.AbstractStatement.GenericStatement;
 import org.eclipse.rdf4j.model.base.AbstractTriple.GenericTriple;
 
 /**
@@ -244,6 +243,44 @@ public abstract class AbstractValueFactory implements ValueFactory {
 		Objects.requireNonNull(object, "null object");
 
 		return new GenericStatement(subject, predicate, object, context);
+	}
+
+	static class GenericStatement extends AbstractStatement {
+
+		private static final long serialVersionUID = -4116676621136121342L;
+
+		private final Resource subject;
+		private final IRI predicate;
+		private final Value object;
+		private final Resource context;
+
+		GenericStatement(Resource subject, IRI predicate, Value object, Resource context) {
+			this.subject = subject;
+			this.predicate = predicate;
+			this.object = object;
+			this.context = context;
+		}
+
+		@Override
+		public Resource getSubject() {
+			return subject;
+		}
+
+		@Override
+		public IRI getPredicate() {
+			return predicate;
+		}
+
+		@Override
+		public Value getObject() {
+			return object;
+		}
+
+		@Override
+		public Resource getContext() {
+			return context;
+		}
+
 	}
 
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ContextStatement.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ContextStatement.java
@@ -53,6 +53,10 @@ public class ContextStatement extends SimpleStatement {
 		return context;
 	}
 
+	public boolean exactSameContext(Resource context) {
+		return context == this.context;
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(256);

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleStatement.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleStatement.java
@@ -88,6 +88,18 @@ public class SimpleStatement extends AbstractStatement {
 		return object;
 	}
 
+	public boolean exactSameSubject(Resource subject) {
+		return subject == this.subject;
+	}
+
+	public boolean exactSamePredicate(IRI predicate) {
+		return predicate == this.predicate;
+	}
+
+	public boolean exactSameObject(Value object) {
+		return object == this.object;
+	}
+
 	// Implements Statement.getContext()
 	@Override
 	public Resource getContext() {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/TupleFunctionRegistry.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/TupleFunctionRegistry.java
@@ -11,18 +11,14 @@ import org.eclipse.rdf4j.common.lang.service.ServiceRegistry;
 
 public class TupleFunctionRegistry extends ServiceRegistry<String, TupleFunction> {
 
-	private static TupleFunctionRegistry defaultRegistry;
+	private final static TupleFunctionRegistry defaultRegistry = new TupleFunctionRegistry();
 
 	/**
 	 * Gets the default TupleFunctionRegistry.
 	 *
 	 * @return The default registry.
 	 */
-	public static synchronized TupleFunctionRegistry getInstance() {
-		if (defaultRegistry == null) {
-			defaultRegistry = new TupleFunctionRegistry();
-		}
-
+	public static TupleFunctionRegistry getInstance() {
 		return defaultRegistry;
 	}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
@@ -35,15 +35,16 @@ import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
  */
 public class EvaluationStatistics {
 
-	protected CardinalityCalculator cc;
+	private CardinalityCalculator calculator;
 
-	public synchronized double getCardinality(TupleExpr expr) {
-		if (cc == null) {
-			cc = createCardinalityCalculator();
+	public double getCardinality(TupleExpr expr) {
+		if (calculator == null) {
+			calculator = createCardinalityCalculator();
+			assert calculator != null;
 		}
 
-		expr.visit(cc);
-		return cc.getCardinality();
+		expr.visit(calculator);
+		return calculator.getCardinality();
 	}
 
 	protected CardinalityCalculator createCardinalityCalculator() {
@@ -56,9 +57,9 @@ public class EvaluationStatistics {
 
 	protected static class CardinalityCalculator extends AbstractQueryModelVisitor<RuntimeException> {
 
-		private static double VAR_CARDINALITY = 10;
+		private static final double VAR_CARDINALITY = 10;
 
-		private static double UNBOUND_SERVICE_CARDINALITY = 100000;
+		private static final double UNBOUND_SERVICE_CARDINALITY = 100000;
 
 		protected double cardinality;
 
@@ -291,5 +292,4 @@ public class EvaluationStatistics {
 		}
 	}
 
-	;
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/BottomUpJoinIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/BottomUpJoinIterator.java
@@ -39,7 +39,7 @@ public class BottomUpJoinIterator extends LookAheadIteration<BindingSet, QueryEv
 
 	private final CloseableIteration<BindingSet, QueryEvaluationException> leftIter;
 
-	private volatile CloseableIteration<BindingSet, QueryEvaluationException> rightIter;
+	private final CloseableIteration<BindingSet, QueryEvaluationException> rightIter;
 
 	private List<BindingSet> scanList;
 
@@ -47,7 +47,7 @@ public class BottomUpJoinIterator extends LookAheadIteration<BindingSet, QueryEv
 
 	private Map<BindingSet, List<BindingSet>> hashTable;
 
-	private Set<String> joinAttributes;
+	private final Set<String> joinAttributes;
 
 	private BindingSet currentScanElem;
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
@@ -16,12 +16,12 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
-import org.eclipse.rdf4j.common.lang.ObjectUtil;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
@@ -274,7 +274,7 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 					Value v1 = bindingSet.getValue(name);
 					Value v2 = otherSolution.getValue(name);
 
-					if (!ObjectUtil.nullEquals(v1, v2)) {
+					if (!Objects.equals(v1, v2)) {
 						return false;
 					}
 				}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIterator.java
@@ -71,20 +71,14 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 	private final BindingSet parentBindings;
 
 	private final Group group;
-
-	private volatile boolean initialized = false;
-
-	private final Object lock = new Object();
-
 	private final File tempFile;
-
 	private final DB db;
-
 	/**
 	 * Number of items cached before internal collections are synced to disk. If set to 0, no disk-syncing is done and
 	 * all internal caching is kept in memory.
 	 */
 	private final long iterationCacheSyncThreshold;
+	private boolean initialized = false;
 
 	/*--------------*
 	 * Constructors *
@@ -122,12 +116,8 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 	@Override
 	public boolean hasNext() throws QueryEvaluationException {
 		if (!initialized) {
-			synchronized (lock) {
-				if (!initialized) {
-					super.setIterator(createIterator());
-					initialized = true;
-				}
-			}
+			super.setIterator(createIterator());
+			initialized = true;
 		}
 		return super.hasNext();
 	}
@@ -135,12 +125,8 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 	@Override
 	public BindingSet next() throws QueryEvaluationException {
 		if (!initialized) {
-			synchronized (lock) {
-				if (!initialized) {
-					super.setIterator(createIterator());
-					initialized = true;
-				}
-			}
+			super.setIterator(createIterator());
+			initialized = true;
 		}
 		return super.next();
 	}
@@ -290,28 +276,24 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 
 		private final BindingSet prototype;
 
-		private volatile Map<String, Aggregate> aggregates;
+		private Map<String, Aggregate> aggregates;
 
-		public Entry(BindingSet prototype) throws ValueExprEvaluationException, QueryEvaluationException {
+		public Entry(BindingSet prototype) throws QueryEvaluationException {
 			this.prototype = prototype;
 
 		}
 
-		private Map<String, Aggregate> getAggregates() throws ValueExprEvaluationException, QueryEvaluationException {
+		private Map<String, Aggregate> getAggregates() throws QueryEvaluationException {
 			Map<String, Aggregate> result = aggregates;
 			if (result == null) {
-				synchronized (this) {
-					result = aggregates;
-					if (result == null) {
-						result = aggregates = new LinkedHashMap<>();
-						for (GroupElem ge : group.getGroupElements()) {
-							Aggregate create = create(ge.getOperator());
-							if (create != null) {
-								aggregates.put(ge.getName(), create);
-							}
-						}
+				result = aggregates = new LinkedHashMap<>();
+				for (GroupElem ge : group.getGroupElements()) {
+					Aggregate create = create(ge.getOperator());
+					if (create != null) {
+						aggregates.put(ge.getName(), create);
 					}
 				}
+
 			}
 			return result;
 		}
@@ -342,7 +324,7 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 		}
 
 		private Aggregate create(AggregateOperator operator)
-				throws ValueExprEvaluationException, QueryEvaluationException {
+				throws QueryEvaluationException {
 			if (operator instanceof Count) {
 				return new CountAggregate((Count) operator);
 			} else if (operator instanceof Min) {
@@ -411,9 +393,8 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 
 	private class CountAggregate extends Aggregate {
 
-		private long count = 0;
-
 		private final Set<BindingSet> distinctBindingSets;
+		private long count = 0;
 
 		public CountAggregate(Count operator) {
 			super(operator);
@@ -636,7 +617,7 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 
 		private Value sample = null;
 
-		private Random random;
+		private final Random random;
 
 		public SampleAggregate(Sample operator) {
 			super(operator);
@@ -666,12 +647,12 @@ public class GroupIterator extends CloseableIteratorIteration<BindingSet, QueryE
 
 	private class ConcatAggregate extends Aggregate {
 
-		private StringBuilder concatenated = new StringBuilder();
+		private final StringBuilder concatenated = new StringBuilder();
 
 		private String separator = " ";
 
 		public ConcatAggregate(GroupConcat groupConcatOp)
-				throws ValueExprEvaluationException, QueryEvaluationException {
+				throws QueryEvaluationException {
 			super(groupConcatOp);
 			ValueExpr separatorExpr = groupConcatOp.getSeparator();
 			if (separatorExpr != null) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
@@ -41,23 +41,15 @@ public class HashJoinIteration extends LookAheadIteration<BindingSet, QueryEvalu
 	 * Variables *
 	 *-----------*/
 
-	private final CloseableIteration<BindingSet, QueryEvaluationException> leftIter;
-
-	private final CloseableIteration<BindingSet, QueryEvaluationException> rightIter;
-
-	private volatile Iterator<BindingSet> scanList;
-
-	private volatile CloseableIteration<BindingSet, QueryEvaluationException> restIter;
-
-	private volatile Map<BindingSetHashKey, List<BindingSet>> hashTable;
-
 	protected final String[] joinAttributes;
-
-	private volatile BindingSet currentScanElem;
-
-	private volatile Iterator<BindingSet> hashTableValues;
-
+	private final CloseableIteration<BindingSet, QueryEvaluationException> leftIter;
+	private final CloseableIteration<BindingSet, QueryEvaluationException> rightIter;
 	private final boolean leftJoin;
+	private Iterator<BindingSet> scanList;
+	private CloseableIteration<BindingSet, QueryEvaluationException> restIter;
+	private Map<BindingSetHashKey, List<BindingSet>> hashTable;
+	private BindingSet currentScanElem;
+	private Iterator<BindingSet> hashTableValues;
 
 	/*--------------*
 	 * Constructors *
@@ -103,13 +95,9 @@ public class HashJoinIteration extends LookAheadIteration<BindingSet, QueryEvalu
 	protected BindingSet getNextElement() throws QueryEvaluationException {
 		Map<BindingSetHashKey, List<BindingSet>> nextHashTable = hashTable;
 		if (nextHashTable == null) {
-			synchronized (this) {
-				nextHashTable = hashTable;
-				if (nextHashTable == null) {
-					nextHashTable = hashTable = setupHashTable();
-				}
-			}
+			nextHashTable = hashTable = setupHashTable();
 		}
+
 		Iterator<BindingSet> nextHashTableValues = hashTableValues;
 
 		while (currentScanElem == null) {
@@ -311,7 +299,7 @@ public class HashJoinIteration extends LookAheadIteration<BindingSet, QueryEvalu
 			nextHashTable = new HashMap<>(initialSize);
 		} else {
 			List<BindingSet> l = (initialSize > 0) ? new ArrayList<>(initialSize) : null;
-			nextHashTable = Collections.<BindingSetHashKey, List<BindingSet>>singletonMap(BindingSetHashKey.EMPTY, l);
+			nextHashTable = Collections.singletonMap(BindingSetHashKey.EMPTY, l);
 		}
 		return nextHashTable;
 	}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/JoinIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/JoinIterator.java
@@ -40,7 +40,7 @@ public class JoinIterator extends LookAheadIteration<BindingSet, QueryEvaluation
 
 	private final CloseableIteration<BindingSet, QueryEvaluationException> leftIter;
 
-	private volatile CloseableIteration<BindingSet, QueryEvaluationException> rightIter;
+	private CloseableIteration<BindingSet, QueryEvaluationException> rightIter;
 
 	/*--------------*
 	 * Constructors *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/LeftJoinIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/LeftJoinIterator.java
@@ -38,7 +38,7 @@ public class LeftJoinIterator extends LookAheadIteration<BindingSet, QueryEvalua
 
 	private final CloseableIteration<BindingSet, QueryEvaluationException> leftIter;
 
-	private volatile CloseableIteration<BindingSet, QueryEvaluationException> rightIter;
+	private CloseableIteration<BindingSet, QueryEvaluationException> rightIter;
 
 	/*--------------*
 	 * Constructors *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/MultiProjectionIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/MultiProjectionIterator.java
@@ -35,9 +35,9 @@ public class MultiProjectionIterator extends LookAheadIteration<BindingSet, Quer
 
 	private final BindingSet[] previousBindings;
 
-	private volatile BindingSet currentBindings;
+	private BindingSet currentBindings;
 
-	private volatile int nextProjectionIdx;
+	private int nextProjectionIdx;
 
 	/*--------------*
 	 * Constructors *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/SPARQLMinusIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/SPARQLMinusIteration.java
@@ -33,11 +33,9 @@ public class SPARQLMinusIteration<X extends Exception> extends FilterIteration<B
 
 	private final Iteration<BindingSet, X> rightArg;
 
-	private final boolean distinct;
+	private boolean initialized;
 
-	private volatile boolean initialized;
-
-	private volatile Set<BindingSet> excludeSet;
+	private Set<BindingSet> excludeSet;
 
 	/*--------------*
 	 * Constructors *
@@ -51,7 +49,12 @@ public class SPARQLMinusIteration<X extends Exception> extends FilterIteration<B
 	 * @param rightArg An Iteration containing the set of elements that should be filtered from the main set.
 	 */
 	public SPARQLMinusIteration(Iteration<BindingSet, X> leftArg, Iteration<BindingSet, X> rightArg) {
-		this(leftArg, rightArg, false);
+		super(leftArg);
+
+		assert rightArg != null;
+
+		this.rightArg = rightArg;
+		this.initialized = false;
 	}
 
 	/**
@@ -60,16 +63,11 @@ public class SPARQLMinusIteration<X extends Exception> extends FilterIteration<B
 	 *
 	 * @param leftArg  An Iteration containing the main set of elements.
 	 * @param rightArg An Iteration containing the set of elements that should be filtered from the main set.
-	 * @param distinct Flag indicating whether duplicate elements should be filtered from the result.
+	 * @param distinct This argument is ignored
 	 */
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	public SPARQLMinusIteration(Iteration<BindingSet, X> leftArg, Iteration<BindingSet, X> rightArg, boolean distinct) {
-		super(leftArg);
-
-		assert rightArg != null;
-
-		this.rightArg = rightArg;
-		this.distinct = distinct;
-		this.initialized = false;
+		this(leftArg, rightArg);
 	}
 
 	/*--------------*
@@ -80,13 +78,9 @@ public class SPARQLMinusIteration<X extends Exception> extends FilterIteration<B
 	@Override
 	protected boolean accept(BindingSet object) throws X {
 		if (!initialized) {
-			synchronized (this) {
-				if (!initialized) {
-					// Build set of elements-to-exclude from right argument
-					excludeSet = makeSet(getRightArg());
-					initialized = true;
-				}
-			}
+			// Build set of elements-to-exclude from right argument
+			excludeSet = makeSet(getRightArg());
+			initialized = true;
 		}
 
 		boolean compatible = false;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/limited/iterator/LimitedSizeSPARQLMinusIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/limited/iterator/LimitedSizeSPARQLMinusIteration.java
@@ -36,7 +36,9 @@ public class LimitedSizeSPARQLMinusIteration extends SPARQLMinusIteration<QueryE
 	 */
 	public LimitedSizeSPARQLMinusIteration(Iteration<BindingSet, QueryEvaluationException> leftArg,
 			Iteration<BindingSet, QueryEvaluationException> rightArg, AtomicLong used, long maxSize) {
-		this(leftArg, rightArg, false, used, maxSize);
+		super(leftArg, rightArg);
+		this.used = used;
+		this.maxSize = maxSize;
 	}
 
 	/**
@@ -45,15 +47,15 @@ public class LimitedSizeSPARQLMinusIteration extends SPARQLMinusIteration<QueryE
 	 *
 	 * @param leftArg  An Iteration containing the main set of elements.
 	 * @param rightArg An Iteration containing the set of elements that should be filtered from the main set.
-	 * @param distinct Flag indicating whether duplicate elements should be filtered from the result.
+	 * @param distinct This argument is ignored!
 	 * @param used     An atomic long used to monitor how many elements are in the set collections.
 	 * @param maxSize  Maximum size allowed by the sum of all collections used by the LimitedSizeQueryEvaluatlion.
 	 */
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	public LimitedSizeSPARQLMinusIteration(Iteration<BindingSet, QueryEvaluationException> leftArg,
 			Iteration<BindingSet, QueryEvaluationException> rightArg, boolean distinct, AtomicLong used, long maxSize) {
-		super(leftArg, rightArg, distinct);
-		this.used = used;
-		this.maxSize = maxSize;
+		this(leftArg, rightArg, used, maxSize);
+
 	}
 
 	@Override

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/IterationStub.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/IterationStub.java
@@ -28,11 +28,6 @@ class IterationStub extends CloseableIteratorIteration<BindingSet, QueryEvaluati
 	int removeCount = 0;
 
 	@Override
-	public void setIterator(Iterator<? extends BindingSet> iter) {
-		super.setIterator(iter);
-	}
-
-	@Override
 	public boolean hasNext() throws QueryEvaluationException {
 		hasNextCount++;
 		return super.hasNext();

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/OrderIteratorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/OrderIteratorTest.java
@@ -36,9 +36,8 @@ public class OrderIteratorTest extends TestCase {
 
 		int removeCount = 0;
 
-		@Override
-		public void setIterator(Iterator<? extends BindingSet> iter) {
-			super.setIterator(iter);
+		public IterationStub(Iterator<BindingSet> iterator) {
+			super(iterator);
 		}
 
 		@Override
@@ -185,8 +184,7 @@ public class OrderIteratorTest extends TestCase {
 	protected void setUp() throws Exception {
 		list = Arrays.asList(b3, b5, b2, b1, b4, b2);
 		cmp = new SizeComparator();
-		iteration = new IterationStub();
-		iteration.setIterator(list.iterator());
+		iteration = new IterationStub(list.iterator());
 		order = new OrderIterator(iteration, cmp);
 	}
 

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/LockingIteration.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/LockingIteration.java
@@ -19,18 +19,10 @@ import org.eclipse.rdf4j.common.iteration.IterationWrapper;
  */
 public class LockingIteration<E, X extends Exception> extends IterationWrapper<E, X> {
 
-	/*-----------*
-	 * Variables *
-	 *-----------*/
-
 	/**
 	 * The lock to release when the Iteration is closed.
 	 */
 	private final Lock lock;
-
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
 
 	/**
 	 * Creates a new LockingIteration.
@@ -45,50 +37,12 @@ public class LockingIteration<E, X extends Exception> extends IterationWrapper<E
 		this.lock = lock;
 	}
 
-	/*---------*
-	 * Methods *
-	 *---------*/
-
-	@Override
-	public synchronized boolean hasNext() throws X {
-		if (isClosed()) {
-			return false;
-		}
-
-		if (super.hasNext()) {
-			return true;
-		}
-
-		close();
-		return false;
-	}
-
-	@Override
-	public synchronized E next() throws X {
-		if (isClosed()) {
-			throw new NoSuchElementException("Iteration has been closed");
-		}
-
-		return super.next();
-	}
-
-	@Override
-	public synchronized void remove() throws X {
-		if (isClosed()) {
-			throw new IllegalStateException("Iteration has been closed");
-		}
-
-		super.remove();
-	}
-
 	@Override
 	protected void handleClose() throws X {
 		try {
 			super.handleClose();
 		} finally {
-			synchronized (this) {
-				lock.release();
-			}
+			lock.release();
 		}
 	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemBNode.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemBNode.java
@@ -28,17 +28,17 @@ public class MemBNode extends SimpleBNode implements MemResource {
 	/**
 	 * The list of statements for which this MemBNode is the subject.
 	 */
-	transient private volatile MemStatementList subjectStatements;
+	transient private final MemStatementList subjectStatements = new MemStatementList();
 
 	/**
 	 * The list of statements for which this MemBNode is the object.
 	 */
-	transient private volatile MemStatementList objectStatements;
+	transient private final MemStatementList objectStatements = new MemStatementList();
 
 	/**
 	 * The list of statements for which this MemBNode represents the context.
 	 */
-	transient private volatile MemStatementList contextStatements;
+	transient private final MemStatementList contextStatements = new MemStatementList();
 
 	/*--------------*
 	 * Constructors *
@@ -66,32 +66,25 @@ public class MemBNode extends SimpleBNode implements MemResource {
 
 	@Override
 	public boolean hasStatements() {
-		return subjectStatements != null || objectStatements != null || contextStatements != null;
+		return !subjectStatements.isEmpty() || !objectStatements.isEmpty() || !contextStatements.isEmpty();
 	}
 
 	@Override
 	public MemStatementList getSubjectStatementList() {
-		if (subjectStatements == null) {
-			return EMPTY_LIST;
-		} else {
-			return subjectStatements;
-		}
+
+		return subjectStatements;
+
 	}
 
 	@Override
 	public int getSubjectStatementCount() {
-		if (subjectStatements == null) {
-			return 0;
-		} else {
-			return subjectStatements.size();
-		}
+
+		return subjectStatements.size();
+
 	}
 
 	@Override
 	public void addSubjectStatement(MemStatement st) {
-		if (subjectStatements == null) {
-			subjectStatements = new MemStatementList(4);
-		}
 
 		subjectStatements.add(st);
 	}
@@ -100,45 +93,30 @@ public class MemBNode extends SimpleBNode implements MemResource {
 	public void removeSubjectStatement(MemStatement st) {
 		subjectStatements.remove(st);
 
-		if (subjectStatements.isEmpty()) {
-			subjectStatements = null;
-		}
 	}
 
 	@Override
 	public void cleanSnapshotsFromSubjectStatements(int currentSnapshot) {
-		if (subjectStatements != null) {
-			subjectStatements.cleanSnapshots(currentSnapshot);
+		subjectStatements.cleanSnapshots(currentSnapshot);
 
-			if (subjectStatements.isEmpty()) {
-				subjectStatements = null;
-			}
-		}
 	}
 
 	@Override
 	public MemStatementList getObjectStatementList() {
-		if (objectStatements == null) {
-			return EMPTY_LIST;
-		} else {
-			return objectStatements;
-		}
+
+		return objectStatements;
+
 	}
 
 	@Override
 	public int getObjectStatementCount() {
-		if (objectStatements == null) {
-			return 0;
-		} else {
-			return objectStatements.size();
-		}
+
+		return objectStatements.size();
+
 	}
 
 	@Override
 	public void addObjectStatement(MemStatement st) {
-		if (objectStatements == null) {
-			objectStatements = new MemStatementList(4);
-		}
 
 		objectStatements.add(st);
 	}
@@ -147,45 +125,30 @@ public class MemBNode extends SimpleBNode implements MemResource {
 	public void removeObjectStatement(MemStatement st) {
 		objectStatements.remove(st);
 
-		if (objectStatements.isEmpty()) {
-			objectStatements = null;
-		}
 	}
 
 	@Override
 	public void cleanSnapshotsFromObjectStatements(int currentSnapshot) {
-		if (objectStatements != null) {
-			objectStatements.cleanSnapshots(currentSnapshot);
+		objectStatements.cleanSnapshots(currentSnapshot);
 
-			if (objectStatements.isEmpty()) {
-				objectStatements = null;
-			}
-		}
 	}
 
 	@Override
 	public MemStatementList getContextStatementList() {
-		if (contextStatements == null) {
-			return EMPTY_LIST;
-		} else {
-			return contextStatements;
-		}
+
+		return contextStatements;
+
 	}
 
 	@Override
 	public int getContextStatementCount() {
-		if (contextStatements == null) {
-			return 0;
-		} else {
-			return contextStatements.size();
-		}
+
+		return contextStatements.size();
+
 	}
 
 	@Override
 	public void addContextStatement(MemStatement st) {
-		if (contextStatements == null) {
-			contextStatements = new MemStatementList(4);
-		}
 
 		contextStatements.add(st);
 	}
@@ -194,19 +157,11 @@ public class MemBNode extends SimpleBNode implements MemResource {
 	public void removeContextStatement(MemStatement st) {
 		contextStatements.remove(st);
 
-		if (contextStatements.isEmpty()) {
-			contextStatements = null;
-		}
 	}
 
 	@Override
 	public void cleanSnapshotsFromContextStatements(int currentSnapshot) {
-		if (contextStatements != null) {
-			contextStatements.cleanSnapshots(currentSnapshot);
+		contextStatements.cleanSnapshots(currentSnapshot);
 
-			if (contextStatements.isEmpty()) {
-				contextStatements = null;
-			}
-		}
 	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemIRI.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemIRI.java
@@ -44,22 +44,22 @@ public class MemIRI implements IRI, MemResource {
 	/**
 	 * The list of statements for which this MemURI is the subject.
 	 */
-	transient private volatile MemStatementList subjectStatements = null;
+	transient private final MemStatementList subjectStatements = new MemStatementList();
 
 	/**
 	 * The list of statements for which this MemURI is the predicate.
 	 */
-	transient private volatile MemStatementList predicateStatements = null;
+	transient private final MemStatementList predicateStatements = new MemStatementList();
 
 	/**
 	 * The list of statements for which this MemURI is the object.
 	 */
-	transient private volatile MemStatementList objectStatements = null;
+	transient private final MemStatementList objectStatements = new MemStatementList();
 
 	/**
 	 * The list of statements for which this MemURI represents the context.
 	 */
-	transient private volatile MemStatementList contextStatements = null;
+	transient private final MemStatementList contextStatements = new MemStatementList();
 
 	/*--------------*
 	 * Constructors *
@@ -137,55 +137,33 @@ public class MemIRI implements IRI, MemResource {
 
 	@Override
 	public boolean hasStatements() {
-		return subjectStatements != null || predicateStatements != null || objectStatements != null
-				|| contextStatements != null;
+		return !subjectStatements.isEmpty() || !predicateStatements.isEmpty() || !objectStatements.isEmpty()
+				|| !contextStatements.isEmpty();
 	}
 
 	@Override
 	public MemStatementList getSubjectStatementList() {
-		if (subjectStatements == null) {
-			return EMPTY_LIST;
-		} else {
-			return subjectStatements;
-		}
+		return subjectStatements;
 	}
 
 	@Override
 	public int getSubjectStatementCount() {
-		if (subjectStatements == null) {
-			return 0;
-		} else {
-			return subjectStatements.size();
-		}
+		return subjectStatements.size();
 	}
 
 	@Override
 	public void addSubjectStatement(MemStatement st) {
-		if (subjectStatements == null) {
-			subjectStatements = new MemStatementList(4);
-		}
-
 		subjectStatements.add(st);
 	}
 
 	@Override
 	public void removeSubjectStatement(MemStatement st) {
 		subjectStatements.remove(st);
-
-		if (subjectStatements.isEmpty()) {
-			subjectStatements = null;
-		}
 	}
 
 	@Override
 	public void cleanSnapshotsFromSubjectStatements(int currentSnapshot) {
-		if (subjectStatements != null) {
-			subjectStatements.cleanSnapshots(currentSnapshot);
-
-			if (subjectStatements.isEmpty()) {
-				subjectStatements = null;
-			}
-		}
+		subjectStatements.cleanSnapshots(currentSnapshot);
 	}
 
 	/**
@@ -194,11 +172,7 @@ public class MemIRI implements IRI, MemResource {
 	 * @return a MemStatementList containing the statements.
 	 */
 	public MemStatementList getPredicateStatementList() {
-		if (predicateStatements == null) {
-			return EMPTY_LIST;
-		} else {
-			return predicateStatements;
-		}
+		return predicateStatements;
 	}
 
 	/**
@@ -207,21 +181,13 @@ public class MemIRI implements IRI, MemResource {
 	 * @return An integer larger than or equal to 0.
 	 */
 	public int getPredicateStatementCount() {
-		if (predicateStatements == null) {
-			return 0;
-		} else {
-			return predicateStatements.size();
-		}
+		return predicateStatements.size();
 	}
 
 	/**
 	 * Adds a statement to this MemURI's list of statements for which it is the predicate.
 	 */
 	public void addPredicateStatement(MemStatement st) {
-		if (predicateStatements == null) {
-			predicateStatements = new MemStatementList(4);
-		}
-
 		predicateStatements.add(st);
 	}
 
@@ -230,10 +196,6 @@ public class MemIRI implements IRI, MemResource {
 	 */
 	public void removePredicateStatement(MemStatement st) {
 		predicateStatements.remove(st);
-
-		if (predicateStatements.isEmpty()) {
-			predicateStatements = null;
-		}
 	}
 
 	/**
@@ -243,104 +205,56 @@ public class MemIRI implements IRI, MemResource {
 	 * @param currentSnapshot The current snapshot version.
 	 */
 	public void cleanSnapshotsFromPredicateStatements(int currentSnapshot) {
-		if (predicateStatements != null) {
-			predicateStatements.cleanSnapshots(currentSnapshot);
-
-			if (predicateStatements.isEmpty()) {
-				predicateStatements = null;
-			}
-		}
+		predicateStatements.cleanSnapshots(currentSnapshot);
 	}
 
 	@Override
 	public MemStatementList getObjectStatementList() {
-		if (objectStatements == null) {
-			return EMPTY_LIST;
-		} else {
-			return objectStatements;
-		}
+		return objectStatements;
 	}
 
 	@Override
 	public int getObjectStatementCount() {
-		if (objectStatements == null) {
-			return 0;
-		} else {
-			return objectStatements.size();
-		}
+		return objectStatements.size();
 	}
 
 	@Override
 	public void addObjectStatement(MemStatement st) {
-		if (objectStatements == null) {
-			objectStatements = new MemStatementList(4);
-		}
 		objectStatements.add(st);
 	}
 
 	@Override
 	public void removeObjectStatement(MemStatement st) {
 		objectStatements.remove(st);
-		if (objectStatements.isEmpty()) {
-			objectStatements = null;
-		}
 	}
 
 	@Override
 	public void cleanSnapshotsFromObjectStatements(int currentSnapshot) {
-		if (objectStatements != null) {
-			objectStatements.cleanSnapshots(currentSnapshot);
-
-			if (objectStatements.isEmpty()) {
-				objectStatements = null;
-			}
-		}
+		objectStatements.cleanSnapshots(currentSnapshot);
 	}
 
 	@Override
 	public MemStatementList getContextStatementList() {
-		if (contextStatements == null) {
-			return EMPTY_LIST;
-		} else {
-			return contextStatements;
-		}
+		return contextStatements;
 	}
 
 	@Override
 	public int getContextStatementCount() {
-		if (contextStatements == null) {
-			return 0;
-		} else {
-			return contextStatements.size();
-		}
+		return contextStatements.size();
 	}
 
 	@Override
 	public void addContextStatement(MemStatement st) {
-		if (contextStatements == null) {
-			contextStatements = new MemStatementList(4);
-		}
-
 		contextStatements.add(st);
 	}
 
 	@Override
 	public void removeContextStatement(MemStatement st) {
 		contextStatements.remove(st);
-
-		if (contextStatements.isEmpty()) {
-			contextStatements = null;
-		}
 	}
 
 	@Override
 	public void cleanSnapshotsFromContextStatements(int currentSnapshot) {
-		if (contextStatements != null) {
-			contextStatements.cleanSnapshots(currentSnapshot);
-
-			if (contextStatements.isEmpty()) {
-				contextStatements = null;
-			}
-		}
+		contextStatements.cleanSnapshots(currentSnapshot);
 	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemLiteral.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemLiteral.java
@@ -32,7 +32,7 @@ public class MemLiteral extends SimpleLiteral implements MemValue {
 	/**
 	 * The list of statements for which this MemLiteral is the object.
 	 */
-	transient private volatile MemStatementList objectStatements;
+	transient private final MemStatementList objectStatements = new MemStatementList();
 
 	/*--------------*
 	 * Constructors *
@@ -84,32 +84,25 @@ public class MemLiteral extends SimpleLiteral implements MemValue {
 
 	@Override
 	public boolean hasStatements() {
-		return objectStatements != null;
+		return !objectStatements.isEmpty();
 	}
 
 	@Override
 	public MemStatementList getObjectStatementList() {
-		if (objectStatements == null) {
-			return EMPTY_LIST;
-		} else {
-			return objectStatements;
-		}
+
+		return objectStatements;
+
 	}
 
 	@Override
 	public int getObjectStatementCount() {
-		if (objectStatements == null) {
-			return 0;
-		} else {
-			return objectStatements.size();
-		}
+
+		return objectStatements.size();
+
 	}
 
 	@Override
 	public void addObjectStatement(MemStatement st) {
-		if (objectStatements == null) {
-			objectStatements = new MemStatementList(1);
-		}
 
 		objectStatements.add(st);
 	}
@@ -118,19 +111,11 @@ public class MemLiteral extends SimpleLiteral implements MemValue {
 	public void removeObjectStatement(MemStatement st) {
 		objectStatements.remove(st);
 
-		if (objectStatements.isEmpty()) {
-			objectStatements = null;
-		}
 	}
 
 	@Override
 	public void cleanSnapshotsFromObjectStatements(int currentSnapshot) {
-		if (objectStatements != null) {
-			objectStatements.cleanSnapshots(currentSnapshot);
+		objectStatements.cleanSnapshots(currentSnapshot);
 
-			if (objectStatements.isEmpty()) {
-				objectStatements = null;
-			}
-		}
 	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatement.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatement.java
@@ -142,4 +142,10 @@ public class MemStatement extends ContextStatement {
 			context.removeContextStatement(this);
 		}
 	}
+
+	public boolean matchesSPO(MemResource subject, MemIRI predicate, MemValue object) {
+		return (subject == null || exactSameSubject(subject)) &&
+				(predicate == null || exactSamePredicate(predicate)) &&
+				(object == null || exactSameObject(object));
+	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatementList.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatementList.java
@@ -63,6 +63,14 @@ public class MemStatementList {
 		return statements[index];
 	}
 
+	public MemStatement getIfExists(int index) {
+		if (index < size) {
+			return statements[index];
+		} else {
+			return null;
+		}
+	}
+
 	public void add(MemStatement st) {
 		if (size == statements.length) {
 			// Grow array

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatementList.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatementList.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
  * memory Sail.
  */
 public class MemStatementList {
+	private static final MemStatement[] EMPTY_ARRAY = new MemStatement[0];
 
 	/*-----------*
 	 * Variables *
@@ -31,7 +32,8 @@ public class MemStatementList {
 	 * Creates a new MemStatementList.
 	 */
 	public MemStatementList() {
-		this(4);
+		statements = EMPTY_ARRAY;
+		size = 0;
 	}
 
 	public MemStatementList(int capacity) {
@@ -40,8 +42,8 @@ public class MemStatementList {
 	}
 
 	public MemStatementList(MemStatementList other) {
-		this(other.size);
-		addAll(other);
+		statements = Arrays.copyOf(other.statements, other.statements.length);
+		size = other.size;
 	}
 
 	/*---------*
@@ -74,7 +76,7 @@ public class MemStatementList {
 	public void add(MemStatement st) {
 		if (size == statements.length) {
 			// Grow array
-			growArray((size == 0) ? 1 : 2 * size);
+			growArray((size == 0) ? 4 : 2 * size);
 		}
 
 		statements[size] = st;
@@ -118,7 +120,7 @@ public class MemStatementList {
 	}
 
 	public void clear() {
-		Arrays.fill(statements, 0, size, null);
+		statements = EMPTY_ARRAY;
 		size = 0;
 	}
 
@@ -149,7 +151,9 @@ public class MemStatementList {
 
 	private void growArray(int newSize) {
 		MemStatement[] newArray = new MemStatement[newSize];
-		System.arraycopy(statements, 0, newArray, 0, size);
+		if (statements != EMPTY_ARRAY) {
+			System.arraycopy(statements, 0, newArray, 0, size);
+		}
 		statements = newArray;
 	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemTriple.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemTriple.java
@@ -1,4 +1,4 @@
-/******************************************************************************* 
+/*******************************************************************************
  * Copyright (c) 2020 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
@@ -7,10 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory.model;
 
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Triple;
-import org.eclipse.rdf4j.model.Value;
 
 import com.google.common.base.Objects;
 
@@ -32,12 +29,12 @@ public class MemTriple implements Triple, MemResource {
 	/**
 	 * The list of statements for which this MemTriple is the subject.
 	 */
-	transient private volatile MemStatementList subjectStatements = null;
+	transient private final MemStatementList subjectStatements = new MemStatementList();
 
 	/**
 	 * The list of statements for which this MemTriple is the object.
 	 */
-	transient private volatile MemStatementList objectStatements = null;
+	transient private final MemStatementList objectStatements = new MemStatementList();
 
 	public MemTriple(Object creator, MemResource subject, MemIRI predicate, MemValue object) {
 		this.creator = creator;
@@ -79,9 +76,6 @@ public class MemTriple implements Triple, MemResource {
 
 	@Override
 	public MemStatementList getObjectStatementList() {
-		if (objectStatements == null) {
-			return EMPTY_LIST;
-		}
 		return objectStatements;
 	}
 
@@ -92,9 +86,7 @@ public class MemTriple implements Triple, MemResource {
 
 	@Override
 	public void addObjectStatement(MemStatement st) {
-		if (objectStatements == null) {
-			objectStatements = new MemStatementList(4);
-		}
+
 		objectStatements.add(st);
 	}
 
@@ -102,28 +94,17 @@ public class MemTriple implements Triple, MemResource {
 	public void removeObjectStatement(MemStatement st) {
 		objectStatements.remove(st);
 
-		if (objectStatements.isEmpty()) {
-			objectStatements = null;
-		}
-
 	}
 
 	@Override
 	public void cleanSnapshotsFromObjectStatements(int currentSnapshot) {
-		if (objectStatements != null) {
-			objectStatements.cleanSnapshots(currentSnapshot);
+		objectStatements.cleanSnapshots(currentSnapshot);
 
-			if (objectStatements.isEmpty()) {
-				objectStatements = null;
-			}
-		}
 	}
 
 	@Override
 	public MemStatementList getSubjectStatementList() {
-		if (subjectStatements == null) {
-			return EMPTY_LIST;
-		}
+
 		return subjectStatements;
 	}
 
@@ -134,9 +115,7 @@ public class MemTriple implements Triple, MemResource {
 
 	@Override
 	public void addSubjectStatement(MemStatement st) {
-		if (subjectStatements == null) {
-			subjectStatements = new MemStatementList(4);
-		}
+
 		subjectStatements.add(st);
 	}
 
@@ -144,20 +123,12 @@ public class MemTriple implements Triple, MemResource {
 	public void removeSubjectStatement(MemStatement st) {
 		subjectStatements.remove(st);
 
-		if (subjectStatements.isEmpty()) {
-			subjectStatements = null;
-		}
 	}
 
 	@Override
 	public void cleanSnapshotsFromSubjectStatements(int currentSnapshot) {
-		if (subjectStatements != null) {
-			subjectStatements.cleanSnapshots(currentSnapshot);
+		subjectStatements.cleanSnapshots(currentSnapshot);
 
-			if (subjectStatements.isEmpty()) {
-				subjectStatements = null;
-			}
-		}
 	}
 
 	@Override
@@ -186,17 +157,17 @@ public class MemTriple implements Triple, MemResource {
 	}
 
 	@Override
-	public Resource getSubject() {
+	public MemResource getSubject() {
 		return subject;
 	}
 
 	@Override
-	public IRI getPredicate() {
+	public MemIRI getPredicate() {
 		return predicate;
 	}
 
 	@Override
-	public Value getObject() {
+	public MemValue getObject() {
 		return object;
 	}
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactory.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactory.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory.model;
 
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Set;
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/NotifyingSailBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/NotifyingSailBenchmark.java
@@ -1,0 +1,248 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.memory.benchmark;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.sail.NotifyingSail;
+import org.eclipse.rdf4j.sail.NotifyingSailConnection;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailConnectionListener;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.helpers.NotifyingSailConnectionWrapper;
+import org.eclipse.rdf4j.sail.helpers.NotifyingSailWrapper;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 20)
+@BenchmarkMode({ Mode.AverageTime })
+//@Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=5s,duration=60s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Fork(value = 1, jvmArgs = { "-Xms2G", "-Xmx2G" })
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class NotifyingSailBenchmark {
+
+	@Param({ "NONE", "SNAPSHOT", "SERIALIZABLE" })
+	public String isolationLevel;
+
+	public static final int REAL_DATA_SIZE = 50000;
+
+	private static final List<Statement> statementList = getStatements();
+	private static final List<Statement> realData = getRealData();
+	private static final List<Statement> realDataRandom = getRealDataRandom();
+	private static final List<Statement> realDataSmall = getSmallList(realData);
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("NotifyingSailBenchmark.load") // adapt to run other benchmark tests
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
+
+	@Benchmark
+	public long load() {
+		long count = 0;
+
+		Sail memoryStore = new TestNotifyingSail(new MemoryStore());
+		memoryStore.initialize();
+
+		try (SailConnection connection = memoryStore.getConnection()) {
+			connection.begin(IsolationLevels.valueOf(isolationLevel));
+			statementList.forEach(getStatementConsumer(connection));
+
+			connection.commit();
+			count += getCount(connection);
+		}
+		try (SailConnection connection = memoryStore.getConnection()) {
+			connection.begin(IsolationLevels.valueOf(isolationLevel));
+			realData.forEach(getStatementConsumer(connection));
+
+			connection.commit();
+		}
+
+		try (SailConnection connection = memoryStore.getConnection()) {
+
+			connection.begin(IsolationLevels.valueOf(isolationLevel));
+
+			realDataSmall.forEach(getStatementConsumer(connection));
+
+			ValueFactory vf = memoryStore.getValueFactory();
+			connection.addStatement(vf.createBNode(), RDFS.LABEL, vf.createLiteral("label"));
+
+			for (int i = 0; i < 10; i++) {
+				count += getCount(connection);
+			}
+
+			connection.commit();
+
+		}
+
+		try (SailConnection connection = memoryStore.getConnection()) {
+			connection.begin(IsolationLevels.valueOf(isolationLevel));
+			realDataRandom.forEach(getStatementConsumer(connection));
+
+			connection.commit();
+		}
+
+		return count;
+
+	}
+
+	private long getCount(SailConnection connection) {
+		long count;
+		try (Stream<? extends Statement> stream = connection.getStatements(null, null, null, false).stream()) {
+			count = stream.count();
+		}
+		return count;
+	}
+
+	private static List<Statement> getStatements() {
+		Random random = new Random();
+
+		ValueFactory vf = SimpleValueFactory.getInstance();
+
+		List<Statement> statementList = new ArrayList<>();
+
+		int size = 5000;
+		for (int i = 0; i < size; i++) {
+
+			IRI subject = vf.createIRI("http://ex/" + i);
+			statementList.add(vf.createStatement(subject, RDF.TYPE, FOAF.PERSON));
+			statementList.add(vf.createStatement(subject, FOAF.AGE, vf.createLiteral(i % 80 + 1)));
+			statementList.add(vf.createStatement(subject, FOAF.NAME, vf.createLiteral("fjeiwojf kldsfjewif " + i)));
+			statementList
+					.add(vf.createStatement(subject, FOAF.KNOWS, vf.createIRI("http://ex/" + random.nextInt(size))));
+			statementList
+					.add(vf.createStatement(subject, FOAF.KNOWS, vf.createIRI("http://ex/" + random.nextInt(size))));
+			statementList
+					.add(vf.createStatement(subject, FOAF.KNOWS, vf.createIRI("http://ex/" + random.nextInt(size))));
+		}
+
+		Collections.shuffle(statementList, new Random(4628462));
+
+		return statementList;
+	}
+
+	private static List<Statement> getSmallList(List<Statement> statements) {
+		List<Statement> ret = new ArrayList<>(statements.subList(0, statements.size() / 4));
+		Collections.shuffle(ret, new Random(4629472));
+		return ret;
+	}
+
+	private static List<Statement> getRealData() {
+		try {
+			try (InputStream inputStream = new BufferedInputStream(NotifyingSailBenchmark.class.getClassLoader()
+					.getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl"))) {
+				return Rio.parse(inputStream, RDFFormat.TURTLE)
+						.stream()
+						.limit(REAL_DATA_SIZE)
+						.collect(Collectors.toList());
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		} catch (NullPointerException e) {
+			throw new RuntimeException("Could not load file: benchmarkFiles/datagovbe-valid.ttl", e);
+		}
+	}
+
+	private static List<Statement> getRealDataRandom() {
+		try {
+			try (InputStream inputStream = new BufferedInputStream(NotifyingSailBenchmark.class.getClassLoader()
+					.getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl"))) {
+				List<Statement> collect = Rio.parse(inputStream, RDFFormat.TURTLE)
+						.stream()
+						.skip(REAL_DATA_SIZE)
+						.limit(REAL_DATA_SIZE)
+						.collect(Collectors.toList());
+				Collections.shuffle(collect, new Random(449583));
+				return collect;
+			}
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		} catch (NullPointerException e) {
+			throw new RuntimeException("Could not load file: benchmarkFiles/datagovbe-valid.ttl", e);
+		}
+	}
+
+	private static Consumer<Statement> getStatementConsumer(SailConnection connection) {
+		return st -> connection.addStatement(st.getSubject(), st.getPredicate(), st.getObject(), st.getContext());
+	}
+}
+
+class TestNotifyingSail extends NotifyingSailWrapper {
+
+	public TestNotifyingSail(NotifyingSail baseSail) {
+		super(baseSail);
+	}
+
+	@Override
+	public NotifyingSailConnection getConnection() throws SailException {
+		return new TestNotifyingSailConnection(super.getConnection());
+	}
+}
+
+class TestNotifyingSailConnection extends NotifyingSailConnectionWrapper implements SailConnectionListener {
+
+	int added;
+	int removed;
+
+	public TestNotifyingSailConnection(NotifyingSailConnection wrappedCon) {
+		super(wrappedCon);
+		addConnectionListener(this);
+	}
+
+	@Override
+	public void statementAdded(Statement statement) {
+		added++;
+	}
+
+	@Override
+	public void statementRemoved(Statement statement) {
+		removed++;
+	}
+
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/SortBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/SortBenchmark.java
@@ -60,12 +60,12 @@ public class SortBenchmark {
 
 	private SailRepository repository;
 
-	private static final String query4;
+	private static final String query9;
 
 	static {
 		try {
 
-			query4 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query4.qr"), StandardCharsets.UTF_8);
+			query9 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query9.qr"), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
@@ -120,7 +120,7 @@ public class SortBenchmark {
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			try (Stream<BindingSet> stream = connection
-					.prepareTupleQuery(query4)
+					.prepareTupleQuery(query9)
 					.evaluate()
 					.stream()) {
 				return stream.limit(1).collect(Collectors.toList());

--- a/tools/config/src/main/java/org/eclipse/rdf4j/common/app/AppVersion.java
+++ b/tools/config/src/main/java/org/eclipse/rdf4j/common/app/AppVersion.java
@@ -8,10 +8,9 @@
 package org.eclipse.rdf4j.common.app;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.eclipse.rdf4j.common.lang.ObjectUtil;
 
 /**
  * A product version in Aduna's version format (i.e. major.minor-modifier). Where major stands for the major version
@@ -326,7 +325,7 @@ public class AppVersion implements Comparable<AppVersion> {
 			}
 		}
 
-		if (result == 0 && !ObjectUtil.nullEquals(modifier, other.modifier)) {
+		if (result == 0 && !Objects.equals(modifier, other.modifier)) {
 			if (modifier == null) {
 				result = 1;
 			} else if (other.modifier == null) {


### PR DESCRIPTION
GitHub issue resolved: #3410 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->
 - optimised the filtering in MemStatementsIterator to prioritise non-volatile variables over volatile ones
     - this is what makes the biggest difference
 - optimise the access to variables needed during filtering
 - cleaned up some code while I was at it
 - updated benchmarks
 - removed a bunch of volatile use in various iterators and in the memory store in general
      - this is kinda unrelated to the general work and I should really make some multithreaded benchmarks to measure these changes

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

