### PR TITLE
GH-3589 cache toString() in MemIRI 

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemIRI.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemIRI.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory.model;
 
+import java.lang.ref.SoftReference;
+
 import org.eclipse.rdf4j.model.IRI;
 
 /**
@@ -82,9 +84,22 @@ public class MemIRI implements IRI, MemResource {
 	 * Methods *
 	 *---------*/
 
+	transient SoftReference<String> toStringCache = null;
+
 	@Override
 	public String toString() {
-		return namespace + localName;
+		String result;
+		if (toStringCache == null) {
+			result = namespace + localName;
+			toStringCache = new SoftReference<>(result);
+		} else {
+			result = toStringCache.get();
+			if (result == null) {
+				result = namespace + localName;
+				toStringCache = new SoftReference<>(result);
+			}
+		}
+		return result;
 	}
 
 	@Override


### PR DESCRIPTION
GitHub issue resolved: #3589 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - cache the results of toString() using a soft reference to reduce the number of times we need to recompute it
    - typically the .toString() method is called when retrieving the MemIRI from MemValueFactory with an AbstractIRI because the .equals() method there uses the full string representation instead of the namespace and local name like MemIRI does.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

