### PR TITLE
GH-3504: use 2.16.0 for ES compliance

### DIFF
--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.15.0</version>
+			<version>2.16.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/core/sail/solr/pom.xml
+++ b/core/sail/solr/pom.xml
@@ -71,8 +71,20 @@
 					<optional>true</optional>
 					<exclusions>
 						<exclusion>
-							<groupId>log4j</groupId>
-							<artifactId>log4j</artifactId>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-core</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-api</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-1.2-api</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>org.apache.logging.log4j</groupId>
+							<artifactId>log4j-sl4j-impl</artifactId>
 						</exclusion>
 						<exclusion>
 							<groupId>jdk.tools</groupId>


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #3504 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- use log4j 2.16.0 for additional hardening <!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

