### PR TITLE
GH-3483: refactor federation execution to use a per-query strategy

### DIFF
--- a/site/content/release-notes/4.0.0.md
+++ b/site/content/release-notes/4.0.0.md
@@ -210,6 +210,7 @@ Removed support for defining `sparqlEvaluationStrategy` and `sailEvaluationStrat
 
 Use `FedXFactory#withFederationEvaluationStrategyFactory` instead to supply a `FederationEvaluationStrategyFactory`.
 
+Removed support for defining the `writeStrategyFactory` through `FedXConfig`. Use `FedXFactory#withWriteStrategyFactory` instead.
 
 ## Acknowledgements
 

--- a/site/content/release-notes/4.0.0.md
+++ b/site/content/release-notes/4.0.0.md
@@ -204,6 +204,13 @@ that use their own implementations of the `IRI` interface will need to verify
 and possibly adjust their `hashCode()` and `equals()` implementation to conform
 to this.
 
+### Refined extension points for evaluation strategies in federation
+
+Removed support for defining `sparqlEvaluationStrategy` and `sailEvaluationStrategy` using `FedXConfig`.
+
+Use `FedXFactory#withFederationEvaluationStrategyFactory` instead to supply a `FederationEvaluationStrategyFactory`.
+
+
 ## Acknowledgements
 
 This release was made possible by contributions from Andreas Schwarte, Florian

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.endpoint.ResolvableEndpoint;
+import org.eclipse.rdf4j.federated.evaluation.FederationEvaluationStrategyFactory;
 import org.eclipse.rdf4j.federated.exception.ExceptionUtil;
 import org.eclipse.rdf4j.federated.exception.FedXException;
 import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
@@ -53,6 +54,8 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 
 	private RepositoryResolver repositoryResolver;
 
+	private FederationEvaluationStrategyFactory strategyFactory;
+
 	private File dataDir;
 
 	public FedX(List<Endpoint> endpoints) {
@@ -64,6 +67,23 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 
 	public void setFederationContext(FederationContext federationContext) {
 		this.federationContext = federationContext;
+	}
+
+	/**
+	 * Note: consumers must obtain the instance through
+	 * {@link FederationManager#getFederationEvaluationStrategyFactory()}
+	 * 
+	 * @return the {@link FederationEvaluationStrategyFactory}
+	 */
+	/* package */ FederationEvaluationStrategyFactory getFederationEvaluationStrategyFactory() {
+		if (strategyFactory == null) {
+			strategyFactory = new FederationEvaluationStrategyFactory();
+		}
+		return strategyFactory;
+	}
+
+	public void setFederationEvaluationStrategy(FederationEvaluationStrategyFactory strategyFactory) {
+		this.strategyFactory = strategyFactory;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedX.java
@@ -33,9 +33,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * FedX serves as implementation of the federation layer. It implements Sesame's Sail interface and can thus be used as
- * a normal repository in a Sesame environment. The federation layer enables transparent access to the underlying
- * members as if they were a central repository.
+ * FedX serves as implementation of the federation layer. It implements RDF4J's Sail interface and can thus be used as a
+ * normal repository in a RDF4J environment. The federation layer enables transparent access to the underlying members
+ * as if they were a central repository.
  * <p>
  *
  * For initialization of the federation and usage see {@link FederationManager}.
@@ -105,6 +105,7 @@ public class FedX extends AbstractSail implements RepositoryResolverClient {
 		try {
 			return federationContext.getConfig()
 					.getWriteStrategyFactory()
+					.getDeclaredConstructor()
 					.newInstance()
 					.create(members, federationContext);
 		} catch (Exception e) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -11,11 +11,9 @@ import java.util.Optional;
 
 import org.eclipse.rdf4j.federated.cache.SourceSelectionCache;
 import org.eclipse.rdf4j.federated.cache.SourceSelectionMemoryCache;
-import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
-import org.eclipse.rdf4j.federated.evaluation.SailFederationEvalStrategy;
-import org.eclipse.rdf4j.federated.evaluation.SparqlFederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.TaskWrapper;
+import org.eclipse.rdf4j.federated.evaluation.iterator.ConsumingIteration;
 import org.eclipse.rdf4j.federated.monitoring.QueryLog;
 import org.eclipse.rdf4j.federated.monitoring.QueryPlanLog;
 import org.eclipse.rdf4j.federated.write.DefaultWriteStrategyFactory;
@@ -58,10 +56,6 @@ public class FedXConfig {
 
 	private String sourceSelectionCacheSpec = null;
 
-	private Class<? extends FederationEvalStrategy> sailEvaluationStrategy = SailFederationEvalStrategy.class;
-
-	private Class<? extends FederationEvalStrategy> sparqlEvaluationStrategy = SparqlFederationEvalStrategy.class;
-
 	private Class<? extends WriteStrategyFactory> writeStrategyFactory = DefaultWriteStrategyFactory.class;
 
 	private TaskWrapper taskWrapper = null;
@@ -99,36 +93,6 @@ public class FedXConfig {
 	 */
 	public FedXConfig withLogQueries(boolean flag) {
 		this.isLogQueries = flag;
-		return this;
-	}
-
-	/**
-	 * Set the {@link FederationEvalStrategy} for SPARQL federations. See {@link #getSPARQLEvaluationStrategy()}.
-	 *
-	 * <p>
-	 * Can only be set before federation initialization.
-	 * </p>
-	 *
-	 * @param sparqlEvaluationStrategy
-	 * @return the current config
-	 */
-	public FedXConfig withSparqlEvaluationStrategy(Class<? extends FederationEvalStrategy> sparqlEvaluationStrategy) {
-		this.sparqlEvaluationStrategy = sparqlEvaluationStrategy;
-		return this;
-	}
-
-	/**
-	 * Set the {@link FederationEvalStrategy} for SAIL federations. See {@link #getSailEvaluationStrategy()}.
-	 *
-	 * <p>
-	 * Can only be set before federation initialization.
-	 * </p>
-	 *
-	 * @param sailEvaluationStrategy
-	 * @return the current config
-	 */
-	public FedXConfig withSailEvaluationStrategy(Class<? extends FederationEvalStrategy> sailEvaluationStrategy) {
-		this.sailEvaluationStrategy = sailEvaluationStrategy;
 		return this;
 	}
 
@@ -450,32 +414,6 @@ public class FedXConfig {
 	 */
 	public String getSourceSelectionCacheSpec() {
 		return this.sourceSelectionCacheSpec;
-	}
-
-	/**
-	 * Returns the class of the {@link FederationEvalStrategy} implementation that is used in the case of SAIL
-	 * implementations, e.g. for native stores.
-	 * <p>
-	 * Default {@link SailFederationEvalStrategy}
-	 * </p>
-	 *
-	 * @return the evaluation strategy class
-	 */
-	public Class<? extends FederationEvalStrategy> getSailEvaluationStrategy() {
-		return sailEvaluationStrategy;
-	}
-
-	/**
-	 * Returns the class of the {@link FederationEvalStrategy} implementation that is used in the case of SPARQL
-	 * implementations, e.g. SPARQL repository or remote repository.
-	 * <p>
-	 * Default {@link SparqlFederationEvalStrategy}
-	 * </p>
-	 *
-	 * @return the evaluation strategy class
-	 */
-	public Class<? extends FederationEvalStrategy> getSPARQLEvaluationStrategy() {
-		return sparqlEvaluationStrategy;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConfig.java
@@ -16,8 +16,6 @@ import org.eclipse.rdf4j.federated.evaluation.concurrent.TaskWrapper;
 import org.eclipse.rdf4j.federated.evaluation.iterator.ConsumingIteration;
 import org.eclipse.rdf4j.federated.monitoring.QueryLog;
 import org.eclipse.rdf4j.federated.monitoring.QueryPlanLog;
-import org.eclipse.rdf4j.federated.write.DefaultWriteStrategyFactory;
-import org.eclipse.rdf4j.federated.write.WriteStrategyFactory;
 import org.eclipse.rdf4j.query.Operation;
 import org.eclipse.rdf4j.query.Query;
 
@@ -56,8 +54,6 @@ public class FedXConfig {
 
 	private String sourceSelectionCacheSpec = null;
 
-	private Class<? extends WriteStrategyFactory> writeStrategyFactory = DefaultWriteStrategyFactory.class;
-
 	private TaskWrapper taskWrapper = null;
 
 	private String prefixDeclarations = null;
@@ -93,17 +89,6 @@ public class FedXConfig {
 	 */
 	public FedXConfig withLogQueries(boolean flag) {
 		this.isLogQueries = flag;
-		return this;
-	}
-
-	/**
-	 * Set the {@link WriteStrategyFactory} to be used.
-	 *
-	 * @param writeStrategyFactory
-	 * @return the current config
-	 */
-	public FedXConfig withWriteStrategyFactory(Class<? extends WriteStrategyFactory> writeStrategyFactory) {
-		this.writeStrategyFactory = writeStrategyFactory;
 		return this;
 	}
 
@@ -414,19 +399,6 @@ public class FedXConfig {
 	 */
 	public String getSourceSelectionCacheSpec() {
 		return this.sourceSelectionCacheSpec;
-	}
-
-	/**
-	 * Returns the class of the {@link WriteStrategyFactory} implementation.
-	 *
-	 * <p>
-	 * Default: {@link DefaultWriteStrategyFactory}
-	 * </p>
-	 *
-	 * @return the {@link WriteStrategyFactory} class
-	 */
-	public Class<? extends WriteStrategyFactory> getWriteStrategyFactory() {
-		return writeStrategyFactory;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -103,7 +103,7 @@ public class FedXConnection extends AbstractSailConnection {
 
 		final TupleExpr _orgQuery = query;
 
-		FederationEvalStrategy strategy = federationContext.createStrategy();
+		FederationEvalStrategy strategy = federationContext.createStrategy(dataset);
 
 		long start = 0;
 		QueryInfo queryInfo = null;
@@ -229,7 +229,7 @@ public class FedXConnection extends AbstractSailConnection {
 	@Override
 	protected CloseableIteration<? extends Resource, SailException> getContextIDsInternal() throws SailException {
 
-		FederationEvalStrategy strategy = federationContext.createStrategy();
+		FederationEvalStrategy strategy = federationContext.createStrategy(new SimpleDataset());
 		final WorkerUnionBase<Resource> union = new SynchronousWorkerUnion<>(
 				new QueryInfo("getContextIDsInternal", null, QueryType.UNKNOWN, 0,
 						federationContext.getConfig().getIncludeInferredDefault(), federationContext, strategy,
@@ -291,9 +291,10 @@ public class FedXConnection extends AbstractSailConnection {
 			final Resource... contexts) throws SailException {
 
 		try {
-			FederationEvalStrategy strategy = federationContext.createStrategy();
+			Dataset dataset = new SimpleDataset();
+			FederationEvalStrategy strategy = federationContext.createStrategy(dataset);
 			QueryInfo queryInfo = new QueryInfo(subj, pred, obj, 0, includeInferred, federationContext, strategy,
-					new SimpleDataset());
+					dataset);
 			federationContext.getMonitoringService().monitorQuery(queryInfo);
 			CloseableIteration<Statement, QueryEvaluationException> res = strategy.getStatements(queryInfo, subj, pred,
 					obj, contexts);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXConnection.java
@@ -103,7 +103,7 @@ public class FedXConnection extends AbstractSailConnection {
 
 		final TupleExpr _orgQuery = query;
 
-		FederationEvalStrategy strategy = federationContext.getStrategy();
+		FederationEvalStrategy strategy = federationContext.createStrategy();
 
 		long start = 0;
 		QueryInfo queryInfo = null;
@@ -113,7 +113,7 @@ public class FedXConnection extends AbstractSailConnection {
 				log.warn("Query string is null. Please check your FedX setup.");
 			}
 			queryInfo = new QueryInfo(queryString, getOriginalBaseURI(bindings), getOriginalQueryType(bindings),
-					getOriginalMaxExecutionTime(bindings), includeInferred, federationContext, dataset);
+					getOriginalMaxExecutionTime(bindings), includeInferred, federationContext, strategy, dataset);
 
 			// check if we have pass-through result handler information for single source queries
 			if (query instanceof PassThroughTupleExpr) {
@@ -229,10 +229,10 @@ public class FedXConnection extends AbstractSailConnection {
 	@Override
 	protected CloseableIteration<? extends Resource, SailException> getContextIDsInternal() throws SailException {
 
-		FederationEvalStrategy strategy = federationContext.getStrategy();
-		final WorkerUnionBase<Resource> union = new SynchronousWorkerUnion<>(strategy,
+		FederationEvalStrategy strategy = federationContext.createStrategy();
+		final WorkerUnionBase<Resource> union = new SynchronousWorkerUnion<>(
 				new QueryInfo("getContextIDsInternal", null, QueryType.UNKNOWN, 0,
-						federationContext.getConfig().getIncludeInferredDefault(), federationContext,
+						federationContext.getConfig().getIncludeInferredDefault(), federationContext, strategy,
 						new SimpleDataset()));
 
 		for (final Endpoint e : federation.getMembers()) {
@@ -291,8 +291,8 @@ public class FedXConnection extends AbstractSailConnection {
 			final Resource... contexts) throws SailException {
 
 		try {
-			FederationEvalStrategy strategy = federationContext.getStrategy();
-			QueryInfo queryInfo = new QueryInfo(subj, pred, obj, includeInferred, federationContext,
+			FederationEvalStrategy strategy = federationContext.createStrategy();
+			QueryInfo queryInfo = new QueryInfo(subj, pred, obj, 0, includeInferred, federationContext, strategy,
 					new SimpleDataset());
 			federationContext.getMonitoringService().monitorQuery(queryInfo);
 			CloseableIteration<Statement, QueryEvaluationException> res = strategy.getStatements(queryInfo, subj, pred,

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.federated.endpoint.EndpointFactory;
 import org.eclipse.rdf4j.federated.endpoint.provider.NativeRepositoryInformation;
 import org.eclipse.rdf4j.federated.endpoint.provider.ResolvableRepositoryInformation;
 import org.eclipse.rdf4j.federated.endpoint.provider.SPARQLRepositoryInformation;
+import org.eclipse.rdf4j.federated.evaluation.FederationEvaluationStrategyFactory;
 import org.eclipse.rdf4j.federated.exception.FedXException;
 import org.eclipse.rdf4j.federated.repository.FedXRepository;
 import org.eclipse.rdf4j.model.Model;
@@ -98,6 +99,7 @@ public class FedXFactory {
 
 	protected RepositoryResolver repositoryResolver;
 	protected FederatedServiceResolver federatedServiceResolver;
+	protected FederationEvaluationStrategyFactory strategyFactory;
 	protected List<Endpoint> members = new ArrayList<>();
 	protected FedXConfig config = FedXConfig.DEFAULT_CONFIG;
 	protected File fedxBaseDir;
@@ -113,6 +115,11 @@ public class FedXFactory {
 
 	public FedXFactory withFederatedServiceResolver(FederatedServiceResolver federatedServiceResolver) {
 		this.federatedServiceResolver = federatedServiceResolver;
+		return this;
+	}
+
+	public FedXFactory withFederationEvaluationStrategyFactory(FederationEvaluationStrategyFactory strategyFactory) {
+		this.strategyFactory = strategyFactory;
 		return this;
 	}
 
@@ -192,6 +199,10 @@ public class FedXFactory {
 		}
 
 		FedX federation = new FedX(members);
+		if (this.strategyFactory != null) {
+			federation.setFederationEvaluationStrategy(strategyFactory);
+		}
+
 		FedXRepository repo = new FedXRepository(federation, this.config);
 		if (this.repositoryResolver != null) {
 			repo.setRepositoryResolver(repositoryResolver);
@@ -202,6 +213,7 @@ public class FedXFactory {
 		if (this.fedxBaseDir != null) {
 			repo.setDataDir(fedxBaseDir);
 		}
+
 		return repo;
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FedXFactory.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.federated.endpoint.provider.SPARQLRepositoryInformation
 import org.eclipse.rdf4j.federated.evaluation.FederationEvaluationStrategyFactory;
 import org.eclipse.rdf4j.federated.exception.FedXException;
 import org.eclipse.rdf4j.federated.repository.FedXRepository;
+import org.eclipse.rdf4j.federated.write.DefaultWriteStrategyFactory;
+import org.eclipse.rdf4j.federated.write.WriteStrategyFactory;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.repository.RepositoryResolver;
@@ -100,6 +102,7 @@ public class FedXFactory {
 	protected RepositoryResolver repositoryResolver;
 	protected FederatedServiceResolver federatedServiceResolver;
 	protected FederationEvaluationStrategyFactory strategyFactory;
+	protected WriteStrategyFactory writeStrategyFactory;
 	protected List<Endpoint> members = new ArrayList<>();
 	protected FedXConfig config = FedXConfig.DEFAULT_CONFIG;
 	protected File fedxBaseDir;
@@ -120,6 +123,18 @@ public class FedXFactory {
 
 	public FedXFactory withFederationEvaluationStrategyFactory(FederationEvaluationStrategyFactory strategyFactory) {
 		this.strategyFactory = strategyFactory;
+		return this;
+	}
+
+	/**
+	 * Specify the {@link WriteStrategyFactory} to be used. If not explicitly set, {@link DefaultWriteStrategyFactory}
+	 * is used.
+	 * 
+	 * @param writeStrategyFactory the {@link WriteStrategyFactory} to be used.
+	 * @return this factory
+	 */
+	public FedXFactory withWriteStrategyFactory(WriteStrategyFactory writeStrategyFactory) {
+		this.writeStrategyFactory = writeStrategyFactory;
 		return this;
 	}
 
@@ -201,6 +216,9 @@ public class FedXFactory {
 		FedX federation = new FedX(members);
 		if (this.strategyFactory != null) {
 			federation.setFederationEvaluationStrategy(strategyFactory);
+		}
+		if (this.writeStrategyFactory != null) {
+			federation.setWriteStrategyFactory(writeStrategyFactory);
 		}
 
 		FedXRepository repo = new FedXRepository(federation, this.config);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationContext.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationContext.java
@@ -59,10 +59,6 @@ public class FederationContext {
 		return this.endpointManager;
 	}
 
-	public FederationEvalStrategy getStrategy() {
-		return manager.getStrategy();
-	}
-
 	public Monitoring getMonitoringService() {
 		return this.monitoring;
 	}
@@ -73,5 +69,13 @@ public class FederationContext {
 
 	public FedXConfig getConfig() {
 		return this.fedXConfig;
+	}
+
+	/**
+	 * Create a fresh {@link FederationEvalStrategy} using information from this federation context.
+	 */
+	public FederationEvalStrategy createStrategy() {
+		// TODO this needs to be changed in a next step to use a factory
+		return manager.getStrategy();
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationManager.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationManager.java
@@ -77,7 +77,6 @@ public class FederationManager {
 	private FederationContext federationContext;
 	private FedX federation;
 	private ExecutorService executor;
-	private FederationEvaluationStrategyFactory strategyFactory;
 	private FederationType federationType;
 	private ControlledWorkerScheduler<BindingSet> joinScheduler;
 	private ControlledWorkerScheduler<BindingSet> leftJoinScheduler;
@@ -101,16 +100,10 @@ public class FederationManager {
 	 * @return the initialized and configured {@link FederationEvaluationStrategyFactory}
 	 */
 	/* package */ FederationEvaluationStrategyFactory getFederationEvaluationStrategyFactory() {
-		if (strategyFactory == null) {
-			strategyFactory = new FederationEvaluationStrategyFactory();
-		}
+		FederationEvaluationStrategyFactory strategyFactory = new FederationEvaluationStrategyFactory();
 		strategyFactory.setFederationType(federationType);
 		strategyFactory.setFederationContext(federationContext);
 		return strategyFactory;
-	}
-
-	public void setFederationEvaluationStrategy(FederationEvaluationStrategyFactory strategyFactory) {
-		this.strategyFactory = strategyFactory;
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationManager.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationManager.java
@@ -150,7 +150,8 @@ public class FederationManager {
 		return this.federation;
 	}
 
-	public FederationEvalStrategy getStrategy() {
+	/* package */ FederationEvalStrategy getStrategy() {
+		// TODO this method will be removed once the instantiation is changed to use a factory
 		return strategy;
 	}
 
@@ -308,11 +309,10 @@ public class FederationManager {
 	 * @see SynchronousWorkerUnion
 	 */
 	public WorkerUnionBase<BindingSet> createWorkerUnion(QueryInfo queryInfo) {
-		FederationEvalStrategy strategy = getStrategy();
 		if (type == FederationType.LOCAL) {
-			return new SynchronousWorkerUnion<>(strategy, queryInfo);
+			return new SynchronousWorkerUnion<>(queryInfo);
 		}
-		return new ControlledWorkerUnion<>(strategy, unionScheduler, queryInfo);
+		return new ControlledWorkerUnion<>(unionScheduler, queryInfo);
 
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/QueryManager.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/QueryManager.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
+import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.FederationEvaluationStatistics;
 import org.eclipse.rdf4j.federated.exception.FedXException;
 import org.eclipse.rdf4j.federated.exception.FedXRuntimeException;
@@ -301,15 +302,17 @@ public class QueryManager {
 		if (!(query instanceof ParsedQuery)) {
 			throw new MalformedQueryException("Not a ParsedQuery: " + query.getClass());
 		}
+		FederationEvalStrategy strategy = federationContext.createStrategy();
 		// we use a dummy query info object here
-		QueryInfo qInfo = new QueryInfo(queryString, QueryType.SELECT,
-				federationContext.getConfig().getIncludeInferredDefault(), federationContext,
+		QueryInfo qInfo = new QueryInfo(queryString, null, QueryType.SELECT,
+				federationContext.getConfig().getEnforceMaxQueryTime(),
+				federationContext.getConfig().getIncludeInferredDefault(), federationContext, strategy,
 				((ParsedQuery) query).getDataset());
 		TupleExpr tupleExpr = ((ParsedQuery) query).getTupleExpr();
 		try {
 			FederationEvaluationStatistics evaluationStatistics = new FederationEvaluationStatistics(qInfo,
 					new SimpleDataset());
-			tupleExpr = federationContext.getStrategy()
+			tupleExpr = strategy
 					.optimize(tupleExpr, evaluationStatistics, EmptyBindingSet.getInstance());
 			return tupleExpr.toString();
 		} catch (SailException e) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/QueryManager.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/QueryManager.java
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.federated.repository.FedXRepository;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.federated.structures.QueryType;
 import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.Query;
@@ -302,12 +303,13 @@ public class QueryManager {
 		if (!(query instanceof ParsedQuery)) {
 			throw new MalformedQueryException("Not a ParsedQuery: " + query.getClass());
 		}
-		FederationEvalStrategy strategy = federationContext.createStrategy();
+		Dataset dataset = ((ParsedQuery) query).getDataset();
+		FederationEvalStrategy strategy = federationContext.createStrategy(dataset);
 		// we use a dummy query info object here
 		QueryInfo qInfo = new QueryInfo(queryString, null, QueryType.SELECT,
 				federationContext.getConfig().getEnforceMaxQueryTime(),
 				federationContext.getConfig().getIncludeInferredDefault(), federationContext, strategy,
-				((ParsedQuery) query).getDataset());
+				dataset);
 		TupleExpr tupleExpr = ((ParsedQuery) query).getTupleExpr();
 		try {
 			FederationEvaluationStatistics evaluationStatistics = new FederationEvaluationStatistics(qInfo,

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveGroup.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveGroup.java
@@ -16,7 +16,6 @@ import java.util.Set;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
-import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -52,8 +51,6 @@ public class ExclusiveGroup extends AbstractQueryModelNode
 	// additional bindings
 	protected transient Endpoint ownedEndpoint = null;
 
-	private final FederationEvalStrategy strategy;
-
 	public ExclusiveGroup(Collection<? extends ExclusiveTupleExpr> ownedNodes, StatementSource owner,
 			QueryInfo queryInfo) {
 		owned.addAll(ownedNodes);
@@ -62,8 +59,6 @@ public class ExclusiveGroup extends AbstractQueryModelNode
 		this.id = NodeFactory.getNextId();
 		this.queryInfo = queryInfo;
 		ownedEndpoint = queryInfo.getFederationContext().getEndpointManager().getEndpoint(owner.getEndpointID());
-
-		strategy = queryInfo.getFederationContext().getStrategy();
 
 		ownedNodes.forEach(node -> node.setParentNode(this));
 	}
@@ -167,7 +162,7 @@ public class ExclusiveGroup extends AbstractQueryModelNode
 
 		try {
 			// use the particular evaluation strategy for evaluation
-			return strategy.evaluateExclusiveGroup(this, bindings);
+			return queryInfo.getStrategy().evaluateExclusiveGroup(this, bindings);
 		} catch (RepositoryException | MalformedQueryException e) {
 			throw new QueryEvaluationException(e);
 		}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -461,7 +461,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 		}
 
 		// TODO why not collect in parallel?
-		WorkerUnionBase<Statement> union = new SynchronousWorkerUnion<>(this, queryInfo);
+		WorkerUnionBase<Statement> union = new SynchronousWorkerUnion<>(queryInfo);
 
 		for (StatementSource source : sources) {
 			Endpoint e = federationContext.getEndpointManager().getEndpoint(source.getEndpointID());
@@ -619,7 +619,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 			throws QueryEvaluationException {
 
 		ControlledWorkerScheduler<BindingSet> unionScheduler = federationContext.getManager().getUnionScheduler();
-		ControlledWorkerUnion<BindingSet> unionRunnable = new ControlledWorkerUnion<>(this, unionScheduler,
+		ControlledWorkerUnion<BindingSet> unionRunnable = new ControlledWorkerUnion<>(unionScheduler,
 				union.getQueryInfo());
 		int numberOfArguments = union.getNumberOfArguments();
 		QueryEvaluationStep[] args = new QueryEvaluationStep[numberOfArguments];

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -37,7 +37,6 @@ import org.eclipse.rdf4j.federated.algebra.StatementSource;
 import org.eclipse.rdf4j.federated.algebra.StatementTupleExpr;
 import org.eclipse.rdf4j.federated.cache.CacheUtils;
 import org.eclipse.rdf4j.federated.cache.SourceSelectionCache;
-import org.eclipse.rdf4j.federated.cache.SourceSelectionMemoryCache;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelServiceExecutor;
@@ -147,18 +146,7 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 		}, federationContext.getFederatedServiceResolver());
 		this.federationContext = federationContext;
 		this.executor = federationContext.getManager().getExecutor();
-		this.cache = createSourceSelectionCache();
-	}
-
-	/**
-	 * Create the {@link SourceSelectionCache}
-	 *
-	 * @return the {@link SourceSelectionCache}
-	 * @see FedXConfig#getSourceSelectionCacheSpec()
-	 */
-	protected SourceSelectionCache createSourceSelectionCache() {
-		String cacheSpec = federationContext.getConfig().getSourceSelectionCacheSpec();
-		return new SourceSelectionMemoryCache(cacheSpec);
+		this.cache = federationContext.getSourceSelectionCache();
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategyFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategyFactory.java
@@ -10,13 +10,49 @@ package org.eclipse.rdf4j.federated.evaluation;
 import org.eclipse.rdf4j.federated.FedXConfig;
 import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.FederationManager.FederationType;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory;
 
 /**
  * Factory class for retrieving the {@link FederationEvalStrategy} to be used
  *
  * @author Andreas Schwarte
  */
-public class FederationEvaluationStrategyFactory {
+public class FederationEvaluationStrategyFactory extends StrictEvaluationStrategyFactory {
+
+	private FederationType federationType;
+	private FederationContext federationContext;
+
+	public FederationType getFederationType() {
+		return federationType;
+	}
+
+	public void setFederationType(FederationType federationType) {
+		this.federationType = federationType;
+	}
+
+	public FederationContext getFederationContext() {
+		return federationContext;
+	}
+
+	public void setFederationContext(FederationContext federationContext) {
+		this.federationContext = federationContext;
+	}
+
+	/**
+	 * Create the {@link FederationEvalStrategy} to be used.
+	 * 
+	 * Note: all parameters may be <code>null</code>
+	 */
+	@Override
+	public FederationEvalStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+			EvaluationStatistics evaluationStatistics) {
+
+		// Note: currently dataset, triplesource and statistics are explicitly ignored in the federation
+		return getEvaluationStrategy(federationType, federationContext);
+	}
 
 	/**
 	 * Return an instance of {@link FederationEvalStrategy} which is used for evaluating the query. The type depends on
@@ -27,7 +63,7 @@ public class FederationEvaluationStrategyFactory {
 	 * @param federationContext
 	 * @return the {@link FederationEvalStrategy}
 	 */
-	public static FederationEvalStrategy getEvaluationStrategy(FederationType federationType,
+	private static FederationEvalStrategy getEvaluationStrategy(FederationType federationType,
 			FederationContext federationContext) {
 
 		switch (federationType) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategyFactory.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvaluationStrategyFactory.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.evaluation;
 
-import org.eclipse.rdf4j.federated.FedXConfig;
+import org.eclipse.rdf4j.federated.FedXFactory;
 import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.FederationManager.FederationType;
 import org.eclipse.rdf4j.query.Dataset;
@@ -16,8 +16,22 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory;
 
 /**
- * Factory class for retrieving the {@link FederationEvalStrategy} to be used
+ * Factory class for retrieving the {@link FederationEvalStrategy} to be used.
+ * 
+ * <p>
+ * Default strategies:
+ * </p>
+ * 
+ * <ul>
+ * <li>local federation: {@link SailFederationEvalStrategy}</li>
+ * <li>endpoint federation: {@link SparqlFederationEvalStrategy}</li>
+ * <li>hybrid federation: {@link SparqlFederationEvalStrategy}</li>
+ * </ul>
  *
+ * <p>
+ * Customized strategies can be supplied to the federation using
+ * {@link FedXFactory#withFederationEvaluationStrategyFactory(FederationEvaluationStrategyFactory)}
+ * 
  * @author Andreas Schwarte
  */
 public class FederationEvaluationStrategyFactory extends StrictEvaluationStrategyFactory {
@@ -51,41 +65,14 @@ public class FederationEvaluationStrategyFactory extends StrictEvaluationStrateg
 			EvaluationStatistics evaluationStatistics) {
 
 		// Note: currently dataset, triplesource and statistics are explicitly ignored in the federation
-		return getEvaluationStrategy(federationType, federationContext);
-	}
-
-	/**
-	 * Return an instance of {@link FederationEvalStrategy} which is used for evaluating the query. The type depends on
-	 * the {@link FederationType} as well as on the actual implementations given by the configuration, in particular
-	 * this is {@link FedXConfig#getSailEvaluationStrategy()} and {@link FedXConfig#getSPARQLEvaluationStrategy()}.
-	 *
-	 * @param federationType
-	 * @param federationContext
-	 * @return the {@link FederationEvalStrategy}
-	 */
-	private static FederationEvalStrategy getEvaluationStrategy(FederationType federationType,
-			FederationContext federationContext) {
 
 		switch (federationType) {
 		case LOCAL:
-			return instantiate(federationContext.getConfig().getSailEvaluationStrategy(), federationContext);
+			return new SailFederationEvalStrategy(federationContext);
 		case REMOTE:
 		case HYBRID:
 		default:
-			return instantiate(federationContext.getConfig().getSPARQLEvaluationStrategy(), federationContext);
-		}
-	}
-
-	private static FederationEvalStrategy instantiate(Class<? extends FederationEvalStrategy> evalStrategyClass,
-			FederationContext federationContext) {
-		try {
-			return (FederationEvalStrategy) evalStrategyClass
-					.getDeclaredConstructor(FederationContext.class)
-					.newInstance(federationContext);
-		} catch (InstantiationException e) {
-			throw new IllegalStateException("Class " + evalStrategyClass + " could not be instantiated.", e);
-		} catch (Exception e) {
-			throw new IllegalStateException("Unexpected error while instantiating " + evalStrategyClass + ":", e);
+			return new SparqlFederationEvalStrategy(federationContext);
 		}
 	}
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailTripleSource.java
@@ -83,7 +83,7 @@ public class SailTripleSource extends TripleSourceBase implements TripleSource {
 			// if filter is set, apply it
 			if (filterExpr != null) {
 				FilteringIteration filteredRes = new FilteringIteration(filterExpr, resultHolder.get(),
-						SailTripleSource.this.strategy);
+						queryInfo.getStrategy());
 				if (!filteredRes.hasNext()) {
 					Iterations.closeCloseable(filteredRes);
 					resultHolder.set(new EmptyIteration<>());

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
@@ -54,13 +54,11 @@ public abstract class TripleSourceBase implements TripleSource {
 	protected final FederationContext federationContext;
 	protected final Monitoring monitoringService;
 	protected final Endpoint endpoint;
-	protected final FederationEvalStrategy strategy;
 
 	public TripleSourceBase(FederationContext federationContext, Endpoint endpoint) {
 		this.federationContext = federationContext;
 		this.monitoringService = federationContext.getMonitoringService();
 		this.endpoint = endpoint;
-		this.strategy = federationContext.getStrategy();
 	}
 
 	@Override
@@ -142,9 +140,9 @@ public abstract class TripleSourceBase implements TripleSource {
 			if (filterExpr != null) {
 				if (bindings.size() > 0) {
 					res = new FilteringInsertBindingsIteration(filterExpr, bindings, res,
-							this.strategy);
+							queryInfo.getStrategy());
 				} else {
-					res = new FilteringIteration(filterExpr, res, this.strategy);
+					res = new FilteringIteration(filterExpr, res, queryInfo.getStrategy());
 				}
 				if (!res.hasNext()) {
 					Iterations.closeCloseable(res);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelExecutorBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelExecutorBase.java
@@ -50,8 +50,8 @@ public abstract class ParallelExecutorBase<T> extends LookAheadIteration<T, Quer
 	protected volatile CloseableIteration<T, QueryEvaluationException> rightIter;
 	protected volatile boolean finished = false;
 
-	public ParallelExecutorBase(FederationEvalStrategy strategy, QueryInfo queryInfo) throws QueryEvaluationException {
-		this.strategy = strategy;
+	public ParallelExecutorBase(QueryInfo queryInfo) throws QueryEvaluationException {
+		this.strategy = queryInfo.getStrategy();
 		this.executorId = NEXT_EXECUTOR_ID.incrementAndGet();
 		this.queryInfo = queryInfo;
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/JoinExecutorBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/JoinExecutorBase.java
@@ -39,7 +39,7 @@ public abstract class JoinExecutorBase<T> extends ParallelExecutorBase<T> {
 	public JoinExecutorBase(FederationEvalStrategy strategy, CloseableIteration<T, QueryEvaluationException> leftIter,
 			TupleExpr rightArg,
 			BindingSet bindings, QueryInfo queryInfo) throws QueryEvaluationException {
-		super(strategy, queryInfo);
+		super(queryInfo);
 		this.leftIter = leftIter;
 		this.rightArg = rightArg;
 		this.bindings = bindings;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ControlledWorkerUnion.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/ControlledWorkerUnion.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.federated.evaluation.union;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 
@@ -31,9 +30,9 @@ public class ControlledWorkerUnion<T> extends WorkerUnionBase<T> {
 
 	protected final Phaser phaser = new Phaser(1);
 
-	public ControlledWorkerUnion(FederationEvalStrategy strategy, ControlledWorkerScheduler<T> scheduler,
+	public ControlledWorkerUnion(ControlledWorkerScheduler<T> scheduler,
 			QueryInfo queryInfo) {
-		super(strategy, queryInfo);
+		super(queryInfo);
 		this.scheduler = scheduler;
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/SynchronousWorkerUnion.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/SynchronousWorkerUnion.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.federated.evaluation.union;
 
-import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTask;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 
@@ -19,8 +18,8 @@ import org.eclipse.rdf4j.federated.structures.QueryInfo;
  */
 public class SynchronousWorkerUnion<T> extends WorkerUnionBase<T> {
 
-	public SynchronousWorkerUnion(FederationEvalStrategy strategy, QueryInfo queryInfo) {
-		super(strategy, queryInfo);
+	public SynchronousWorkerUnion(QueryInfo queryInfo) {
+		super(queryInfo);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/UnionExecutorBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/UnionExecutorBase.java
@@ -8,7 +8,6 @@
 package org.eclipse.rdf4j.federated.evaluation.union;
 
 import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
-import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelExecutorBase;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 
@@ -23,8 +22,8 @@ import org.eclipse.rdf4j.federated.structures.QueryInfo;
  */
 public abstract class UnionExecutorBase<T> extends ParallelExecutorBase<T> {
 
-	public UnionExecutorBase(FederationEvalStrategy strategy, QueryInfo queryInfo) {
-		super(strategy, queryInfo);
+	public UnionExecutorBase(QueryInfo queryInfo) {
+		super(queryInfo);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/WorkerUnionBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/union/WorkerUnionBase.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.federated.evaluation.union;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTask;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
 
@@ -26,8 +25,8 @@ public abstract class WorkerUnionBase<T> extends UnionExecutorBase<T> {
 
 	protected List<ParallelTask<T>> tasks = new ArrayList<>();
 
-	public WorkerUnionBase(FederationEvalStrategy strategy, QueryInfo queryInfo) {
-		super(strategy, queryInfo);
+	public WorkerUnionBase(QueryInfo queryInfo) {
+		super(queryInfo);
 	}
 
 	/**

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryInfo.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.rdf4j.federated.FederationContext;
 import org.eclipse.rdf4j.federated.algebra.PassThroughTupleExpr;
+import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelTask;
 import org.eclipse.rdf4j.federated.util.QueryStringUtil;
 import org.eclipse.rdf4j.model.IRI;
@@ -56,14 +57,11 @@ public class QueryInfo {
 
 	private final FederationContext federationContext;
 
+	private final FederationEvalStrategy strategy;
+
 	protected boolean done = false;
 
 	protected Set<ParallelTask<?>> scheduledSubtasks = ConcurrentHashMap.newKeySet();
-
-	public QueryInfo(String query, QueryType queryType, boolean incluedInferred,
-			FederationContext federationContext, Dataset dataset) {
-		this(query, null, queryType, 0, incluedInferred, federationContext, dataset);
-	}
 
 	/**
 	 *
@@ -76,7 +74,7 @@ public class QueryInfo {
 	 * @param dataset           the {@link Dataset}
 	 */
 	public QueryInfo(String query, String baseURI, QueryType queryType, int maxExecutionTime, boolean includeInferred,
-			FederationContext federationContext, Dataset dataset) {
+			FederationContext federationContext, FederationEvalStrategy strategy, Dataset dataset) {
 		super();
 		this.queryID = federationContext.getQueryManager().getNextQueryId();
 
@@ -92,12 +90,15 @@ public class QueryInfo {
 		this.maxExecutionTimeMs = _maxExecutionTime * 1000;
 		this.includeInferred = includeInferred;
 		this.start = System.currentTimeMillis();
+
+		this.strategy = strategy;
 	}
 
-	public QueryInfo(Resource subj, IRI pred, Value obj, boolean includeInferred,
-			FederationContext federationContext, Dataset dataset) {
-		this(QueryStringUtil.toString(subj, pred, obj), QueryType.GET_STATEMENTS, includeInferred,
-				federationContext, dataset);
+	public QueryInfo(Resource subj, IRI pred, Value obj, int maxExecutionTime, boolean includeInferred,
+			FederationContext federationContext, FederationEvalStrategy strategy, Dataset dataset) {
+		this(QueryStringUtil.toString(subj, pred, obj), null, QueryType.GET_STATEMENTS, maxExecutionTime,
+				includeInferred,
+				federationContext, strategy, dataset);
 	}
 
 	public BigInteger getQueryID() {
@@ -125,6 +126,14 @@ public class QueryInfo {
 	 */
 	public String getBaseURI() {
 		return baseURI;
+	}
+
+	/**
+	 * 
+	 * @return the {@link FederationEvalStrategy} active in the current query context
+	 */
+	public FederationEvalStrategy getStrategy() {
+		return this.strategy;
 	}
 
 	/**

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/WriteTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/WriteTest.java
@@ -173,7 +173,7 @@ public class WriteTest extends SPARQLBaseTest {
 		prepareTest(Arrays.asList("/tests/basic/data_emptyStore.ttl", "/tests/basic/data_emptyStore.ttl"));
 
 		// configure the test write strategy factory
-		fedxRule.getFederationContext().getConfig().withWriteStrategyFactory(TestWriteStrategyFactory.class);
+		fedxRule.getFederationContext().getFederation().setWriteStrategyFactory(new TestWriteStrategyFactory());
 
 		try (RepositoryConnection conn = fedxRule.getRepository().getConnection()) {
 			Update update = conn.prepareUpdate(QueryLanguage.SPARQL,


### PR DESCRIPTION
GitHub issue resolved: #3483 

Briefly describe the changes proposed in this PR:

(NOTE: it is recommended to do any review commit wise, as this is much easier to follow)

Commit 1: GH-3483: refactor federation execution to use a per-query strategy

This change refactors the execution of federated queries to use a
per-query instance of the FederationEvaluationStrategy.

The instance is passed via the QueryInfo object, which is already
specific to a given query execution.

Note that as a next step a proper factory mechanism needs to be put in
place in FederationManager and FederationContext (i.e. this change is
only the preparation, and it in fact still uses the same instance of the
strategy).


Commit 2: GH-3483: instantiate federation strategy through a factory

Adjust the federation initialization to use a proper
FederationEvaluationStrategyFactory for instantiating the actual
strategy.

Note that the SourceSelectionCache is now managed in the
FederationContext (to make it reusable across query executions)


Commit 3: GH-3483: make the Federation Strategy Factory configurable

This change allows to supply a custom FederationEvaluationStrategy
through the FedXFactory.

The previous mechanism of defining the class names trough the FedXConfig
and using reflection for instantiation is removed. A corresponding note
is added to the changelog


Commit 4: GH-3483: make federation write strategy configurable through FedXFactory

The WriteStrategyFactory is now configurable through the FedXFactory.
This avoids use of reflection (as previously done in FedXConfig)



----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

