### PR TITLE
nativerdf use cleaner to close overflowmemory backing store when not used.

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowModel.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowModel.java
@@ -270,26 +270,7 @@ abstract class MemoryOverflowModel extends AbstractModel {
 			dataDir = Files.createTempDirectory("model").toFile();
 			logger.debug("memory overflow using temp directory {}", dataDir);
 			store = createSailStore(dataDir);
-			disk = new SailSourceModel(store) {
-
-				@Override
-				protected void finalize() throws Throwable {
-					logger.debug("finalizing {}", dataDir);
-					if (disk == this) {
-						try {
-							store.close();
-						} catch (SailException e) {
-							logger.error(e.toString(), e);
-						} finally {
-							FileUtil.deleteDir(dataDir);
-							dataDir = null;
-							store = null;
-							disk = null;
-						}
-					}
-					super.finalize();
-				}
-			};
+			disk = new SailSourceModel(store);
 			disk.addAll(memory);
 			memory = new LinkedHashModel(memory.getNamespaces(), LARGE_BLOCK);
 			logger.debug("overflow synced to disk");

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowModel.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowModel.java
@@ -17,7 +17,6 @@ import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
@@ -52,12 +52,18 @@ import org.slf4j.LoggerFactory;
  */
 public class NativeStore extends AbstractNotifyingSail implements FederatedServiceResolverClient {
 
+	private static final Logger logger = LoggerFactory.getLogger(NativeStore.class);
+
+	private static final String VERSION = MavenUtil.loadVersion("org.eclipse.rdf4j", "rdf4j-sail-nativerdf", "devel");
+
+	private static final Cleaner REMOVE_STORES_USED_FOR_MEMORY_OVERFLOW = Cleaner.create();
+
 	/**
 	 * When we are close to running out of memory we start using a native store instead of a model in memory.
 	 * Performance craters to near zero. So it is dubious if this is worth the effort. The class is static to avoid
 	 * taking a pointer which might make it hard to get a phantom reference.
 	 */
-	private final static class MemoryOverflowIntoNativeStore extends MemoryOverflowModel {
+	final static class MemoryOverflowIntoNativeStore extends MemoryOverflowModel {
 		private static final long serialVersionUID = 1L;
 
 		/**
@@ -80,8 +86,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 					try {
 						FileUtils.deleteDirectory(dataDir);
 					} catch (IOException e) {
-						LoggerFactory.getLogger(getClass())
-								.error("Could not remove data dir of overlow model store", e);
+						NativeStore.logger.error("Could not remove data dir of overflow model store", e);
 					}
 				}
 			}
@@ -97,14 +102,6 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 			return nativeSailStore;
 		}
 	}
-
-	private static final Logger logger = LoggerFactory.getLogger(NativeStore.class);
-
-	/*-----------*
-	 * Variables *
-	 *-----------*/
-
-	private static final String VERSION = MavenUtil.loadVersion("org.eclipse.rdf4j", "rdf4j-sail-nativerdf", "devel");
 
 	/**
 	 * Specifies which triple indexes this native store must use.
@@ -161,7 +158,6 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 	 */
 	private final LockManager disabledIsolationLockManager = new LockManager(debugEnabled());
 
-	private static final Cleaner REMOVE_STORES_USED_FOR_MEMORY_OVERFLOW = Cleaner.create();
 	/*--------------*
 	 * Constructors *
 	 *--------------*/

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowToDiskTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowToDiskTest.java
@@ -17,11 +17,13 @@ import java.nio.file.Files;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.sail.base.SailStore;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class MemoryOverflowToDiskTest {
 
 	@Test
-	public void testCleaner() throws IOException, InterruptedException {
+	@Timeout(5)
+	public void testCleanerRemovesTempDirWhenMemoryOverflowModelGetsGCed() throws IOException, InterruptedException {
 		File file = Files.createTempDirectory("model").toFile();
 
 		Model model = createModel(file);
@@ -32,7 +34,6 @@ public class MemoryOverflowToDiskTest {
 		while (file.exists()) {
 			System.gc();
 			Thread.sleep(10);
-			System.out.println();
 		}
 
 		assertFalse(file.exists());

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowToDiskTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/MemoryOverflowToDiskTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.sail.base.SailStore;
+import org.junit.jupiter.api.Test;
+
+public class MemoryOverflowToDiskTest {
+
+	@Test
+	public void testCleaner() throws IOException, InterruptedException {
+		File file = Files.createTempDirectory("model").toFile();
+
+		Model model = createModel(file);
+		assertTrue(file.exists());
+		model = null;
+
+		System.gc();
+		while (file.exists()) {
+			System.gc();
+			Thread.sleep(10);
+			System.out.println();
+		}
+
+		assertFalse(file.exists());
+
+	}
+
+	private Model createModel(File file) throws IOException {
+		NativeStore.MemoryOverflowIntoNativeStore model = new NativeStore.MemoryOverflowIntoNativeStore();
+		SailStore sailStore = model.createSailStore(file);
+		assertNotNull(sailStore);
+		assertNotNull(model);
+		assertEquals(0, model.size());
+		return model;
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #3541

Briefly describe the changes proposed in this PR:

Similar to #3540 but now for native store, doesn't use a shutdown hook so might be better/cleaner.

@kenwenzel I now see where the code came from. Still would like your opinion though :)

This can not be backported to the 3 series as requires java11
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

