### PR TITLE
GH-3479: Fix Rio.parse() calls in console tests

### DIFF
--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
@@ -52,8 +53,9 @@ public class ExportTest extends AbstractCommandTest {
 	public final void testExportAll() throws RepositoryException, IOException {
 		File nq = new File(locationFile, "all.nq");
 		cmd.execute("export", nq.getAbsolutePath());
-		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
-
+		Reader reader = Files.newReader(nq, StandardCharsets.UTF_8);
+		Model exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
+		reader.close();
 		assertTrue(nq.length() > 0, "File is empty");
 		assertEquals(3, exp.contexts().size(), "Number of contexts incorrect");
 
@@ -66,8 +68,9 @@ public class ExportTest extends AbstractCommandTest {
 
 		File nq = new File(locationFile, "all.nq");
 		cmd.execute("export", nq.getName());
-		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
-
+		Reader reader = Files.newReader(nq, StandardCharsets.UTF_8);
+		Model exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
+		reader.close();
 		assertTrue(nq.length() > 0, "File is empty");
 		assertEquals(3, exp.contexts().size(), "Number of contexts incorrect");
 	}
@@ -76,8 +79,9 @@ public class ExportTest extends AbstractCommandTest {
 	public final void testExportContexts() throws RepositoryException, IOException {
 		File nq = new File(locationFile, "default.nq");
 		cmd.execute("export", nq.getAbsolutePath(), "null", "http://example.org/ns/context/resurrection");
-		Model exp = Rio.parse(Files.newReader(nq, StandardCharsets.UTF_8), "http://example.com", RDFFormat.NQUADS);
-
+		Reader reader = Files.newReader(nq, StandardCharsets.UTF_8);
+		Model exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
+		reader.close();
 		assertTrue(nq.length() > 0, "File is empty");
 
 		assertEquals(2, exp.contexts().size(), "Number of contexts incorrect");

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/ExportTest.java
@@ -7,8 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -53,9 +52,11 @@ public class ExportTest extends AbstractCommandTest {
 	public final void testExportAll() throws RepositoryException, IOException {
 		File nq = new File(locationFile, "all.nq");
 		cmd.execute("export", nq.getAbsolutePath());
-		Reader reader = Files.newReader(nq, StandardCharsets.UTF_8);
-		Model exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
-		reader.close();
+		Model exp = null;
+		try (Reader reader = Files.newReader(nq, StandardCharsets.UTF_8)) {
+			exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
+		}
+		assertNotNull(exp);
 		assertTrue(nq.length() > 0, "File is empty");
 		assertEquals(3, exp.contexts().size(), "Number of contexts incorrect");
 
@@ -68,9 +69,11 @@ public class ExportTest extends AbstractCommandTest {
 
 		File nq = new File(locationFile, "all.nq");
 		cmd.execute("export", nq.getName());
-		Reader reader = Files.newReader(nq, StandardCharsets.UTF_8);
-		Model exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
-		reader.close();
+		Model exp = null;
+		try (Reader reader = Files.newReader(nq, StandardCharsets.UTF_8)) {
+			exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
+		}
+		assertNotNull(exp);
 		assertTrue(nq.length() > 0, "File is empty");
 		assertEquals(3, exp.contexts().size(), "Number of contexts incorrect");
 	}
@@ -79,11 +82,12 @@ public class ExportTest extends AbstractCommandTest {
 	public final void testExportContexts() throws RepositoryException, IOException {
 		File nq = new File(locationFile, "default.nq");
 		cmd.execute("export", nq.getAbsolutePath(), "null", "http://example.org/ns/context/resurrection");
-		Reader reader = Files.newReader(nq, StandardCharsets.UTF_8);
-		Model exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
-		reader.close();
+		Model exp = null;
+		try (Reader reader = Files.newReader(nq, StandardCharsets.UTF_8)) {
+			exp = Rio.parse(reader, "http://example.com", RDFFormat.NQUADS);
+		}
+		assertNotNull(exp);
 		assertTrue(nq.length() > 0, "File is empty");
-
 		assertEquals(2, exp.contexts().size(), "Number of contexts incorrect");
 		assertEquals(4, exp.size(), "Number of triples incorrect");
 	}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -10,13 +10,12 @@ package org.eclipse.rdf4j.console.command;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.Reader;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.Model;
@@ -91,8 +90,9 @@ public class SparqlTest extends AbstractCommandTest {
 
 		assertTrue(f.exists(), "File does not exist");
 		assertTrue(f.length() > 0, "Empty file");
-
-		Model m = Rio.parse(new FileReader(f), "", RDFFormat.TURTLE);
+		Reader reader = new FileReader(f);
+		Model m = Rio.parse(reader, "", RDFFormat.TURTLE);
+		reader.close();
 		assertTrue(m.size() > 0, "Empty model");
 	}
 
@@ -107,8 +107,9 @@ public class SparqlTest extends AbstractCommandTest {
 
 		assertTrue(f.exists(), "File does not exist");
 		assertTrue(f.length() > 0, "Empty file");
-
-		Model m = Rio.parse(new FileReader(f), "", RDFFormat.TURTLE);
+		Reader reader = new FileReader(f);
+		Model m = Rio.parse(reader, "", RDFFormat.TURTLE);
+		reader.close();
 		assertTrue(m.size() > 0, "Empty model");
 	}
 

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -7,8 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -90,9 +89,11 @@ public class SparqlTest extends AbstractCommandTest {
 
 		assertTrue(f.exists(), "File does not exist");
 		assertTrue(f.length() > 0, "Empty file");
-		Reader reader = new FileReader(f);
-		Model m = Rio.parse(reader, "", RDFFormat.TURTLE);
-		reader.close();
+		Model m = null;
+		try (Reader reader = new FileReader(f)) {
+			m = Rio.parse(reader, "", RDFFormat.TURTLE);
+		}
+		assertNotNull(m);
 		assertTrue(m.size() > 0, "Empty model");
 	}
 
@@ -107,9 +108,11 @@ public class SparqlTest extends AbstractCommandTest {
 
 		assertTrue(f.exists(), "File does not exist");
 		assertTrue(f.length() > 0, "Empty file");
-		Reader reader = new FileReader(f);
-		Model m = Rio.parse(reader, "", RDFFormat.TURTLE);
-		reader.close();
+		Model m = null;
+		try (Reader reader = new FileReader(f)) {
+			m = Rio.parse(reader, "", RDFFormat.TURTLE);
+		}
+		assertNotNull(m);
 		assertTrue(m.size() > 0, "Empty model");
 	}
 


### PR DESCRIPTION
Rio.parse(Reader, String, RDFFormat) does not close the reader after reading (at least not for TTL), causing tests to fail on Windows. Closing the reader fixes that problem.


GitHub issue resolved: #3479

Briefly describe the changes proposed in this PR:

The reader passed to `Rio.parse()` is closed after the call.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

