### PR TITLE
GH-3594 Only do toString on the Number value when getLabel is called

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/NumericLiteral.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/NumericLiteral.java
@@ -145,15 +145,14 @@ public class NumericLiteral extends AbstractLiteral {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof NumericLiteral)
-			return equals((NumericLiteral) o);
-		else
+		if (this == o) {
+			return true;
+		}
+		if (o instanceof NumericLiteral) {
+			return datatype == ((NumericLiteral) o).datatype && number.equals(((NumericLiteral) o).number);
+		} else {
 			return super.equals(o);
+		}
 	}
 
-	private boolean equals(NumericLiteral o) {
-		if (this == o)
-			return true;
-		return number.equals(o.number) && datatype.equals(o.datatype);
-	}
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/NumericLiteral.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/NumericLiteral.java
@@ -7,38 +7,47 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.impl;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.base.AbstractLiteral;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
- * An extension of {@link SimpleLiteral} that stores a numeric value to avoid parsing.
+ * An extension of {@link AbstractLiteral} that stores a numeric value to avoid parsing.
  *
  * @author David Huynh
+ * @author Jerven Bolleman
  */
-public class NumericLiteral extends SimpleLiteral {
+public class NumericLiteral extends AbstractLiteral {
 
 	private static final long serialVersionUID = 3004497457768807919L;
 
 	private final Number number;
 
+	private final CoreDatatype datatype;
+
 	/**
 	 * Creates a literal with the specified value and datatype.
 	 */
 	protected NumericLiteral(Number number, IRI datatype) {
-		super(XMLDatatypeUtil.toString(number), datatype);
+		super();
+		assert Objects.nonNull(number);
+		assert Objects.nonNull(datatype);
+		this.datatype = CoreDatatype.from(datatype);
 		this.number = number;
 	}
 
 	@Deprecated(since = "4.0.0", forRemoval = true)
 	protected NumericLiteral(Number number, XSD.Datatype datatype) {
-		super(XMLDatatypeUtil.toString(number), datatype);
-		this.number = number;
+		this(number, datatype.getCoreDatatype());
 	}
 
 	protected NumericLiteral(Number number, CoreDatatype datatype) {
-		super(XMLDatatypeUtil.toString(number), datatype);
+		this.datatype = datatype;
 		this.number = number;
 	}
 
@@ -112,5 +121,39 @@ public class NumericLiteral extends SimpleLiteral {
 	@Override
 	public double doubleValue() {
 		return number.doubleValue();
+	}
+
+	@Override
+	public String getLabel() {
+		return XMLDatatypeUtil.toString(number);
+	}
+
+	@Override
+	public Optional<String> getLanguage() {
+		return Optional.empty();
+	}
+
+	@Override
+	public IRI getDatatype() {
+		return datatype.getIri();
+	}
+
+	@Override
+	public CoreDatatype getCoreDatatype() {
+		return datatype;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof NumericLiteral)
+			return equals((NumericLiteral) o);
+		else
+			return super.equals(o);
+	}
+
+	private boolean equals(NumericLiteral o) {
+		if (this == o)
+			return true;
+		return number.equals(o.number) && datatype.equals(o.datatype);
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jerven Bolleman <jerven.bolleman@sib.swiss>


GitHub issue resolved: #3594 

Briefly describe the changes proposed in this PR:

For a NumericLiteral store only the Number value and datatype.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

