### PR TITLE
GH-3535 pr-verify uses checkout v2

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         jdk: [11, 17]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
GitHub issue resolved: #3533 

Briefly describe the changes proposed in this PR:
bump checkout action to v2

