### PR TITLE
GH-3624 Sending an empty SPARQL update with application/sparql-update…

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/StatementsController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/statements/StatementsController.java
@@ -145,11 +145,12 @@ public class StatementsController extends AbstractController {
 			} catch (IOException e) {
 				throw new ClientHTTPException(SC_BAD_REQUEST, "Error reading request message body", e);
 			}
-			if (sparqlUpdateString.isEmpty()) {
-				sparqlUpdateString = null;
-			}
 		} else {
 			sparqlUpdateString = request.getParameterValues(Protocol.UPDATE_PARAM_NAME)[0];
+		}
+
+		if (sparqlUpdateString.isEmpty()) {
+			throw new ClientHTTPException("Updates must be non-empty");
 		}
 
 		// default query language is SPARQL

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
@@ -7,13 +7,17 @@
  */
 package org.eclipse.rdf4j.http.server.repository.statements;
 
+import static org.junit.Assert.assertTrue;
+
 import java.nio.charset.StandardCharsets;
 
 import org.eclipse.rdf4j.http.protocol.Protocol;
+import org.eclipse.rdf4j.http.server.ClientHTTPException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 
@@ -46,5 +50,25 @@ public class TestStatementsController extends TestStatementsCommon {
 		controller.handleRequest(request, response);
 
 		Mockito.verify(updateMock).setMaxExecutionTime(maxExecution);
+	}
+
+	@Test
+	public void shouldThrowDescriptiveErrorOnEmpryUpdateQueries_SparqlUpdateMimeType() {
+		request.setContentType(Protocol.SPARQL_UPDATE_MIME_TYPE);
+		request.addParameter(Protocol.UPDATE_PARAM_NAME, "");
+		Exception exception = Assertions.assertThrows(ClientHTTPException.class, () -> {
+			controller.handleRequest(request, response);
+		});
+		assertTrue(exception.getMessage().contains("Updates must be non-empty"));
+	}
+
+	@Test
+	public void shouldThrowDescriptiveErrorOnEmptyUpdateQueries_FormMimeType() {
+		request.setContentType(Protocol.FORM_MIME_TYPE);
+		request.addParameter(Protocol.UPDATE_PARAM_NAME, "");
+		Exception exception = Assertions.assertThrows(ClientHTTPException.class, () -> {
+			controller.handleRequest(request, response);
+		});
+		assertTrue(exception.getMessage().contains("Updates must be non-empty"));
 	}
 }


### PR DESCRIPTION
…-leads to NPE

Add exception throwing when update string is empty at getSparqlUpdateResult. Added 2 tests to check the result of post requests with  application/sparql-update' and application/x-www-form-urlencoded


GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

