### PR TITLE
GH-3648 Reduce default maximum DB size of LMDB store

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfig.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfig.java
@@ -22,12 +22,12 @@ public class LmdbStoreConfig extends BaseSailConfig {
 	/**
 	 * The default size of the triple database.
 	 */
-	public static final long TRIPLE_DB_SIZE = 10_737_418_240L; // 10 GiB
+	public static final long TRIPLE_DB_SIZE = 10_485_760; // 10 MiB
 
 	/**
 	 * The default size of the value database.
 	 */
-	public static final long VALUE_DB_SIZE = 10_737_418_240L; // 10 GiB
+	public static final long VALUE_DB_SIZE = 10_485_760; // 10 MiB
 
 	/**
 	 * The default value cache size.

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreConcurrencyTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreConcurrencyTest.java
@@ -35,7 +35,10 @@ public class LmdbStoreConcurrencyTest extends SailConcurrencyTest {
 	@Override
 	protected NotifyingSail createSail() throws SailException {
 		try {
-			return new LmdbStore(tempDir.newFolder(), new LmdbStoreConfig("spoc,posc"));
+			LmdbStoreConfig config = new LmdbStoreConfig("spoc,posc");
+			config.setValueDBSize(52428800); // 50 MiB
+			config.setTripleDBSize(config.getValueDBSize());
+			return new LmdbStore(tempDir.newFolder(), config);
 		} catch (IOException e) {
 			throw new AssertionError(e);
 		}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/QueryBenchmarkTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/QueryBenchmarkTest.java
@@ -62,7 +62,10 @@ public class QueryBenchmarkTest {
 		tempDir.create();
 		File file = tempDir.newFolder();
 
-		repository = new SailRepository(new LmdbStore(file, new LmdbStoreConfig("spoc,ospc,psoc")));
+		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		config.setValueDBSize(209715200); // 200 MiB
+		config.setTripleDBSize(config.getValueDBSize());
+		repository = new SailRepository(new LmdbStore(file, config));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(IsolationLevels.NONE);

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/BenchmarkBaseFoaf.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/BenchmarkBaseFoaf.java
@@ -20,7 +20,6 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
-import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 
 public class BenchmarkBaseFoaf {
 
@@ -43,7 +42,7 @@ public class BenchmarkBaseFoaf {
 		}
 		file = Files.newTemporaryFolder();
 
-		LmdbStore sail = new LmdbStore(file, new LmdbStoreConfig("spoc,ospc,psoc").setForceSync(false));
+		LmdbStore sail = new LmdbStore(file, ConfigUtil.createConfig());
 		repository = new SailRepository(sail);
 		connection = repository.getConnection();
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ConfigUtil.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/ConfigUtil.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb.benchmark;
+
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+
+/**
+ * Creates LMDB store configurations for benchmarking.
+ */
+final class ConfigUtil {
+	static LmdbStoreConfig createConfig() {
+		LmdbStoreConfig config = new LmdbStoreConfig("spoc,ospc,psoc");
+		config.setForceSync(false);
+		config.setValueDBSize(1_073_741_824L); // 1 GiB
+		config.setTripleDBSize(config.getValueDBSize());
+		return config;
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/OverflowBenchmarkReal.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/OverflowBenchmarkReal.java
@@ -68,7 +68,7 @@ public class OverflowBenchmarkReal {
 		File temporaryFolder = Files.newTemporaryFolder();
 		SailRepository sailRepository = null;
 		try {
-			sailRepository = new SailRepository(new LmdbStore(temporaryFolder));
+			sailRepository = new SailRepository(new LmdbStore(temporaryFolder, ConfigUtil.createConfig()));
 
 			try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/OverflowBenchmarkSynthetic.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/OverflowBenchmarkSynthetic.java
@@ -77,7 +77,7 @@ public class OverflowBenchmarkSynthetic {
 		File temporaryFolder = Files.newTemporaryFolder();
 		SailRepository sailRepository = null;
 		try {
-			sailRepository = new SailRepository(new LmdbStore(temporaryFolder));
+			sailRepository = new SailRepository(new LmdbStore(temporaryFolder, ConfigUtil.createConfig()));
 
 			try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
@@ -25,7 +25,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
-import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -100,7 +99,7 @@ public class QueryBenchmark {
 		tempDir.create();
 		File file = tempDir.newFolder();
 
-		repository = new SailRepository(new LmdbStore(file, new LmdbStoreConfig("spoc,ospc,psoc")));
+		repository = new SailRepository(new LmdbStore(file, ConfigUtil.createConfig()));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(IsolationLevels.NONE);

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/TransactionsPerSecondBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/TransactionsPerSecondBenchmark.java
@@ -19,7 +19,6 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
-import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -74,7 +73,7 @@ public class TransactionsPerSecondBenchmark {
 		i = 0;
 		file = Files.newTemporaryFolder();
 
-		LmdbStore sail = new LmdbStore(file, new LmdbStoreConfig("spoc,ospc,psoc").setForceSync(false));
+		LmdbStore sail = new LmdbStore(file, ConfigUtil.createConfig());
 		repository = new SailRepository(sail);
 		connection = repository.getConnection();
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/TransactionsPerSecondForceSyncBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/TransactionsPerSecondForceSyncBenchmark.java
@@ -19,7 +19,6 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
-import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -74,7 +73,7 @@ public class TransactionsPerSecondForceSyncBenchmark {
 		i = 0;
 		file = Files.newTemporaryFolder();
 
-		LmdbStore sail = new LmdbStore(file, new LmdbStoreConfig("spoc,ospc,psoc").setForceSync(true));
+		LmdbStore sail = new LmdbStore(file, ConfigUtil.createConfig().setForceSync(true));
 		repository = new SailRepository(sail);
 		connection = repository.getConnection();
 


### PR DESCRIPTION
GitHub issue resolved: #3648   <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Reduce default maximum DB size to 10 MiB for value and triple store.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

