### PR TITLE
GH-3439 Filters next to each other in the algebra can be merged.

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizer.java
@@ -35,23 +35,46 @@ import org.eclipse.rdf4j.query.algebra.helpers.VarNameCollector;
 /**
  * Optimizes a query model by pushing {@link Filter}s as far down in the model tree as possible.
  * 
- * @author Arjohn Kampman Then it optimizes a query model by merging adjacent {@link Filter}s. e.g. <code>
+ * To make the first optimization succeed more often it splits filters which contains {@link And} conditions.
+ * 
+ * <code>
+ * SELECT * WHERE {
+ * ?s ?p ?o . 
+ * ?s ?p ?o2  . 
+ * FILTER(?o > '2'^^xsd:int && ?o2 < '4'^^xsd:int) 
+ * }
+ * </code> May be more efficient when decomposed into <code>
+ * SELECT * WHERE {
+ * ?s ?p ?o .
+ * FILTER(?o > '2'^^xsd:int) 
+ * ?s ?p ?o2  . 
+ * FILTER(?o2 < '4'^^xsd:int) 
+ * }
+ * </code>
+ * 
+ * Then it optimizes a query model by merging adjacent {@link Filter}s. e.g. <code>
  * SELECT * WHERE {
  *  ?s ?p ?o .
  *  FILTER(?o > 2) .
  *  FILTER(?o < 4) .
  *  } 
- *  </code> may be merged into * ?s ?p ?o . FILTER(?o > 2 && ?o < 4) . } </code>
+ * </code> may be merged into <code> 
+ * SELECT * WHERE {
+ *   ?s ?p ?o . 
+ *   FILTER(?o > 2 && ?o < 4) . }
+ *  </code>
  * 
- *         This optimization allows for sharing evaluation costs in the future and removes an iterator. This is done as
- *         a second step to not break the first optimization.
- *
+ * This optimization allows for sharing evaluation costs in the future and removes an iterator. This is done as a second
+ * step to not break the first optimization. In the case that the splitting was done but did not help it is now undone.
+ * 
+ * @author Arjohn Kampman
  * @author Jerven Bolleman
  */
 public class FilterOptimizer implements QueryOptimizer {
 
 	@Override
 	public void optimize(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings) {
+		tupleExpr.visit(new DeMergeFilterFinder());
 		tupleExpr.visit(new FilterFinder(tupleExpr));
 		tupleExpr.visit(new MergeFilterFinder());
 	}
@@ -230,10 +253,6 @@ public class FilterOptimizer implements QueryOptimizer {
 
 	protected static class MergeFilterFinder extends AbstractQueryModelVisitor<RuntimeException> {
 
-		public MergeFilterFinder() {
-
-		}
-
 		@Override
 		public void meet(Filter filter) {
 			super.meet(filter);
@@ -246,6 +265,29 @@ public class FilterOptimizer implements QueryOptimizer {
 				And merge = new And(parentCondition, thisCondition);
 				filter.setCondition(merge);
 				grandParent.replaceChildNode(parentFilter, filter);
+			}
+		}
+	}
+
+	/*--------------------------*
+	 * Inner class DeMergeFilterFinder *
+	 *--------------------------*/
+
+	protected static class DeMergeFilterFinder extends AbstractQueryModelVisitor<RuntimeException> {
+
+		@Override
+		public void meet(Filter filter) {
+			super.meet(filter);
+			if (filter.getCondition() instanceof And) {
+
+				And and = (And) filter.getCondition();
+				ValueExpr left = and.getLeftArg();
+				ValueExpr right = and.getRightArg();
+				filter.setCondition(left);
+				Filter newFilter = new Filter(filter.getArg(), right);
+				filter.replaceChildNode(filter.getArg(), newFilter);
+				meet(newFilter);
+				meet(filter);
 			}
 		}
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
@@ -7,7 +7,27 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.UnsupportedQueryLanguageException;
+import org.eclipse.rdf4j.query.algebra.Compare;
+import org.eclipse.rdf4j.query.algebra.Compare.CompareOp;
+import org.eclipse.rdf4j.query.algebra.Filter;
+import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.Projection;
+import org.eclipse.rdf4j.query.algebra.ProjectionElem;
+import org.eclipse.rdf4j.query.algebra.ProjectionElemList;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.ValueConstant;
+import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.junit.Test;
 
 public class FilterOptimizerTest extends QueryOptimizerTest {
 
@@ -16,4 +36,49 @@ public class FilterOptimizerTest extends QueryOptimizerTest {
 		return new FilterOptimizer();
 	}
 
+	@Test
+	public void merge() {
+		String expectedQuery = "SELECT * WHERE {?s ?p ?o . FILTER(?o > 2 && ?o <4) }";
+		String query = "SELECT * WHERE {?s ?p ?o . FILTER(?o > 2) .FILTER(?o <4) }";
+
+		testOptimizer(expectedQuery, query);
+	}
+
+	@Test
+	public void dontMerge() {
+		Var s = new Var("s");
+		Var p = new Var("p");
+		Var o = new Var("o");
+		Var o2 = new Var("o2");
+		ValueConstant two = new ValueConstant(SimpleValueFactory.getInstance().createLiteral(2));
+		ValueConstant four = new ValueConstant(SimpleValueFactory.getInstance().createLiteral(4));
+		Compare oSmallerThanTwo = new Compare(o, two, CompareOp.GT);
+		Filter spo = new Filter(new StatementPattern(s, p, o), oSmallerThanTwo);
+		Compare o2SmallerThanFour = new Compare(o2, four, CompareOp.LT);
+		Filter spo2 = new Filter(new StatementPattern(s, p, o2), o2SmallerThanFour);
+		TupleExpr expected = new Projection(new Join(spo, spo2), new ProjectionElemList(new ProjectionElem("s"),
+				new ProjectionElem("p"), new ProjectionElem("o"), new ProjectionElem("o2")));
+		String query = "SELECT * WHERE {?s ?p ?o . ?s ?p ?o2  . FILTER(?o > '2'^^xsd:int)  . FILTER(?o2 < '4'^^xsd:int) }";
+
+		testOptimizer(expected, query);
+	}
+
+	void testOptimizer(String expectedQuery, String actualQuery)
+			throws MalformedQueryException, UnsupportedQueryLanguageException {
+		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, actualQuery, null);
+		FilterOptimizer opt = getOptimizer();
+		opt.optimize(pq.getTupleExpr(), null, null);
+
+		ParsedQuery expectedParsedQuery = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, expectedQuery, null);
+		assertEquals(pq.getTupleExpr(), expectedParsedQuery.getTupleExpr());
+	}
+
+	void testOptimizer(TupleExpr expectedQuery, String actualQuery)
+			throws MalformedQueryException, UnsupportedQueryLanguageException {
+		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, actualQuery, null);
+		FilterOptimizer opt = getOptimizer();
+		opt.optimize(pq.getTupleExpr(), null, null);
+
+		assertEquals(pq.getTupleExpr(), expectedQuery);
+	}
 }


### PR DESCRIPTION
GitHub issue resolved: #GH-3439

Briefly describe the changes proposed in this PR:

Merge adjacent filters into one via "and"ing the valueexpresions of them and removing one from the algebra.
Must run after the existing placing filter which is slightly changed to place filter next to statementpatterns now that produce the variables,
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

