### PR TITLE
GH-1815: Escape String literals in SparqlBuilder

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteral.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteral.java
@@ -8,9 +8,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
-import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
-
 import java.util.Optional;
+
+import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
 
 /**
  * Denotes an RDF literal

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteral.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteral.java
@@ -8,9 +8,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
-import java.util.Optional;
-
 import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
+
+import java.util.Optional;
 
 /**
  * Denotes an RDF literal
@@ -98,13 +98,8 @@ public abstract class RdfLiteral<T> implements RdfValue {
 		@Override
 		public String getQueryString() {
 			StringBuilder literal = new StringBuilder();
-
-			if (value.contains("'") || value.contains("\"")) {
-				literal.append(SparqlBuilderUtils.getLongQuotedString(value));
-			} else {
-				literal.append(SparqlBuilderUtils.getQuotedString(value));
-			}
-
+			String escaped = SparqlBuilderUtils.escape(value);
+			literal.append(SparqlBuilderUtils.getQuotedString(escaped));
 			SparqlBuilderUtils.appendQueryElementIfPresent(dataType, literal, DATATYPE_SPECIFIER, null);
 			SparqlBuilderUtils.appendStringIfPresent(languageTag, literal, LANG_TAG_SPECIFIER, null);
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteral.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteral.java
@@ -98,7 +98,7 @@ public abstract class RdfLiteral<T> implements RdfValue {
 		@Override
 		public String getQueryString() {
 			StringBuilder literal = new StringBuilder();
-			String escaped = SparqlBuilderUtils.escape(value);
+			String escaped = SparqlBuilderUtils.getEscapedString(value);
 			literal.append(SparqlBuilderUtils.getQuotedString(escaped));
 			SparqlBuilderUtils.appendQueryElementIfPresent(dataType, literal, DATATYPE_SPECIFIER, null);
 			SparqlBuilderUtils.appendStringIfPresent(languageTag, literal, LANG_TAG_SPECIFIER, null);

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtils.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtils.java
@@ -8,11 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.util;
 
-import org.eclipse.rdf4j.sparqlbuilder.core.QueryElement;
-
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.Optional;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.QueryElement;
 
 /**
  * Utility functions for the SparqlBuilder
@@ -104,7 +104,7 @@ public class SparqlBuilderUtils {
 	 * @param value The String to escape
 	 * @return the escaped String
 	 */
-	public static String escape(String value) {
+	public static String getEscapedString(String value) {
 		if (value == null) {
 			return null;
 		}

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtils.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtils.java
@@ -8,9 +8,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.util;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-import java.util.Optional;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.QueryElement;
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtils.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtils.java
@@ -8,11 +8,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.util;
 
+import org.eclipse.rdf4j.sparqlbuilder.core.QueryElement;
+
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
-
-import org.eclipse.rdf4j.sparqlbuilder.core.QueryElement;
 
 /**
  * Utility functions for the SparqlBuilder
@@ -92,5 +92,30 @@ public class SparqlBuilderUtils {
 		es.append(close);
 
 		return es.toString();
+	}
+
+	/**
+	 * Escape the specified String value according to the SPARQL 1.1 Spec
+	 * https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#grammarEscapes
+	 *
+	 * Note that there is no special handling for Codepoint escape sequences as described by
+	 * https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#codepointEscape
+	 *
+	 * @param value The String to escape
+	 * @return the escaped String
+	 */
+	public static String escape(String value) {
+		if (value == null) {
+			return null;
+		}
+		return value
+				.replace("\\", "\\\\")
+				.replace("\n", "\\n")
+				.replace("\t", "\\t")
+				.replace("\b", "\\b")
+				.replace("\r", "\\r")
+				.replace("\f", "\\f")
+				.replace("\"", "\\\"")
+				.replace("'", "\\'");
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
@@ -7,10 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
 import org.junit.Test;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RdfLiteralTest {
 
@@ -25,4 +27,151 @@ public class RdfLiteralTest {
 		StringLiteral literal = new StringLiteral("foo");
 		assertThat(literal.getQueryString()).isEqualTo("\"foo\"");
 	}
+
+	@Test
+	public void testNewline() {
+		StringLiteral literal = new StringLiteral("foo\nbar");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\nbar\"");
+		literal = new StringLiteral("foo\nbar\n");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\nbar\\n\"");
+		literal = new StringLiteral("\nfoo\nbar\n");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\nfoo\\nbar\\n\"");
+		literal = new StringLiteral("foobar\n");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\n\"");
+		literal = new StringLiteral("\nfoobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\nfoobar\"");
+		literal = new StringLiteral("\n\n\nfoobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\n\\n\\nfoobar\"");
+		literal = new StringLiteral("\nfoobar\n\n\n");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\nfoobar\\n\\n\\n\"");
+	}
+
+	@Test
+	public void testCarriageReturn() {
+		StringLiteral literal = new StringLiteral("foo\rbar");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\rbar\"");
+		literal = new StringLiteral("foobar\r");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\r\"");
+		literal = new StringLiteral("\rfoobar\r");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\rfoobar\\r\"");
+		literal = new StringLiteral("\rfoo\rbar\r");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\rfoo\\rbar\\r\"");
+		literal = new StringLiteral("\rfoobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\rfoobar\"");
+	}
+
+	@Test
+	public void testTab() {
+		StringLiteral literal = new StringLiteral("foo\tbar");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\tbar\"");
+		literal = new StringLiteral("foobar\t");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\t\"");
+		literal = new StringLiteral("\tfoobar\t");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\tfoobar\\t\"");
+		literal = new StringLiteral("\tfoo\tbar\t");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\tfoo\\tbar\\t\"");
+		literal = new StringLiteral("\tfoobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\tfoobar\"");
+	}
+
+	@Test
+	public void testBackspace() {
+		StringLiteral literal = new StringLiteral("foo\bbar");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\bbar\"");
+		literal = new StringLiteral("foobar\b");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\b\"");
+		literal = new StringLiteral("\bfoobar\b");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\bfoobar\\b\"");
+		literal = new StringLiteral("\bfoo\bbar\b");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\bfoo\\bbar\\b\"");
+		literal = new StringLiteral("\bfoobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\bfoobar\"");
+	}
+
+	@Test
+	public void testFormFeed() {
+		StringLiteral literal = new StringLiteral("foo\fbar");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\fbar\"");
+		literal = new StringLiteral("foobar\f");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\f\"");
+		literal = new StringLiteral("\ffoobar\f");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\ffoobar\\f\"");
+		literal = new StringLiteral("\ffoo\fbar\f");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\ffoo\\fbar\\f\"");
+		literal = new StringLiteral("\ffoobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\ffoobar\"");
+	}
+
+	@Test
+	public void testSingleQuote() {
+		StringLiteral literal = new StringLiteral("'foobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\'foobar\"");
+		literal = new StringLiteral("foobar'");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\'\"");
+		literal = new StringLiteral("foo'bar");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\'bar\"");
+		literal = new StringLiteral("'foo'bar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\'foo\\'bar\"");
+		literal = new StringLiteral("'foobar'");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\'foobar\\'\"");
+		literal = new StringLiteral("foo'bar'");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\'bar\\'\"");
+		literal = new StringLiteral("'foo'bar'");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\'foo\\'bar\\'\"");
+		literal = new StringLiteral("foobar'''");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\'\\'\\'\"");
+		literal = new StringLiteral("'''foobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\'\\'\\'foobar\"");
+	}
+
+	@Test
+	public void testDoubleQuote() {
+		StringLiteral literal = new StringLiteral("\"foobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\\"foobar\"");
+		literal = new StringLiteral("foobar\"");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\\"\"");
+		literal = new StringLiteral("foo\"bar");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\\"bar\"");
+		literal = new StringLiteral("\"foo\"bar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\\"foo\\\"bar\"");
+		literal = new StringLiteral("\"foobar\"");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\\"foobar\\\"\"");
+		literal = new StringLiteral("foo\"bar\"");
+		assertThat(literal.getQueryString()).isEqualTo("\"foo\\\"bar\\\"\"");
+		literal = new StringLiteral("\"foo\"bar\"");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\\"foo\\\"bar\\\"\"");
+		literal = new StringLiteral("foobar\"\"\"");
+		assertThat(literal.getQueryString()).isEqualTo("\"foobar\\\"\\\"\\\"\"");
+		literal = new StringLiteral("\"\"\"foobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\\"\\\"\\\"foobar\"");
+	}
+
+	@Test
+	public void testCornerCases() {
+		StringLiteral literal = new StringLiteral("\\nfoobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\\\nfoobar\"");
+		literal = new StringLiteral("\\\"foobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\\\\\\"foobar\"");
+		literal = new StringLiteral("\\'foobar");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\\\\\'foobar\"");
+		literal = new StringLiteral("\n\n\t\t\tfoo\\bar\n");
+		assertThat(literal.getQueryString()).isEqualTo("\"\\n\\n\\t\\t\\tfoo\\\\bar\\n\"");
+	}
+
+	@Test
+	public void testBoolean() {
+		RdfLiteral.BooleanLiteral literal = new RdfLiteral.BooleanLiteral(true);
+		assertThat(literal.getQueryString()).isEqualTo("true");
+	}
+
+	@Test
+	public void testNumeric() {
+		RdfLiteral.NumericLiteral literal = new RdfLiteral.NumericLiteral(10);
+		assertThat(literal.getQueryString()).isEqualTo("10");
+		literal = new RdfLiteral.NumericLiteral(10.00001);
+		assertThat(literal.getQueryString()).isEqualTo("10.00001");
+		literal = new RdfLiteral.NumericLiteral(new BigInteger("999999999999999999999999999999999999999999999"));
+		assertThat(literal.getQueryString()).isEqualTo("999999999999999999999999999999999999999999999");
+	}
+
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
@@ -7,12 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
-import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigInteger;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
+import org.junit.Test;
 
 public class RdfLiteralTest {
 


### PR DESCRIPTION
GitHub issue resolved: #1815 

Briefly describe the changes proposed in this PR:

Handles escape sequences, such as `\n`, in string literals as prescribed by the spec
https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#grammarEscapes

Note: codepoint escape sequences are not treated in any special way. Users who want unusual characters in their literals must find a way to get them into the Java String, e.g. by encoding them in Java source code as, e.g. `\u2021`, in which case they will be properly represented in the literal's String representation.
(see https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#codepointEscape )

Fixes #1815 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

