### PR TITLE
increase the line number on newlines inside long string literals

### DIFF
--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleParser.java
@@ -766,6 +766,11 @@ public class TurtleParser extends AbstractRDFParser {
 
 			appendCodepoint(sb, c);
 
+			if (c == '\n') {
+				lineNumber++;
+				reportLocation();
+			}
+
 			if (c == '\\') {
 				// This escapes the next character, which might be a '"'
 				c = readCodePoint();

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
@@ -360,6 +360,16 @@ public class TurtleParserTest {
 	}
 
 	@Test
+	public void testLineNumberReportingInLongStringLiterals() throws IOException {
+		assertEquals(0, locationListener.getLineNo());
+		assertEquals(0, locationListener.getColumnNo());
+		Reader in = new StringReader("<urn:a> <urn:b> \"\"\"is\nallowed\nin\na very long string\"\"\" .");
+		parser.parse(in, baseURI);
+		assertEquals(4, locationListener.getLineNo());
+		assertEquals(-1, locationListener.getColumnNo());
+	}
+
+	@Test
 	public void testParseBooleanLiteralComma() throws IOException {
 		String data = "<urn:a> <urn:b> true, false .";
 		Reader r = new StringReader(data);


### PR DESCRIPTION
GitHub issue resolved: #3412

Briefly describe the changes proposed in this PR:

The line number counter is incremented on each new line character inside multi-line string literals in Turtle.

----
PR Author Checklist:

 - [X] my pull request is self-contained
 - [X] I've added tests for the changes I made
 - [X] I've applied code formatting
 - [X] I've squashed my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

