### PR TITLE
GH-3483: wrap up the use of FederationEvalStrategy per query

### DIFF
--- a/site/content/release-notes/4.0.0.md
+++ b/site/content/release-notes/4.0.0.md
@@ -221,6 +221,8 @@ Use `FedXFactory#withFederationEvaluationStrategyFactory` instead to supply a `F
 
 Removed support for defining the `writeStrategyFactory` through `FedXConfig`. Use `FedXFactory#withWriteStrategyFactory` instead.
 
+Removed deprecated support for specifying `fedxConfig` as a location in `FedXConfig`. Use `FedXConfig#setConfig` instead.
+
 ## Acknowledgements
 
 This release was made possible by contributions from Andreas Schwarte, Florian

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationManager.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/FederationManager.java
@@ -100,7 +100,7 @@ public class FederationManager {
 	 * @return the initialized and configured {@link FederationEvaluationStrategyFactory}
 	 */
 	/* package */ FederationEvaluationStrategyFactory getFederationEvaluationStrategyFactory() {
-		FederationEvaluationStrategyFactory strategyFactory = new FederationEvaluationStrategyFactory();
+		FederationEvaluationStrategyFactory strategyFactory = federation.getFederationEvaluationStrategyFactory();
 		strategyFactory.setFederationType(federationType);
 		strategyFactory.setFederationContext(federationContext);
 		return strategyFactory;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfig.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryConfig.java
@@ -90,12 +90,6 @@ public class FedXRepositoryConfig extends AbstractRepositoryImplConfig {
 	public static final IRI MEMBER = vf.createIRI(NAMESPACE, "member");
 
 	/**
-	 * the location of the fedx configuration
-	 */
-	@Deprecated
-	private String fedxConfig;
-
-	/**
 	 * the location of the data configuration
 	 */
 	private String dataConfig;
@@ -119,25 +113,6 @@ public class FedXRepositoryConfig extends AbstractRepositoryImplConfig {
 
 	public FedXRepositoryConfig() {
 		super(FedXRepositoryFactory.REPOSITORY_TYPE);
-	}
-
-	/**
-	 * @return the location of the FedX configuration
-	 * @deprecated use {@link #getConfig()}, scheduled for removal in 4.0
-	 */
-	@Deprecated
-	public String getFedxConfig() {
-		return fedxConfig;
-	}
-
-	/**
-	 * Set the location of the FedX configuration
-	 * 
-	 * @deprecated use {@link #setConfig(FedXConfig)}, scheduled for removal in 4.0
-	 */
-	@Deprecated
-	public void setFedxConfig(String fedxConfig) {
-		this.fedxConfig = fedxConfig;
 	}
 
 	public String getDataConfig() {
@@ -192,9 +167,9 @@ public class FedXRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.validate();
 
 		if (getMembers() == null) {
-			if (getDataConfig() == null && getFedxConfig() == null) {
+			if (getDataConfig() == null) {
 				throw new RepositoryConfigException(
-						"At least one of fedxConfig or dataConfig needs to be "
+						"DataConfig needs to be "
 								+ "provided to initialize the federation, if no explicit members are defined");
 			}
 		}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryWrapper.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/repository/FedXRepositoryWrapper.java
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
  * @see FedXFactory
  *
  */
-/* package */ class FedXRepositoryWrapper extends RepositoryWrapper
+public class FedXRepositoryWrapper extends RepositoryWrapper
 		implements RepositoryResolverClient, FederatedServiceResolverClient {
 
 	private final FedXRepositoryConfig fedXConfig;
@@ -46,7 +46,7 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 
 	private FederatedServiceResolver serviceResolver;
 
-	/* package */ FedXRepositoryWrapper(FedXRepositoryConfig fedXConfig) {
+	public FedXRepositoryWrapper(FedXRepositoryConfig fedXConfig) {
 		super();
 		this.fedXConfig = fedXConfig;
 	}
@@ -76,6 +76,26 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 			return;
 		}
 
+		FedXRepository fedxRepo;
+		try {
+			FedXFactory factory = createFactory();
+
+			fedxRepo = factory.create();
+
+			fedxRepo.init();
+		} catch (Exception e) {
+			throw new RepositoryException(e);
+		}
+		setDelegate(fedxRepo);
+	}
+
+	/**
+	 * Create the initialized {@link FedXFactory}
+	 * 
+	 * @return
+	 */
+	protected FedXFactory createFactory() {
+
 		File baseDir = getDataDir();
 		if (baseDir == null) {
 			baseDir = new File(".");
@@ -95,33 +115,25 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 					"No federation members defined: neither explicitly nor via data config.");
 		}
 
-		FedXRepository fedxRepo;
-		try {
-			// apply a repository resolver (if any) set from RepositoryManager
-			FedXFactory factory = FedXFactory.newFederation()
-					.withRepositoryResolver(repositoryResolver)
-					.withFederatedServiceResolver(serviceResolver)
-					.withFedXBaseDir(baseDir);
+		// apply a repository resolver (if any) set from RepositoryManager
+		FedXFactory factory = FedXFactory.newFederation()
+				.withRepositoryResolver(repositoryResolver)
+				.withFederatedServiceResolver(serviceResolver)
+				.withFedXBaseDir(baseDir);
 
-			if (dataConfigFile != null) {
-				factory.withMembers(dataConfigFile);
-			}
-
-			if (members != null) {
-				factory.withMembers(members);
-			}
-
-			if (fedXConfig.getConfig() != null) {
-				factory.withConfig(fedXConfig.getConfig());
-			}
-
-			fedxRepo = factory.create();
-
-			fedxRepo.init();
-		} catch (Exception e) {
-			throw new RepositoryException(e);
+		if (dataConfigFile != null) {
+			factory.withMembers(dataConfigFile);
 		}
-		setDelegate(fedxRepo);
+
+		if (members != null) {
+			factory.withMembers(members);
+		}
+
+		if (fedXConfig.getConfig() != null) {
+			factory.withConfig(fedXConfig.getConfig());
+		}
+
+		return factory;
 	}
 
 	@Override


### PR DESCRIPTION
GitHub issue resolved: #3483 

- remove deprecate FedXConfig#setFedXConfig (to specify a location)
- fix use of supplied strategy factory in FederationManager (we need to
use the factory that is available in the federation instead of creating
a new one)
- refine FedXRepositoryWrapper for slightly better extensibility
(use-case: support fine-tuning the FedXFactory without requiring to
overwrite the entire file. Note that this is now required because the
evaluationstrategy can no longer be influenced through the FedXConfig)


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

