### PR TITLE
Gh 3597 wrong status code in export statements view on exception

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/ExportStatementsView.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/ExportStatementsView.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.http.server.repository.statements;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
+import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -84,10 +85,18 @@ public class ExportStatementsView implements View {
 
 		RDFFormat rdfFormat = rdfWriterFactory.getRDFFormat();
 
-		try {
+		try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+			RDFWriter rdfWriter = rdfWriterFactory.getWriter(baos);
+			if (!headersOnly) {
+				try (RepositoryConnection conn = RepositoryInterceptor.getRepositoryConnection(request)) {
+					conn.exportStatements(subj, pred, obj, useInferencing, rdfWriter, contexts);
+				} catch (RDFHandlerException e) {
+					throw new ServerHTTPException("Serialization error: " + e.getMessage(), e);
+				} catch (RepositoryException e) {
+					throw new ServerHTTPException("Repository error: " + e.getMessage(), e);
+				}
+			}
 			try (OutputStream out = response.getOutputStream()) {
-				RDFWriter rdfWriter = rdfWriterFactory.getWriter(out);
-
 				response.setStatus(SC_OK);
 
 				String mimeType = rdfFormat.getDefaultMIMEType();
@@ -102,17 +111,8 @@ public class ExportStatementsView implements View {
 					filename += "." + rdfFormat.getDefaultFileExtension();
 				}
 				response.setHeader("Content-Disposition", "attachment; filename=" + filename);
-
-				if (!headersOnly) {
-					try (RepositoryConnection conn = RepositoryInterceptor.getRepositoryConnection(request)) {
-						conn.exportStatements(subj, pred, obj, useInferencing, rdfWriter, contexts);
-					}
-				}
+				out.write(baos.toByteArray());
 			}
-		} catch (RDFHandlerException e) {
-			throw new ServerHTTPException("Serialization error: " + e.getMessage(), e);
-		} catch (RepositoryException e) {
-			throw new ServerHTTPException("Repository error: " + e.getMessage(), e);
 		}
 	}
 

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestExportStatementsView.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestExportStatementsView.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import org.eclipse.rdf4j.http.server.ServerHTTPException;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,6 +60,6 @@ public class TestExportStatementsView extends TestStatementsCommon {
 		}
 
 		Assert.assertNotNull(exception);
-		Assert.assertThat(exception.getMessage(), CoreMatchers.containsString(REPOSITORY_ERROR_MSG));
+		Assert.assertTrue(exception.getMessage().contains(REPOSITORY_ERROR_MSG));
 	}
 }

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestExportStatementsView.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestExportStatementsView.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository.statements;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
+import java.util.Map;
+
+import org.eclipse.rdf4j.http.server.ServerHTTPException;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpMethod;
+import org.springframework.ui.ModelMap;
+
+public class TestExportStatementsView extends TestStatementsCommon {
+	public static final String REPOSITORY_ERROR_MSG = "Unable to get statements from Sail";
+	private final ExportStatementsView exportStatementsView = ExportStatementsView.getInstance();
+	private final Map<String, Object> model = new ModelMap();
+
+	@Before
+	public void initMocks() {
+		request.setMethod(HttpMethod.GET.name());
+		model.put(ExportStatementsView.FACTORY_KEY, new TurtleWriterFactory());
+		model.put(ExportStatementsView.USE_INFERENCING_KEY, false);
+		model.put(ExportStatementsView.HEADERS_ONLY, false);
+
+		super.initMocks();
+	}
+
+	@Test
+	public void shouldReturnSC_OKIfNoExceptionIsThrown() throws Exception {
+		// act
+		exportStatementsView.render(model, request, response);
+
+		Assert.assertEquals(SC_OK, response.getStatus());
+	}
+
+	@Test
+	public void shouldReturnSC_INTERNAL_SERVER_ERRORIfExceptionIsThrown() throws Exception {
+		Exception exception = null;
+		Mockito.doThrow(new RepositoryException(REPOSITORY_ERROR_MSG))
+				.when(connectionMock)
+				.exportStatements(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(Boolean.class),
+						Mockito.notNull(), Mockito.any());
+
+		try {
+			// act
+			exportStatementsView.render(model, request, response);
+		} catch (ServerHTTPException ex) {
+			exception = ex;
+		}
+
+		Assert.assertNotNull(exception);
+		Assert.assertThat(exception.getMessage(), CoreMatchers.containsString(REPOSITORY_ERROR_MSG));
+	}
+}

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsCommon.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsCommon.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository.statements;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.rio.ParserConfig;
+import org.junit.Before;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class TestStatementsCommon {
+	protected final MockHttpServletRequest request = new MockHttpServletRequest();
+	protected final MockHttpServletResponse response = new MockHttpServletResponse();
+	protected final Repository repMock = Mockito.mock(Repository.class);
+	protected final RepositoryConnection connectionMock = Mockito.mock(RepositoryConnection.class);
+	private final ParserConfig parserConfigMock = Mockito.mock(ParserConfig.class);
+
+	@Before
+	public void initMocks() {
+		Mockito.when(repMock.getConnection()).thenReturn(connectionMock);
+		Mockito.when(connectionMock.getParserConfig()).thenReturn(parserConfigMock);
+		// repository interceptor uses this attribute
+		request.setAttribute("repository", repMock);
+	}
+}

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
@@ -12,47 +12,38 @@ import java.nio.charset.StandardCharsets;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.eclipse.rdf4j.rio.ParserConfig;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author jeen
  */
-public class TestStatementsController {
+public class TestStatementsController extends TestStatementsCommon {
+
+	private final StatementsController controller = new StatementsController();
+
+	@Before
+	public void initMocks() {
+		request.setMethod(HttpMethod.POST.name());
+
+		super.initMocks();
+	}
 
 	@Test
 	public void shouldUseTimeoutParameterForUpdateQueries() throws Exception {
-		// prepare
-		StatementsController controller = new StatementsController();
-
 		final int maxExecution = 1;
-		final MockHttpServletRequest request = new MockHttpServletRequest();
-		request.setMethod(HttpMethod.POST.name());
 		request.setContentType(Protocol.SPARQL_UPDATE_MIME_TYPE);
 		request.addParameter(Protocol.TIMEOUT_PARAM_NAME, String.valueOf(maxExecution));
 		final String updateString = "delete where { <monkey:pod> ?p ?o . }";
 		request.setContent(updateString.getBytes(StandardCharsets.UTF_8));
 
-		// prepare mocks
-		final Repository repMock = Mockito.mock(Repository.class);
-		final RepositoryConnection connectionMock = Mockito.mock(RepositoryConnection.class);
-		final ParserConfig parserConfigMock = Mockito.mock(ParserConfig.class);
 		final Update updateMock = Mockito.mock(Update.class);
-		Mockito.when(repMock.getConnection()).thenReturn(connectionMock);
 		Mockito.when(connectionMock.prepareUpdate(QueryLanguage.SPARQL, updateString, null)).thenReturn(updateMock);
-		Mockito.when(connectionMock.getParserConfig()).thenReturn(parserConfigMock);
-
-		// repository interceptor uses this attribute
-		request.setAttribute("repository", repMock);
 
 		// act
-		controller.handleRequest(request, new MockHttpServletResponse());
+		controller.handleRequest(request, response);
 
 		Mockito.verify(updateMock).setMaxExecutionTime(maxExecution);
 	}


### PR DESCRIPTION
GitHub issue resolved: #3597

Briefly describe the changes proposed in this PR:

Passed new ByteArrayOutputStream to RDFWriter, which is written in response output stream if no exception is thrown.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [X ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ X] I've added tests for the changes I made
 - [ X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

