### PR TITLE
GH-3406 affected GH-3439 by adding a queryroot to the parsed TupleExpr

### DIFF
--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.Projection;
 import org.eclipse.rdf4j.query.algebra.ProjectionElem;
 import org.eclipse.rdf4j.query.algebra.ProjectionElemList;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.ValueConstant;
@@ -56,8 +57,9 @@ public class FilterOptimizerTest extends QueryOptimizerTest {
 		Filter spo = new Filter(new StatementPattern(s, p, o), oSmallerThanTwo);
 		Compare o2SmallerThanFour = new Compare(o2, four, CompareOp.LT);
 		Filter spo2 = new Filter(new StatementPattern(s, p, o2), o2SmallerThanFour);
-		TupleExpr expected = new Projection(new Join(spo, spo2), new ProjectionElemList(new ProjectionElem("s"),
-				new ProjectionElem("p"), new ProjectionElem("o"), new ProjectionElem("o2")));
+		TupleExpr expected = new QueryRoot(
+				new Projection(new Join(spo, spo2), new ProjectionElemList(new ProjectionElem("s"),
+						new ProjectionElem("p"), new ProjectionElem("o"), new ProjectionElem("o2"))));
 		String query = "SELECT * WHERE {?s ?p ?o . ?s ?p ?o2  . FILTER(?o > '2'^^xsd:int)  . FILTER(?o2 < '4'^^xsd:int) }";
 
 		testOptimizer(expected, query);
@@ -75,8 +77,9 @@ public class FilterOptimizerTest extends QueryOptimizerTest {
 		Filter spo = new Filter(new StatementPattern(s, p, o), oSmallerThanTwo);
 		Compare o2SmallerThanFour = new Compare(o2, four, CompareOp.LT);
 		Filter spo2 = new Filter(new StatementPattern(s, p, o2), o2SmallerThanFour);
-		TupleExpr expected = new Projection(new Join(spo, spo2), new ProjectionElemList(new ProjectionElem("s"),
-				new ProjectionElem("p"), new ProjectionElem("o"), new ProjectionElem("o2")));
+		TupleExpr expected = new QueryRoot(
+				new Projection(new Join(spo, spo2), new ProjectionElemList(new ProjectionElem("s"),
+						new ProjectionElem("p"), new ProjectionElem("o"), new ProjectionElem("o2"))));
 
 		String query = "SELECT * WHERE {?s ?p ?o . ?s ?p ?o2  . FILTER(?o > '2'^^xsd:int && ?o2 < '4'^^xsd:int) }";
 


### PR DESCRIPTION
GitHub issue resolved: #3439 
Briefly describe the changes proposed in this PR:
#GH-3406 added a QueryRoot to everything parsed. This was not reflected in the test of #3440 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

