### PR TITLE
GH-3496 Replace RepositoryUtil.difference by methods of LinkedHashModel.

### DIFF
--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConsistencyIT.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConsistencyIT.java
@@ -133,23 +133,27 @@ public class NativeStoreConsistencyIT {
 		// Step 6: computing the differences of the contents of the indices
 		logger.info("Computing differences of sets...");
 
-		Collection<? extends Statement> differenceA = RepositoryUtil.difference(spocStatements, psocStatements);
-		Collection<? extends Statement> differenceB = RepositoryUtil.difference(psocStatements, spocStatements);
+		if (!spocStatements.equals(psocStatements)) {
+			Model differenceA = new LinkedHashModel(spocStatements);
+			differenceA.removeAll(psocStatements);
+			Model differenceB = new LinkedHashModel(psocStatements);
+			differenceB.removeAll(spocStatements);
 
-		logger.info("Difference SPOC MINUS PSOC: " + differenceA.size());
-		logger.info("Difference PSOC MINUS SPOC: " + differenceB.size());
+			logger.info("Difference SPOC MINUS PSOC: " + differenceA.size());
+			logger.info("Difference PSOC MINUS SPOC: " + differenceB.size());
 
-		logger.info("Different statements in SPOC MINUS PSOC (Mind the contexts):");
-		for (Statement st : differenceA) {
-			logger.error("  * " + st);
+			logger.info("Different statements in SPOC MINUS PSOC (Mind the contexts):");
+			for (Statement st : differenceA) {
+				logger.error("  * " + st);
+			}
+
+			logger.info("Different statements in PSOC MINUS SPOC (Mind the contexts):");
+			for (Statement st : differenceB) {
+				logger.error("  * " + st);
+			}
+
+			assertEquals(0, differenceA.size());
+			assertEquals(0, differenceB.size());
 		}
-
-		logger.info("Different statements in PSOC MINUS SPOC (Mind the contexts):");
-		for (Statement st : differenceB) {
-			logger.error("  * " + st);
-		}
-
-		assertEquals(0, differenceA.size());
-		assertEquals(0, differenceB.size());
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #3496 

Briefly describe the changes proposed in this PR:

Speed up test NativeStoreConsistencyIT by using other methods for computing the difference.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

