### PR TITLE
GH-3042 no volatile atomic in iterators that are not threadsafe

### DIFF
--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/DelayedIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/DelayedIteration.java
@@ -22,7 +22,7 @@ public abstract class DelayedIteration<E, X extends Exception> extends AbstractC
 	 * Variables *
 	 *-----------*/
 
-	private volatile Iteration<? extends E, ? extends X> iter;
+	private Iteration<? extends E, ? extends X> iter;
 
 	/*--------------*
 	 * Constructors *
@@ -56,11 +56,9 @@ public abstract class DelayedIteration<E, X extends Exception> extends AbstractC
 		Iteration<? extends E, ? extends X> resultIter = iter;
 		if (resultIter == null) {
 			// Underlying iterator has not yet been initialized
-			synchronized (this) {
-				resultIter = iter;
-				if (resultIter == null) {
-					resultIter = iter = createIteration();
-				}
+			resultIter = iter;
+			if (resultIter == null) {
+				resultIter = iter = createIteration();
 			}
 		}
 
@@ -78,11 +76,9 @@ public abstract class DelayedIteration<E, X extends Exception> extends AbstractC
 		Iteration<? extends E, ? extends X> resultIter = iter;
 		if (resultIter == null) {
 			// Underlying iterator has not yet been initialized
-			synchronized (this) {
-				resultIter = iter;
-				if (resultIter == null) {
-					resultIter = iter = createIteration();
-				}
+			resultIter = iter;
+			if (resultIter == null) {
+				resultIter = iter = createIteration();
 			}
 		}
 

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/FilterIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/FilterIteration.java
@@ -20,7 +20,7 @@ public abstract class FilterIteration<E, X extends Exception> extends IterationW
 	 * Variables *
 	 *-----------*/
 
-	private volatile E nextElement;
+	private E nextElement;
 
 	/*--------------*
 	 * Constructors *

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/IntersectIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/IntersectIteration.java
@@ -28,9 +28,9 @@ public class IntersectIteration<E, X extends Exception> extends FilterIteration<
 
 	private final boolean distinct;
 
-	private volatile boolean initialized;
+	private boolean initialized;
 
-	private volatile Set<E> includeSet;
+	private Set<E> includeSet;
 
 	/*--------------*
 	 * Constructors *
@@ -75,13 +75,9 @@ public class IntersectIteration<E, X extends Exception> extends FilterIteration<
 	@Override
 	protected boolean accept(E object) throws X {
 		if (!initialized) {
-			synchronized (this) {
-				if (!initialized) {
-					// Build set of elements-to-include from second argument
-					includeSet = Iterations.asSet(arg2);
-					initialized = true;
-				}
-			}
+			// Build set of elements-to-include from second argument
+			includeSet = Iterations.asSet(arg2);
+			initialized = true;
 		}
 
 		if (inIncludeSet(object)) {

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/LimitIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/LimitIteration.java
@@ -28,7 +28,7 @@ public class LimitIteration<E, X extends Exception> extends IterationWrapper<E, 
 	/**
 	 * The number of elements that have been returned so far.
 	 */
-	private volatile long returnCount;
+	private long returnCount;
 
 	/*--------------*
 	 * Constructors *

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/MinusIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/MinusIteration.java
@@ -27,9 +27,9 @@ public class MinusIteration<E, X extends Exception> extends FilterIteration<E, X
 
 	private final boolean distinct;
 
-	private volatile boolean initialized;
+	private boolean initialized;
 
-	private volatile Set<E> excludeSet;
+	private Set<E> excludeSet;
 
 	/*--------------*
 	 * Constructors *
@@ -72,13 +72,9 @@ public class MinusIteration<E, X extends Exception> extends FilterIteration<E, X
 	@Override
 	protected boolean accept(E object) throws X {
 		if (!initialized) {
-			synchronized (this) {
-				if (!initialized) {
-					// Build set of elements-to-exclude from right argument
-					excludeSet = Iterations.asSet(rightArg);
-					initialized = true;
-				}
-			}
+			// Build set of elements-to-exclude from right argument
+			excludeSet = Iterations.asSet(rightArg);
+			initialized = true;
 		}
 
 		if (!excludeSet.contains(object)) {

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/SingletonIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/SingletonIteration.java
@@ -9,7 +9,6 @@
 package org.eclipse.rdf4j.common.iteration;
 
 import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * An Iteration that contains exactly one element.
@@ -20,7 +19,7 @@ public class SingletonIteration<E, X extends Exception> extends AbstractCloseabl
 	 * Variables *
 	 *-----------*/
 
-	private final AtomicReference<E> value;
+	private E value;
 
 	/*--------------*
 	 * Constructors *
@@ -30,7 +29,7 @@ public class SingletonIteration<E, X extends Exception> extends AbstractCloseabl
 	 * Creates a new EmptyIteration.
 	 */
 	public SingletonIteration(E value) {
-		this.value = new AtomicReference<>(value);
+		this.value = value;
 	}
 
 	/*---------*
@@ -39,12 +38,13 @@ public class SingletonIteration<E, X extends Exception> extends AbstractCloseabl
 
 	@Override
 	public boolean hasNext() {
-		return value.get() != null;
+		return value != null;
 	}
 
 	@Override
 	public E next() throws X {
-		E result = value.getAndSet(null);
+		E result = value;
+		value = null;
 		if (result == null) {
 			close();
 			throw new NoSuchElementException();
@@ -59,10 +59,6 @@ public class SingletonIteration<E, X extends Exception> extends AbstractCloseabl
 
 	@Override
 	protected void handleClose() throws X {
-		try {
-			super.handleClose();
-		} finally {
-			value.set(null);
-		}
+		value = null;
 	}
 }

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/UnionIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/UnionIteration.java
@@ -72,14 +72,12 @@ public class UnionIteration<E, X extends Exception> extends LookAheadIteration<E
 
 			// Current Iteration exhausted, continue with the next one
 			Iterations.closeCloseable(nextCurrentIter);
-
-			synchronized (this) {
-				if (argIter.hasNext()) {
-					currentIter = argIter.next();
-				} else {
-					// All elements have been returned
-					return null;
-				}
+			
+			if (argIter.hasNext()) {
+				currentIter = argIter.next();
+			} else {
+				// All elements have been returned
+				return null;
 			}
 		}
 	}
@@ -93,13 +91,11 @@ public class UnionIteration<E, X extends Exception> extends LookAheadIteration<E
 		} finally {
 			try {
 				List<Throwable> collectedExceptions = new ArrayList<>();
-				synchronized (this) {
-					while (argIter.hasNext()) {
-						try {
-							Iterations.closeCloseable(argIter.next());
-						} catch (Throwable e) {
-							collectedExceptions.add(e);
-						}
+				while (argIter.hasNext()) {
+					try {
+						Iterations.closeCloseable(argIter.next());
+					} catch (Throwable e) {
+						collectedExceptions.add(e);
 					}
 				}
 				if (!collectedExceptions.isEmpty()) {

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/UnionIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/UnionIteration.java
@@ -26,7 +26,7 @@ public class UnionIteration<E, X extends Exception> extends LookAheadIteration<E
 
 	private final Iterator<? extends Iteration<? extends E, X>> argIter;
 
-	private volatile Iteration<? extends E, X> currentIter;
+	private Iteration<? extends E, X> currentIter;
 
 	/*--------------*
 	 * Constructors *
@@ -72,7 +72,7 @@ public class UnionIteration<E, X extends Exception> extends LookAheadIteration<E
 
 			// Current Iteration exhausted, continue with the next one
 			Iterations.closeCloseable(nextCurrentIter);
-			
+
 			if (argIter.hasNext()) {
 				currentIter = argIter.next();
 			} else {

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iterator/LookAheadIterator.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iterator/LookAheadIterator.java
@@ -20,9 +20,9 @@ public abstract class LookAheadIterator<E> extends AbstractCloseableIterator<E> 
 	 * Variables *
 	 *-----------*/
 
-	private volatile E nextElement;
+	private E nextElement;
 
-	private volatile IOException closeException;
+	private IOException closeException;
 
 	/*--------------*
 	 * Constructors *

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iterator/UnionIterator.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iterator/UnionIterator.java
@@ -23,7 +23,7 @@ public class UnionIterator<E> extends LookAheadIterator<E> {
 
 	private final Iterator<? extends Iterable<? extends E>> argIter;
 
-	private volatile Iterator<? extends E> currentIter;
+	private Iterator<? extends E> currentIter;
 
 	/*--------------*
 	 * Constructors *

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/MutableTupleQueryResult.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/MutableTupleQueryResult.java
@@ -41,13 +41,13 @@ public class MutableTupleQueryResult implements TupleQueryResult, Cloneable {
 	/**
 	 * The index of the next element that will be returned by a call to {@link #next()}.
 	 */
-	private volatile int currentIndex = 0;
+	private int currentIndex = 0;
 
 	/**
 	 * The index of the last element that was returned by a call to {@link #next()} or {@link #previous()}. Equal to -1
 	 * if there is no such element.
 	 */
-	private volatile int lastReturned = -1;
+	private int lastReturned = -1;
 
 	/*--------------*
 	 * Constructors *

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/TupleFunctionFederatedService.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/TupleFunctionFederatedService.java
@@ -45,7 +45,7 @@ public class TupleFunctionFederatedService implements FederatedService {
 
 	private final ValueFactory vf;
 
-	private volatile boolean isInitialized;
+	private boolean isInitialized;
 
 	public TupleFunctionFederatedService(TupleFunctionRegistry tupleFunctionRegistry, ValueFactory vf) {
 		this.tupleFunctionRegistry = tupleFunctionRegistry;


### PR DESCRIPTION
GitHub issue resolved: #3042 

Briefly describe the changes proposed in this PR:

Remove volatile and synchronized in iterators that are inherently not threadsafe.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

