### PR TITLE
GH-3534 Optimize reading from LMDB SailSource by using different DBs for explicit and inferred statements.

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -29,7 +29,7 @@ import org.lwjgl.util.lmdb.MDBVal;
  * A record iterator that wraps a native LMDB iterator.
  *
  */
-public class LmdbRecordIterator implements RecordIterator {
+class LmdbRecordIterator implements RecordIterator {
 	private final Pool pool;
 
 	private final TripleIndex index;
@@ -58,9 +58,8 @@ public class LmdbRecordIterator implements RecordIterator {
 
 	private boolean fetchNext = false;
 
-	public LmdbRecordIterator(Pool pool, TripleIndex index, boolean rangeSearch, long subj, long pred, long obj,
-			long context,
-			TxnRef txnRef) {
+	LmdbRecordIterator(Pool pool, TripleIndex index, boolean rangeSearch, long subj, long pred, long obj,
+			long context, TxnRef txnRef) {
 		this.pool = pool;
 		this.keyData = pool.getVal();
 		this.valueData = pool.getVal();

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -23,7 +23,6 @@ import org.eclipse.rdf4j.sail.lmdb.TripleStore.TripleIndex;
 import org.eclipse.rdf4j.sail.lmdb.Varint.GroupMatcher;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
-import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.util.lmdb.MDBVal;
 
 /**
@@ -31,6 +30,8 @@ import org.lwjgl.util.lmdb.MDBVal;
  *
  */
 public class LmdbRecordIterator implements RecordIterator {
+	private final Pool pool;
+
 	private final TripleIndex index;
 
 	private final long cursor;
@@ -41,28 +42,36 @@ public class LmdbRecordIterator implements RecordIterator {
 
 	private final TxnRef txnRef;
 
+	private final long txn;
+
 	private boolean closed = false;
 
-	private final MDBVal keyData = MDBVal.malloc();
+	private final MDBVal keyData;
 
-	private final MDBVal valueData = MDBVal.malloc();
+	private final MDBVal valueData;
 
 	private ByteBuffer minKeyBuf;
+
+	private ByteBuffer maxKeyBuf;
 
 	private int lastResult;
 
 	private boolean fetchNext = false;
 
-	public LmdbRecordIterator(TripleIndex index, boolean rangeSearch, long subj, long pred, long obj, long context,
+	public LmdbRecordIterator(Pool pool, TripleIndex index, boolean rangeSearch, long subj, long pred, long obj,
+			long context,
 			TxnRef txnRef) {
+		this.pool = pool;
+		this.keyData = pool.getVal();
+		this.valueData = pool.getVal();
 		this.index = index;
 		if (rangeSearch) {
-			minKeyBuf = MemoryUtil.memAlloc(TripleStore.MAX_KEY_LENGTH);
+			minKeyBuf = pool.getKeyBuffer();
 			index.getMinKey(minKeyBuf, subj, pred, obj, context);
 			minKeyBuf.flip();
 
-			this.maxKey = MDBVal.malloc();
-			ByteBuffer maxKeyBuf = MemoryUtil.memAlloc(TripleStore.MAX_KEY_LENGTH);
+			this.maxKey = pool.getVal();
+			this.maxKeyBuf = pool.getKeyBuffer();
 			index.getMaxKey(maxKeyBuf, subj, pred, obj, context);
 			maxKeyBuf.flip();
 			this.maxKey.mv_data(maxKeyBuf);
@@ -78,10 +87,11 @@ public class LmdbRecordIterator implements RecordIterator {
 			this.groupMatcher = null;
 		}
 		this.txnRef = txnRef;
+		this.txn = txnRef.create();
 
 		try (MemoryStack stack = MemoryStack.stackPush()) {
 			PointerBuffer pp = stack.mallocPointer(1);
-			E(mdb_cursor_open(txnRef.get(), index.getDB(), pp));
+			E(mdb_cursor_open(txn, index.getDB(), pp));
 			cursor = pp.get(0);
 		}
 
@@ -103,7 +113,7 @@ public class LmdbRecordIterator implements RecordIterator {
 		}
 		while (lastResult == 0) {
 			// if (maxKey != null && TripleStore.COMPARATOR.compare(keyData.mv_data(), maxKey.mv_data()) > 0) {
-			if (maxKey != null && mdb_cmp(txnRef.get(), index.getDB(), keyData, maxKey) > 0) {
+			if (maxKey != null && mdb_cmp(txn, index.getDB(), keyData, maxKey) > 0) {
 				lastResult = MDB_NOTFOUND;
 			} else if (groupMatcher != null && !groupMatcher.matches(keyData.mv_data())) {
 				// value doesn't match search key/mask, fetch next value
@@ -125,18 +135,16 @@ public class LmdbRecordIterator implements RecordIterator {
 		if (!closed) {
 			try {
 				mdb_cursor_close(cursor);
-				keyData.close();
-				valueData.close();
+				pool.free(keyData);
+				pool.free(valueData);
 				if (minKeyBuf != null) {
-					MemoryUtil.memFree(minKeyBuf);
+					pool.free(minKeyBuf);
 				}
 				if (maxKey != null) {
-					MemoryUtil.memFree(maxKey.mv_data());
-					maxKey.close();
+					pool.free(maxKeyBuf);
+					pool.free(maxKey);
 				}
-				if (txnRef != null) {
-					txnRef.end();
-				}
+				txnRef.free(txn);
 			} finally {
 				closed = true;
 			}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -43,9 +43,9 @@ public class LmdbRecordIterator implements RecordIterator {
 
 	private boolean closed = false;
 
-	private final MDBVal keyData = MDBVal.calloc();
+	private final MDBVal keyData = MDBVal.malloc();
 
-	private final MDBVal valueData = MDBVal.calloc();
+	private final MDBVal valueData = MDBVal.malloc();
 
 	private ByteBuffer minKeyBuf;
 
@@ -61,7 +61,7 @@ public class LmdbRecordIterator implements RecordIterator {
 			index.getMinKey(minKeyBuf, subj, pred, obj, context);
 			minKeyBuf.flip();
 
-			this.maxKey = MDBVal.calloc();
+			this.maxKey = MDBVal.malloc();
 			ByteBuffer maxKeyBuf = MemoryUtil.memAlloc(TripleStore.MAX_KEY_LENGTH);
 			index.getMaxKey(maxKeyBuf, subj, pred, obj, context);
 			maxKeyBuf.flip();

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
@@ -247,7 +247,7 @@ class LmdbSailStore implements SailStore {
 		ArrayList<LmdbStatementIterator> perContextIterList = new ArrayList<>(contextIDList.size());
 
 		for (long contextID : contextIDList) {
-			RecordIterator records = tripleStore.getTriples(subjID, predID, objID, contextID, explicit, false);
+			RecordIterator records = tripleStore.getTriples(subjID, predID, objID, contextID, explicit);
 			perContextIterList.add(new LmdbStatementIterator(records, valueStore));
 		}
 

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
@@ -62,18 +62,18 @@ class LmdbStatementIterator extends LookAheadIteration<Statement, SailException>
 			nextRecord.toQuad(quad);
 
 			long subjID = quad[TripleStore.SUBJ_IDX];
-			Resource subj = (Resource) valueStore.getValue(subjID);
+			Resource subj = (Resource) valueStore.getLazyValue(subjID);
 
 			long predID = quad[TripleStore.PRED_IDX];
-			IRI pred = (IRI) valueStore.getValue(predID);
+			IRI pred = (IRI) valueStore.getLazyValue(predID);
 
 			long objID = quad[TripleStore.OBJ_IDX];
-			Value obj = valueStore.getValue(objID);
+			Value obj = valueStore.getLazyValue(objID);
 
 			Resource context = null;
 			long contextID = quad[TripleStore.CONTEXT_IDX];
 			if (contextID != 0) {
-				context = (Resource) valueStore.getValue(contextID);
+				context = (Resource) valueStore.getLazyValue(contextID);
 			}
 
 			return valueStore.createStatement(subj, pred, obj, context);

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.nio.ByteBuffer;
+
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.util.lmdb.MDBVal;
+
+/**
+ * A simple pool for {@link MDBVal} and {@link java.nio.Buffer} instances
+ */
+class Pool {
+
+	private final MDBVal[] valPool = new MDBVal[1024];
+	private final ByteBuffer[] keyPool = new ByteBuffer[1024];
+	private volatile int valPoolIndex = -1;
+	private volatile int keyPoolIndex = -1;
+
+	synchronized MDBVal getVal() {
+		synchronized (valPool) {
+			if (valPoolIndex >= 0) {
+				return valPool[valPoolIndex--];
+			}
+		}
+		return MDBVal.malloc();
+	}
+
+	ByteBuffer getKeyBuffer() {
+		synchronized (keyPool) {
+			if (keyPoolIndex >= 0) {
+				ByteBuffer bb = keyPool[keyPoolIndex--];
+				bb.clear();
+				return bb;
+			}
+		}
+		return MemoryUtil.memAlloc(TripleStore.MAX_KEY_LENGTH);
+	}
+
+	void free(MDBVal val) {
+		synchronized (valPool) {
+			if (valPoolIndex < valPool.length - 1) {
+				valPool[++valPoolIndex] = val;
+			} else {
+				val.close();
+			}
+		}
+	}
+
+	void free(ByteBuffer bb) {
+		synchronized (keyPool) {
+			if (keyPoolIndex < keyPool.length - 1) {
+				keyPool[++keyPoolIndex] = bb;
+			} else {
+				MemoryUtil.memFree(bb);
+			}
+		}
+	}
+
+	void close() {
+		synchronized (valPool) {
+			while (valPoolIndex >= 0) {
+				valPool[valPoolIndex--].close();
+			}
+		}
+		synchronized (keyPool) {
+			while (keyPoolIndex >= 0) {
+				MemoryUtil.memFree(keyPool[keyPoolIndex--]);
+			}
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
@@ -13,7 +13,7 @@ import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.util.lmdb.MDBVal;
 
 /**
- * A simple pool for {@link MDBVal} and {@link java.nio.Buffer} instances
+ * A simple pool for {@link MDBVal} and {@link ByteBuffer} instances.
  */
 class Pool {
 
@@ -22,7 +22,7 @@ class Pool {
 	private volatile int valPoolIndex = -1;
 	private volatile int keyPoolIndex = -1;
 
-	synchronized MDBVal getVal() {
+	MDBVal getVal() {
 		synchronized (valPool) {
 			if (valPoolIndex >= 0) {
 				return valPool[valPoolIndex--];

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/RecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/RecordIterator.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  * An iterator that iterates over records, for example those in a key-value database.
  *
  */
-public interface RecordIterator extends Closeable {
+interface RecordIterator extends Closeable {
 
 	/**
 	 * Returns the next record.

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -15,6 +15,7 @@ import static org.eclipse.rdf4j.sail.lmdb.Varint.writeListUnsigned;
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.system.MemoryUtil.NULL;
 import static org.lwjgl.util.lmdb.LMDB.MDB_CREATE;
+import static org.lwjgl.util.lmdb.LMDB.MDB_LAST;
 import static org.lwjgl.util.lmdb.LMDB.MDB_NEXT;
 import static org.lwjgl.util.lmdb.LMDB.MDB_NOMETASYNC;
 import static org.lwjgl.util.lmdb.LMDB.MDB_NOSYNC;
@@ -511,9 +512,12 @@ class TripleStore implements Closeable {
 								keyData.mv_data(maxKeyBuf);
 								rc = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
 								if (rc != 0) {
-									break;
+									// directly go to last value
+									rc = mdb_cursor_get(cursor, keyData, valueData, MDB_LAST);
+								} else {
+									// go to previous value of selected key
+									rc = mdb_cursor_get(cursor, keyData, valueData, MDB_PREV);
 								}
-								rc = mdb_cursor_get(cursor, keyData, valueData, MDB_PREV);
 								if (rc == 0) {
 									Varint.readListUnsigned(keyData.mv_data(), values);
 									int pos = 0;

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -94,10 +94,6 @@ class TripleStore implements Closeable {
 	static final int MAX_KEY_LENGTH = 4 * 9;
 
 	/**
-	 * Bit field indicating that a statement has been explicitly added (instead of being inferred).
-	 */
-	static final byte EXPLICIT_FLAG = (byte) 0x1; // 0000 0001
-	/**
 	 * The default triple indexes.
 	 */
 	private static final String DEFAULT_INDEXES = "spoc,posc";
@@ -180,7 +176,7 @@ class TripleStore implements Closeable {
 		}
 
 		mdb_env_set_mapsize(env, config.getTripleDBSize());
-		mdb_env_set_maxdbs(env, 6);
+		mdb_env_set_maxdbs(env, 12);
 		nmdb_env_set_maxreaders(env, 256);
 
 		// Open environment
@@ -318,44 +314,47 @@ class TripleStore implements Closeable {
 
 		if (!addedIndexSpecs.isEmpty()) {
 			TripleIndex sourceIndex = indexes.get(0);
-			transaction(env, (stack, txn) -> {
-				MDBVal keyValue = MDBVal.callocStack(stack);
-				ByteBuffer keyBuf = stack.malloc(MAX_KEY_LENGTH);
-				keyValue.mv_data(keyBuf);
-				MDBVal dataValue = MDBVal.callocStack(stack);
-				long[] quad = new long[4];
-				for (String fieldSeq : addedIndexSpecs) {
-					logger.debug("Initializing new index '{}'...", fieldSeq);
+			for (boolean explicit : new boolean[] { true, false }) {
+				transaction(env, (stack, txn) -> {
+					MDBVal keyValue = MDBVal.callocStack(stack);
+					ByteBuffer keyBuf = stack.malloc(MAX_KEY_LENGTH);
+					keyValue.mv_data(keyBuf);
+					MDBVal dataValue = MDBVal.callocStack(stack);
+					long[] quad = new long[4];
+					for (String fieldSeq : addedIndexSpecs) {
+						logger.debug("Initializing new index '{}'...", fieldSeq);
 
-					TripleIndex addedIndex = new TripleIndex(fieldSeq);
-					RecordIterator[] sourceIter = { null };
-					try {
-						sourceIter[0] = new LmdbRecordIterator(pool, sourceIndex, false, -1, -1, -1, -1,
-								new TxnRef(txn));
+						TripleIndex addedIndex = new TripleIndex(fieldSeq);
+						RecordIterator[] sourceIter = { null };
+						try {
+							sourceIter[0] = new LmdbRecordIterator(pool, sourceIndex, false, -1, -1, -1, -1,
+									explicit, new TxnRef(txn));
 
-						RecordIterator it = sourceIter[0];
-						Record record;
-						while ((record = it.next()) != null) {
-							record.toQuad(quad);
-							keyBuf.clear();
-							addedIndex.toKey(keyBuf, quad[SUBJ_IDX], quad[PRED_IDX], quad[OBJ_IDX], quad[CONTEXT_IDX]);
-							keyBuf.flip();
+							RecordIterator it = sourceIter[0];
+							Record record;
+							while ((record = it.next()) != null) {
+								record.toQuad(quad);
+								keyBuf.clear();
+								addedIndex.toKey(keyBuf, quad[SUBJ_IDX], quad[PRED_IDX], quad[OBJ_IDX],
+										quad[CONTEXT_IDX]);
+								keyBuf.flip();
 
-							dataValue.mv_data(record.val);
+								dataValue.mv_data(record.val);
 
-							mdb_put(txn, addedIndex.getDB(), keyValue, dataValue, 0);
+								mdb_put(txn, addedIndex.getDB(explicit), keyValue, dataValue, 0);
+							}
+						} finally {
+							if (sourceIter[0] != null) {
+								sourceIter[0].close();
+							}
 						}
-					} finally {
-						if (sourceIter[0] != null) {
-							sourceIter[0].close();
-						}
+
+						currentIndexes.put(fieldSeq, addedIndex);
 					}
 
-					currentIndexes.put(fieldSeq, addedIndex);
-				}
-
-				return null;
-			});
+					return null;
+				});
+			}
 
 			logger.debug("New index(es) initialized");
 		}
@@ -424,127 +423,116 @@ class TripleStore implements Closeable {
 		for (TripleIndex index : indexes) {
 			if (index.getFieldSeq()[0] == 'c') {
 				// found a context-first index
-				return getTriplesUsingIndex(-1, -1, -1, -1, index, false);
+				return getTriplesUsingIndex(-1, -1, -1, -1, true, index, false);
 			}
 		}
-
 		return null;
 	}
 
 	public RecordIterator getTriples(long subj, long pred, long obj, long context, boolean explicit)
 			throws IOException {
-		RecordIterator recordIt = getTriples(subj, pred, obj, context);
-
-		if (explicit) {
-			// Filter implicit statements from the result
-			recordIt = new ExplicitStatementFilter(recordIt);
-		} else {
-			// Filter out explicit statements from the result
-			recordIt = new ImplicitStatementFilter(recordIt);
-		}
-
-		return recordIt;
-	}
-
-	private RecordIterator getTriples(long subj, long pred, long obj, long context) {
 		TripleIndex index = getBestIndex(subj, pred, obj, context);
 		// System.out.println("get triples: " + Arrays.asList(subj, pred, obj,context));
 		boolean doRangeSearch = index.getPatternScore(subj, pred, obj, context) > 0;
-		return getTriplesUsingIndex(subj, pred, obj, context, index, doRangeSearch);
+		return getTriplesUsingIndex(subj, pred, obj, context, explicit, index, doRangeSearch);
 	}
 
 	private RecordIterator getTriplesUsingIndex(long subj, long pred, long obj, long context,
-			TripleIndex index, boolean rangeSearch) {
-		return new LmdbRecordIterator(pool, index, rangeSearch, subj, pred, obj, context, readTxnRef);
+			boolean explicit, TripleIndex index, boolean rangeSearch) {
+		return new LmdbRecordIterator(pool, index, rangeSearch, subj, pred, obj, context, explicit, readTxnRef);
 	}
 
 	protected double cardinality(long subj, long pred, long obj, long context) throws IOException {
 		TripleIndex index = getBestIndex(subj, pred, obj, context);
 
-		if (index.getPatternScore(subj, pred, obj, context) == 0) {
-			return readTxnRef.doWith((stack, txn) -> {
-				MDBStat stat = MDBStat.mallocStack(stack);
-				mdb_stat(txn, index.getDB(), stat);
-				return (double) stat.ms_entries();
-			});
-		} else {
-			// TODO currently uses a scan to determine range size
-			long[] startValues = new long[4];
-			return readTxnRef.doWith((stack, txn) -> {
-				MDBVal maxKey = MDBVal.malloc(stack);
-				ByteBuffer maxKeyBuf = stack.malloc(TripleStore.MAX_KEY_LENGTH);
-				index.getMaxKey(maxKeyBuf, subj, pred, obj, context);
-				maxKeyBuf.flip();
-				maxKey.mv_data(maxKeyBuf);
+		double cardinality = 0;
+		for (boolean explicit : new boolean[] { true, false }) {
+			int dbi = index.getDB(explicit);
+			if (index.getPatternScore(subj, pred, obj, context) == 0) {
+				cardinality += readTxnRef.doWith((stack, txn) -> {
+					MDBStat stat = MDBStat.mallocStack(stack);
+					mdb_stat(txn, dbi, stat);
+					return (double) stat.ms_entries();
+				});
+			} else {
+				// TODO currently uses a scan to determine range size
+				long[] startValues = new long[4];
+				cardinality += readTxnRef.doWith((stack, txn) -> {
+					MDBVal maxKey = MDBVal.malloc(stack);
+					ByteBuffer maxKeyBuf = stack.malloc(TripleStore.MAX_KEY_LENGTH);
+					index.getMaxKey(maxKeyBuf, subj, pred, obj, context);
+					maxKeyBuf.flip();
+					maxKey.mv_data(maxKeyBuf);
 
-				int dbi = index.getDB();
-				long cursor = 0;
-				try {
-					PointerBuffer pp = stack.mallocPointer(1);
-					E(mdb_cursor_open(txn, dbi, pp));
-					cursor = pp.get(0);
+					long cursor = 0;
+					try {
+						PointerBuffer pp = stack.mallocPointer(1);
+						E(mdb_cursor_open(txn, dbi, pp));
+						cursor = pp.get(0);
 
-					MDBVal keyData = MDBVal.callocStack(stack);
-					ByteBuffer keyBuf = stack.malloc(TripleStore.MAX_KEY_LENGTH);
-					index.getMinKey(keyBuf, subj, pred, obj, context);
-					keyBuf.flip();
+						MDBVal keyData = MDBVal.callocStack(stack);
+						ByteBuffer keyBuf = stack.malloc(TripleStore.MAX_KEY_LENGTH);
+						index.getMinKey(keyBuf, subj, pred, obj, context);
+						keyBuf.flip();
 
-					// set cursor to min key
-					keyData.mv_data(keyBuf);
-					MDBVal valueData = MDBVal.callocStack(stack);
-					long rangeSize = 0;
-					int rc = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
-					if (rc == 0) {
-						Varint.readListUnsigned(keyData.mv_data(), startValues);
+						// set cursor to min key
+						keyData.mv_data(keyBuf);
+						MDBVal valueData = MDBVal.callocStack(stack);
+						long rangeSize = 0;
+						int rc = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
+						if (rc == 0) {
+							Varint.readListUnsigned(keyData.mv_data(), startValues);
 
-						rangeSize += 1;
-						rc = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
-						while (rc == 0) {
-							if (mdb_cmp(txn, dbi, keyData, maxKey) >= 0) {
-								// if (COMPARATOR.compare(keyData.mv_data(), maxKeyBuf) >= 0) {
-								break;
-							}
 							rangeSize += 1;
-
-							if (rangeSize == 1000) {
-								long[] lastValues = new long[4];
-								long[] values = new long[4];
-
-								Varint.readListUnsigned(keyData.mv_data(), lastValues);
-
-								keyData.mv_data(maxKeyBuf);
-								rc = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
-								if (rc != 0) {
-									// directly go to last value
-									rc = mdb_cursor_get(cursor, keyData, valueData, MDB_LAST);
-								} else {
-									// go to previous value of selected key
-									rc = mdb_cursor_get(cursor, keyData, valueData, MDB_PREV);
+							rc = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
+							while (rc == 0) {
+								if (mdb_cmp(txn, dbi, keyData, maxKey) >= 0) {
+									// if (COMPARATOR.compare(keyData.mv_data(), maxKeyBuf) >= 0) {
+									break;
 								}
-								if (rc == 0) {
-									Varint.readListUnsigned(keyData.mv_data(), values);
-									int pos = 0;
-									while (pos < values.length && values[pos] == lastValues[pos]) {
-										pos++;
+								rangeSize += 1;
+
+								if (rangeSize == 1000) {
+									long[] lastValues = new long[4];
+									long[] values = new long[4];
+
+									Varint.readListUnsigned(keyData.mv_data(), lastValues);
+
+									keyData.mv_data(maxKeyBuf);
+									rc = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
+									if (rc != 0) {
+										// directly go to last value
+										rc = mdb_cursor_get(cursor, keyData, valueData, MDB_LAST);
+									} else {
+										// go to previous value of selected key
+										rc = mdb_cursor_get(cursor, keyData, valueData, MDB_PREV);
 									}
-									if (pos < values.length) {
-										rangeSize += (values[pos] - lastValues[pos])
-												/ Math.max(1, lastValues[pos] - startValues[pos])
-												* 1000;
+									if (rc == 0) {
+										Varint.readListUnsigned(keyData.mv_data(), values);
+										int pos = 0;
+										while (pos < values.length && values[pos] == lastValues[pos]) {
+											pos++;
+										}
+										if (pos < values.length) {
+											rangeSize += (values[pos] - lastValues[pos])
+													/ Math.max(1, lastValues[pos] - startValues[pos])
+													* 1000;
+										}
 									}
+									return (double) rangeSize;
 								}
-								return (double) rangeSize;
 							}
 						}
+						return (double) rangeSize;
+					} finally {
+						if (cursor != 0) {
+							mdb_cursor_close(cursor);
+						}
 					}
-					return (double) rangeSize;
-				} finally {
-					if (cursor != 0) {
-						mdb_cursor_close(cursor);
-					}
-				}
-			});
+				});
+			}
 		}
+		return cardinality;
 	}
 
 	protected TripleIndex getBestIndex(long subj, long pred, long obj, long context) {
@@ -563,29 +551,25 @@ class TripleStore implements Closeable {
 	}
 
 	public boolean storeTriple(long subj, long pred, long obj, long context, boolean explicit) throws IOException {
-		Byte storedValue = null;
-
 		TripleIndex mainIndex = indexes.get(0);
 		try (MemoryStack stack = MemoryStack.stackPush()) {
-			MDBVal keyVal = MDBVal.callocStack(stack), dataVal = MDBVal.callocStack(stack);
+			MDBVal keyVal = MDBVal.mallocStack(stack);
+			// use calloc to get an empty data value
+			MDBVal dataVal = MDBVal.callocStack(stack);
 			ByteBuffer keyBuf = stack.malloc(MAX_KEY_LENGTH);
 			mainIndex.toKey(keyBuf, subj, pred, obj, context);
 			keyBuf.flip();
 			keyVal.mv_data(keyBuf);
 
-			if (mdb_get(writeTxn, mainIndex.getDB(), keyVal, dataVal) == 0) {
-				storedValue = dataVal.mv_data().get(0);
-			}
+			boolean foundExplicit = mdb_get(writeTxn, mainIndex.getDB(true), keyVal, dataVal) == 0;
+			boolean foundImplicit = !foundExplicit && mdb_get(writeTxn, mainIndex.getDB(false), keyVal, dataVal) == 0;
 
-			boolean stAdded = storedValue == null;
-			byte newValue = 0;
-			if (explicit) {
-				newValue |= EXPLICIT_FLAG;
-			}
-			if (storedValue == null || newValue != storedValue) {
-				dataVal.mv_data(stack.bytes(newValue));
-
-				mdb_put(writeTxn, mainIndex.getDB(), keyVal, dataVal, 0);
+			boolean stAdded = !(foundExplicit || foundImplicit);
+			if (stAdded || explicit && foundImplicit) {
+				if (explicit && foundImplicit) {
+					mdb_del(writeTxn, mainIndex.getDB(false), keyVal, dataVal);
+				}
+				mdb_put(writeTxn, mainIndex.getDB(explicit), keyVal, dataVal, 0);
 
 				for (int i = 1; i < indexes.size(); i++) {
 					TripleIndex index = indexes.get(i);
@@ -596,7 +580,10 @@ class TripleStore implements Closeable {
 					// update buffer positions in MDBVal
 					keyVal.mv_data(keyBuf);
 
-					mdb_put(writeTxn, index.getDB(), keyVal, dataVal, 0);
+					if (explicit && foundImplicit) {
+						mdb_del(writeTxn, mainIndex.getDB(false), keyVal, dataVal);
+					}
+					mdb_put(writeTxn, index.getDB(explicit), keyVal, dataVal, 0);
 				}
 			}
 
@@ -618,10 +605,10 @@ class TripleStore implements Closeable {
 	public Map<Long, Long> removeTriplesByContext(long subj, long pred, long obj, long context, boolean explicit)
 			throws IOException {
 		RecordIterator records = getTriples(subj, pred, obj, context, explicit);
-		return removeTriples(records);
+		return removeTriples(records, explicit);
 	}
 
-	private Map<Long, Long> removeTriples(RecordIterator iter) throws IOException {
+	private Map<Long, Long> removeTriples(RecordIterator iter, boolean explicit) throws IOException {
 		final Map<Long, Long> perContextCounts = new HashMap<>();
 
 		try (MemoryStack stack = MemoryStack.stackPush()) {
@@ -642,7 +629,7 @@ class TripleStore implements Closeable {
 					// update buffer positions in MDBVal
 					keyValue.mv_data(keyBuf);
 
-					mdb_del(writeTxn, index.getDB(), keyValue, null);
+					mdb_del(writeTxn, index.getDB(explicit), keyValue, null);
 				}
 
 				perContextCounts.merge(quad[CONTEXT_IDX], 1L, (c, one) -> c + one);
@@ -702,81 +689,26 @@ class TripleStore implements Closeable {
 		}
 	}
 
-	private static class ExplicitStatementFilter implements RecordIterator {
-
-		private final RecordIterator wrappedIter;
-
-		public ExplicitStatementFilter(RecordIterator wrappedIter) {
-			this.wrappedIter = wrappedIter;
-		}
-
-		@Override
-		public Record next() throws IOException {
-			Record record;
-			while ((record = wrappedIter.next()) != null) {
-				byte flags = record.val.get(0);
-				boolean explicit = (flags & TripleStore.EXPLICIT_FLAG) != 0;
-				if (explicit) {
-					break;
-				}
-			}
-			return record;
-		}
-
-		@Override
-		public void close() throws IOException {
-			wrappedIter.close();
-		}
-	}
-
-	private static class ImplicitStatementFilter implements RecordIterator {
-
-		private final RecordIterator wrappedIter;
-
-		public ImplicitStatementFilter(RecordIterator wrappedIter) {
-			this.wrappedIter = wrappedIter;
-		}
-
-		@Override
-		public Record next() throws IOException {
-			Record record;
-			while ((record = wrappedIter.next()) != null) {
-				byte flags = record.val.get(0);
-				boolean explicit = (flags & TripleStore.EXPLICIT_FLAG) != 0;
-				if (!explicit) {
-					// Statement is implicit
-					break;
-				}
-			}
-
-			return record;
-		}
-
-		@Override
-		public void close() throws IOException {
-			wrappedIter.close();
-		}
-	}
-
 	class TripleIndex {
 
 		private final char[] fieldSeq;
-		private final int dbi;
+		private final int dbiExplicit, dbiInferred;
 		private final int[] indexMap;
 
 		public TripleIndex(String fieldSeq) throws IOException {
 			this.fieldSeq = fieldSeq.toCharArray();
 			this.indexMap = getIndexes(this.fieldSeq);
 			// open database and use native sort order without comparator
-			dbi = openDatabase(env, new String(fieldSeq), MDB_CREATE, null);
+			dbiExplicit = openDatabase(env, fieldSeq, MDB_CREATE, null);
+			dbiInferred = openDatabase(env, fieldSeq + "-inf", MDB_CREATE, null);
 		}
 
 		public char[] getFieldSeq() {
 			return fieldSeq;
 		}
 
-		public int getDB() {
-			return dbi;
+		public int getDB(boolean explicit) {
+			return explicit ? dbiExplicit : dbiInferred;
 		}
 
 		protected int[] getIndexes(char[] fieldSeq) {
@@ -926,16 +858,19 @@ class TripleStore implements Closeable {
 		}
 
 		void close() {
-			mdb_dbi_close(env, dbi);
+			mdb_dbi_close(env, dbiExplicit);
+			mdb_dbi_close(env, dbiInferred);
 			pool.close();
 		}
 
 		void clear(long txn) throws IOException {
-			mdb_drop(txn, dbi, false);
+			mdb_drop(txn, dbiExplicit, false);
+			mdb_drop(txn, dbiInferred, false);
 		}
 
 		void destroy(long txn) throws IOException {
-			mdb_drop(txn, dbi, true);
+			mdb_drop(txn, dbiExplicit, true);
+			mdb_drop(txn, dbiInferred, true);
 		}
 	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -166,7 +166,7 @@ class TripleStore implements Closeable {
 		}
 	};
 
-	public TripleStore(File dir, LmdbStoreConfig config) throws IOException, SailException {
+	TripleStore(File dir, LmdbStoreConfig config) throws IOException, SailException {
 		this.dir = dir;
 		this.forceSync = config.getForceSync();
 
@@ -762,16 +762,12 @@ class TripleStore implements Closeable {
 	class TripleIndex {
 
 		private final char[] fieldSeq;
-		private int dbi;
-		private int[] indexMap;
+		private final int dbi;
+		private final int[] indexMap;
 
 		public TripleIndex(String fieldSeq) throws IOException {
 			this.fieldSeq = fieldSeq.toCharArray();
 			this.indexMap = getIndexes(this.fieldSeq);
-			open();
-		}
-
-		private void open() throws IOException {
 			// open database and use native sort order without comparator
 			dbi = openDatabase(env, new String(fieldSeq), MDB_CREATE, null);
 		}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -431,14 +431,14 @@ class TripleStore implements Closeable {
 		return null;
 	}
 
-	public RecordIterator getTriples(long subj, long pred, long obj, long context, boolean explicit,
-			boolean readTransaction) throws IOException {
+	public RecordIterator getTriples(long subj, long pred, long obj, long context, boolean explicit)
+			throws IOException {
 		RecordIterator recordIt = getTriples(subj, pred, obj, context);
 
-		if (readTransaction && explicit) {
+		if (explicit) {
 			// Filter implicit statements from the result
 			recordIt = new ExplicitStatementFilter(recordIt);
-		} else if (!explicit) {
+		} else {
 			// Filter out explicit statements from the result
 			recordIt = new ImplicitStatementFilter(recordIt);
 		}
@@ -617,7 +617,7 @@ class TripleStore implements Closeable {
 	 */
 	public Map<Long, Long> removeTriplesByContext(long subj, long pred, long obj, long context, boolean explicit)
 			throws IOException {
-		RecordIterator records = getTriples(subj, pred, obj, context, explicit, true);
+		RecordIterator records = getTriples(subj, pred, obj, context, explicit);
 		return removeTriples(records);
 	}
 

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TxnRef.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TxnRef.java
@@ -7,55 +7,178 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import static org.eclipse.rdf4j.sail.lmdb.LmdbUtil.E;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_begin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
 import org.lwjgl.util.lmdb.LMDB;
 
 /**
  * Reference for a LMDB transaction.
- *
  */
-public class TxnRef {
+class TxnRef {
+
+	private final Mode mode;
+	private final Map<Thread, TxnState> state = new HashMap<>();
+	private final Txn[] pool;
+	private long env;
+	private volatile int poolIndex = -1;
+
+	TxnRef(long txn) {
+		synchronized (state) {
+			state.put(Thread.currentThread(), new TxnState(new Txn(txn)));
+			mode = Mode.NONE;
+			pool = null;
+		}
+	}
+
+	TxnRef(long env, Mode mode) {
+		this.env = env;
+		this.mode = mode;
+		this.pool = mode == Mode.RESET ? new Txn[128] : null;
+	}
+
+	private Txn createTxnInternal() {
+		long readTxn;
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer pp = stack.mallocPointer(1);
+			E(mdb_txn_begin(env, NULL, MDB_RDONLY, pp));
+			readTxn = pp.get(0);
+		}
+		return new Txn(readTxn);
+	}
+
+	long create() {
+		TxnState s;
+		synchronized (state) {
+			s = state.get(Thread.currentThread());
+		}
+		Txn currentTxn;
+		if (s == null) {
+			s = new TxnState(createTxnInternal());
+			currentTxn = s.currentTxn;
+			synchronized (state) {
+				state.put(Thread.currentThread(), s);
+			}
+		} else {
+			currentTxn = s.currentTxn;
+			if (currentTxn == null) {
+				if (mode == Mode.RESET) {
+					synchronized (state) {
+						if (poolIndex >= 0) {
+							currentTxn = pool[poolIndex--];
+						}
+					}
+					if (currentTxn == null) {
+						currentTxn = createTxnInternal();
+					} else {
+						LMDB.mdb_txn_renew(currentTxn.txn);
+						currentTxn.refCount = 0;
+					}
+				} else {
+					currentTxn = createTxnInternal();
+				}
+				s.currentTxn = currentTxn;
+			}
+		}
+		currentTxn.refCount++;
+		return currentTxn.txn;
+	}
+
+	void free(long txn) {
+		synchronized (state) {
+			TxnState s = state.get(Thread.currentThread());
+			Txn t = s.currentTxn;
+			if (t == null || t.txn != txn) {
+				// check if a stale transaction has to be closed
+				t = s.staleTxns.stream().filter(oldTxn -> oldTxn.txn == txn).findFirst().get();
+			}
+			if (--t.refCount <= 0) {
+				switch (mode) {
+				case RESET:
+					if (poolIndex < pool.length - 1) {
+						LMDB.mdb_txn_reset(txn);
+						pool[++poolIndex] = t;
+					} else {
+						LMDB.mdb_txn_abort(txn);
+					}
+					break;
+				case ABORT:
+					LMDB.mdb_txn_abort(txn);
+					break;
+				case NONE:
+					break;
+				}
+
+				if (t == s.currentTxn) {
+					if (s.staleTxns == null || s.staleTxns.isEmpty()) {
+						// remove complete state object
+						state.remove(Thread.currentThread());
+					} else {
+						// reset only currentTxn
+						s.currentTxn = null;
+					}
+				} else {
+					if (s.staleTxns.size() == 1) {
+						// remove complete state object
+						state.remove(Thread.currentThread());
+					} else {
+						// remove only the stale txn
+						s.staleTxns.remove(t);
+					}
+				}
+			}
+		}
+	}
+
+	void invalidate() {
+		synchronized (state) {
+			state.values().forEach(s -> s.invalidate());
+		}
+	}
+
 	enum Mode {
 		RESET,
 		ABORT,
 		NONE
-	};
-
-	private long txn;
-	private long refCount;
-	private final Mode mode;
-	private boolean mustRenew = false;
-
-	public TxnRef(long txn, Mode mode) {
-		this.txn = txn;
-		this.mode = mode;
 	}
 
-	public synchronized void begin() {
-		refCount++;
-		if (mustRenew) {
-			LMDB.mdb_txn_renew(txn);
-			mustRenew = false;
+	static class TxnState {
+
+		Txn currentTxn;
+		List<Txn> staleTxns;
+
+		TxnState(Txn txn) {
+			this.currentTxn = txn;
 		}
-	}
 
-	public synchronized void end() {
-		if (--refCount <= 0) {
-			switch (mode) {
-			case RESET:
-				LMDB.mdb_txn_reset(txn);
-				mustRenew = true;
-				break;
-			case ABORT:
-				LMDB.mdb_txn_abort(txn);
-				break;
-			case NONE:
-				break;
+		void invalidate() {
+			if (currentTxn != null) {
+				if (staleTxns == null) {
+					staleTxns = new ArrayList<>(5);
+				}
+				staleTxns.add(currentTxn);
+				currentTxn = null;
 			}
-			refCount = 0;
 		}
 	}
 
-	public long get() {
-		return txn;
+	static class Txn {
+
+		long txn;
+		long refCount;
+
+		Txn(long txn) {
+			this.txn = txn;
+		}
 	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
@@ -71,10 +71,6 @@ import org.lwjgl.util.lmdb.MDBVal;
  */
 class ValueStore extends AbstractValueFactory {
 
-	/*-----------*
-	 * Constants *
-	 *-----------*/
-
 	private static final byte URI_VALUE = 0x0; // 00
 
 	private static final byte LITERAL_VALUE = 0x1; // 01
@@ -89,9 +85,6 @@ class ValueStore extends AbstractValueFactory {
 
 	private static final byte HASHID_KEY = 0x6;
 
-	/*-----------*
-	 * Variables *
-	 *-----------*/
 	/***
 	 * Maximum size of keys before hashing is used (size of two long values)
 	 */
@@ -141,15 +134,7 @@ class ValueStore extends AbstractValueFactory {
 	 */
 	private long nextId;
 
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
-
-	public ValueStore(File dir) throws IOException {
-		this(dir, new LmdbStoreConfig());
-	}
-
-	public ValueStore(File dir, LmdbStoreConfig config) throws IOException {
+	ValueStore(File dir, LmdbStoreConfig config) throws IOException {
 		this.dir = dir;
 		this.forceSync = config.getForceSync();
 		this.dbSize = config.getValueDBSize();
@@ -161,6 +146,7 @@ class ValueStore extends AbstractValueFactory {
 		namespaceIDCache = new ConcurrentCache<>(config.getNamespaceIDCacheSize());
 
 		setNewRevision();
+
 		// read maximum id from store
 		LmdbUtil.<Long>readTransaction(env, (stack, txn) -> {
 			long cursor = 0;
@@ -188,27 +174,6 @@ class ValueStore extends AbstractValueFactory {
 			}
 		});
 	}
-
-	public static void main(String[] args) throws Exception {
-		File dataDir = new File(args[0]);
-		ValueStore valueStore = new ValueStore(dataDir);
-
-		int maxID = (int) valueStore.nextId - 1;
-		for (int id = 1; id <= maxID; id++) {
-			byte[] data = valueStore.getData(id);
-			if (valueStore.isNamespaceData(data)) {
-				String ns = valueStore.data2namespace(data);
-				System.out.println("[" + id + "] " + ns);
-			} else {
-				Value value = valueStore.data2value(id, data, null);
-				System.out.println("[" + id + "] " + value.toString());
-			}
-		}
-	}
-
-	/*---------*
-	 * Methods *
-	 *---------*/
 
 	private void open() throws IOException {
 		// create directory if it not exists

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStoreRevision.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStoreRevision.java
@@ -47,4 +47,8 @@ public class ValueStoreRevision implements Serializable {
 	public ValueStore getValueStore() {
 		return valueStore;
 	}
+
+	public boolean resolveValue(long id, LmdbValue value) {
+		return valueStore.resolveValue(id, value);
+	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Varint.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Varint.java
@@ -85,26 +85,19 @@ public final class Varint {
 	 * @param bb    buffer for writing bytes
 	 * @param value value to encode
 	 */
-	public static void writeUnsigned(ByteBuffer bb, long value) {
+	public static void writeUnsigned(final ByteBuffer bb, final long value) {
 		if (value <= 240) {
-			byte a0 = (byte) value;
-			bb.put(a0);
+			bb.put((byte) value);
 		} else if (value <= 2287) {
-			byte a0 = (byte) ((value - 240) / 256 + 241);
-			byte a1 = (byte) ((value - 240) % 256);
-			bb.put(a0);
-			bb.put(a1);
+			bb.put((byte) ((value - 240) / 256 + 241));
+			bb.put((byte) ((value - 240) % 256));
 		} else if (value <= 67823) {
-			byte a0 = (byte) 249;
-			byte a1 = (byte) ((value - 2288) / 256);
-			byte a2 = (byte) ((value - 2288) % 256);
-			bb.put(a0);
-			bb.put(a1);
-			bb.put(a2);
+			bb.put((byte) 249);
+			bb.put((byte) ((value - 2288) / 256));
+			bb.put((byte) ((value - 2288) % 256));
 		} else {
 			int bytes = descriptor(value) + 1;
-			byte a0 = (byte) (250 + (bytes - 3));
-			bb.put(a0);
+			bb.put((byte) (250 + (bytes - 3)));
 			writeSignificantBits(bb, value, bytes);
 		}
 	}
@@ -248,9 +241,23 @@ public final class Varint {
 	 * @param bb     buffer for writing bytes
 	 * @param values array with values to write
 	 */
-	public static void writeListUnsigned(ByteBuffer bb, long[] values) {
+	public static void writeListUnsigned(final ByteBuffer bb, final long[] values) {
 		for (int i = 0; i < values.length; i++) {
-			writeUnsigned(bb, values[i]);
+			final long value = values[i];
+			if (value <= 240) {
+				bb.put((byte) value);
+			} else if (value <= 2287) {
+				bb.put((byte) ((value - 240) / 256 + 241));
+				bb.put((byte) ((value - 240) % 256));
+			} else if (value <= 67823) {
+				bb.put((byte) 249);
+				bb.put((byte) ((value - 2288) / 256));
+				bb.put((byte) ((value - 2288) % 256));
+			} else {
+				int bytes = descriptor(value) + 1;
+				bb.put((byte) (250 + (bytes - 3)));
+				writeSignificantBits(bb, value, bytes);
+			}
 		}
 	}
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreTest.java
@@ -50,20 +50,20 @@ public class TripleStoreTest {
 		tripleStore.commit();
 
 		assertEquals("Store should have 1 inferred statement", 1,
-				count(tripleStore.getTriples(1, 2, 3, 1, false, false)));
+				count(tripleStore.getTriples(1, 2, 3, 1, false)));
 
 		assertEquals("Store should have 0 explicit statements", 0,
-				count(tripleStore.getTriples(1, 2, 3, 1, true, true)));
+				count(tripleStore.getTriples(1, 2, 3, 1, true)));
 
 		tripleStore.startTransaction();
 		tripleStore.storeTriple(1, 2, 3, 1, true);
 		tripleStore.commit();
 
 		assertEquals("Store should have 0 inferred statements", 0,
-				count(tripleStore.getTriples(1, 2, 3, 1, false, false)));
+				count(tripleStore.getTriples(1, 2, 3, 1, false)));
 
 		assertEquals("Store should have 1 explicit statements", 1,
-				count(tripleStore.getTriples(1, 2, 3, 1, true, true)));
+				count(tripleStore.getTriples(1, 2, 3, 1, true)));
 	}
 
 	@After


### PR DESCRIPTION
GitHub issue resolved: #3534 

Briefly describe the changes proposed in this PR:

Improves query speed for LMDB based store by using different DBs for explicit and inferred statements.
This is the best solution until SailSourceConnection is rewritten to use a combined source for explicit and inferred statements while querying. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

