### PR TITLE
GH-3498: use method which reports line/column numbers

### DIFF
--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesParser.java
@@ -278,7 +278,7 @@ public class NTriplesParser extends AbstractRDFParser {
 		} else if (lineChars[currentIndex] == '@') {
 			parseLangLiteral(label);
 		} else {
-			object = createLiteral(label, null, null);
+			object = createLiteral(label, null, null, lineNo, lineChars[currentIndex]);
 		}
 	}
 
@@ -308,7 +308,7 @@ public class NTriplesParser extends AbstractRDFParser {
 			reportError("Expected '<', found: " + new String(Character.toChars(lineChars[currentIndex])),
 					NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 		}
-		object = createLiteral(label, null, parseIRI());
+		object = createLiteral(label, null, parseIRI(), lineNo, lineChars[currentIndex]);
 	}
 
 	private void parseLangLiteral(String label) {
@@ -327,7 +327,8 @@ public class NTriplesParser extends AbstractRDFParser {
 		if (currentIndex >= lineChars.length) {
 			throwEOFException();
 		}
-		object = createLiteral(label, new String(lineChars, startIndex, currentIndex - startIndex), null);
+		object = createLiteral(label, new String(lineChars, startIndex, currentIndex - startIndex), null,
+				lineNo, lineChars[currentIndex]);
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #3498 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
- pass line/column number to helper method when checking datatype / language tag
- added test

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

