### PR TITLE
GH-3543 deprecate like from serql

### DIFF
--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Like.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Like.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.algebra;
 /**
  * Compares the string representation of a value expression to a pattern.
  */
+@Deprecated(forRemoval = true)
 public class Like extends UnaryValueOperator {
 
 	/*-----------*

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelVisitor.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelVisitor.java
@@ -104,6 +104,7 @@ public interface QueryModelVisitor<X extends Exception> {
 
 	void meet(LeftJoin node) throws X;
 
+	@Deprecated(forRemoval = true)
 	void meet(Like node) throws X;
 
 	void meet(Load load) throws X;

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/AbstractQueryModelVisitor.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/AbstractQueryModelVisitor.java
@@ -326,8 +326,9 @@ public abstract class AbstractQueryModelVisitor<X extends Exception> implements 
 	}
 
 	@Override
+	@Deprecated(forRemoval = true)
 	public void meet(Like node) throws X {
-		meetUnaryValueOperator(node);
+		// From SERQL should not be seen
 	}
 
 	@Override

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SparqlValueExprRenderer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SparqlValueExprRenderer.java
@@ -28,7 +28,6 @@ import org.eclipse.rdf4j.query.algebra.IsURI;
 import org.eclipse.rdf4j.query.algebra.Label;
 import org.eclipse.rdf4j.query.algebra.Lang;
 import org.eclipse.rdf4j.query.algebra.LangMatches;
-import org.eclipse.rdf4j.query.algebra.Like;
 import org.eclipse.rdf4j.query.algebra.LocalName;
 import org.eclipse.rdf4j.query.algebra.MathExpr;
 import org.eclipse.rdf4j.query.algebra.Max;
@@ -377,18 +376,6 @@ final class SparqlValueExprRenderer extends AbstractQueryModelVisitor<Exception>
 	@Override
 	public void meet(Lang theOp) throws Exception {
 		unaryMeet("lang", theOp);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void meet(Like theOp) throws Exception {
-		theOp.getArg().visit(this);
-		mBuffer.append(" like \"").append(theOp.getPattern()).append("\"");
-		if (!theOp.isCaseSensitive()) {
-			mBuffer.append(" ignore case");
-		}
 	}
 
 	/**

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/ParsedQueryPreprocessor.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/ParsedQueryPreprocessor.java
@@ -604,11 +604,6 @@ class ParsedQueryPreprocessor extends AbstractQueryModelVisitor<RuntimeException
 	}
 
 	@Override
-	public void meet(Like node) throws RuntimeException {
-		super.meet(node);
-	}
-
-	@Override
 	public void meet(Load load) throws RuntimeException {
 		super.meet(load);
 	}

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/PreprocessedQuerySerializer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/PreprocessedQuerySerializer.java
@@ -830,12 +830,6 @@ class PreprocessedQuerySerializer extends AbstractQueryModelVisitor<RuntimeExcep
 	}
 
 	@Override
-	public void meet(Like node) throws RuntimeException {
-		super.meet(node);
-
-	}
-
-	@Override
 	public void meet(ListMemberOperator node) throws RuntimeException {
 		Iterator<ValueExpr> argIter = node.getArguments().iterator();
 		ValueExpr operand = argIter.next();


### PR DESCRIPTION
GitHub issue resolved: #3543 

Briefly describe the changes proposed in this PR:

Marks the Like code as deprecated for removal.

Alternatively we can just remove the class 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

