### PR TITLE
GH-3587 CoreDatatype enum for literals

### DIFF
--- a/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrIndexTest.java
+++ b/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrIndexTest.java
@@ -33,6 +33,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -383,6 +384,19 @@ public class SolrIndexTest {
 		Literal literal2 = fac.createLiteral("hi there, too", XSD.STRING);
 		Literal literal3 = fac.createLiteral("1.0");
 		Literal literal4 = fac.createLiteral("1.0", XSD.FLOAT);
+
+		assertEquals("Is the first literal accepted?", true, index.accept(literal1));
+		assertEquals("Is the second literal accepted?", true, index.accept(literal2));
+		assertEquals("Is the third literal accepted?", true, index.accept(literal3));
+		assertEquals("Is the fourth literal accepted?", false, index.accept(literal4));
+	}
+
+	@Test
+	public void testRejectedCoreDatatypes() {
+		Literal literal1 = fac.createLiteral("hi there");
+		Literal literal2 = fac.createLiteral("hi there, too", CoreDatatype.XSD.STRING);
+		Literal literal3 = fac.createLiteral("1.0");
+		Literal literal4 = fac.createLiteral("1.0", CoreDatatype.XSD.FLOAT);
 
 		assertEquals("Is the first literal accepted?", true, index.accept(literal1));
 		assertEquals("Is the second literal accepted?", true, index.accept(literal2));

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/Literal.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/Literal.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+
 /**
  * An RDF-1.1 literal consisting of a label (the lexical value), a datatype, and optionally a language tag.
  *
@@ -144,12 +146,12 @@ public interface Literal extends Value {
 
 	/**
 	 * Retrieves the {@link TemporalAccessor temporal accessor} value of this literal.
-	 * 
+	 *
 	 * <p>
 	 * A temporal accessor representation can be given for literals whose label conforms to the syntax of the following
 	 * <a href="https://www.w3.org/TR/xmlschema11-2">XML Schema 1.1</a> date/time datatypes:
 	 * </p>
-	 * 
+	 *
 	 * <ul>
 	 *
 	 * <li><a href="https://www.w3.org/TR/xmlschema11-2/#dateTime">xsd:dateTime</a>,</li>
@@ -161,24 +163,24 @@ public interface Literal extends Value {
 	 * <li><a href="https://www.w3.org/TR/xmlschema11-2/#gMonthDay">xsd:gMonthDay</a>,</li>
 	 * <li><a href="https://www.w3.org/TR/xmlschema11-2/#gDay">xsd:gDay</a>,</li>
 	 * <li><a href="https://www.w3.org/TR/xmlschema11-2/#gMonth">xsd:gMonth</a>.</li>
-	 * 
+	 *
 	 * </ul>
-	 * 
+	 *
 	 * <p>
 	 * Temporal accessor representations may be converted to specific {@link java.time} values like
 	 * {@link OffsetDateTime} using target static factory methods, for instance
 	 * {@code OffsetDateTime.from(literal.temporalAccessorValue())}.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * Note however that {@link java.time} doesn't include dedicated classes for some legal XML Schema date/time values,
 	 * like offset dates (for instance, {@code 2020-11-16+01:00}) and {@code xsd:gDay} (for instance, {@code ---16}).
 	 * </p>
-	 * 
+	 *
 	 * @return the temporal accessor value of this literal
 	 *
 	 * @throws DateTimeException if this literal cannot be represented by a {@link TemporalAccessor} value
-	 * 
+	 *
 	 * @since 3.5.0
 	 * @author Alessandro Bollini
 	 *
@@ -192,7 +194,7 @@ public interface Literal extends Value {
 	 *          Datatypes Second Edition</a>: it is not included among temporal datatypes automatically assigned by
 	 *          {@link ValueFactory#createLiteral(TemporalAmount)} in order to provide better interoperability with the
 	 *          latter version of the standard.
-	 * 
+	 *
 	 * @implSpec The default method implementation throws an {@link UnsupportedOperationException} and is only supplied
 	 *           as a stop-gap measure for backward compatibility: concrete classes implementing this interface are
 	 *           expected to override it.
@@ -209,7 +211,7 @@ public interface Literal extends Value {
 	 * <a href="https://www.w3.org/TR/xmlschema-2/">XML Schema 2</a>
 	 * <a href="https://www.w3.org/TR/xmlschema-2/#duration">xsd:duration</a> datatype.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * The adoption of the <a href="https://www.w3.org/TR/xmlschema-2/">XML Schema 2</a> definition is a known deviation
 	 * from the <a href="http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal">RDF 1.1</a> standard;
@@ -225,7 +227,7 @@ public interface Literal extends Value {
 	 * Note however that {@link java.time} doesn't include dedicated classes for legal XML Schema duration values
 	 * including both date and time components (for instance, {@code P1YT23H}).
 	 * </p>
-	 * 
+	 *
 	 * @return the temporal amount value of this literal
 	 *
 	 * @throws DateTimeException if this literal cannot be represented by a {@link TemporalAmount} value
@@ -266,6 +268,22 @@ public interface Literal extends Value {
 	 * @throws IllegalArgumentException If the literal cannot be represented by a {@link XMLGregorianCalendar}.
 	 */
 	XMLGregorianCalendar calendarValue();
+
+	/**
+	 * CoreDatatype is an interface for natively supported datatypes in RDF4J. This includes, among others, the XML
+	 * Schema datatypes and rdf:langString. CoreDatatypes are implemented as enums and more performant and convenient to
+	 * work with than IRI-based datatypes. The constant {@link CoreDatatype#NONE)} is used to represent a datatype that
+	 * is not one of the supported core datatypes.
+	 *
+	 * @return The CoreDatatype or {@link CoreDatatype#NONE)} if the datatype matches none of the core datatypes. This
+	 *         method will not return null.
+	 *
+	 * @implNote This method may not return null. Returning {@link CoreDatatype#NONE)} is only permitted if the datatype
+	 *           does not match any of the core datatypes. A literal with a language tag must return
+	 *           {@link CoreDatatype.RDF#LANGSTRING)}. A literal without a specified datatype must return
+	 *           {@link CoreDatatype.XSD#STRING)}.
+	 */
+	CoreDatatype getCoreDatatype();
 
 	/**
 	 * Compares this literal to another object.

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -15,6 +15,8 @@ import java.util.Date;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+
 /**
  * A factory for creating {@link IRI IRIs}, {@link BNode blank nodes}, {@link Literal literals} and {@link Statement
  * statements} based on the RDF-1.1 Concepts and Abstract Syntax, a W3C Recommendation.
@@ -89,6 +91,14 @@ public interface ValueFactory {
 	 *                 literal.
 	 */
 	Literal createLiteral(String label, IRI datatype);
+
+	/**
+	 * Creates a new literal with the supplied label and datatype.
+	 *
+	 * @param label    The literal's label, must not be <var>null</var>.
+	 * @param datatype The literal's datatype. It may not be null.
+	 */
+	Literal createLiteral(String label, CoreDatatype datatype);
 
 	/**
 	 * Creates a new <var>xsd:boolean</var>-typed literal representing the specified value.

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
@@ -45,6 +45,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -60,7 +61,6 @@ import javax.xml.namespace.QName;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.base.AbstractIRI.GenericIRI;
 
 /**
  * Base class for {@link Literal}, offering common functionality.
@@ -73,37 +73,12 @@ public abstract class AbstractLiteral implements Literal {
 
 	private static final long serialVersionUID = -1286527360744086451L;
 
-	private static final String RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-	private static final String XSD = "http://www.w3.org/2001/XMLSchema#";
-
-	private static final IRI RDF_LANGSTRING = new GenericIRI(RDF, "langString");
-
-	private static final IRI XSD_STRING = new GenericIRI(XSD, "string");
-	private static final IRI XSD_BOOLEAN = new GenericIRI(XSD, "boolean");
-
-	private static final IRI XSD_BYTE = new GenericIRI(XSD, "byte");
-	private static final IRI XSD_SHORT = new GenericIRI(XSD, "short");
-	private static final IRI XSD_INT = new GenericIRI(XSD, "int");
-	private static final IRI XSD_LONG = new GenericIRI(XSD, "long");
-	private static final IRI XSD_FLOAT = new GenericIRI(XSD, "float");
-	private static final IRI XSD_DOUBLE = new GenericIRI(XSD, "double");
-	private static final IRI XSD_INTEGER = new GenericIRI(XSD, "integer");
-	private static final IRI XSD_DECIMAL = new GenericIRI(XSD, "decimal");
-
-	private static final IRI XSD_DATETIME = new GenericIRI(XSD, "dateTime");
-	private static final IRI XSD_DATE = new GenericIRI(XSD, "date");
-	private static final IRI XSD_TIME = new GenericIRI(XSD, "time");
-	private static final IRI XSD_GYEARMONTH = new GenericIRI(XSD, "gYearMonth");
-	private static final IRI XSD_GMONTHDAY = new GenericIRI(XSD, "gMonthDay");
-	private static final IRI XSD_GYEAR = new GenericIRI(XSD, "gYear");
-	private static final IRI XSD_GMONTH = new GenericIRI(XSD, "gMonth");
-	private static final IRI XSD_GDAY = new GenericIRI(XSD, "gDay");
-	private static final IRI XSD_DURATION = new GenericIRI(XSD, "duration");
-	private static final IRI XSD_DURATION_DAYTIME = new GenericIRI(XSD, "dayTimeDuration");
-	private static final IRI XSD_DURATION_YEARMONTH = new GenericIRI(XSD, "yearMonthDuration");
-
 	static boolean reserved(IRI datatype) {
-		return RDF_LANGSTRING.equals(datatype);
+		return CoreDatatype.RDF.LANGSTRING.getIri().equals(datatype);
+	}
+
+	static boolean reserved(CoreDatatype datatype) {
+		return CoreDatatype.RDF.LANGSTRING == datatype;
 	}
 
 	/**
@@ -216,7 +191,7 @@ public abstract class AbstractLiteral implements Literal {
 
 					final IRI datatype = getDatatype();
 
-					return datatype.equals(XSD_STRING) ? label
+					return datatype.equals(CoreDatatype.XSD.STRING) ? label
 							: label + "^^<" + datatype.stringValue() + ">";
 
 				});
@@ -234,17 +209,31 @@ public abstract class AbstractLiteral implements Literal {
 
 		private static final long serialVersionUID = -19640527584237291L;
 
-		private String label;
-		private IRI datatype;
+		private final String label;
+		private final CoreDatatype coreDatatype;
+		private final IRI datatype;
 
 		TypedLiteral(String label) {
 			this.label = label;
-			this.datatype = XSD_STRING;
+			this.coreDatatype = CoreDatatype.XSD.STRING;
+			this.datatype = CoreDatatype.XSD.STRING.getIri();
 		}
 
 		TypedLiteral(String label, IRI datatype) {
 			this.label = label;
-			this.datatype = datatype != null ? datatype : XSD_STRING;
+			if (datatype == null) {
+				this.datatype = CoreDatatype.XSD.STRING.getIri();
+				this.coreDatatype = CoreDatatype.XSD.STRING;
+			} else {
+				this.datatype = datatype;
+				this.coreDatatype = CoreDatatype.from(datatype);
+			}
+		}
+
+		TypedLiteral(String label, CoreDatatype datatype) {
+			this.label = label;
+			this.coreDatatype = Objects.requireNonNull(datatype);
+			this.datatype = datatype.getIri();
 		}
 
 		@Override
@@ -262,14 +251,18 @@ public abstract class AbstractLiteral implements Literal {
 			return datatype;
 		}
 
+		@Override
+		public CoreDatatype getCoreDatatype() {
+			return coreDatatype;
+		}
 	}
 
 	static class TaggedLiteral extends AbstractLiteral {
 
 		private static final long serialVersionUID = -19640527584237291L;
 
-		private String label;
-		private String language;
+		private final String label;
+		private final String language;
 
 		TaggedLiteral(String label, String language) {
 			this.label = label;
@@ -288,9 +281,13 @@ public abstract class AbstractLiteral implements Literal {
 
 		@Override
 		public IRI getDatatype() {
-			return RDF_LANGSTRING;
+			return CoreDatatype.RDF.LANGSTRING.getIri();
 		}
 
+		@Override
+		public CoreDatatype.RDF getCoreDatatype() {
+			return CoreDatatype.RDF.LANGSTRING;
+		}
 	}
 
 	static class BooleanLiteral extends AbstractLiteral {
@@ -310,7 +307,7 @@ public abstract class AbstractLiteral implements Literal {
 					.orElse(null);
 		}
 
-		private boolean value;
+		private final boolean value;
 
 		BooleanLiteral(boolean value) {
 			this.value = value;
@@ -328,7 +325,12 @@ public abstract class AbstractLiteral implements Literal {
 
 		@Override
 		public IRI getDatatype() {
-			return XSD_BOOLEAN;
+			return CoreDatatype.XSD.BOOLEAN.getIri();
+		}
+
+		@Override
+		public CoreDatatype.XSD getCoreDatatype() {
+			return CoreDatatype.XSD.BOOLEAN;
 		}
 
 		@Override
@@ -376,34 +378,34 @@ public abstract class AbstractLiteral implements Literal {
 
 		protected Number value;
 
-		private String label;
-		private IRI datatype;
+		private final String label;
+		private final CoreDatatype datatype;
 
 		NumberLiteral(byte value) {
-			this(value, Byte.toString(value), XSD_BYTE);
+			this(value, Byte.toString(value), CoreDatatype.XSD.BYTE);
 		}
 
 		NumberLiteral(short value) {
-			this(value, Short.toString(value), XSD_SHORT);
+			this(value, Short.toString(value), CoreDatatype.XSD.SHORT);
 		}
 
 		NumberLiteral(int value) {
-			this(value, Integer.toString(value), XSD_INT);
+			this(value, Integer.toString(value), CoreDatatype.XSD.INT);
 		}
 
 		NumberLiteral(long value) {
-			this(value, Long.toString(value), XSD_LONG);
+			this(value, Long.toString(value), CoreDatatype.XSD.LONG);
 		}
 
 		NumberLiteral(float value) {
-			this(value, toString(value), XSD_FLOAT);
+			this(value, toString(value), CoreDatatype.XSD.FLOAT);
 		}
 
 		NumberLiteral(double value) {
-			this(value, toString(value), XSD_DOUBLE);
+			this(value, toString(value), CoreDatatype.XSD.DOUBLE);
 		}
 
-		NumberLiteral(Number value, String label, IRI datatype) {
+		NumberLiteral(Number value, String label, CoreDatatype datatype) {
 			this.value = value;
 			this.label = label;
 			this.datatype = datatype;
@@ -421,7 +423,7 @@ public abstract class AbstractLiteral implements Literal {
 
 		@Override
 		public IRI getDatatype() {
-			return datatype;
+			return datatype.getIri();
 		}
 
 		@Override
@@ -454,6 +456,10 @@ public abstract class AbstractLiteral implements Literal {
 			return value.doubleValue();
 		}
 
+		@Override
+		public CoreDatatype getCoreDatatype() {
+			return datatype;
+		}
 	}
 
 	static class IntegerLiteral extends NumberLiteral {
@@ -461,7 +467,7 @@ public abstract class AbstractLiteral implements Literal {
 		private static final long serialVersionUID = -4274941248972496665L;
 
 		IntegerLiteral(BigInteger value) {
-			super(value, value.toString(), XSD_INTEGER);
+			super(value, value.toString(), CoreDatatype.XSD.INTEGER);
 		}
 
 		@Override
@@ -481,7 +487,7 @@ public abstract class AbstractLiteral implements Literal {
 		private static final long serialVersionUID = -4382147098035463886L;
 
 		DecimalLiteral(BigDecimal value) {
-			super(value, value.toPlainString(), XSD_DECIMAL);
+			super(value, value.toPlainString(), CoreDatatype.XSD.DECIMAL);
 		}
 
 		@Override
@@ -579,12 +585,12 @@ public abstract class AbstractLiteral implements Literal {
 
 				.toFormatter();
 
-		private static final Map<Integer, IRI> DATATYPES = datatypes();
-		private static final Map<IRI, DateTimeFormatter> FORMATTERS = formatters();
+		private static final Map<Integer, CoreDatatype> DATATYPES = datatypes();
+		private static final Map<CoreDatatype.XSD, DateTimeFormatter> FORMATTERS = formatters();
 
 		static TemporalAccessor parseTemporalAccessor(String label) throws DateTimeException {
 
-			final TemporalAccessor value = formatter(label).parse(label);
+			TemporalAccessor value = formatter(label).parse(label);
 
 			if (!DATATYPES.containsKey(key(value))) {
 				throw new DateTimeException(String.format(
@@ -595,50 +601,50 @@ public abstract class AbstractLiteral implements Literal {
 			return value;
 		}
 
-		private static Map<Integer, IRI> datatypes() {
+		private static Map<Integer, CoreDatatype> datatypes() {
 
-			final Map<Integer, IRI> datatypes = new HashMap<>();
+			int date = key(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH);
+			int time = key(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE);
+			int nano = key(NANO_OF_SECOND);
+			int zone = key(OFFSET_SECONDS);
 
-			final int date = key(YEAR, MONTH_OF_YEAR, DAY_OF_MONTH);
-			final int time = key(HOUR_OF_DAY, MINUTE_OF_HOUR, SECOND_OF_MINUTE);
-			final int nano = key(NANO_OF_SECOND);
-			final int zone = key(OFFSET_SECONDS);
+			Map<Integer, CoreDatatype> datatypes = new HashMap<>();
 
-			datatypes.put(date + time, XSD_DATETIME);
-			datatypes.put(date + time + nano, XSD_DATETIME);
-			datatypes.put((date + time + zone), XSD_DATETIME);
-			datatypes.put((date + time + nano + zone), XSD_DATETIME);
+			datatypes.put(date + time, CoreDatatype.XSD.DATETIME);
+			datatypes.put(date + time + nano, CoreDatatype.XSD.DATETIME);
+			datatypes.put((date + time + zone), CoreDatatype.XSD.DATETIME);
+			datatypes.put((date + time + nano + zone), CoreDatatype.XSD.DATETIME);
 
-			datatypes.put(time, XSD_TIME);
-			datatypes.put(time + nano, XSD_TIME);
-			datatypes.put(time + zone, XSD_TIME);
-			datatypes.put(time + nano + zone, XSD_TIME);
+			datatypes.put(time, CoreDatatype.XSD.TIME);
+			datatypes.put(time + nano, CoreDatatype.XSD.TIME);
+			datatypes.put(time + zone, CoreDatatype.XSD.TIME);
+			datatypes.put(time + nano + zone, CoreDatatype.XSD.TIME);
 
-			datatypes.put(date, XSD_DATE);
-			datatypes.put(date + zone, XSD_DATE);
+			datatypes.put(date, CoreDatatype.XSD.DATE);
+			datatypes.put(date + zone, CoreDatatype.XSD.DATE);
 
-			datatypes.put(key(YEAR, MONTH_OF_YEAR), XSD_GYEARMONTH);
-			datatypes.put(key(YEAR), XSD_GYEAR);
-			datatypes.put(key(MONTH_OF_YEAR, DAY_OF_MONTH), XSD_GMONTHDAY);
-			datatypes.put(key(DAY_OF_MONTH), XSD_GDAY);
-			datatypes.put(key(MONTH_OF_YEAR), XSD_GMONTH);
+			datatypes.put(key(YEAR, MONTH_OF_YEAR), CoreDatatype.XSD.GYEARMONTH);
+			datatypes.put(key(YEAR), CoreDatatype.XSD.GYEAR);
+			datatypes.put(key(MONTH_OF_YEAR, DAY_OF_MONTH), CoreDatatype.XSD.GMONTHDAY);
+			datatypes.put(key(DAY_OF_MONTH), CoreDatatype.XSD.GDAY);
+			datatypes.put(key(MONTH_OF_YEAR), CoreDatatype.XSD.GMONTH);
 
 			return datatypes;
 		}
 
-		private static Map<IRI, DateTimeFormatter> formatters() {
+		private static Map<CoreDatatype.XSD, DateTimeFormatter> formatters() {
 
-			final Map<IRI, DateTimeFormatter> formatters = new HashMap<>();
+			final Map<CoreDatatype.XSD, DateTimeFormatter> formatters = new EnumMap<>(CoreDatatype.XSD.class);
 
-			formatters.put(XSD_DATETIME, DATETIME_FORMATTER);
-			formatters.put(XSD_TIME, OFFSET_TIME_FORMATTER);
-			formatters.put(XSD_DATE, OFFSET_DATE_FORMATTER);
+			formatters.put(CoreDatatype.XSD.DATETIME, DATETIME_FORMATTER);
+			formatters.put(CoreDatatype.XSD.TIME, OFFSET_TIME_FORMATTER);
+			formatters.put(CoreDatatype.XSD.DATE, OFFSET_DATE_FORMATTER);
 
-			formatters.put(XSD_GYEARMONTH, LOCAL_DATE_FORMATTER);
-			formatters.put(XSD_GYEAR, LOCAL_DATE_FORMATTER);
-			formatters.put(XSD_GMONTHDAY, DASH_FORMATTER);
-			formatters.put(XSD_GDAY, DASH_FORMATTER);
-			formatters.put(XSD_GMONTH, DASH_FORMATTER);
+			formatters.put(CoreDatatype.XSD.GYEARMONTH, LOCAL_DATE_FORMATTER);
+			formatters.put(CoreDatatype.XSD.GYEAR, LOCAL_DATE_FORMATTER);
+			formatters.put(CoreDatatype.XSD.GMONTHDAY, DASH_FORMATTER);
+			formatters.put(CoreDatatype.XSD.GDAY, DASH_FORMATTER);
+			formatters.put(CoreDatatype.XSD.GMONTH, DASH_FORMATTER);
 
 			return formatters;
 		}
@@ -680,16 +686,16 @@ public abstract class AbstractLiteral implements Literal {
 			return index;
 		}
 
-		private TemporalAccessor value;
+		private final TemporalAccessor value;
 
-		private String label;
-		private IRI datatype;
+		private final String label;
+		private final CoreDatatype datatype;
 
 		TemporalAccessorLiteral(TemporalAccessor value) {
 
 			this.value = value;
 
-			final IRI datatype = DATATYPES.get(key(value));
+			datatype = DATATYPES.get(key(value));
 
 			if (datatype == null) {
 				throw new IllegalArgumentException(String.format(
@@ -698,7 +704,6 @@ public abstract class AbstractLiteral implements Literal {
 			}
 
 			this.label = FORMATTERS.get(datatype).format(value);
-			this.datatype = datatype;
 		}
 
 		@Override
@@ -713,12 +718,17 @@ public abstract class AbstractLiteral implements Literal {
 
 		@Override
 		public IRI getDatatype() {
-			return datatype;
+			return datatype.getIri();
 		}
 
 		@Override
 		public TemporalAccessor temporalAccessorValue() {
 			return value;
+		}
+
+		@Override
+		public CoreDatatype getCoreDatatype() {
+			return datatype;
 		}
 
 	}
@@ -742,9 +752,9 @@ public abstract class AbstractLiteral implements Literal {
 				"(?:(?<" + SECONDS + ">\\d+)(?:\\.(?<" + NANOS + ">\\d+))?S)?"
 		);
 
-		private TemporalAmount value;
+		private final TemporalAmount value;
 
-		private String label;
+		private final String label;
 
 		TemporalAmountLiteral(TemporalAmount value) {
 
@@ -893,12 +903,17 @@ public abstract class AbstractLiteral implements Literal {
 
 		@Override
 		public IRI getDatatype() {
-			return XSD_DURATION;
+			return CoreDatatype.XSD.DURATION.getIri();
 		}
 
 		@Override
 		public TemporalAmount temporalAmountValue() throws DateTimeException {
 			return value;
+		}
+
+		@Override
+		public CoreDatatype.XSD getCoreDatatype() {
+			return CoreDatatype.XSD.DURATION;
 		}
 
 	}
@@ -919,43 +934,37 @@ public abstract class AbstractLiteral implements Literal {
 			}
 		});
 
-		private static IRI datatype(QName qname) {
+		private static final Map<QName, CoreDatatype.XSD> DATATYPES = datatypes();
 
-			if (DatatypeConstants.DATETIME == qname) {
-				return XSD_DATETIME;
-			} else if (DatatypeConstants.DATE == qname) {
-				return XSD_DATE;
-			} else if (DatatypeConstants.TIME == qname) {
-				return XSD_TIME;
-			} else if (DatatypeConstants.GYEARMONTH == qname) {
-				return XSD_GYEARMONTH;
-			} else if (DatatypeConstants.GMONTHDAY == qname) {
-				return XSD_GMONTHDAY;
-			} else if (DatatypeConstants.GYEAR == qname) {
-				return XSD_GYEAR;
-			} else if (DatatypeConstants.GMONTH == qname) {
-				return XSD_GMONTH;
-			} else if (DatatypeConstants.GDAY == qname) {
-				return XSD_GDAY;
-			} else if (DatatypeConstants.DURATION == qname) {
-				return XSD_DURATION;
-			} else if (DatatypeConstants.DURATION_DAYTIME == qname) {
-				return XSD_DURATION_DAYTIME;
-			} else if (DatatypeConstants.DURATION_YEARMONTH == qname) {
-				return XSD_DURATION_YEARMONTH;
-			} else {
-				throw new IllegalArgumentException("QName cannot be mapped to an XML Schema IRI: " + qname.toString());
-			}
+		private static Map<QName, CoreDatatype.XSD> datatypes() {
+
+			final Map<QName, CoreDatatype.XSD> datatypes = new HashMap<>();
+
+			datatypes.put(DatatypeConstants.DATETIME, CoreDatatype.XSD.DATETIME);
+			datatypes.put(DatatypeConstants.TIME, CoreDatatype.XSD.TIME);
+			datatypes.put(DatatypeConstants.DATE, CoreDatatype.XSD.DATE);
+
+			datatypes.put(DatatypeConstants.GYEARMONTH, CoreDatatype.XSD.GYEARMONTH);
+			datatypes.put(DatatypeConstants.GYEAR, CoreDatatype.XSD.GYEAR);
+			datatypes.put(DatatypeConstants.GMONTHDAY, CoreDatatype.XSD.GMONTHDAY);
+			datatypes.put(DatatypeConstants.GDAY, CoreDatatype.XSD.GDAY);
+			datatypes.put(DatatypeConstants.GMONTH, CoreDatatype.XSD.GMONTH);
+
+			datatypes.put(DatatypeConstants.DURATION, CoreDatatype.XSD.DURATION);
+			datatypes.put(DatatypeConstants.DURATION_DAYTIME, CoreDatatype.XSD.DAYTIMEDURATION);
+			datatypes.put(DatatypeConstants.DURATION_YEARMONTH, CoreDatatype.XSD.YEARMONTHDURATION);
+
+			return datatypes;
 		}
 
 		private static XMLGregorianCalendar parseCalendar(String label) {
 			return DATATYPE_FACTORY.get().newXMLGregorianCalendar(label);
 		}
 
-		private XMLGregorianCalendar value;
+		private final XMLGregorianCalendar value;
 
-		private String label;
-		private IRI datatype;
+		private final String label;
+		private final CoreDatatype.XSD datatype;
 
 		CalendarLiteral(GregorianCalendar calendar) {
 			this(DATATYPE_FACTORY.get().newXMLGregorianCalendar(calendar));
@@ -966,7 +975,15 @@ public abstract class AbstractLiteral implements Literal {
 			this.value = calendar;
 
 			this.label = calendar.toXMLFormat();
-			this.datatype = datatype(calendar.getXMLSchemaType());
+			QName qname = calendar.getXMLSchemaType();
+
+			datatype = DATATYPES.get(qname);
+
+			if (datatype == null) {
+				throw new IllegalArgumentException(String.format(
+						"QName <%s> cannot be mapped to an XML Schema date/time datatype", qname
+				));
+			}
 		}
 
 		@Override
@@ -981,7 +998,7 @@ public abstract class AbstractLiteral implements Literal {
 
 		@Override
 		public IRI getDatatype() {
-			return datatype;
+			return datatype.getIri();
 		}
 
 		@Override
@@ -989,6 +1006,10 @@ public abstract class AbstractLiteral implements Literal {
 			return value;
 		}
 
+		@Override
+		public CoreDatatype getCoreDatatype() {
+			return datatype;
+		}
 	}
 
 }

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
@@ -116,6 +116,18 @@ public abstract class AbstractValueFactory implements ValueFactory {
 	}
 
 	@Override
+	public Literal createLiteral(String label, CoreDatatype datatype) {
+
+		Objects.requireNonNull(label, "null label");
+
+		if (reserved(datatype)) {
+			throw new IllegalArgumentException("reserved datatype <" + datatype + ">");
+		}
+
+		return new TypedLiteral(label, datatype);
+	}
+
+	@Override
 	public Literal createLiteral(String label, String language) {
 
 		Objects.requireNonNull(label, "null label");

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractValueFactory.java
@@ -118,7 +118,8 @@ public abstract class AbstractValueFactory implements ValueFactory {
 	@Override
 	public Literal createLiteral(String label, CoreDatatype datatype) {
 
-		Objects.requireNonNull(label, "null label");
+		Objects.requireNonNull(label, "Label may not be null");
+		Objects.requireNonNull(datatype, "CoreDatatype may not be null");
 
 		if (reserved(datatype)) {
 			throw new IllegalArgumentException("reserved datatype <" + datatype + ">");

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatype.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatype.java
@@ -123,6 +123,9 @@ public interface CoreDatatype {
 		private final boolean decimal;
 		private final boolean floatingPoint;
 		private final boolean calendar;
+		private final boolean builtIn;
+		private final boolean numeric;
+		private final boolean ordered;
 
 		// Creating optionals are expensive so we precompute one
 		private final Optional<XSD> optional;
@@ -137,6 +140,11 @@ public interface CoreDatatype {
 			this.decimal = decimal;
 			this.floatingPoint = floatingPoint;
 			this.calendar = calendar;
+
+			this.builtIn = primitive || derived;
+			this.numeric = decimal || floatingPoint;
+			this.ordered = numeric || calendar;
+
 			this.optional = Optional.of(this);
 		}
 
@@ -164,7 +172,7 @@ public interface CoreDatatype {
 		 * @return true if it is a primitive or derived XML Schema type
 		 */
 		public boolean isBuiltInDatatype() {
-			return isPrimitiveDatatype() || isDerivedDatatype();
+			return builtIn;
 		}
 
 		/**
@@ -174,7 +182,7 @@ public interface CoreDatatype {
 		 * @return true of it is a decimal or floating point type
 		 */
 		public boolean isNumericDatatype() {
-			return isDecimalDatatype() || isFloatingPointDatatype();
+			return numeric;
 		}
 
 		/**
@@ -238,7 +246,7 @@ public interface CoreDatatype {
 		 * @return true if the datatype is ordered
 		 */
 		public boolean isOrderedDatatype() {
-			return isNumericDatatype() || isCalendarDatatype();
+			return ordered;
 		}
 
 		@Override

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatype.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatype.java
@@ -1,0 +1,332 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.model.base;
+
+import java.util.Optional;
+
+import javax.xml.datatype.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.eclipse.rdf4j.model.IRI;
+
+public interface CoreDatatype {
+
+	CoreDatatype NONE = () -> {
+		throw new IllegalStateException();
+	};
+
+	/**
+	 * Checks whether the supplied datatype is an XML Schema Datatype.
+	 *
+	 * @return true if the datatype is an XML Schema Datatype
+	 */
+	default boolean isXSDDatatype() {
+		return false;
+	}
+
+	default boolean isRDFDatatype() {
+		return false;
+	}
+
+	default boolean isGEODatatype() {
+		return false;
+	}
+
+	default Optional<XSD> asXSDDatatype() {
+		return Optional.empty();
+	}
+
+	default Optional<RDF> asRDFDatatype() {
+		return Optional.empty();
+	}
+
+	default Optional<GEO> asGEODatatype() {
+		return Optional.empty();
+	}
+
+	IRI getIri();
+
+	static CoreDatatype from(IRI datatype) {
+		if (datatype == null) {
+			return CoreDatatype.NONE;
+		}
+		return CoreDatatypeHelper.getReverseLookup().getOrDefault(datatype, CoreDatatype.NONE);
+	}
+
+	enum XSD implements CoreDatatype {
+
+		ENTITIES(iri("ENTITIES"), false, false, false, true, false, false, false),
+		ENTITY(iri("ENTITY"), false, false, false, true, false, false, false),
+		ID(iri("ID"), false, false, false, true, false, false, false),
+		IDREF(iri("IDREF"), false, false, false, true, false, false, false),
+		IDREFS(iri("IDREFS"), false, false, false, true, false, false, false),
+		NCNAME(iri("NCName"), false, false, false, true, false, false, false),
+		NMTOKEN(iri("NMTOKEN"), false, false, false, true, false, false, false),
+		NMTOKENS(iri("NMTOKENS"), false, false, false, true, false, false, false),
+		NOTATION(iri("NOTATION"), true, false, false, false, false, false, false),
+		NAME(iri("Name"), false, false, false, true, false, false, false),
+		QNAME(iri("QName"), true, false, false, false, false, false, false),
+		ANYURI(iri("anyURI"), true, false, false, false, false, false, false),
+		BASE64BINARY(iri("base64Binary"), true, false, false, false, false, false, false),
+		BOOLEAN(iri("boolean"), true, false, false, false, false, false, false),
+		BYTE(iri("byte"), false, false, true, true, true, false, false),
+		DATE(iri("date"), true, false, false, false, false, false, true),
+		DATETIME(iri("dateTime"), true, false, false, false, false, false, true),
+		DATETIMESTAMP(iri("dateTimeStamp"), false, false, false, true, false, false, true),
+		DAYTIMEDURATION(iri("dayTimeDuration"), false, true, false, true, false, false, false),
+		DECIMAL(iri("decimal"), true, false, false, false, true, false, false),
+		DOUBLE(iri("double"), true, false, false, false, false, true, false),
+		DURATION(iri("duration"), true, true, false, false, false, false, false),
+		FLOAT(iri("float"), true, false, false, false, false, true, false),
+		GDAY(iri("gDay"), true, false, false, false, false, false, true),
+		GMONTH(iri("gMonth"), true, false, false, false, false, false, true),
+		GMONTHDAY(iri("gMonthDay"), true, false, false, false, false, false, true),
+		GYEAR(iri("gYear"), true, false, false, false, false, false, true),
+		GYEARMONTH(iri("gYearMonth"), true, false, false, false, false, false, true),
+		HEXBINARY(iri("hexBinary"), true, false, false, false, false, false, false),
+		INT(iri("int"), false, false, true, true, true, false, false),
+		INTEGER(iri("integer"), false, false, true, true, true, false, false),
+		LANGUAGE(iri("language"), false, false, false, true, false, false, false),
+		LONG(iri("long"), false, false, true, true, true, false, false),
+		NEGATIVE_INTEGER(iri("negativeInteger"), false, false, true, true, true, false, false),
+		NON_NEGATIVE_INTEGER(iri("nonNegativeInteger"), false, false, true, true, true, false, false),
+		NON_POSITIVE_INTEGER(iri("nonPositiveInteger"), false, false, true, true, true, false, false),
+		NORMALIZEDSTRING(iri("normalizedString"), false, false, false, true, false, false, false),
+		POSITIVE_INTEGER(iri("positiveInteger"), false, false, true, true, true, false, false),
+		SHORT(iri("short"), false, false, true, true, true, false, false),
+		STRING(iri("string"), true, false, false, false, false, false, false),
+		TIME(iri("time"), true, false, false, false, false, false, true),
+		TOKEN(iri("token"), false, false, false, true, false, false, false),
+		UNSIGNED_BYTE(iri("unsignedByte"), false, false, true, true, true, false, false),
+		UNSIGNED_INT(iri("unsignedInt"), false, false, true, true, true, false, false),
+		UNSIGNED_LONG(iri("unsignedLong"), false, false, true, true, true, false, false),
+		UNSIGNED_SHORT(iri("unsignedShort"), false, false, true, true, true, false, false),
+		YEARMONTHDURATION(iri("yearMonthDuration"), false, true, false, true, false, false, false);
+
+		public static final String NAMESPACE = "http://www.w3.org/2001/XMLSchema#";
+
+		private static IRI iri(String localName) {
+			return new CoreDatatypeHelper.DatatypeIRI(NAMESPACE, localName);
+		}
+
+		private final IRI iri;
+		private final boolean primitive;
+		private final boolean duration;
+		private final boolean integer;
+		private final boolean derived;
+		private final boolean decimal;
+		private final boolean floatingPoint;
+		private final boolean calendar;
+
+		// Creating optionals are expensive so we precompute one
+		private final Optional<XSD> optional;
+
+		XSD(IRI iri, boolean primitive, boolean duration, boolean integer, boolean derived, boolean decimal,
+				boolean floatingPoint, boolean calendar) {
+			this.iri = iri;
+			this.primitive = primitive;
+			this.duration = duration;
+			this.integer = integer;
+			this.derived = derived;
+			this.decimal = decimal;
+			this.floatingPoint = floatingPoint;
+			this.calendar = calendar;
+			this.optional = Optional.of(this);
+		}
+
+		/**
+		 * Checks whether the supplied datatype is a primitive XML Schema datatype.
+		 *
+		 * @return true if the datatype is a primitive type
+		 */
+		public boolean isPrimitiveDatatype() {
+			return primitive;
+		}
+
+		/**
+		 * Checks whether the supplied datatype is a derived XML Schema datatype.
+		 *
+		 * @return true if the datatype is a derived type
+		 */
+		public boolean isDerivedDatatype() {
+			return derived;
+		}
+
+		/**
+		 * Checks whether the supplied datatype is a built-in XML Schema datatype.
+		 *
+		 * @return true if it is a primitive or derived XML Schema type
+		 */
+		public boolean isBuiltInDatatype() {
+			return isPrimitiveDatatype() || isDerivedDatatype();
+		}
+
+		/**
+		 * Checks whether the supplied datatype is a numeric datatype, i.e.if it is equal to xsd:float, xsd:double,
+		 * xsd:decimal or one of the datatypes derived from xsd:decimal.
+		 *
+		 * @return true of it is a decimal or floating point type
+		 */
+		public boolean isNumericDatatype() {
+			return isDecimalDatatype() || isFloatingPointDatatype();
+		}
+
+		/**
+		 * Checks whether the supplied datatype is equal to xsd:decimal or one of the built-in datatypes that is derived
+		 * from xsd:decimal.
+		 *
+		 * @return true if it is a decimal datatype
+		 */
+		public boolean isDecimalDatatype() {
+			return decimal;
+		}
+
+		/**
+		 * Checks whether the supplied datatype is equal to xsd:integer or one of the built-in datatypes that is derived
+		 * from xsd:integer.
+		 *
+		 * @return true if it is an integer type
+		 */
+		public boolean isIntegerDatatype() {
+			return integer;
+		}
+
+		/**
+		 * Checks whether the supplied datatype is equal to xsd:float or xsd:double.
+		 *
+		 * @return true if it is a floating point type
+		 */
+		public boolean isFloatingPointDatatype() {
+			return floatingPoint;
+		}
+
+		/**
+		 * Checks whether the supplied datatype is equal to xsd:dateTime, xsd:date, xsd:time, xsd:gYearMonth,
+		 * xsd:gMonthDay, xsd:gYear, xsd:gMonth or xsd:gDay.These are the primitive datatypes that represent dates
+		 * and/or times.
+		 *
+		 * @return true if it is a calendar type
+		 *
+		 * @see XMLGregorianCalendar
+		 */
+		public boolean isCalendarDatatype() {
+			return calendar;
+		}
+
+		/**
+		 * Checks whether the supplied datatype is equal to xsd:duration, xsd:dayTimeDuration, xsd:yearMonthDuration.
+		 * These are the datatypes that represents durations.
+		 *
+		 * @return true if it is a duration type
+		 *
+		 * @see Duration
+		 */
+		public boolean isDurationDatatype() {
+			return duration;
+		}
+
+		/**
+		 * Checks whether the supplied datatype is ordered.The values of an ordered datatype can be compared to each
+		 * other using operators like <var>&lt;</var> and <var>&gt;</var>.
+		 *
+		 * @return true if the datatype is ordered
+		 */
+		public boolean isOrderedDatatype() {
+			return isNumericDatatype() || isCalendarDatatype();
+		}
+
+		@Override
+		public boolean isXSDDatatype() {
+			return true;
+		}
+
+		public IRI getIri() {
+			return iri;
+		}
+
+		@Override
+		public Optional<XSD> asXSDDatatype() {
+			return optional;
+		}
+
+	}
+
+	enum RDF implements CoreDatatype {
+
+		LANGSTRING(iri("langString"));
+
+		public static final String NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
+		private static IRI iri(String localName) {
+			return new CoreDatatypeHelper.DatatypeIRI(NAMESPACE, localName);
+		}
+
+		private final IRI iri;
+
+		// Creating optionals are expensive so we precompute one
+		private final Optional<RDF> optional;
+
+		RDF(IRI iri) {
+			this.iri = iri;
+			this.optional = Optional.of(this);
+		}
+
+		@Override
+		public boolean isRDFDatatype() {
+			return true;
+		}
+
+		public IRI getIri() {
+			return iri;
+		}
+
+		@Override
+		public Optional<RDF> asRDFDatatype() {
+			return optional;
+		}
+
+	}
+
+	enum GEO implements CoreDatatype {
+
+		WKT_LITERAL(iri("wktLiteral"));
+
+		public static final String NAMESPACE = "http://www.opengis.net/ont/geosparql#";
+
+		private static IRI iri(String localName) {
+			return new CoreDatatypeHelper.DatatypeIRI(NAMESPACE, localName);
+		}
+
+		private final IRI iri;
+
+		// Creating optionals are expensive so we precompute one
+		private final Optional<GEO> optional;
+
+		GEO(IRI iri) {
+			this.iri = iri;
+			this.optional = Optional.of(this);
+		}
+
+		@Override
+		public boolean isGEODatatype() {
+			return true;
+		}
+
+		public IRI getIri() {
+			return iri;
+		}
+
+		@Override
+		public Optional<GEO> asGEODatatype() {
+			return optional;
+		}
+
+	}
+
+}

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatypeHelper.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatypeHelper.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.model.base;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
+import org.eclipse.rdf4j.model.IRI;
+
+@InternalUseOnly
+class CoreDatatypeHelper {
+
+	static Map<IRI, CoreDatatype> reverseLookup;
+
+	static Map<IRI, CoreDatatype> getReverseLookup() {
+
+		if (reverseLookup == null) {
+			HashMap<IRI, CoreDatatype> map = new HashMap<>();
+
+			for (CoreDatatype value : CoreDatatype.RDF.values()) {
+				map.put(value.getIri(), value);
+			}
+
+			for (CoreDatatype value : CoreDatatype.GEO.values()) {
+				map.put(value.getIri(), value);
+			}
+
+			for (CoreDatatype value : CoreDatatype.XSD.values()) {
+				map.put(value.getIri(), value);
+			}
+
+			reverseLookup = Collections.unmodifiableMap(map);
+		}
+
+		return reverseLookup;
+	}
+
+	static class DatatypeIRI extends AbstractIRI {
+
+		private static final long serialVersionUID = 169243624049169159L;
+
+		private final String namespace;
+		private final String localName;
+		private final String stringValue;
+
+		public DatatypeIRI(String namespace, String localName) {
+			this.namespace = namespace;
+			this.localName = localName;
+			this.stringValue = namespace.concat(localName);
+		}
+
+		@Override
+		public String stringValue() {
+			return stringValue;
+		}
+
+		@Override
+		public String getNamespace() {
+			return namespace;
+		}
+
+		@Override
+		public String getLocalName() {
+			return localName;
+		}
+
+	}
+}

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
@@ -189,10 +189,10 @@ public abstract class LiteralTest {
 	@Test
 	public final void testTypedConstructorNullDatatype() {
 
-		final String label = "label";
-		final IRI datatype = null;
+		String label = "label";
+		IRI datatype = null;
 
-		final Literal literal = literal(label, datatype);
+		Literal literal = literal(label, datatype);
 
 		assertThat(literal.getLabel()).isEqualTo(label);
 		assertThat(literal.getLanguage()).isNotPresent();

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
@@ -37,6 +37,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.junit.Test;
 
 /**
@@ -102,6 +103,16 @@ public abstract class LiteralTest {
 	 * @return a new instance of the concrete literal class under test
 	 */
 	protected abstract Literal literal(String label, IRI datatype);
+
+	/**
+	 * Creates a test literal instance.
+	 *
+	 * @param label    the label of the literal
+	 * @param datatype the CoreDatatype of the literal
+	 *
+	 * @return a new instance of the concrete literal class under test
+	 */
+	protected abstract Literal literal(String label, CoreDatatype datatype);
 
 	/**
 	 * Creates a test datatype IRI instance.
@@ -801,6 +812,690 @@ public abstract class LiteralTest {
 
 		final Literal plain = literal("label");
 		final Literal typed = literal("label", datatype(XSD_STRING));
+
+		assertThat(plain).isEqualTo(typed);
+		assertThat(plain.hashCode()).isEqualTo(typed.hashCode());
+	}
+
+	@Test
+	public final void testCoreDatatypePlainConstructor() {
+
+		String label = "label";
+
+		Literal literal = literal(label);
+
+		assertThat(literal.getLabel()).isEqualTo(label);
+		assertThat(literal.getLanguage()).isNotPresent();
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.STRING);
+
+		assertThatNullPointerException().isThrownBy(() -> literal(null));
+	}
+
+	@Test
+	public final void testCoreDatatypePlainConstructorWithLongLabel() {
+
+		StringBuilder label = new StringBuilder(1000000);
+
+		for (int i = 0; i < 1000000; i++) {
+			label.append(Integer.toHexString(i % 16));
+		}
+
+		Literal literal = literal(label.toString());
+
+		assertThat(literal.getLabel()).isEqualTo(label.toString());
+		assertThat(literal.getLanguage()).isNotPresent();
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.STRING);
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTaggedConstructor() {
+
+		String label = "label";
+		String language = "en";
+
+		Literal literal = literal(label, language);
+
+		assertThat(literal.getLabel()).isEqualTo(label);
+		assertThat(literal.getLanguage()).contains(language);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.RDF.LANGSTRING);
+
+		assertThatNullPointerException().isThrownBy(() -> literal(null, (String) null));
+		assertThatNullPointerException().isThrownBy(() -> literal("", (String) null));
+		assertThatNullPointerException().isThrownBy(() -> literal(null, ""));
+		assertThatNullPointerException().isThrownBy(() -> literal(null, (CoreDatatype) null));
+
+		assertThatIllegalArgumentException().isThrownBy(() -> literal("", ""));
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTypedConstructor() {
+
+		String label = "label";
+		String datatype = "http://examplle.org/datatype";
+
+		Literal literal = literal(label, datatype(datatype));
+
+		assertThat(literal.getLabel()).isEqualTo(label);
+		assertThat(literal.getLanguage()).isNotPresent();
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.NONE);
+
+		assertThatNullPointerException().isThrownBy(() -> literal(null, (CoreDatatype) null));
+		assertThatNullPointerException().isThrownBy(() -> literal(null, CoreDatatype.XSD.STRING));
+		assertThatNullPointerException().isThrownBy(() -> literal(null, CoreDatatype.RDF.LANGSTRING));
+
+		assertThatIllegalArgumentException().isThrownBy(() -> literal("", CoreDatatype.RDF.LANGSTRING));
+
+	}
+
+	@Test(expected = NullPointerException.class)
+	public final void testCoreDatatypeTypedConstructorNullDatatype() {
+		literal("label", ((CoreDatatype) null));
+	}
+
+	//// String Value //////////////////////////////////////////////////////////////////////////////////////////////////
+
+	@Test
+	public void testCoreDatatypeStringValue() {
+
+		String label = "literal";
+		String language = "en";
+		CoreDatatype datatype = CoreDatatype.XSD.DECIMAL;
+
+		assertThat(literal(label).stringValue()).isEqualTo(label);
+		assertThat(literal(label, language).stringValue()).isEqualTo(label);
+		assertThat(literal(label, datatype).stringValue()).isEqualTo(label);
+	}
+
+	//// Object Values /////////////////////////////////////////////////////////////////////////////////////////////////
+
+	@Test
+	public void testCoreDatatypeBooleanValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.BOOLEAN;
+
+		assertThat(literal("true", datatype).booleanValue()).isTrue();
+		assertThat(literal("false", datatype).booleanValue()).isFalse();
+
+		assertThat(literal("1", datatype).booleanValue()).isTrue();
+		assertThat(literal("0", datatype).booleanValue()).isFalse();
+
+		assertThat(literal("\ttrue", datatype).booleanValue()).isTrue();
+		assertThat(literal("false\t", datatype).booleanValue()).isFalse();
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).booleanValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeByteValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.BYTE;
+		Class<Byte> type = Byte.class;
+
+		assertThat(literal("100", datatype).byteValue()).isInstanceOf(type).isEqualTo((byte) 100);
+		assertThat(literal("+100", datatype).byteValue()).isInstanceOf(type).isEqualTo((byte) 100);
+		assertThat(literal("-100", datatype).byteValue()).isInstanceOf(type).isEqualTo((byte) -100);
+
+		assertThatIllegalArgumentException().as("not normalized")
+				.isThrownBy(() -> literal("\t100", datatype).byteValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).booleanValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeShortValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.SHORT;
+		Class<Short> type = Short.class;
+
+		assertThat(literal("100", datatype).shortValue()).isInstanceOf(type).isEqualTo((short) 100);
+		assertThat(literal("+100", datatype).shortValue()).isInstanceOf(type).isEqualTo((short) 100);
+		assertThat(literal("-100", datatype).shortValue()).isInstanceOf(type).isEqualTo((short) -100);
+
+		assertThatIllegalArgumentException().as("not normalized")
+				.isThrownBy(() -> literal("\t100", datatype).shortValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).shortValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeIntValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.INT;
+		Class<Integer> type = Integer.class;
+
+		assertThat(literal("100", datatype).intValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("+100", datatype).intValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("-100", datatype).intValue()).isInstanceOf(type).isEqualTo(-100);
+
+		assertThatIllegalArgumentException().as("not normalized")
+				.isThrownBy(() -> literal("\t100", datatype).intValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).intValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeLongValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.LONG;
+		Class<Long> type = Long.class;
+
+		assertThat(literal("100", datatype).longValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("+100", datatype).longValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("-100", datatype).longValue()).isInstanceOf(type).isEqualTo(-100);
+
+		assertThatIllegalArgumentException().as("not normalized")
+				.isThrownBy(() -> literal("\t100", datatype).longValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).longValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeFloatValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.FLOAT;
+		Class<Float> type = Float.class;
+
+		assertThat(literal("100", datatype).floatValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("+100", datatype).floatValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("-100", datatype).floatValue()).isInstanceOf(type).isEqualTo(-100);
+		assertThat(literal("100.0", datatype).floatValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("10e1", datatype).floatValue()).isInstanceOf(type).isEqualTo(100);
+
+		assertThat(literal("INF", datatype).floatValue()).isInstanceOf(type).isEqualTo(Float.POSITIVE_INFINITY);
+		assertThat(literal("-INF", datatype).floatValue()).isInstanceOf(type).isEqualTo(Float.NEGATIVE_INFINITY);
+		assertTrue(Float.isNaN(literal("NaN", datatype).floatValue()));
+
+		// assertThatIllegalArgumentException().as("not normalized")
+		// .isThrownBy(() -> literal("\t100", datatype).floatValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).floatValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeDoubleValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.DOUBLE;
+		Class<Double> type = Double.class;
+
+		assertThat(literal("100", datatype).doubleValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("+100", datatype).doubleValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("-100", datatype).doubleValue()).isInstanceOf(type).isEqualTo(-100);
+		assertThat(literal("100.0", datatype).doubleValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("10e1", datatype).doubleValue()).isInstanceOf(type).isEqualTo(100);
+
+		assertThat(literal("INF", datatype).doubleValue()).isInstanceOf(type).isEqualTo(Double.POSITIVE_INFINITY);
+		assertThat(literal("-INF", datatype).doubleValue()).isInstanceOf(type).isEqualTo(Double.NEGATIVE_INFINITY);
+		assertTrue(Double.isNaN(literal("NaN", datatype).doubleValue()));
+
+		// assertThatIllegalArgumentException().as("not normalized")
+		// .isThrownBy(() -> literal("\t100", datatype).doubleValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).doubleValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeIntegerValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.INTEGER;
+		Class<BigInteger> type = BigInteger.class;
+
+		assertThat(literal("100", datatype).integerValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("+100", datatype).integerValue()).isInstanceOf(type).isEqualTo(100);
+		assertThat(literal("-100", datatype).integerValue()).isInstanceOf(type).isEqualTo(-100);
+
+		assertThatIllegalArgumentException().as("not normalized")
+				.isThrownBy(() -> literal("\t100", datatype).integerValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).integerValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeDecimalValue() {
+
+		CoreDatatype datatype = CoreDatatype.XSD.DECIMAL;
+		Class<BigDecimal> type = BigDecimal.class;
+
+		assertThat(literal("100", datatype).decimalValue()).isInstanceOf(type).isEqualTo(new BigDecimal("100"));
+		assertThat(literal("+100", datatype).decimalValue()).isInstanceOf(type).isEqualTo(new BigDecimal("100"));
+		assertThat(literal("-100", datatype).decimalValue()).isInstanceOf(type).isEqualTo(new BigDecimal("-100"));
+		assertThat(literal("100.0", datatype).decimalValue()).isInstanceOf(type).isEqualTo(new BigDecimal("100.0"));
+		assertThat(literal("10e1", datatype).decimalValue()).isInstanceOf(type).isEqualTo(new BigDecimal("1.0e2"));
+
+		assertThatIllegalArgumentException().as("not normalized")
+				.isThrownBy(() -> literal("\t100", datatype).decimalValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", datatype).decimalValue());
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalDateTimeValue() {
+
+		String integral = "2020-09-29T01:02:03";
+		String fractional = "2020-09-29T01:02:03.004";
+
+		String offset = "2020-09-29T01:02:03+05:00";
+		String zero = "2020-09-29T01:02:03Z";
+
+		assertThat(LocalDateTime.from(literal(integral, CoreDatatype.XSD.DATETIME).temporalAccessorValue()))
+				.isEqualTo(LocalDateTime.parse(integral));
+
+		assertThat(LocalDateTime.from(literal(fractional, CoreDatatype.XSD.DATETIME).temporalAccessorValue()))
+				.isEqualTo(LocalDateTime.parse(fractional));
+
+		assertThat(OffsetDateTime.from(literal(offset, CoreDatatype.XSD.DATETIME).temporalAccessorValue()))
+				.isEqualTo(OffsetDateTime.parse(offset));
+
+		assertThat(OffsetDateTime.from(literal(zero, CoreDatatype.XSD.DATETIME).temporalAccessorValue()))
+				.isEqualTo(OffsetDateTime.parse(zero));
+
+		Stream.of(
+
+				"0001-01-01T00:00:00",
+				"0001-01-01T00:00:00.0",
+				"0001-01-01T00:00:00Z",
+				"0001-01-01T00:00:00.0Z",
+				"0001-01-01T00:00:00+00:00",
+				"0001-01-01T00:00:00.0+00:00",
+				"0001-01-01T00:00:00.0-00:00",
+				"0001-01-01T00:00:00.0+14:00",
+				"0001-01-01T00:00:00.0-14:00",
+				"0001-05-31T00:00:00.00",
+				"0001-07-31T00:00:00.00",
+				"0001-08-31T00:00:00.00",
+				"0001-10-31T00:00:00.00",
+				"0001-12-31T00:00:00.00",
+				"-0001-01-01T00:00:00",
+				"1234-12-31T23:59:59",
+				"1234-12-31T24:00:00",
+				// "12345-12-31T24:00:00",
+				// "1234-12-31T24:00:00.1234567890",
+				"2004-02-29T00:00:00"
+
+		)
+				.forEach(
+						value -> assertThatCode(() -> literal(value, CoreDatatype.XSD.DATETIME).temporalAccessorValue())
+								.as(value)
+								.doesNotThrowAnyException()
+				);
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalTimeValue() {
+
+		String integral = "01:02:03";
+		String fractional = "01:02:03.004";
+
+		String offset = "01:02:03+05:00";
+		String zero = "01:02:03Z";
+
+		assertThat(LocalTime.from(literal(integral, CoreDatatype.XSD.TIME).temporalAccessorValue()))
+				.isEqualTo(LocalTime.parse(integral));
+
+		assertThat(LocalTime.from(literal(fractional, CoreDatatype.XSD.TIME).temporalAccessorValue()))
+				.isEqualTo(LocalTime.parse(fractional));
+
+		assertThat(OffsetTime.from(literal(offset, CoreDatatype.XSD.TIME).temporalAccessorValue()))
+				.isEqualTo(OffsetTime.parse(offset));
+
+		assertThat(OffsetTime.from(literal(zero, CoreDatatype.XSD.TIME).temporalAccessorValue()))
+				.isEqualTo(OffsetTime.parse(zero));
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalDateValue() {
+
+		String local = "2020-11-14";
+		String offset = "2020-11-14+05:00";
+		String zero = "2020-11-14Z";
+
+		assertThat(LocalDate.from(literal(local, CoreDatatype.XSD.DATE).temporalAccessorValue()))
+				.isEqualTo(LocalDate.parse(local));
+
+		assertThat(LocalDate.from(literal(offset, CoreDatatype.XSD.DATE).temporalAccessorValue()))
+				.isEqualTo(LocalDate.parse(offset.substring(0, 10))); // OffsetDate not supported by java.time
+
+		assertThat(LocalDate.from(literal(zero, CoreDatatype.XSD.DATE).temporalAccessorValue()))
+				.isEqualTo(LocalDate.parse(offset.substring(0, 10))); // OffsetDate not supported by java.time
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalGYearMonthValue() {
+
+		String base = "2020-11";
+
+		assertThat(YearMonth.from(literal(base, CoreDatatype.XSD.GYEARMONTH).temporalAccessorValue()))
+				.isEqualTo(YearMonth.parse(base));
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalGYearValue() {
+
+		String local = "2020";
+
+		assertThat(Year.from(literal(local, CoreDatatype.XSD.GYEAR).temporalAccessorValue()))
+				.isEqualTo(Year.parse(local));
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalGMonthDayValue() {
+
+		String local = "--11-14";
+
+		assertThat(MonthDay.from(literal(local, CoreDatatype.XSD.GMONTHDAY).temporalAccessorValue()))
+				.isEqualTo(MonthDay.parse(local));
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalGDayValue() {
+
+		String local = "---14";
+
+		assertThat(literal(local, CoreDatatype.XSD.GDAY).temporalAccessorValue().get(ChronoField.DAY_OF_MONTH))
+				.isEqualTo(14);
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalGMonthValue() {
+
+		String local = "--11";
+
+		assertThat(Month.from(literal(local, CoreDatatype.XSD.GMONTH).temporalAccessorValue()))
+				.isEqualTo(Month.NOVEMBER);
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalAccessorMalformedValue() {
+
+		assertThatExceptionOfType(DateTimeException.class)
+				.isThrownBy(() -> literal("", CoreDatatype.XSD.DATETIME).temporalAccessorValue());
+
+		assertThatExceptionOfType(DateTimeException.class)
+				.isThrownBy(() -> literal("--", CoreDatatype.XSD.DATETIME).temporalAccessorValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("no time components")
+				.isThrownBy(() -> literal("2020-11-16T", CoreDatatype.XSD.DATETIME).temporalAccessorValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("missing fractional digits after dot")
+				.isThrownBy(() -> literal("2020-11-16T11:12:13.", CoreDatatype.XSD.DATETIME).temporalAccessorValue());
+
+		assertThatExceptionOfType(DateTimeException.class)
+				.isThrownBy(() -> literal("malformed", CoreDatatype.XSD.DATETIME).temporalAccessorValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("no time components")
+				.isThrownBy(() -> literal("2020-11-16T", CoreDatatype.XSD.DATETIME).temporalAccessorValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("missing fractional digits after dot")
+				.isThrownBy(() -> literal("2020-11-16T11:12:13.", CoreDatatype.XSD.DATETIME).temporalAccessorValue());
+
+		Stream.of(
+
+				"foo", "Mon, 11 Jul 2005 09:22:29 +0200",
+				"0001-01-01T00:00",
+				"0001-01-01T00:00.00",
+				"0001-13-01T00:00:00.00",
+				"0001-01-32T00:00:00.00",
+				// "0001-02-30T00:00:00.00",
+				// "2005-02-29T00:00:00", // not a leap year
+				// "0001-04-31T00:00:00.00",
+				"0001-01-01T25:00:00.00",
+				"0001-01-01T00:61:00.00",
+				"0001-01-01T00:00:61.00",
+				"0001-01-01T00:00.00+15:00",
+				"0001-01-01T00:00.00-15:00",
+				"001-01-01T00:00:00.0",
+				"0001-1-01T00:00:00.0",
+				"0001-01-1T00:00:00.0",
+				"0001-01-01T0:00:00.0",
+				"0001-01-01T00:0:00.0",
+				"0001-01-01T00:00:0.0",
+				"0001/01-01T00:00:00.0",
+				"0001-01/01T00:00:00.0",
+				"0001-01-01t00:00:00.0",
+				"0001-01-01T00.00:00.0",
+				"0001-01-01T00:00.00.0",
+				"0001-01-01T00:00:00:0",
+				"0001-01-01T00:00.00+0:00",
+				"0001-01-01T00:00.00+00:0",
+				"0001-jan-01T00:00:00",
+				"0001-01-01T00:00:00+00:00Z",
+				"0001-01-01T24:01:00", "0001-01-01T24:00:01",
+				"00001-01-01T00:00:00",
+				"0001-001-01T00:00:00",
+				"0001-01-001T00:00:00",
+				"0001-01-01T000:00:00",
+				"0001-01-01T00:000:00",
+				"0001-01-01T00:00:000",
+				"0001-01-01T00:00:000",
+				"0001-01-01T00:00:00z",
+				"0001-01-01T00:00:00+05",
+				"0001-01-01T00:00:00+0500",
+				"0001-01-01T00:00:00GMT",
+				"0001-01-01T00:00:00PST",
+				"0001-01-01T00:00:00GMT+05",
+				// "0000-01-01T00:00:00",
+				"-0000-01-01T00:00:00",
+				"+0001-01-01T00:00:00"
+
+		)
+				.forEach(value -> assertThatExceptionOfType(DateTimeException.class)
+						.as(value)
+						.isThrownBy(() -> literal(value, CoreDatatype.XSD.DATETIME).temporalAccessorValue())
+				);
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalDurationValue() {
+
+		String period = "P1Y2M3D";
+		String duration = "PT1H2M3.4S";
+
+		assertThat(Period.from(literal(period, CoreDatatype.XSD.DURATION).temporalAmountValue()))
+				.isEqualTo(Period.parse(period));
+
+		assertThat(Period.from(literal("-P1Y2M3D", CoreDatatype.XSD.DURATION).temporalAmountValue()))
+				.isEqualTo(Period.parse(period).negated());
+
+		assertThat(Duration.from(literal(duration, CoreDatatype.XSD.DURATION).temporalAmountValue()))
+				.isEqualTo(Duration.parse(duration));
+
+	}
+
+	@Test
+	public final void testCoreDatatypeTemporalAmountMalformedValue() {
+
+		assertThatExceptionOfType(DateTimeException.class)
+				.isThrownBy(() -> literal("", CoreDatatype.XSD.DURATION).temporalAmountValue());
+
+		assertThatExceptionOfType(DateTimeException.class)
+				.isThrownBy(() -> literal("malformed", CoreDatatype.XSD.DURATION).temporalAmountValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("no  components")
+				.isThrownBy(() -> literal("P", CoreDatatype.XSD.DURATION).temporalAmountValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("no time components")
+				.isThrownBy(() -> literal("P1Y2MT", CoreDatatype.XSD.DURATION).temporalAmountValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("negative component")
+				.isThrownBy(() -> literal("P-1347M ", CoreDatatype.XSD.DURATION).temporalAmountValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("no time separator")
+				.isThrownBy(() -> literal("P1Y1S ", CoreDatatype.XSD.DURATION).temporalAmountValue());
+
+		assertThatExceptionOfType(DateTimeException.class).as("missing fractional digits after dot")
+				.isThrownBy(() -> literal("PT1.S", CoreDatatype.XSD.DURATION).temporalAmountValue());
+	}
+
+	@Test
+	public final void testCoreDatatypeCalendarValue() throws DatatypeConfigurationException {
+
+		Class<XMLGregorianCalendar> type = XMLGregorianCalendar.class;
+
+		DatatypeFactory factory = DatatypeFactory.newInstance();
+
+		Function<Consumer<XMLGregorianCalendar>, XMLGregorianCalendar> setup = consumer -> {
+
+			XMLGregorianCalendar calendar = factory.newXMLGregorianCalendar();
+
+			consumer.accept(calendar);
+
+			return calendar;
+
+		};
+
+		assertThat(literal("2020-09-29T01:02:03.004Z", CoreDatatype.XSD.DATETIME).calendarValue())
+				.isInstanceOf(type)
+				.isEqualTo(setup.apply(calendar -> {
+					calendar.setYear(2020);
+					calendar.setMonth(9);
+					calendar.setDay(29);
+					calendar.setTime(1, 2, 3, 4);
+					calendar.setTimezone(0);
+				}));
+
+		assertThat(literal("01:02:03.004", CoreDatatype.XSD.TIME).calendarValue())
+				.isInstanceOf(type)
+				.isEqualTo(setup.apply(calendar -> {
+					calendar.setTime(1, 2, 3, 4);
+				}));
+
+		assertThat(literal("2020-09-29", CoreDatatype.XSD.DATE).calendarValue())
+				.isInstanceOf(type)
+				.isEqualTo(setup.apply(calendar -> {
+					calendar.setYear(2020);
+					calendar.setMonth(9);
+					calendar.setDay(29);
+				}));
+
+		assertThat(literal("2020-09", CoreDatatype.XSD.GYEARMONTH).calendarValue())
+				.isInstanceOf(type)
+				.isEqualTo(setup.apply(calendar -> {
+					calendar.setYear(2020);
+					calendar.setMonth(9);
+				}));
+
+		assertThat(literal("--09-29", CoreDatatype.XSD.GMONTHDAY).calendarValue())
+				.isInstanceOf(type)
+				.isEqualTo(setup.apply(calendar -> {
+					calendar.setMonth(9);
+					calendar.setDay(29);
+				}));
+
+		assertThat(literal("2020", CoreDatatype.XSD.GYEAR).calendarValue())
+				.isInstanceOf(type)
+				.isEqualTo(setup.apply(calendar -> {
+					calendar.setYear(2020);
+				}));
+
+		assertThat(literal("--09", CoreDatatype.XSD.GMONTH).calendarValue())
+				.isInstanceOf(type)
+				.isEqualTo(setup.apply(calendar -> {
+					calendar.setMonth(9);
+				}));
+
+		assertThat(literal("---29", CoreDatatype.XSD.GDAY).calendarValue())
+				.isInstanceOf(type)
+				.isEqualTo(setup.apply(calendar -> {
+					calendar.setDay(29);
+				}));
+
+		assertThatIllegalArgumentException().as("not normalized")
+				.isThrownBy(() -> literal("\t100", CoreDatatype.XSD.DATETIME).calendarValue());
+
+		assertThatIllegalArgumentException().as("malformed")
+				.isThrownBy(() -> literal("malformed", CoreDatatype.XSD.DATETIME).calendarValue());
+
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+	@Test
+	public void testCoreDatatypeEqualsAndHashCode() {
+
+		Literal plain = literal("plain");
+		Literal tagged = literal("tagged", "en");
+		Literal typed = literal("typed", datatype("http://example.org/datatype"));
+
+		Literal _plain = literal(plain.getLabel());
+		Literal _tagged = literal(tagged.getLabel(), tagged.getLanguage().orElse(""));
+		Literal _typed = literal(typed.getLabel(), typed.getDatatype());
+
+		assertThat(plain).isEqualTo(plain);
+		assertThat(plain).isEqualTo(_plain);
+
+		assertThat(tagged).isEqualTo(tagged);
+		assertThat(tagged).isEqualTo(_tagged);
+
+		assertThat(typed).isEqualTo(typed);
+		assertThat(typed).isEqualTo(_typed);
+
+		assertThat(plain).isNotEqualTo(null);
+		assertThat(plain).isNotEqualTo(new Object());
+
+		assertThat(plain).isNotEqualTo(tagged);
+		assertThat(plain).isNotEqualTo(typed);
+		assertThat(tagged).isNotEqualTo(typed);
+
+		assertThat(plain).isNotEqualTo(literal("other"));
+		assertThat(tagged).isNotEqualTo(literal(tagged.getLabel(), "other"));
+		assertThat(typed).isNotEqualTo(literal(typed.getLabel(), "http://example.org/other"));
+
+		// hashCode() should return identical values for literals for which equals() is true
+
+		assertThat(plain.hashCode()).isEqualTo(_plain.hashCode());
+		assertThat(tagged.hashCode()).isEqualTo(_tagged.hashCode());
+		assertThat(typed.hashCode()).isEqualTo(_typed.hashCode());
+
+		assertThat(tagged.hashCode())
+				.as("computed according to contract")
+				.isEqualTo(tagged.getLabel().hashCode()); // !!! label >> label+language+datatype
+
+	}
+
+	@Test
+	public final void testCoreDatatypeEqualsAndHashCodeCaseInsensitiveLanguage() {
+
+		Literal lowercase = literal("label", "en");
+		Literal uppercase = literal("label", "EN");
+
+		assertThat(lowercase).isEqualTo(uppercase);
+		assertThat(lowercase.hashCode()).isEqualTo(uppercase.hashCode());
+	}
+
+	@Test
+	public final void testCoreDatatypeEqualsAndHashCodeXSDString() {
+
+		// in RDF 1.1, there is no distinction between plain and string-typed literals
+
+		Literal plain = literal("label");
+		Literal typed = literal("label", CoreDatatype.XSD.STRING);
 
 		assertThat(plain).isEqualTo(typed);
 		assertThat(plain.hashCode()).isEqualTo(typed.hashCode());

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/base/AbstractLiteralTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/base/AbstractLiteralTest.java
@@ -40,6 +40,11 @@ public class AbstractLiteralTest extends LiteralTest {
 	}
 
 	@Override
+	protected Literal literal(String label, CoreDatatype datatype) {
+		return factory.createLiteral(label, datatype);
+	}
+
+	@Override
 	protected IRI datatype(String iri) {
 		return factory.createIRI(iri);
 	}

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/base/CoreDatatypeTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/base/CoreDatatypeTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.model.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CoreDatatypeTest {
+
+	@Test
+	public void testOrderOfXSD() {
+		ArrayList<CoreDatatype.XSD> datatypes = getDatatypesShuffled();
+
+		List<String> datatypeIRIs = getDatatypesShuffled().stream()
+				.map(CoreDatatype::getIri)
+				.map(Object::toString)
+				.collect(Collectors.toList());
+
+		Collections.sort(datatypes);
+		Collections.sort(datatypeIRIs);
+
+		List<String> datatypeIRIsSortedByEnum = datatypes.stream()
+				.map(CoreDatatype::getIri)
+				.map(Object::toString)
+				.collect(Collectors.toList());
+		Assert.assertEquals(datatypeIRIs, datatypeIRIsSortedByEnum);
+
+	}
+
+	private ArrayList<CoreDatatype.XSD> getDatatypesShuffled() {
+		Random random = new Random(42353245);
+
+		ArrayList<CoreDatatype.XSD> xsds = new ArrayList<>(Arrays.asList(CoreDatatype.XSD.values()));
+
+		Collections.shuffle(xsds);
+		return xsds;
+	}
+
+	@Test
+	public void testUnknownDatatype() {
+		assertEquals(CoreDatatype.NONE, CoreDatatype.from(new AbstractIRI.GenericIRI("http://example.com")));
+	}
+
+}

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/GEO.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/GEO.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.model.vocabulary;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 
 /**
  * @version 1.0
@@ -16,7 +17,7 @@ import org.eclipse.rdf4j.model.IRI;
  */
 public class GEO {
 
-	public static final String NAMESPACE = "http://www.opengis.net/ont/geosparql#";
+	public static final String NAMESPACE = CoreDatatype.GEO.NAMESPACE;
 
 	public static final IRI AS_WKT;
 
@@ -26,6 +27,6 @@ public class GEO {
 
 	static {
 		AS_WKT = Vocabularies.createIRI(NAMESPACE, "asWKT");
-		WKT_LITERAL = Vocabularies.createIRI(NAMESPACE, "wktLiteral");
+		WKT_LITERAL = CoreDatatype.GEO.WKT_LITERAL.getIri();
 	}
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/RDF.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/RDF.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.model.vocabulary;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 
 /**
  * Constants for RDF primitives and for the RDF namespace.
@@ -18,7 +19,7 @@ import org.eclipse.rdf4j.model.Namespace;
 public class RDF {
 
 	/** http://www.w3.org/1999/02/22-rdf-syntax-ns# */
-	public static final String NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+	public static final String NAMESPACE = CoreDatatype.RDF.NAMESPACE;
 
 	/**
 	 * Recommended prefix for the RDF namespace: "rdf"
@@ -101,7 +102,7 @@ public class RDF {
 		FIRST = Vocabularies.createIRI(RDF.NAMESPACE, "first");
 		REST = Vocabularies.createIRI(RDF.NAMESPACE, "rest");
 		NIL = Vocabularies.createIRI(RDF.NAMESPACE, "nil");
-		LANGSTRING = Vocabularies.createIRI(RDF.NAMESPACE, "langString");
+		LANGSTRING = CoreDatatype.RDF.LANGSTRING.getIri();
 		HTML = Vocabularies.createIRI(RDF.NAMESPACE, "HTML");
 	}
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/XSD.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/XSD.java
@@ -7,7 +7,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.vocabulary;
 
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.xml.datatype.Duration;
@@ -15,6 +17,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 
 /**
  * Constants for the standard <a href="https://www.w3.org/TR/xmlschema11-2/">XML Schema 1.1 datatypes</a>.
@@ -24,220 +27,222 @@ import org.eclipse.rdf4j.model.Namespace;
 public class XSD {
 
 	/** The XML Schema namespace (<var>http://www.w3.org/2001/XMLSchema#</var>). */
-	public static final String NAMESPACE = "http://www.w3.org/2001/XMLSchema#";
+	public final static String NAMESPACE = CoreDatatype.XSD.NAMESPACE;
 
 	/**
 	 * Recommended prefix for XML Schema datatypes: "xsd"
 	 */
-	public static final String PREFIX = "xsd";
+	public final static String PREFIX = "xsd";
 
 	/**
 	 * An immutable {@link Namespace} constant that represents the XML Schema namespace.
 	 */
-	public static final Namespace NS = Vocabularies.createNamespace(PREFIX, NAMESPACE);
+	public final static Namespace NS = Vocabularies.createNamespace(PREFIX, NAMESPACE);
 
 	/*
 	 * Primitive datatypes
 	 */
 
 	/** <var>http://www.w3.org/2001/XMLSchema#duration</var> */
-	public final static IRI DURATION = create("duration");
+	public final static IRI DURATION = CoreDatatype.XSD.DURATION.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#dateTime</var> */
-	public final static IRI DATETIME = create("dateTime");
+	public final static IRI DATETIME = CoreDatatype.XSD.DATETIME.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#dateTimeStamp</var> */
-	public final static IRI DATETIMESTAMP = create("dateTimeStamp");
+	public final static IRI DATETIMESTAMP = CoreDatatype.XSD.DATETIMESTAMP.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#dayTimeDuration</var> */
-	public static final IRI DAYTIMEDURATION = create("dayTimeDuration");
+	public final static IRI DAYTIMEDURATION = CoreDatatype.XSD.DAYTIMEDURATION.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#time</var> */
-	public final static IRI TIME = create("time");
+	public final static IRI TIME = CoreDatatype.XSD.TIME.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#date</var> */
-	public final static IRI DATE = create("date");
+	public final static IRI DATE = CoreDatatype.XSD.DATE.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#gYearMonth</var> */
-	public final static IRI GYEARMONTH = create("gYearMonth");
+	public final static IRI GYEARMONTH = CoreDatatype.XSD.GYEARMONTH.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#gYear</var> */
-	public final static IRI GYEAR = create("gYear");
+	public final static IRI GYEAR = CoreDatatype.XSD.GYEAR.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#gMonthDay</var> */
-	public final static IRI GMONTHDAY = create("gMonthDay");
+	public final static IRI GMONTHDAY = CoreDatatype.XSD.GMONTHDAY.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#gDay</var> */
-	public final static IRI GDAY = create("gDay");
+	public final static IRI GDAY = CoreDatatype.XSD.GDAY.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#gMonth</var> */
-	public final static IRI GMONTH = create("gMonth");
+	public final static IRI GMONTH = CoreDatatype.XSD.GMONTH.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#string</var> */
-	public final static IRI STRING = create("string");
+	public final static IRI STRING = CoreDatatype.XSD.STRING.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#boolean</var> */
-	public final static IRI BOOLEAN = create("boolean");
+	public final static IRI BOOLEAN = CoreDatatype.XSD.BOOLEAN.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#base64Binary</var> */
-	public final static IRI BASE64BINARY = create("base64Binary");
+	public final static IRI BASE64BINARY = CoreDatatype.XSD.BASE64BINARY.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#hexBinary</var> */
-	public final static IRI HEXBINARY = create("hexBinary");
+	public final static IRI HEXBINARY = CoreDatatype.XSD.HEXBINARY.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#float</var> */
-	public final static IRI FLOAT = create("float");
+	public final static IRI FLOAT = CoreDatatype.XSD.FLOAT.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#decimal</var> */
-	public final static IRI DECIMAL = create("decimal");
+	public final static IRI DECIMAL = CoreDatatype.XSD.DECIMAL.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#double</var> */
-	public final static IRI DOUBLE = create("double");
+	public final static IRI DOUBLE = CoreDatatype.XSD.DOUBLE.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#anyURI</var> */
-	public final static IRI ANYURI = create("anyURI");
+	public final static IRI ANYURI = CoreDatatype.XSD.ANYURI.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#QName</var> */
-	public final static IRI QNAME = create("QName");
+	public final static IRI QNAME = CoreDatatype.XSD.QNAME.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#NOTATION</var> */
-	public final static IRI NOTATION = create("NOTATION");
+	public final static IRI NOTATION = CoreDatatype.XSD.NOTATION.getIri();
 
 	/*
 	 * Derived datatypes
 	 */
 
 	/** <var>http://www.w3.org/2001/XMLSchema#normalizedString</var> */
-	public final static IRI NORMALIZEDSTRING = create("normalizedString");
+	public final static IRI NORMALIZEDSTRING = CoreDatatype.XSD.NORMALIZEDSTRING.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#token</var> */
-	public final static IRI TOKEN = create("token");
+	public final static IRI TOKEN = CoreDatatype.XSD.TOKEN.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#language</var> */
-	public final static IRI LANGUAGE = create("language");
+	public final static IRI LANGUAGE = CoreDatatype.XSD.LANGUAGE.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#NMTOKEN</var> */
-	public final static IRI NMTOKEN = create("NMTOKEN");
+	public final static IRI NMTOKEN = CoreDatatype.XSD.NMTOKEN.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#NMTOKENS</var> */
-	public final static IRI NMTOKENS = create("NMTOKENS");
+	public final static IRI NMTOKENS = CoreDatatype.XSD.NMTOKENS.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#Name</var> */
-	public final static IRI NAME = create("Name");
+	public final static IRI NAME = CoreDatatype.XSD.NAME.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#NCName</var> */
-	public final static IRI NCNAME = create("NCName");
+	public final static IRI NCNAME = CoreDatatype.XSD.NCNAME.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#ID</var> */
-	public final static IRI ID = create("ID");
+	public final static IRI ID = CoreDatatype.XSD.ID.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#IDREF</var> */
-	public final static IRI IDREF = create("IDREF");
+	public final static IRI IDREF = CoreDatatype.XSD.IDREF.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#IDREFS</var> */
-	public final static IRI IDREFS = create("IDREFS");
+	public final static IRI IDREFS = CoreDatatype.XSD.IDREFS.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#ENTITY</var> */
-	public final static IRI ENTITY = create("ENTITY");
+	public final static IRI ENTITY = CoreDatatype.XSD.ENTITY.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#ENTITIES</var> */
-	public final static IRI ENTITIES = create("ENTITIES");
+	public final static IRI ENTITIES = CoreDatatype.XSD.ENTITIES.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#integer</var> */
-	public final static IRI INTEGER = create("integer");
+	public final static IRI INTEGER = CoreDatatype.XSD.INTEGER.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#long</var> */
-	public final static IRI LONG = create("long");
+	public final static IRI LONG = CoreDatatype.XSD.LONG.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#int</var> */
-	public final static IRI INT = create("int");
+	public final static IRI INT = CoreDatatype.XSD.INT.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#short</var> */
-	public final static IRI SHORT = create("short");
+	public final static IRI SHORT = CoreDatatype.XSD.SHORT.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#byte</var> */
-	public final static IRI BYTE = create("byte");
+	public final static IRI BYTE = CoreDatatype.XSD.BYTE.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#nonPositiveInteger</var> */
-	public final static IRI NON_POSITIVE_INTEGER = create("nonPositiveInteger");
+	public final static IRI NON_POSITIVE_INTEGER = CoreDatatype.XSD.NON_POSITIVE_INTEGER.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#negativeInteger</var> */
-	public final static IRI NEGATIVE_INTEGER = create("negativeInteger");
+	public final static IRI NEGATIVE_INTEGER = CoreDatatype.XSD.NEGATIVE_INTEGER.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#nonNegativeInteger</var> */
-	public final static IRI NON_NEGATIVE_INTEGER = create("nonNegativeInteger");
+	public final static IRI NON_NEGATIVE_INTEGER = CoreDatatype.XSD.NON_NEGATIVE_INTEGER.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#positiveInteger</var> */
-	public final static IRI POSITIVE_INTEGER = create("positiveInteger");
+	public final static IRI POSITIVE_INTEGER = CoreDatatype.XSD.POSITIVE_INTEGER.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#unsignedLong</var> */
-	public final static IRI UNSIGNED_LONG = create("unsignedLong");
+	public final static IRI UNSIGNED_LONG = CoreDatatype.XSD.UNSIGNED_LONG.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#unsignedInt</var> */
-	public final static IRI UNSIGNED_INT = create("unsignedInt");
+	public final static IRI UNSIGNED_INT = CoreDatatype.XSD.UNSIGNED_INT.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#unsignedShort</var> */
-	public final static IRI UNSIGNED_SHORT = create("unsignedShort");
+	public final static IRI UNSIGNED_SHORT = CoreDatatype.XSD.UNSIGNED_SHORT.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#unsignedByte</var> */
-	public final static IRI UNSIGNED_BYTE = create("unsignedByte");
+	public final static IRI UNSIGNED_BYTE = CoreDatatype.XSD.UNSIGNED_BYTE.getIri();
 
 	/** <var>http://www.w3.org/2001/XMLSchema#yearMonthDuration</var> */
-	public static final IRI YEARMONTHDURATION = create("yearMonthDuration");
+	public final static IRI YEARMONTHDURATION = CoreDatatype.XSD.YEARMONTHDURATION.getIri();
 
 	private static IRI create(String localName) {
-		return Vocabularies.createIRI(XSD.NAMESPACE, localName);
+		return Vocabularies.createIRI(org.eclipse.rdf4j.model.vocabulary.XSD.NAMESPACE, localName);
 	}
 
 	public enum Datatype {
 
-		DURATION(XSD.DURATION, true, true, false, false, false, false, false),
-		DATETIME(XSD.DATETIME, true, false, false, false, false, false, true),
-		DATETIMESTAMP(XSD.DATETIMESTAMP, false, false, false, true, false, false, true),
-		DAYTIMEDURATION(XSD.DAYTIMEDURATION, false, true, false, true, false, false, false),
-		TIME(XSD.TIME, true, false, false, false, false, false, true),
-		DATE(XSD.DATE, true, false, false, false, false, false, true),
-		GYEARMONTH(XSD.GYEARMONTH, true, false, false, false, false, false, true),
-		GYEAR(XSD.GYEAR, true, false, false, false, false, false, true),
-		GMONTHDAY(XSD.GMONTHDAY, true, false, false, false, false, false, true),
-		GDAY(XSD.GDAY, true, false, false, false, false, false, true),
-		GMONTH(XSD.GMONTH, true, false, false, false, false, false, true),
-		STRING(XSD.STRING, true, false, false, false, false, false, false),
-		BOOLEAN(XSD.BOOLEAN, true, false, false, false, false, false, false),
-		BASE64BINARY(XSD.BASE64BINARY, true, false, false, false, false, false, false),
-		HEXBINARY(XSD.HEXBINARY, true, false, false, false, false, false, false),
-		FLOAT(XSD.FLOAT, true, false, false, false, false, true, false),
-		DECIMAL(XSD.DECIMAL, true, false, false, false, true, false, false),
-		DOUBLE(XSD.DOUBLE, true, false, false, false, false, true, false),
-		ANYURI(XSD.ANYURI, true, false, false, false, false, false, false),
-		QNAME(XSD.QNAME, true, false, false, false, false, false, false),
-		NOTATION(XSD.NOTATION, true, false, false, false, false, false, false),
-		NORMALIZEDSTRING(XSD.NORMALIZEDSTRING, false, false, false, true, false, false, false),
-		TOKEN(XSD.TOKEN, false, false, false, true, false, false, false),
-		LANGUAGE(XSD.LANGUAGE, false, false, false, true, false, false, false),
-		NMTOKEN(XSD.NMTOKEN, false, false, false, true, false, false, false),
-		NMTOKENS(XSD.NMTOKENS, false, false, false, true, false, false, false),
-		NAME(XSD.NAME, false, false, false, true, false, false, false),
-		NCNAME(XSD.NCNAME, false, false, false, true, false, false, false),
-		ID(XSD.ID, false, false, false, true, false, false, false),
-		IDREF(XSD.IDREF, false, false, false, true, false, false, false),
-		IDREFS(XSD.IDREFS, false, false, false, true, false, false, false),
-		ENTITY(XSD.ENTITY, false, false, false, true, false, false, false),
-		ENTITIES(XSD.ENTITIES, false, false, false, true, false, false, false),
-		INTEGER(XSD.INTEGER, false, false, true, true, true, false, false),
-		LONG(XSD.LONG, false, false, true, true, true, false, false),
-		INT(XSD.INT, false, false, true, true, true, false, false),
-		SHORT(XSD.SHORT, false, false, true, true, true, false, false),
-		BYTE(XSD.BYTE, false, false, true, true, true, false, false),
-		NON_POSITIVE_INTEGER(XSD.NON_POSITIVE_INTEGER, false, false, true, true, true, false, false),
-		NEGATIVE_INTEGER(XSD.NEGATIVE_INTEGER, false, false, true, true, true, false, false),
-		NON_NEGATIVE_INTEGER(XSD.NON_NEGATIVE_INTEGER, false, false, true, true, true, false, false),
-		POSITIVE_INTEGER(XSD.POSITIVE_INTEGER, false, false, true, true, true, false, false),
-		UNSIGNED_LONG(XSD.UNSIGNED_LONG, false, false, true, true, true, false, false),
-		UNSIGNED_INT(XSD.UNSIGNED_INT, false, false, true, true, true, false, false),
-		UNSIGNED_SHORT(XSD.UNSIGNED_SHORT, false, false, true, true, true, false, false),
-		UNSIGNED_BYTE(XSD.UNSIGNED_BYTE, false, false, true, true, true, false, false),
-		YEARMONTHDURATION(XSD.YEARMONTHDURATION, false, true, false, true, false, false, false);
+		DURATION(CoreDatatype.XSD.DURATION.getIri(), true, true, false, false, false, false, false),
+		DATETIME(CoreDatatype.XSD.DATETIME.getIri(), true, false, false, false, false, false, true),
+		DATETIMESTAMP(CoreDatatype.XSD.DATETIMESTAMP.getIri(), false, false, false, true, false, false, true),
+		DAYTIMEDURATION(CoreDatatype.XSD.DAYTIMEDURATION.getIri(), false, true, false, true, false, false, false),
+		TIME(CoreDatatype.XSD.TIME.getIri(), true, false, false, false, false, false, true),
+		DATE(CoreDatatype.XSD.DATE.getIri(), true, false, false, false, false, false, true),
+		GYEARMONTH(CoreDatatype.XSD.GYEARMONTH.getIri(), true, false, false, false, false, false, true),
+		GYEAR(CoreDatatype.XSD.GYEAR.getIri(), true, false, false, false, false, false, true),
+		GMONTHDAY(CoreDatatype.XSD.GMONTHDAY.getIri(), true, false, false, false, false, false, true),
+		GDAY(CoreDatatype.XSD.GDAY.getIri(), true, false, false, false, false, false, true),
+		GMONTH(CoreDatatype.XSD.GMONTH.getIri(), true, false, false, false, false, false, true),
+		STRING(CoreDatatype.XSD.STRING.getIri(), true, false, false, false, false, false, false),
+		BOOLEAN(CoreDatatype.XSD.BOOLEAN.getIri(), true, false, false, false, false, false, false),
+		BASE64BINARY(CoreDatatype.XSD.BASE64BINARY.getIri(), true, false, false, false, false, false, false),
+		HEXBINARY(CoreDatatype.XSD.HEXBINARY.getIri(), true, false, false, false, false, false, false),
+		FLOAT(CoreDatatype.XSD.FLOAT.getIri(), true, false, false, false, false, true, false),
+		DECIMAL(CoreDatatype.XSD.DECIMAL.getIri(), true, false, false, false, true, false, false),
+		DOUBLE(CoreDatatype.XSD.DOUBLE.getIri(), true, false, false, false, false, true, false),
+		ANYURI(CoreDatatype.XSD.ANYURI.getIri(), true, false, false, false, false, false, false),
+		QNAME(CoreDatatype.XSD.QNAME.getIri(), true, false, false, false, false, false, false),
+		NOTATION(CoreDatatype.XSD.NOTATION.getIri(), true, false, false, false, false, false, false),
+		NORMALIZEDSTRING(CoreDatatype.XSD.NORMALIZEDSTRING.getIri(), false, false, false, true, false, false, false),
+		TOKEN(CoreDatatype.XSD.TOKEN.getIri(), false, false, false, true, false, false, false),
+		LANGUAGE(CoreDatatype.XSD.LANGUAGE.getIri(), false, false, false, true, false, false, false),
+		NMTOKEN(CoreDatatype.XSD.NMTOKEN.getIri(), false, false, false, true, false, false, false),
+		NMTOKENS(CoreDatatype.XSD.NMTOKENS.getIri(), false, false, false, true, false, false, false),
+		NAME(CoreDatatype.XSD.NAME.getIri(), false, false, false, true, false, false, false),
+		NCNAME(CoreDatatype.XSD.NCNAME.getIri(), false, false, false, true, false, false, false),
+		ID(CoreDatatype.XSD.ID.getIri(), false, false, false, true, false, false, false),
+		IDREF(CoreDatatype.XSD.IDREF.getIri(), false, false, false, true, false, false, false),
+		IDREFS(CoreDatatype.XSD.IDREFS.getIri(), false, false, false, true, false, false, false),
+		ENTITY(CoreDatatype.XSD.ENTITY.getIri(), false, false, false, true, false, false, false),
+		ENTITIES(CoreDatatype.XSD.ENTITIES.getIri(), false, false, false, true, false, false, false),
+		INTEGER(CoreDatatype.XSD.INTEGER.getIri(), false, false, true, true, true, false, false),
+		LONG(CoreDatatype.XSD.LONG.getIri(), false, false, true, true, true, false, false),
+		INT(CoreDatatype.XSD.INT.getIri(), false, false, true, true, true, false, false),
+		SHORT(CoreDatatype.XSD.SHORT.getIri(), false, false, true, true, true, false, false),
+		BYTE(CoreDatatype.XSD.BYTE.getIri(), false, false, true, true, true, false, false),
+		NON_POSITIVE_INTEGER(CoreDatatype.XSD.NON_POSITIVE_INTEGER.getIri(), false, false, true, true, true, false,
+				false),
+		NEGATIVE_INTEGER(CoreDatatype.XSD.NEGATIVE_INTEGER.getIri(), false, false, true, true, true, false, false),
+		NON_NEGATIVE_INTEGER(CoreDatatype.XSD.NON_NEGATIVE_INTEGER.getIri(), false, false, true, true, true, false,
+				false),
+		POSITIVE_INTEGER(CoreDatatype.XSD.POSITIVE_INTEGER.getIri(), false, false, true, true, true, false, false),
+		UNSIGNED_LONG(CoreDatatype.XSD.UNSIGNED_LONG.getIri(), false, false, true, true, true, false, false),
+		UNSIGNED_INT(CoreDatatype.XSD.UNSIGNED_INT.getIri(), false, false, true, true, true, false, false),
+		UNSIGNED_SHORT(CoreDatatype.XSD.UNSIGNED_SHORT.getIri(), false, false, true, true, true, false, false),
+		UNSIGNED_BYTE(CoreDatatype.XSD.UNSIGNED_BYTE.getIri(), false, false, true, true, true, false, false),
+		YEARMONTHDURATION(CoreDatatype.XSD.YEARMONTHDURATION.getIri(), false, true, false, true, false, false, false);
 
 		private final IRI iri;
 		private final boolean primitive;
@@ -247,6 +252,7 @@ public class XSD {
 		private final boolean decimal;
 		private final boolean floatingPoint;
 		private final boolean calendar;
+		private final CoreDatatype.XSD coreDatatype;
 
 		Datatype(IRI iri, boolean primitive, boolean duration, boolean integer, boolean derived, boolean decimal,
 				boolean floatingPoint, boolean calendar) {
@@ -258,6 +264,7 @@ public class XSD {
 			this.decimal = decimal;
 			this.floatingPoint = floatingPoint;
 			this.calendar = calendar;
+			this.coreDatatype = CoreDatatype.from(iri).asXSDDatatype().orElseThrow();
 		}
 
 		/**
@@ -361,11 +368,23 @@ public class XSD {
 			return isNumericDatatype() || isCalendarDatatype();
 		}
 
-		static HashMap<IRI, Optional<Datatype>> reverseLookup = new HashMap<>();
+		public IRI getIri() {
+			return iri;
+		}
+
+		public CoreDatatype getCoreDatatype() {
+			return coreDatatype;
+		}
+
+		private static final Map<IRI, Optional<Datatype>> reverseLookup = new HashMap<>();
+
+		private static final Map<CoreDatatype.XSD, Optional<Datatype>> reverseLookupXSDDatatype = new EnumMap<>(
+				CoreDatatype.XSD.class);
 
 		static {
 			for (Datatype value : Datatype.values()) {
 				reverseLookup.put(value.iri, Optional.of(value));
+				reverseLookupXSDDatatype.put(value.coreDatatype, Optional.of(value));
 			}
 		}
 
@@ -373,8 +392,10 @@ public class XSD {
 			return reverseLookup.getOrDefault(datatype, Optional.empty());
 		}
 
-		public IRI getIri() {
-			return iri;
+		public static Optional<Datatype> from(CoreDatatype.XSD datatype) {
+			if (datatype == null)
+				return Optional.empty();
+			return reverseLookupXSDDatatype.getOrDefault(datatype, Optional.empty());
 		}
 
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -248,75 +248,73 @@ public class XMLDatatypeUtil {
 	 * @return true if the supplied lexical value is valid, false otherwise.
 	 */
 	public static boolean isValidValue(String value, IRI datatype) {
-		boolean result = true;
-
 		if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DECIMAL)) {
-			result = isValidDecimal(value);
+			return isValidDecimal(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.INTEGER)) {
-			result = isValidInteger(value);
+			return isValidInteger(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NEGATIVE_INTEGER)) {
-			result = isValidNegativeInteger(value);
+			return isValidNegativeInteger(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NON_POSITIVE_INTEGER)) {
-			result = isValidNonPositiveInteger(value);
+			return isValidNonPositiveInteger(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NON_NEGATIVE_INTEGER)) {
-			result = isValidNonNegativeInteger(value);
+			return isValidNonNegativeInteger(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.POSITIVE_INTEGER)) {
-			result = isValidPositiveInteger(value);
+			return isValidPositiveInteger(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.LONG)) {
-			result = isValidLong(value);
+			return isValidLong(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.INT)) {
-			result = isValidInt(value);
+			return isValidInt(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.SHORT)) {
-			result = isValidShort(value);
+			return isValidShort(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.BYTE)) {
-			result = isValidByte(value);
+			return isValidByte(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_LONG)) {
-			result = isValidUnsignedLong(value);
+			return isValidUnsignedLong(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_INT)) {
-			result = isValidUnsignedInt(value);
+			return isValidUnsignedInt(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_SHORT)) {
-			result = isValidUnsignedShort(value);
+			return isValidUnsignedShort(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_BYTE)) {
-			result = isValidUnsignedByte(value);
+			return isValidUnsignedByte(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.FLOAT)) {
-			result = isValidFloat(value);
+			return isValidFloat(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DOUBLE)) {
-			result = isValidDouble(value);
+			return isValidDouble(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.BOOLEAN)) {
-			result = isValidBoolean(value);
+			return isValidBoolean(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATETIME)) {
-			result = isValidDateTime(value);
+			return isValidDateTime(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATETIMESTAMP)) {
-			result = isValidDateTimeStamp(value);
+			return isValidDateTimeStamp(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATE)) {
-			result = isValidDate(value);
+			return isValidDate(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.TIME)) {
-			result = isValidTime(value);
+			return isValidTime(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GDAY)) {
-			result = isValidGDay(value);
+			return isValidGDay(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GMONTH)) {
-			result = isValidGMonth(value);
+			return isValidGMonth(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GMONTHDAY)) {
-			result = isValidGMonthDay(value);
+			return isValidGMonthDay(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GYEAR)) {
-			result = isValidGYear(value);
+			return isValidGYear(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GYEARMONTH)) {
-			result = isValidGYearMonth(value);
+			return isValidGYearMonth(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DURATION)) {
-			result = isValidDuration(value);
+			return isValidDuration(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DAYTIMEDURATION)) {
-			result = isValidDayTimeDuration(value);
+			return isValidDayTimeDuration(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.YEARMONTHDURATION)) {
-			result = isValidYearMonthDuration(value);
+			return isValidYearMonthDuration(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.QNAME)) {
-			result = isValidQName(value);
+			return isValidQName(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.ANYURI)) {
-			result = isValidAnyURI(value);
+			return isValidAnyURI(value);
 		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.LANGUAGE)) {
-			result = Literals.isValidLanguageTag(value);
+			return Literals.isValidLanguageTag(value);
 		}
 
-		return result;
+		return true;
 	}
 
 	public static boolean isValidValue(String value, CoreDatatype datatype) {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.model.datatypes;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URISyntaxException;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
@@ -25,6 +24,7 @@ import javax.xml.namespace.QName;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.common.text.ASCIIUtil;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
@@ -35,13 +35,20 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
  */
 public class XMLDatatypeUtil {
 
+	private static final IllegalArgumentExceptionWithoutStackTrace VALUE_SMALLER_THAN_MINIMUM_VALUE_EXCEPTION = new IllegalArgumentExceptionWithoutStackTrace(
+			"Value smaller than minimum value");
+	private static final IllegalArgumentExceptionWithoutStackTrace VALUE_LARGER_THAN_MAXIMUM_VALUE_EXCEPTION = new IllegalArgumentExceptionWithoutStackTrace(
+			"Value larger than maximum value");
+	private static final IllegalArgumentExceptionWithoutStackTrace NAN_COMPARE_EXCEPTION = new IllegalArgumentExceptionWithoutStackTrace(
+			"NaN cannot be compared to other floats");
+
 	public static final String POSITIVE_INFINITY = "INF";
 
 	public static final String NEGATIVE_INFINITY = "-INF";
 
 	public static final String NaN = "NaN";
 
-	private static DatatypeFactory dtFactory;
+	private static final DatatypeFactory dtFactory;
 
 	static {
 		try {
@@ -57,46 +64,68 @@ public class XMLDatatypeUtil {
 			"-?P((\\d)+D)?((T(\\d)+H((\\d)+M)?((\\d)+(\\.(\\d)+)?S)?)|(T(\\d)+M((\\d)+(\\.(\\d)+)?S)?)|(T(\\d)+(\\.(\\d)+)?S))?");
 	private final static Pattern P_YEARMONTHDURATION = Pattern.compile("-?P((\\d)+Y)?((\\d)+M)?");
 	private final static Pattern P_TIMEZONE = Pattern.compile(".*(Z|[+-]((0\\d|1[0-3]):[0-5]\\d|14:00))$");
-	private final static Pattern P_DATE = Pattern.compile("-?\\d{4,}-\\d\\d-\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?");
-	private final static Pattern P_TIME = Pattern.compile("\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(Z|(\\+|-)\\d\\d:\\d\\d)?");
-	private final static Pattern P_GDAY = Pattern.compile("---\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?");
-	private final static Pattern P_GMONTH = Pattern.compile("--\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?");
-	private final static Pattern P_GMONTHDAY = Pattern.compile("--\\d\\d-\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?");
-	private final static Pattern P_GYEAR = Pattern.compile("-?\\d{4,}(Z|(\\+|-)\\d\\d:\\d\\d)?");
-	private final static Pattern P_GYEARMONTH = Pattern.compile("-?\\d{4,}-\\d\\d(Z|(\\+|-)\\d\\d:\\d\\d)?");
+	private final static Pattern P_DATE = Pattern.compile("-?\\d{4,}-\\d\\d-\\d\\d(Z|([+\\-])\\d\\d:\\d\\d)?");
+	private final static Pattern P_TIME = Pattern.compile("\\d\\d:\\d\\d:\\d\\d(\\.\\d+)?(Z|([+\\-])\\d\\d:\\d\\d)?");
+	private final static Pattern P_GDAY = Pattern.compile("---\\d\\d(Z|([+\\-])\\d\\d:\\d\\d)?");
+	private final static Pattern P_GMONTH = Pattern.compile("--\\d\\d(Z|([+\\-])\\d\\d:\\d\\d)?");
+	private final static Pattern P_GMONTHDAY = Pattern.compile("--\\d\\d-\\d\\d(Z|([+\\-])\\d\\d:\\d\\d)?");
+	private final static Pattern P_GYEAR = Pattern.compile("-?\\d{4,}(Z|([+\\-])\\d\\d:\\d\\d)?");
+	private final static Pattern P_GYEARMONTH = Pattern.compile("-?\\d{4,}-\\d\\d(Z|([+\\-])\\d\\d:\\d\\d)?");
 
-	private static final Set<IRI> primitiveDatatypes = createSet(XSD.DURATION, XSD.DATETIME, XSD.TIME, XSD.DATE,
-			XSD.GYEARMONTH, XSD.GYEAR, XSD.GMONTHDAY, XSD.GDAY, XSD.GMONTH, XSD.STRING, XSD.BOOLEAN, XSD.BASE64BINARY,
-			XSD.HEXBINARY, XSD.FLOAT, XSD.DECIMAL, XSD.DOUBLE, XSD.ANYURI, XSD.QNAME, XSD.NOTATION
-	);
+	private static final Set<IRI> primitiveDatatypes = Set.of(org.eclipse.rdf4j.model.vocabulary.XSD.DURATION,
+			org.eclipse.rdf4j.model.vocabulary.XSD.DATETIME, org.eclipse.rdf4j.model.vocabulary.XSD.TIME,
+			org.eclipse.rdf4j.model.vocabulary.XSD.DATE,
+			org.eclipse.rdf4j.model.vocabulary.XSD.GYEARMONTH, org.eclipse.rdf4j.model.vocabulary.XSD.GYEAR,
+			org.eclipse.rdf4j.model.vocabulary.XSD.GMONTHDAY, org.eclipse.rdf4j.model.vocabulary.XSD.GDAY,
+			org.eclipse.rdf4j.model.vocabulary.XSD.GMONTH, org.eclipse.rdf4j.model.vocabulary.XSD.STRING,
+			org.eclipse.rdf4j.model.vocabulary.XSD.BOOLEAN, org.eclipse.rdf4j.model.vocabulary.XSD.BASE64BINARY,
+			org.eclipse.rdf4j.model.vocabulary.XSD.HEXBINARY, org.eclipse.rdf4j.model.vocabulary.XSD.FLOAT,
+			org.eclipse.rdf4j.model.vocabulary.XSD.DECIMAL, org.eclipse.rdf4j.model.vocabulary.XSD.DOUBLE,
+			org.eclipse.rdf4j.model.vocabulary.XSD.ANYURI, org.eclipse.rdf4j.model.vocabulary.XSD.QNAME,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NOTATION);
 
-	private static final Set<IRI> derivedDatatypes = createSet(XSD.NORMALIZEDSTRING, XSD.TOKEN, XSD.LANGUAGE,
-			XSD.NMTOKEN, XSD.NMTOKENS, XSD.NAME, XSD.NCNAME, XSD.ID, XSD.IDREF, XSD.IDREFS, XSD.ENTITY, XSD.ENTITIES,
-			XSD.INTEGER, XSD.LONG, XSD.INT, XSD.SHORT, XSD.BYTE, XSD.NON_POSITIVE_INTEGER, XSD.NEGATIVE_INTEGER,
-			XSD.NON_NEGATIVE_INTEGER, XSD.POSITIVE_INTEGER, XSD.UNSIGNED_LONG, XSD.UNSIGNED_INT, XSD.UNSIGNED_SHORT,
-			XSD.UNSIGNED_BYTE, XSD.DAYTIMEDURATION, XSD.YEARMONTHDURATION, XSD.DATETIMESTAMP
-	);
+	private static final Set<IRI> derivedDatatypes = Set.of(org.eclipse.rdf4j.model.vocabulary.XSD.NORMALIZEDSTRING,
+			org.eclipse.rdf4j.model.vocabulary.XSD.TOKEN, org.eclipse.rdf4j.model.vocabulary.XSD.LANGUAGE,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NMTOKEN,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NMTOKENS, org.eclipse.rdf4j.model.vocabulary.XSD.NAME,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NCNAME, org.eclipse.rdf4j.model.vocabulary.XSD.ID,
+			org.eclipse.rdf4j.model.vocabulary.XSD.IDREF, org.eclipse.rdf4j.model.vocabulary.XSD.IDREFS,
+			org.eclipse.rdf4j.model.vocabulary.XSD.ENTITY, org.eclipse.rdf4j.model.vocabulary.XSD.ENTITIES,
+			org.eclipse.rdf4j.model.vocabulary.XSD.INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.LONG, org.eclipse.rdf4j.model.vocabulary.XSD.INT,
+			org.eclipse.rdf4j.model.vocabulary.XSD.SHORT, org.eclipse.rdf4j.model.vocabulary.XSD.BYTE,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NON_POSITIVE_INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NEGATIVE_INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NON_NEGATIVE_INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.POSITIVE_INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_LONG, org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_INT,
+			org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_SHORT,
+			org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_BYTE,
+			org.eclipse.rdf4j.model.vocabulary.XSD.DAYTIMEDURATION,
+			org.eclipse.rdf4j.model.vocabulary.XSD.YEARMONTHDURATION,
+			org.eclipse.rdf4j.model.vocabulary.XSD.DATETIMESTAMP);
 
-	private static final Set<IRI> integerDatatypes = createSet(XSD.INTEGER, XSD.LONG, XSD.INT, XSD.SHORT,
-			XSD.BYTE, XSD.NON_POSITIVE_INTEGER, XSD.NEGATIVE_INTEGER, XSD.NON_NEGATIVE_INTEGER, XSD.POSITIVE_INTEGER,
-			XSD.UNSIGNED_LONG, XSD.UNSIGNED_INT, XSD.UNSIGNED_SHORT, XSD.UNSIGNED_BYTE
-	);
+	private static final Set<IRI> integerDatatypes = Set.of(org.eclipse.rdf4j.model.vocabulary.XSD.INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.LONG, org.eclipse.rdf4j.model.vocabulary.XSD.INT,
+			org.eclipse.rdf4j.model.vocabulary.XSD.SHORT, org.eclipse.rdf4j.model.vocabulary.XSD.BYTE,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NON_POSITIVE_INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NEGATIVE_INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.NON_NEGATIVE_INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.POSITIVE_INTEGER,
+			org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_LONG, org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_INT,
+			org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_SHORT,
+			org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_BYTE);
 
-	private static final Set<IRI> calendarDatatypes = createSet(XSD.DATETIME, XSD.DATE, XSD.TIME, XSD.GYEARMONTH,
-			XSD.GMONTHDAY, XSD.GYEAR, XSD.GMONTH, XSD.GDAY, XSD.DATETIMESTAMP
-	);
+	private static final Set<IRI> calendarDatatypes = Set.of(org.eclipse.rdf4j.model.vocabulary.XSD.DATETIME,
+			org.eclipse.rdf4j.model.vocabulary.XSD.DATE, org.eclipse.rdf4j.model.vocabulary.XSD.TIME,
+			org.eclipse.rdf4j.model.vocabulary.XSD.GYEARMONTH,
+			org.eclipse.rdf4j.model.vocabulary.XSD.GMONTHDAY, org.eclipse.rdf4j.model.vocabulary.XSD.GYEAR,
+			org.eclipse.rdf4j.model.vocabulary.XSD.GMONTH, org.eclipse.rdf4j.model.vocabulary.XSD.GDAY,
+			org.eclipse.rdf4j.model.vocabulary.XSD.DATETIMESTAMP);
 
-	private static final Set<IRI> durationDatatypes = createSet(XSD.DURATION, XSD.DAYTIMEDURATION,
-			XSD.YEARMONTHDURATION
-	);
-
-	private static final Set<IRI> createSet(IRI... values) {
-		final Set<IRI> set = new HashSet<IRI>(values.length);
-		for (IRI value : values) {
-			set.add(value);
-		}
-		return set;
-	}
+	private static final Set<IRI> durationDatatypes = Set.of(org.eclipse.rdf4j.model.vocabulary.XSD.DURATION,
+			org.eclipse.rdf4j.model.vocabulary.XSD.DAYTIMEDURATION,
+			org.eclipse.rdf4j.model.vocabulary.XSD.YEARMONTHDURATION);
 
 	/**
 	 * Checks whether the supplied datatype is a primitive XML Schema datatype.
@@ -147,7 +176,7 @@ public class XMLDatatypeUtil {
 	 * @return true if it is a decimal datatype
 	 */
 	public static boolean isDecimalDatatype(IRI datatype) {
-		return datatype.equals(XSD.DECIMAL) || isIntegerDatatype(datatype);
+		return datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DECIMAL) || isIntegerDatatype(datatype);
 	}
 
 	/**
@@ -168,7 +197,8 @@ public class XMLDatatypeUtil {
 	 * @return true if it is a floating point type
 	 */
 	public static boolean isFloatingPointDatatype(IRI datatype) {
-		return datatype.equals(XSD.FLOAT) || datatype.equals(XSD.DOUBLE);
+		return datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.FLOAT)
+				|| datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DOUBLE);
 	}
 
 	/**
@@ -220,73 +250,146 @@ public class XMLDatatypeUtil {
 	public static boolean isValidValue(String value, IRI datatype) {
 		boolean result = true;
 
-		if (datatype.equals(XSD.DECIMAL)) {
+		if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DECIMAL)) {
 			result = isValidDecimal(value);
-		} else if (datatype.equals(XSD.INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.INTEGER)) {
 			result = isValidInteger(value);
-		} else if (datatype.equals(XSD.NEGATIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NEGATIVE_INTEGER)) {
 			result = isValidNegativeInteger(value);
-		} else if (datatype.equals(XSD.NON_POSITIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NON_POSITIVE_INTEGER)) {
 			result = isValidNonPositiveInteger(value);
-		} else if (datatype.equals(XSD.NON_NEGATIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NON_NEGATIVE_INTEGER)) {
 			result = isValidNonNegativeInteger(value);
-		} else if (datatype.equals(XSD.POSITIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.POSITIVE_INTEGER)) {
 			result = isValidPositiveInteger(value);
-		} else if (datatype.equals(XSD.LONG)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.LONG)) {
 			result = isValidLong(value);
-		} else if (datatype.equals(XSD.INT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.INT)) {
 			result = isValidInt(value);
-		} else if (datatype.equals(XSD.SHORT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.SHORT)) {
 			result = isValidShort(value);
-		} else if (datatype.equals(XSD.BYTE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.BYTE)) {
 			result = isValidByte(value);
-		} else if (datatype.equals(XSD.UNSIGNED_LONG)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_LONG)) {
 			result = isValidUnsignedLong(value);
-		} else if (datatype.equals(XSD.UNSIGNED_INT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_INT)) {
 			result = isValidUnsignedInt(value);
-		} else if (datatype.equals(XSD.UNSIGNED_SHORT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_SHORT)) {
 			result = isValidUnsignedShort(value);
-		} else if (datatype.equals(XSD.UNSIGNED_BYTE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_BYTE)) {
 			result = isValidUnsignedByte(value);
-		} else if (datatype.equals(XSD.FLOAT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.FLOAT)) {
 			result = isValidFloat(value);
-		} else if (datatype.equals(XSD.DOUBLE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DOUBLE)) {
 			result = isValidDouble(value);
-		} else if (datatype.equals(XSD.BOOLEAN)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.BOOLEAN)) {
 			result = isValidBoolean(value);
-		} else if (datatype.equals(XSD.DATETIME)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATETIME)) {
 			result = isValidDateTime(value);
-		} else if (datatype.equals(XSD.DATETIMESTAMP)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATETIMESTAMP)) {
 			result = isValidDateTimeStamp(value);
-		} else if (datatype.equals(XSD.DATE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATE)) {
 			result = isValidDate(value);
-		} else if (datatype.equals(XSD.TIME)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.TIME)) {
 			result = isValidTime(value);
-		} else if (datatype.equals(XSD.GDAY)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GDAY)) {
 			result = isValidGDay(value);
-		} else if (datatype.equals(XSD.GMONTH)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GMONTH)) {
 			result = isValidGMonth(value);
-		} else if (datatype.equals(XSD.GMONTHDAY)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GMONTHDAY)) {
 			result = isValidGMonthDay(value);
-		} else if (datatype.equals(XSD.GYEAR)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GYEAR)) {
 			result = isValidGYear(value);
-		} else if (datatype.equals(XSD.GYEARMONTH)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.GYEARMONTH)) {
 			result = isValidGYearMonth(value);
-		} else if (datatype.equals(XSD.DURATION)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DURATION)) {
 			result = isValidDuration(value);
-		} else if (datatype.equals(XSD.DAYTIMEDURATION)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DAYTIMEDURATION)) {
 			result = isValidDayTimeDuration(value);
-		} else if (datatype.equals(XSD.YEARMONTHDURATION)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.YEARMONTHDURATION)) {
 			result = isValidYearMonthDuration(value);
-		} else if (datatype.equals(XSD.QNAME)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.QNAME)) {
 			result = isValidQName(value);
-		} else if (datatype.equals(XSD.ANYURI)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.ANYURI)) {
 			result = isValidAnyURI(value);
-		} else if (datatype.equals(XSD.LANGUAGE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.LANGUAGE)) {
 			result = Literals.isValidLanguageTag(value);
 		}
 
 		return result;
+	}
+
+	public static boolean isValidValue(String value, CoreDatatype datatype) {
+		if (datatype.isXSDDatatype()) {
+			switch (((CoreDatatype.XSD) datatype)) {
+			case DECIMAL:
+				return isValidDecimal(value);
+			case INTEGER:
+				return isValidInteger(value);
+			case NEGATIVE_INTEGER:
+				return isValidNegativeInteger(value);
+			case NON_POSITIVE_INTEGER:
+				return isValidNonPositiveInteger(value);
+			case NON_NEGATIVE_INTEGER:
+				return isValidNonNegativeInteger(value);
+			case POSITIVE_INTEGER:
+				return isValidPositiveInteger(value);
+			case LONG:
+				return isValidLong(value);
+			case INT:
+				return isValidInt(value);
+			case SHORT:
+				return isValidShort(value);
+			case BYTE:
+				return isValidByte(value);
+			case UNSIGNED_LONG:
+				return isValidUnsignedLong(value);
+			case UNSIGNED_INT:
+				return isValidUnsignedInt(value);
+			case UNSIGNED_SHORT:
+				return isValidUnsignedShort(value);
+			case UNSIGNED_BYTE:
+				return isValidUnsignedByte(value);
+			case FLOAT:
+				return isValidFloat(value);
+			case DOUBLE:
+				return isValidDouble(value);
+			case BOOLEAN:
+				return isValidBoolean(value);
+			case DATETIME:
+				return isValidDateTime(value);
+			case DATETIMESTAMP:
+				return isValidDateTimeStamp(value);
+			case DATE:
+				return isValidDate(value);
+			case TIME:
+				return isValidTime(value);
+			case GDAY:
+				return isValidGDay(value);
+			case GMONTH:
+				return isValidGMonth(value);
+			case GMONTHDAY:
+				return isValidGMonthDay(value);
+			case GYEAR:
+				return isValidGYear(value);
+			case GYEARMONTH:
+				return isValidGYearMonth(value);
+			case DURATION:
+				return isValidDuration(value);
+			case DAYTIMEDURATION:
+				return isValidDayTimeDuration(value);
+			case YEARMONTHDURATION:
+				return isValidYearMonthDuration(value);
+			case QNAME:
+				return isValidQName(value);
+			case ANYURI:
+				return isValidAnyURI(value);
+			case LANGUAGE:
+				return Literals.isValidLanguageTag(value);
+			}
+		}
+		return true;
+
 	}
 
 	/**
@@ -615,7 +718,7 @@ public class XMLDatatypeUtil {
 	 * @return <var>true</var> if valid, <var>false</var> otherwise
 	 */
 	public static boolean isValidDate(String value) {
-		return P_DATE.matcher(value).matches() ? isValidCalendarValue(value) : false;
+		return P_DATE.matcher(value).matches() && isValidCalendarValue(value);
 	}
 
 	/**
@@ -625,7 +728,7 @@ public class XMLDatatypeUtil {
 	 * @return <var>true</var> if valid, <var>false</var> otherwise
 	 */
 	public static boolean isValidTime(String value) {
-		return P_TIME.matcher(value).matches() ? isValidCalendarValue(value) : false;
+		return P_TIME.matcher(value).matches() && isValidCalendarValue(value);
 	}
 
 	/**
@@ -635,7 +738,7 @@ public class XMLDatatypeUtil {
 	 * @return <var>true</var> if valid, <var>false</var> otherwise
 	 */
 	public static boolean isValidGDay(String value) {
-		return P_GDAY.matcher(value).matches() ? isValidCalendarValue(value) : false;
+		return P_GDAY.matcher(value).matches() && isValidCalendarValue(value);
 	}
 
 	/**
@@ -645,7 +748,7 @@ public class XMLDatatypeUtil {
 	 * @return <var>true</var> if valid, <var>false</var> otherwise
 	 */
 	public static boolean isValidGMonth(String value) {
-		return P_GMONTH.matcher(value).matches() ? isValidCalendarValue(value) : false;
+		return P_GMONTH.matcher(value).matches() && isValidCalendarValue(value);
 	}
 
 	/**
@@ -655,7 +758,7 @@ public class XMLDatatypeUtil {
 	 * @return <var>true</var> if valid, <var>false</var> otherwise
 	 */
 	public static boolean isValidGMonthDay(String value) {
-		return P_GMONTHDAY.matcher(value).matches() ? isValidCalendarValue(value) : false;
+		return P_GMONTHDAY.matcher(value).matches() && isValidCalendarValue(value);
 	}
 
 	/**
@@ -665,7 +768,7 @@ public class XMLDatatypeUtil {
 	 * @return <var>true</var> if valid, <var>false</var> otherwise
 	 */
 	public static boolean isValidGYear(String value) {
-		return P_GYEAR.matcher(value).matches() ? isValidCalendarValue(value) : false;
+		return P_GYEAR.matcher(value).matches() && isValidCalendarValue(value);
 	}
 
 	/**
@@ -675,7 +778,7 @@ public class XMLDatatypeUtil {
 	 * @return <var>true</var> if valid, <var>false</var> otherwise
 	 */
 	public static boolean isValidGYearMonth(String value) {
-		return P_GYEARMONTH.matcher(value).matches() ? isValidCalendarValue(value) : false;
+		return P_GYEARMONTH.matcher(value).matches() && isValidCalendarValue(value);
 	}
 
 	/**
@@ -696,12 +799,12 @@ public class XMLDatatypeUtil {
 		// check prefix
 		String prefix = split[0];
 		if (!"".equals(prefix)) {
-			if (!isPrefixStartChar(prefix.charAt(0))) {
+			if (isNotPrefixStartChar(prefix.charAt(0))) {
 				return false;
 			}
 
 			for (int i = 1; i < prefix.length(); i++) {
-				if (!isNameChar(prefix.charAt(i))) {
+				if (isNotNameChar(prefix.charAt(i))) {
 					return false;
 				}
 			}
@@ -711,12 +814,12 @@ public class XMLDatatypeUtil {
 
 		if (!"".equals(name)) {
 			// check name
-			if (!isNameStartChar(name.charAt(0))) {
+			if (isNotNameStartChar(name.charAt(0))) {
 				return false;
 			}
 
 			for (int i = 1; i < name.length(); i++) {
-				if (!isNameChar(name.charAt(i))) {
+				if (isNotNameChar(name.charAt(i))) {
 					return false;
 				}
 			}
@@ -743,21 +846,21 @@ public class XMLDatatypeUtil {
 		}
 	}
 
-	private static boolean isPrefixStartChar(int c) {
-		return ASCIIUtil.isLetter(c) || c >= 0x00C0 && c <= 0x00D6 || c >= 0x00D8 && c <= 0x00F6
-				|| c >= 0x00F8 && c <= 0x02FF || c >= 0x0370 && c <= 0x037D || c >= 0x037F && c <= 0x1FFF
-				|| c >= 0x200C && c <= 0x200D || c >= 0x2070 && c <= 0x218F || c >= 0x2C00 && c <= 0x2FEF
-				|| c >= 0x3001 && c <= 0xD7FF || c >= 0xF900 && c <= 0xFDCF || c >= 0xFDF0 && c <= 0xFFFD
-				|| c >= 0x10000 && c <= 0xEFFFF;
+	private static boolean isNotPrefixStartChar(int c) {
+		return !ASCIIUtil.isLetter(c) && (c < 0x00C0 || c > 0x00D6) && (c < 0x00D8 || c > 0x00F6)
+				&& (c < 0x00F8 || c > 0x02FF) && (c < 0x0370 || c > 0x037D) && (c < 0x037F || c > 0x1FFF)
+				&& (c < 0x200C || c > 0x200D) && (c < 0x2070 || c > 0x218F) && (c < 0x2C00 || c > 0x2FEF)
+				&& (c < 0x3001 || c > 0xD7FF) && (c < 0xF900 || c > 0xFDCF) && (c < 0xFDF0 || c > 0xFFFD)
+				&& (c < 0x10000 || c > 0xEFFFF);
 	}
 
-	private static boolean isNameStartChar(int c) {
-		return c == '_' || isPrefixStartChar(c);
+	private static boolean isNotNameStartChar(int c) {
+		return c != '_' && isNotPrefixStartChar(c);
 	}
 
-	private static boolean isNameChar(int c) {
-		return isNameStartChar(c) || ASCIIUtil.isNumber(c) || c == '-' || c == 0x00B7 || c >= 0x0300 && c <= 0x036F
-				|| c >= 0x203F && c <= 0x2040;
+	private static boolean isNotNameChar(int c) {
+		return isNotNameStartChar(c) && !ASCIIUtil.isNumber(c) && c != '-' && c != 0x00B7 && (c < 0x0300 || c > 0x036F)
+				&& (c < 0x203F || c > 0x2040);
 	}
 
 	/**
@@ -791,43 +894,89 @@ public class XMLDatatypeUtil {
 	public static String normalize(String value, IRI datatype) {
 		String result = value;
 
-		if (datatype.equals(XSD.DECIMAL)) {
+		if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DECIMAL)) {
 			result = normalizeDecimal(value);
-		} else if (datatype.equals(XSD.INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.INTEGER)) {
 			result = normalizeInteger(value);
-		} else if (datatype.equals(XSD.NEGATIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NEGATIVE_INTEGER)) {
 			result = normalizeNegativeInteger(value);
-		} else if (datatype.equals(XSD.NON_POSITIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NON_POSITIVE_INTEGER)) {
 			result = normalizeNonPositiveInteger(value);
-		} else if (datatype.equals(XSD.NON_NEGATIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NON_NEGATIVE_INTEGER)) {
 			result = normalizeNonNegativeInteger(value);
-		} else if (datatype.equals(XSD.POSITIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.POSITIVE_INTEGER)) {
 			result = normalizePositiveInteger(value);
-		} else if (datatype.equals(XSD.LONG)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.LONG)) {
 			result = normalizeLong(value);
-		} else if (datatype.equals(XSD.INT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.INT)) {
 			result = normalizeInt(value);
-		} else if (datatype.equals(XSD.SHORT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.SHORT)) {
 			result = normalizeShort(value);
-		} else if (datatype.equals(XSD.BYTE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.BYTE)) {
 			result = normalizeByte(value);
-		} else if (datatype.equals(XSD.UNSIGNED_LONG)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_LONG)) {
 			result = normalizeUnsignedLong(value);
-		} else if (datatype.equals(XSD.UNSIGNED_INT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_INT)) {
 			result = normalizeUnsignedInt(value);
-		} else if (datatype.equals(XSD.UNSIGNED_SHORT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_SHORT)) {
 			result = normalizeUnsignedShort(value);
-		} else if (datatype.equals(XSD.UNSIGNED_BYTE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_BYTE)) {
 			result = normalizeUnsignedByte(value);
-		} else if (datatype.equals(XSD.FLOAT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.FLOAT)) {
 			result = normalizeFloat(value);
-		} else if (datatype.equals(XSD.DOUBLE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DOUBLE)) {
 			result = normalizeDouble(value);
-		} else if (datatype.equals(XSD.BOOLEAN)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.BOOLEAN)) {
 			result = normalizeBoolean(value);
-		} else if (datatype.equals(XSD.DATETIME)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATETIME)) {
 			result = normalizeDateTime(value);
-		} else if (datatype.equals(XSD.ANYURI)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.ANYURI)) {
+			result = collapseWhiteSpace(value);
+		}
+
+		return result;
+	}
+
+	public static String normalize(String value, CoreDatatype.XSD datatype) {
+		String result = value;
+
+		if (datatype == CoreDatatype.XSD.DECIMAL) {
+			result = normalizeDecimal(value);
+		} else if (datatype == CoreDatatype.XSD.INTEGER) {
+			result = normalizeInteger(value);
+		} else if (datatype == CoreDatatype.XSD.NEGATIVE_INTEGER) {
+			result = normalizeNegativeInteger(value);
+		} else if (datatype == CoreDatatype.XSD.NON_POSITIVE_INTEGER) {
+			result = normalizeNonPositiveInteger(value);
+		} else if (datatype == CoreDatatype.XSD.NON_NEGATIVE_INTEGER) {
+			result = normalizeNonNegativeInteger(value);
+		} else if (datatype == CoreDatatype.XSD.POSITIVE_INTEGER) {
+			result = normalizePositiveInteger(value);
+		} else if (datatype == CoreDatatype.XSD.LONG) {
+			result = normalizeLong(value);
+		} else if (datatype == CoreDatatype.XSD.INT) {
+			result = normalizeInt(value);
+		} else if (datatype == CoreDatatype.XSD.SHORT) {
+			result = normalizeShort(value);
+		} else if (datatype == CoreDatatype.XSD.BYTE) {
+			result = normalizeByte(value);
+		} else if (datatype == CoreDatatype.XSD.UNSIGNED_LONG) {
+			result = normalizeUnsignedLong(value);
+		} else if (datatype == CoreDatatype.XSD.UNSIGNED_INT) {
+			result = normalizeUnsignedInt(value);
+		} else if (datatype == CoreDatatype.XSD.UNSIGNED_SHORT) {
+			result = normalizeUnsignedShort(value);
+		} else if (datatype == CoreDatatype.XSD.UNSIGNED_BYTE) {
+			result = normalizeUnsignedByte(value);
+		} else if (datatype == CoreDatatype.XSD.FLOAT) {
+			result = normalizeFloat(value);
+		} else if (datatype == CoreDatatype.XSD.DOUBLE) {
+			result = normalizeDouble(value);
+		} else if (datatype == CoreDatatype.XSD.BOOLEAN) {
+			result = normalizeBoolean(value);
+		} else if (datatype == CoreDatatype.XSD.DATETIME) {
+			result = normalizeDateTime(value);
+		} else if (datatype == CoreDatatype.XSD.ANYURI) {
 			result = collapseWhiteSpace(value);
 		}
 
@@ -853,7 +1002,7 @@ public class XMLDatatypeUtil {
 		} else if (value.equals("true") || value.equals("false")) {
 			return value;
 		} else {
-			throw new IllegalArgumentException("Not a legal boolean value: " + value);
+			throw new IllegalArgumentExceptionWithoutStackTrace("Not a legal boolean value: " + value);
 		}
 	}
 
@@ -873,7 +1022,7 @@ public class XMLDatatypeUtil {
 		StringBuilder result = new StringBuilder(decLength + 2);
 
 		if (decLength == 0) {
-			throwIAE("Not a legal decimal: " + decimal);
+			throw new IllegalArgumentExceptionWithoutStackTrace("Not a legal decimal: " + decimal);
 		}
 
 		boolean isZeroPointZero = true;
@@ -888,7 +1037,7 @@ public class XMLDatatypeUtil {
 		}
 
 		if (idx == decLength) {
-			throwIAE("Not a legal decimal: " + decimal);
+			throw new IllegalArgumentExceptionWithoutStackTrace("Not a legal decimal: " + decimal);
 		}
 
 		// skip any leading zeros
@@ -912,8 +1061,8 @@ public class XMLDatatypeUtil {
 				if (c == '.') {
 					break;
 				}
-				if (!isDigit(c)) {
-					throwIAE("Not a legal decimal: " + decimal);
+				if (isNotDigit(c)) {
+					throw new IllegalArgumentExceptionWithoutStackTrace("Not a legal decimal: " + decimal);
 				}
 				result.append(c);
 				idx++;
@@ -943,8 +1092,8 @@ public class XMLDatatypeUtil {
 
 				while (idx <= lastIdx) {
 					char c = decimal.charAt(idx);
-					if (!isDigit(c)) {
-						throwIAE("Not a legal decimal: " + decimal);
+					if (isNotDigit(c)) {
+						throw new IllegalArgumentExceptionWithoutStackTrace("Not a legal decimal: " + decimal);
 					}
 					result.append(c);
 					idx++;
@@ -1066,7 +1215,7 @@ public class XMLDatatypeUtil {
 		int intLength = integer.length();
 
 		if (intLength == 0) {
-			throwIAE("Not a legal integer: " + integer);
+			throw new IllegalArgumentExceptionWithoutStackTrace("Not a legal integer: " + integer);
 		}
 
 		int idx = 0;
@@ -1081,7 +1230,7 @@ public class XMLDatatypeUtil {
 		}
 
 		if (idx == intLength) {
-			throwIAE("Not a legal integer: " + integer);
+			throw new IllegalArgumentExceptionWithoutStackTrace("Not a legal integer: " + integer);
 		}
 
 		if (integer.charAt(idx) == '0' && idx < intLength - 1) {
@@ -1097,8 +1246,8 @@ public class XMLDatatypeUtil {
 
 		// Check that all characters in 'norm' are digits
 		for (int i = 0; i < norm.length(); i++) {
-			if (!isDigit(norm.charAt(i))) {
-				throwIAE("Not a legal integer: " + integer);
+			if (isNotDigit(norm.charAt(i))) {
+				throw new IllegalArgumentExceptionWithoutStackTrace("Not a legal integer: " + integer);
 			}
 		}
 
@@ -1109,12 +1258,12 @@ public class XMLDatatypeUtil {
 		// Check lower and upper bounds, if applicable
 		if (minValue != null) {
 			if (compareCanonicalIntegers(norm, minValue) < 0) {
-				throwIAE("Value smaller than minimum value");
+				throw VALUE_SMALLER_THAN_MINIMUM_VALUE_EXCEPTION;
 			}
 		}
 		if (maxValue != null) {
 			if (compareCanonicalIntegers(norm, maxValue) > 0) {
-				throwIAE("Value larger than maximum value");
+				throw VALUE_LARGER_THAN_MAXIMUM_VALUE_EXCEPTION;
 			}
 		}
 
@@ -1171,7 +1320,8 @@ public class XMLDatatypeUtil {
 
 		if (value.contains(" ")) {
 			// floating point lexical value can not contain spaces after collapse
-			throwIAE("No space allowed in floating point lexical value (" + value + ")");
+			throw new IllegalArgumentExceptionWithoutStackTrace(
+					"No space allowed in floating point lexical value (" + value + ")");
 		}
 
 		// handle special values
@@ -1215,7 +1365,7 @@ public class XMLDatatypeUtil {
 			}
 			sb.append(mantissa.charAt(firstDigitIdx));
 			sb.append('.');
-			sb.append(mantissa.substring(firstDigitIdx + 1, dotIdx));
+			sb.append(mantissa, firstDigitIdx + 1, dotIdx);
 			sb.append(mantissa.substring(dotIdx + 1));
 
 			mantissa = sb.toString();
@@ -1286,22 +1436,26 @@ public class XMLDatatypeUtil {
 		// applicable
 		if (minMantissa != null) {
 			if (compareCanonicalDecimals(mantissa, minMantissa) < 0) {
-				throwIAE("Mantissa smaller than minimum value (" + minMantissa + ")");
+				throw new IllegalArgumentExceptionWithoutStackTrace(
+						"Mantissa smaller than minimum value (" + minMantissa + ")");
 			}
 		}
 		if (maxMantissa != null) {
 			if (compareCanonicalDecimals(mantissa, maxMantissa) > 0) {
-				throwIAE("Mantissa larger than maximum value (" + maxMantissa + ")");
+				throw new IllegalArgumentExceptionWithoutStackTrace(
+						"Mantissa larger than maximum value (" + maxMantissa + ")");
 			}
 		}
 		if (minExponent != null) {
 			if (compareCanonicalIntegers(exponent, minExponent) < 0) {
-				throwIAE("Exponent smaller than minimum value (" + minExponent + ")");
+				throw new IllegalArgumentExceptionWithoutStackTrace(
+						"Exponent smaller than minimum value (" + minExponent + ")");
 			}
 		}
 		if (maxExponent != null) {
 			if (compareCanonicalIntegers(exponent, maxExponent) > 0) {
-				throwIAE("Exponent larger than maximum value (" + maxExponent + ")");
+				throw new IllegalArgumentExceptionWithoutStackTrace(
+						"Exponent larger than maximum value (" + maxExponent + ")");
 			}
 		}
 
@@ -1320,17 +1474,6 @@ public class XMLDatatypeUtil {
 		dt.normalize();
 		return dt.toString();
 	}
-
-	/**
-	 * Replaces all occurences of #x9 (tab), #xA (line feed) and #xD (carriage return) with #x20 (space), as specified
-	 * for whiteSpace facet <var>replace</var>.
-	 */
-	// private static String replaceWhiteSpace(String s) {
-	// s = StringUtil.gsub("\t", " ", s);
-	// s = StringUtil.gsub("\r", " ", s);
-	// s = StringUtil.gsub("\n", " ", s);
-	// return s;
-	// }
 
 	/**
 	 * Replaces all contiguous sequences of #x9 (tab), #xA (line feed) and #xD (carriage return) with a single #x20
@@ -1361,39 +1504,40 @@ public class XMLDatatypeUtil {
 	 *------------------*/
 
 	public static int compare(String value1, String value2, IRI datatype) {
-		if (datatype.equals(XSD.DECIMAL)) {
+		if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DECIMAL)) {
 			return compareDecimals(value1, value2);
-		} else if (datatype.equals(XSD.INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.INTEGER)) {
 			return compareIntegers(value1, value2);
-		} else if (datatype.equals(XSD.NEGATIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NEGATIVE_INTEGER)) {
 			return compareNegativeIntegers(value1, value2);
-		} else if (datatype.equals(XSD.NON_POSITIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NON_POSITIVE_INTEGER)) {
 			return compareNonPositiveIntegers(value1, value2);
-		} else if (datatype.equals(XSD.NON_NEGATIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.NON_NEGATIVE_INTEGER)) {
 			return compareNonNegativeIntegers(value1, value2);
-		} else if (datatype.equals(XSD.POSITIVE_INTEGER)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.POSITIVE_INTEGER)) {
 			return comparePositiveIntegers(value1, value2);
-		} else if (datatype.equals(XSD.LONG)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.LONG)) {
 			return compareLongs(value1, value2);
-		} else if (datatype.equals(XSD.INT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.INT)) {
 			return compareInts(value1, value2);
-		} else if (datatype.equals(XSD.SHORT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.SHORT)) {
 			return compareShorts(value1, value2);
-		} else if (datatype.equals(XSD.BYTE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.BYTE)) {
 			return compareBytes(value1, value2);
-		} else if (datatype.equals(XSD.UNSIGNED_LONG)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_LONG)) {
 			return compareUnsignedLongs(value1, value2);
-		} else if (datatype.equals(XSD.UNSIGNED_INT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_INT)) {
 			return compareUnsignedInts(value1, value2);
-		} else if (datatype.equals(XSD.UNSIGNED_SHORT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_SHORT)) {
 			return compareUnsignedShorts(value1, value2);
-		} else if (datatype.equals(XSD.UNSIGNED_BYTE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_BYTE)) {
 			return compareUnsignedBytes(value1, value2);
-		} else if (datatype.equals(XSD.FLOAT)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.FLOAT)) {
 			return compareFloats(value1, value2);
-		} else if (datatype.equals(XSD.DOUBLE)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DOUBLE)) {
 			return compareDoubles(value1, value2);
-		} else if (datatype.equals(XSD.DATETIME) || datatype.equals(XSD.DATETIMESTAMP)) {
+		} else if (datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATETIME)
+				|| datatype.equals(org.eclipse.rdf4j.model.vocabulary.XSD.DATETIMESTAMP)) {
 			return compareDateTime(value1, value2);
 		} else {
 			throw new IllegalArgumentException("datatype is not ordered");
@@ -1456,7 +1600,7 @@ public class XMLDatatypeUtil {
 			// Continue comparing digits after the dot if necessary
 			int dec1Length = dec1.length();
 			int dec2Length = dec2.length();
-			int lastIdx = dec1Length <= dec2Length ? dec1Length : dec2Length;
+			int lastIdx = Math.min(dec1Length, dec2Length);
 
 			for (int i = dotIdx1 + 1; result == 0 && i < lastIdx; i++) {
 				result = dec1.charAt(i) - dec2.charAt(i);
@@ -1694,10 +1838,7 @@ public class XMLDatatypeUtil {
 	 *         <var>NaN</var> is compared to a floating point number other than <var>NaN</var>.
 	 */
 	public static int compareFPNumbers(String fp1, String fp2) {
-		fp1 = normalizeFPNumber(fp1);
-		fp2 = normalizeFPNumber(fp2);
-
-		return compareCanonicalFPNumbers(fp1, fp2);
+		return compareCanonicalFPNumbers(normalizeFPNumber(fp1), normalizeFPNumber(fp2));
 	}
 
 	/**
@@ -1718,7 +1859,7 @@ public class XMLDatatypeUtil {
 				// NaN is equal to itself
 				return 0;
 			} else {
-				throwIAE("NaN cannot be compared to other floats");
+				throw NAN_COMPARE_EXCEPTION;
 			}
 		}
 
@@ -2018,14 +2159,20 @@ public class XMLDatatypeUtil {
 	/**
 	 * Checks whether the supplied character is a digit.
 	 */
-	private static final boolean isDigit(char c) {
-		return c >= '0' && c <= '9';
+	private static boolean isNotDigit(char c) {
+		return c < '0' || c > '9';
 	}
 
-	/**
-	 * Throws an IllegalArgumentException that contains the supplied message.
-	 */
-	private static final void throwIAE(String msg) {
-		throw new IllegalArgumentException(msg);
+	private static class IllegalArgumentExceptionWithoutStackTrace extends IllegalArgumentException {
+		public IllegalArgumentExceptionWithoutStackTrace(String msg) {
+			super(msg);
+		}
+
+		@Override
+		public synchronized Throwable fillInStackTrace() {
+			// no-op because we don't need to have the entire stacktrace when we are just using these exceptions for
+			// control flow
+			return this;
+		}
 	}
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DecimalLiteral.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DecimalLiteral.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
@@ -40,8 +41,13 @@ public class DecimalLiteral extends SimpleLiteral {
 		this.value = value;
 	}
 
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	protected DecimalLiteral(BigDecimal value, XSD.Datatype datatype) {
-		// TODO: maybe DecimalLiteral should not extend SimpleLiteral?
+		super(value.toPlainString(), datatype);
+		this.value = value;
+	}
+
+	protected DecimalLiteral(BigDecimal value, CoreDatatype datatype) {
 		super(value.toPlainString(), datatype);
 		this.value = value;
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/IntegerLiteral.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/IntegerLiteral.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
@@ -40,7 +41,14 @@ public class IntegerLiteral extends SimpleLiteral {
 		this.value = value;
 	}
 
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	protected IntegerLiteral(BigInteger value, XSD.Datatype datatype) {
+		// TODO: maybe IntegerLiteralImpl should not extend LiteralImpl?
+		super(value.toString(), datatype);
+		this.value = value;
+	}
+
+	protected IntegerLiteral(BigInteger value, CoreDatatype datatype) {
 		// TODO: maybe IntegerLiteralImpl should not extend LiteralImpl?
 		super(value.toString(), datatype);
 		this.value = value;

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/NumericLiteral.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/NumericLiteral.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.model.impl;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
@@ -30,7 +31,13 @@ public class NumericLiteral extends SimpleLiteral {
 		this.number = number;
 	}
 
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	protected NumericLiteral(Number number, XSD.Datatype datatype) {
+		super(XMLDatatypeUtil.toString(number), datatype);
+		this.number = number;
+	}
+
+	protected NumericLiteral(Number number, CoreDatatype datatype) {
 		super(XMLDatatypeUtil.toString(number), datatype);
 		this.number = number;
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
@@ -119,8 +119,6 @@ public class SimpleLiteral extends AbstractLiteral {
 		setLabel(label);
 		if (datatype == CoreDatatype.RDF.LANGSTRING) {
 			throw new IllegalArgumentException("datatype rdf:langString requires a language tag");
-		} else if (datatype == null) {
-			setDatatype(CoreDatatype.XSD.STRING);
 		} else {
 			setDatatype(datatype);
 		}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
@@ -17,9 +17,9 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.base.AbstractLiteral;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.util.Literals;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 /**
@@ -55,11 +55,7 @@ public class SimpleLiteral extends AbstractLiteral {
 	 */
 	private IRI datatype;
 
-	// The XSD.Datatype enum that matches the datatype IRI for this literal. This value is calculated on the fly and
-	// cached in this variable. `null` means we have not calculated and cached this value yet. We are not worried about
-	// race conditions, since calculating this value multiple times must lead to the same effective result. Transient is
-	// only used to stop this field from be serialised.
-	transient private Optional<XSD.Datatype> xsdDatatype = null;
+	private CoreDatatype coreDatatype = null;
 
 	/*--------------*
 	 * Constructors *
@@ -75,7 +71,7 @@ public class SimpleLiteral extends AbstractLiteral {
 	 */
 	protected SimpleLiteral(String label) {
 		setLabel(label);
-		setDatatype(XSD.STRING);
+		setDatatype(org.eclipse.rdf4j.model.vocabulary.XSD.STRING);
 	}
 
 	/**
@@ -97,21 +93,34 @@ public class SimpleLiteral extends AbstractLiteral {
 	 */
 	protected SimpleLiteral(String label, IRI datatype) {
 		setLabel(label);
-		if (RDF.LANGSTRING.equals(datatype)) {
+		if (org.eclipse.rdf4j.model.vocabulary.RDF.LANGSTRING.equals(datatype)) {
 			throw new IllegalArgumentException("datatype rdf:langString requires a language tag");
 		} else if (datatype == null) {
-			setDatatype(XSD.Datatype.STRING);
+			setDatatype(CoreDatatype.XSD.STRING);
 		} else {
 			setDatatype(datatype);
 		}
 	}
 
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	protected SimpleLiteral(String label, XSD.Datatype datatype) {
 		setLabel(label);
-		if (RDF.LANGSTRING.equals(datatype.getIri())) {
+		if (org.eclipse.rdf4j.model.vocabulary.RDF.LANGSTRING.equals(datatype.getIri())) {
 			throw new IllegalArgumentException("datatype rdf:langString requires a language tag");
 		} else if (datatype == null) {
-			setDatatype(XSD.Datatype.STRING);
+			setDatatype(CoreDatatype.XSD.STRING);
+		} else {
+			setDatatype(datatype.getCoreDatatype());
+		}
+
+	}
+
+	protected SimpleLiteral(String label, CoreDatatype datatype) {
+		setLabel(label);
+		if (datatype == CoreDatatype.RDF.LANGSTRING) {
+			throw new IllegalArgumentException("datatype rdf:langString requires a language tag");
+		} else if (datatype == null) {
+			setDatatype(CoreDatatype.XSD.STRING);
 		} else {
 			setDatatype(datatype);
 		}
@@ -138,7 +147,7 @@ public class SimpleLiteral extends AbstractLiteral {
 			throw new IllegalArgumentException("Language tag cannot be empty");
 		}
 		this.language = language;
-		setDatatype(RDF.LANGSTRING);
+		setDatatype(org.eclipse.rdf4j.model.vocabulary.RDF.LANGSTRING);
 	}
 
 	@Override
@@ -148,11 +157,18 @@ public class SimpleLiteral extends AbstractLiteral {
 
 	protected void setDatatype(IRI datatype) {
 		this.datatype = datatype;
+		coreDatatype = CoreDatatype.from(datatype);
 	}
 
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	protected void setDatatype(XSD.Datatype datatype) {
 		this.datatype = datatype.getIri();
-		this.xsdDatatype = Optional.of(datatype);
+		coreDatatype = datatype.getCoreDatatype();
+	}
+
+	protected void setDatatype(CoreDatatype datatype) {
+		this.datatype = datatype.getIri();
+		this.coreDatatype = datatype;
 	}
 
 	@Override
@@ -160,12 +176,15 @@ public class SimpleLiteral extends AbstractLiteral {
 		return datatype;
 	}
 
+	/**
+	 * @deprecated Use {@link #getCoreDatatype()} instead.
+	 * @return
+	 */
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	public Optional<XSD.Datatype> getXsdDatatype() {
-		// we are caching the optional value, so null means that we haven't cached anything yet
-		if (xsdDatatype == null) {
-			xsdDatatype = XSD.Datatype.from(datatype);
-		}
-		return xsdDatatype;
+		CoreDatatype coreDatatype = getCoreDatatype();
+
+		return org.eclipse.rdf4j.model.vocabulary.XSD.Datatype.from(coreDatatype.asXSDDatatype().orElse(null));
 	}
 
 	// Overrides Object.equals(Object), implements Literal.equals(Object)
@@ -219,7 +238,7 @@ public class SimpleLiteral extends AbstractLiteral {
 			sb.append('"').append(label).append('"');
 			sb.append('@').append(language);
 			return sb.toString();
-		} else if (XSD.STRING.equals(datatype) || datatype == null) {
+		} else if (org.eclipse.rdf4j.model.vocabulary.XSD.STRING.equals(datatype) || datatype == null) {
 			StringBuilder sb = new StringBuilder(label.length() + 2);
 			sb.append('"').append(label).append('"');
 			return sb.toString();
@@ -284,6 +303,14 @@ public class SimpleLiteral extends AbstractLiteral {
 	@Override
 	public XMLGregorianCalendar calendarValue() {
 		return XMLDatatypeUtil.parseCalendar(label);
+	}
+
+	@Override
+	public CoreDatatype getCoreDatatype() {
+		if (coreDatatype == null) {
+			coreDatatype = CoreDatatype.from(datatype);
+		}
+		return coreDatatype;
 	}
 
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleValueFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.base.AbstractValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
@@ -110,7 +111,7 @@ public class SimpleValueFactory extends AbstractValueFactory {
 
 	@Override
 	public Literal createLiteral(String value) {
-		return new SimpleLiteral(value, XSD.Datatype.STRING);
+		return new SimpleLiteral(value, CoreDatatype.XSD.STRING);
 	}
 
 	@Override
@@ -172,7 +173,7 @@ public class SimpleValueFactory extends AbstractValueFactory {
 	 */
 	@Override
 	public Literal createLiteral(byte value) {
-		return createIntegerLiteral(value, XSD.Datatype.BYTE);
+		return createIntegerLiteral(value, org.eclipse.rdf4j.model.vocabulary.XSD.Datatype.BYTE);
 	}
 
 	/**
@@ -180,7 +181,7 @@ public class SimpleValueFactory extends AbstractValueFactory {
 	 */
 	@Override
 	public Literal createLiteral(short value) {
-		return createIntegerLiteral(value, XSD.Datatype.SHORT);
+		return createIntegerLiteral(value, org.eclipse.rdf4j.model.vocabulary.XSD.Datatype.SHORT);
 	}
 
 	/**
@@ -188,7 +189,7 @@ public class SimpleValueFactory extends AbstractValueFactory {
 	 */
 	@Override
 	public Literal createLiteral(int value) {
-		return createIntegerLiteral(value, XSD.Datatype.INT);
+		return createIntegerLiteral(value, org.eclipse.rdf4j.model.vocabulary.XSD.Datatype.INT);
 	}
 
 	/**
@@ -196,7 +197,7 @@ public class SimpleValueFactory extends AbstractValueFactory {
 	 */
 	@Override
 	public Literal createLiteral(long value) {
-		return createIntegerLiteral(value, XSD.Datatype.LONG);
+		return createIntegerLiteral(value, org.eclipse.rdf4j.model.vocabulary.XSD.Datatype.LONG);
 	}
 
 	/**
@@ -215,7 +216,7 @@ public class SimpleValueFactory extends AbstractValueFactory {
 	 */
 	@Override
 	public Literal createLiteral(float value) {
-		return createFPLiteral(value, XSD.Datatype.FLOAT);
+		return createFPLiteral(value, org.eclipse.rdf4j.model.vocabulary.XSD.Datatype.FLOAT);
 	}
 
 	/**
@@ -223,17 +224,17 @@ public class SimpleValueFactory extends AbstractValueFactory {
 	 */
 	@Override
 	public Literal createLiteral(double value) {
-		return createFPLiteral(value, XSD.Datatype.DOUBLE);
+		return createFPLiteral(value, org.eclipse.rdf4j.model.vocabulary.XSD.Datatype.DOUBLE);
 	}
 
 	@Override
 	public Literal createLiteral(BigInteger bigInteger) {
-		return createIntegerLiteral(bigInteger, XSD.INTEGER);
+		return createIntegerLiteral(bigInteger, org.eclipse.rdf4j.model.vocabulary.XSD.INTEGER);
 	}
 
 	@Override
 	public Literal createLiteral(BigDecimal bigDecimal) {
-		return createNumericLiteral(bigDecimal, XSD.DECIMAL);
+		return createNumericLiteral(bigDecimal, org.eclipse.rdf4j.model.vocabulary.XSD.DECIMAL);
 	}
 
 	/**
@@ -260,7 +261,18 @@ public class SimpleValueFactory extends AbstractValueFactory {
 		return new NumericLiteral(number, datatype);
 	}
 
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	protected Literal createNumericLiteral(Number number, XSD.Datatype datatype) {
+		if (number instanceof BigDecimal) {
+			return new DecimalLiteral((BigDecimal) number, datatype);
+		}
+		if (number instanceof BigInteger) {
+			return new IntegerLiteral((BigInteger) number, datatype);
+		}
+		return new NumericLiteral(number, datatype);
+	}
+
+	protected Literal createNumericLiteral(Number number, CoreDatatype datatype) {
 		if (number instanceof BigDecimal) {
 			return new DecimalLiteral((BigDecimal) number, datatype);
 		}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/ValidatingValueFactory.java
@@ -25,6 +25,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.util.URIUtil;
@@ -106,6 +107,14 @@ public class ValidatingValueFactory implements ValueFactory {
 
 	@Override
 	public Literal createLiteral(String label, IRI datatype) {
+		if (!XMLDatatypeUtil.isValidValue(label, datatype)) {
+			throw new IllegalArgumentException("Not a valid literal value");
+		}
+		return delegate.createLiteral(label, datatype);
+	}
+
+	@Override
+	public Literal createLiteral(String label, CoreDatatype datatype) {
 		if (!XMLDatatypeUtil.isValidValue(label, datatype)) {
 			throw new IllegalArgumentException("Not a valid literal value");
 		}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -69,7 +69,9 @@ public class Literals {
 	 *         the absence of this enum does <i>not</i> indicate that the literal has no datatype, merely that it has no
 	 *         cached enum representation of that datatype.
 	 * @since 3.5.0
+	 * @deprecated Use {@link Literal#getCoreDatatype()} instead.
 	 */
+	@Deprecated(since = "4.0.0", forRemoval = true)
 	public static Optional<XSD.Datatype> getXsdDatatype(Literal l) {
 		if (l instanceof SimpleLiteral) {
 			return ((SimpleLiteral) l).getXsdDatatype();

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
@@ -1,9 +1,9 @@
-/******************************************************************************* 
- * Copyright (c) 2020 Eclipse RDF4J contributors. 
- * All rights reserved. This program and the accompanying materials 
- * are made available under the terms of the Eclipse Distribution License v1.0 
- * which accompanies this distribution, and is available at 
- * http://www.eclipse.org/org/documents/edl-v10.php. 
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
@@ -24,6 +24,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.ValidatingValueFactory;
@@ -35,18 +36,18 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
  * {@link Triple}) without having to create a {@link ValueFactory} first.
  * <p>
  * Example usage:
- * 
+ *
  * <pre>
  * import static org.eclipse.rdf4j.model.util.Values.iri;
- * 
- * ... 
+ *
+ * ...
  * IRI foo = iri("http://example.org/foo");
  * </pre>
  * <p>
- * 
+ *
  * @author Jeen Broekstra
  * @since 3.5.0
- * 
+ *
  * @see Statements
  */
 public class Values {
@@ -66,11 +67,11 @@ public class Values {
 
 	/**
 	 * Create a new {@link IRI} using the supplied iri string
-	 * 
+	 *
 	 * @param iri a string representing a valid (absolute) iri
-	 * 
+	 *
 	 * @return an {@link IRI} object for the supplied iri string.
-	 * 
+	 *
 	 * @throws NullPointerException     if the suppplied iri is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI.
 	 */
@@ -80,12 +81,12 @@ public class Values {
 
 	/**
 	 * Create a new {@link IRI} using the supplied iri string
-	 * 
+	 *
 	 * @param vf  the {@link ValueFactory} to use for creation of the IRI.
 	 * @param iri a string representing a valid (absolute) iri
-	 * 
+	 *
 	 * @return an {@link IRI} object for the supplied iri string.
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI by the supplied
 	 *                                  {@link ValueFactory} .
@@ -96,12 +97,12 @@ public class Values {
 
 	/**
 	 * Create a new {@link IRI} using the supplied namespace name and local name
-	 * 
+	 *
 	 * @param namespace the IRI's namespace name
 	 * @param localName the IRI's local name
-	 * 
+	 *
 	 * @return an {@link IRI} object for the supplied IRI namespace name and localName.
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI.
 	 */
@@ -111,12 +112,12 @@ public class Values {
 
 	/**
 	 * Create a new {@link IRI} using the supplied {@link Namespace} and local name
-	 * 
+	 *
 	 * @param namespace the IRI's {@link Namespace}
 	 * @param localName the IRI's local name
-	 * 
+	 *
 	 * @return an {@link IRI} object for the supplied IRI namespace and localName.
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI.
 	 * @since 3.6.0
@@ -127,7 +128,7 @@ public class Values {
 
 	/**
 	 * Create a new {@link IRI} from a supplied prefixed name, using the supplied {@link Namespace namespaces}
-	 * 
+	 *
 	 * @param namespaces   the Namespaces from which to find the correct namespace to map the prefixed name to
 	 * @param prefixedName a prefixed name that is a shorthand for a full iri, using syntax form
 	 *                     <code>prefix:localName</code>. For example, <code>rdf:type</code> is a prefixed name where
@@ -135,9 +136,9 @@ public class Values {
 	 *                     this expands to the full namespace name
 	 *                     <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#</code>, leading to a full IRI
 	 *                     <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</code>.
-	 * 
+	 *
 	 * @return an {@link IRI} object for the supplied IRI namespace and localName.
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied prefixed name can not be transformed to a legal IRI.
 	 * @since 3.6.0
@@ -158,13 +159,13 @@ public class Values {
 
 	/**
 	 * Create a new {@link IRI} using the supplied namespace and local name
-	 * 
+	 *
 	 * @param vf        the {@link ValueFactory} to use for creation of the IRI.
 	 * @param namespace the IRI's namespace
 	 * @param localName the IRI's local name
-	 * 
+	 *
 	 * @return an {@link IRI} object for the supplied IRI namespace and localName.
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied iri string can not be parsed as a legal IRI by the supplied
 	 *                                  {@link ValueFactory}
@@ -178,7 +179,7 @@ public class Values {
 
 	/**
 	 * Creates a new {@link BNode}
-	 * 
+	 *
 	 * @return a new {@link BNode}
 	 */
 	public static BNode bnode() {
@@ -187,11 +188,11 @@ public class Values {
 
 	/**
 	 * Creates a new {@link BNode}
-	 * 
+	 *
 	 * @param vf the {@link ValueFactory} to use for creation of the {@link BNode}
-	 * 
+	 *
 	 * @return a new {@link BNode}
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>
 	 */
 	public static BNode bnode(ValueFactory vf) {
@@ -200,11 +201,11 @@ public class Values {
 
 	/**
 	 * Creates a new {@link BNode} with the supplied node identifier.
-	 * 
+	 *
 	 * @param nodeId the node identifier
-	 * 
+	 *
 	 * @return a new {@link BNode}
-	 * 
+	 *
 	 * @throws NullPointerException     if the supplied node identifier is <code>null</code>.
 	 * @throws IllegalArgumentException if the supplied node identifier is not valid
 	 */
@@ -214,12 +215,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link BNode} with the supplied node identifier.
-	 * 
+	 *
 	 * @param vf     the {@link ValueFactory} to use for creation of the {@link BNode}
 	 * @param nodeId the node identifier
-	 * 
+	 *
 	 * @return a new {@link BNode}
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>
 	 * @throws IllegalArgumentException if the supplied node identifier is not valid
 	 */
@@ -231,11 +232,11 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied lexical value.
-	 * 
+	 *
 	 * @param lexicalValue the lexical value for the literal
-	 * 
+	 *
 	 * @return a new {@link Literal} of type {@link XSD#STRING}
-	 * 
+	 *
 	 * @throws NullPointerException if the supplied lexical value is <code>null</code>.
 	 */
 	public static Literal literal(String lexicalValue) {
@@ -247,9 +248,9 @@ public class Values {
 	 *
 	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param lexicalValue the lexical value for the literal
-	 * 
+	 *
 	 * @return a new {@link Literal} of type {@link XSD#STRING}
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>
 	 */
 	public static Literal literal(ValueFactory vf, String lexicalValue) {
@@ -258,12 +259,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied lexical value.
-	 * 
+	 *
 	 * @param lexicalValue the lexical value for the literal
 	 * @param languageTag  the language tag for the literal.
-	 * 
+	 *
 	 * @return a new {@link Literal} of type {@link RDF#LANGSTRING}
-	 * 
+	 *
 	 * @throws NullPointerException if the supplied lexical value or language tag is <code>null</code>.
 	 */
 	public static Literal literal(String lexicalValue, String languageTag) {
@@ -276,9 +277,9 @@ public class Values {
 	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param lexicalValue the lexical value for the literal
 	 * @param languageTag  the language tag for the literal.
-	 * 
+	 *
 	 * @return a new {@link Literal} of type {@link RDF#LANGSTRING}
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>
 	 */
 	public static Literal literal(ValueFactory vf, String lexicalValue, String languageTag) {
@@ -288,12 +289,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied lexical value and datatype.
-	 * 
+	 *
 	 * @param lexicalValue the lexical value for the literal
-	 * @param datatype     the datatype URI
-	 * 
+	 * @param datatype     the datatype IRI
+	 *
 	 * @return a new {@link Literal} with the supplied lexical value and datatype
-	 * 
+	 *
 	 * @throws NullPointerException     if the supplied lexical value or datatype is <code>null</code>.
 	 * @throws IllegalArgumentException if the supplied lexical value is not valid for the given datatype
 	 */
@@ -303,13 +304,28 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied lexical value and datatype.
-	 * 
+	 *
+	 * @param lexicalValue the lexical value for the literal
+	 * @param datatype     the CoreDatatype
+	 *
+	 * @return a new {@link Literal} with the supplied lexical value and datatype
+	 *
+	 * @throws NullPointerException     if the supplied lexical value or datatype is <code>null</code>.
+	 * @throws IllegalArgumentException if the supplied lexical value is not valid for the given datatype
+	 */
+	public static Literal literal(String lexicalValue, CoreDatatype datatype) throws IllegalArgumentException {
+		return literal(VALUE_FACTORY, lexicalValue, datatype);
+	}
+
+	/**
+	 * Creates a new {@link Literal} with the supplied lexical value and datatype.
+	 *
 	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param lexicalValue the lexical value for the literal
-	 * @param datatype     the datatype URI
-	 * 
+	 * @param datatype     the datatype IRI
+	 *
 	 * @return a new {@link Literal} with the supplied lexical value and datatype
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>.
 	 * @throws IllegalArgumentException if the supplied lexical value is not valid for the given datatype
 	 */
@@ -319,10 +335,28 @@ public class Values {
 	}
 
 	/**
+	 * Creates a new {@link Literal} with the supplied lexical value and datatype.
+	 *
+	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
+	 * @param lexicalValue the lexical value for the literal
+	 * @param datatype     the CoreDatatype
+	 *
+	 * @return a new {@link Literal} with the supplied lexical value and datatype
+	 *
+	 * @throws NullPointerException     if any of the input parameters is <code>null</code>.
+	 * @throws IllegalArgumentException if the supplied lexical value is not valid for the given datatype
+	 */
+	public static Literal literal(ValueFactory vf, String lexicalValue, CoreDatatype datatype)
+			throws IllegalArgumentException {
+		return vf.createLiteral(Objects.requireNonNull(lexicalValue, "lexicalValue may not be null"),
+				Objects.requireNonNull(datatype, "datatype may not be null"));
+	}
+
+	/**
 	 * Creates a new {@link Literal} with the supplied boolean value
-	 * 
+	 *
 	 * @param booleanValue a boolean value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#BOOLEAN} with the supplied value
 	 */
 	public static Literal literal(boolean booleanValue) {
@@ -331,12 +365,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied boolean value
-	 * 
+	 *
 	 * @param vf           the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param booleanValue a boolean value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#BOOLEAN} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, boolean booleanValue) {
@@ -345,9 +379,9 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied byte value
-	 * 
+	 *
 	 * @param byteValue a byte value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#BYTE} with the supplied value
 	 */
 	public static Literal literal(byte byteValue) {
@@ -356,12 +390,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied byte value
-	 * 
+	 *
 	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param byteValue a byte value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#BYTE} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, byte byteValue) {
@@ -370,9 +404,9 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied short value
-	 * 
+	 *
 	 * @param shortValue a short value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#SHORT} with the supplied value
 	 */
 	public static Literal literal(short shortValue) {
@@ -381,12 +415,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied short value
-	 * 
+	 *
 	 * @param vf         the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param shortValue a short value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#SHORT} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, short shortValue) {
@@ -395,9 +429,9 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied int value
-	 * 
+	 *
 	 * @param intValue an int value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#INT} with the supplied value
 	 */
 	public static Literal literal(int intValue) {
@@ -406,12 +440,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied int value
-	 * 
+	 *
 	 * @param vf       the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param intValue an int value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#INT} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, int intValue) {
@@ -420,9 +454,9 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied long value
-	 * 
+	 *
 	 * @param longValue a long value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#LONG} with the supplied value
 	 */
 	public static Literal literal(long longValue) {
@@ -431,12 +465,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied long value
-	 * 
+	 *
 	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param longValue a long value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#LONG} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, long longValue) {
@@ -445,9 +479,9 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied float value
-	 * 
+	 *
 	 * @param floatValue a float value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#FLOAT} with the supplied value
 	 */
 	public static Literal literal(float floatValue) {
@@ -456,12 +490,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied float value
-	 * 
+	 *
 	 * @param vf         the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param floatValue a float value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#FLOAT} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, float floatValue) {
@@ -470,9 +504,9 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied double value
-	 * 
+	 *
 	 * @param doubleValue a double value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#DOUBLE} with the supplied value
 	 */
 	public static Literal literal(double doubleValue) {
@@ -481,12 +515,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied double value
-	 * 
+	 *
 	 * @param vf          the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param doubleValue a double value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#DOUBLE} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, double doubleValue) {
@@ -495,11 +529,11 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied {@link BigDecimal} value
-	 * 
+	 *
 	 * @param bigDecimal a {@link BigDecimal} value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#DECIMAL} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if the supplied bigDecimal is <code>null</code>.
 	 */
 	public static Literal literal(BigDecimal bigDecimal) {
@@ -508,12 +542,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied {@link BigDecimal} value
-	 * 
+	 *
 	 * @param vf         the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param bigDecimal a {@link BigDecimal} value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#DECIMAL} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, BigDecimal bigDecimal) {
@@ -522,11 +556,11 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied {@link BigInteger} value
-	 * 
+	 *
 	 * @param bigInteger a {@link BigInteger} value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#INTEGER} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if the supplied bigInteger is <code>null</code>.
 	 */
 	public static Literal literal(BigInteger bigInteger) {
@@ -535,12 +569,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied {@link BigInteger} value
-	 * 
+	 *
 	 * @param vf         the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param bigInteger a {@link BigInteger} value
-	 * 
+	 *
 	 * @return a {@link Literal} of type {@link XSD#INTEGER} with the supplied value
-	 * 
+	 *
 	 * @throws NullPointerException if any of the input parameters is <code>null</code>.
 	 */
 	public static Literal literal(ValueFactory vf, BigInteger bigInteger) {
@@ -549,12 +583,12 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Literal} with the supplied {@link TemporalAccessor} value
-	 * 
+	 *
 	 * @param value a {@link TemporalAccessor} value.
-	 * 
+	 *
 	 * @return a {@link Literal} with the supplied calendar value and the appropriate {@link XSD} date/time datatype for
 	 *         the specific value.
-	 * 
+	 *
 	 * @throws NullPointerException     if the supplied {@link TemporalAccessor} value is <code>null</code>.
 	 * @throws IllegalArgumentException if value cannot be represented by an XML Schema date/time datatype
 	 */
@@ -567,10 +601,10 @@ public class Values {
 	 *
 	 * @param vf    the {@link ValueFactory} to use for creation of the {@link Literal}
 	 * @param value a {@link TemporalAccessor} value.
-	 * 
+	 *
 	 * @return a {@link Literal} with the supplied calendar value and the appropriate {@link XSD} date/time datatype for
 	 *         the specific value.
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>..
 	 * @throws IllegalArgumentException if value cannot be represented by an XML Schema date/time datatype
 	 */
@@ -587,9 +621,9 @@ public class Values {
 	 * {@link Short}, {@link XMLGregorianCalendar } , {@link TemporalAccessor} and {@link Date}.
 	 *
 	 * @param object an object to be converted to a typed literal.
-	 * 
+	 *
 	 * @return a typed literal representation of the supplied object.
-	 * 
+	 *
 	 * @throws NullPointerException if the input parameter is <code>null</code>..
 	 */
 	public static Literal literal(Object object) {
@@ -608,9 +642,9 @@ public class Values {
 	 *                          method returns a literal with the string representation of the supplied object as the
 	 *                          value, and {@link XSD#STRING} as the datatype. If set to <code>true</code> the method
 	 *                          throws an {@link IllegalArgumentException} if no mapping available.
-	 * 
+	 *
 	 * @return a typed literal representation of the supplied object.
-	 * 
+	 *
 	 * @throws NullPointerException if the input parameter is <code>null</code>..
 	 */
 	public static Literal literal(Object object, boolean failOnUnknownType) {
@@ -630,9 +664,9 @@ public class Values {
 	 *                          method returns a literal with the string representation of the supplied object as the
 	 *                          value, and {@link XSD#STRING} as the datatype. If set to <code>true</code> the method
 	 *                          throws an {@link IllegalArgumentException} if no mapping available.
-	 * 
+	 *
 	 * @return a typed literal representation of the supplied object.
-	 * 
+	 *
 	 * @throws NullPointerException     if any of the input parameters is <code>null</code>.
 	 * @throws IllegalArgumentException if <code>failOnUnknownType</code> is set to <code>true</code> and the runtime
 	 *                                  type of the supplied object could not be mapped.
@@ -649,9 +683,9 @@ public class Values {
 	 * @param subject   the Triple subject
 	 * @param predicate the Triple predicate
 	 * @param object    the Triple object
-	 * 
+	 *
 	 * @return a {@link Triple} with the supplied subject, predicate, and object.
-	 * 
+	 *
 	 * @throws NullPointerException if any of the supplied input parameters is <code>null</code>.
 	 */
 	public static Triple triple(Resource subject, IRI predicate, Value object) {
@@ -660,14 +694,14 @@ public class Values {
 
 	/**
 	 * Creates a new {@link Triple RDF-star embedded triple} with the supplied subject, predicate, and object.
-	 * 
+	 *
 	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Triple}
 	 * @param subject   the Triple subject
 	 * @param predicate the Triple predicate
 	 * @param object    the Triple object
-	 * 
+	 *
 	 * @return a {@link Triple} with the supplied subject, predicate, and object.
-	 * 
+	 *
 	 * @throws NullPointerException if any of the supplied input parameters is <code>null</code>.
 	 */
 	public static Triple triple(ValueFactory vf, Resource subject, IRI predicate, Value object) {
@@ -683,9 +717,9 @@ public class Values {
 	 * {@link Statement}.
 	 *
 	 * @param statement the {@link Statement} from which to construct a {@link Triple}
-	 * 
+	 *
 	 * @return a {@link Triple} with the same subject, predicate, and object as the supplied Statement.
-	 * 
+	 *
 	 * @throws NullPointerException if statement is <code>null</code>.
 	 */
 	public static Triple triple(Statement statement) {
@@ -696,12 +730,12 @@ public class Values {
 	/**
 	 * Creates a new {@link Triple RDF-star embedded triple} using the subject, predicate and object from the supplied
 	 * {@link Statement}.
-	 * 
+	 *
 	 * @param vf        the {@link ValueFactory} to use for creation of the {@link Triple}
 	 * @param statement the {@link Statement} from which to construct a {@link Triple}
-	 * 
+	 *
 	 * @return a {@link Triple} with the same subject, predicate, and object as the supplied Statement.
-	 * 
+	 *
 	 * @throws NullPointerException if any of the supplied input parameters is <code>null</code>.
 	 */
 	public static Triple triple(ValueFactory vf, Statement statement) {
@@ -711,7 +745,7 @@ public class Values {
 
 	/**
 	 * Create a new {@link Namespace} object.
-	 * 
+	 *
 	 * @param prefix the prefix associated with the namespace
 	 * @param name   the namespace name (typically an IRI) for the namespace.
 	 * @return a {@link Namespace} object.
@@ -723,7 +757,7 @@ public class Values {
 
 	/**
 	 * Get a {@link ValueFactory}.
-	 * 
+	 *
 	 * @return a {@link ValueFactory}.
 	 */
 	public static ValueFactory getValueFactory() {

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/DateTimeTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/DateTimeTest.java
@@ -74,24 +74,24 @@ public class DateTimeTest extends TestCase {
 	public static Test suite() {
 		TestSuite suite = new TestSuite();
 
-		for (int i = 0; i < VALID_DATES.length; i++) {
-			suite.addTest(new ValidDateTest(VALID_DATES[i]));
+		for (String validDate : VALID_DATES) {
+			suite.addTest(new ValidDateTest(validDate));
 		}
 
-		for (int i = 0; i < INVALID_DATES.length; i++) {
-			suite.addTest(new InvalidDateTest(INVALID_DATES[i]));
+		for (String invalidDate : INVALID_DATES) {
+			suite.addTest(new InvalidDateTest(invalidDate));
 		}
 
-		for (int i = 0; i < NORMALIZED_DATES.length; i++) {
-			suite.addTest(new NormalizedDateTest(NORMALIZED_DATES[i][0], NORMALIZED_DATES[i][1]));
+		for (String[] normalizedDate : NORMALIZED_DATES) {
+			suite.addTest(new NormalizedDateTest(normalizedDate[0], normalizedDate[1]));
 		}
 
-		for (int i = 0; i < EQUAL_DATES.length; i++) {
-			suite.addTest(new EqualDateTest(EQUAL_DATES[i][0], EQUAL_DATES[i][1]));
+		for (String[] equalDate : EQUAL_DATES) {
+			suite.addTest(new EqualDateTest(equalDate[0], equalDate[1]));
 		}
 
-		for (int i = 0; i < COMPARISON_DATES.length; i++) {
-			suite.addTest(new CompareDateTest(COMPARISON_DATES[i][0], COMPARISON_DATES[i][1]));
+		for (String[] comparisonDate : COMPARISON_DATES) {
+			suite.addTest(new CompareDateTest(comparisonDate[0], comparisonDate[1]));
 		}
 
 		return suite;
@@ -105,7 +105,7 @@ public class DateTimeTest extends TestCase {
 	 * run test
 	 */
 	public static void main(String[] args) {
-		TestRunner.run(new TestSuite(DateTimeTest.class));
+		TestRunner.run(suite());
 	}
 
 	/*--------------------------------------------------*
@@ -114,7 +114,7 @@ public class DateTimeTest extends TestCase {
 
 	private static class ValidDateTest extends TestCase {
 
-		private String dateString;
+		private final String dateString;
 
 		public ValidDateTest(String dateString) {
 			super("valid: " + dateString);
@@ -133,7 +133,7 @@ public class DateTimeTest extends TestCase {
 
 	private static class InvalidDateTest extends TestCase {
 
-		private String dateString;
+		private final String dateString;
 
 		public InvalidDateTest(String dateString) {
 			super("invalid: " + dateString);
@@ -152,9 +152,8 @@ public class DateTimeTest extends TestCase {
 
 	private static class NormalizedDateTest extends TestCase {
 
-		private String input;
-
-		private String expected;
+		private final String input;
+		private final String expected;
 
 		public NormalizedDateTest(String input, String expected) {
 			super("normalize: " + input + " --> " + expected);
@@ -175,9 +174,8 @@ public class DateTimeTest extends TestCase {
 
 	private static class EqualDateTest extends TestCase {
 
-		private String dateString1;
-
-		private String dateString2;
+		private final String dateString1;
+		private final String dateString2;
 
 		public EqualDateTest(String dateString1, String dateString2) {
 			super(dateString1 + " == " + dateString2);
@@ -199,9 +197,8 @@ public class DateTimeTest extends TestCase {
 
 	private static class CompareDateTest extends TestCase {
 
-		private String dateString1;
-
-		private String dateString2;
+		private final String dateString1;
+		private final String dateString2;
 
 		public CompareDateTest(String dateString1, String dateString2) {
 			super(dateString1 + " < " + dateString2);

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.junit.Test;
 
@@ -177,6 +178,9 @@ public class XMLDatatypeUtilTest {
 	private void testValidation(String[] values, IRI datatype, boolean validValues) {
 		for (String value : values) {
 			boolean result = XMLDatatypeUtil.isValidValue(value, datatype);
+			boolean resultCoreDatatype = XMLDatatypeUtil.isValidValue(value, CoreDatatype.from(datatype));
+			assertEquals(result, resultCoreDatatype);
+
 			if (validValues) {
 				if (!result) {
 					fail("value " + value + " should have validated for type " + datatype);

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/SimpleLiteralTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/SimpleLiteralTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.model.impl;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.LiteralTest;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 
 /**
  * Unit tests for {@link SimpleLiteral}.
@@ -28,6 +29,11 @@ public class SimpleLiteralTest extends LiteralTest {
 
 	@Override
 	protected Literal literal(String label, IRI datatype) {
+		return new SimpleLiteral(label, datatype);
+	}
+
+	@Override
+	protected Literal literal(String label, CoreDatatype datatype) {
 		return new SimpleLiteral(label, datatype);
 	}
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
@@ -1,9 +1,9 @@
-/******************************************************************************* 
- * Copyright (c) 2020 Eclipse RDF4J contributors. 
- * All rights reserved. This program and the accompanying materials 
- * are made available under the terms of the Eclipse Distribution License v1.0 
- * which accompanies this distribution, and is available at 
- * http://www.eclipse.org/org/documents/edl-v10.php. 
+/*******************************************************************************
+ * Copyright (c) 2020 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
@@ -34,6 +34,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -48,7 +49,7 @@ import org.junit.Test;
  * Note that this is not intended to be a complete compliance suite for handling all possible cases of syntactically
  * (il)legal inputs: that kind of testing is handled at the level of the {@link ValueFactory} implementations. We merely
  * test common cases against user expectations here.
- * 
+ *
  * @author Jeen Broekstra
  *
  */
@@ -191,6 +192,7 @@ public class ValuesTest {
 
 		assertThat(literal.getLabel()).isEqualTo(lexValue);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.STRING);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.STRING);
 	}
 
 	@Test
@@ -217,6 +219,7 @@ public class ValuesTest {
 		assertThat(literal.getLabel()).isEqualTo(lexValue);
 		assertThat(literal.getLanguage()).isNotEmpty().contains(languageTag);
 		assertThat(literal.getDatatype()).isEqualTo(RDF.LANGSTRING);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.RDF.LANGSTRING);
 	}
 
 	@Test
@@ -248,11 +251,12 @@ public class ValuesTest {
 	@Test
 	public void testValidTypedLiteral() {
 		String lexValue = "42";
-		Literal literal = literal(lexValue, XSD.INT);
+		Literal literal = literal(lexValue, CoreDatatype.XSD.INT);
 
 		assertThat(literal.getLabel()).isEqualTo(lexValue);
 		assertThat(literal.intValue()).isEqualTo(42);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.INT);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.INT);
 	}
 
 	@Test
@@ -268,8 +272,14 @@ public class ValuesTest {
 		literal(lexValue, XSD.INT);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidTypedLiteralCoreDatatype() {
+		String lexValue = "fourty two";
+		literal(lexValue, CoreDatatype.XSD.INT);
+	}
+
 	@Test
-	public void testTypedLiteralNull1() {
+	public void testTypedLiteralNullLexValue() {
 		String lexValue = null;
 		assertThatThrownBy(() -> literal(lexValue, XSD.INT))
 				.isInstanceOf(NullPointerException.class)
@@ -277,9 +287,18 @@ public class ValuesTest {
 	}
 
 	@Test
-	public void testTypedLiteralNull2() {
+	public void testTypedLiteralNullDatatype() {
 		String lexValue = "42";
 		IRI datatype = null;
+		assertThatThrownBy(() -> literal(lexValue, datatype))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessageContaining("datatype may not be null");
+	}
+
+	@Test
+	public void testTypedLiteralNullCoreDatatype() {
+		String lexValue = "42";
+		CoreDatatype datatype = null;
 		assertThatThrownBy(() -> literal(lexValue, datatype))
 				.isInstanceOf(NullPointerException.class)
 				.hasMessageContaining("datatype may not be null");
@@ -291,11 +310,13 @@ public class ValuesTest {
 		assertThat(literal.getLabel()).isEqualTo("true");
 		assertThat(literal.booleanValue()).isTrue();
 		assertThat(literal.getDatatype()).isEqualTo(XSD.BOOLEAN);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.BOOLEAN);
 
 		literal = literal(false);
 		assertThat(literal.getLabel()).isEqualTo("false");
 		assertThat(literal.booleanValue()).isFalse();
 		assertThat(literal.getDatatype()).isEqualTo(XSD.BOOLEAN);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.BOOLEAN);
 	}
 
 	@Test
@@ -311,6 +332,7 @@ public class ValuesTest {
 		assertThat(literal.getLabel()).isEqualTo("42");
 		assertThat(literal.byteValue()).isEqualTo(value);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.BYTE);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.BYTE);
 	}
 
 	@Test
@@ -327,6 +349,7 @@ public class ValuesTest {
 		assertThat(literal.getLabel()).isEqualTo("42");
 		assertThat(literal.shortValue()).isEqualTo(value);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.SHORT);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.SHORT);
 	}
 
 	@Test
@@ -343,6 +366,7 @@ public class ValuesTest {
 		assertThat(literal.getLabel()).isEqualTo("42");
 		assertThat(literal.intValue()).isEqualTo(value);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.INT);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.INT);
 	}
 
 	@Test
@@ -358,6 +382,7 @@ public class ValuesTest {
 		Literal literal = literal(value);
 		assertThat(literal.longValue()).isEqualTo(value);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.LONG);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.LONG);
 	}
 
 	@Test
@@ -373,6 +398,7 @@ public class ValuesTest {
 		Literal literal = literal(value);
 		assertThat(literal.floatValue()).isEqualTo(value);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.FLOAT);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.FLOAT);
 	}
 
 	@Test
@@ -388,6 +414,7 @@ public class ValuesTest {
 		Literal literal = literal(value);
 		assertThat(literal.doubleValue()).isEqualTo(value);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.DOUBLE);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.DOUBLE);
 	}
 
 	@Test
@@ -403,6 +430,7 @@ public class ValuesTest {
 		Literal literal = literal(value);
 		assertThat(literal.decimalValue()).isEqualTo(value);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.DECIMAL);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.DECIMAL);
 	}
 
 	@Test
@@ -428,6 +456,7 @@ public class ValuesTest {
 		Literal literal = literal(value);
 		assertThat(literal.integerValue()).isEqualTo(value);
 		assertThat(literal.getDatatype()).isEqualTo(XSD.INTEGER);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.INTEGER);
 	}
 
 	@Test
@@ -455,6 +484,7 @@ public class ValuesTest {
 		assertThat(literal.temporalAccessorValue()).isEqualTo(value);
 		assertThat(literal.getLabel()).isEqualTo(value.toString());
 		assertThat(literal.getDatatype()).isEqualTo(XSD.DATETIME);
+		assertThat(literal.getCoreDatatype()).isEqualTo(CoreDatatype.XSD.DATETIME);
 	}
 
 	@Test

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
@@ -24,6 +24,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.Compare;
@@ -619,6 +620,11 @@ public class QueryEvaluationUtilTest {
 			@Override
 			public XMLGregorianCalendar calendarValue() {
 				return nested.calendarValue();
+			}
+
+			@Override
+			public CoreDatatype getCoreDatatype() {
+				return nested.getCoreDatatype();
 			}
 
 			@Override

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarDecodingValueFactory.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/RDFStarDecodingValueFactory.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 
 /**
  * A {@link ValueFactory} that will delegate everything to another {@link ValueFactory} and create statements whose
@@ -69,6 +70,11 @@ class RDFStarDecodingValueFactory implements ValueFactory {
 
 	@Override
 	public Literal createLiteral(String label, IRI datatype) {
+		return delegate.createLiteral(label, datatype);
+	}
+
+	@Override
+	public Literal createLiteral(String label, CoreDatatype datatype) {
 		return delegate.createLiteral(label, datatype);
 	}
 

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
@@ -52,9 +52,8 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.base.AbstractValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.util.Literals;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.sail.lmdb.LmdbUtil.Transaction;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.sail.lmdb.model.LmdbBNode;
@@ -751,7 +750,8 @@ class ValueStore extends AbstractValueFactory {
 
 	private byte[] literal2legacy(Literal literal) throws IOException {
 		IRI dt = literal.getDatatype();
-		if (XSD.STRING.equals(dt) || RDF.LANGSTRING.equals(dt)) {
+		if (org.eclipse.rdf4j.model.vocabulary.XSD.STRING.equals(dt)
+				|| org.eclipse.rdf4j.model.vocabulary.RDF.LANGSTRING.equals(dt)) {
 			return literal2data(literal.getLabel(), literal.getLanguage(), null, false);
 		}
 		return literal2data(literal.getLabel(), literal.getLanguage(), dt, false);
@@ -868,17 +868,17 @@ class ValueStore extends AbstractValueFactory {
 			} else if (datatype != null) {
 				return new LmdbLiteral(revision, label, datatype, id);
 			} else {
-				return new LmdbLiteral(revision, label, XSD.STRING, id);
+				return new LmdbLiteral(revision, label, org.eclipse.rdf4j.model.vocabulary.XSD.STRING, id);
 			}
 		} else {
 			value.setLabel(label);
 			if (lang != null) {
 				value.setLanguage(lang);
-				value.setDatatype(RDF.LANGSTRING);
+				value.setDatatype(CoreDatatype.RDF.LANGSTRING);
 			} else if (datatype != null) {
 				value.setDatatype(datatype);
 			} else {
-				value.setDatatype(XSD.STRING);
+				value.setDatatype(CoreDatatype.XSD.STRING);
 			}
 			return value;
 		}
@@ -943,7 +943,7 @@ class ValueStore extends AbstractValueFactory {
 
 	@Override
 	public LmdbLiteral createLiteral(String value) {
-		return new LmdbLiteral(revision, value, XSD.STRING);
+		return new LmdbLiteral(revision, value, CoreDatatype.XSD.STRING);
 	}
 
 	@Override
@@ -1026,9 +1026,11 @@ class ValueStore extends AbstractValueFactory {
 
 		if (Literals.isLanguageLiteral(l)) {
 			return new LmdbLiteral(revision, l.getLabel(), l.getLanguage().get());
+		} else if (l.getCoreDatatype() != CoreDatatype.NONE) {
+			return new LmdbLiteral(revision, l.getLabel(), l.getCoreDatatype());
 		} else {
 			LmdbIRI datatype = getLmdbURI(l.getDatatype());
-			return new LmdbLiteral(revision, l.getLabel(), datatype);
+			return new LmdbLiteral(revision, l.getLabel(), datatype, l.getCoreDatatype());
 		}
 	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
@@ -12,8 +12,7 @@ import java.util.Optional;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.base.AbstractLiteral;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.sail.lmdb.ValueStoreRevision;
 
 public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
@@ -43,6 +42,11 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	 */
 	private IRI datatype;
 
+	/**
+	 * The literal's core datatype.
+	 */
+	private CoreDatatype coreDatatype = null;
+
 	private volatile ValueStoreRevision revision;
 
 	private volatile long internalID;
@@ -56,11 +60,13 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	public LmdbLiteral(ValueStoreRevision revision, long internalID) {
 		super();
 		setInternalID(internalID, revision);
+		coreDatatype = null;
 	}
 
 	public LmdbLiteral(ValueStoreRevision revision, String label, long internalID) {
 		this.label = label;
-		this.datatype = XSD.STRING;
+		coreDatatype = CoreDatatype.XSD.STRING;
+		datatype = CoreDatatype.XSD.STRING.getIri();
 		setInternalID(internalID, revision);
 		this.initialized = true;
 	}
@@ -72,7 +78,8 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	public LmdbLiteral(ValueStoreRevision revision, String label, String lang, long internalID) {
 		this.label = label;
 		this.language = lang;
-		this.datatype = RDF.LANGSTRING;
+		coreDatatype = CoreDatatype.RDF.LANGSTRING;
+		datatype = CoreDatatype.RDF.LANGSTRING.getIri();
 		setInternalID(internalID, revision);
 		this.initialized = true;
 	}
@@ -81,9 +88,35 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 		this(revision, label, datatype, UNKNOWN_ID);
 	}
 
+	public LmdbLiteral(ValueStoreRevision revision, String label, IRI datatype, CoreDatatype coreDatatype) {
+		this(revision, label, datatype, coreDatatype, UNKNOWN_ID);
+	}
+
+	public LmdbLiteral(ValueStoreRevision revision, String label, CoreDatatype datatype) {
+		this(revision, label, datatype, UNKNOWN_ID);
+	}
+
 	public LmdbLiteral(ValueStoreRevision revision, String label, IRI datatype, long internalID) {
 		this.label = label;
 		this.datatype = datatype;
+		this.coreDatatype = null;
+		setInternalID(internalID, revision);
+		this.initialized = true;
+	}
+
+	public LmdbLiteral(ValueStoreRevision revision, String label, IRI datatype, CoreDatatype coreDatatype,
+			long internalID) {
+		this.label = label;
+		this.datatype = datatype;
+		this.coreDatatype = coreDatatype;
+		setInternalID(internalID, revision);
+		this.initialized = true;
+	}
+
+	public LmdbLiteral(ValueStoreRevision revision, String label, CoreDatatype coreDatatype, long internalID) {
+		this.label = label;
+		this.coreDatatype = coreDatatype;
+		this.datatype = coreDatatype.getIri();
 		setInternalID(internalID, revision);
 		this.initialized = true;
 	}
@@ -114,8 +147,21 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 		return datatype;
 	}
 
+	@Override
+	public CoreDatatype getCoreDatatype() {
+		if (coreDatatype == null)
+			coreDatatype = CoreDatatype.from(datatype);
+		return coreDatatype;
+	}
+
 	public void setDatatype(IRI datatype) {
 		this.datatype = datatype;
+		coreDatatype = null;
+	}
+
+	public void setDatatype(CoreDatatype coreDatatype) {
+		this.coreDatatype = coreDatatype;
+		datatype = coreDatatype.getIri();
 	}
 
 	@Override

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
@@ -43,9 +43,9 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	private IRI datatype;
 
 	/**
-	 * The literal's core datatype.
+	 * The literal's core datatype. This value is null if there is no know datatype.
 	 */
-	private CoreDatatype coreDatatype = null;
+	private CoreDatatype coreDatatype;
 
 	private volatile ValueStoreRevision revision;
 
@@ -149,6 +149,7 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 
 	@Override
 	public CoreDatatype getCoreDatatype() {
+		init();
 		if (coreDatatype == null)
 			coreDatatype = CoreDatatype.from(datatype);
 		return coreDatatype;

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTest.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Random;
 
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -122,7 +123,7 @@ public abstract class AbstractQueryResultIOTest {
 		solution1.addBinding("a", vf.createIRI("foo:bar"));
 
 		MapBindingSet solution2 = new MapBindingSet(bindingNames.size());
-		solution2.addBinding("a", vf.createLiteral("2.0", XSD.DOUBLE));
+		solution2.addBinding("a", vf.createLiteral("2.0", CoreDatatype.XSD.DOUBLE));
 
 		MapBindingSet solution3 = new MapBindingSet(bindingNames.size());
 		solution3.addBinding("a", vf.createBNode("bnode3"));
@@ -134,7 +135,7 @@ public abstract class AbstractQueryResultIOTest {
 		solution5.addBinding("a", vf.createLiteral("\"\"double-quoted string", XSD.STRING));
 
 		MapBindingSet solution6 = new MapBindingSet(bindingNames.size());
-		solution6.addBinding("a", vf.createLiteral("space at the end         ", XSD.STRING));
+		solution6.addBinding("a", vf.createLiteral("space at the end         ", CoreDatatype.XSD.STRING));
 
 		MapBindingSet solution7 = new MapBindingSet(bindingNames.size());
 		solution7.addBinding("a", vf.createLiteral("space at the end         ", XSD.STRING));
@@ -143,7 +144,7 @@ public abstract class AbstractQueryResultIOTest {
 		solution8.addBinding("a", vf.createLiteral("\"\"double-quoted string with no datatype"));
 
 		MapBindingSet solution9 = new MapBindingSet(bindingNames.size());
-		solution9.addBinding("a", vf.createLiteral("newline at the end \n", XSD.STRING));
+		solution9.addBinding("a", vf.createLiteral("newline at the end \n", CoreDatatype.XSD.STRING));
 
 		MapBindingSet solution10 = new MapBindingSet(bindingNames.size());
 		solution10.addBinding("a", vf.createTriple(vf.createIRI("urn:a"), RDF.TYPE, vf.createIRI("urn:b")));
@@ -165,7 +166,7 @@ public abstract class AbstractQueryResultIOTest {
 		solution1.addBinding("c", vf.createLiteral("baz"));
 
 		MapBindingSet solution2 = new MapBindingSet(bindingNames.size());
-		solution2.addBinding("a", vf.createLiteral("1", XSD.INTEGER));
+		solution2.addBinding("a", vf.createLiteral("1", CoreDatatype.XSD.INTEGER));
 		solution2.addBinding("c", vf.createLiteral("Hello World!", "en"));
 
 		MapBindingSet solution3 = new MapBindingSet(bindingNames.size());

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/EquivalentTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/EquivalentTest.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -52,7 +53,7 @@ public abstract class EquivalentTest {
 
 	private static Literal xyz_EN = vf.createLiteral("xyz", "EN");
 
-	private static Literal xyz_string = vf.createLiteral("xyz", XSD.STRING);
+	private static Literal xyz_string = vf.createLiteral("xyz", CoreDatatype.XSD.STRING);
 
 	private static Literal xyz_integer = vf.createLiteral("xyz", XSD.INTEGER);
 
@@ -68,7 +69,7 @@ public abstract class EquivalentTest {
 
 	private static Literal abc_string = vf.createLiteral("abc", XSD.STRING);
 
-	private static Literal abc_integer = vf.createLiteral("abc", XSD.INTEGER);
+	private static Literal abc_integer = vf.createLiteral("abc", CoreDatatype.XSD.INTEGER);
 
 	private static Literal abc_unknown = vf.createLiteral("abc", vf.createIRI("http://example/unknown"));
 

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/IsolationLevelTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/IsolationLevelTest.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.repository.Repository;
@@ -485,7 +486,7 @@ public class IsolationLevelTest {
 
 	protected void insertTestStatement(RepositoryConnection connection, int i) throws RepositoryException {
 		ValueFactory vf = connection.getValueFactory();
-		Literal lit = vf.createLiteral(Integer.toString(i), XSD.INTEGER);
+		Literal lit = vf.createLiteral(Integer.toString(i), CoreDatatype.XSD.INTEGER);
 		connection.add(vf.createIRI("http://test#s" + i), vf.createIRI("http://test#p"), lit,
 				vf.createIRI("http://test#context_" + i));
 	}

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/EvaluationStrategyTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/EvaluationStrategyTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -89,7 +90,7 @@ public abstract class EvaluationStrategyTest {
 
 		try (RepositoryConnection conn = strictRepo.getConnection()) {
 			Literal l1 = vf.createLiteral("2009", XSD.GYEAR);
-			Literal l2 = vf.createLiteral("2009-01", XSD.GYEARMONTH);
+			Literal l2 = vf.createLiteral("2009-01", CoreDatatype.XSD.GYEARMONTH);
 			IRI s1 = vf.createIRI("urn:s1");
 			IRI s2 = vf.createIRI("urn:s2");
 			conn.add(s1, RDFS.LABEL, l1);
@@ -107,7 +108,7 @@ public abstract class EvaluationStrategyTest {
 		ValueFactory vf = extendedRepo.getValueFactory();
 
 		try (RepositoryConnection conn = extendedRepo.getConnection()) {
-			Literal l1 = vf.createLiteral("2009", XSD.GYEAR);
+			Literal l1 = vf.createLiteral("2009", CoreDatatype.XSD.GYEAR);
 			Literal l2 = vf.createLiteral("2009-01", XSD.GYEARMONTH);
 			IRI s1 = vf.createIRI("urn:s1");
 			IRI s2 = vf.createIRI("urn:s2");

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/RDFStoreTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/RDFStoreTest.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -251,14 +252,14 @@ public abstract class RDFStoreTest {
 	public void testTimeZoneRoundTrip() throws Exception {
 		IRI subj = vf.createIRI(EXAMPLE_NS + PICASSO);
 		IRI pred = vf.createIRI(EXAMPLE_NS + PAINTS);
-		Literal obj = vf.createLiteral("2006-08-23+00:00", XSD.DATE);
+		Literal obj = vf.createLiteral("2006-08-23+00:00", CoreDatatype.XSD.DATE);
 		testValueRoundTrip(subj, pred, obj);
 
 		con.begin();
 		con.removeStatements(null, null, null);
 		con.commit();
 
-		obj = vf.createLiteral("2006-08-23", XSD.DATE);
+		obj = vf.createLiteral("2006-08-23", CoreDatatype.XSD.DATE);
 		testValueRoundTrip(subj, pred, obj);
 	}
 
@@ -380,7 +381,7 @@ public abstract class RDFStoreTest {
 	public void testInvalidDateTime() throws Exception {
 		// SES-711
 		Literal date1 = vf.createLiteral("2004-12-20", XSD.DATETIME);
-		Literal date2 = vf.createLiteral("2004-12-20", XSD.DATETIME);
+		Literal date2 = vf.createLiteral("2004-12-20", CoreDatatype.XSD.DATETIME);
 		Assert.assertEquals(date1, date2);
 	}
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -32,6 +32,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
@@ -979,7 +980,7 @@ public abstract class ComplexSPARQLQueryTest {
 			Value y = bs.getValue("y");
 			assertNotNull(y);
 			assertTrue(y instanceof Literal);
-			assertEquals(f.createLiteral("1", XSD.INTEGER), y);
+			assertEquals(f.createLiteral("1", CoreDatatype.XSD.INTEGER), y);
 		}
 	}
 
@@ -1151,7 +1152,7 @@ public abstract class ComplexSPARQLQueryTest {
 
 	/**
 	 * See https://github.com/eclipse/rdf4j/issues/3072
-	 * 
+	 *
 	 */
 	@Test
 	public void testValuesAfterOptional() throws Exception {
@@ -2661,7 +2662,7 @@ public abstract class ComplexSPARQLQueryTest {
 		assertThat(result.size()).isEqualTo(1);
 		BindingSet solution = result.get(0);
 
-		assertThat(solution.getValue("b1")).isEqualTo(literal("1", XSD.INTEGER));
+		assertThat(solution.getValue("b1")).isEqualTo(literal("1", CoreDatatype.XSD.INTEGER));
 		assertThat(solution.getValue("b2")).isNull();
 		assertThat(solution.getValue("b3")).isNull();
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/SPARQLUpdateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/SPARQLUpdateTest.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -548,7 +549,7 @@ public abstract class SPARQLUpdateTest {
 
 		IRI age = f.createIRI(EX_NS, "age");
 		Literal originalAgeValue = f.createLiteral("42", XSD.INTEGER);
-		Literal correctAgeValue = f.createLiteral("43", XSD.INTEGER);
+		Literal correctAgeValue = f.createLiteral("43", CoreDatatype.XSD.INTEGER);
 		Literal inCorrectAgeValue = f.createLiteral("46", XSD.INTEGER);
 
 		assertTrue(con.hasStatement(bob, age, originalAgeValue, true));
@@ -861,7 +862,8 @@ public abstract class SPARQLUpdateTest {
 
 		String msg = "new statement about ex:book1 should have been inserted";
 
-		assertTrue(msg, con.hasStatement(book1, DC.TITLE, f.createLiteral("the number four", XSD.INTEGER), true));
+		assertTrue(msg,
+				con.hasStatement(book1, DC.TITLE, f.createLiteral("the number four", CoreDatatype.XSD.INTEGER), true));
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #3587 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - create an enum for all the core datatypes without depending on any vocabularies (like XSD.Datatype does)
     - also include rdf:langString
     - includes all the methods from XSD.Datatype
     - also has a bunch of other helper methods and a cache implementation to simplify implementation for us
 - add method to Literal interface to return an Optional<CoreDatatype>
     - this method is not allowed to return null and if it returns an empty optional then that is because the datatype is note one of the XSD datatypes or rdf:langString
 - implemented the new method in our code
 
The next step would be to take advantage of the new datatype enum throughout our code base to simplify and speed the places where we check the datatype against either rdf:langString or one of the XSD datatypes.


<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

