### PR TITLE
GH-2759: add support for DESCRIBE in FedX federation

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/DescribeIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/DescribeIteration.java
@@ -35,11 +35,11 @@ import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
  */
 public class DescribeIteration extends LookAheadIteration<BindingSet, QueryEvaluationException> {
 
-	private final static String VARNAME_SUBJECT = "subject";
+	protected final static String VARNAME_SUBJECT = "subject";
 
-	private final static String VARNAME_PREDICATE = "predicate";
+	protected final static String VARNAME_PREDICATE = "predicate";
 
-	private final static String VARNAME_OBJECT = "object";
+	protected final static String VARNAME_OBJECT = "object";
 
 	private final List<String> describeExprNames;
 
@@ -74,7 +74,7 @@ public class DescribeIteration extends LookAheadIteration<BindingSet, QueryEvalu
 
 	private int describeExprsIndex;
 
-	private BindingSet parentBindings;
+	protected BindingSet parentBindings;
 
 	private void resetCurrentDescribeExprIter() throws QueryEvaluationException {
 		while (currentDescribeExprIter == null) {
@@ -202,7 +202,7 @@ public class DescribeIteration extends LookAheadIteration<BindingSet, QueryEvalu
 		return null;
 	}
 
-	private CloseableIteration<BindingSet, QueryEvaluationException> createNextIteration(Value subject, Value object)
+	protected CloseableIteration<BindingSet, QueryEvaluationException> createNextIteration(Value subject, Value object)
 			throws QueryEvaluationException {
 		if (subject == null && object == null) {
 			return new EmptyIteration<>();

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FederatedDescribeOperator.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FederatedDescribeOperator.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.algebra;
+
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.query.algebra.DescribeOperator;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+/**
+ * Specialized {@link DescribeOperator} Node for maintaining {@link QueryInfo}.
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public class FederatedDescribeOperator extends DescribeOperator implements QueryRef {
+
+	private static final long serialVersionUID = -5623698444166736806L;
+
+	private final QueryInfo queryInfo;
+
+	public FederatedDescribeOperator(TupleExpr arg, QueryInfo queryInfo) {
+		super(arg);
+		this.queryInfo = queryInfo;
+	}
+
+	@Override
+	public QueryInfo getQueryInfo() {
+		return queryInfo;
+	}
+
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExpr;
 import org.eclipse.rdf4j.federated.algebra.ExclusiveTupleExprRenderer;
 import org.eclipse.rdf4j.federated.algebra.FedXLeftJoin;
 import org.eclipse.rdf4j.federated.algebra.FedXService;
+import org.eclipse.rdf4j.federated.algebra.FederatedDescribeOperator;
 import org.eclipse.rdf4j.federated.algebra.FilterExpr;
 import org.eclipse.rdf4j.federated.algebra.FilterValueExpr;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
@@ -41,6 +42,7 @@ import org.eclipse.rdf4j.federated.cache.SourceSelectionMemoryCache;
 import org.eclipse.rdf4j.federated.endpoint.Endpoint;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ControlledWorkerScheduler;
 import org.eclipse.rdf4j.federated.evaluation.concurrent.ParallelServiceExecutor;
+import org.eclipse.rdf4j.federated.evaluation.iterator.FederatedDescribeIteration;
 import org.eclipse.rdf4j.federated.evaluation.iterator.SingleBindingSetIteration;
 import org.eclipse.rdf4j.federated.evaluation.join.ControlledWorkerBoundJoin;
 import org.eclipse.rdf4j.federated.evaluation.join.ControlledWorkerJoin;
@@ -81,6 +83,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.DescribeOperator;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.Service;
@@ -224,10 +227,10 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 
 		// if the query has a single relevant source (and if it is not a SERVICE query), evaluate at this source only
 		// Note: UPDATE queries are always handled in the federation engine to adhere to the configured
-		// write strategy
+		// write strategy. Also DESCRIBE queries are handled in the federation
 		Set<Endpoint> relevantSources = performSourceSelection(members, cache, queryInfo, info);
 		if (relevantSources.size() == 1 && propagateServices(info.getServices())
-				&& queryInfo.getQueryType() != QueryType.UPDATE) {
+				&& queryInfo.getQueryType() != QueryType.UPDATE && queryInfo.getQueryType() != QueryType.DESCRIBE) {
 			return new SingleSourceQuery(query, relevantSources.iterator().next(), queryInfo);
 		}
 
@@ -874,6 +877,20 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 				return BooleanLiteral.TRUE;
 			}
 		};
+	}
+
+	@Override
+	public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(DescribeOperator operator,
+			final BindingSet bindings) throws QueryEvaluationException {
+
+		if (!(operator instanceof FederatedDescribeOperator)) {
+			throw new FedXRuntimeException(
+					"Expected a FedXDescribeOperator Node. Found " + operator.getClass() + " instead.");
+		}
+		CloseableIteration<BindingSet, QueryEvaluationException> iter = evaluate(operator.getArg(), bindings);
+		// Note: we need to evaluate the DESCRIBE over the entire federation
+		return new FederatedDescribeIteration(iter, this, operator.getBindingNames(), bindings,
+				((FederatedDescribeOperator) operator).getQueryInfo());
 	}
 
 	protected CloseableIteration<BindingSet, QueryEvaluationException> evaluateAtStatementSources(Object preparedQuery,

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/FederatedDescribeIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/FederatedDescribeIteration.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.federated.evaluation.iterator;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.ConvertingIteration;
+import org.eclipse.rdf4j.common.iteration.EmptyIteration;
+import org.eclipse.rdf4j.common.iteration.Iteration;
+import org.eclipse.rdf4j.federated.algebra.StatementSource;
+import org.eclipse.rdf4j.federated.algebra.StatementSource.StatementSourceType;
+import org.eclipse.rdf4j.federated.algebra.StatementSourcePattern;
+import org.eclipse.rdf4j.federated.endpoint.Endpoint;
+import org.eclipse.rdf4j.federated.evaluation.FederationEvalStrategy;
+import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.iterator.DescribeIteration;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Specialized {@link DescribeIteration} for evaluation of DESCRIBE queries in the federation. ‚
+ * 
+ * @author Andreas Schwarte
+ *
+ */
+public class FederatedDescribeIteration extends DescribeIteration {
+
+	private final QueryInfo queryInfo;
+
+	private final List<StatementSource> allSources;
+
+	public FederatedDescribeIteration(Iteration<BindingSet, QueryEvaluationException> sourceIter,
+			FederationEvalStrategy strategy, Set<String> describeExprNames, BindingSet parentBindings,
+			QueryInfo queryInfo) {
+		super(sourceIter, strategy, describeExprNames, parentBindings);
+		this.queryInfo = queryInfo;
+
+		// initialize StatementSources for all federation members
+		allSources = Lists.newArrayList();
+		for (Endpoint member : queryInfo.getFederationContext().getFederation().getMembers()) {
+			allSources.add(new StatementSource(member.getId(), StatementSourceType.REMOTE));
+		}
+	}
+
+	@Override
+	protected CloseableIteration<BindingSet, QueryEvaluationException> createNextIteration(Value subject, Value object)
+			throws QueryEvaluationException {
+		if (subject == null && object == null) {
+			return new EmptyIteration<>();
+		}
+
+		Var subjVar = new Var(VARNAME_SUBJECT, subject);
+		Var predVar = new Var(VARNAME_PREDICATE);
+		Var objVar = new Var(VARNAME_OBJECT, object);
+
+		StatementPattern pattern = new StatementPattern(subjVar, predVar, objVar);
+
+		// associate all federation members as sources for this pattern
+		// Note: for DESCRIBE we currently do not perform any extra source selection,
+		// i.e. we assume all members to be relevant for describing the resource
+		StatementSourcePattern stmtSourcePattern = new StatementSourcePattern(pattern, queryInfo);
+		allSources.forEach(source -> stmtSourcePattern.addStatementSource(source));
+
+		CloseableIteration<BindingSet, QueryEvaluationException> res = stmtSourcePattern.evaluate(parentBindings);
+
+		// we need to make sure that subject or object are added to the binding set
+		// Note: FedX uses prepared SELECT queries to evaluate a statement pattern and
+		// thus does not add bound values to the result bindingset
+		return new ConvertingIteration<BindingSet, BindingSet, QueryEvaluationException>(res) {
+
+			@Override
+			protected BindingSet convert(BindingSet sourceObject) throws QueryEvaluationException {
+				QueryBindingSet bs = new QueryBindingSet(sourceObject);
+				if (subject != null && !bs.hasBinding(VARNAME_SUBJECT)) {
+					bs.addBinding(VARNAME_SUBJECT, subject);
+				}
+				if (object != null && !bs.hasBinding(VARNAME_OBJECT)) {
+					bs.addBinding(VARNAME_OBJECT, object);
+				}
+				return bs;
+			}
+		};
+	}
+}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/GenericInfoOptimizer.java
@@ -12,9 +12,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.rdf4j.federated.algebra.FedXLeftJoin;
+import org.eclipse.rdf4j.federated.algebra.FederatedDescribeOperator;
 import org.eclipse.rdf4j.federated.algebra.NJoin;
 import org.eclipse.rdf4j.federated.exception.OptimizationException;
 import org.eclipse.rdf4j.federated.structures.QueryInfo;
+import org.eclipse.rdf4j.query.algebra.DescribeOperator;
 import org.eclipse.rdf4j.query.algebra.Filter;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.LeftJoin;
@@ -150,6 +152,17 @@ public class GenericInfoOptimizer extends AbstractQueryModelVisitor<Optimization
 			limit = node.getLimit();
 		}
 		super.meet(node);
+	}
+
+	@Override
+	public void meet(DescribeOperator node) throws OptimizationException {
+		/*
+		 * Replace with a FedX Describe Operator
+		 */
+		FederatedDescribeOperator newNode = new FederatedDescribeOperator(node.getArg(), queryInfo);
+		newNode.visitChildren(this);
+
+		node.replaceWith(newNode);
 	}
 
 	public boolean hasService() {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryType.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/structures/QueryType.java
@@ -11,6 +11,7 @@ public enum QueryType {
 
 	SELECT,
 	CONSTRUCT,
+	DESCRIBE,
 	ASK,
 	UPDATE,
 	GET_STATEMENTS,

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
@@ -452,4 +452,20 @@ public class BasicTests extends SPARQLBaseTest {
 			Assertions.assertEquals(0, numberOfResults.get());
 		}
 	}
+
+	@Test
+	public void testDescribe_SingleResource() throws Exception {
+
+		/* test DESCRIBE query for a single resource (data in two members) */
+		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint2.ttl"));
+		execute("/tests/basic/query_describe1.rq", "/tests/basic/query_describe1.ttl", false);
+	}
+
+	@Test
+	public void testDescribe_MultipleResources() throws Exception {
+
+		/* test DESCRIBE query for multiple resources (data in two members) */
+		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint2.ttl"));
+		execute("/tests/basic/query_describe2.rq", "/tests/basic/query_describe2.ttl", false);
+	}
 }

--- a/tools/federation/src/test/resources/tests/basic/query_describe1.rq
+++ b/tools/federation/src/test/resources/tests/basic/query_describe1.rq
@@ -1,0 +1,6 @@
+# describe alan
+
+PREFIX : <http://example.org/> 
+PREFIX foaf: <http://xmlns.com/foaf/0.1/> 
+
+DESCRIBE ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> "Alan" }

--- a/tools/federation/src/test/resources/tests/basic/query_describe1.ttl
+++ b/tools/federation/src/test/resources/tests/basic/query_describe1.ttl
@@ -1,0 +1,5 @@
+@prefix : <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+:a foaf:name "Alan" .
+:a foaf:interest "SPARQL 1.1 Basic Federated Query" .

--- a/tools/federation/src/test/resources/tests/basic/query_describe2.rq
+++ b/tools/federation/src/test/resources/tests/basic/query_describe2.rq
@@ -1,0 +1,5 @@
+# describe all resources
+PREFIX : <http://example.org/> 
+PREFIX foaf: <http://xmlns.com/foaf/0.1/> 
+
+DESCRIBE ?s WHERE { ?s ?p ?o }

--- a/tools/federation/src/test/resources/tests/basic/query_describe2.ttl
+++ b/tools/federation/src/test/resources/tests/basic/query_describe2.ttl
@@ -1,0 +1,7 @@
+@prefix : <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+:a foaf:name "Alan" .
+:a foaf:interest "SPARQL 1.1 Basic Federated Query" .
+:b foaf:name "Bob" .
+:b foaf:interest  "SPARQL 1.1 Query" .


### PR DESCRIPTION
GitHub issue resolved: #2759 

Briefly describe the changes proposed in this PR:

This change adds support for DESCRIBE queries to the federation and
makes sure that these are evaluated properly against the federation
members.

Notes:

* the existing DescribeIteration is extended for use in the federation.
In order to avoid code duplication some methods have been declared
protected
* the FedX internal query type "DESCRIBE" has been introduced
* tests for single and multiple resource descriptions are provided

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

