### PR TITLE
GH-3533 set checkout action version to v2 in all workflows

### DIFF
--- a/.github/workflows/develop-status.yml
+++ b/.github/workflows/develop-status.yml
@@ -14,7 +14,7 @@ jobs:
         jdk: [1.8, 15]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/main-status.yml
+++ b/.github/workflows/main-status.yml
@@ -14,7 +14,7 @@ jobs:
         jdk: [1.8, 11, 15]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/merge_main_to_develop.yml
+++ b/.github/workflows/merge_main_to_develop.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: pull-request
       uses: repo-sync/pull-request@v2.0.1
       with:

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         jdk: [1.8, 15]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
@@ -38,7 +38,7 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
@@ -69,7 +69,7 @@ jobs:
   slow-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
GitHub issue resolved: #3533  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- use action/checkout@v2 in all github action workflows

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

