### PR TITLE
GH-1243 removed deprecated initialize method in Sail and Repository

### DIFF
--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
@@ -351,7 +351,6 @@ public class ElasticsearchIndexTest extends ESIntegTestCase {
 
 		// create a Repository wrapping the LuceneSail
 		SailRepository repository = new SailRepository(sail);
-		repository.initialize();
 
 		// now add the statements through the repo
 		// add statements with context
@@ -403,7 +402,6 @@ public class ElasticsearchIndexTest extends ESIntegTestCase {
 
 		// create a Repository wrapping the LuceneSail
 		SailRepository repository = new SailRepository(sail);
-		repository.initialize();
 
 		// now add the statements through the repo
 		// add statements with context

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/examples/ElasticsearchSailExample.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/examples/ElasticsearchSailExample.java
@@ -59,7 +59,6 @@ public class ElasticsearchSailExample {
 
 		// create a Repository to access the sails
 		SailRepository repository = new SailRepository(lucenesail);
-		repository.initialize();
 
 		try ( // add some test data, the FOAF ont
 				SailRepositoryConnection connection = repository.getConnection()) {

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTransactionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTransactionTest.java
@@ -19,7 +19,6 @@ public class HTTPRepositoryTransactionTest {
 			try {
 				server.start();
 				testRepository = new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
-				testRepository.initialize();
 			} catch (Exception e) {
 				server.stop();
 				throw e;

--- a/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrIndexTest.java
+++ b/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrIndexTest.java
@@ -292,7 +292,6 @@ public class SolrIndexTest {
 
 		// create a Repository wrapping the LuceneSail
 		SailRepository repository = new SailRepository(sail);
-		repository.initialize();
 
 		try ( // now add the statements through the repo
 				// add statements with context
@@ -344,7 +343,6 @@ public class SolrIndexTest {
 
 		// create a Repository wrapping the LuceneSail
 		SailRepository repository = new SailRepository(sail);
-		repository.initialize();
 
 		try ( // now add the statements through the repo
 				// add statements with context

--- a/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/examples/SolrSailExample.java
+++ b/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/examples/SolrSailExample.java
@@ -60,7 +60,6 @@ public class SolrSailExample {
 
 		// create a Repository to access the sails
 		SailRepository repository = new SailRepository(lucenesail);
-		repository.initialize();
 
 		try ( // add some test data, the FOAF ont
 				SailRepositoryConnection connection = repository.getConnection()) {

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/ArbitraryLengthPathTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/ArbitraryLengthPathTest.java
@@ -35,7 +35,6 @@ public class ArbitraryLengthPathTest extends TestCase {
 	@Override
 	public void setUp() throws Exception {
 		repo = new SailRepository(new MemoryStore());
-		repo.initialize();
 		con = repo.getConnection();
 	}
 

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLServiceEvaluationTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLServiceEvaluationTest.java
@@ -117,12 +117,11 @@ public class SPARQLServiceEvaluationTest extends TestCase {
 		remoteRepositories = new ArrayList<>(MAX_ENDPOINTS);
 		for (int i = 1; i <= MAX_ENDPOINTS; i++) {
 			HTTPRepository r = new HTTPRepository(getRepositoryUrl(i));
-			r.initialize();
+			r.init();
 			remoteRepositories.add(r);
 		}
 
 		localRepository = new SailRepository(new MemoryStore());
-		localRepository.initialize();
 	}
 
 	/**

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/sail/federation/FederationSparqlTest.java
@@ -27,7 +27,6 @@ public class FederationSparqlTest {
 		fed.addMember(repo1);
 		fed.addMember(repo2);
 		SailRepository repoFed = new SailRepository(fed);
-		repoFed.initialize();
 
 		try (RepositoryConnection conn = repo1.getConnection()) {
 			conn.add(getClass().getResource("/testcases-sparql-1.0-w3c/data-r2/algebra/var-scope-join-1.ttl"),

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeoSPARQLTests.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeoSPARQLTests.java
@@ -86,7 +86,6 @@ public class GeoSPARQLTests {
 
 	private static Repository setupTestRepository() {
 		SailRepository repo = new SailRepository(new MemoryStore());
-		repo.initialize();
 		ValueFactory f = repo.getValueFactory();
 
 		Map<String, String> cities = new HashMap<>();

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/Repository.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/Repository.java
@@ -41,15 +41,6 @@ public interface Repository {
 	File getDataDir();
 
 	/**
-	 * Initializes this repository.
-	 *
-	 * @throws RepositoryException If the initialization failed.
-	 * @deprecated Use {@link #init()} instead.
-	 */
-	@Deprecated
-	void initialize() throws RepositoryException;
-
-	/**
 	 * Initializes this repository. A repository needs to be initialized before it can be used, however explicitly
 	 * calling this method is not necessary: the repository will automatically initialize itself if an operation is
 	 * executed on it that requires it to be initialized.
@@ -57,9 +48,7 @@ public interface Repository {
 	 * @throws RepositoryException If the initialization failed.
 	 * @since 2.5
 	 */
-	default void init() throws RepositoryException {
-		initialize();
-	}
+	void init() throws RepositoryException;
 
 	/**
 	 * Indicates if the Repository has been initialized. Note that the initialization status may change if the

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/AbstractRepository.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/AbstractRepository.java
@@ -26,12 +26,6 @@ public abstract class AbstractRepository implements Repository {
 	protected final Logger logger = LoggerFactory.getLogger(getClass());
 
 	@Override
-	@Deprecated
-	public final void initialize() throws RepositoryException {
-		init();
-	}
-
-	@Override
 	public final void init() throws RepositoryException {
 		if (!initialized) {
 			synchronized (initLock) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/RepositoryWrapper.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/RepositoryWrapper.java
@@ -60,11 +60,6 @@ public class RepositoryWrapper implements DelegatingRepository {
 	}
 
 	@Override
-	public void initialize() throws RepositoryException {
-		getDelegate().initialize();
-	}
-
-	@Override
 	public void shutDown() throws RepositoryException {
 		getDelegate().shutDown();
 	}
@@ -92,5 +87,10 @@ public class RepositoryWrapper implements DelegatingRepository {
 	@Override
 	public boolean isInitialized() {
 		return getDelegate().isInitialized();
+	}
+
+	@Override
+	public void init() throws RepositoryException {
+		getDelegate().init();
 	}
 }

--- a/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/RepositoryInterceptor.java
+++ b/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/RepositoryInterceptor.java
@@ -22,7 +22,7 @@ public interface RepositoryInterceptor extends EventListener {
 
 	boolean getConnection(Repository repo, RepositoryConnection conn);
 
-	boolean initialize(Repository repo);
+	boolean init(Repository repo);
 
 	boolean setDataDir(Repository repo, File dataDir);
 

--- a/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/RepositoryListener.java
+++ b/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/RepositoryListener.java
@@ -19,7 +19,7 @@ public interface RepositoryListener extends EventListener {
 
 	void getConnection(NotifyingRepository repo, NotifyingRepositoryConnection conn);
 
-	void initialize(NotifyingRepository repo);
+	void init(NotifyingRepository repo);
 
 	void setDataDir(NotifyingRepository repo, File dataDir);
 

--- a/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/base/InterceptingRepositoryWrapper.java
+++ b/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/base/InterceptingRepositoryWrapper.java
@@ -120,18 +120,18 @@ public class InterceptingRepositoryWrapper extends RepositoryWrapper implements 
 	}
 
 	@Override
-	public void initialize() throws RepositoryException {
+	public void init() throws RepositoryException {
 		boolean denied = false;
 		if (activated) {
 			for (RepositoryInterceptor interceptor : interceptors) {
-				denied = interceptor.initialize(getDelegate());
+				denied = interceptor.init(getDelegate());
 				if (denied) {
 					break;
 				}
 			}
 		}
 		if (!denied) {
-			getDelegate().initialize();
+			getDelegate().init();
 		}
 	}
 

--- a/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/base/NotifyingRepositoryWrapper.java
+++ b/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/base/NotifyingRepositoryWrapper.java
@@ -127,12 +127,12 @@ public class NotifyingRepositoryWrapper extends RepositoryWrapper implements Not
 	}
 
 	@Override
-	public void initialize() throws RepositoryException {
-		super.initialize();
+	public void init() throws RepositoryException {
+		super.init();
 
 		if (activated) {
 			for (RepositoryListener listener : listeners) {
-				listener.initialize(this);
+				listener.init(this);
 			}
 		}
 	}

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManager.java
@@ -167,7 +167,7 @@ public class RemoteRepositoryManager extends RepositoryManager {
 		HTTPRepository systemRepository = new HTTPRepository(serverURL, SystemRepository.ID);
 		systemRepository.setHttpClientSessionManager(getSharedHttpClientSessionManager());
 		systemRepository.setUsernameAndPassword(username, password);
-		systemRepository.initialize();
+		systemRepository.init();
 		return systemRepository;
 	}
 

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/SystemRepository.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/SystemRepository.java
@@ -104,8 +104,8 @@ public class SystemRepository extends NotifyingRepositoryWrapper {
 	}
 
 	@Override
-	public void initialize() throws RepositoryException {
-		super.initialize();
+	public void init() throws RepositoryException {
+		super.init();
 
 		try (RepositoryConnection con = getConnection()) {
 			if (con.isEmpty()) {

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/ProxyRepository.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/ProxyRepository.java
@@ -141,7 +141,7 @@ public class ProxyRepository extends AbstractRepository implements RepositoryRes
 		if (resolver == null) {
 			throw new RepositoryException("Expected RepositoryResolver to be set.");
 		}
-		getProxiedRepository().initialize();
+		getProxiedRepository().init();
 	}
 
 	@Override

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/Sail.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/Sail.java
@@ -43,22 +43,10 @@ public interface Sail {
 	 * method is called. Please consult the specific Sail implementation for information about the relevant parameters.
 	 *
 	 * @throws SailException If the Sail could not be initialized.
-	 * @deprecated Use {{@link #init()} instead.
-	 */
-	@Deprecated
-	void initialize() throws SailException;
-
-	/**
-	 * Initializes the Sail. Care should be taken that required initialization parameters have been set before this
-	 * method is called. Please consult the specific Sail implementation for information about the relevant parameters.
-	 *
-	 * @throws SailException If the Sail could not be initialized.
 	 *
 	 * @since 2.5
 	 */
-	default void init() throws SailException {
-		initialize();
-	}
+	void init() throws SailException;
 
 	/**
 	 * Shuts down the Sail, giving it the opportunity to synchronize any stale data. Care should be taken that all

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
@@ -175,11 +175,6 @@ public abstract class AbstractSail implements Sail {
 	}
 
 	@Override
-	public void initialize() throws SailException {
-		init();
-	}
-
-	@Override
 	public void init() throws SailException {
 		initializationLock.writeLock().lock();
 		try {

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailWrapper.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailWrapper.java
@@ -91,9 +91,9 @@ public class SailWrapper implements StackableSail, FederatedServiceResolverClien
 	}
 
 	@Override
-	public void initialize() throws SailException {
+	public void init() throws SailException {
 		verifyBaseSailSet();
-		baseSail.initialize();
+		baseSail.init();
 	}
 
 	@Override

--- a/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/Federation.java
+++ b/core/sail/federation/src/main/java/org/eclipse/rdf4j/sail/federation/Federation.java
@@ -250,17 +250,11 @@ public class Federation implements Sail, Executor, FederatedServiceResolverClien
 		}
 	}
 
-	@Deprecated
-	@Override
-	public void initialize() throws SailException {
-		init();
-	}
-
 	@Override
 	public void init() throws SailException {
 		for (Repository member : members) {
 			try {
-				member.initialize();
+				member.init();
 			} catch (RepositoryException e) {
 				throw new SailException(e);
 			}

--- a/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/CustomFederationConnectionTest.java
+++ b/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/CustomFederationConnectionTest.java
@@ -54,7 +54,7 @@ public class CustomFederationConnectionTest {
 		SailRepository repository = new SailRepository(new MemoryStore());
 		federation.addMember(repository);
 
-		federation.initialize();
+		federation.init();
 		try {
 			try (SailConnection connection = federation.getConnection()) {
 				assertEquals("Should get size", 0, connection.size());
@@ -81,7 +81,7 @@ public class CustomFederationConnectionTest {
 
 		federation.addMember(repository);
 
-		federation.initialize();
+		federation.init();
 		try {
 			try (SailConnection connection = federation.getConnection()) {
 				connection.begin();

--- a/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationNamespacesTest.java
+++ b/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationNamespacesTest.java
@@ -81,14 +81,12 @@ public class FederationNamespacesTest {
 			federation.addMember(createMember(Integer.toString(i), "http://test/" + paths[i] + "#"));
 		}
 		SailRepository repo = new SailRepository(federation);
-		repo.initialize();
 		return repo.getConnection();
 	}
 
 	private Repository createMember(String memberID, String name)
 			throws RepositoryException, RDFParseException, IOException {
 		SailRepository member = new SailRepository(new MemoryStore());
-		member.initialize();
 		try (SailRepositoryConnection con = member.getConnection()) {
 			con.setNamespace(PREFIX, name);
 		}

--- a/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationQueryTest.java
+++ b/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationQueryTest.java
@@ -114,11 +114,9 @@ public class FederationQueryTest {
 	@Before
 	public void setUp() throws Exception {
 		SailRepository ref = new SailRepository(new MemoryStore());
-		ref.initialize();
 		reference = ref.getConnection();
 		Federation federation = new Federation();
 		SailRepository repo = new SailRepository(federation);
-		repo.initialize();
 		configure(federation);
 		con = repo.getConnection();
 	}
@@ -132,7 +130,6 @@ public class FederationQueryTest {
 
 	private Repository createMember(String memberID) throws RepositoryException, RDFParseException, IOException {
 		SailRepository member = new SailRepository(new MemoryStore());
-		member.initialize();
 		try (SailRepositoryConnection con = member.getConnection()) {
 			String resource = "testcases/federation-member-" + memberID + ".ttl";
 			con.add(classLoader.getResource(resource), "", RDFFormat.TURTLE);

--- a/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationTest.java
+++ b/core/sail/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationTest.java
@@ -35,7 +35,7 @@ public class FederationTest extends RDFStoreTest {
 		sail.addMember(new SailRepository(new MemoryStore()));
 		sail.addMember(new SailRepository(new MemoryStore()));
 		sail.addMember(new SailRepository(new MemoryStore()));
-		sail.initialize();
+		sail.init();
 		return sail;
 	}
 }

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/CustomGraphQueryInferencer.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/CustomGraphQueryInferencer.java
@@ -146,8 +146,8 @@ public class CustomGraphQueryInferencer extends NotifyingSailWrapper {
 	}
 
 	@Override
-	public void initialize() throws SailException {
-		super.initialize();
+	public void init() throws SailException {
+		super.init();
 		try (InferencerConnection con = getConnection()) {
 			con.begin();
 			con.flushUpdates();

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/DirectTypeHierarchyInferencer.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/DirectTypeHierarchyInferencer.java
@@ -145,8 +145,8 @@ public class DirectTypeHierarchyInferencer extends NotifyingSailWrapper {
 	}
 
 	@Override
-	public void initialize() throws SailException {
-		super.initialize();
+	public void init() throws SailException {
+		super.init();
 
 		try (InferencerConnection con = getConnection()) {
 			con.begin();

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencer.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencer.java
@@ -53,8 +53,8 @@ public class ForwardChainingRDFSInferencer extends AbstractForwardChainingInfere
 	 * Adds axiom statements to the underlying Sail.
 	 */
 	@Override
-	public void initialize() throws SailException {
-		super.initialize();
+	public void init() throws SailException {
+		super.init();
 
 		try (ForwardChainingRDFSInferencerConnection con = getConnection()) {
 			con.begin();

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencer.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencer.java
@@ -204,9 +204,9 @@ public class SchemaCachingRDFSInferencer extends NotifyingSailWrapper {
 	}
 
 	@Override
-	public void initialize()
+	public void init()
 			throws SailException {
-		super.initialize();
+		super.init();
 
 		if (sharedSchema) {
 			return;

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/InferredContextTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/InferredContextTest.java
@@ -25,8 +25,6 @@ public class InferredContextTest {
 	@Test
 	public void testInferrecContextNull() {
 		SchemaCachingRDFSInferencer sail = new SchemaCachingRDFSInferencer(new MemoryStore());
-
-		sail.initialize();
 		sail.setAddInferredStatementsToDefaultContext(true);
 
 		try (SchemaCachingRDFSInferencerConnection connection = sail.getConnection()) {
@@ -44,8 +42,6 @@ public class InferredContextTest {
 	@Test
 	public void testInferrecContextNoNull() {
 		SchemaCachingRDFSInferencer sail = new SchemaCachingRDFSInferencer(new MemoryStore());
-
-		sail.initialize();
 		sail.setAddInferredStatementsToDefaultContext(false);
 
 		try (SchemaCachingRDFSInferencerConnection connection = sail.getConnection()) {

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/MemInferencingTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/MemInferencingTest.java
@@ -41,7 +41,6 @@ public class MemInferencingTest extends InferencingTest {
 
 		SchemaCachingRDFSInferencer sailStack = new SchemaCachingRDFSInferencer(new MemoryStore(datadir), true);
 		SailRepository repo = new SailRepository(sailStack);
-		repo.initialize();
 		ValueFactory vf = repo.getValueFactory();
 
 		IRI s1 = vf.createIRI("foo:s1");
@@ -60,7 +59,7 @@ public class MemInferencingTest extends InferencingTest {
 		// re-init
 //		sailStack = new SchemaCachingRDFSInferencer(new MemoryStore(datadir), true);
 //		repo = new SailRepository(sailStack);
-		repo.initialize();
+		repo.init();
 
 		try (RepositoryConnection conn = repo.getConnection()) {
 			assertTrue(conn.hasStatement(s1, RDF.TYPE, c2, true));
@@ -154,7 +153,6 @@ public class MemInferencingTest extends InferencingTest {
 
 		SailRepository sailRepository1 = new SailRepository(SchemaCachingRDFSInferencer.fastInstantiateFrom(
 				(SchemaCachingRDFSInferencer) ((SailRepository) sailRepository).getSail(), new MemoryStore()));
-		sailRepository1.initialize();
 
 		try (RepositoryConnection connection = sailRepository1.getConnection()) {
 			connection.add(vf.createStatement(aInstance, RDF.TYPE, A));

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest.java
@@ -111,8 +111,6 @@ public class SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest
 	public void testUpdateInsertData() {
 
 		SailRepository sail = new SailRepository(new SchemaCachingRDFSInferencer(new MemoryStore()));
-		sail.initialize();
-
 		try (SailRepositoryConnection connection = sail.getConnection()) {
 
 			IRI foo_s1 = connection.getValueFactory().createIRI("foo:s1");
@@ -133,8 +131,6 @@ public class SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest
 	public void testUpdateInsert() {
 
 		SailRepository sail = new SailRepository(new SchemaCachingRDFSInferencer(new MemoryStore()));
-		sail.initialize();
-
 		try (SailRepositoryConnection connection = sail.getConnection()) {
 
 			IRI foo_s1 = connection.getValueFactory().createIRI("foo:s1");
@@ -156,8 +152,6 @@ public class SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest
 	public void testInsert() {
 
 		SailRepository sail = new SailRepository(new SchemaCachingRDFSInferencer(new MemoryStore()));
-		sail.initialize();
-
 		try (SailRepositoryConnection connection = sail.getConnection()) {
 
 			IRI foo_s1 = connection.getValueFactory().createIRI("foo:s1");
@@ -179,8 +173,6 @@ public class SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest
 	public void testUpdateRemove() {
 
 		SailRepository sail = new SailRepository(new SchemaCachingRDFSInferencer(new MemoryStore()));
-		sail.initialize();
-
 		try (SailRepositoryConnection connection = sail.getConnection()) {
 
 			IRI foo_s1 = connection.getValueFactory().createIRI("foo:s1");

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -347,8 +347,8 @@ public class LuceneSail extends NotifyingSailWrapper {
 	}
 
 	@Override
-	public void initialize() throws SailException {
-		super.initialize();
+	public void init() throws SailException {
+		super.init();
 		if (parameters.containsKey(INDEXEDFIELDS)) {
 			String indexedfieldsString = parameters.getProperty(INDEXEDFIELDS);
 			Properties prop = new Properties();

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexLocationTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexLocationTest.java
@@ -62,7 +62,6 @@ public class LuceneIndexLocationTest {
 
 		repository = new SailRepository(lucene);
 		repository.setDataDir(dataDir);
-		repository.initialize();
 
 		try ( // create temporary transaction to load data
 				SailRepositoryConnection cnx = repository.getConnection()) {

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexTest.java
@@ -301,7 +301,6 @@ public class LuceneIndexTest {
 
 		// create a Repository wrapping the LuceneSail
 		SailRepository repository = new SailRepository(sail);
-		repository.initialize();
 
 		try ( // now add the statements through the repo
 				// add statements with context
@@ -353,7 +352,6 @@ public class LuceneIndexTest {
 
 		// create a Repository wrapping the LuceneSail
 		SailRepository repository = new SailRepository(sail);
-		repository.initialize();
 
 		try ( // now add the statements through the repo
 				// add statements with context

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/examples/LuceneSailExample.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/examples/LuceneSailExample.java
@@ -64,7 +64,6 @@ public class LuceneSailExample {
 
 		// create a Repository to access the sails
 		SailRepository repository = new SailRepository(lucenesail);
-		repository.initialize();
 
 		try ( // add some test data, the FOAF ont
 				SailRepositoryConnection connection = repository.getConnection()) {

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemTripleSourceTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemTripleSourceTest.java
@@ -71,7 +71,7 @@ public class MemTripleSourceTest {
 	@Before
 	public void setUp() throws Exception {
 		store = new MemoryStore();
-		store.initialize();
+		store.init();
 		f = store.getValueFactory();
 
 		bob = f.createIRI(EX_NS, "bob");

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/StoreSerializationTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/StoreSerializationTest.java
@@ -55,7 +55,7 @@ public class StoreSerializationTest extends TestCase {
 
 	public void testShortLiterals() throws Exception {
 		MemoryStore store = new MemoryStore(dataDir);
-		store.initialize();
+		store.init();
 
 		ValueFactory factory = store.getValueFactory();
 		IRI foo = factory.createIRI("http://www.foo.example/foo");
@@ -76,7 +76,7 @@ public class StoreSerializationTest extends TestCase {
 		store.shutDown();
 
 		store = new MemoryStore(dataDir);
-		store.initialize();
+		store.init();
 
 		con = store.getConnection();
 
@@ -91,7 +91,7 @@ public class StoreSerializationTest extends TestCase {
 
 	public void testSerialization() throws Exception {
 		MemoryStore store = new MemoryStore(dataDir);
-		store.initialize();
+		store.init();
 
 		ValueFactory factory = store.getValueFactory();
 		IRI foo = factory.createIRI("http://www.foo.example/foo");
@@ -121,7 +121,7 @@ public class StoreSerializationTest extends TestCase {
 		store.shutDown();
 
 		store = new MemoryStore(dataDir);
-		store.initialize();
+		store.init();
 
 		factory = store.getValueFactory();
 		foo = factory.createIRI("http://www.foo.example/foo");
@@ -148,7 +148,7 @@ public class StoreSerializationTest extends TestCase {
 
 	public void testLongLiterals() throws Exception {
 		MemoryStore store = new MemoryStore(dataDir);
-		store.initialize();
+		store.init();
 
 		ValueFactory factory = store.getValueFactory();
 		IRI foo = factory.createIRI("http://www.foo.example/foo");
@@ -169,7 +169,7 @@ public class StoreSerializationTest extends TestCase {
 		store.shutDown();
 
 		store = new MemoryStore(dataDir);
-		store.initialize();
+		store.init();
 
 		con = store.getConnection();
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/LoadingBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/LoadingBenchmark.java
@@ -77,7 +77,7 @@ public class LoadingBenchmark {
 	public void loadSynthetic() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));
@@ -92,7 +92,7 @@ public class LoadingBenchmark {
 	public void loadRealData() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));
@@ -107,7 +107,7 @@ public class LoadingBenchmark {
 	public long loadSyntheticAndSize() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));
@@ -124,7 +124,7 @@ public class LoadingBenchmark {
 	public long loadSyntheticWithDuplicates() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));
@@ -153,7 +153,7 @@ public class LoadingBenchmark {
 	public long loadSyntheticWithDuplicatesFlush() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));
@@ -184,7 +184,7 @@ public class LoadingBenchmark {
 	public long loadSyntheticWithDuplicatesAndNewStatements() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));
@@ -216,7 +216,7 @@ public class LoadingBenchmark {
 	public long loadSyntheticWithDuplicatesAndNewStatementsGetFirst() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));
@@ -251,7 +251,7 @@ public class LoadingBenchmark {
 	public long loadSyntheticSingleTransactionGetFirstStatement() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));
@@ -277,7 +277,7 @@ public class LoadingBenchmark {
 	public long loadSyntheticWithDuplicatesAndNewStatementsIteratorMatchesNothing() {
 
 		MemoryStore memoryStore = new MemoryStore();
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (NotifyingSailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/NotifyingSailBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/NotifyingSailBenchmark.java
@@ -88,7 +88,7 @@ public class NotifyingSailBenchmark {
 		long count = 0;
 
 		Sail memoryStore = new TestNotifyingSail(new MemoryStore());
-		memoryStore.initialize();
+		memoryStore.init();
 
 		try (SailConnection connection = memoryStore.getConnection()) {
 			connection.begin(IsolationLevels.valueOf(isolationLevel));

--- a/core/sail/model/src/test/java/org/eclipse/rdf4j/sail/model/SailModelNamespacesTest.java
+++ b/core/sail/model/src/test/java/org/eclipse/rdf4j/sail/model/SailModelNamespacesTest.java
@@ -28,7 +28,7 @@ public class SailModelNamespacesTest extends ModelNamespacesTest {
 	protected Model getModelImplementation() {
 		sail = new MemoryStore();
 		try {
-			sail.initialize();
+			sail.init();
 			conn = sail.getConnection();
 			conn.begin();
 			return new SailModel(conn, false);

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreDirLockTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreDirLockTest.java
@@ -26,11 +26,11 @@ public class NativeStoreDirLockTest {
 	public void testLocking() throws Exception {
 		File dataDir = tempDir.newFolder();
 		NativeStore sail = new NativeStore(dataDir, "spoc,posc");
-		sail.initialize();
+		sail.init();
 
 		try {
 			NativeStore sail2 = new NativeStore(dataDir, "spoc,posc");
-			sail2.initialize();
+			sail2.init();
 			try {
 				fail("initialized a second native store with same dataDir");
 			} finally {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTmpDatadirTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTmpDatadirTest.java
@@ -27,7 +27,7 @@ public class NativeStoreTmpDatadirTest {
 		File dataDir = tempFolder.newFolder();
 		NativeStore store = new NativeStore(dataDir);
 
-		store.initialize();
+		store.init();
 		assertTrue("Data dir not set correctly", dataDir.equals(store.getDataDir()));
 
 		store.shutDown();
@@ -37,7 +37,7 @@ public class NativeStoreTmpDatadirTest {
 	@Test
 	public void testTmpDatadir() throws IOException {
 		NativeStore store = new NativeStore();
-		store.initialize();
+		store.init();
 		File dataDir = store.getDataDir();
 		assertTrue("Temp data dir not created", dataDir != null && dataDir.exists());
 
@@ -48,11 +48,11 @@ public class NativeStoreTmpDatadirTest {
 	@Test
 	public void testTmpDatadirReinit() throws IOException {
 		NativeStore store = new NativeStore();
-		store.initialize();
+		store.init();
 		File dataDir1 = store.getDataDir();
 		store.shutDown();
 
-		store.initialize();
+		store.init();
 		File dataDir2 = store.getDataDir();
 		store.shutDown();
 		assertFalse("Temp data dirs are the same", dataDir1.equals(dataDir2));
@@ -63,11 +63,11 @@ public class NativeStoreTmpDatadirTest {
 		File dataDir = tempFolder.newFolder();
 		NativeStore store = new NativeStore(dataDir);
 
-		store.initialize();
+		store.init();
 		store.shutDown();
 
 		store.setDataDir(null);
-		store.initialize();
+		store.init();
 		File tmpDataDir = store.getDataDir();
 		store.shutDown();
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreMemoryOverflow.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreMemoryOverflow.java
@@ -59,7 +59,6 @@ public class TestNativeStoreMemoryOverflow {
 	@Before
 	public void setUp() throws Exception {
 		testRepository = createRepository();
-		testRepository.initialize();
 
 		testCon = testRepository.getConnection();
 		testCon.setIsolationLevel(level);

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreUpgrade.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreUpgrade.java
@@ -48,7 +48,7 @@ public class TestNativeStoreUpgrade {
 		File dataDir = tmpDir.getRoot();
 		NativeStore store = new NativeStore(dataDir);
 		try {
-			store.initialize();
+			store.init();
 			try (NotifyingSailConnection con = store.getConnection()) {
 				ValueFactory vf = store.getValueFactory();
 				con.begin();
@@ -79,7 +79,7 @@ public class TestNativeStoreUpgrade {
 		assertFalse(new File(dataDir, "nativerdf.ver").exists());
 		NativeStore store = new NativeStore(dataDir);
 		try {
-			store.initialize();
+			store.init();
 			// we expect init to still succeed, but the store not to be marked as upgraded. See SES-2244.
 			assertFalse(new File(dataDir, "nativerdf.ver").exists());
 		} finally {
@@ -91,7 +91,7 @@ public class TestNativeStoreUpgrade {
 	public void assertValue(File dataDir) throws SailException {
 		NativeStore store = new NativeStore(dataDir);
 		try {
-			store.initialize();
+			store.init();
 			try (NotifyingSailConnection con = store.getConnection()) {
 				ValueFactory vf = store.getValueFactory();
 				CloseableIteration<? extends Statement, SailException> iter;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -328,13 +328,13 @@ public class ShaclSail extends NotifyingSailWrapper {
 	private final AtomicBoolean initialized = new AtomicBoolean(false);
 
 	@Override
-	public void initialize() throws SailException {
+	public void init() throws SailException {
 		if (!initialized.compareAndSet(false, true)) {
 			// already initialized
 			return;
 		}
 
-		super.initialize();
+		super.init();
 
 		if (shapesRepo != null) {
 			shapesRepo.shutDown();

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShutdownTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShutdownTest.java
@@ -29,7 +29,7 @@ public class ShutdownTest {
 	public void shutdownWhileRunningValidation() throws InterruptedException {
 
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
-		shaclSail.initialize();
+		shaclSail.init();
 
 		Future<Object> objectFuture = shaclSail.submitRunnableToExecutorService(getSleepingCallable());
 
@@ -50,7 +50,7 @@ public class ShutdownTest {
 
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 		for (int j = 0; j < 3; j++) {
-			shaclSail.initialize();
+			shaclSail.init();
 
 			Future<Object> objectFuture = shaclSail.submitRunnableToExecutorService(getSleepingCallable());
 
@@ -91,7 +91,7 @@ public class ShutdownTest {
 	private ExecutorService[] startShaclSailAndTask()
 			throws InterruptedException, NoSuchFieldException, IllegalAccessException {
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
-		shaclSail.initialize();
+		shaclSail.init();
 
 		Future<Object> objectFuture = shaclSail.submitRunnableToExecutorService(getSleepingCallable());
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/Utils.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/Utils.java
@@ -96,7 +96,6 @@ public class Utils {
 
 	public static SailRepository getInitializedShaclRepository(URL resourceName) {
 		SailRepository repo = new SailRepository(new ShaclSail(new MemoryStore()));
-		repo.initialize();
 		try {
 			Utils.loadShapeData(repo, resourceName);
 		} catch (IOException e) {
@@ -107,7 +106,6 @@ public class Utils {
 
 	public static SailRepository getSailRepository(URL resourceName) {
 		SailRepository sailRepository = new SailRepository(new MemoryStore());
-		sailRepository.initialize();
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 			connection.add(resourceName, resourceName.toString(), RDFFormat.TURTLE);
 		} catch (IOException | NullPointerException e) {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/W3cComplianceTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/W3cComplianceTest.java
@@ -129,7 +129,6 @@ public class W3cComplianceTest {
 
 		public Manifest(URL filename) {
 			SailRepository sailRepository = new SailRepository(new MemoryStore());
-			sailRepository.initialize();
 			try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 				connection.add(filename, filename.toString(), RDFFormat.TURTLE);
 			} catch (IOException e) {

--- a/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/InitializationBenchmark.java
+++ b/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/InitializationBenchmark.java
@@ -32,9 +32,8 @@ abstract class InitializationBenchmark {
 	@Benchmark
 	@BenchmarkMode(Mode.AverageTime)
 	@OutputTimeUnit(TimeUnit.MILLISECONDS)
-	public void initialize() {
-
-		getSail(null).initialize();
+	public void init() {
+		getSail(null).init();
 	}
 
 }

--- a/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/QueryOrderBenchmark.java
+++ b/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/QueryOrderBenchmark.java
@@ -75,7 +75,6 @@ public class QueryOrderBenchmark {
 	}
 
 	private void initialize() {
-		repository.initialize();
 		try (RepositoryConnection conn = repository.getConnection()) {
 			ValueFactory vf = conn.getValueFactory();
 			for (int i = 0; i < countk; i++) {

--- a/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/ReasoningBenchmark.java
+++ b/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/ReasoningBenchmark.java
@@ -196,8 +196,6 @@ public class ReasoningBenchmark {
 
 	private SailRepository createSchema() throws IOException {
 		SailRepository schema = new SailRepository(new MemoryStore());
-		schema.initialize();
-
 		try (SailRepositoryConnection schemaConnection = schema.getConnection()) {
 			schemaConnection.begin();
 			schemaConnection.add(resourceAsStream("schema.ttl"), "", RDFFormat.TURTLE);

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailGeoSPARQLTest.java
@@ -96,7 +96,6 @@ public abstract class AbstractLuceneSailGeoSPARQLTest {
 
 		// create a Repository wrapping the LuceneSail
 		repository = new SailRepository(sail);
-		repository.initialize();
 
 		// add some statements to it
 		loadPoints();

--- a/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailIndexedPropertiesTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractLuceneSailIndexedPropertiesTest.java
@@ -92,7 +92,6 @@ public abstract class AbstractLuceneSailIndexedPropertiesTest {
 
 		// create a Repository wrapping the LuceneSail
 		repository = new SailRepository(sail);
-		repository.initialize();
 
 		// add some statements to it
 		try (RepositoryConnection connection = repository.getConnection()) {

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/CascadeValueExceptionTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/CascadeValueExceptionTest.java
@@ -158,7 +158,6 @@ public abstract class CascadeValueExceptionTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
 		try (RepositoryConnection con = repository.getConnection()) {
 			con.clear();
 			con.clearNamespaces();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/EquivalentTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/EquivalentTest.java
@@ -204,7 +204,6 @@ public abstract class EquivalentTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
 		try (RepositoryConnection con = repository.getConnection()) {
 			con.begin();
 			con.clear();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/GraphQueryResultTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/GraphQueryResultTest.java
@@ -72,13 +72,9 @@ public abstract class GraphQueryResultTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		try {
+		try (RepositoryConnection con = repository.getConnection()) {
 			con.clear();
 			con.clearNamespaces();
-		} finally {
-			con.close();
 		}
 		return repository;
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/OptimisticIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/OptimisticIsolationTest.java
@@ -62,13 +62,9 @@ public abstract class OptimisticIsolationTest {
 		dataDir = Files.createTempDirectory(caller.getSimpleName()).toFile();
 		Repository repository = factory.getRepository(factory.getConfig());
 		repository.setDataDir(dataDir);
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		try {
+		try (RepositoryConnection con = repository.getConnection()) {
 			con.clear();
 			con.clearNamespaces();
-		} finally {
-			con.close();
 		}
 		return repository;
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnectionTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnectionTest.java
@@ -267,7 +267,6 @@ public abstract class RepositoryConnectionTest {
 		assertTrue(NEWLY_ADDED, testCon.hasStatement(alice, name, nameAlice, false));
 
 		Repository tempRep = createRepository();
-		tempRep.initialize();
 		try (RepositoryConnection con = tempRep.getConnection();) {
 
 			con.add(testCon.getStatements(null, null, null, false));

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlAggregatesTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlAggregatesTest.java
@@ -128,13 +128,9 @@ public abstract class SparqlAggregatesTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		try {
+		try (RepositoryConnection con = repository.getConnection()) {
 			con.clear();
 			con.clearNamespaces();
-		} finally {
-			con.close();
 		}
 		return repository;
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlDatasetTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlDatasetTest.java
@@ -137,13 +137,9 @@ public abstract class SparqlDatasetTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		try {
+		try (RepositoryConnection con = repository.getConnection()) {
 			con.clear();
 			con.clearNamespaces();
-		} finally {
-			con.close();
 		}
 		return repository;
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlOrderByTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlOrderByTest.java
@@ -77,13 +77,9 @@ public abstract class SparqlOrderByTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		try {
+		try (RepositoryConnection con = repository.getConnection()) {
 			con.clear();
 			con.clearNamespaces();
-		} finally {
-			con.close();
 		}
 		return repository;
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlRegexTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlRegexTest.java
@@ -112,13 +112,9 @@ public abstract class SparqlRegexTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		try {
+		try (RepositoryConnection con = repository.getConnection()) {
 			con.clear();
 			con.clearNamespaces();
-		} finally {
-			con.close();
 		}
 		return repository;
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlSetBindingTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/SparqlSetBindingTest.java
@@ -81,13 +81,9 @@ public abstract class SparqlSetBindingTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		try {
+		try (RepositoryConnection con = repository.getConnection()) {
 			con.clear();
 			con.clearNamespaces();
-		} finally {
-			con.close();
 		}
 		return repository;
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/TupleQueryResultTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/TupleQueryResultTest.java
@@ -74,11 +74,10 @@ public abstract class TupleQueryResultTest {
 
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		con.clear();
-		con.clearNamespaces();
-		con.close();
+		try (RepositoryConnection con = repository.getConnection()) {
+			con.clear();
+			con.clearNamespaces();
+		}
 		return repository;
 	}
 

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserTest.java
@@ -57,16 +57,13 @@ public abstract class AbstractNQuadsParserTest {
 
 		// Add the manifest for W3C test cases to a repository and query it
 		Repository w3cRepository = new SailRepository(new MemoryStore());
-		w3cRepository.initialize();
-		RepositoryConnection w3cCon = w3cRepository.getConnection();
+		try (RepositoryConnection w3cCon = w3cRepository.getConnection()) {
+			InputStream inputStream = this.getClass().getResourceAsStream(TEST_W3C_MANIFEST_URL);
+			w3cCon.add(inputStream, TEST_W3C_MANIFEST_URI_BASE, RDFFormat.TURTLE);
 
-		InputStream inputStream = this.getClass().getResourceAsStream(TEST_W3C_MANIFEST_URL);
-		w3cCon.add(inputStream, TEST_W3C_MANIFEST_URI_BASE, RDFFormat.TURTLE);
-
-		parsePositiveNQuadsSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TEST_W3C_TEST_URI_BASE, w3cCon);
-		parseNegativeNQuadsSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TEST_W3C_TEST_URI_BASE, w3cCon);
-
-		w3cCon.close();
+			parsePositiveNQuadsSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TEST_W3C_TEST_URI_BASE, w3cCon);
+			parseNegativeNQuadsSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TEST_W3C_TEST_URI_BASE, w3cCon);
+		}
 		w3cRepository.shutDown();
 
 		return suite;

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserTest.java
@@ -57,16 +57,13 @@ public abstract class AbstractNTriplesParserTest {
 
 		// Add the manifest for W3C test cases to a repository and query it
 		Repository w3cRepository = new SailRepository(new MemoryStore());
-		w3cRepository.initialize();
-		RepositoryConnection w3cCon = w3cRepository.getConnection();
+		try (RepositoryConnection w3cCon = w3cRepository.getConnection()) {
+			InputStream inputStream = this.getClass().getResourceAsStream(TEST_W3C_MANIFEST_URL);
+			w3cCon.add(inputStream, TEST_W3C_MANIFEST_URI_BASE, RDFFormat.TURTLE);
 
-		InputStream inputStream = this.getClass().getResourceAsStream(TEST_W3C_MANIFEST_URL);
-		w3cCon.add(inputStream, TEST_W3C_MANIFEST_URI_BASE, RDFFormat.TURTLE);
-
-		parsePositiveNTriplesSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TEST_W3C_TEST_URI_BASE, w3cCon);
-		parseNegativeNTriplesSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TEST_W3C_TEST_URI_BASE, w3cCon);
-
-		w3cCon.close();
+			parsePositiveNTriplesSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TEST_W3C_TEST_URI_BASE, w3cCon);
+			parseNegativeNTriplesSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TEST_W3C_TEST_URI_BASE, w3cCon);
+		}
 		w3cRepository.shutDown();
 
 		return suite;

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserTestCase.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserTestCase.java
@@ -59,97 +59,93 @@ public abstract class RDFJSONParserTestCase {
 
 		// Add the manifest for positive test cases to a repository and query it
 		Repository repository = new SailRepository(new MemoryStore());
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
+		try (RepositoryConnection con = repository.getConnection()) {
 
-		InputStream inputStream = this.getClass().getResourceAsStream(MANIFEST_GOOD_URL);
-		con.add(inputStream, BASE_URL, RDFFormat.TURTLE);
+			InputStream inputStream = this.getClass().getResourceAsStream(MANIFEST_GOOD_URL);
+			con.add(inputStream, BASE_URL, RDFFormat.TURTLE);
 
-		StringBuilder positiveQuery = new StringBuilder();
-		positiveQuery.append(" PREFIX mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>\n");
-		positiveQuery.append(" PREFIX qt:   <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>\n");
-		positiveQuery.append(" PREFIX rdft: <http://www.w3.org/ns/rdftest#>\n");
-		positiveQuery.append(" SELECT ?test ?testName ?inputURL ?outputURL \n");
-		positiveQuery.append(" WHERE { \n");
-		positiveQuery.append("     ?test a rdft:TestRDFJSONPositiveSyntax . ");
-		positiveQuery.append("     ?test mf:name ?testName . ");
-		positiveQuery.append("     ?test mf:action ?inputURL . ");
-		positiveQuery.append(" }");
+			StringBuilder positiveQuery = new StringBuilder();
+			positiveQuery.append(" PREFIX mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>\n");
+			positiveQuery.append(" PREFIX qt:   <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>\n");
+			positiveQuery.append(" PREFIX rdft: <http://www.w3.org/ns/rdftest#>\n");
+			positiveQuery.append(" SELECT ?test ?testName ?inputURL ?outputURL \n");
+			positiveQuery.append(" WHERE { \n");
+			positiveQuery.append("     ?test a rdft:TestRDFJSONPositiveSyntax . ");
+			positiveQuery.append("     ?test mf:name ?testName . ");
+			positiveQuery.append("     ?test mf:action ?inputURL . ");
+			positiveQuery.append(" }");
 
-		TupleQueryResult queryResult = con.prepareTupleQuery(QueryLanguage.SPARQL, positiveQuery.toString()).evaluate();
+			try (TupleQueryResult queryResult = con.prepareTupleQuery(QueryLanguage.SPARQL, positiveQuery.toString())
+					.evaluate()) {
+				// Add all positive parser tests to the test suite
+				while (queryResult.hasNext()) {
+					BindingSet bindingSet = queryResult.next();
+					String nextTestName = ((Literal) bindingSet.getValue("testName")).getLabel();
+					String nextTestFile = removeBase(((IRI) bindingSet.getValue("inputURL")).toString());
+					String nextInputURL = TEST_FILE_BASE_PATH + nextTestFile;
 
-		// Add all positive parser tests to the test suite
-		while (queryResult.hasNext()) {
-			BindingSet bindingSet = queryResult.next();
-			String nextTestName = ((Literal) bindingSet.getValue("testName")).getLabel();
-			String nextTestFile = removeBase(((IRI) bindingSet.getValue("inputURL")).toString());
-			String nextInputURL = TEST_FILE_BASE_PATH + nextTestFile;
+					String nextBaseUrl = BASE_URL + nextTestFile;
 
-			String nextBaseUrl = BASE_URL + nextTestFile;
+					suite.addTest(new PositiveParserTest(nextTestName, nextInputURL, null, nextBaseUrl));
+				}
+			}
 
-			suite.addTest(new PositiveParserTest(nextTestName, nextInputURL, null, nextBaseUrl));
+			StringBuilder negativeQuery = new StringBuilder();
+			negativeQuery.append(" PREFIX mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>\n");
+			negativeQuery.append(" PREFIX qt:   <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>\n");
+			negativeQuery.append(" PREFIX rdft: <http://www.w3.org/ns/rdftest#>\n");
+			negativeQuery.append(" SELECT ?test ?testName ?inputURL ?outputURL \n");
+			negativeQuery.append(" WHERE { \n");
+			negativeQuery.append("     ?test a rdft:TestRDFJSONNegativeSyntax . ");
+			negativeQuery.append("     ?test mf:name ?testName . ");
+			negativeQuery.append("     ?test mf:action ?inputURL . ");
+			negativeQuery.append(" }");
+
+			try (var queryResult = con.prepareTupleQuery(QueryLanguage.SPARQL, negativeQuery.toString()).evaluate()) {
+
+				// Add all negative parser tests to the test suite
+				while (queryResult.hasNext()) {
+					BindingSet bindingSet = queryResult.next();
+					String nextTestName = ((Literal) bindingSet.getValue("testName")).toString();
+					String nextTestFile = removeBase(((IRI) bindingSet.getValue("inputURL")).toString());
+					String nextInputURL = TEST_FILE_BASE_PATH + nextTestFile;
+
+					String nextBaseUrl = BASE_URL + nextTestFile;
+
+					suite.addTest(new NegativeParserTest(nextTestName, nextInputURL, nextBaseUrl));
+				}
+			}
+
+			StringBuilder positiveEvalQuery = new StringBuilder();
+			positiveEvalQuery.append(" PREFIX mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>\n");
+			positiveEvalQuery.append(" PREFIX qt:   <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>\n");
+			positiveEvalQuery.append(" PREFIX rdft: <http://www.w3.org/ns/rdftest#>\n");
+			positiveEvalQuery.append(" SELECT ?test ?testName ?inputURL ?outputURL \n");
+			positiveEvalQuery.append(" WHERE { \n");
+			positiveEvalQuery.append("     ?test a rdft:TestRDFJSONEval . ");
+			positiveEvalQuery.append("     ?test mf:name ?testName . ");
+			positiveEvalQuery.append("     ?test mf:action ?inputURL . ");
+			positiveEvalQuery.append("     ?test mf:result ?outputURL . ");
+			positiveEvalQuery.append(" }");
+
+			try (var queryResult = con.prepareTupleQuery(QueryLanguage.SPARQL, positiveEvalQuery.toString())
+					.evaluate()) {
+
+				// Add all positive eval tests to the test suite
+				while (queryResult.hasNext()) {
+					BindingSet bindingSet = queryResult.next();
+					String nextTestName = ((Literal) bindingSet.getValue("testName")).getLabel();
+					String nextTestFile = removeBase(((IRI) bindingSet.getValue("inputURL")).toString());
+					String nextInputURL = TEST_FILE_BASE_PATH + nextTestFile;
+					String nextOutputURL = TEST_FILE_BASE_PATH
+							+ removeBase(((IRI) bindingSet.getValue("outputURL")).toString());
+
+					String nextBaseUrl = BASE_URL + nextTestFile;
+
+					suite.addTest(new PositiveParserTest(nextTestName, nextInputURL, nextOutputURL, nextBaseUrl));
+				}
+			}
 		}
-
-		queryResult.close();
-
-		StringBuilder negativeQuery = new StringBuilder();
-		negativeQuery.append(" PREFIX mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>\n");
-		negativeQuery.append(" PREFIX qt:   <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>\n");
-		negativeQuery.append(" PREFIX rdft: <http://www.w3.org/ns/rdftest#>\n");
-		negativeQuery.append(" SELECT ?test ?testName ?inputURL ?outputURL \n");
-		negativeQuery.append(" WHERE { \n");
-		negativeQuery.append("     ?test a rdft:TestRDFJSONNegativeSyntax . ");
-		negativeQuery.append("     ?test mf:name ?testName . ");
-		negativeQuery.append("     ?test mf:action ?inputURL . ");
-		negativeQuery.append(" }");
-
-		queryResult = con.prepareTupleQuery(QueryLanguage.SPARQL, negativeQuery.toString()).evaluate();
-
-		// Add all negative parser tests to the test suite
-		while (queryResult.hasNext()) {
-			BindingSet bindingSet = queryResult.next();
-			String nextTestName = ((Literal) bindingSet.getValue("testName")).toString();
-			String nextTestFile = removeBase(((IRI) bindingSet.getValue("inputURL")).toString());
-			String nextInputURL = TEST_FILE_BASE_PATH + nextTestFile;
-
-			String nextBaseUrl = BASE_URL + nextTestFile;
-
-			suite.addTest(new NegativeParserTest(nextTestName, nextInputURL, nextBaseUrl));
-		}
-
-		queryResult.close();
-
-		StringBuilder positiveEvalQuery = new StringBuilder();
-		positiveEvalQuery.append(" PREFIX mf:   <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>\n");
-		positiveEvalQuery.append(" PREFIX qt:   <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>\n");
-		positiveEvalQuery.append(" PREFIX rdft: <http://www.w3.org/ns/rdftest#>\n");
-		positiveEvalQuery.append(" SELECT ?test ?testName ?inputURL ?outputURL \n");
-		positiveEvalQuery.append(" WHERE { \n");
-		positiveEvalQuery.append("     ?test a rdft:TestRDFJSONEval . ");
-		positiveEvalQuery.append("     ?test mf:name ?testName . ");
-		positiveEvalQuery.append("     ?test mf:action ?inputURL . ");
-		positiveEvalQuery.append("     ?test mf:result ?outputURL . ");
-		positiveEvalQuery.append(" }");
-
-		queryResult = con.prepareTupleQuery(QueryLanguage.SPARQL, positiveEvalQuery.toString()).evaluate();
-
-		// Add all positive eval tests to the test suite
-		while (queryResult.hasNext()) {
-			BindingSet bindingSet = queryResult.next();
-			String nextTestName = ((Literal) bindingSet.getValue("testName")).getLabel();
-			String nextTestFile = removeBase(((IRI) bindingSet.getValue("inputURL")).toString());
-			String nextInputURL = TEST_FILE_BASE_PATH + nextTestFile;
-			String nextOutputURL = TEST_FILE_BASE_PATH
-					+ removeBase(((IRI) bindingSet.getValue("outputURL")).toString());
-
-			String nextBaseUrl = BASE_URL + nextTestFile;
-
-			suite.addTest(new PositiveParserTest(nextTestName, nextInputURL, nextOutputURL, nextBaseUrl));
-		}
-
-		queryResult.close();
-
-		con.close();
 		repository.shutDown();
 
 		return suite;

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParserTestCase.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/trig/TriGParserTestCase.java
@@ -66,20 +66,19 @@ public abstract class TriGParserTestCase {
 
 		// Add the manifest for W3C test cases to a repository and query it
 		Repository w3cRepository = new SailRepository(new MemoryStore());
-		w3cRepository.initialize();
-		RepositoryConnection w3cCon = w3cRepository.getConnection();
+		try (RepositoryConnection w3cCon = w3cRepository.getConnection()) {
+			InputStream inputStream = this.getClass().getResourceAsStream(TEST_W3C_MANIFEST_URL);
+			w3cCon.add(inputStream, TEST_W3C_MANIFEST_URI_BASE, RDFFormat.TURTLE);
 
-		InputStream inputStream = this.getClass().getResourceAsStream(TEST_W3C_MANIFEST_URL);
-		w3cCon.add(inputStream, TEST_W3C_MANIFEST_URI_BASE, RDFFormat.TURTLE);
-
-		parsePositiveTriGSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
-				w3cCon);
-		parseNegativeTriGSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
-				w3cCon);
-		parsePositiveTriGEvalTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE, w3cCon);
-		parseNegativeTriGEvalTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE, w3cCon);
-
-		w3cCon.close();
+			parsePositiveTriGSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
+					w3cCon);
+			parseNegativeTriGSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
+					w3cCon);
+			parsePositiveTriGEvalTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
+					w3cCon);
+			parseNegativeTriGEvalTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
+					w3cCon);
+		}
 		w3cRepository.shutDown();
 
 		return suite;

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTestCase.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTestCase.java
@@ -80,22 +80,19 @@ public abstract class TurtleParserTestCase {
 
 		// Add the manifest for W3C test cases to a repository and query it
 		Repository w3cRepository = new SailRepository(new MemoryStore());
-		w3cRepository.initialize();
-		RepositoryConnection w3cCon = w3cRepository.getConnection();
+		try (RepositoryConnection w3cCon = w3cRepository.getConnection()) {
+			InputStream inputStream = this.getClass().getResourceAsStream(TEST_W3C_MANIFEST_URL);
+			w3cCon.add(inputStream, TEST_W3C_MANIFEST_URI_BASE, RDFFormat.TURTLE);
 
-		InputStream inputStream = this.getClass().getResourceAsStream(TEST_W3C_MANIFEST_URL);
-		w3cCon.add(inputStream, TEST_W3C_MANIFEST_URI_BASE, RDFFormat.TURTLE);
-
-		parsePositiveTurtleSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
-				w3cCon);
-		parseNegativeTurtleSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
-				w3cCon);
-		parsePositiveTurtleEvalTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
-				w3cCon);
-		parseNegativeTurtleEvalTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
-				w3cCon);
-
-		w3cCon.close();
+			parsePositiveTurtleSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
+					w3cCon);
+			parseNegativeTurtleSyntaxTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
+					w3cCon);
+			parsePositiveTurtleEvalTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
+					w3cCon);
+			parseNegativeTurtleEvalTests(suite, TEST_W3C_FILE_BASE_PATH, TESTS_W3C_BASE_URL, TEST_W3C_TEST_URI_BASE,
+					w3cCon);
+		}
 		w3cRepository.shutDown();
 
 		return suite;

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailConcurrencyTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailConcurrencyTest.java
@@ -64,7 +64,7 @@ public abstract class SailConcurrencyTest {
 	@Before
 	public void setUp() throws Exception {
 		store = createSail();
-		store.initialize();
+		store.init();
 		vf = store.getValueFactory();
 	}
 

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailInterruptTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailInterruptTest.java
@@ -38,7 +38,7 @@ public abstract class SailInterruptTest {
 	@Before
 	public void setUp() throws Exception {
 		store = createSail();
-		store.initialize();
+		store.init();
 		vf = store.getValueFactory();
 	}
 

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailIsolationLevelTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/sail/SailIsolationLevelTest.java
@@ -70,7 +70,7 @@ public abstract class SailIsolationLevelTest {
 	@Before
 	public void setUp() throws Exception {
 		store = createSail();
-		store.initialize();
+		store.init();
 		vf = store.getValueFactory();
 		failed = null;
 	}

--- a/testsuites/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/AbstractSHACLTest.java
+++ b/testsuites/shacl/src/main/java/org/eclipse/rdf4j/shacl/manifest/AbstractSHACLTest.java
@@ -81,8 +81,6 @@ public abstract class AbstractSHACLTest extends TestCase {
 
 	protected Repository createRepository(Model shapesGraph) throws Exception {
 		Repository repo = new SailRepository(newSail());
-		repo.initialize();
-
 		try (RepositoryConnection conn = repo.getConnection()) {
 			conn.clear();
 			conn.clearNamespaces();

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -104,7 +104,6 @@ public abstract class ComplexSPARQLQueryTest {
 	public void setUp() throws Exception {
 		logger.debug("setting up test");
 		this.rep = newRepository();
-		rep.initialize();
 
 		f = rep.getValueFactory();
 		conn = rep.getConnection();

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateTest.java
@@ -1815,11 +1815,10 @@ public abstract class SPARQLUpdateTest {
 	 */
 	protected Repository createRepository() throws Exception {
 		Repository repository = newRepository();
-		repository.initialize();
-		RepositoryConnection con = repository.getConnection();
-		con.clear();
-		con.clearNamespaces();
-		con.close();
+		try (RepositoryConnection con = repository.getConnection()) {
+			con.clear();
+			con.clearNamespaces();
+		}
 		return repository;
 	}
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL10ManifestTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL10ManifestTest.java
@@ -98,27 +98,27 @@ public class SPARQL10ManifestTest {
 		};
 
 		Repository manifestRep = new SailRepository(new MemoryStore());
-		manifestRep.initialize();
-		RepositoryConnection con = manifestRep.getConnection();
+		try (RepositoryConnection con = manifestRep.getConnection()) {
 
-		addTurtle(con, new URL(manifestFile), manifestFile);
+			addTurtle(con, new URL(manifestFile), manifestFile);
 
-		String query = ""
-				+ "PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>\n "
-				+ "PRFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>"
-				+ "SELECT DISTINCT ?manifestFile\n"
-				+ "WHERE { ?x rdf:first ?manifestFile .} ";
+			String query = ""
+					+ "PREFIX mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>\n "
+					+ "PRFIX qt: <http://www.w3.org/2001/sw/DataAccess/tests/test-query#>"
+					+ "SELECT DISTINCT ?manifestFile\n"
+					+ "WHERE { ?x rdf:first ?manifestFile .} ";
 
-		TupleQueryResult manifestResults = con.prepareTupleQuery(QueryLanguage.SPARQL, query, manifestFile).evaluate();
+			TupleQueryResult manifestResults = con.prepareTupleQuery(QueryLanguage.SPARQL, query, manifestFile)
+					.evaluate();
 
-		while (manifestResults.hasNext()) {
-			BindingSet bindingSet = manifestResults.next();
-			String subManifestFile = bindingSet.getValue("manifestFile").stringValue();
-			suite.addTest(SPARQLQueryTest.suite(subManifestFile, factory));
+			while (manifestResults.hasNext()) {
+				BindingSet bindingSet = manifestResults.next();
+				String subManifestFile = bindingSet.getValue("manifestFile").stringValue();
+				suite.addTest(SPARQLQueryTest.suite(subManifestFile, factory));
+			}
+
+			manifestResults.close();
 		}
-
-		manifestResults.close();
-		con.close();
 		manifestRep.shutDown();
 
 		logger.info("Created aggregated test suite with " + suite.countTestCases() + " test cases.");

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQLQueryTest.java
@@ -154,13 +154,9 @@ public abstract class SPARQLQueryTest extends TestCase {
 
 	protected final Repository createRepository() throws Exception {
 		Repository repo = newRepository();
-		repo.initialize();
-		RepositoryConnection con = repo.getConnection();
-		try {
+		try (RepositoryConnection con = repo.getConnection()) {
 			con.clear();
 			con.clearNamespaces();
-		} finally {
-			con.close();
 		}
 		return repo;
 	}

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQLSyntaxComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQLSyntaxComplianceTest.java
@@ -193,7 +193,7 @@ public abstract class SPARQLSyntaxComplianceTest extends SPARQLComplianceTest {
 							dataBlockUpdate = true;
 
 							MemoryStore store = new MemoryStore();
-							store.initialize();
+							store.init();
 							NotifyingSailConnection conn = store.getConnection();
 							try {
 								conn.begin();

--- a/tools/console/src/main/java/org/eclipse/rdf4j/console/LockRemover.java
+++ b/tools/console/src/main/java/org/eclipse/rdf4j/console/LockRemover.java
@@ -38,7 +38,7 @@ public class LockRemover {
 				.askProceed("WARNING: The lock from another process on this repository needs to be removed", true)) {
 			repo.shutDown();
 			lockRemoved = lockManager.revokeLock();
-			repo.initialize();
+			repo.init();
 		}
 		return lockRemoved;
 	}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/UtilTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/UtilTest.java
@@ -30,7 +30,6 @@ public class UtilTest {
 	@BeforeAll
 	public static void setupClass() {
 		repo = new SailRepository(new MemoryStore());
-		repo.initialize();
 	}
 
 	@AfterAll

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryWrapper.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryWrapper.java
@@ -70,7 +70,7 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 	}
 
 	@Override
-	public void initialize() throws RepositoryException {
+	public void init() throws RepositoryException {
 
 		if (getDelegate() != null) {
 			return;

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestExploreServlet.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestExploreServlet.java
@@ -54,7 +54,6 @@ public class TestExploreServlet {
 	@Before
 	public void setUp() throws RepositoryException, MalformedQueryException, UpdateExecutionException {
 		Repository repo = new SailRepository(new MemoryStore());
-		repo.initialize();
 		connection = repo.getConnection();
 		servlet = new ExploreServlet();
 		ValueFactory factory = connection.getValueFactory();


### PR DESCRIPTION
GitHub issue resolved: #1243  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- removed `initialize` from Repository interface, replaced all usages with `init` where necessary, removed where not necessary.
- removed `initialize` from Sail interface, replaced all usages with `init`
- removed `initialize` from RepositoryListener and RepositoryInterceptor interfaces, replaced usages with `init`.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

