### PR TITLE
GH-3570 LMDB store multi-threading

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
@@ -758,7 +758,7 @@ class ValueStore extends AbstractValueFactory {
 	}
 
 	private byte[] literal2data(String label, Optional<String> lang, IRI dt, boolean create)
-			throws IOException, UnsupportedEncodingException {
+			throws IOException {
 		// Get datatype ID
 		long datatypeID = LmdbValue.UNKNOWN_ID;
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/BenchmarkBaseFoaf.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/BenchmarkBaseFoaf.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb.benchmark;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Random;
+
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.util.Files;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+
+public class BenchmarkBaseFoaf {
+
+	protected File file;
+
+	protected SailRepository repository;
+	protected SailRepositoryConnection connection;
+
+	protected Random random = new Random(12345);
+
+	private int i = 1;
+	private final String[] countries = Locale.getISOCountries();
+	private final String[] languages = Locale.getISOLanguages();
+
+	public void setup() throws IOException {
+		i = 1;
+		if (connection != null) {
+			connection.close();
+			connection = null;
+		}
+		file = Files.newTemporaryFolder();
+
+		LmdbStore sail = new LmdbStore(file, new LmdbStoreConfig("spoc,ospc,psoc").setForceSync(false));
+		repository = new SailRepository(sail);
+		connection = repository.getConnection();
+
+		System.gc();
+	}
+
+	public void tearDown() throws IOException {
+		if (connection != null) {
+			connection.close();
+			connection = null;
+		}
+		repository.shutDown();
+		FileUtils.deleteDirectory(file);
+	}
+
+	void addPersonNameOnly() {
+		ValueFactory vf = connection.getValueFactory();
+
+		IRI person = vf.createIRI("http://www.example.org/persons/person_" + i);
+		// English label
+		connection.add(person, vf.createIRI("http://www.w3.org/2000/01/rdf-schema#label"),
+				vf.createLiteral("Name @en" + i, "en"));
+
+		i++;
+	}
+
+	void addPerson() {
+		ValueFactory vf = connection.getValueFactory();
+
+		IRI person = vf.createIRI("http://www.example.org/persons/person_" + i);
+		connection.add(person, vf.createIRI("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+				vf.createIRI("http://xmlns.com/foaf/0.1/Person"));
+
+		// English label
+		connection.add(person, vf.createIRI("http://www.w3.org/2000/01/rdf-schema#label"),
+				vf.createLiteral("Name @en" + i, "en"));
+
+		// 3 other languages
+		random.ints(3, 0, languages.length).distinct().forEach(langIndex -> {
+			connection.add(person, vf.createIRI("http://www.w3.org/2000/01/rdf-schema#label"),
+					vf.createLiteral("Name " + i, languages[langIndex]));
+		});
+
+		int countryIndex = random.nextInt(countries.length);
+		int organizationNr = countryIndex + 1;
+		connection.add(vf.createIRI("http://www.example.org/organizations/org_" + organizationNr),
+				vf.createIRI("http://xmlns.com/foaf/0.1/member"), person);
+
+		connection.add(person, vf.createIRI("http://www.example.org/vocab/countryCode"),
+				vf.createLiteral(countries[countryIndex]));
+
+		int knowsMemberNr = random.nextInt(i) + 1;
+		for (int nr = 0; nr < 3; nr++) {
+			connection.add(person, vf.createIRI("http://xmlns.com/foaf/0.1/knows"),
+					vf.createIRI("http://www.example.org/persons/person_" + (knowsMemberNr + nr)));
+		}
+
+		i++;
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
@@ -67,6 +67,7 @@ public class QueryBenchmark {
 	private static final String query3;
 	private static final String query4;
 	private static final String query5;
+	private static final String query7_pathexpression1;
 
 	static {
 		try {
@@ -75,6 +76,8 @@ public class QueryBenchmark {
 			query3 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query3.qr"), StandardCharsets.UTF_8);
 			query4 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query4.qr"), StandardCharsets.UTF_8);
 			query5 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query5.qr"), StandardCharsets.UTF_8);
+			query7_pathexpression1 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query7-pathexpression1.qr"),
+					StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
@@ -157,6 +160,19 @@ public class QueryBenchmark {
 					.evaluate()
 					.stream()
 					.count();
+		}
+	}
+
+	@Benchmark
+	public long pathExpressionQuery1() {
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query7_pathexpression1)
+					.evaluate()
+					.stream()
+					.count();
+
 		}
 	}
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmarkFoaf.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmarkFoaf.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb.benchmark;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmarks query performance with extended FOAF data.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms2G", "-Xmx2G", "-Xmn1G", "-XX:+UseSerialGC" })
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class QueryBenchmarkFoaf extends BenchmarkBaseFoaf {
+	private static final String query1, query2, query3;
+
+	static {
+		try {
+			query1 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query-persons-friends.qr"),
+					StandardCharsets.UTF_8);
+			query2 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query-persons-count-friends-sorted.qr"),
+					StandardCharsets.UTF_8);
+			query3 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query-persons-count-friends.qr"),
+					StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("QueryBenchmarkFoaf") // adapt to control which benchmark tests to run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws IOException {
+		super.setup();
+
+		// add 100,000 persons => 1,000,000 triples
+		for (int i = 0; i < 10; i++) {
+			connection.begin(IsolationLevels.NONE);
+			for (int j = 0; j < 10000; j++) {
+				addPerson();
+			}
+			connection.commit();
+		}
+		connection.close();
+
+		connection = repository.getConnection();
+
+		System.gc();
+	}
+
+	private static InputStream getResourceAsStream(String name) {
+		return QueryBenchmarkFoaf.class.getClassLoader().getResourceAsStream(name);
+	}
+
+	@TearDown(Level.Trial)
+	public void tearDown() throws IOException {
+		super.tearDown();
+		repository.shutDown();
+	}
+
+	@Benchmark
+	public long personsAndFriends() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query1)
+					.evaluate()
+					.stream()
+					.count();
+		}
+	}
+
+	@Benchmark
+	public long groupByCount() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query2)
+					.evaluate()
+					.stream()
+					.count();
+		}
+	}
+
+	@Benchmark
+	public long groupByCountSorted() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return connection
+					.prepareTupleQuery(query3)
+					.evaluate()
+					.stream()
+					.count();
+		}
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/TransactionsPerSecondBenchmarkFoaf.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/TransactionsPerSecondBenchmarkFoaf.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb.benchmark;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmarks insertion performance with extended FOAF data.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@BenchmarkMode({ Mode.Throughput })
+@Fork(value = 1, jvmArgs = { "-Xms2G", "-Xmx2G", "-XX:+UseG1GC" })
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class TransactionsPerSecondBenchmarkFoaf extends BenchmarkBaseFoaf {
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("TransactionsPerSecondBenchmarkFoaf") // adapt to control which benchmark tests to run
+				// .addProfiler("stack", "lines=20;period=1;top=20")
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
+
+	@Setup(Level.Iteration)
+	public void setup() throws IOException {
+		super.setup();
+	}
+
+	@TearDown(Level.Iteration)
+	public void tearDown() throws IOException {
+		super.tearDown();
+	}
+
+	@Benchmark
+	public void transaction1x() {
+		connection.begin();
+		addPersonNameOnly();
+		connection.commit();
+	}
+
+	@Benchmark
+	public void transaction1xLevelNone() {
+		connection.begin(IsolationLevels.NONE);
+		addPersonNameOnly();
+		connection.commit();
+	}
+
+	@Benchmark
+	public void transaction10x() {
+		connection.begin();
+		addPerson();
+		connection.commit();
+	}
+
+	@Benchmark
+	public void transaction10xLevelNone() {
+		connection.begin(IsolationLevels.NONE);
+		addPerson();
+		connection.commit();
+	}
+
+	@Benchmark
+	public void transaction10kx() {
+		connection.begin();
+		for (int k = 0; k < 1000; k++) {
+			addPerson();
+		}
+		connection.commit();
+	}
+
+	@Benchmark
+	public void transaction10kxLevelNone() {
+		connection.begin(IsolationLevels.NONE);
+		for (int k = 0; k < 1000; k++) {
+			addPerson();
+		}
+		connection.commit();
+	}
+
+	@Benchmark
+	public void transaction100kx() {
+		connection.begin();
+		for (int k = 0; k < 10000; k++) {
+			addPerson();
+		}
+		connection.commit();
+	}
+
+	@Benchmark
+	public void transaction100kxLevelNone() {
+		connection.begin(IsolationLevels.NONE);
+		for (int k = 0; k < 10000; k++) {
+			addPerson();
+		}
+		connection.commit();
+	}
+}

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/query-persons-count-friends-sorted.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/query-persons-count-friends-sorted.qr
@@ -1,0 +1,13 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+
+SELECT DISTINCT ?p ?name (COUNT(?other) AS ?count) WHERE {
+        ?p a foaf:Person ; foaf:knows ?other ; rdfs:label ?name
+        FILTER (LANG(?name) = "en")
+}
+GROUP BY ?p ?name
+ORDER BY desc(?count)
+LIMIT 100

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/query-persons-count-friends.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/query-persons-count-friends.qr
@@ -1,0 +1,12 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+
+SELECT DISTINCT ?p ?name (COUNT(?other) AS ?count) WHERE {
+        ?p a foaf:Person ; foaf:knows ?other ; rdfs:label ?name
+        FILTER (LANG(?name) = "en")
+}
+GROUP BY ?p ?name
+LIMIT 100

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/query-persons-friends.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/query-persons-friends.qr
@@ -1,0 +1,9 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+
+SELECT ?p ?other WHERE {
+        ?p a foaf:Person ; foaf:knows ?other
+}

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/query7-pathexpression1.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/query7-pathexpression1.qr
@@ -1,0 +1,13 @@
+prefix dcat: <http://www.w3.org/ns/dcat#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix foaf: <http://xmlns.com/foaf/0.1/>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix vcard: <http://www.w3.org/2006/vcard/ns#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT * 
+WHERE {
+    ?catalog dcat:dataset/(dct:identifier|dct:title) ?idOrTitle .
+}


### PR DESCRIPTION
GitHub issue resolved: #3570 

Briefly describe the changes proposed in this PR:

Rewrite LmdbSailStore and introduce the possibility to insert triples on a second thread.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

