### PR TITLE
GH-2565 IRI equals/hashCode now based on stringValue instead of toString

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/IRI.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/IRI.java
@@ -59,8 +59,8 @@ public interface IRI extends Resource {
 	 *
 	 * @param o the object to compare this IRI to
 	 *
-	 * @return {@code true}, if the other object is an instance of {@code IRI} and their {@linkplain #toString() string
-	 *         values} are equal; {@code false}, otherwise
+	 * @return {@code true}, if the other object is an instance of {@code IRI} and their {@linkplain #stringValue()
+	 *         string values} are equal; {@code false}, otherwise
 	 */
 	@Override
 	boolean equals(Object o);
@@ -68,7 +68,7 @@ public interface IRI extends Resource {
 	/**
 	 * Computes the hash code of this IRI.
 	 *
-	 * @return a hash code for this IRI computed as {@link #toString()}{@code .hashCode()}
+	 * @return a hash code for this IRI computed as {@link #stringValue()}{@code .hashCode()}
 	 */
 	@Override
 	int hashCode();

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractIRI.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractIRI.java
@@ -31,12 +31,12 @@ public abstract class AbstractIRI implements IRI {
 	@Override
 	public boolean equals(Object o) {
 		return this == o || o instanceof IRI
-				&& toString().equals(o.toString()); // TODO stringValue() (https://github.com/eclipse/rdf4j/issues/2565)
+				&& stringValue().equals(o.toString());
 	}
 
 	@Override
 	public int hashCode() {
-		return toString().hashCode(); // TODO stringValue() (https://github.com/eclipse/rdf4j/issues/2565)
+		return stringValue().hashCode();
 	}
 
 	@Override

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/IRITest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/IRITest.java
@@ -118,7 +118,7 @@ public abstract class IRITest {
 
 		assertThat(iri.hashCode())
 				.as("computed according to contract")
-				.isEqualTo(iri.toString().hashCode()); // !!! .toString() >> .valueString()
+				.isEqualTo(iri.stringValue().hashCode());
 	}
 
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemIRI.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemIRI.java
@@ -112,7 +112,7 @@ public class MemIRI implements IRI, MemResource {
 			MemIRI o = (MemIRI) other;
 			return namespace.equals(o.getNamespace()) && localName.equals(o.getLocalName());
 		} else if (other instanceof IRI) {
-			String otherStr = other.toString();
+			String otherStr = ((IRI) other).stringValue();
 
 			return namespace.length() + localName.length() == otherStr.length() && otherStr.endsWith(localName)
 					&& otherStr.startsWith(namespace);
@@ -124,7 +124,7 @@ public class MemIRI implements IRI, MemResource {
 	@Override
 	public int hashCode() {
 		if (hashCode == 0) {
-			hashCode = toString().hashCode();
+			hashCode = stringValue().hashCode();
 		}
 
 		return hashCode;

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStore.java
@@ -40,11 +40,10 @@ import org.eclipse.rdf4j.sail.nativerdf.model.NativeValue;
  *
  * @author Arjohn Kampman
  *
- * @deprecated since 3.0. This feature is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @apiNote This feature is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
 @InternalUseOnly
-@Deprecated
 public class ValueStore extends SimpleValueFactory {
 
 	/*-----------*
@@ -256,7 +255,7 @@ public class ValueStore extends SimpleValueFactory {
 					// Store id in cache
 					NativeValue nv = getNativeValue(value);
 					nv.setInternalID(id, revision);
-					valueIDCache.put(nv, new Integer(id));
+					valueIDCache.put(nv, Integer.valueOf(id));
 				}
 			}
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStoreRevision.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStoreRevision.java
@@ -19,10 +19,9 @@ import org.eclipse.rdf4j.sail.nativerdf.model.NativeValue;
  *
  * @author Arjohn Kampman
  *
- * @deprecated since 3.0. This feature is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @apiNote This feature is for internal use only: its existence, signature or behavior may change without warning from
+ *          one release to the next.
  */
-@Deprecated
 @InternalUseOnly
 public class ValueStoreRevision implements Serializable {
 

--- a/site/content/release-notes/4.0.0.md
+++ b/site/content/release-notes/4.0.0.md
@@ -188,6 +188,15 @@ Removed `org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation` system prope
 SPARQL based validation is now enabled by default. This can be disabled by setting
 `org.eclipse.rdf4j.sail.shacl.sparqlValidation` to false.
 
+### IRI hashCode / equals contract changed
+
+The contract on the `hashCode()` and `equals()` methods for `IRI` has changed
+slightly: previously, it was defined to use the value of `toString()` to
+calculate the hash, now it's defined to use `stringValue()` instead. Projects
+that use their own implementations of the `IRI` interface will need to verify
+and possibly adjust their `hashCode()` and `equals()` implementation to conform
+to this.
+
 ## Acknowledgements
 
 This release was made possible by contributions from Andreas Schwarte, Florian


### PR DESCRIPTION
GitHub issue resolved: #2565  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- adjusted javadoc on `IRI` interface
- fixed code in all core implementations of `IRI`
- adjusted relevant unit test case
- small unrelated change in native store that I stumbled across
- added entry to release notes

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

