### PR TITLE
GH-2874 interface to signal a SailConnection that supports concurrent reads

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/features/ThreadSafetyAware.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/features/ThreadSafetyAware.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.features;
+
+/**
+ * An interface used to signal thread safety features of a sail or its related classes.
+ */
+public interface ThreadSafetyAware {
+
+	/**
+	 * A class may support concurrent reads from multiple threads against the same object. This ability may change based
+	 * on an object's current state.
+	 *
+	 * @return true if this object supports concurrent reads
+	 */
+	boolean supportsConcurrentReads();
+
+}

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailConnectionWrapper.java
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.UnknownSailTransactionStateException;
 import org.eclipse.rdf4j.sail.UpdateContext;
+import org.eclipse.rdf4j.sail.features.ThreadSafetyAware;
 
 /**
  * An implementation of the SailConnection interface that wraps another SailConnection object and forwards any method
@@ -37,7 +38,8 @@ import org.eclipse.rdf4j.sail.UpdateContext;
  *
  * @author Jeen Broekstra
  */
-public class SailConnectionWrapper implements SailConnection, FederatedServiceResolverClient {
+public class SailConnectionWrapper
+		implements SailConnection, FederatedServiceResolverClient, ThreadSafetyAware {
 
 	/*-----------*
 	 * Variables *
@@ -243,4 +245,10 @@ public class SailConnectionWrapper implements SailConnection, FederatedServiceRe
 		return wrappedCon.isActive();
 	}
 
+	@Override
+	public boolean supportsConcurrentReads() {
+		if (wrappedCon instanceof ThreadSafetyAware)
+			return ((ThreadSafetyAware) wrappedCon).supportsConcurrentReads();
+		return false;
+	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
@@ -8,12 +8,14 @@
 
 package org.eclipse.rdf4j.sail.memory;
 
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
 import org.eclipse.rdf4j.sail.base.SailSourceConnection;
+import org.eclipse.rdf4j.sail.features.ThreadSafetyAware;
 import org.eclipse.rdf4j.sail.helpers.DefaultSailChangedEvent;
 
 /**
@@ -22,7 +24,7 @@ import org.eclipse.rdf4j.sail.helpers.DefaultSailChangedEvent;
  * @author Arjohn Kampman
  * @author jeen
  */
-public class MemoryStoreConnection extends SailSourceConnection {
+public class MemoryStoreConnection extends SailSourceConnection implements ThreadSafetyAware {
 
 	/*-----------*
 	 * Variables *
@@ -115,5 +117,10 @@ public class MemoryStoreConnection extends SailSourceConnection {
 
 	public MemoryStore getSail() {
 		return sail;
+	}
+
+	@Override
+	public boolean supportsConcurrentReads() {
+		return getTransactionIsolation() != null && getTransactionIsolation() != IsolationLevels.SERIALIZABLE;
 	}
 }

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnection.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnection.java
@@ -17,12 +17,13 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
 import org.eclipse.rdf4j.sail.base.SailSourceConnection;
+import org.eclipse.rdf4j.sail.features.ThreadSafetyAware;
 import org.eclipse.rdf4j.sail.helpers.DefaultSailChangedEvent;
 
 /**
  * @author Arjohn Kampman
  */
-public class NativeStoreConnection extends SailSourceConnection {
+public class NativeStoreConnection extends SailSourceConnection implements ThreadSafetyAware {
 
 	/*-----------*
 	 * Constants *
@@ -142,6 +143,11 @@ public class NativeStoreConnection extends SailSourceConnection {
 	public void clearInferred(Resource... contexts) throws SailException {
 		super.clearInferred(contexts);
 		sailChangedEvent.setStatementsRemoved(true);
+	}
+
+	@Override
+	public boolean supportsConcurrentReads() {
+		return getTransactionIsolation() != null && getTransactionIsolation() != IsolationLevels.SERIALIZABLE;
 	}
 
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -11,7 +11,6 @@ package org.eclipse.rdf4j.sail.shacl;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -170,32 +169,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 	 *         without considering any sail level settings for things like caching or parallel validation.
 	 */
 	private Settings getLocalTransactionSettings() {
-		Settings localTransactionSettings = new Settings();
-
-		Arrays.stream(transactionSettingsRaw)
-				.filter(Objects::nonNull)
-				.forEach(setting -> {
-					if (setting instanceof ValidationApproach) {
-						localTransactionSettings.validationApproach = (ValidationApproach) setting;
-					}
-					if (setting instanceof ShaclSail.TransactionSettings.PerformanceHint) {
-						switch (((ShaclSail.TransactionSettings.PerformanceHint) setting)) {
-						case ParallelValidation:
-							localTransactionSettings.parallelValidation = true;
-							break;
-						case SerialValidation:
-							localTransactionSettings.parallelValidation = false;
-							break;
-						case CacheDisabled:
-							localTransactionSettings.cacheSelectedNodes = false;
-							break;
-						case CacheEnabled:
-							localTransactionSettings.cacheSelectedNodes = true;
-							break;
-						}
-					}
-				});
-		return localTransactionSettings;
+		return new Settings(this);
 	}
 
 	@Override
@@ -544,6 +518,10 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 	}
 
 	private boolean isParallelValidation() {
+		assert !(transactionSettings.isParallelValidation() && !supportsConcurrentReads());
+		assert !(getIsolationLevel() == IsolationLevels.SERIALIZABLE && transactionSettings
+				.isParallelValidation()) : "Concurrent reads is buggy for SERIALIZABLE transactions.";
+
 		return transactionSettings.isParallelValidation();
 	}
 
@@ -877,7 +855,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 				logger.debug("Transaction size limit exceeded, reverting to bulk validation.");
 				removeConnectionListener(this);
 				Settings bulkValidation = getLocalTransactionSettings();
-				bulkValidation.validationApproach = ShaclSail.TransactionSettings.ValidationApproach.Bulk;
+				bulkValidation.setValidationApproach(ShaclSail.TransactionSettings.ValidationApproach.Bulk);
 				getTransactionSettings().applyTransactionSettings(bulkValidation);
 				removedStatementsSet.clear();
 				addedStatementsSet.clear();
@@ -936,7 +914,9 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		private Boolean cacheSelectedNodes;
 		private Boolean parallelValidation;
 		private IsolationLevel isolationLevel;
+		transient private Settings previous = null;
 
+		@Deprecated(since = "4.0.0", forRemoval = true)
 		public Settings() {
 		}
 
@@ -950,6 +930,55 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			}
 			this.parallelValidation = parallelValidation;
 			this.isolationLevel = isolationLevel;
+		}
+
+		public Settings(ShaclSailConnection connection) {
+
+			TransactionSetting[] transactionSettingsRaw = connection.transactionSettingsRaw;
+			assert transactionSettingsRaw != null;
+
+			ValidationApproach validationApproach = null;
+			Boolean cacheSelectedNodes = null;
+			Boolean parallelValidation = null;
+
+			for (TransactionSetting transactionSetting : transactionSettingsRaw) {
+				if (transactionSetting instanceof ValidationApproach) {
+					validationApproach = (ValidationApproach) transactionSetting;
+				} else if (transactionSetting instanceof ShaclSail.TransactionSettings.PerformanceHint) {
+					switch (((ShaclSail.TransactionSettings.PerformanceHint) transactionSetting)) {
+					case ParallelValidation:
+						parallelValidation = true;
+						break;
+					case SerialValidation:
+						parallelValidation = false;
+						break;
+					case CacheDisabled:
+						cacheSelectedNodes = false;
+						break;
+					case CacheEnabled:
+						cacheSelectedNodes = true;
+						break;
+					}
+
+				}
+			}
+
+			this.validationApproach = validationApproach;
+			this.cacheSelectedNodes = cacheSelectedNodes;
+
+			if (!connection.supportsConcurrentReads()) {
+				this.parallelValidation = false;
+			} else {
+				this.parallelValidation = parallelValidation;
+			}
+		}
+
+		private Settings(Settings settings) {
+			this.validationApproach = settings.validationApproach;
+			this.cacheSelectedNodes = settings.cacheSelectedNodes;
+			this.parallelValidation = settings.parallelValidation;
+			this.isolationLevel = settings.isolationLevel;
+			this.previous = settings.previous;
 		}
 
 		public ValidationApproach getValidationApproach() {
@@ -980,6 +1009,9 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		}
 
 		void applyTransactionSettings(Settings transactionSettingsLocal) {
+
+			previous = new Settings(this);
+
 			// get the most significant validation approach first (eg. if validation is disabled on the sail level, then
 			// validation can not be enabled on the transaction level
 			validationApproach = getMostSignificantValidationApproach(validationApproach,
@@ -1002,14 +1034,6 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 			assert transactionSettingsLocal.isolationLevel == null;
 
-			if (isolationLevel == IsolationLevels.SERIALIZABLE) {
-				if (parallelValidation) {
-					logger.warn("Parallel validation is not compatible with SERIALIZABLE isolation level!");
-				}
-
-				parallelValidation = false;
-			}
-
 		}
 
 		@Override
@@ -1031,6 +1055,22 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 				parallelValidation = false;
 				cacheSelectedNodes = false;
 			}
+		}
+
+		private void setValidationApproach(ValidationApproach validationApproach) {
+			this.validationApproach = validationApproach;
+		}
+
+		private void setCacheSelectedNodes(Boolean cacheSelectedNodes) {
+			this.cacheSelectedNodes = cacheSelectedNodes;
+		}
+
+		private void setParallelValidation(Boolean parallelValidation) {
+			this.parallelValidation = parallelValidation;
+		}
+
+		private void setIsolationLevel(IsolationLevel isolationLevel) {
+			this.isolationLevel = isolationLevel;
 		}
 	}
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionValidationLimitTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TransactionValidationLimitTest.java
@@ -99,8 +99,10 @@ public class TransactionValidationLimitTest {
 			assertEquals(ShaclSail.TransactionSettings.ValidationApproach.Bulk,
 					shaclSailConnection.getTransactionSettings().getValidationApproach(),
 					"We have added more than 3 statements so the validation approach should have switched to Bulk.");
+
 			assertFalse(shaclSailConnection.getTransactionSettings().isCacheSelectNodes(),
 					"Bulk validation should by default disable caching select nodes.");
+
 			assertFalse(shaclSailConnection.getTransactionSettings().isParallelValidation(),
 					"Bulk validation should by default disable parallel validation.");
 


### PR DESCRIPTION
GitHub issue resolved: #2874 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - an interface with a single method to signal support
 - implemented in the MemoryStore and NativeStore, wrapper connections and the ShaclSail
 - no tests planned for this at the moment

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

