### PR TITLE
GH-3609: use replace instead of replaceAll

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
@@ -107,7 +107,7 @@ public class EvaluationStatistics {
 
 		@Override
 		public void meet(ArbitraryLengthPath node) {
-			final Var pathVar = new Var("_anon_" + UUID.randomUUID().toString().replaceAll("-", "_"));
+			final Var pathVar = new Var("_anon_" + UUID.randomUUID().toString().replace("-", "_"));
 			pathVar.setAnonymous(true);
 			// cardinality of ALP is determined based on the cost of a
 			// single ?s ?p ?o ?c pattern where ?p is unbound, compensating for the fact that

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -310,7 +310,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		// the
 		// varname
 		// remains compatible with the SPARQL grammar. See SES-2310.
-		final Var var = new Var("_anon_" + UUID.randomUUID().toString().replaceAll("-", "_"));
+		final Var var = new Var("_anon_" + UUID.randomUUID().toString().replace("-", "_"));
 		var.setAnonymous(true);
 		return var;
 	}
@@ -974,7 +974,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			if (resource instanceof Var) {
 				projectionElements.addElement(new ProjectionElem(((Var) resource).getName()));
 			} else {
-				String alias = "_describe_" + UUID.randomUUID().toString().replaceAll("-", "_");
+				String alias = "_describe_" + UUID.randomUUID().toString().replace("-", "_");
 				ExtensionElem elem = new ExtensionElem(resource, alias);
 				e.addElement(elem);
 				projectionElements.addElement(new ProjectionElem(alias));

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/BaseTupleExprRenderer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/BaseTupleExprRenderer.java
@@ -173,7 +173,7 @@ public abstract class BaseTupleExprRenderer extends AbstractQueryModelVisitor<Ex
 	 * @return the name scrubbed of any illegal characters
 	 */
 	public static String scrubVarName(String theName) {
-		return theName.replaceAll("-", "");
+		return theName.replace("-", "");
 	}
 
 	/**

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLResultsCSVWriter.java
@@ -182,11 +182,7 @@ public class SPARQLResultsCSVWriter extends AbstractQueryResultWriter implements
 			quoted = true;
 
 			// escape quotes inside the string
-			label = label.replaceAll("\"", "\"\"");
-
-			// add quotes around the string (escaped with a second quote for the
-			// CSV parser)
-			// label = "\"\"" + label + "\"\"";
+			label = label.replace("\"", "\"\"");
 		}
 
 		if (quoted) {

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -774,7 +774,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	private final String createUniqueBNodePrefix() {
-		return UUID.randomUUID().toString().replaceAll("-", "") + "-";
+		return UUID.randomUUID().toString().replace("-", "") + "-";
 	}
 
 	/**


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #3609 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- use String.replace instead of replaceAll when not using a regular expression<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

