### PR TITLE
GH-3473: Fix platform-dependent test failing on Windows

### DIFF
--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryCostEstimatesTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryCostEstimatesTest.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
-import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.junit.Test;
@@ -19,6 +18,8 @@ import org.junit.Test;
  * Tests that cost estimates are printed as part of the plan
  */
 public class QueryCostEstimatesTest {
+
+	private final String LINE_SEP = System.lineSeparator();
 
 	@Test
 	public void testBindingSetAssignmentOptimization() throws RDF4JException {
@@ -31,29 +32,30 @@ public class QueryCostEstimatesTest {
 		QueryJoinOptimizer opt = new QueryJoinOptimizer();
 		opt.optimize(q.getTupleExpr(), null, null);
 
-		assertEquals("QueryRoot\n" +
-				"   Projection\n" +
-				"      ProjectionElemList\n" +
-				"         ProjectionElem \"s\"\n" +
-				"         ProjectionElem \"p\"\n" +
-				"         ProjectionElem \"o\"\n" +
-				"         ProjectionElem \"x\"\n" +
-				"      Join\n" +
-				"         StatementPattern (costEstimate=1, resultSizeEstimate=1)\n" +
-				"            Var (name=_const_5c6ba46_uri, value=ex:s2, anonymous)\n" +
-				"            Var (name=_const_af00e088_uri, value=ex:pred, anonymous)\n" +
-				"            Var (name=_const_17c09_lit_e2eec718_0, value=\"bah\", anonymous)\n" +
-				"         Join\n" +
-				"            StatementPattern (costEstimate=10, resultSizeEstimate=10)\n" +
-				"               Var (name=_const_5c6ba45_uri, value=ex:s1, anonymous)\n" +
-				"               Var (name=_const_af00e088_uri, value=ex:pred, anonymous)\n" +
-				"               Var (name=v)\n" +
-				"            LeftJoin (new scope) (costEstimate=1000, resultSizeEstimate=1000)\n" +
-				"               StatementPattern (resultSizeEstimate=1000)\n" +
-				"                  Var (name=s)\n" +
-				"                  Var (name=p)\n" +
-				"                  Var (name=o)\n" +
-				"               BindingSetAssignment ([[x=ex:a], [x=ex:b], [x=ex:c], [x=ex:d], [x=ex:e], [x=ex:f], [x=ex:g]])\n",
+		assertEquals("QueryRoot" + LINE_SEP +
+				"   Projection" + LINE_SEP +
+				"      ProjectionElemList" + LINE_SEP +
+				"         ProjectionElem \"s\"" + LINE_SEP +
+				"         ProjectionElem \"p\"" + LINE_SEP +
+				"         ProjectionElem \"o\"" + LINE_SEP +
+				"         ProjectionElem \"x\"" + LINE_SEP +
+				"      Join" + LINE_SEP +
+				"         StatementPattern (costEstimate=1, resultSizeEstimate=1)" + LINE_SEP +
+				"            Var (name=_const_5c6ba46_uri, value=ex:s2, anonymous)" + LINE_SEP +
+				"            Var (name=_const_af00e088_uri, value=ex:pred, anonymous)" + LINE_SEP +
+				"            Var (name=_const_17c09_lit_e2eec718_0, value=\"bah\", anonymous)" + LINE_SEP +
+				"         Join" + LINE_SEP +
+				"            StatementPattern (costEstimate=10, resultSizeEstimate=10)" + LINE_SEP +
+				"               Var (name=_const_5c6ba45_uri, value=ex:s1, anonymous)" + LINE_SEP +
+				"               Var (name=_const_af00e088_uri, value=ex:pred, anonymous)" + LINE_SEP +
+				"               Var (name=v)" + LINE_SEP +
+				"            LeftJoin (new scope) (costEstimate=1000, resultSizeEstimate=1000)" + LINE_SEP +
+				"               StatementPattern (resultSizeEstimate=1000)" + LINE_SEP +
+				"                  Var (name=s)" + LINE_SEP +
+				"                  Var (name=p)" + LINE_SEP +
+				"                  Var (name=o)" + LINE_SEP +
+				"               BindingSetAssignment ([[x=ex:a], [x=ex:b], [x=ex:c], [x=ex:d], [x=ex:e], [x=ex:f], [x=ex:g]])"
+				+ LINE_SEP,
 				q.getTupleExpr().toString());
 
 	}


### PR DESCRIPTION
GitHub issue resolved: #3473 

Briefly describe the changes proposed in this PR:

Building `develop` fails on windows. One of the tests is platform-dependent. Fixed by using `System.lineSeparator()` for line endings.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

