### PR TITLE
GH-3073: Add convenience methods in sparqlbuilder for IRI parameters

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/CustomFunction.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/CustomFunction.java
@@ -8,9 +8,16 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.constraint;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 public class CustomFunction extends Expression<CustomFunction> {
+	CustomFunction(IRI functionIri) {
+		this(iri(functionIri));
+	}
+
 	CustomFunction(Iri functionIri) {
 		super(functionIri, ", ");
 		parenthesize();

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
@@ -16,6 +16,7 @@ import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.COALESCE
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.CONCAT;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.REGEX;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.AlternativePath;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.GroupedPath;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.InversePath;

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
@@ -224,6 +224,10 @@ public class Expressions {
 		return new CustomFunction(functionIri).addOperand(operands);
 	}
 
+	public static Expression<?> custom(IRI functionIri, Operand... operands) {
+		return new CustomFunction(functionIri).addOperand(operands);
+	}
+
 	/**
 	 * {@code operand IN (expression1, expression2...)}
 	 * 
@@ -630,7 +634,15 @@ public class Expressions {
 		return new PredicatePath(predicate);
 	}
 
+	public static PredicatePath p(IRI predicate) {
+		return new PredicatePath(predicate);
+	}
+
 	public static InversePredicatePath pInv(Iri predicate) {
+		return new InversePredicatePath(predicate);
+	}
+
+	public static InversePredicatePath pInv(IRI predicate) {
 		return new InversePredicatePath(predicate);
 	}
 
@@ -663,6 +675,10 @@ public class Expressions {
 	}
 
 	public static PropertyPathBuilder path(Iri property) {
+		return new EmptyPropertyPathBuilder().pred(property);
+	}
+
+	public static PropertyPathBuilder path(IRI property) {
 		return new EmptyPropertyPathBuilder().pred(property);
 	}
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/InversePredicatePath.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/InversePredicatePath.java
@@ -10,6 +10,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 /**
@@ -21,6 +24,10 @@ public class InversePredicatePath implements PredicatePathOrInversePredicatePath
 
 	public InversePredicatePath(Iri predicate) {
 		this.predicate = predicate;
+	}
+
+	public InversePredicatePath(IRI predicate) {
+		this(iri(predicate));
 	}
 
 	@Override

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/PredicatePath.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/PredicatePath.java
@@ -10,6 +10,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 /**
@@ -21,6 +24,10 @@ public class PredicatePath implements PredicatePathOrInversePredicatePath {
 
 	public PredicatePath(Iri predicate) {
 		this.predicate = predicate;
+	}
+
+	public PredicatePath(IRI predicate) {
+		this(iri(predicate));
 	}
 
 	@Override

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/EmptyPropertyPathBuilder.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/EmptyPropertyPathBuilder.java
@@ -11,6 +11,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.PropertyPath;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
@@ -32,6 +35,10 @@ public class EmptyPropertyPathBuilder {
 		}
 		this.negatedPropertySetBuilder = new NegatedPropertySetBuilder();
 		return negatedPropertySetBuilder;
+	}
+
+	public PropertyPathBuilder pred(IRI predicate) {
+		return pred(iri(predicate));
 	}
 
 	public PropertyPathBuilder pred(Iri predicate) {

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/NegatedPropertySetBuilder.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/NegatedPropertySetBuilder.java
@@ -10,9 +10,12 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.InversePredicatePath;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.NegatedPropertySet;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.PredicatePath;
@@ -26,9 +29,17 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 public class NegatedPropertySetBuilder {
 	private List<PredicatePathOrInversePredicatePath> propertySet = new ArrayList<>();
 
+	public NegatedPropertySetBuilder pred(IRI predicate) {
+		return pred(iri(predicate));
+	}
+
 	public NegatedPropertySetBuilder pred(Iri predicate) {
 		propertySet.add(new PredicatePath(predicate));
 		return this;
+	}
+
+	public NegatedPropertySetBuilder invPred(IRI predicate) {
+		return invPred(iri(predicate));
 	}
 
 	public NegatedPropertySetBuilder invPred(Iri predicate) {

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/PropertyPathBuilder.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/PropertyPathBuilder.java
@@ -10,18 +10,14 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder;
 
-import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.p;
-import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.pAlt;
-import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.pGroup;
-import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.pOneOrMore;
-import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.pSeq;
-import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.pZeroOrMore;
-import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.pZeroOrOne;
+import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.*;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.GroupedPath;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.InversePath;
@@ -43,7 +39,15 @@ public class PropertyPathBuilder {
 		this.head = p(predicate);
 	}
 
+	PropertyPathBuilder(IRI predicate) {
+		this(iri(predicate));
+	}
+
 	public static PropertyPathBuilder of(Iri predicate) {
+		return new PropertyPathBuilder(predicate);
+	}
+
+	public static PropertyPathBuilder of(IRI predicate) {
 		return new PropertyPathBuilder(predicate);
 	}
 
@@ -68,6 +72,10 @@ public class PropertyPathBuilder {
 		return then(p(predicate));
 	}
 
+	public PropertyPathBuilder then(IRI predicate) {
+		return then(iri(predicate));
+	}
+
 	public PropertyPathBuilder then(PropertyPath path) {
 		Objects.requireNonNull(head);
 		head = pSeq(head, path);
@@ -90,6 +98,10 @@ public class PropertyPathBuilder {
 
 	public PropertyPathBuilder or(Iri predicate) {
 		return or(p(predicate));
+	}
+
+	public PropertyPathBuilder or(IRI predicate) {
+		return or(iri(predicate));
 	}
 
 	public PropertyPathBuilder or(PropertyPath path) {

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Base.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Base.java
@@ -8,6 +8,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 /**
@@ -22,6 +25,10 @@ public class Base implements QueryElement {
 
 	Base(Iri iri) {
 		this.iri = iri;
+	}
+
+	Base(IRI iri) {
+		this(iri(iri));
 	}
 
 	@Override

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Dataset.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Dataset.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 /**
@@ -35,6 +36,12 @@ public class Dataset extends StandardQueryElementCollection<From> {
 	 * @return this
 	 */
 	public Dataset from(Iri... iris) {
+		addElements(SparqlBuilder::from, iris);
+
+		return this;
+	}
+
+	public Dataset from(IRI... iris) {
 		addElements(SparqlBuilder::from, iris);
 
 		return this;

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/From.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/From.java
@@ -8,6 +8,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 /**
@@ -28,6 +31,14 @@ public class From implements QueryElement {
 	From(Iri iri, boolean isNamed) {
 		this.iri = iri;
 		this.isNamed = isNamed;
+	}
+
+	From(IRI iri) {
+		this(iri, false);
+	}
+
+	From(IRI iri, boolean isNamed) {
+		this(iri(iri), isNamed);
 	}
 
 	@Override

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Prefix.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Prefix.java
@@ -8,7 +8,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
 
 /**
  * A SPARQL Prefix declaration
@@ -23,6 +25,10 @@ public class Prefix implements QueryElement {
 	Prefix(String alias, Iri iri) {
 		this.label = alias;
 		this.iri = iri;
+	}
+
+	Prefix(String alias, IRI iri) {
+		this(alias, Rdf.iri(iri));
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/PropertyPaths.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/PropertyPaths.java
@@ -8,6 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfPredicate;
 
 public class PropertyPaths {
@@ -34,11 +39,23 @@ public class PropertyPaths {
 		};
 	}
 
+	public static RdfPredicate path(IRI... aElements) {
+		return path(Arrays.stream(aElements).map(Rdf::iri).collect(Collectors.toList()).toArray(new RdfPredicate[0]));
+	}
+
 	public static RdfPredicate zeroOrMore(RdfPredicate aElement) {
 		return () -> aElement.getQueryString() + "*";
 	}
 
+	public static RdfPredicate zeroOrMore(IRI aElement) {
+		return zeroOrMore(Rdf.iri(aElement));
+	}
+
 	public static RdfPredicate oneOrMore(RdfPredicate aElement) {
 		return () -> aElement.getQueryString() + "+";
+	}
+
+	public static RdfPredicate oneOrMore(IRI aElement) {
+		return oneOrMore(Rdf.iri(aElement));
 	}
 }

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilder.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilder.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
@@ -57,6 +59,16 @@ public class SparqlBuilder {
 	}
 
 	/**
+	 * Create a SPARQL Base declaration
+	 *
+	 * @param iri the base iri
+	 * @return a Base object
+	 */
+	public static Base base(IRI iri) {
+		return new Base(iri);
+	}
+
+	/**
 	 * Create a SPARQL Prefix declaration
 	 *
 	 * @param alias the alias of the prefix
@@ -64,6 +76,17 @@ public class SparqlBuilder {
 	 * @return a Prefix object
 	 */
 	public static Prefix prefix(String alias, Iri iri) {
+		return new Prefix(alias, iri);
+	}
+
+	/**
+	 * Create a SPARQL Prefix declaration
+	 *
+	 * @param alias the alias of the prefix
+	 * @param iri   the iri the alias refers to
+	 * @return a Prefix object
+	 */
+	public static Prefix prefix(String alias, IRI iri) {
 		return new Prefix(alias, iri);
 	}
 
@@ -78,23 +101,23 @@ public class SparqlBuilder {
 	}
 
 	/**
-	 * Create SPARQL Prefix declaration from the given {@link Namespace}.
-	 *
-	 * @param namespace the {@link Namespace} to convert to a prefix declaration.
-	 * @return a Prefix object.
-	 */
-	public static Prefix prefix(Namespace namespace) {
-		return prefix(namespace.getPrefix(), Rdf.iri(namespace.getName()));
-	}
-
-	/**
 	 * Create a SPARQL default Prefix declaration
 	 *
 	 * @param iri the default iri prefix as an {@link IRI}.
 	 * @return a Prefix object
 	 */
 	public static Prefix prefix(IRI iri) {
-		return prefix(Rdf.iri(iri));
+		return prefix(iri(iri));
+	}
+
+	/**
+	 * Create SPARQL Prefix declaration from the given {@link Namespace}.
+	 *
+	 * @param namespace the {@link Namespace} to convert to a prefix declaration.
+	 * @return a Prefix object.
+	 */
+	public static Prefix prefix(Namespace namespace) {
+		return prefix(namespace.getPrefix(), iri(namespace.getName()));
 	}
 
 	/**
@@ -119,6 +142,17 @@ public class SparqlBuilder {
 	}
 
 	/**
+	 * Create a default graph reference
+	 *
+	 * @param iri the source of the graph
+	 * @return a From clause
+	 * @see <a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rdfDataset"> RDF Datasets</a>
+	 */
+	public static From from(IRI iri) {
+		return new From(iri);
+	}
+
+	/**
 	 * Create a named graph reference
 	 *
 	 * @param iri the source of the graph
@@ -126,6 +160,17 @@ public class SparqlBuilder {
 	 * @see <a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rdfDataset"> RDF Datasets</a>
 	 */
 	public static From fromNamed(Iri iri) {
+		return new From(iri, true);
+	}
+
+	/**
+	 * Create a named graph reference
+	 *
+	 * @param iri the source of the graph
+	 * @return a named From clause
+	 * @see <a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rdfDataset"> RDF Datasets</a>
+	 */
+	public static From fromNamed(IRI iri) {
 		return new From(iri, true);
 	}
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/CreateQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/CreateQuery.java
@@ -8,6 +8,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core.query;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 /**
@@ -35,6 +38,10 @@ public class CreateQuery extends GraphManagementQuery<CreateQuery> {
 		this.graph = graph;
 
 		return this;
+	}
+
+	public CreateQuery graph(IRI graph) {
+		return graph(iri(graph));
 	}
 
 	@Override

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/DestinationSourceManagementQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/DestinationSourceManagementQuery.java
@@ -8,8 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core.query;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import java.util.Optional;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 /**
@@ -39,6 +42,10 @@ public abstract class DestinationSourceManagementQuery<T extends DestinationSour
 		return fromDefault(false);
 	}
 
+	public T from(IRI from) {
+		return from(iri(from));
+	}
+
 	/**
 	 * Specify the query destination graph
 	 *
@@ -50,6 +57,17 @@ public abstract class DestinationSourceManagementQuery<T extends DestinationSour
 		this.to = Optional.ofNullable(to);
 
 		return toDefault(false);
+	}
+
+	/**
+	 * Specify the query destination graph
+	 *
+	 * @param to the Iri identifying the destination graph
+	 *
+	 * @return this query instance
+	 */
+	public T to(IRI to) {
+		return to(iri(to));
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/LoadQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/LoadQuery.java
@@ -8,8 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core.query;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import java.util.Optional;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
 
@@ -42,6 +45,17 @@ public class LoadQuery extends GraphManagementQuery<LoadQuery> {
 	}
 
 	/**
+	 * Specify which graph to load form
+	 *
+	 * @param from the IRI identifying the graph to load triples from
+	 *
+	 * @return this LoadQuery instance
+	 */
+	public LoadQuery from(IRI from) {
+		return from(iri(from));
+	}
+
+	/**
 	 * Specify which graph to load into, if not the default graph
 	 *
 	 * @param to the IRI identifying the graph to load into
@@ -52,6 +66,17 @@ public class LoadQuery extends GraphManagementQuery<LoadQuery> {
 		this.to = Optional.ofNullable(to);
 
 		return this;
+	}
+
+	/**
+	 * Specify which graph to load into, if not the default graph
+	 *
+	 * @param to the IRI identifying the graph to load into
+	 *
+	 * @return this LoadQuery instance
+	 */
+	public LoadQuery to(IRI to) {
+		return to(iri(to));
 	}
 
 	@Override

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQuery.java
@@ -8,8 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core.query;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import java.util.Optional;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.core.QueryPattern;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.TriplesTemplate;
@@ -56,6 +59,17 @@ public class ModifyQuery extends UpdateQuery<ModifyQuery> {
 		with = Optional.ofNullable(iri);
 
 		return this;
+	}
+
+	/**
+	 * Define the graph that will be modified or matched against in the absence of more explicit graph definitions
+	 *
+	 * @param iri the IRI identifying the desired graph
+	 *
+	 * @return this modify query instance
+	 */
+	public ModifyQuery with(IRI iri) {
+		return with(iri(iri));
 	}
 
 	/**
@@ -128,6 +142,17 @@ public class ModifyQuery extends UpdateQuery<ModifyQuery> {
 	}
 
 	/**
+	 * Specify the graph used when evaluating the WHERE clause
+	 *
+	 * @param iri the IRI identifying the desired graph
+	 *
+	 * @return this modify query instance
+	 */
+	public ModifyQuery using(IRI iri) {
+		return using(iri(iri));
+	}
+
+	/**
 	 * Specify a named graph to use to when evaluating the WHERE clause
 	 *
 	 * @param iri the IRI identifying the desired graph
@@ -138,6 +163,17 @@ public class ModifyQuery extends UpdateQuery<ModifyQuery> {
 		usingNamed = true;
 
 		return using(iri);
+	}
+
+	/**
+	 * Specify a named graph to use to when evaluating the WHERE clause
+	 *
+	 * @param iri the IRI identifying the desired graph
+	 *
+	 * @return this modify query instance
+	 */
+	public ModifyQuery usingNamed(IRI iri) {
+		return usingNamed(iri(iri));
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/OuterQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/OuterQuery.java
@@ -8,8 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core.query;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import java.util.Optional;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.core.Base;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.PrefixDeclarations;
@@ -37,6 +40,16 @@ public abstract class OuterQuery<T extends OuterQuery<T>> extends Query<T> {
 		this.base = Optional.of(SparqlBuilder.base(iri));
 
 		return (T) this;
+	}
+
+	/**
+	 * Set the base IRI of this query
+	 *
+	 * @param iri the base IRI
+	 * @return this
+	 */
+	public T base(IRI iri) {
+		return base(iri(iri));
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/TargetedGraphManagementQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/TargetedGraphManagementQuery.java
@@ -8,8 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core.query;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import java.util.Optional;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 @SuppressWarnings("javadoc")
@@ -35,6 +38,18 @@ public abstract class TargetedGraphManagementQuery<T extends TargetedGraphManage
 		this.graph = Optional.ofNullable(graph);
 
 		return (T) this;
+	}
+
+	/**
+	 * Specify which graph to target
+	 *
+	 * @param graph the IRI identifying the graph to target
+	 *
+	 * @return this query instance
+	 */
+	@SuppressWarnings("unchecked")
+	public T graph(IRI graph) {
+		return graph(iri(graph));
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/UpdateQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/UpdateQuery.java
@@ -8,8 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core.query;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import java.util.Optional;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.core.Base;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.PrefixDeclarations;
@@ -45,6 +48,16 @@ abstract class UpdateQuery<T extends UpdateQuery<T>> implements QueryElement {
 		this.base = Optional.of(SparqlBuilder.base(iri));
 
 		return (T) this;
+	}
+
+	/**
+	 * Set the base IRI of this query
+	 *
+	 * @param iri the base IRI
+	 * @return this
+	 */
+	public T base(IRI iri) {
+		return base(iri(iri));
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
@@ -24,7 +26,7 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 	private static final String GRAPH = "GRAPH ";
 
 	private Optional<GraphName> from = Optional.empty();
-	private Optional<Filter> filter = Optional.empty();
+	private List<Filter> filters = new ArrayList<>();
 	protected boolean isOptional = false;
 
 	GroupGraphPattern() {
@@ -47,7 +49,7 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 		this.elements = original.elements;
 		this.isOptional = original.isOptional;
 		this.from = original.from;
-		this.filter = original.filter;
+		this.filters = new ArrayList<>(original.filters);
 	}
 
 	@Override
@@ -77,7 +79,7 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 
 	@Override
 	public GroupGraphPattern filter(Expression<?> constraint) {
-		filter = Optional.of(new Filter(constraint));
+		filters.add(new Filter(constraint));
 
 		return this;
 	}
@@ -100,7 +102,9 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 
 		innerPattern.append(super.getQueryString());
 
-		SparqlBuilderUtils.appendQueryElementIfPresent(filter, innerPattern, "\n", null);
+		filters.forEach(filter -> SparqlBuilderUtils.appendQueryElementIfPresent(
+				Optional.of(filter),
+				innerPattern, "\n", null));
 
 		if (bracketInner()) {
 			pattern.append(SparqlBuilderUtils.getBracedString(innerPattern.toString()));

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/TriplePattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/TriplePattern.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
 
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.toRdfLiteralArray;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfObject;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfPredicate;
@@ -40,6 +41,18 @@ public interface TriplePattern extends GraphPattern {
 	/**
 	 * Add predicate-object lists describing this triple pattern's subject
 	 *
+	 * @param predicate the predicate to use to describe this triple pattern's subject
+	 * @param objects   the corresponding object(s)
+	 *
+	 * @return this triple pattern
+	 */
+	default TriplePattern andHas(IRI predicate, RdfObject... objects) {
+		return andHas(Rdf.iri(predicate), objects);
+	}
+
+	/**
+	 * Add predicate-object lists describing this triple pattern's subject
+	 *
 	 * @param lists the {@link RdfPredicateObjectList}(s) to add
 	 *
 	 * @return this triple pattern
@@ -59,6 +72,19 @@ public interface TriplePattern extends GraphPattern {
 		return andHas(predicate, toRdfLiteralArray(objects));
 	}
 
+	/**
+	 * Convenience version of {@link #andHas(RdfPredicate, RdfObject...)} that takes Strings and converts them to
+	 * StringLiterals
+	 *
+	 * @param predicate the predicate to use to describe this triple pattern's subject
+	 * @param objects   the corresponding object(s)
+	 *
+	 * @return this triple pattern
+	 */
+	default TriplePattern andHas(IRI predicate, String... objects) {
+		return andHas(Rdf.iri(predicate), objects);
+	}
+
 	;
 
 	/**
@@ -74,6 +100,19 @@ public interface TriplePattern extends GraphPattern {
 		return andHas(predicate, toRdfLiteralArray(objects));
 	}
 
+	/**
+	 * Convenience version of {@link #andHas(RdfPredicate, RdfObject...)} that takes Boolean and converts them to
+	 * BooleanLiterals
+	 *
+	 * @param predicate the predicate to use to describe this triple pattern's subject
+	 * @param objects   the corresponding object(s)
+	 *
+	 * @return this triple pattern
+	 */
+	default TriplePattern andHas(IRI predicate, Boolean... objects) {
+		return andHas(Rdf.iri(predicate), objects);
+	}
+
 	;
 
 	/**
@@ -87,6 +126,19 @@ public interface TriplePattern extends GraphPattern {
 	 */
 	default TriplePattern andHas(RdfPredicate predicate, Number... objects) {
 		return andHas(predicate, toRdfLiteralArray(objects));
+	}
+
+	/**
+	 * Convenience version of {@link #andHas(RdfPredicate, RdfObject...)} that takes Numbers and converts them to
+	 * NumberLiterals
+	 *
+	 * @param predicate the predicate to use to describe this triple pattern's subject
+	 * @param objects   the corresponding object(s)
+	 *
+	 * @return this triple pattern
+	 */
+	default TriplePattern andHas(IRI predicate, Number... objects) {
+		return andHas(Rdf.iri(predicate), objects);
 	}
 
 	;

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/TriplesSameSubject.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/TriplesSameSubject.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfObject;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfPredicate;
@@ -27,6 +28,10 @@ class TriplesSameSubject implements TriplePattern {
 	TriplesSameSubject(RdfSubject subject, RdfPredicate predicate, RdfObject... objects) {
 		this.subject = subject;
 		andHas(predicate, objects);
+	}
+
+	TriplesSameSubject(RdfSubject subject, IRI predicate, RdfObject... objects) {
+		this(subject, Rdf.iri(predicate), objects);
 	}
 
 	TriplesSameSubject(RdfSubject subject, RdfPredicateObjectList... lists) {

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/Rdf.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/Rdf.java
@@ -95,6 +95,18 @@ public class Rdf {
 	}
 
 	/**
+	 * creates a label-less blank node, identified by the supplied predicate-object lists
+	 *
+	 * @param predicate the predicate of the initial predicate-object list to populate this blank node with
+	 * @param objects   the objects of the initial predicate-object list to populate this blank node with
+	 * @return a new {@link PropertiesBlankNode} instance
+	 * @see <a href="https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#QSynBlankNodes"> Blank node syntax</a>
+	 */
+	public static PropertiesBlankNode bNode(IRI predicate, RdfObject... objects) {
+		return bNode(Rdf.iri(predicate), objects);
+	}
+
+	/**
 	 * create an empty anonymous blank node
 	 *
 	 * @return an empty {@link AnonymousBlankNode} instance
@@ -178,6 +190,17 @@ public class Rdf {
 	}
 
 	/**
+	 * Create a {@link RdfPredicateObjectList}
+	 *
+	 * @param predicate the {@link RdfPredicate} of the predicate-object list
+	 * @param objects   the {@link RdfObject}(s) of the list
+	 * @return a new {@link RdfPredicateObjectList}
+	 */
+	public static RdfPredicateObjectList predicateObjectList(IRI predicate, RdfObject... objects) {
+		return predicateObjectList(Rdf.iri(predicate), objects);
+	}
+
+	/**
 	 * Create a {@link RdfPredicateObjectListCollection} with an initial {@link RdfPredicateObjectList}
 	 *
 	 * @param predicate the {@link RdfPredicate} of the initial {@link RdfPredicateObjectList}
@@ -187,6 +210,18 @@ public class Rdf {
 	public static RdfPredicateObjectListCollection predicateObjectListCollection(RdfPredicate predicate,
 			RdfObject... objects) {
 		return new RdfPredicateObjectListCollection().andHas(predicate, objects);
+	}
+
+	/**
+	 * Create a {@link RdfPredicateObjectListCollection} with an initial {@link RdfPredicateObjectList}
+	 *
+	 * @param predicate the {@link RdfPredicate} of the initial {@link RdfPredicateObjectList}
+	 * @param objects   the {@link RdfObject}(s) of the initial {@link RdfPredicateObjectList}
+	 * @return a new {@link RdfPredicateObjectListCollection}
+	 */
+	public static RdfPredicateObjectListCollection predicateObjectListCollection(IRI predicate,
+			RdfObject... objects) {
+		return predicateObjectListCollection(Rdf.iri(predicate), objects);
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfBlankNode.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfBlankNode.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
@@ -56,6 +57,10 @@ public interface RdfBlankNode extends RdfResource {
 			andHas(predicate, objects);
 		}
 
+		PropertiesBlankNode(IRI predicate, RdfObject... objects) {
+			andHas(predicate, objects);
+		}
+
 		/**
 		 * Using the predicate-object and object list mechanisms, expand this blank node's pattern to include triples
 		 * consisting of this blank node as the subject, and the given predicate and object(s)
@@ -73,6 +78,23 @@ public interface RdfBlankNode extends RdfResource {
 			predicateObjectLists.andHas(predicate, objects);
 
 			return this;
+		}
+
+		/**
+		 * Using the predicate-object and object list mechanisms, expand this blank node's pattern to include triples
+		 * consisting of this blank node as the subject, and the given predicate and object(s)
+		 *
+		 * @param predicate the predicate of the triple to add
+		 * @param objects   the object or objects of the triple to add
+		 *
+		 * @return this blank node
+		 *
+		 * @see <a href="https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#predObjLists"> Predicate-Object
+		 *      Lists</a>
+		 * @see <a href="https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#objLists"> Object Lists</a>
+		 */
+		public PropertiesBlankNode andHas(IRI predicate, RdfObject... objects) {
+			return andHas(Rdf.iri(predicate), objects);
 		}
 
 		/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteral.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteral.java
@@ -8,8 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
 import java.util.Optional;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
 
 /**
@@ -78,6 +81,10 @@ public abstract class RdfLiteral<T> implements RdfValue {
 			ofType(dataType);
 		}
 
+		StringLiteral(String stringValue, IRI dataType) {
+			this(stringValue, iri(dataType));
+		}
+
 		StringLiteral(String stringValue, String languageTag) {
 			super(stringValue);
 			ofLanguage(languageTag);
@@ -87,6 +94,10 @@ public abstract class RdfLiteral<T> implements RdfValue {
 			this.dataType = Optional.ofNullable(dataType);
 
 			return this;
+		}
+
+		public StringLiteral ofType(IRI dataType) {
+			return ofType(iri(dataType));
 		}
 
 		public StringLiteral ofLanguage(String languageTag) {

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfPredicateObjectList.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfPredicateObjectList.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.core.StandardQueryElementCollection;
 
 /**
@@ -20,6 +21,10 @@ public class RdfPredicateObjectList extends StandardQueryElementCollection<RdfOb
 		super(predicate.getQueryString(), ", ");
 		printNameIfEmpty(false);
 		and(objects);
+	}
+
+	RdfPredicateObjectList(IRI predicate, RdfObject... objects) {
+		this(Rdf.iri(predicate), objects);
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfPredicateObjectListCollection.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfPredicateObjectListCollection.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.core.QueryElementCollection;
 
 /**
@@ -35,6 +36,18 @@ public class RdfPredicateObjectListCollection extends QueryElementCollection<Rdf
 	 */
 	public RdfPredicateObjectListCollection andHas(RdfPredicate predicate, RdfObject... objects) {
 		return andHas(Rdf.predicateObjectList(predicate, objects));
+	}
+
+	/**
+	 * add predicate-object lists to this collection
+	 *
+	 * @param predicate the predicate of the predicate-object list to add
+	 * @param objects   the object or objects to add
+	 *
+	 * @return this instance
+	 */
+	public RdfPredicateObjectListCollection andHas(IRI predicate, RdfObject... objects) {
+		return andHas(Rdf.predicateObjectList(Rdf.iri(predicate), objects));
 	}
 
 	/**

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfSubject.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfSubject.java
@@ -36,18 +36,6 @@ public interface RdfSubject extends QueryElement {
 	/**
 	 * Create a triple pattern from this subject and the given predicate and object
 	 *
-	 * @param predicate the predicate of the triple pattern
-	 * @param values    the object value(s) of the triple pattern.
-	 * @return a new {@link TriplePattern} with this subject, and the given predicate and object(s)
-	 * @see <a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#QSynTriples"> Triple pattern syntax</a>
-	 */
-	default TriplePattern has(RdfPredicate predicate, Value... values) {
-		return has(predicate, Rdf.objects(values));
-	}
-
-	/**
-	 * Create a triple pattern from this subject and the given predicate and object
-	 *
 	 * @param predicate the predicate {@link IRI} of the triple pattern
 	 * @param objects   the object(s) of the triple pattern
 	 * @return a new {@link TriplePattern} with this subject, and the given predicate and object(s)
@@ -55,6 +43,18 @@ public interface RdfSubject extends QueryElement {
 	 */
 	default TriplePattern has(IRI predicate, RdfObject... objects) {
 		return has(Rdf.iri(predicate), objects);
+	}
+
+	/**
+	 * Create a triple pattern from this subject and the given predicate and object
+	 *
+	 * @param predicate the predicate of the triple pattern
+	 * @param values    the object value(s) of the triple pattern.
+	 * @return a new {@link TriplePattern} with this subject, and the given predicate and object(s)
+	 * @see <a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#QSynTriples"> Triple pattern syntax</a>
+	 */
+	default TriplePattern has(RdfPredicate predicate, Value... values) {
+		return has(predicate, Rdf.objects(values));
 	}
 
 	/**
@@ -91,6 +91,17 @@ public interface RdfSubject extends QueryElement {
 	}
 
 	/**
+	 * Wrapper for {@link #has(RdfPredicate, RdfObject...)} that converts String objects into RdfLiteral instances
+	 *
+	 * @param predicate the predicate of the triple pattern
+	 * @param objects   the String object(s) of the triple pattern
+	 * @return a new {@link TriplePattern} with this subject, and the given predicate and object(s)
+	 */
+	default TriplePattern has(IRI predicate, String... objects) {
+		return GraphPatterns.tp(this, Rdf.iri(predicate), toRdfLiteralArray(objects));
+	}
+
+	/**
 	 * Wrapper for {@link #has(RdfPredicate, RdfObject...)} that converts Number objects into RdfLiteral instances
 	 *
 	 * @param predicate the predicate of the triple pattern
@@ -99,6 +110,17 @@ public interface RdfSubject extends QueryElement {
 	 */
 	default TriplePattern has(RdfPredicate predicate, Number... objects) {
 		return GraphPatterns.tp(this, predicate, toRdfLiteralArray(objects));
+	}
+
+	/**
+	 * Wrapper for {@link #has(RdfPredicate, RdfObject...)} that converts Number objects into RdfLiteral instances
+	 *
+	 * @param predicate the predicate of the triple pattern
+	 * @param objects   the Number object(s) of the triple pattern
+	 * @return a new {@link TriplePattern} with this subject, and the given predicate and object(s)
+	 */
+	default TriplePattern has(IRI predicate, Number... objects) {
+		return GraphPatterns.tp(this, Rdf.iri(predicate), toRdfLiteralArray(objects));
 	}
 
 	/**
@@ -113,6 +135,17 @@ public interface RdfSubject extends QueryElement {
 	}
 
 	/**
+	 * Wrapper for {@link #has(RdfPredicate, RdfObject...)} that converts Boolean objects into RdfLiteral instances
+	 *
+	 * @param predicate the predicate of the triple pattern
+	 * @param objects   the Boolean object(s) of the triple pattern
+	 * @return a new {@link TriplePattern} with this subject, and the given predicate and object(s)
+	 */
+	default TriplePattern has(IRI predicate, Boolean... objects) {
+		return GraphPatterns.tp(this, Rdf.iri(predicate), toRdfLiteralArray(objects));
+	}
+
+	/**
 	 * Use the built-in shortcut "a" for <code>rdf:type</code> to build a triple with this subject and the given objects
 	 *
 	 * @param objects the objects to use to describe the <code>rdf:type</code> of this subject
@@ -120,6 +153,17 @@ public interface RdfSubject extends QueryElement {
 	 * @see <a href="https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#abbrevRdfType"> RDF Type abbreviation</a>
 	 */
 	default TriplePattern isA(RdfObject... objects) {
+		return has(RdfPredicate.a, objects);
+	}
+
+	/**
+	 * Use the built-in shortcut "a" for <code>rdf:type</code> to build a triple with this subject and the given objects
+	 *
+	 * @param objects the objects to use to describe the <code>rdf:type</code> of this subject
+	 * @return a {@link TriplePattern} object with this subject, the "a" shortcut predicate, and the given objects
+	 * @see <a href="https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#abbrevRdfType"> RDF Type abbreviation</a>
+	 */
+	default TriplePattern isA(IRI... objects) {
 		return has(RdfPredicate.a, objects);
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
@@ -126,4 +126,21 @@ public class SparqlBuilderTest {
 		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 + ( 10 / 5 ) ) || 30 < 50 )"));
 	}
 
+	@Test
+	public void testMultipleFilters() {
+		Prefix dc = SparqlBuilder.prefix("dc", iri(DC_NS)), ns = SparqlBuilder.prefix("ns", iri(EXAMPLE_ORG_NS));
+		Variable title = SparqlBuilder.var("title"), price = SparqlBuilder.var("price"), x = SparqlBuilder.var("x");
+
+		GraphPatternNotTriples pricePattern = GraphPatterns.and(x.has(ns.iri("price"), price))
+				.filter(Expressions.lt(price, Rdf.literalOf(50)))
+				.filter(Expressions.gt(price, Rdf.literalOf(30)))
+				.optional();
+		query.prefix(dc, ns)
+				.select(title, price)
+				.where(x.has(dc.iri("title"), title),
+						pricePattern);
+		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("FILTER ( ?price < 50 )"));
+		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("FILTER ( ?price > 30 )"));
+	}
+
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/BaseExamples.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/BaseExamples.java
@@ -93,8 +93,8 @@ public class BaseExamples {
 		return s.toLowerCase().replaceAll("[\n\\s]", "");
 	}
 
-	protected Matcher<? super String> stringEqualsIgnoreCaseAndWhitespace(String compareTo) {
-		final String compareToConverted = toLowerRemoveWhitespace(compareTo);
+	protected Matcher<? super String> stringEqualsIgnoreCaseAndWhitespace(String expected) {
+		final String expectedConverted = toLowerRemoveWhitespace(expected);
 		return new BaseMatcher<String>() {
 			private String aroundString = null;
 
@@ -105,10 +105,10 @@ public class BaseExamples {
 				}
 				String itemConverted = toLowerRemoveWhitespace((String) item);
 				if (itemConverted == null) {
-					return compareToConverted == null;
+					return expectedConverted == null;
 				}
-				if (!itemConverted.equals(compareToConverted)) {
-					aroundString = getFirstDifference(compareToConverted, itemConverted, 20);
+				if (!itemConverted.equals(expectedConverted)) {
+					aroundString = getFirstDifference(expectedConverted, itemConverted, 20);
 					return false;
 				}
 				return true;
@@ -117,30 +117,31 @@ public class BaseExamples {
 			@Override
 			public void describeTo(Description description) {
 				description.appendText(
-						"To match the following String after lowercasing, removal of newlines and whitespaces:\n");
-				description.appendText(compareTo);
-				description.appendText("\nHint:Found a difference around '" + aroundString + "'\n");
+						"To match the following String after lowercasing, removal of newlines and whitespaces.\n");
+				description.appendText("\nHint: first difference: " + aroundString + "\n");
+				description.appendText(
+						"Expected: was \"" + expected.replaceAll("\n", "\\\\n").replaceAll("\\s+", " ") + "\"");
 			}
 		};
 	}
 
-	private String getFirstDifference(String s1, String s2, int length) {
-		int minLength = Math.min(s1.length(), s2.length());
+	private String getFirstDifference(String expected, String actual, int length) {
+		int minLength = Math.min(expected.length(), actual.length());
 		int pos = 0;
-		while (s1.charAt(pos) == s2.charAt(pos) && pos < minLength) {
+		while (expected.charAt(pos) == actual.charAt(pos) && pos < minLength) {
 			pos++;
 		}
 		if (pos == minLength) {
-			if (s1.length() == s2.length()) {
+			if (expected.length() == actual.length()) {
 				return "[no difference found]";
-			} else if (s1.length() < s2.length()) {
-				return s2.substring(pos);
+			} else if (expected.length() < actual.length()) {
+				return String.format("expected string ends, actual continues: '%s'", actual.substring(pos));
 			}
-			return s1.substring(pos);
+			return String.format("actual string ends, expected continues:'%s'", expected.substring(pos));
 		}
-		if (s1.length() > s2.length()) {
-			return s1.substring(pos, Math.min(s1.length(), pos + length));
-		}
-		return s2.substring(pos, Math.min(s2.length(), pos + length));
+
+		String expectedDiff = expected.substring(pos, Math.min(expected.length(), pos + length));
+		String actualDiff = actual.substring(pos, Math.min(actual.length(), pos + length));
+		return String.format("\nexpected: '%s',\nactual :  '%s'", expectedDiff, actualDiff);
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/BaseExamples.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/BaseExamples.java
@@ -59,31 +59,10 @@ public class BaseExamples {
 	@Before
 	public void before() {
 		resetQuery();
-		printTestHeader();
-	}
-
-	protected void p() {
-		p(query);
-	}
-
-	protected void p(QueryElement... qe) {
-		p(Arrays.stream(qe).map(QueryElement::getQueryString).collect(Collectors.joining(" ;\n\n")));
-	}
-
-	protected void p(String s) {
-		System.out.println(s);
 	}
 
 	protected void resetQuery() {
 		query = Queries.SELECT();
-	}
-
-	private void printTestHeader() {
-		String name = testName.getMethodName();
-		String[] tokens = name.split("_");
-
-		p(Stream.of(Arrays.copyOfRange(tokens, 1, tokens.length))
-				.collect(Collectors.joining(".", tokens[0].toUpperCase() + " ", ":")));
 	}
 
 	private String toLowerRemoveWhitespace(String s) {
@@ -128,7 +107,7 @@ public class BaseExamples {
 	private String getFirstDifference(String expected, String actual, int length) {
 		int minLength = Math.min(expected.length(), actual.length());
 		int pos = 0;
-		while (expected.charAt(pos) == actual.charAt(pos) && pos < minLength) {
+		while (expected.charAt(pos) == actual.charAt(pos) && pos < minLength - 1) {
 			pos++;
 		}
 		if (pos == minLength) {

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section11Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section11Test.java
@@ -20,7 +20,9 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class Section11Test extends BaseExamples {
 	@Test
@@ -39,7 +41,16 @@ public class Section11Test extends BaseExamples {
 						book.has(base.iri("price"), lprice))
 				.groupBy(org)
 				.having(Expressions.gt(sum, 10));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://books.example/>\n"
+						+ "SELECT (SUM(?lprice) AS ?totalPrice)\n"
+						+ "WHERE {\n"
+						+ "  ?org :affiliates ?auth .\n"
+						+ "  ?auth :writesBook ?book .\n"
+						+ "  ?book :price ?lprice .\n"
+						+ "}\n"
+						+ "GROUP BY ?org\n"
+						+ "HAVING (SUM(?lprice) > 10)"));
 	}
 
 	@Test
@@ -63,24 +74,40 @@ public class Section11Test extends BaseExamples {
 				.where(org.has(affiliates, auth), auth.has(writesBook, book), book.has(price, lprice))
 				.groupBy(org)
 				.having(Expressions.gt(sum, 10));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://books.example/>\n"
+						+ "SELECT (SUM(?lprice) AS ?totalPrice)\n"
+						+ "WHERE {\n"
+						+ "  ?org <http://example.org/book/affiliates> ?auth .\n"
+						+ "  ?auth <http://example.org/book/writesBook> ?book .\n"
+						+ "  ?book <http://example.org/book/price> ?lprice .\n"
+						+ "}\n"
+						+ "GROUP BY ?org\n"
+						+ "HAVING (SUM(?lprice) > 10)"));
 	}
 
 	@Test
 	public void example_11_2() {
 		Prefix base = SparqlBuilder.prefix((Iri) null);
-		Variable y = query.var(), avg = query.var(), a = query.var(), x = query.var();
+		Variable y = SparqlBuilder.var("y"), avg = SparqlBuilder.var("avg"), a = SparqlBuilder.var("a"),
+				x = SparqlBuilder.var("x");
 
 		query.select(SparqlBuilder.as(Expressions.avg(y), avg))
 				.where(a.has(base.iri("x"), x).andHas(base.iri("y"), y))
 				.groupBy(x);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT (AVG(?y) AS ?avg)\n"
+						+ "WHERE {\n"
+						+ "  ?a :x ?x ;\n"
+						+ "     :y ?y .\n"
+						+ "}\n"
+						+ "GROUP BY ?x"));
 	}
 
 	@Test
 	public void example_11_3() {
 		Prefix base = SparqlBuilder.prefix(iri("http://data.example/"));
-		Variable size = SparqlBuilder.var("size"), asize = SparqlBuilder.var("asize"), x = query.var();
+		Variable size = SparqlBuilder.var("size"), asize = SparqlBuilder.var("asize"), x = SparqlBuilder.var("x");
 		Expression<?> avgSize = Expressions.avg(size);
 
 		query.prefix(base)
@@ -88,26 +115,41 @@ public class Section11Test extends BaseExamples {
 				.where(x.has(base.iri("size"), size))
 				.groupBy(x)
 				.having(Expressions.gt(avgSize, 10));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://data.example/>\n"
+						+ "SELECT (AVG(?size) AS ?asize)\n"
+						+ "WHERE {\n"
+						+ "  ?x :size ?size .\n"
+						+ "}\n"
+						+ "GROUP BY ?x\n"
+						+ "HAVING(AVG(?size) > 10)"));
 	}
 
 	@Test
 	public void example_11_4() {
 		Prefix base = SparqlBuilder.prefix(iri("http://example.com/data/#"));
-		Variable x = query.var(), y = query.var(), z = query.var(), min = query.var();
+		Variable x = SparqlBuilder.var("x"), y = SparqlBuilder.var("y"), z = SparqlBuilder.var("z"),
+				min = SparqlBuilder.var("min");
 		Expression<?> twiceMin = Expressions.multiply(Expressions.min(y), Rdf.literalOf(2));
 
 		query.prefix(base)
 				.select(x, twiceMin.as(min))
 				.where(x.has(base.iri("p"), y), x.has(base.iri("q"), z))
 				.groupBy(x, Expressions.str(z));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://example.com/data/#>\n"
+						+ "SELECT ?x ((MIN(?y) * 2) AS ?min)\n"
+						+ "WHERE {\n"
+						+ "  ?x :p ?y .\n"
+						+ "  ?x :q ?z .\n"
+						+ "} GROUP BY ?x STR(?z)"));
 	}
 
 	@Test
 	public void example_11_5() {
 		Prefix base = SparqlBuilder.prefix(iri("http://example.com/data/#"));
-		Variable g = query.var(), p = query.var(), avg = query.var(), c = query.var();
+		Variable g = SparqlBuilder.var("g"), p = SparqlBuilder.var("p"), avg = SparqlBuilder.var("avg"),
+				c = SparqlBuilder.var("c");
 		Expression<?> midRange = Expressions
 				.divide(Expressions.add(Expressions.min(p), Expressions.max(p)).parenthesize(), Rdf.literalOf(2));
 
@@ -115,6 +157,12 @@ public class Section11Test extends BaseExamples {
 				.select(g, Expressions.avg(p).as(avg), midRange.as(c))
 				.where(g.has(base.iri("p"), p))
 				.groupBy(g);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://example.com/data/#>\n"
+						+ "SELECT ?g (AVG(?p) AS ?avg) (((MIN(?p) + MAX(?p)) / 2) AS ?c)\n"
+						+ "WHERE {\n"
+						+ "  ?g :p ?p .\n"
+						+ "}\n"
+						+ "GROUP BY ?g"));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section12Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section12Test.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.SubSelect;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section12Test extends BaseExamples {
@@ -26,15 +27,25 @@ public class Section12Test extends BaseExamples {
 
 		// using this method of variable creation, as ?y and ?minName will be
 		// used in both the outer and inner queries
-		Variable y = SparqlBuilder.var("y"), minName = SparqlBuilder.var("minName");
+		Variable y = SparqlBuilder.var("y"), minName = SparqlBuilder.var("minName"), name = SparqlBuilder.var("name");
 
 		SubSelect sub = GraphPatterns.select();
-		Variable name = sub.var();
 		sub.select(y, Expressions.min(name).as(minName)).where(y.has(base.iri("name"), name)).groupBy(y);
 
 		query.prefix(base, base) // SparqlBuilder even fixes typos for you ;)
 				.select(y, minName)
 				.where(base.iri("alice").has(base.iri("knows"), y), sub);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://people.example/>\n"
+						+ "SELECT ?y ?minName\n"
+						+ "WHERE {\n"
+						+ "  :alice :knows ?y .\n"
+						+ "  {\n"
+						+ "    SELECT ?y (MIN(?name) AS ?minName)\n"
+						+ "    WHERE {\n"
+						+ "      ?y :name ?name .\n"
+						+ "    } GROUP BY ?y\n"
+						+ "  }\n"
+						+ "}"));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section13Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section13Test.java
@@ -5,90 +5,130 @@
  which accompanies this distribution, and is available at
  http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
-import org.eclipse.rdf4j.sparqlbuilder.core.Dataset;
-import org.eclipse.rdf4j.sparqlbuilder.core.From;
-import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
-import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
-import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.core.*;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section13Test extends BaseExamples {
 	@Test
 	public void example_13_2_1() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable name = query.var();
+		Variable name = var("name");
+		Variable x = var("x");
 		From defaultGraph = SparqlBuilder.from(iri("http://example.org/foaf/aliceFoaf"));
-
-		query.prefix(foaf).select(name).from(defaultGraph).where(query.var().has(foaf.iri("name"), name));
-		p();
+		query.prefix(foaf).select(name).from(defaultGraph).where(x.has(foaf.iri("name"), name));
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT  ?name\n"
+						+ "FROM    <http://example.org/foaf/aliceFoaf>\n"
+						+ "WHERE   { ?x foaf:name ?name . }"));
 	}
 
 	@Test
 	public void example_13_2_2() {
 		Dataset dataset = SparqlBuilder.dataset(SparqlBuilder.fromNamed(iri("http://example.org/alice")),
 				SparqlBuilder.fromNamed(iri("http://example.org/bob")));
-		p(dataset);
+		Assert.assertThat(dataset.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(""
+				+ "FROM NAMED <http://example.org/alice>\n"
+				+ "FROM NAMED <http://example.org/bob>"));
 	}
 
 	@Test
 	public void example_13_2_3() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
 		Prefix dc = SparqlBuilder.prefix("dc", iri(DC_NS));
-
 		From defaultGraph = SparqlBuilder.from(iri("http://example.org/dft.ttl"));
 		From aliceGraph = SparqlBuilder.fromNamed(iri("http://example.org/alice"));
 		From bobGraph = SparqlBuilder.fromNamed(iri("http://example.org/bob"));
-
-		Variable who = query.var(), g = query.var(), mbox = query.var();
-		GraphPattern namedGraph = GraphPatterns.and(query.var().has(foaf.iri("mbox"), mbox)).from(g);
-
+		Variable who = var("who"),
+				g = var("g"),
+				mbox = var("mbox"),
+				x = var("x");
+		GraphPattern namedGraph = GraphPatterns.and(x.has(foaf.iri("mbox"), mbox)).from(g);
 		query.prefix(foaf, dc)
 				.select(who, g, mbox)
 				.from(defaultGraph, aliceGraph, bobGraph)
 				.where(g.has(dc.iri("publisher"), who), namedGraph);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "PREFIX dc: <http://purl.org/dc/elements/1.1/>\n"
+						+ "\n"
+						+ "SELECT ?who ?g ?mbox\n"
+						+ "FROM <http://example.org/dft.ttl>\n"
+						+ "FROM NAMED <http://example.org/alice>\n"
+						+ "FROM NAMED <http://example.org/bob>\n"
+						+ "WHERE\n"
+						+ "{\n"
+						+ "   ?g dc:publisher ?who .\n"
+						+ "   GRAPH ?g { ?x foaf:mbox ?mbox . }\n"
+						+ "}"));
 	}
 
 	@Test
 	public void example_13_3_1() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable src = query.var(), bobNick = query.var(), x = query.var();
-
+		Variable src = var("src"), bobNick = var("bobNick"), x = var("x");
 		// TODO: still need to bracket GGP's that aren't explicitly GGP instances,
 		// even if there's only 1
 		query.prefix(foaf)
 				.select(src, bobNick)
-				.from(SparqlBuilder.fromNamed(iri("http://example.org/alice")),
-						SparqlBuilder.fromNamed(iri("http://example.org/bob")))
+				.from(SparqlBuilder.fromNamed(iri("http://example.org/foaf/aliceFoaf")),
+						SparqlBuilder.fromNamed(iri("http://example.org/foaf/bobFoaf")))
 				.where(GraphPatterns
-						.and(x.has(foaf.iri("mbox"), iri("mailto:bob@work.example")), x.has(foaf.iri("nick"), bobNick))
+						.and(x.has(foaf.iri("mbox"), iri("mailto:bob@work.example")),
+								x.has(foaf.iri("nick"), bobNick))
 						.from(src));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "\n"
+						+ "SELECT ?src ?bobNick\n"
+						+ "FROM NAMED <http://example.org/foaf/aliceFoaf>\n"
+						+ "FROM NAMED <http://example.org/foaf/bobFoaf>\n"
+						+ "WHERE\n"
+						+ "  {\n"
+						+ "    GRAPH ?src\n"
+						+ "    { ?x foaf:mbox <mailto:bob@work.example> .\n"
+						+ "      ?x foaf:nick ?bobNick .\n"
+						+ "    }\n"
+						+ "  }"));
 	}
 
 	@Test
 	public void example_13_3_2() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
 		Prefix data = SparqlBuilder.prefix("data", iri("http://example.org/foaf/"));
-		Variable x = query.var(), nick = query.var();
-
+		Variable x = var("x"), nick = var("nick");
 		query.prefix(foaf, data)
 				.select(nick)
 				.from(SparqlBuilder.fromNamed(iri("http://example.org/foaf/aliceFoaf")),
 						SparqlBuilder.fromNamed(iri("http://example.org/foaf/bobFoaf")))
 				.where(GraphPatterns
-						.and(x.has(foaf.iri("mbox"), iri("mailto:bob@work.example")), x.has(foaf.iri("nick"), nick))
+						.and(x.has(foaf.iri("mbox"), iri("mailto:bob@work.example")),
+								x.has(foaf.iri("nick"), nick))
 						.from(data.iri("bobFoaf")));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "PREFIX data: <http://example.org/foaf/>\n"
+						+ "\n"
+						+ "SELECT ?nick\n"
+						+ "FROM NAMED <http://example.org/foaf/aliceFoaf>\n"
+						+ "FROM NAMED <http://example.org/foaf/bobFoaf>\n"
+						+ "WHERE\n"
+						+ "  {\n"
+						+ "     GRAPH data:bobFoaf {\n"
+						+ "         ?x foaf:mbox <mailto:bob@work.example> .\n"
+						+ "         ?x foaf:nick ?nick .}\n"
+						+ "  }"
+		));
 	}
 
 	@Test
@@ -96,38 +136,75 @@ public class Section13Test extends BaseExamples {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
 		Prefix data = SparqlBuilder.prefix("data", iri("http://example.org/foaf/"));
 		Prefix rdfs = SparqlBuilder.prefix("rdfs", iri("http://www.w3.org/2000/01/rdf-schema#"));
-
-		Variable mbox = query.var(), nick = query.var(), ppd = query.var(), alice = query.var(), whom = query.var(),
-				w = query.var();
-
+		Variable mbox = var("mbox"),
+				nick = var("nick"),
+				ppd = var("ppd"),
+				alice = var("alice"),
+				whom = var("whom"),
+				w = var("w");
 		Iri foafMbox = foaf.iri("mbox");
-
 		GraphPattern aliceFoafGraph = GraphPatterns
-				.and(alice.has(foafMbox, iri("mailto:bob@work.example")).andHas(foaf.iri("knows"), whom),
+				.and(alice.has(foafMbox, iri("mailto:alice@work.example")).andHas(foaf.iri("knows"), whom),
 						whom.has(foafMbox, mbox).andHas(rdfs.iri("seeAlso"), ppd),
 						ppd.isA(foaf.iri("PersonalProfileDocument")))
 				.from(data.iri("aliceFoaf"));
 		GraphPattern ppdGraph = GraphPatterns.and(w.has(foafMbox, mbox).andHas(foaf.iri("nick"), nick)).from(ppd);
-
 		query.prefix(data, foaf, rdfs)
 				.select(mbox, nick, ppd)
 				.from(SparqlBuilder.fromNamed(iri("http://example.org/foaf/aliceFoaf")),
 						SparqlBuilder.fromNamed(iri("http://example.org/foaf/bobFoaf")))
 				.where(aliceFoafGraph, ppdGraph);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX  data:  <http://example.org/foaf/>\n"
+						+ "PREFIX  foaf:  <http://xmlns.com/foaf/0.1/>\n"
+						+ "PREFIX  rdfs:  <http://www.w3.org/2000/01/rdf-schema#>\n"
+						+ "\n"
+						+ "SELECT ?mbox ?nick ?ppd\n"
+						+ "FROM NAMED <http://example.org/foaf/aliceFoaf>\n"
+						+ "FROM NAMED <http://example.org/foaf/bobFoaf>\n"
+						+ "WHERE\n"
+						+ "{\n"
+						+ "  GRAPH data:aliceFoaf\n"
+						+ "  {\n"
+						+ "    ?alice foaf:mbox <mailto:alice@work.example> ;\n"
+						+ "           foaf:knows ?whom .\n"
+						+ "    ?whom  foaf:mbox ?mbox ;\n"
+						+ "           rdfs:seeAlso ?ppd .\n"
+						+ "    ?ppd  a foaf:PersonalProfileDocument .\n"
+						+ "  } \n"
+						+ "  GRAPH ?ppd\n"
+						+ "  {\n"
+						+ "      ?w foaf:mbox ?mbox ;\n"
+						+ "         foaf:nick ?nick .\n"
+						+ "  }\n"
+						+ "}"));
 	}
 
 	@Test
 	public void example_13_3_4() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
 		Prefix dc = SparqlBuilder.prefix("dc", iri(DC_NS));
-
-		Variable name = query.var(), mbox = query.var(), date = query.var(), g = query.var(), person = query.var();
-
+		Variable name = var("name"),
+				mbox = var("mbox"),
+				date = var("date"),
+				g = var("g"),
+				person = var("person");
 		query.prefix(foaf, dc)
 				.select(name, mbox, date)
 				.where(g.has(dc.iri("publisher"), name).andHas(dc.iri("date"), date),
-						GraphPatterns.and(person.has(foaf.iri("name"), name).andHas(foaf.iri("mbox"), mbox)).from(g));
-		p();
+						GraphPatterns.and(person.has(foaf.iri("name"), name)
+								.andHas(foaf.iri("mbox"), mbox)).from(g));
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "PREFIX dc:   <http://purl.org/dc/elements/1.1/>\n"
+						+ "\n"
+						+ "SELECT ?name ?mbox ?date\n"
+						+ "WHERE\n"
+						+ "  {  ?g dc:publisher ?name ;\n"
+						+ "        dc:date ?date .\n"
+						+ "    GRAPH ?g\n"
+						+ "      { ?person foaf:name ?name ; foaf:mbox ?mbox . }\n"
+						+ "  }"
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section15Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section15Test.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.OrderBy;
@@ -18,21 +19,28 @@ import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section15Test extends BaseExamples {
 	@Test
 	public void example_15_1() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable name = query.var(), x = query.var();
+		Variable name = var("name"), x = var("x");
 
 		TriplePattern employeePattern = x.has(foaf.iri("name"), name);
 		query.prefix(foaf).select(name).where(employeePattern).orderBy(name);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "\n"
+						+ "SELECT ?name\n"
+						+ "WHERE { ?x foaf:name ?name .}\n"
+						+ "ORDER BY ?name"
+		));
 
 		Prefix base = SparqlBuilder.prefix(iri("http://example.org/ns#"));
-		PrefixDeclarations prefixes = SparqlBuilder.prefixes(foaf, base);
-		Variable emp = query.var();
+		PrefixDeclarations prefixes = SparqlBuilder.prefixes(base, foaf);
+		Variable emp = var("emp");
 
 		OrderCondition empDesc = SparqlBuilder.desc(emp);
 
@@ -48,20 +56,37 @@ public class Section15Test extends BaseExamples {
 		// than Orderable instances) replaces (rather than augments)
 		// the query's order conditions
 		query.orderBy(SparqlBuilder.orderBy(empDesc));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX     :    <http://example.org/ns#>\n"
+						+ "PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "\n"
+						+ "SELECT ?name\n"
+						+ "WHERE { ?x foaf:name ?name ; :empId ?emp .}\n"
+						+ "ORDER BY DESC(?emp)"
+		));
 
 		OrderBy order = SparqlBuilder.orderBy(name, empDesc);
 		query.orderBy(order);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX     :    <http://example.org/ns#>\n"
+						+ "PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "\n"
+						+ "SELECT ?name\n"
+						+ "WHERE { ?x foaf:name ?name ; :empId ?emp . }\n"
+						+ "ORDER BY ?name DESC(?emp)"
+		));
 	}
 
 	@Test
 	public void example_15_3_1() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable name = query.var(), x = query.var();
+		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).distinct().where(x.has(foaf.iri("name"), name));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT DISTINCT ?name WHERE { ?x foaf:name ?name .}"
+		));
 	}
 
 	@Test
@@ -72,18 +97,32 @@ public class Section15Test extends BaseExamples {
 	@Test
 	public void example_15_4() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable name = query.var(), x = query.var();
+		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).where(x.has(foaf.iri("name"), name)).orderBy(name).limit(5).offset(10);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "\n"
+						+ "SELECT  ?name\n"
+						+ "WHERE   { ?x foaf:name ?name . }\n"
+						+ "ORDER BY ?name\n"
+						+ "LIMIT   5\n"
+						+ "OFFSET  10"
+		));
 	}
 
 	@Test
 	public void example_15_5() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable name = query.var(), x = query.var();
+		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).where(x.has(foaf.iri("name"), name)).limit(20);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "\n"
+						+ "SELECT ?name\n"
+						+ "WHERE { ?x foaf:name ?name . }\n"
+						+ "LIMIT 20"
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section15Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section15Test.java
@@ -91,7 +91,7 @@ public class Section15Test extends BaseExamples {
 
 	@Test
 	public void example_15_3_2() {
-		p("REDUCED not yet implemented");
+		System.err.println("REDUCED not yet implemented");
 	}
 
 	@Test

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section17Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section17Test.java
@@ -1,5 +1,6 @@
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -8,6 +9,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section17Test extends BaseExamples {
@@ -17,7 +19,9 @@ public class Section17Test extends BaseExamples {
 		Variable attributeIRI = SparqlBuilder.var("attribute_iri");
 		Iri type = rdf.iri("type");
 		Expression in = Expressions.in(attributeIRI, type);
-		p(in);
+		Assert.assertThat(in.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"?attribute_iri IN ( rdf:type )"
+		));
 	}
 
 	@Test
@@ -26,6 +30,8 @@ public class Section17Test extends BaseExamples {
 		Variable attributeIRI = SparqlBuilder.var("attribute_iri");
 		Iri type = rdf.iri("type");
 		Expression notIn = Expressions.notIn(attributeIRI, type);
-		p(notIn);
+		Assert.assertThat(notIn.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"?attribute_iri NOT IN ( rdf:type )"
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section2Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section2Test.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.vocabulary.DC;
@@ -25,24 +27,30 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section2Test extends BaseExamples {
 	@Test
 	public void example_2_1() {
-		Variable title = SparqlBuilder.var("title");
+		Variable title = var("title");
 
 		TriplePattern book1_has_title = GraphPatterns.tp(Rdf.iri(EXAMPLE_ORG_BOOK_NS, "book1"), Rdf.iri(DC_NS, "title"),
 				title);
 
 		query.select(title).where(book1_has_title);
-
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT ?title\n"
+						+ "WHERE\n"
+						+ "{\n"
+						+ "  <http://example.org/book/book1> <http://purl.org/dc/elements/1.1/title> ?title .\n"
+						+ "}"
+		));
 	}
 
 	@Test
 	public void example_2_1_model() {
-		Variable title = SparqlBuilder.var("title");
+		Variable title = var("title");
 		String ex = EXAMPLE_ORG_BOOK_NS;
 		IRI book1 = VF.createIRI(ex, "book1");
 
@@ -50,7 +58,13 @@ public class Section2Test extends BaseExamples {
 
 		query.select(title).where(book1_has_title);
 
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT ?title\n"
+						+ "WHERE\n"
+						+ "{\n"
+						+ "  <http://example.org/book/book1> <http://purl.org/dc/elements/1.1/title> ?title .\n"
+						+ "}"
+		));
 	}
 
 	@Test
@@ -60,14 +74,20 @@ public class Section2Test extends BaseExamples {
 		/**
 		 * As a shortcut, Query objects can create variables that will be unique to the query instance.
 		 */
-		Variable name = query.var(), mbox = query.var(), x = query.var();
+		Variable name = var("name"), mbox = var("mbox"), x = var("x");
 
 		TriplePattern x_hasFoafName_name = GraphPatterns.tp(x, foaf.iri("name"), name);
 		TriplePattern x_hasFoafMbox_mbox = GraphPatterns.tp(x, foaf.iri("mbox"), mbox);
 
 		query.prefix(foaf).select(name, mbox).where(x_hasFoafName_name, x_hasFoafMbox_mbox);
 
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ?name ?mbox\n"
+						+ "WHERE\n"
+						+ "  { ?x foaf:name ?name .\n"
+						+ "    ?x foaf:mbox ?mbox .}"
+		));
 	}
 
 	@Test
@@ -77,62 +97,78 @@ public class Section2Test extends BaseExamples {
 		/**
 		 * As a shortcut, Query objects can create variables that will be unique to the query instance.
 		 */
-		Variable name = query.var(), mbox = query.var(), x = query.var();
+		Variable name = var("name"), mbox = var("mbox"), x = var("x");
 
-		TriplePattern x_hasFoafName_name = GraphPatterns.tp(x, FOAF.NAME, name);
-		TriplePattern x_hasFoafMbox_mbox = GraphPatterns.tp(x, FOAF.MBOX, mbox);
+		TriplePattern x_hasFoafName_name = GraphPatterns.tp(x, foaf.iri("name"), name);
+		TriplePattern x_hasFoafMbox_mbox = GraphPatterns.tp(x, foaf.iri("mbox"), mbox);
 
 		query.prefix(foaf).select(name, mbox).where(x_hasFoafName_name, x_hasFoafMbox_mbox);
 
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ?name ?mbox\n"
+						+ "WHERE\n"
+						+ "  { ?x foaf:name ?name .\n"
+						+ "    ?x foaf:mbox ?mbox .}"
+		));
 	}
 
 	@Test
 	public void example_2_3_1() {
-		Variable v = query.var(), p = query.var();
+		Variable v = var("v"), p = var("p");
 
 		TriplePattern v_hasP_cat = GraphPatterns.tp(v, p, Rdf.literalOf("cat"));
 
 		query.select(v).where(v_hasP_cat);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT ?v WHERE { ?v ?p \"cat\" .}"
+		));
 
 		TriplePattern v_hasP_cat_en = GraphPatterns.tp(v, p, Rdf.literalOfLanguage("cat", "en"));
 		SelectQuery queryWithLangTag = Queries.SELECT(v).where(v_hasP_cat_en);
-		p(queryWithLangTag);
+		Assert.assertThat(queryWithLangTag.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT ?v WHERE { ?v ?p \"cat\"@en . }"
+		));
 	}
 
 	@Test
 	public void example_2_3_2() {
-		Variable v = query.var(), p = query.var();
+		Variable v = var("v"), p = var("p");
 
 		TriplePattern v_hasP_42 = GraphPatterns.tp(v, p, Rdf.literalOf(42));
 
 		query.select(v).where(v_hasP_42);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT ?v WHERE { ?v ?p 42 . }"
+		));
 	}
 
 	@Test
 	public void example_2_3_3() {
 		String datatype = "specialDatatype";
-		Variable v = query.var(), p = query.var();
+		Variable v = var("v"), p = var("p");
 		TriplePattern v_hasP_abc_dt = GraphPatterns.tp(v, p,
 				Rdf.literalOfType("abc", Rdf.iri(EXAMPLE_DATATYPE_NS, datatype)));
 
 		query.select(v).where(v_hasP_abc_dt);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT ?v WHERE { ?v ?p \"abc\"^^<http://example.org/datatype#specialDatatype> .}"
+		));
 	}
 
 	@Test
 	public void example_2_3_3_model() {
 		String datatype = "specialDatatype";
-		Variable v = query.var(), p = query.var();
+		Variable v = var("v"), p = var("p");
 
 		Literal lit = VF.createLiteral("abc", VF.createIRI(EXAMPLE_DATATYPE_NS, datatype));
 
 		TriplePattern v_hasP_abc_dt = GraphPatterns.tp(v, p, lit);
 
 		query.select(v).where(v_hasP_abc_dt);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT ?v WHERE { ?v ?p \"abc\"^^<http://example.org/datatype#specialDatatype> .}"
+		));
 
 	}
 
@@ -140,27 +176,49 @@ public class Section2Test extends BaseExamples {
 	public void example_2_4() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", Rdf.iri(FOAF_NS));
 
-		Variable x = query.var(), name = query.var();
+		Variable x = var("x"), name = var("name");
 		query.prefix(foaf).select(x, name).where(x.has(foaf.iri("name"), name));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ?x ?name\n"
+						+ "WHERE  { ?x foaf:name ?name . }"
+		));
 	}
 
 	@Test
 	public void example_2_5() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", Rdf.iri(FOAF_NS));
-		Variable G = SparqlBuilder.var("G"), P = SparqlBuilder.var("P"), S = SparqlBuilder.var("S"),
-				name = SparqlBuilder.var("name");
+		Variable G = var("G"), P = var("P"), S = var("S"),
+				name = var("name");
 
 		Assignment concatAsName = SparqlBuilder.as(Expressions.concat(G, Rdf.literalOf(" "), S), name);
 
 		query.prefix(foaf)
 				.select(concatAsName)
 				.where(GraphPatterns.tp(P, foaf.iri("givenName"), G).andHas(foaf.iri("surname"), S));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ( CONCAT(?G, \" \", ?S) AS ?name )\n"
+						+ "WHERE  { ?P foaf:givenName ?G ; foaf:surname ?S .}"
+		));
+		query = Queries.SELECT();
+		query.prefix(foaf)
+				.select(name)
+				.where(
+						P
+								.has(foaf.iri("givenName"), G)
+								.andHas(foaf.iri("surname"), S),
+						Expressions.bind(Expressions.concat(G, Rdf.literalOf(" "), S), name));
 
-		// TODO add BIND() capability in graph patterns (also show example of
-		// saving PrefixDeclarations object and using it in both queries)
-		p("Missing BIND capability right now");
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ?name\n"
+						+ "WHERE  { \n"
+						+ "   ?P foaf:givenName ?G ; \n"
+						+ "      foaf:surname ?S . \n"
+						+ "   BIND(CONCAT(?G, \" \", ?S) AS ?name)\n"
+						+ "}"
+		));
 	}
 
 	@Test
@@ -170,12 +228,18 @@ public class Section2Test extends BaseExamples {
 		PrefixDeclarations prefixes = SparqlBuilder.prefixes(foaf, org);
 
 		ConstructQuery graphQuery = Queries.CONSTRUCT();
-		Variable x = graphQuery.var(), name = SparqlBuilder.var("name");
+		Variable x = var("x"), name = var("name");
 
 		TriplePattern foafName = GraphPatterns.tp(x, foaf.iri("name"), name);
 		TriplePattern orgName = GraphPatterns.tp(x, org.iri("employeeName"), name);
 
 		graphQuery.prefix(prefixes).construct(foafName).where(orgName);
-		p(graphQuery);
+		Assert.assertThat(graphQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
+						+ "PREFIX org:    <https://example.com/ns#>\n"
+						+ "\n"
+						+ "CONSTRUCT { ?x foaf:name ?name .}\n"
+						+ "WHERE  { ?x org:employeeName ?name .}"
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section3Test.java
@@ -8,6 +8,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
+import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
@@ -15,11 +17,13 @@ import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section3Test extends BaseExamples {
@@ -27,31 +31,52 @@ public class Section3Test extends BaseExamples {
 	public void example_3_1() {
 		Prefix dc = SparqlBuilder.prefix("dc", iri(DC_NS));
 
-		Variable x = query.var(), title = SparqlBuilder.var("title");
+		Variable x = var("x"), title = var("title");
 		TriplePattern xTitle = GraphPatterns.tp(x, dc.iri("title"), title);
 
 		Expression<?> regex = Expressions.regex(title, Rdf.literalOf("^SPARQL"));
 		GraphPattern where = xTitle.filter(regex);
 
 		query.prefix(dc).select(title).where(where);
-		p();
-
-		where.filter(Expressions.regex(title, "web", "i"));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
+						+ "SELECT  ?title\n"
+						+ "WHERE   { ?x dc:title ?title .\n"
+						+ "          FILTER (regex(?title, \"^SPARQL\")) \n"
+						+ "        }"
+		));
+		query = Queries.SELECT();
+		query.prefix(dc).select(title).where(xTitle.filter(Expressions.regex(title, "web", "i")));
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
+						+ "SELECT  ?title\n"
+						+ "WHERE   { ?x dc:title ?title .\n"
+						+ "          FILTER (regex(?title, \"web\", \"i\" ) )\n"
+						+ "        }"
+		));
 	}
 
 	@Test
 	public void example_3_2() {
 		Prefix dc = SparqlBuilder.prefix("dc", iri(DC_NS)), ns = SparqlBuilder.prefix("ns", iri(EXAMPLE_COM_NS));
 
-		Variable title = SparqlBuilder.var("title"), price = SparqlBuilder.var("price");
-		Variable x = query.var();
+		Variable title = var("title"), price = var("price");
+		Variable x = var("x");
 		Expression<?> priceConstraint = Expressions.lt(price, 30.5);
 
-		GraphPattern where = GraphPatterns.and(x.has(ns.iri("price"), price), x.has(dc.iri("title"), title))
-				.filter(priceConstraint);
+		GraphPattern where = x.has(ns.iri("price"), price).and(x.has(dc.iri("title"), title)).filter(priceConstraint);
 
 		query.prefix(dc, ns).select(title, price).where(where);
-		p();
+		// NOTE: had to move FILTER to the end of the group graph pattern (in the original, it's between the two triple
+		// patterns).
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
+						+ "PREFIX  ns:  <https://example.com/ns#>\n"
+						+ "SELECT  ?title ?price\n"
+						+ "WHERE   { ?x ns:price ?price .\n"
+						+ "          ?x dc:title ?title .\n "
+						+ "          FILTER (?price < 30.5) "
+						+ "}"
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section4Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section4Test.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode.PropertiesBlankNode;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfPredicate;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section4Test extends BaseExamples {
@@ -34,28 +35,33 @@ public class Section4Test extends BaseExamples {
 
 		// [ :p "v" ] .
 		PropertiesBlankNode bnode = Rdf.bNode(defPrefix.iri("p"), Rdf.literalOf("v"));
-		p(bnode.toTp());
+		Assert.assertThat(bnode.toTp().getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\"] ."));
 
 		// [] :p "v" .
 		TriplePattern tp = Rdf.bNode().has(defPrefix.iri("p"), Rdf.literalOf("v"));
-		p(tp);
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[] :p \"v\" ."));
 
 		// [ :p "v" ] :q "w" .
 		tp = bnode.has(defPrefix.iri("q"), Rdf.literalOf("w"));
-		p(tp);
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\" ] :q \"w\" ."));
 
 		// :x :q [ :p "v" ] .
 		tp = defPrefix.iri("x").has(defPrefix.iri("q"), bnode);
-		p(tp);
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(":x :q [ :p \"v\" ] ."));
 
 		RdfBlankNode labelledNode = Rdf.bNode("b57");
-		p(defPrefix.iri("x").has(defPrefix.iri("q"), labelledNode));
-		p(labelledNode.has(defPrefix.iri("p"), "v"));
+		tp = defPrefix.iri("x").has(defPrefix.iri("q"), labelledNode);
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(":x :q _:b57 ."));
+		tp = labelledNode.has(defPrefix.iri("p"), "v");
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("_:b57 :p \"v\". "));
 
 		// [ foaf:name ?name ;
 		// foaf:mbox <mailto:alice@example.org> ]
 		bnode = Rdf.bNode(foaf.iri("name"), name).andHas(foaf.iri("mbox"), iri("mailto:alice@example.org"));
-		p(bnode);
+		Assert.assertThat(bnode.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"[ foaf:name ?name ;"
+						+ "foaf:mbox <mailto:alice@example.org> ]"
+		));
 	}
 
 	@Test
@@ -63,7 +69,10 @@ public class Section4Test extends BaseExamples {
 		Variable mbox = SparqlBuilder.var("mbox");
 
 		TriplePattern tp = GraphPatterns.tp(x, foaf.iri("name"), name).andHas(foaf.iri("mbox"), mbox);
-		p(tp);
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"    ?x  foaf:name  ?name ;\n"
+						+ "        foaf:mbox  ?mbox ."
+		));
 	}
 
 	@Test
@@ -73,11 +82,15 @@ public class Section4Test extends BaseExamples {
 		Iri nick = foaf.iri("nick");
 		StringLiteral aliceNick = Rdf.literalOf("Alice"), alice_Nick = Rdf.literalOf("Alice_");
 
-		TriplePattern tp = GraphPatterns.tp(x, nick, alice_Nick, aliceNick);
-		p(tp);
+		TriplePattern tp = GraphPatterns.tp(x, nick, aliceNick, alice_Nick);
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"?x foaf:nick  \"Alice\" , \"Alice_\" ."
+		));
 
-		tp = x.has(nick, aliceNick, alice_Nick).andHas(foaf.iri("name"), name);
-		p(tp);
+		tp = x.has(foaf.iri("name"), name).andHas(nick, aliceNick, alice_Nick);
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"?x  foaf:name ?name ; foaf:nick  \"Alice\" , \"Alice_\" ."
+		));
 	}
 
 	@Test
@@ -85,9 +98,13 @@ public class Section4Test extends BaseExamples {
 		Prefix defPrefix = SparqlBuilder.prefix(iri(DC_NS));
 
 		// isA() is a shortcut method to create triples using the "a" keyword
-		p(SparqlBuilder.var("x").isA(defPrefix.iri("Class1")));
+		TriplePattern tp = SparqlBuilder.var("x").isA(defPrefix.iri("Class1"));
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("?x  a  :Class1 ."));
 
 		// the isA predicate is a static member of RdfPredicate
-		p(Rdf.bNode(RdfPredicate.a, defPrefix.iri("appClass")).has(defPrefix.iri("p"), "v"));
+		tp = Rdf.bNode(RdfPredicate.a, defPrefix.iri("appClass")).has(defPrefix.iri("p"), "v");
+		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"  [ a :appClass ] :p \"v\" ."
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section5Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section5Test.java
@@ -52,7 +52,6 @@ public class Section5Test extends BaseExamples {
 
 	@Test
 	public void example_5_2_1() {
-		p(and());
 		Variable x = var("x");
 		query.select(x);
 		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section5Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section5Test.java
@@ -5,9 +5,10 @@
  which accompanies this distribution, and is available at
  http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
+import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -18,43 +19,67 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section5Test extends BaseExamples {
 	@Test
 	public void example_5_2() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable name = SparqlBuilder.var("name"), mbox = SparqlBuilder.var("mbox");
-		Variable x = query.var();
-
+		Variable name = var("name"), mbox = var("mbox");
+		Variable x = var("x");
 		query.prefix(foaf).select(name, mbox).where(x.has(foaf.iri("name"), name), x.has(foaf.iri("mbox"), mbox));
-		p();
-
-		GraphPattern namePattern = GraphPatterns.and(x.has(foaf.iri("name"), name));
-		GraphPattern mboxPattern = GraphPatterns.and(x.has(foaf.iri("mbox"), mbox));
-		QueryPattern where = SparqlBuilder.where(GraphPatterns.and(namePattern, mboxPattern));
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ?name ?mbox\n"
+						+ "WHERE  {\n"
+						+ "          ?x foaf:name ?name .\n"
+						+ "          ?x foaf:mbox ?mbox .\n"
+						+ "       }"
+		));
+		GraphPattern namePattern = and(x.has(foaf.iri("name"), name));
+		GraphPattern mboxPattern = and(x.has(foaf.iri("mbox"), mbox));
+		QueryPattern where = SparqlBuilder.where(and(namePattern, mboxPattern));
 		query.where(where);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ?name ?mbox\n"
+						+ "WHERE  { { ?x foaf:name ?name . }\n"
+						+ "         { ?x foaf:mbox ?mbox . }\n"
+						+ "       }"
+		));
 	}
 
 	@Test
 	public void example_5_2_1() {
-		p(GraphPatterns.and());
-
-		query.select(query.var());
-		p();
+		p(and());
+		Variable x = var("x");
+		query.select(x);
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"SELECT ?x\n"
+						+ "WHERE {}"));
 	}
 
 	@Test
 	public void example_5_2_3() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable x = SparqlBuilder.var("x"), name = SparqlBuilder.var("name"), mbox = SparqlBuilder.var("mbox");
-
-		p(GraphPatterns.and(x.has(foaf.iri("name"), name), x.has(foaf.iri("mbox"), mbox)),
-
-				GraphPatterns.and(x.has(foaf.iri("name"), name), x.has(foaf.iri("mbox"), mbox))
-						.filter(Expressions.regex(name, "Smith")),
-
-				GraphPatterns.and(x.has(foaf.iri("name"), name), GraphPatterns.and(), x.has(foaf.iri("mbox"), mbox)));
+		Variable x = var("x"), name = var("name"), mbox = var("mbox");
+		Assert.assertThat(
+				x.has(foaf.iri("name"), name)
+						.and(x.has(foaf.iri("mbox"), mbox))
+						.and()
+						.filter(Expressions.regex(name, "Smith"))
+						.getQueryString(),
+				stringEqualsIgnoreCaseAndWhitespace(
+						" {  ?x foaf:name ?name .\n"
+								+ "    ?x foaf:mbox ?mbox .\n"
+								+ "    FILTER ( regex(?name, \"Smith\"))\n"
+								+ " }\n"
+				));
+		// NOTE: removed the other two examples in which the filter expression is before or between the
+		// triple patterns, respectively. The SparqlBuilder cannot generate this without additional curly
+		// braces, and the point of the examples is to show that all these versions are equivalent, so
+		// we can probably live witouth being able to generate filters at random places inside the
+		// graph pattern.
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section6Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section6Test.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -18,40 +19,54 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatternNotTriples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section6Test extends BaseExamples {
 	@Test
 	public void example_6_1() {
-		Variable name = SparqlBuilder.var("name"), mbox = SparqlBuilder.var("mbox");
-		Variable x = query.var();
+		Variable name = var("name"), mbox = var("mbox");
+		Variable x = var("x");
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
 
 		GraphPatternNotTriples where = GraphPatterns.and(x.has(foaf.iri("name"), name),
 				GraphPatterns.optional(x.has(foaf.iri("mbox"), mbox)));
 
 		query.prefix(foaf).select(name, mbox).where(where);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ?name ?mbox\n"
+						+ "WHERE  { ?x foaf:name  ?name .\n"
+						+ "         OPTIONAL { ?x  foaf:mbox  ?mbox . }\n"
+						+ "       }"
+		));
 	}
 
 	@Test
 	public void example_6_2() {
 		Prefix dc = SparqlBuilder.prefix("dc", iri(DC_NS)), ns = SparqlBuilder.prefix("ns", iri(EXAMPLE_ORG_NS));
-		Variable title = SparqlBuilder.var("title"), price = SparqlBuilder.var("price"), x = SparqlBuilder.var("x");
+		Variable title = var("title"), price = var("price"), x = var("x");
 
 		GraphPatternNotTriples pricePattern = GraphPatterns.and(x.has(ns.iri("price"), price))
 				.filter(Expressions.lt(price, 30))
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
+						+ "PREFIX  ns:  <https://example.org/ns#>\n"
+						+ "SELECT  ?title ?price\n"
+						+ "WHERE   { ?x dc:title ?title .\n"
+						+ "          OPTIONAL { ?x ns:price ?price . FILTER (?price < 30) }\n"
+						+ "        }"
+		));
 	}
 
 	@Test
 	public void example_6_3() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable name = SparqlBuilder.var("name"), mbox = SparqlBuilder.var("mbox"), hpage = SparqlBuilder.var("hpage");
-		Variable x = query.var();
+		Variable name = var("name"), mbox = var("mbox"), hpage = var("hpage");
+		Variable x = var("x");
 
 		TriplePattern namePattern = x.has(foaf.iri("name"), name);
 
@@ -59,6 +74,13 @@ public class Section6Test extends BaseExamples {
 				.select(name, mbox, hpage)
 				.where(namePattern, GraphPatterns.and(x.has(foaf.iri("mbox"), mbox)).optional(),
 						GraphPatterns.and(x.has(foaf.iri("homepage"), hpage)).optional());
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "SELECT ?name ?mbox ?hpage\n"
+						+ "WHERE  { ?x foaf:name  ?name .\n"
+						+ "         OPTIONAL { ?x foaf:mbox ?mbox . } \n"
+						+ "         OPTIONAL { ?x foaf:homepage ?hpage .}\n"
+						+ "       }"
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section7Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section7Test.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -17,6 +18,7 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section7Test extends BaseExamples {
@@ -24,7 +26,7 @@ public class Section7Test extends BaseExamples {
 	public void example_7() {
 		String DC_10_NS = "http://purl.org/dc/elements/1.0/";
 		Prefix dc10 = SparqlBuilder.prefix("dc10", iri(DC_10_NS)), dc11 = SparqlBuilder.prefix("dc11", iri(DC_NS));
-		Variable title = SparqlBuilder.var("title"), book = SparqlBuilder.var("book");
+		Variable title = var("title"), book = var("book");
 
 		Iri dc10TitleIri = dc10.iri("title");
 		Iri dc11TitleIri = dc11.iri("title");
@@ -32,13 +34,25 @@ public class Section7Test extends BaseExamples {
 		GraphPattern titlePattern = GraphPatterns.union(book.has(dc10TitleIri, title), book.has(dc11TitleIri, title));
 
 		query.prefix(dc10).prefix(dc11).select(title).where(titlePattern);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
+						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
+						+ "\n"
+						+ "SELECT ?title\n"
+						+ "WHERE  { { ?book dc10:title  ?title . } UNION { ?book dc11:title  ?title . } }"
+		));
 
 		resetQuery();
-		Variable x = query.var(), y = query.var(), author = SparqlBuilder.var("author");
+		Variable x = var("x"), y = var("y"), author = var("author");
 		GraphPattern dc10Title = book.has(dc10TitleIri, x), dc11Title = book.has(dc11TitleIri, y);
 		query.prefix(dc10, dc11).select(x, y).where(GraphPatterns.union(dc10Title, dc11Title));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
+						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
+						+ "\n"
+						+ "SELECT ?x ?y\n"
+						+ "WHERE  { { ?book dc10:title ?x . } UNION { ?book dc11:title  ?y . } }"
+		));
 
 		resetQuery();
 		GraphPattern dc10Author = book.has(dc10.iri("creator"), author),
@@ -48,6 +62,15 @@ public class Section7Test extends BaseExamples {
 		query.prefix(dc10, dc11)
 				.select(title, author)
 				.where(GraphPatterns.and(dc10Title, dc10Author).union(GraphPatterns.and(dc11Title, dc11Author)));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
+						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
+						+ "\n"
+						+ "SELECT ?title ?author\n"
+						+ "WHERE  { { ?book dc10:title ?title .  ?book dc10:creator ?author .}\n"
+						+ "         UNION\n"
+						+ "         { ?book dc11:title ?title .  ?book dc11:creator ?author .}\n"
+						+ "       }"
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section8Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section8Test.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
@@ -22,6 +23,7 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatternNotTriples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class Section8Test extends BaseExamples {
@@ -30,12 +32,22 @@ public class Section8Test extends BaseExamples {
 		String rdf_ns = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 		Prefix rdf = SparqlBuilder.prefix("rdf", iri(rdf_ns));
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable person = query.var();
+		Variable person = var("person");
 
-		GraphPattern personWithName = person.has(foaf.iri("name"), SparqlBuilder.var("name"));
+		GraphPattern personWithName = person.has(foaf.iri("name"), var("name"));
 		GraphPatternNotTriples personOfTypePerson = GraphPatterns.and(person.has(rdf.iri("type"), foaf.iri("Person")));
 		query.prefix(rdf, foaf).select(person).where(personOfTypePerson.filterNotExists(personWithName));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n"
+						+ "PREFIX  foaf:   <http://xmlns.com/foaf/0.1/> \n"
+						+ "\n"
+						+ "SELECT ?person\n"
+						+ "WHERE \n"
+						+ "{\n"
+						+ "    ?person rdf:type  foaf:Person .\n"
+						+ "    FILTER NOT EXISTS { ?person foaf:name ?name .}\n"
+						+ "}     "
+		));
 	}
 
 	@Test
@@ -43,36 +55,64 @@ public class Section8Test extends BaseExamples {
 		String rdf_ns = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 		Prefix rdf = SparqlBuilder.prefix("rdf", iri(rdf_ns));
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable person = query.var();
+		Variable person = var("person");
 
-		GraphPattern personWithName = person.has(foaf.iri("name"), SparqlBuilder.var("name"));
+		GraphPattern personWithName = person.has(foaf.iri("name"), var("name"));
 		GraphPatternNotTriples personOfTypePerson = GraphPatterns.and(person.has(rdf.iri("type"), foaf.iri("Person")));
 		query.prefix(rdf, foaf).select(person).where(personOfTypePerson.filterExists(personWithName));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n"
+						+ "PREFIX  foaf:   <http://xmlns.com/foaf/0.1/> \n"
+						+ "\n"
+						+ "SELECT ?person\n"
+						+ "WHERE \n"
+						+ "{\n"
+						+ "    ?person rdf:type  foaf:Person .\n"
+						+ "    FILTER EXISTS { ?person foaf:name ?name . }\n"
+						+ "}"
+		));
 	}
 
 	@Test
 	public void example_8_2() {
 		Prefix base = SparqlBuilder.prefix(iri("http://example/"));
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
-		Variable s = query.var();
+		Variable s = var("s"), p = var("p"), o = var("o");
 		/*
 		 * "{ ?s ?x1 ?x2} MINUS { ?s foaf:givenName "Bob" }
 		 */
-		GraphPattern allNotNamedBob = GraphPatterns.and(s.has(query.var(), query.var()))
+		GraphPattern allNotNamedBob = GraphPatterns.and(s.has(p, o))
 				.minus(s.has(foaf.iri("givenName"), Rdf.literalOf("Bob")));
 		query.prefix(base, foaf).select(s).distinct().where(allNotNamedBob);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX :       <http://example/>\n"
+						+ "PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
+						+ "\n"
+						+ "SELECT DISTINCT ?s\n"
+						+ "WHERE {\n"
+						+ "   ?s ?p ?o .\n"
+						+ "   MINUS {\n"
+						+ "      ?s foaf:givenName \"Bob\" .\n"
+						+ "   }\n"
+						+ "}"
+		));
 	}
 
 	@Test
 	public void example_8_3_2() {
 		Prefix base = SparqlBuilder.prefix(iri("http://example/"));
-		Variable s = query.var(), p = query.var(), o = query.var();
+		Variable s = var("s"), p = var("p"), o = var("o");
 		Iri a = base.iri("a"), b = base.iri("b"), c = base.iri("c");
 
 		query.prefix(base).all().where(GraphPatterns.and(s.has(p, o)).filterNotExists(GraphPatterns.tp(a, b, c)));
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://example/>\n"
+						+ "SELECT * WHERE \n"
+						+ "{ \n"
+						+ "  ?s ?p ?o .\n"
+						+ "  FILTER NOT EXISTS { :a :b :c .}\n"
+						+ "}"
+		));
 
 		QueryPattern where = SparqlBuilder.where(GraphPatterns.and(s.has(p, o)).minus(GraphPatterns.tp(a, b, c)));
 
@@ -80,24 +120,49 @@ public class Section8Test extends BaseExamples {
 		// pattern(s)) replaces (rather than augments) the query's
 		// query pattern. This allows reuse of the other elements of the query.
 		query.where(where);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://example/>\n"
+						+ "SELECT * WHERE \n"
+						+ "{ \n"
+						+ "  ?s ?p ?o .\n"
+						+ "  MINUS { :a :b :c . }\n"
+						+ "}"
+		));
 	}
 
 	@Test
 	public void example_8_3_3() {
-		Prefix base = SparqlBuilder.prefix(iri("http://example/"));
-		Variable x = query.var(), m = query.var(), n = query.var();
+		Prefix base = SparqlBuilder.prefix(iri("http://example.com/"));
+		Variable x = var("x"), m = var("m"), n = var("n");
 		Expression<?> filter = Expressions.equals(n, m);
 
 		GraphPattern notExistsFilter = GraphPatterns.and(x.has(base.iri("p"), n))
 				.filterNotExists(GraphPatterns.and(x.has(base.iri("q"), m)).filter(filter));
 
 		query.prefix(base).select().all().where(notExistsFilter);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://example.com/>\n"
+						+ "SELECT * WHERE {\n"
+						+ "        ?x :p ?n . \n"
+						+ "        FILTER NOT EXISTS {\n"
+						+ "                ?x :q ?m .\n"
+						+ "                FILTER(?n = ?m)\n"
+						+ "        }\n"
+						+ "}"
+		));
 
 		QueryPattern where = SparqlBuilder.where(GraphPatterns.and(x.has(base.iri("p"), n))
 				.minus(GraphPatterns.and(x.has(base.iri("q"), m)).filter(filter)));
 		query.where(where);
-		p();
+		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://example.com/>\n"
+						+ "SELECT * WHERE {\n"
+						+ "        ?x :p ?n . \n"
+						+ "        MINUS {\n"
+						+ "                ?x :q ?m .\n"
+						+ "                FILTER(?n = ?m)\n"
+						+ "        }\n"
+						+ "}"
+		));
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
@@ -120,7 +120,7 @@ public class Section3Test extends BaseExamples {
 
 		// DELETE { GRAPH <g1> { a b c } } INSERT { GRAPH <g1> { x y z } } USING <g1>
 		// WHERE { ... }
-		modify.with(null).delete(abc).from(g1).insert(xyz).into(g1).using(g1).where(examplePattern);
+		modify.with((Iri) null).delete(abc).from(g1).insert(xyz).into(g1).using(g1).where(examplePattern);
 		p("is considered equivalent to:");
 		p(modify);
 	}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
@@ -15,16 +15,14 @@ import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
-import org.eclipse.rdf4j.sparqlbuilder.core.query.DeleteDataQuery;
-import org.eclipse.rdf4j.sparqlbuilder.core.query.InsertDataQuery;
-import org.eclipse.rdf4j.sparqlbuilder.core.query.ModifyQuery;
-import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.*;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -48,8 +46,13 @@ public class Section3Test extends BaseExamples {
 		insertDataQuery.prefix(dc)
 				.insertData(iri("http://example/book1").has(dc.iri("title"), Rdf.literalOf("A new book"))
 						.andHas(dc.iri("creator"), Rdf.literalOf("A.N.Other")));
-
-		p(insertDataQuery);
+		Assert.assertThat(insertDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
+						+ "INSERT DATA { "
+						+ "<http://example/book1> dc:title \"A new book\" ;\n"
+						+ "	dc:creator \"A.N.Other\" . "
+						+ "}"
+		));
 	}
 
 	/**
@@ -64,7 +67,13 @@ public class Section3Test extends BaseExamples {
 				.insertData(iri("http://example/book1").has(ns.iri("price"), Rdf.literalOf(42)))
 				.into(iri("http://example/bookStore"));
 
-		p(insertDataQuery);
+		Assert.assertThat(insertDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
+						+ "PREFIX ns: <https://example.org/ns#> "
+						+ "INSERT DATA { GRAPH "
+						+ "<http://example/bookStore> { <http://example/book1> ns:price 42 . } "
+						+ "}"
+		));
 	}
 
 	/**
@@ -79,7 +88,13 @@ public class Section3Test extends BaseExamples {
 		deleteDataQuery.deleteData(iri("http://example/book2").has(dc.iri("title"), Rdf.literalOf("David Copperfield"))
 				.andHas(dc.iri("creator"), Rdf.literalOf("Edmund Wells")));
 
-		p(deleteDataQuery);
+		Assert.assertThat(deleteDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc: <http://purl.org/dc/elements/1.1/>\n"
+						+ "DELETE DATA { "
+						+ "<http://example/book2> dc:title \"David Copperfield\" ; "
+						+ "dc:creator \"Edmund Wells\" . "
+						+ "}"
+		));
 	}
 
 	/**
@@ -98,11 +113,24 @@ public class Section3Test extends BaseExamples {
 				.prefix(dc)
 				.deleteData(exampleBook.has(title, "Fundamentals of Compiler Desing"))
 				.from(bookStore);
+		Assert.assertThat(deleteTypoQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
+						+ "DELETE DATA { "
+						+ "GRAPH <http://example/bookStore> {\n"
+						+ " <http://example/book1> dc:title \"Fundamentals of Compiler Desing\" . } "
+						+ "} "
+		));
 		InsertDataQuery insertFixedTitleQuery = Queries.INSERT_DATA()
 				.prefix(dc)
 				.insertData(exampleBook.has(title, "Fundamentals of Compiler Design"))
 				.into(bookStore);
-		p(deleteTypoQuery, insertFixedTitleQuery);
+		Assert.assertThat(insertFixedTitleQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
+						+ "INSERT DATA { "
+						+ "GRAPH <http://example/bookStore> {\n"
+						+ "<http://example/book1> dc:title \"Fundamentals of Compiler Design\" . }"
+						+ " }"
+		));
 	}
 
 	@Test
@@ -115,14 +143,18 @@ public class Section3Test extends BaseExamples {
 
 		// WITH <g1> DELETE { a b c } INSERT { x y z } WHERE { ... }
 		modify.with(g1).delete(abc).insert(xyz).where(examplePattern);
-		p("To illustrate the use of the WITH clause, an operation of the general form:");
-		p(modify);
+		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"WITH <g1> DELETE { ?a ?b ?c . } INSERT { ?x ?y ?z . } where { ... }"
+		));
 
 		// DELETE { GRAPH <g1> { a b c } } INSERT { GRAPH <g1> { x y z } } USING <g1>
 		// WHERE { ... }
 		modify.with((Iri) null).delete(abc).from(g1).insert(xyz).into(g1).using(g1).where(examplePattern);
-		p("is considered equivalent to:");
-		p(modify);
+		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"DELETE { GRAPH <g1> {?a ?b ?c . } } "
+						+ "INSERT { GRAPH <g1> { ?x ?y ?z .} } "
+						+ "USING <g1> WHERE { ... }"
+		));
 	}
 
 	/**
@@ -142,7 +174,13 @@ public class Section3Test extends BaseExamples {
 				.insert(person.has(foaf.iri("givenName"), "William"))
 				.where(person.has(foaf.iri("givenName"), "Bill"));
 
-		p(modify);
+		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "WITH <http://example/addresses> "
+						+ "DELETE { ?person foaf:givenName \"Bill\" .} "
+						+ "INSERT { ?person foaf:givenName \"William\" .} "
+						+ "WHERE { ?person foaf:givenName \"Bill\" . }"
+		));
 	}
 
 	/**
@@ -163,7 +201,16 @@ public class Section3Test extends BaseExamples {
 				.where(GraphPatterns.and(book.has(dc.iri("date"), date), book.has(p, v))
 						.filter(Expressions.gt(date,
 								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
-		p(modify);
+		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
+						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+						+ "DELETE { ?book ?p ?v . } "
+						+ "WHERE { "
+						+ "?book dc:date ?date . "
+						+ "?book ?p ?v ."
+						+ "FILTER ( ?date > \"1970-01-01T00:00:00-02:00\"^^xsd:dateTime )\n"
+						+ "}"
+		));
 	}
 
 	/**
@@ -183,7 +230,15 @@ public class Section3Test extends BaseExamples {
 				.delete(person.has(property, value))
 				.where(person.has(property, value).andHas(foaf.iri("givenName"), "Fred"));
 
-		p(modify);
+		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "WITH <http://example/addresses> "
+						+ "DELETE { ?person ?property ?value .} "
+						+ "WHERE { "
+						+ "?person ?property ?value ;\n"
+						+ "foaf:givenName \"Fred\" ."
+						+ "}"
+		));
 	}
 
 	/**
@@ -197,13 +252,25 @@ public class Section3Test extends BaseExamples {
 		Variable book = SparqlBuilder.var("book"), p = SparqlBuilder.var("p"), v = SparqlBuilder.var("v"),
 				date = SparqlBuilder.var("date");
 
-		p(Queries.MODIFY()
+		ModifyQuery modify = Queries.MODIFY()
 				.prefix(dc, xsd)
 				.insert(book.has(p, v))
 				.into(iri("http://example/bookStore2"))
 				.where(and(book.has(dc.iri("date"), date), book.has(p, v)).from(iri("http://example/bookStore"))
 						.filter(Expressions.gt(date,
-								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime"))))));
+								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
+		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
+						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+						+ "INSERT { "
+						+ "GRAPH <http://example/bookStore2> { ?book ?p ?v .} } "
+						+ "WHERE { GRAPH <http://example/bookStore> { "
+						+ "?book dc:date ?date . "
+						+ "?book ?p ?v ."
+						+ "FILTER ( ?date > \"1970-01-01T00:00:00-02:00\"^^xsd:dateTime ) "
+						+ "} "
+						+ "}"
+		));
 	}
 
 	/**
@@ -226,7 +293,22 @@ public class Section3Test extends BaseExamples {
 				.where(and(personNameTriple, GraphPatterns.optional(personEmailTriple))
 						.from(iri("http://example/people")));
 
-		p(insertAddressesQuery);
+		Assert.assertThat(insertAddressesQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/> "
+						+ "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+						+ "INSERT { "
+						+ "GRAPH <http://example/addresses> { "
+						+ "?person foaf:name ?name . "
+						+ "?person foaf:mbox ?email ."
+						+ "} "
+						+ "} "
+						+ "WHERE { "
+						+ "GRAPH <http://example/people> { "
+						+ "?person foaf:name ?name . "
+						+ "OPTIONAL { ?person foaf:mbox ?email .} "
+						+ "} "
+						+ "}"
+		));
 	}
 
 	/**
@@ -246,12 +328,29 @@ public class Section3Test extends BaseExamples {
 		Prefix dcmitype = SparqlBuilder.prefix("dcmitype", iri("http://purl.org/dc/dcmitype/"));
 
 		ModifyQuery insertIntobookStore2Query = Queries.MODIFY()
-				.prefix(dcmitype, dc, xsd)
+				.prefix(dc, dcmitype, xsd)
 				.insert(book.has(p, v))
 				.into(iri("http://example/bookStore2"))
 				.where(and(book.has(dc.iri("date"), date), book.has(p, v)).from(iri("http://example/bookStore"))
 						.filter(Expressions.lt(date,
 								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
+		Assert.assertThat(insertIntobookStore2Query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
+						+ "PREFIX dcmitype: <http://purl.org/dc/dcmitype/> "
+						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+						+ "INSERT { "
+						+ "GRAPH <http://example/bookStore2> { "
+						+ "?book ?p ?v ."
+						+ "} "
+						+ "} "
+						+ "WHERE { "
+						+ "GRAPH <http://example/bookStore> { "
+						+ "?book dc:date ?date . "
+						+ "?book ?p ?v ."
+						+ "FILTER ( ?date < \"1970-01-01T00:00:00-02:00\"^^xsd:dateTime ) "
+						+ "} "
+						+ "}"
+		));
 		ModifyQuery deleteFromBookStoreQuery = Queries.MODIFY()
 				.with(iri("http://example/bookStore"))
 				.delete(book.has(p, v))
@@ -260,7 +359,14 @@ public class Section3Test extends BaseExamples {
 								.filter(Expressions.lt(date,
 										Rdf.literalOfType("2000-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
 
-		p(insertIntobookStore2Query, deleteFromBookStoreQuery);
+		Assert.assertThat(deleteFromBookStoreQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"WITH <http://example/bookStore>\n"
+						+ "DELETE { ?book ?p ?v . }\n"
+						+ "WHERE { ?book dc:date ?date ;\n"
+						+ "    dc:type dcmitype:PhysicalObject .\n"
+						+ "?book ?p ?v .\n"
+						+ "FILTER ( ?date < \"2000-01-01T00:00:00-02:00\"^^xsd:dateTime ) }"
+		));
 	}
 
 	/**
@@ -273,10 +379,17 @@ public class Section3Test extends BaseExamples {
 		Variable person = SparqlBuilder.var("person"), property = SparqlBuilder.var("property"),
 				value = SparqlBuilder.var("value");
 
-		p(Queries.MODIFY()
+		ModifyQuery modify = Queries.MODIFY()
 				.prefix(foaf)
 				.delete()
-				.where(person.has(foaf.iri("givenName"), "Fred").andHas(property, value)));
+				.where(person.has(foaf.iri("givenName"), "Fred").andHas(property, value));
+		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "DELETE WHERE {"
+						+ " ?person foaf:givenName \"Fred\";"
+						+ " ?property ?value . "
+						+ "}"
+		));
 	}
 
 	/**
@@ -298,49 +411,93 @@ public class Section3Test extends BaseExamples {
 				.where(and(person.has(foaf.iri("givenName"), "Fred").andHas(property1, value1)).from(namesGraph),
 						and(person.has(property2, value2)).from(addressesGraph));
 
-		p(deleteFredFromNamesAndAddressesQuery);
+		Assert.assertThat(deleteFredFromNamesAndAddressesQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
+						+ "DELETE WHERE { "
+						+ "GRAPH <http://example.com/names> { "
+						+ "?person foaf:givenName \"Fred\" ; "
+						+ "?property1 ?value1 . "
+						+ "} "
+						+ "GRAPH <http://example.com/addresses> { "
+						+ "?person ?property2 ?value2 ."
+						+ " } "
+						+ "}"
+		));
 	}
 
 	@Test
 	public void example_load() {
-		p(Queries.LOAD().from(iri(EXAMPLE_ORG_NS)));
-		p(Queries.LOAD().silent().from(iri(EXAMPLE_ORG_NS)).to(iri(EXAMPLE_COM_NS)));
+		LoadQuery load = Queries.LOAD().from(iri(EXAMPLE_ORG_NS));
+		Assert.assertThat(load.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"LOAD <https://example.org/ns#>"
+		));
+		load = Queries.LOAD().silent().from(iri(EXAMPLE_ORG_NS)).to(iri(EXAMPLE_COM_NS));
+		Assert.assertThat(load.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"LOAD SILENT <https://example.org/ns#> INTO GRAPH <https://example.com/ns#>"
+		));
 	}
 
 	@Test
 	public void example_clear() {
-		p(Queries.CLEAR().def());
-		p(Queries.CLEAR().silent().graph(iri(EXAMPLE_ORG_NS)));
+		ClearQuery clear = Queries.CLEAR().def();
+		Assert.assertThat(clear.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"CLEAR DEFAULT"
+		));
+		clear = Queries.CLEAR().silent().graph(iri(EXAMPLE_ORG_NS));
+		Assert.assertThat(clear.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"CLEAR SILENT GRAPH <https://example.org/ns#>"
+		));
 	}
 
 	@Test
 	public void example_create() {
-		p(Queries.CREATE().graph(iri(EXAMPLE_ORG_NS)));
-		p(Queries.CREATE().silent().graph(iri(EXAMPLE_ORG_NS)));
+		CreateQuery create = Queries.CREATE().graph(iri(EXAMPLE_ORG_NS));
+		Assert.assertThat(create.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"CREATE GRAPH <https://example.org/ns#>"
+		));
+		create = Queries.CREATE().silent().graph(iri(EXAMPLE_ORG_NS));
+		Assert.assertThat(create.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"CREATE SILENT GRAPH <https://example.org/ns#>"
+		));
 	}
 
 	@Test
 	public void example_drop() {
-		p(Queries.DROP().def());
-		p(Queries.DROP().silent().graph(iri(EXAMPLE_ORG_NS)));
+		DropQuery drop = Queries.DROP().def();
+		Assert.assertThat(drop.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"DROP DEFAULT"
+		));
+		drop = Queries.DROP().silent().graph(iri(EXAMPLE_ORG_NS));
+		Assert.assertThat(drop.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"DROP SILENT GRAPH <https://example.org/ns#>"
+		));
 	}
 
 	/** COPY DEFAULT TO \<http://example.org/named> */
 	@Test
 	public void example_13() {
-		p(Queries.COPY().fromDefault().to(iri("http://example.org/named")));
+		CopyQuery copy = Queries.COPY().fromDefault().to(iri("http://example.org/named"));
+		Assert.assertThat(copy.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"COPY DEFAULT TO <http://example.org/named>"
+		));
 	}
 
 	/** MOVE DEFAULT TO <http://example.org/named> */
 	@Test
 	public void example_14() {
-		p(Queries.MOVE().fromDefault().to(iri("http://example.org/named")));
+		MoveQuery move = Queries.MOVE().fromDefault().to(iri("http://example.org/named"));
+		Assert.assertThat(move.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"MOVE DEFAULT TO <http://example.org/named>"
+		));
 	}
 
 	/** ADD DEFAULT TO <http://example.org/named> */
 	@Test
 	public void example_15() {
-		p(Queries.ADD().fromDefault().to(iri("http://example.org/named")));
+		AddQuery add = Queries.ADD().fromDefault().to(iri("http://example.org/named"));
+		Assert.assertThat(add.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+				"ADD DEFAULT TO <http://example.org/named>"
+		));
 	}
 
 }


### PR DESCRIPTION
GitHub issue resolved: #3073

Briefly describe the changes proposed in this PR:

For any method in the sparqlbuilder code that takes `Iri` or `RdfPredicate` as a parameter, a method is added that takes an `IRI` instead and delegates to the method.

Fixes #1385
Fixes #3349

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

