### PR TITLE
GH-3486 memorystore explicit inferred performance

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatement.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatement.java
@@ -7,13 +7,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory.model;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
 import org.eclipse.rdf4j.model.impl.ContextStatement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A MemStatement is a Statement which contains context information and a flag indicating whether the statement is
  * explicit or inferred.
  */
 public class MemStatement extends ContextStatement {
+
+	private static final Logger logger = LoggerFactory.getLogger(MemStatement.class);
 
 	/*-----------*
 	 * Constants *
@@ -28,7 +35,7 @@ public class MemStatement extends ContextStatement {
 	/**
 	 * Flag indicating whether or not this statement has been added explicitly or that it has been inferred.
 	 */
-	private volatile boolean explicit;
+	private final boolean explicit;
 
 	/**
 	 * Identifies the snapshot in which this statement was introduced.
@@ -59,7 +66,7 @@ public class MemStatement extends ContextStatement {
 	public MemStatement(MemResource subject, MemIRI predicate, MemValue object, MemResource context, boolean explicit,
 			int sinceSnapshot) {
 		super(subject, predicate, object, context);
-		setExplicit(explicit);
+		this.explicit = explicit;
 		setSinceSnapshot(sinceSnapshot);
 	}
 
@@ -107,8 +114,20 @@ public class MemStatement extends ContextStatement {
 		return snapshot >= sinceSnapshot && snapshot < tillSnapshot;
 	}
 
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	public void setExplicit(boolean explicit) {
-		this.explicit = explicit;
+		logger.warn(
+				"The explicit field has been set to final for improved performance. Java reflection will be used " +
+						"to modify it. Take note that the MemorySailStore will not detect this change and may " +
+						"assume that it doesn't have any inferred statements!");
+
+		try {
+			Field explicitField = MemStatement.class.getDeclaredField("explicit");
+			explicitField.setAccessible(true);
+			explicitField.set(this, explicit);
+		} catch (NoSuchFieldException | IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	public boolean isExplicit() {

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/InferredMemStatementTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/InferredMemStatementTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.sail.memory.model.MemStatement;
+import org.junit.Test;
+
+/**
+ * This test class should be removed when we remove
+ * {@link org.eclipse.rdf4j.sail.memory.model.MemStatement#setExplicit(boolean)}
+ */
+@Deprecated(since = "4.0.0", forRemoval = true)
+public class InferredMemStatementTest {
+
+	@Test
+	public void testChangingInferredStatement() {
+		MemoryStore memoryStore = new MemoryStore();
+
+		// add our explicit statement
+		try (MemoryStoreConnection connection = (MemoryStoreConnection) memoryStore.getConnection()) {
+			connection.begin();
+			connection.addStatement(RDF.TYPE, RDF.TYPE, RDF.TYPE);
+			connection.commit();
+		}
+
+		// make the statement inferred
+		try (MemoryStoreConnection connection = (MemoryStoreConnection) memoryStore.getConnection()) {
+			connection.begin();
+			MemStatement statement = connection.getStatements(RDF.TYPE, RDF.TYPE, RDF.TYPE, true)
+					.stream()
+					.map(s -> (MemStatement) s)
+					.findAny()
+					.get();
+
+			assertThat(statement.isExplicit()).isTrue();
+			statement.setExplicit(false);
+			assertThat(statement.isExplicit()).isFalse();
+
+			connection.commit();
+		}
+
+		// we need to add an inferred statement so that the MemorySailStore doesn't assume that the inferred branch is
+		// empty
+		try (MemoryStoreConnection connection = (MemoryStoreConnection) memoryStore.getConnection()) {
+			connection.begin();
+			connection.addInferredStatement(RDF.SUBJECT, RDF.PREDICATE, RDF.OBJECT);
+			connection.commit();
+		}
+
+		// check the statement is still set as inferred
+		try (MemoryStoreConnection connection = (MemoryStoreConnection) memoryStore.getConnection()) {
+			connection.begin();
+
+			Optional<MemStatement> statement = connection.getStatements(RDF.TYPE, RDF.TYPE, RDF.TYPE, true)
+					.stream()
+					.map(s -> (MemStatement) s)
+					.findAny();
+
+			assertThat(statement).isPresent();
+			assertThat(statement.get().isExplicit()).isFalse();
+
+			connection.commit();
+		}
+
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #3486 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - MemorySailStore can optimize read operations against the inferred source when there are no statements. This is done by having a flag that gets set to `true` once inferred statements have been added.
 - The explicit flag in MemStatement is now final and no longer volatile. There were no uses for modifying this flag in our code base, so I've deprecated the setter and modified it to use reflection (so it will still work, but not very well).
 
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

