### PR TITLE
GH-3533 bump pull-request action to be compatible with checkout v2

### DIFF
--- a/.github/workflows/merge_main_to_develop.yml
+++ b/.github/workflows/merge_main_to_develop.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: pull-request
-      uses: repo-sync/pull-request@v2.0.1
+      uses: repo-sync/pull-request@v2.6.1
       with:
         destination_branch: "develop"         # If blank, default: main
         pr_title: "Merge main into develop"


### PR DESCRIPTION
GitHub issue resolved: #3533  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- merge-main-develop workflow started failing after updating to checkout v2
- a recent fix in the repo-sync/pull-request action should address this, so bumping to latest

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

