### PR TITLE
Concurent safe set used for share static in after class

### DIFF
--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclSailSupportedPredicatesDocumentationIT.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclSailSupportedPredicatesDocumentationIT.java
@@ -15,7 +15,7 @@ import java.io.StringReader;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -34,7 +34,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class ShaclSailSupportedPredicatesDocumentationIT extends AbstractShaclTest {
 
-	private static final Set<IRI> STATIC_SHACL_PREDICATES = new ConcurrentSkipListSet<>(
+	private static final Set<IRI> STATIC_SHACL_PREDICATES = new CopyOnWriteArraySet<>(
 			ShaclSail.getSupportedShaclPredicates());
 
 	@AfterAll

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclSailSupportedPredicatesDocumentationIT.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclSailSupportedPredicatesDocumentationIT.java
@@ -15,6 +15,7 @@ import java.io.StringReader;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -33,13 +34,14 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class ShaclSailSupportedPredicatesDocumentationIT extends AbstractShaclTest {
 
-	private static HashSet<IRI> staticShaclPredicates = new HashSet<>(ShaclSail.getSupportedShaclPredicates());
+	private static final Set<IRI> STATIC_SHACL_PREDICATES = new ConcurrentSkipListSet<>(
+			ShaclSail.getSupportedShaclPredicates());
 
 	@AfterAll
 	public static void afterClass() {
 
 		assertTrue("No test uses the following predicate that the ShaclSail announces as supported: "
-				+ Arrays.toString(staticShaclPredicates.toArray()), staticShaclPredicates.isEmpty());
+				+ Arrays.toString(STATIC_SHACL_PREDICATES.toArray()), STATIC_SHACL_PREDICATES.isEmpty());
 	}
 
 	@ParameterizedTest
@@ -60,7 +62,7 @@ public class ShaclSailSupportedPredicatesDocumentationIT extends AbstractShaclTe
 		for (IRI predicate : predicatesInUseInTest) {
 			assertTrue("Predicate used in test but not listed in ShaclSail: " + predicate,
 					shaclPredicates.contains(predicate));
-			staticShaclPredicates.remove(predicate);
+			STATIC_SHACL_PREDICATES.remove(predicate);
 		}
 
 	}


### PR DESCRIPTION
GitHub issue resolved: #3519

Briefly describe the changes proposed in this PR:

Use a concurrent safe set implementation for a field that may be accessed by multiple threads during junit testing.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

