### PR TITLE
GH-3476: Pedantically rename maven modules according to guidelines

### DIFF
--- a/assembly-descriptors/pom.xml
+++ b/assembly-descriptors/pom.xml
@@ -7,6 +7,6 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-assembly-descriptors</artifactId>
-	<name>RDF4J Assembly Descriptors</name>
+	<name>RDF4J: Assembly Descriptors</name>
 	<description/>
 </project>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>rdf4j-bom</artifactId>
 	<packaging>pom</packaging>
-	<name>RDF4J BOM</name>
+	<name>RDF4J: BOM</name>
 	<description>RDF4J Bill of Materials (BOM)</description>
 	<dependencyManagement>
 		<dependencies>

--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-elasticsearch-compliance</artifactId>
-	<name>RDF4J Elasticsearch Sail Tests</name>
+	<name>RDF4J: Elasticsearch Sail Tests</name>
 	<description>Tests for Elasticsearch.</description>
 	<!-- disable the Java security manager for elasticsearch tests -->
 	<build>

--- a/compliance/geosparql/pom.xml
+++ b/compliance/geosparql/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-geosparql-compliance</artifactId>
-	<name>RDF4J GeoSPARQL compliance tests</name>
+	<name>RDF4J: GeoSPARQL compliance tests</name>
 	<description>Tests for the GeoSPARQL query language implementation</description>
 	<dependencies>
 		<dependency>

--- a/compliance/lucene/pom.xml
+++ b/compliance/lucene/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-lucene-compliance</artifactId>
-	<name>RDF4J Lucene Sail Tests</name>
+	<name>RDF4J: Lucene Sail Tests</name>
 	<description>Compliance Tests for LuceneSail.</description>
 	<dependencies>
 		<dependency>

--- a/compliance/model/pom.xml
+++ b/compliance/model/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rdf4j-model-compliance</artifactId>
-	<name>RDF4J Model compliance tests</name>
+	<name>RDF4J: Model compliance tests</name>
 	<dependencies>
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>

--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -19,7 +19,7 @@
 		<module>elasticsearch</module>
 		<module>geosparql</module>
 	</modules>
-	<name>RDF4J Compliance tests</name>
+	<name>RDF4J: Compliance tests</name>
 	<description>Eclipse RDF4J compliance and integration tests</description>
 	<dependencyManagement>
 		<dependencies>

--- a/compliance/repository/pom.xml
+++ b/compliance/repository/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>rdf4j-repository-compliance</artifactId>
 	<packaging>war</packaging>
-	<name>RDF4J Repository compliance tests</name>
+	<name>RDF4J: Repository compliance tests</name>
 	<description>Compliance testing for the Repository API implementations</description>
 	<properties>
 		<testserver.webapp.dir>${project.build.directory}/rdf4j-server</testserver.webapp.dir>

--- a/compliance/rio/pom.xml
+++ b/compliance/rio/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-compliance</artifactId>
-	<name>RDF4J Rio compliance tests</name>
+	<name>RDF4J: Rio compliance tests</name>
 	<description>Tests for parsers and writers of various RDF file formats.</description>
 	<dependencies>
 		<dependency>

--- a/compliance/shacl/pom.xml
+++ b/compliance/shacl/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-shacl-compliance</artifactId>
-	<name>RDF4J SHACL compliance tests</name>
+	<name>RDF4J: SHACL compliance tests</name>
 	<description>Tests for the SHACL constraint language implementation</description>
 	<dependencies>
 		<dependency>

--- a/compliance/solr/pom.xml
+++ b/compliance/solr/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-solr-compliance</artifactId>
-	<name>RDF4J Solr Sail Tests</name>
+	<name>RDF4J: Solr Sail Tests</name>
 	<description>Tests for Solr Sail.</description>
 	<properties>
 		<!-- used to set up embedded solr server in integration tests -->

--- a/compliance/sparql/pom.xml
+++ b/compliance/sparql/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>rdf4j-sparql-compliance</artifactId>
 	<packaging>war</packaging>
-	<name>RDF4J SPARQL query parser compliance tests</name>
+	<name>RDF4J: SPARQL query parser compliance tests</name>
 	<description>Tests for the SPARQL query language implementation</description>
 	<properties>
 		<testserver.webapp.dir>${project.build.directory}/rdf4j-server</testserver.webapp.dir>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
 		<module>client</module>
 		<module>storage</module>
 	</modules>
-	<name>RDF4J Core</name>
+	<name>RDF4J: Core</name>
 	<description>Core modules for RDF4J</description>
 	<profiles>
 		<profile>

--- a/core/sail/elasticsearch-store/pom.xml
+++ b/core/sail/elasticsearch-store/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-elasticsearch-store</artifactId>
-	<name>RDF4J Elasticsearch Store</name>
+	<name>RDF4J: Elasticsearch Store</name>
 	<description>Store for utilizing Elasticsearch as a triplestore.</description>
 	<dependencies>
 		<dependency>

--- a/core/sail/elasticsearch/pom.xml
+++ b/core/sail/elasticsearch/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-elasticsearch</artifactId>
-	<name>RDF4J Elastic Search Sail Index</name>
+	<name>RDF4J: Elastic Search Sail Index</name>
 	<description>StackableSail implementation offering full-text search on literals, based on Elastic Search.</description>
 	<dependencies>
 		<dependency>

--- a/core/sail/extensible-store/pom.xml
+++ b/core/sail/extensible-store/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-extensible-store</artifactId>
-	<name>RDF4J Extensible Store</name>
+	<name>RDF4J: Extensible Store</name>
 	<description>Store that can be extended with a simple user-made backend.</description>
 	<dependencies>
 		<dependency>

--- a/core/sail/lucene-api/pom.xml
+++ b/core/sail/lucene-api/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-lucene-api</artifactId>
-	<name>RDF4J Lucene Sail API</name>
+	<name>RDF4J: Lucene Sail API</name>
 	<description>StackableSail API offering full-text search on literals, based on Apache Lucene.</description>
 	<dependencies>
 		<dependency>

--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-lucene</artifactId>
-	<name>RDF4J Lucene Sail Index</name>
+	<name>RDF4J: Lucene Sail Index</name>
 	<description>StackableSail implementation offering full-text search on literals, based on Apache Lucene.</description>
 	<dependencies>
 		<dependency>

--- a/core/sail/solr/pom.xml
+++ b/core/sail/solr/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-solr</artifactId>
-	<name>RDF4J Solr Sail Index</name>
+	<name>RDF4J: Solr Sail Index</name>
 	<description>StackableSail implementation offering full-text search on literals, based on Solr.</description>
 	<dependencies>
 		<dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rdf4j-examples</artifactId>
-	<name>RDF4J code examples</name>
+	<name>RDF4J: Code examples</name>
 	<description>Examples and HowTos for use of RDF4J in Java</description>
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>

--- a/testsuites/geosparql/pom.xml
+++ b/testsuites/geosparql/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-geosparql-testsuite</artifactId>
-	<name>RDF4J GeoSPARQL compliance test suite</name>
+	<name>RDF4J: GeoSPARQL compliance test suite</name>
 	<description>Test suite for the GeoSPARQL query language</description>
 	<dependencies>
 		<dependency>

--- a/testsuites/lucene/pom.xml
+++ b/testsuites/lucene/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-lucene-testsuite</artifactId>
-	<name>RDF4J Lucene Sail Tests</name>
+	<name>RDF4J: Lucene Sail Tests</name>
 	<description>Generic tests for Lucene Sail implementations.</description>
 	<dependencies>
 		<dependency>

--- a/testsuites/pom.xml
+++ b/testsuites/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>rdf4j-testsuites</artifactId>
 	<packaging>pom</packaging>
-	<name>RDF4J : Test Suites</name>
+	<name>RDF4J: Test Suites</name>
 	<description>Test suites for Eclipse RDF4J modules</description>
 	<modules>
 		<module>model</module>

--- a/testsuites/rio/pom.xml
+++ b/testsuites/rio/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-testsuite</artifactId>
-	<name>RDF4J Rio compliance test suite</name>
+	<name>RDF4J: Rio compliance test suite</name>
 	<description>Test suite for Rio</description>
 	<dependencies>
 		<dependency>

--- a/testsuites/shacl/pom.xml
+++ b/testsuites/shacl/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-shacl-testsuite</artifactId>
-	<name>RDF4J SHACL compliance test suite</name>
+	<name>RDF4J: SHACL compliance test suite</name>
 	<description>Test suite for the SHACL Shapes Constraint Language</description>
 	<dependencies>
 		<dependency>

--- a/testsuites/sparql/pom.xml
+++ b/testsuites/sparql/pom.xml
@@ -7,7 +7,7 @@
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sparql-testsuite</artifactId>
-	<name>RDF4J SPARQL compliance test suite</name>
+	<name>RDF4J: SPARQL compliance test suite</name>
 	<description>Test suite for the SPARQL query language</description>
 	<dependencies>
 		<dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>rdf4j-tools</artifactId>
 	<packaging>pom</packaging>
-	<name>RDF4J Tools</name>
+	<name>RDF4J: Tools</name>
 	<description>Server, Workbench, Console and other end-user tools for RDF4J.</description>
 	<modules>
 		<module>config</module>

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>rdf4j-http-workbench</artifactId>
 	<packaging>war</packaging>
-	<name>RDF4J Workbench</name>
+	<name>RDF4J: Workbench</name>
 	<description>Workbench to interact with RDF4J servers.</description>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Renames all module names such that they start with
'RDF4J: '


GitHub issue resolved: #3476

Briefly describe the changes proposed in this PR:

maven modules are renamed so they all start with the same prefix

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

