### PR TITLE
GH-3598 use == everywhere we compare the xml schema datatype with the DatatypeConstants from the XMLGregorianCalendar

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
@@ -919,40 +919,33 @@ public abstract class AbstractLiteral implements Literal {
 			}
 		});
 
-		private static final Map<QName, IRI> DATATYPES = datatypes();
-
-		private static Map<QName, IRI> datatypes() {
-
-			final Map<QName, IRI> datatypes = new HashMap<>();
-
-			datatypes.put(DatatypeConstants.DATETIME, XSD_DATETIME);
-			datatypes.put(DatatypeConstants.TIME, XSD_TIME);
-			datatypes.put(DatatypeConstants.DATE, XSD_DATE);
-
-			datatypes.put(DatatypeConstants.GYEARMONTH, XSD_GYEARMONTH);
-			datatypes.put(DatatypeConstants.GYEAR, XSD_GYEAR);
-			datatypes.put(DatatypeConstants.GMONTHDAY, XSD_GMONTHDAY);
-			datatypes.put(DatatypeConstants.GDAY, XSD_GDAY);
-			datatypes.put(DatatypeConstants.GMONTH, XSD_GMONTH);
-
-			datatypes.put(DatatypeConstants.DURATION, XSD_DURATION);
-			datatypes.put(DatatypeConstants.DURATION_DAYTIME, XSD_DURATION_DAYTIME);
-			datatypes.put(DatatypeConstants.DURATION_YEARMONTH, XSD_DURATION_YEARMONTH);
-
-			return datatypes;
-		}
-
 		private static IRI datatype(QName qname) {
 
-			final IRI datatype = DATATYPES.get(qname);
-
-			if (datatype == null) {
-				throw new IllegalArgumentException(String.format(
-						"QName <%s> cannot be mapped to an XML Schema date/time datatype", qname
-				));
+			if (DatatypeConstants.DATETIME == qname) {
+				return XSD_DATETIME;
+			} else if (DatatypeConstants.DATE == qname) {
+				return XSD_DATE;
+			} else if (DatatypeConstants.TIME == qname) {
+				return XSD_TIME;
+			} else if (DatatypeConstants.GYEARMONTH == qname) {
+				return XSD_GYEARMONTH;
+			} else if (DatatypeConstants.GMONTHDAY == qname) {
+				return XSD_GMONTHDAY;
+			} else if (DatatypeConstants.GYEAR == qname) {
+				return XSD_GYEAR;
+			} else if (DatatypeConstants.GMONTH == qname) {
+				return XSD_GMONTH;
+			} else if (DatatypeConstants.GDAY == qname) {
+				return XSD_GDAY;
+			} else if (DatatypeConstants.DURATION == qname) {
+				return XSD_DURATION;
+			} else if (DatatypeConstants.DURATION_DAYTIME == qname) {
+				return XSD_DURATION_DAYTIME;
+			} else if (DatatypeConstants.DURATION_YEARMONTH == qname) {
+				return XSD_DURATION_YEARMONTH;
+			} else {
+				throw new IllegalArgumentException("QName cannot be mapped to an XML Schema IRI: " + qname.toString());
 			}
-
-			return datatype;
 		}
 
 		private static XMLGregorianCalendar parseCalendar(String label) {

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtil.java
@@ -1971,30 +1971,30 @@ public class XMLDatatypeUtil {
 	 * @see DatatypeConstants
 	 */
 	public static IRI qnameToURI(QName qname) {
-		if (DatatypeConstants.DATETIME.equals(qname)) {
+		if (DatatypeConstants.DATETIME == qname) {
 			return XSD.DATETIME;
-		} else if (DatatypeConstants.DATE.equals(qname)) {
+		} else if (DatatypeConstants.DATE == qname) {
 			return XSD.DATE;
-		} else if (DatatypeConstants.TIME.equals(qname)) {
+		} else if (DatatypeConstants.TIME == qname) {
 			return XSD.TIME;
-		} else if (DatatypeConstants.GYEARMONTH.equals(qname)) {
+		} else if (DatatypeConstants.GYEARMONTH == qname) {
 			return XSD.GYEARMONTH;
-		} else if (DatatypeConstants.GMONTHDAY.equals(qname)) {
+		} else if (DatatypeConstants.GMONTHDAY == qname) {
 			return XSD.GMONTHDAY;
-		} else if (DatatypeConstants.GYEAR.equals(qname)) {
+		} else if (DatatypeConstants.GYEAR == qname) {
 			return XSD.GYEAR;
-		} else if (DatatypeConstants.GMONTH.equals(qname)) {
+		} else if (DatatypeConstants.GMONTH == qname) {
 			return XSD.GMONTH;
-		} else if (DatatypeConstants.GDAY.equals(qname)) {
+		} else if (DatatypeConstants.GDAY == qname) {
 			return XSD.GDAY;
-		} else if (DatatypeConstants.DURATION.equals(qname)) {
+		} else if (DatatypeConstants.DURATION == qname) {
 			return XSD.DURATION;
-		} else if (DatatypeConstants.DURATION_DAYTIME.equals(qname)) {
+		} else if (DatatypeConstants.DURATION_DAYTIME == qname) {
 			return XSD.DAYTIMEDURATION;
-		} else if (DatatypeConstants.DURATION_YEARMONTH.equals(qname)) {
+		} else if (DatatypeConstants.DURATION_YEARMONTH == qname) {
 			return XSD.YEARMONTHDURATION;
 		} else {
-			throw new IllegalArgumentException("QName cannot be mapped to an XML Schema URI: " + qname.toString());
+			throw new IllegalArgumentException("QName cannot be mapped to an XML Schema IRI: " + qname.toString());
 		}
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #3598 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

XMLGregorianCalendar.getXMLSchemaType() is defined to only return the constants from DatatypeConstants. This means we can use == instead of .equals(...). See https://docs.oracle.com/javase/8/docs/api/javax/xml/datatype/XMLGregorianCalendar.html#getXMLSchemaType--

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

