### PR TITLE
GH-3641 Introduce a scheduler within ActiveTransactionsRegistry to cl…

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/Transaction.java
@@ -385,14 +385,7 @@ class Transaction implements AutoCloseable {
 	public void close() throws InterruptedException, ExecutionException {
 		if (isClosed.compareAndSet(false, true)) {
 			try {
-				// Stop new tasks being submitted to the executor from now
-				Future<Boolean> result = submitAndShutdown(() -> {
-					txnConnection.close();
-					return true;
-				});
-				// Shutdown is atomic with the close operation above, so just need to block for it to complete before
-				// returning
-				getFromFuture(result);
+				txnConnection.close();
 			} finally {
 				try {
 					if (!executor.isTerminated()) {

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -83,6 +83,7 @@ import org.eclipse.rdf4j.rio.RDFWriterRegistry;
 import org.eclipse.rdf4j.rio.Rio;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
@@ -93,7 +94,7 @@ import org.springframework.web.servlet.mvc.AbstractController;
  *
  * @author Jeen Broekstra
  */
-public class TransactionController extends AbstractController {
+public class TransactionController extends AbstractController implements DisposableBean {
 
 	private Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -172,7 +173,11 @@ public class TransactionController extends AbstractController {
 				try {
 					transaction.rollback();
 				} finally {
-					ActiveTransactionRegistry.INSTANCE.deregister(transaction);
+					try {
+						transaction.close();
+					} finally {
+						ActiveTransactionRegistry.INSTANCE.deregister(transaction);
+					}
 				}
 				result = new ModelAndView(EmptySuccessView.getInstance());
 				logger.info("transaction rollback request finished.");
@@ -187,7 +192,9 @@ public class TransactionController extends AbstractController {
 			}
 			break;
 		}
-		ActiveTransactionRegistry.INSTANCE.active(transaction);
+		if (!(transaction.isClosed() || transaction.isComplete())) {
+			ActiveTransactionRegistry.INSTANCE.active(transaction);
+		}
 		return result;
 	}
 
@@ -651,6 +658,13 @@ public class TransactionController extends AbstractController {
 			ErrorInfo errInfo = new ErrorInfo(ErrorType.MALFORMED_QUERY, e.getMessage());
 			throw new ClientHTTPException(SC_BAD_REQUEST, errInfo.toString());
 		}
+	}
+
+	// Comes from disposableBean interface so to be able to stop the ActiveTransactionRegistry scheduler
+	@Override
+	public void destroy()
+			throws Exception {
+		ActiveTransactionRegistry.INSTANCE.destroyScheduler();
 	}
 
 }


### PR DESCRIPTION
Fixes GH-3641 
Cleanup entries that expire from the secondary transaction cache using a scheduled tasks

Signed-off-by: damyan.ognyanov <damyan.ognyanov@ontotext.com>


GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

