### PR TITLE
GH-3557 add parse overloads for supplying custom ParserConfig

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLServiceEvaluationTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLServiceEvaluationTest.java
@@ -55,7 +55,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
@@ -555,7 +554,6 @@ public class SPARQLServiceEvaluationTest extends TestCase {
 		RDFFormat rdfFormat = Rio.getParserFormatForFileName(resultFile).orElseThrow(Rio.unsupportedFormat(resultFile));
 
 		RDFParser parser = Rio.createParser(rdfFormat);
-		parser.setDatatypeHandling(DatatypeHandling.IGNORE);
 		parser.setPreserveBNodeIDs(true);
 		parser.setValueFactory(SimpleValueFactory.getInstance());
 

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/ParserConfig.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/ParserConfig.java
@@ -12,10 +12,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
-import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
-import org.eclipse.rdf4j.rio.helpers.TriXParserSettings;
 
 /**
  * A container object for easy setting and passing of {@link RDFParser} configuration options.
@@ -36,50 +33,6 @@ public class ParserConfig extends RioConfig implements Serializable {
 	 */
 	public ParserConfig() {
 		super();
-	}
-
-	/**
-	 * Creates a ParserConfig object with the supplied config settings.
-	 *
-	 * @deprecated Use {@link ParserConfig#ParserConfig()} instead and set preserveBNodeIDs using
-	 *             {@link #set(RioSetting, Object)} with {@link BasicParserSettings#PRESERVE_BNODE_IDS}.
-	 *             <p>
-	 *             The other parameters are all deprecated and this constructor may be removed in a future release.
-	 *             <p>
-	 *             This constructor calls #setNonFatalErrors using a best-effort algorithm that may not match the exact
-	 *             semantics of the pre-2.7 constructor.
-	 */
-	@Deprecated
-	public ParserConfig(boolean verifyData, boolean stopAtFirstError, boolean preserveBNodeIDs,
-			DatatypeHandling datatypeHandling) {
-		this();
-
-		this.set(BasicParserSettings.PRESERVE_BNODE_IDS, preserveBNodeIDs);
-
-		// If they wanted to stop at the first error, then all optional errors are
-		// fatal, which is the default.
-		// We only attempt to map the parameters for cases where they wanted the
-		// parser to attempt to recover.
-		if (!stopAtFirstError) {
-			Set<RioSetting<?>> nonFatalErrors = new HashSet<>();
-			nonFatalErrors.add(TriXParserSettings.FAIL_ON_INVALID_STATEMENT);
-			nonFatalErrors.add(TriXParserSettings.FAIL_ON_MISSING_DATATYPE);
-			nonFatalErrors.add(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
-			if (verifyData) {
-				nonFatalErrors.add(BasicParserSettings.VERIFY_RELATIVE_URIS);
-				if (datatypeHandling == DatatypeHandling.IGNORE) {
-					nonFatalErrors.add(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES);
-					nonFatalErrors.add(BasicParserSettings.VERIFY_DATATYPE_VALUES);
-					nonFatalErrors.add(BasicParserSettings.NORMALIZE_DATATYPE_VALUES);
-				} else if (datatypeHandling == DatatypeHandling.VERIFY) {
-					nonFatalErrors.add(BasicParserSettings.NORMALIZE_DATATYPE_VALUES);
-				} else {
-					// For DatatypeHandling.NORMALIZE, all three datatype settings
-					// are fatal.
-				}
-			}
-			setNonFatalErrors(nonFatalErrors);
-		}
 	}
 
 	/**
@@ -144,24 +97,6 @@ public class ParserConfig extends RioConfig implements Serializable {
 	}
 
 	/**
-	 * @deprecated All non-fatal verification errors must be specified using {@link #addNonFatalError(RioSetting)} and
-	 *             checked using {@link #isNonFatalError(RioSetting)}.
-	 */
-	@Deprecated
-	public boolean verifyData() {
-		return get(BasicParserSettings.VERIFY_RELATIVE_URIS);
-	}
-
-	/**
-	 * @deprecated All non-fatal errors must be specified using {@link #setNonFatalErrors(Set)} or
-	 *             {@link #addNonFatalError(RioSetting)} and checked using {@link #isNonFatalError(RioSetting)}.
-	 */
-	@Deprecated
-	public boolean stopAtFirstError() {
-		return getNonFatalErrors().isEmpty();
-	}
-
-	/**
 	 * This method is preserved for backwards compatibility.
 	 * <p>
 	 * Code should be gradually migrated to use {@link BasicParserSettings#PRESERVE_BNODE_IDS}.
@@ -170,18 +105,6 @@ public class ParserConfig extends RioConfig implements Serializable {
 	 */
 	public boolean isPreserveBNodeIDs() {
 		return this.get(BasicParserSettings.PRESERVE_BNODE_IDS);
-	}
-
-	/**
-	 * @deprecated Datatype handling is now split across {@link BasicParserSettings#VERIFY_DATATYPE_VALUES},
-	 *             {@link BasicParserSettings#FAIL_ON_UNKNOWN_DATATYPES} and
-	 *             {@link BasicParserSettings#NORMALIZE_DATATYPE_VALUES}.
-	 *             <p>
-	 *             This method will be removed in a future release.
-	 */
-	@Deprecated
-	public DatatypeHandling datatypeHandling() {
-		throw new RuntimeException("This method is not supported anymore.");
 	}
 
 	@Override

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFParser.java
@@ -13,37 +13,12 @@ import java.io.Reader;
 import java.util.Collection;
 
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 
 /**
  * An interface for RDF parsers. All implementing classes should define a public zero-argument constructor to allow them
  * to be created through reflection.
  */
 public interface RDFParser {
-
-	/**
-	 * @deprecated These settings are not recognised and will be removed in a future version. Use
-	 *             {@link BasicParserSettings#FAIL_ON_UNKNOWN_DATATYPES}
-	 *             {@link BasicParserSettings#NORMALIZE_DATATYPE_VALUES} and
-	 *             {@link BasicParserSettings#VERIFY_DATATYPE_VALUES} instead.
-	 */
-	@Deprecated
-	enum DatatypeHandling {
-		/**
-		 * Indicates that datatype semantics should be ignored.
-		 */
-		IGNORE,
-
-		/**
-		 * Indicates that values of datatyped literals should be verified.
-		 */
-		VERIFY,
-
-		/**
-		 * Indicates that values of datatyped literals should be normalized to their canonical representation.
-		 */
-		NORMALIZE
-	}
 
 	/**
 	 * Gets the RDF format that this parser can parse.
@@ -113,44 +88,9 @@ public interface RDFParser {
 	<T> RDFParser set(RioSetting<T> setting, T value);
 
 	/**
-	 * Sets whether the parser should verify the data it parses (default value is <var>true</var>).
-	 *
-	 * @deprecated since 2.0. Use {@link #getParserConfig()} with {@link BasicParserSettings#FAIL_ON_UNKNOWN_DATATYPES},
-	 *             {@link BasicParserSettings#VERIFY_DATATYPE_VALUES}, and/or
-	 *             {@link BasicParserSettings#NORMALIZE_DATATYPE_VALUES} instead.
-	 */
-	@Deprecated
-	void setVerifyData(boolean verifyData);
-
-	/**
 	 * Set whether the parser should preserve bnode identifiers specified in the source (default is <var>false</var>).
 	 */
 	void setPreserveBNodeIDs(boolean preserveBNodeIDs);
-
-	/**
-	 * Sets whether the parser should stop immediately if it finds an error in the data (default value is
-	 * <var>true</var>).
-	 *
-	 * @deprecated since 2.0. Use {@link #getParserConfig()} with {@link ParserConfig#addNonFatalError(RioSetting)} to
-	 *             select which errors will not always fail the parse prematurely.
-	 */
-	@Deprecated
-	void setStopAtFirstError(boolean stopAtFirstError);
-
-	/**
-	 * Sets the datatype handling mode. There are three modes for handling datatyped literals: <em>ignore</em> ,
-	 * <em>verify</em>and <em>normalize</em> . If set to <em>ignore</em>, no special action will be taken to handle
-	 * datatyped literals. If set to <em>verify</em>, any literals with known (XML Schema built-in) datatypes are
-	 * checked to see if their values are valid. If set to <em>normalize</em>, the literal values are not only checked,
-	 * but also normalized to their canonical representation. The default value is <em>verify</em>.
-	 *
-	 * @param datatypeHandling A datatype handling option.
-	 * @deprecated since 2.0. Use {@link #getParserConfig()} with {@link BasicParserSettings#FAIL_ON_UNKNOWN_DATATYPES},
-	 *             {@link BasicParserSettings#VERIFY_DATATYPE_VALUES}, and/or
-	 *             {@link BasicParserSettings#NORMALIZE_DATATYPE_VALUES} instead.
-	 */
-	@Deprecated
-	void setDatatypeHandling(DatatypeHandling datatypeHandling);
 
 	/**
 	 * Parses the data from the supplied InputStream.

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/Rio.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/Rio.java
@@ -220,6 +220,29 @@ public class Rio {
 	 * Adds RDF data from an {@link InputStream} to a {@link Model}, optionally to one or more named contexts.
 	 *
 	 * @param in         An InputStream from which RDF data can be read.
+	 * @param dataFormat The serialization format of the data.
+	 * @param settings   The {@link ParserConfig} containing settings for configuring the parser.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are supplied the method ignores
+	 *                   contextual information in the actual data. If no contexts are supplied the contextual
+	 *                   information in the input stream is used, if no context information is available the data is
+	 *                   added without any context.
+	 * @return A {@link Model} containing the parsed statements.
+	 * @throws IOException                  If an I/O error occurred while reading from the input stream.
+	 * @throws UnsupportedRDFormatException If no {@link RDFParser} is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * 
+	 * @since 4.0.0
+	 */
+	public static Model parse(InputStream in, RDFFormat dataFormat, ParserConfig settings, Resource... contexts)
+			throws IOException, RDFParseException, UnsupportedRDFormatException {
+		return parse(in, null, dataFormat, settings, SimpleValueFactory.getInstance(),
+				new ParseErrorLogger(), contexts);
+	}
+
+	/**
+	 * Adds RDF data from an {@link InputStream} to a {@link Model}, optionally to one or more named contexts.
+	 *
+	 * @param in         An InputStream from which RDF data can be read.
 	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against. May be
 	 *                   <code>null</code>.
 	 * @param dataFormat The serialization format of the data.
@@ -235,6 +258,32 @@ public class Rio {
 	public static Model parse(InputStream in, String baseURI, RDFFormat dataFormat, Resource... contexts)
 			throws IOException, RDFParseException, UnsupportedRDFormatException {
 		return parse(in, baseURI, dataFormat, new ParserConfig(), SimpleValueFactory.getInstance(),
+				new ParseErrorLogger(), contexts);
+	}
+
+	/**
+	 * Adds RDF data from an {@link InputStream} to a {@link Model}, optionally to one or more named contexts.
+	 *
+	 * @param in         An InputStream from which RDF data can be read.
+	 * @param baseURI    The base URI to resolve any relative URIs that are in the data against. May be
+	 *                   <code>null</code>.
+	 * @param dataFormat The serialization format of the data.
+	 * @param settings   The {@link ParserConfig} containing settings for configuring the parser.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are supplied the method ignores
+	 *                   contextual information in the actual data. If no contexts are supplied the contextual
+	 *                   information in the input stream is used, if no context information is available the data is
+	 *                   added without any context.
+	 * @return A {@link Model} containing the parsed statements.
+	 * @throws IOException                  If an I/O error occurred while reading from the input stream.
+	 * @throws UnsupportedRDFormatException If no {@link RDFParser} is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * 
+	 * @since 4.0.0
+	 */
+	public static Model parse(InputStream in, String baseURI, RDFFormat dataFormat, ParserConfig settings,
+			Resource... contexts)
+			throws IOException, RDFParseException, UnsupportedRDFormatException {
+		return parse(in, baseURI, dataFormat, settings, SimpleValueFactory.getInstance(),
 				new ParseErrorLogger(), contexts);
 	}
 
@@ -320,6 +369,30 @@ public class Rio {
 	public static Model parse(Reader reader, RDFFormat dataFormat, Resource... contexts)
 			throws IOException, RDFParseException, UnsupportedRDFormatException {
 		return parse(reader, null, dataFormat, new ParserConfig(), SimpleValueFactory.getInstance(),
+				new ParseErrorLogger(), contexts);
+	}
+
+	/**
+	 * Adds RDF data from a {@link Reader} to a {@link Model}, optionally to one or more named contexts. <b>Note: using
+	 * a Reader to upload byte-based data means that you have to be careful not to destroy the data's character encoding
+	 * by enforcing a default character encoding upon the bytes. If possible, adding such data using an InputStream is
+	 * to be preferred.</b>
+	 *
+	 * @param reader     A Reader from which RDF data can be read.
+	 * @param dataFormat The serialization format of the data.
+	 * @param settings   The {@link ParserConfig} containing settings for configuring the parser.
+	 * @param contexts   The contexts to add the data to. If one or more contexts are specified the data is added to
+	 *                   these contexts, ignoring any context information in the data itself.
+	 * @return A {@link Model} containing the parsed statements.
+	 * @throws IOException                  If an I/O error occurred while reading from the reader.
+	 * @throws UnsupportedRDFormatException If no {@link RDFParser} is available for the specified RDF format.
+	 * @throws RDFParseException            If an error was found while parsing the RDF data.
+	 * 
+	 * @since 4.0.0
+	 */
+	public static Model parse(Reader reader, RDFFormat dataFormat, ParserConfig settings, Resource... contexts)
+			throws IOException, RDFParseException, UnsupportedRDFormatException {
+		return parse(reader, null, dataFormat, settings, SimpleValueFactory.getInstance(),
 				new ParseErrorLogger(), contexts);
 	}
 

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -230,14 +230,6 @@ public abstract class AbstractRDFParser implements RDFParser {
 		this.parserConfig.set(BasicParserSettings.VERIFY_RELATIVE_URIS, verifyData);
 	}
 
-	/**
-	 * @deprecated Use specific settings instead.
-	 */
-	@Deprecated
-	public boolean verifyData() {
-		return this.parserConfig.verifyData();
-	}
-
 	@Override
 	public void setPreserveBNodeIDs(boolean preserveBNodeIDs) {
 		this.parserConfig.set(BasicParserSettings.PRESERVE_BNODE_IDS, preserveBNodeIDs);
@@ -260,14 +252,6 @@ public abstract class AbstractRDFParser implements RDFParser {
 			set.remove(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
 			getParserConfig().setNonFatalErrors(set);
 		}
-	}
-
-	/**
-	 * @deprecated Check specific settings instead.
-	 */
-	@Deprecated
-	public boolean stopAtFirstError() {
-		return this.parserConfig.stopAtFirstError();
 	}
 
 	@SuppressWarnings("deprecation")

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -15,7 +15,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
@@ -226,55 +225,12 @@ public abstract class AbstractRDFParser implements RDFParser {
 	}
 
 	@Override
-	public void setVerifyData(boolean verifyData) {
-		this.parserConfig.set(BasicParserSettings.VERIFY_RELATIVE_URIS, verifyData);
-	}
-
-	@Override
 	public void setPreserveBNodeIDs(boolean preserveBNodeIDs) {
 		this.parserConfig.set(BasicParserSettings.PRESERVE_BNODE_IDS, preserveBNodeIDs);
 	}
 
 	public boolean preserveBNodeIDs() {
 		return this.parserConfig.get(BasicParserSettings.PRESERVE_BNODE_IDS);
-	}
-
-	@Deprecated
-	@Override
-	public void setStopAtFirstError(boolean stopAtFirstError) {
-		getParserConfig().set(NTriplesParserSettings.FAIL_ON_INVALID_LINES, stopAtFirstError);
-		if (!stopAtFirstError) {
-			getParserConfig().addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
-		} else {
-			// TODO: Add a ParserConfig.removeNonFatalError function to avoid
-			// this
-			Set<RioSetting<?>> set = new HashSet<>(getParserConfig().getNonFatalErrors());
-			set.remove(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
-			getParserConfig().setNonFatalErrors(set);
-		}
-	}
-
-	@SuppressWarnings("deprecation")
-	@Override
-	public void setDatatypeHandling(DatatypeHandling datatypeHandling) {
-		if (datatypeHandling == DatatypeHandling.VERIFY) {
-			this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
-			this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
-		} else if (datatypeHandling == DatatypeHandling.NORMALIZE) {
-			this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
-			this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, true);
-			this.parserConfig.set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, true);
-		} else {
-			// Only ignore if they have not explicitly set any of the relevant
-			// settings before this point
-			if (!this.parserConfig.isSet(BasicParserSettings.NORMALIZE_DATATYPE_VALUES)
-					&& !this.parserConfig.isSet(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES)
-					&& !this.parserConfig.isSet(BasicParserSettings.NORMALIZE_DATATYPE_VALUES)) {
-				this.parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, false);
-				this.parserConfig.set(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES, false);
-				this.parserConfig.set(BasicParserSettings.NORMALIZE_DATATYPE_VALUES, false);
-			}
-		}
 	}
 
 	/**

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/ParserConfigTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/ParserConfigTest.java
@@ -15,9 +15,7 @@ import static org.junit.Assert.fail;
 import java.util.Collections;
 import java.util.HashSet;
 
-import org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
-import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -59,36 +57,6 @@ public class ParserConfigTest {
 		// values
 		assertFalse(testConfig.get(BasicParserSettings.PRESERVE_BNODE_IDS));
 		assertFalse(testConfig.isPreserveBNodeIDs());
-	}
-
-	/**
-	 * Test that the explicit constructor sets all of the basic settings using the default values.
-	 */
-	@Test
-	public final void testParserConfigSameAsDefaults() {
-		ParserConfig testConfig = new ParserConfig(true, true, false, DatatypeHandling.VERIFY);
-
-		// check that the basic settings are explicitly set
-		assertTrue(testConfig.isSet(BasicParserSettings.PRESERVE_BNODE_IDS));
-
-		// check that the basic settings all return their expected default values
-		assertFalse(testConfig.get(BasicParserSettings.PRESERVE_BNODE_IDS));
-		assertFalse(testConfig.isPreserveBNodeIDs());
-	}
-
-	/**
-	 * Test that the explicit constructor sets all of the basic settings using non-default values.
-	 */
-	@Test
-	public final void testParserConfigNonDefaults() {
-		ParserConfig testConfig = new ParserConfig(false, false, true, DatatypeHandling.IGNORE);
-
-		// check that the basic settings are explicitly set
-		assertTrue(testConfig.isSet(BasicParserSettings.PRESERVE_BNODE_IDS));
-
-		// check that the basic settings all return their set values
-		assertTrue(testConfig.get(BasicParserSettings.PRESERVE_BNODE_IDS));
-		assertTrue(testConfig.isPreserveBNodeIDs());
 	}
 
 	/**
@@ -195,34 +163,6 @@ public class ParserConfigTest {
 		testConfig.addNonFatalError(BasicParserSettings.PRESERVE_BNODE_IDS);
 
 		assertFalse(testConfig.getNonFatalErrors().isEmpty());
-	}
-
-	/**
-	 * Test method for {@link org.eclipse.rdf4j.rio.ParserConfig#verifyData()}.
-	 */
-	@Test
-	public final void testVerifyData() {
-		ParserConfig testConfig = new ParserConfig();
-
-		assertTrue(testConfig.verifyData());
-
-		testConfig.set(BasicParserSettings.VERIFY_RELATIVE_URIS, false);
-
-		assertFalse(testConfig.verifyData());
-	}
-
-	/**
-	 * Test method for {@link org.eclipse.rdf4j.rio.ParserConfig#stopAtFirstError()}. Test specifically for SES-1947
-	 */
-	@Test
-	public final void testStopAtFirstError() {
-		ParserConfig testConfig = new ParserConfig();
-
-		assertTrue(testConfig.stopAtFirstError());
-
-		testConfig.addNonFatalError(NTriplesParserSettings.FAIL_ON_INVALID_LINES);
-
-		assertFalse(testConfig.stopAtFirstError());
 	}
 
 	/**

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RioTest {
+
+	private static final InputStream testInputStream = new ByteArrayInputStream("test data".getBytes());
+
+	private static final Reader testReader = new StringReader("test data");
+
+	private static final RDFFormat TEST_FORMAT = new RDFFormat(
+			"TestFormat", "text/test", StandardCharsets.UTF_8, "test", false, false, false
+	);
+
+	private RDFParser mockParser;
+
+	@BeforeEach
+	public void setUp() {
+		mockParser = mock(RDFParser.class);
+		RDFParserRegistry.getInstance().add(new RDFParserFactory() {
+			@Override
+			public RDFFormat getRDFFormat() {
+				return TEST_FORMAT;
+			}
+
+			@Override
+			public RDFParser getParser() {
+				return mockParser;
+			}
+		});
+	}
+
+	@Test
+	public void parseInputStream_DefaultSettings() throws Exception {
+		Rio.parse(testInputStream, TEST_FORMAT);
+
+		verify(mockParser).setRDFHandler(any(ContextStatementCollector.class));
+		verify(mockParser).parse(testInputStream, null);
+	}
+
+	@Test
+	public void parseInputStream_BaseURI() throws Exception {
+		String baseURI = "test:baseURI";
+		Rio.parse(testInputStream, baseURI, TEST_FORMAT);
+
+		verify(mockParser).parse(testInputStream, baseURI);
+	}
+
+	@Test
+	public void parseInputStream_CustomConfig() throws Exception {
+		ParserConfig config = new ParserConfig();
+		Rio.parse(testInputStream, TEST_FORMAT, config);
+
+		verify(mockParser).setParserConfig(config);
+		verify(mockParser).parse(testInputStream, null);
+	}
+
+	@Test
+	public void parseReader_DefaultSettings() throws Exception {
+		Rio.parse(testReader, TEST_FORMAT);
+
+		verify(mockParser).setRDFHandler(any(ContextStatementCollector.class));
+		verify(mockParser).parse(testReader, null);
+	}
+
+	@Test
+	public void parseReader_CustomConfig() throws Exception {
+		ParserConfig config = new ParserConfig();
+		Rio.parse(testReader, TEST_FORMAT, config);
+
+		verify(mockParser).setParserConfig(config);
+		verify(mockParser).parse(testReader, null);
+	}
+
+	@Test
+	public void createParser_existing() throws Exception {
+		RDFParser parser = Rio.createParser(TEST_FORMAT);
+		assertThat(parser).isEqualTo(mockParser);
+	}
+
+	public void createParser_unknown() throws Exception {
+		RDFFormat unknownFormat = new RDFFormat("unknown", "test/unknown", StandardCharsets.UTF_8, "unknown", false,
+				false,
+				false);
+		assertThatExceptionOfType(UnsupportedRDFormatException.class).isThrownBy(() -> Rio.createParser(unknownFormat));
+	}
+}

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -47,7 +47,6 @@ public abstract class AbstractNTriplesParserUnitTest {
 	@Test
 	public void testNTriplesFile() throws Exception {
 		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
 		Model model = new LinkedHashModel();
 		ntriplesParser.setRDFHandler(new StatementCollector(model));
 
@@ -68,7 +67,6 @@ public abstract class AbstractNTriplesParserUnitTest {
 		String data = "invalid nt";
 
 		RDFParser ntriplesParser = createRDFParser();
-		ntriplesParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
 		Model model = new LinkedHashModel();
 		ntriplesParser.setRDFHandler(new StatementCollector(model));
 

--- a/site/content/release-notes/4.0.0.md
+++ b/site/content/release-notes/4.0.0.md
@@ -16,7 +16,7 @@ RDF4J 4.0.0 is a major release of the Eclipse RDF4J framework. Some highlights:
 
 For a complete overview, see [all issues fixed in 4.0.0](https://github.com/eclipse/rdf4j/milestone/30?closed=1).
 
-## Upgrade notes 
+## Upgrade notes
 
 RDF4J 4.0.0 contains several [backward incompatible
 changes](https://github.com/eclipse/rdf4j/issues?q=is%3Aclosed+is%3Aissue+label%3A%22%E2%9B%94+Not+backwards+compatible%22+milestone%3A%224.0.0%22), including removal of several deprecated modules and classes.
@@ -68,9 +68,9 @@ Both options may require shutting down the application(s) using the indexed data
 
 The RDF4J SDK contains both the `lucene-core` and `lucene-backwards-codec` jars.
 
-### Lucene default SearchIndex implementation renamed 
+### Lucene default SearchIndex implementation renamed
 
-The default Lucene `SearchIndex` implementation has been renamed. Prevously, it was `org.eclipse.rdf4j.sail.lucene.LuceneIndex`. The new name is `org.eclipse.rdf4j.sail.lucene.impl.LuceneIndex`. 
+The default Lucene `SearchIndex` implementation has been renamed. Prevously, it was `org.eclipse.rdf4j.sail.lucene.LuceneIndex`. The new name is `org.eclipse.rdf4j.sail.lucene.impl.LuceneIndex`.
 
 ### Solr client libraries upgraded
 
@@ -95,7 +95,7 @@ The `rdf4j-util` module has been split up into 8 separate modules, to allow for 
 - `rdf4j-common-util` contains generically applicable base classes and interfaces.
 - `rdf4j-common-xml` contains base functionality and some utility functions for working with XML.
 
-Projects that _directly_ depended on the `rdf4j-util` module will need to change their dependencies to more precisely figure out which of these new 'common' modules to use. 
+Projects that _directly_ depended on the `rdf4j-util` module will need to change their dependencies to more precisely figure out which of these new 'common' modules to use.
 
 ### `org.eclipse.rdf4j.RDF4JException` moved to `org.eclipse.rdf4j.common.exception.RDF4JException`
 
@@ -156,6 +156,19 @@ The following deprecated settings were removed from `org.eclipse.rdf4j.rio.helpe
 - `FAIL_ON_TRIX_MISSING_DATATYPE` (use `FAIL_ON_MISSING_DATATYPE` instead)
 - `FAIL_ON_TRIX_INVALID_STATEMENT` (use `FAIL_ON_INVALID_STATEMENT` instead)
 
+Several deprecated `ParserConfig` methods were removed:
+
+- `ParserConfig(boolean verifyData, boolean stopAtFirstError, boolean preserveBNodeIDs, DatatypeHandling datatypeHandling)`
+- `stopAtFirstError`
+- `verifyData`
+- `datatypeHandling`
+
+Several deprecated `RDFParser` methods were removed:
+
+- `setStopAtFirstError`
+- `setDatatypeHandling`
+- `setVerifyData`
+
 ### Removed deprecated utility methods
 
 The following methods were removed from `org.eclipse.rdf4j.common.io.FileUtil`
@@ -198,9 +211,9 @@ The `org.eclipse.rdf4j.common.platform.ProcessLauncher` class was removed.
 
 Removed support for `UndefinedTargetValidatesAllSubjects`, use the dash vocabulary instead.
 
-Removed support for `IgnoreNoShapesLoadedException`. 
+Removed support for `IgnoreNoShapesLoadedException`.
 
-Removed `org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation` system property because 
+Removed `org.eclipse.rdf4j.sail.shacl.experimentalSparqlValidation` system property because
 SPARQL based validation is now enabled by default. This can be disabled by setting
 `org.eclipse.rdf4j.sail.shacl.sparqlValidation` to false.
 

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/testsuite/rio/PositiveParserTest.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/testsuite/rio/PositiveParserTest.java
@@ -101,8 +101,6 @@ public class PositiveParserTest extends TestCase {
 
 		if (outputURL != null) {
 			// Parse expected output data
-			ntriplesParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
-
 			Set<Statement> outputCollection = new LinkedHashSet<>();
 			StatementCollector outputCollector = new StatementCollector(outputCollection);
 			ntriplesParser.setRDFHandler(outputCollector);

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/testsuite/rio/n3/N3ParserTestCase.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/testsuite/rio/n3/N3ParserTestCase.java
@@ -124,7 +124,6 @@ public abstract class N3ParserTestCase {
 		protected void runTest() throws Exception {
 			// Parse input data
 			RDFParser turtleParser = createRDFParser();
-			turtleParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
 
 			Set<Statement> inputCollection = new LinkedHashSet<>();
 			StatementCollector inputCollector = new StatementCollector(inputCollection);
@@ -136,7 +135,6 @@ public abstract class N3ParserTestCase {
 
 			// Parse expected output data
 			NTriplesParser ntriplesParser = new NTriplesParser();
-			ntriplesParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
 
 			Set<Statement> outputCollection = new LinkedHashSet<>();
 			StatementCollector outputCollector = new StatementCollector(outputCollection);
@@ -203,7 +201,6 @@ public abstract class N3ParserTestCase {
 				// Try parsing the input; this should result in an error being
 				// reported.
 				RDFParser turtleParser = createRDFParser();
-				turtleParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
 
 				turtleParser.setRDFHandler(new StatementCollector());
 

--- a/testsuites/rio/src/main/java/org/eclipse/rdf4j/testsuite/rio/rdfjson/RDFJSONParserTestCase.java
+++ b/testsuites/rio/src/main/java/org/eclipse/rdf4j/testsuite/rio/rdfjson/RDFJSONParserTestCase.java
@@ -191,7 +191,6 @@ public abstract class RDFJSONParserTestCase {
 		protected void runTest() throws Exception {
 			// Parse input data
 			RDFParser rdfjsonParser = createRDFParser();
-			rdfjsonParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
 
 			Set<Statement> inputCollection = new LinkedHashSet<>();
 			StatementCollector inputCollector = new StatementCollector(inputCollection);
@@ -203,7 +202,6 @@ public abstract class RDFJSONParserTestCase {
 
 			// Parse expected output data
 			NTriplesParser ntriplesParser = new NTriplesParser();
-			ntriplesParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
 
 			Set<Statement> outputCollection = new LinkedHashSet<>();
 			StatementCollector outputCollector = new StatementCollector(outputCollection);
@@ -271,7 +269,6 @@ public abstract class RDFJSONParserTestCase {
 				// Try parsing the input; this should result in an error being
 				// reported.
 				RDFParser rdfjsonParser = createRDFParser();
-				rdfjsonParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
 
 				rdfjsonParser.setRDFHandler(new StatementCollector());
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL10ManifestTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL10ManifestTest.java
@@ -140,10 +140,6 @@ public class SPARQL10ManifestTest {
 			RDFParser rdfParser = new TurtleParser();
 			rdfParser.setValueFactory(vf);
 
-			rdfParser.setVerifyData(false);
-			rdfParser.setStopAtFirstError(true);
-			rdfParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
-
 			RDFInserter rdfInserter = new RDFInserter(con);
 			rdfInserter.enforceContext(contexts);
 			rdfParser.setRDFHandler(rdfInserter);

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11ManifestTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11ManifestTest.java
@@ -210,10 +210,6 @@ public class SPARQL11ManifestTest {
 			RDFParser rdfParser = new TurtleParser();
 			rdfParser.setValueFactory(vf);
 
-			rdfParser.setVerifyData(false);
-			rdfParser.setStopAtFirstError(true);
-			rdfParser.setDatatypeHandling(RDFParser.DatatypeHandling.IGNORE);
-
 			RDFInserter rdfInserter = new RDFInserter(con);
 			rdfInserter.enforceContext(contexts);
 			rdfParser.setRDFHandler(rdfInserter);

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLComplianceTest.java
@@ -30,7 +30,6 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.util.RDFInserter;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling;
 import org.eclipse.rdf4j.rio.Rio;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -141,8 +140,6 @@ public abstract class SPARQLComplianceTest {
 			con.begin();
 			RDFFormat rdfFormat = Rio.getParserFormatForFileName(graphURI.toString()).orElse(RDFFormat.TURTLE);
 			RDFParser rdfParser = Rio.createParser(rdfFormat, getDataRepository().getValueFactory());
-			rdfParser.setVerifyData(false);
-			rdfParser.setDatatypeHandling(DatatypeHandling.IGNORE);
 			// rdfParser.setPreserveBNodeIDs(true);
 
 			RDFInserter rdfInserter = new RDFInserter(con);

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryComplianceTest.java
@@ -52,7 +52,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
@@ -222,7 +221,6 @@ public abstract class SPARQLQueryComplianceTest extends SPARQLComplianceTest {
 				.orElseThrow(Rio.unsupportedFormat(resultFileURL));
 
 		RDFParser parser = Rio.createParser(rdfFormat);
-		parser.setDatatypeHandling(DatatypeHandling.IGNORE);
 		parser.setPreserveBNodeIDs(true);
 		parser.setValueFactory(getDataRepository().getValueFactory());
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryTest.java
@@ -56,7 +56,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.util.RDFInserter;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
@@ -435,8 +434,6 @@ public abstract class SPARQLQueryTest extends TestCase {
 			con.begin();
 			RDFFormat rdfFormat = Rio.getParserFormatForFileName(graphURI.toString()).orElse(RDFFormat.TURTLE);
 			RDFParser rdfParser = Rio.createParser(rdfFormat, dataRep.getValueFactory());
-			rdfParser.setVerifyData(false);
-			rdfParser.setDatatypeHandling(DatatypeHandling.IGNORE);
 			// rdfParser.setPreserveBNodeIDs(true);
 
 			RDFInserter rdfInserter = new RDFInserter(con);
@@ -516,7 +513,6 @@ public abstract class SPARQLQueryTest extends TestCase {
 				.orElseThrow(Rio.unsupportedFormat(resultFileURL));
 
 		RDFParser parser = Rio.createParser(rdfFormat);
-		parser.setDatatypeHandling(DatatypeHandling.IGNORE);
 		parser.setPreserveBNodeIDs(true);
 		parser.setValueFactory(dataRep.getValueFactory());
 


### PR DESCRIPTION
GitHub issue resolved: #3557  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- add overloaded parse methods for supplying (only) custom parser config
- added some testing around the Rio util methods
- cleaned up some deprecated code

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

