### PR TITLE
GH-3677: added tests and convenience methods for literals

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/ValueFactory.java
@@ -94,6 +94,7 @@ public interface ValueFactory {
 	 * object must be <a href="http://www.w3.org/2001/XMLSchema#string">{@code xsd:string}</a>.
 	 *
 	 * @param label The literal's label, must not be <tt>null</tt>.
+	 * @return A literal for the specified value.
 	 */
 	Literal createLiteral(String label);
 
@@ -104,6 +105,7 @@ public interface ValueFactory {
 	 *
 	 * @param label    The literal's label, must not be <tt>null</tt>.
 	 * @param language The literal's language attribute, must not be <tt>null</tt>.
+	 * @return A literal for the specified value and language attribute.
 	 */
 	Literal createLiteral(String label, String language);
 
@@ -114,6 +116,7 @@ public interface ValueFactory {
 	 * @param datatype The literal's datatype. If it is null, the datatype
 	 *                 <a href="http://www.w3.org/2001/XMLSchema#string">{@code xsd:string}</a> will be assigned to this
 	 *                 literal.
+	 * @return A literal for the specified value and type.
 	 */
 	Literal createLiteral(String label, IRI datatype);
 
@@ -188,12 +191,18 @@ public interface ValueFactory {
 	Literal createLiteral(double value);
 
 	/**
-	 * Creates a new literal representing the specified bigDecimal that is typed as an <tt>xsd:Decimal</tt>.
+	 * Creates a new literal representing the specified bigDecimal that is typed as an <tt>xsd:decimal</tt>.
+	 * 
+	 * @param bigDecimal The value for the literal.
+	 * @return An <tt>xsd:decimal</tt>-typed literal for the specified value.
 	 */
 	Literal createLiteral(BigDecimal bigDecimal);
 
 	/**
-	 * Creates a new literal representing the specified bigInteger that is typed as an <tt>xsd:Integer</tt>.
+	 * Creates a new literal representing the specified bigInteger that is typed as an <tt>xsd:integer</tt>.
+	 * 
+	 * @param bigInteger The value for the literal.
+	 * @return An <tt>xsd:integer</tt>-typed literal for the specified value.
 	 */
 	Literal createLiteral(BigInteger bigInteger);
 
@@ -257,6 +266,9 @@ public interface ValueFactory {
 	/**
 	 * Creates a new literal representing the specified date that is typed using the appropriate XML Schema date/time
 	 * datatype.
+	 * 
+	 * @param date The value for the literal.
+	 * @return A typed literal for the specified date.
 	 */
 	Literal createLiteral(Date date);
 

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Values.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.model.util;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
 import java.util.Date;
 import java.util.Objects;
 
@@ -600,8 +601,9 @@ public class Values {
 	 * Creates a new typed {@link Literal} out of the supplied object, mapping the runtime type of the object to the
 	 * appropriate {@link XSD} datatype.
 	 * <p>
-	 * Recognized types are {@link Boolean}, {@link Byte}, {@link Double}, {@link Float}, {@link Integer}, {@link Long},
-	 * {@link Short}, {@link XMLGregorianCalendar } , {@link TemporalAccessor} and {@link Date}.
+	 * Recognized types are {@link Boolean}, {@link Byte}, {@link Double}, {@link Float}, {@link BigDecimal},
+	 * {@link Integer}, {@link BigInteger}, {@link Long}, {@link Short}, {@link XMLGregorianCalendar},
+	 * {@link TemporalAccessor}, {@link TemporalAmpount} and {@link Date}.
 	 *
 	 * @param object            an object to be converted to a typed literal.
 	 * @param failOnUnknownType If no mapping is available and <code>failOnUnknownType</code> is <code>false</code> the
@@ -762,8 +764,12 @@ public class Values {
 			return valueFactory.createLiteral(((Double) object).doubleValue());
 		} else if (object instanceof Float) {
 			return valueFactory.createLiteral(((Float) object).floatValue());
+		} else if (object instanceof BigDecimal) {
+			return valueFactory.createLiteral((BigDecimal) object);
 		} else if (object instanceof Integer) {
 			return valueFactory.createLiteral(((Integer) object).intValue());
+		} else if (object instanceof BigInteger) {
+			return valueFactory.createLiteral((BigInteger) object);
 		} else if (object instanceof Long) {
 			return valueFactory.createLiteral(((Long) object).longValue());
 		} else if (object instanceof Short) {
@@ -774,6 +780,8 @@ public class Values {
 			return valueFactory.createLiteral((Date) object);
 		} else if (object instanceof TemporalAccessor) {
 			return valueFactory.createLiteral((TemporalAccessor) object);
+		} else if (object instanceof TemporalAmount) {
+			return valueFactory.createLiteral((TemporalAmount) object);
 		} else if (object instanceof String) {
 			return valueFactory.createLiteral(object.toString(), XSD.STRING);
 		} else {

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
@@ -579,6 +580,15 @@ public class ValuesTest {
 	}
 
 	@Test
+	public void testLiteralObjectBigDecimal() throws Exception {
+		Object obj = BigDecimal.valueOf(42.1);
+		Literal l = literal(obj);
+		assertThat(l).isNotNull();
+		assertThat(l.getDatatype()).isEqualTo(XSD.DECIMAL);
+		assertThat(l.decimalValue().doubleValue()).isEqualTo(42.1);
+	}
+
+	@Test
 	public void testLiteralObjectInteger() throws Exception {
 		Object obj = Integer.valueOf(42);
 		Literal l = literal(obj);
@@ -588,12 +598,12 @@ public class ValuesTest {
 	}
 
 	@Test
-	public void testLiteralObjectLong() throws Exception {
-		Object obj = Long.valueOf(42l);
+	public void testLiteralObjectBigInteger() throws Exception {
+		Object obj = BigInteger.valueOf(42l);
 		Literal l = literal(obj);
 		assertThat(l).isNotNull();
-		assertThat(l.getDatatype()).isEqualTo(XSD.LONG);
-		assertThat(l.longValue()).isEqualTo(42l);
+		assertThat(l.getDatatype()).isEqualTo(XSD.INTEGER);
+		assertThat(l.integerValue()).isEqualTo(42l);
 	}
 
 	@Test
@@ -617,7 +627,6 @@ public class ValuesTest {
 		} catch (DatatypeConfigurationException e) {
 			fail("Could not instantiate javax.xml.datatype.DatatypeFactory");
 		}
-
 	}
 
 	@Test
@@ -626,6 +635,15 @@ public class ValuesTest {
 		Literal l = literal(obj);
 		assertThat(l).isNotNull();
 		assertThat(l.getDatatype()).isEqualTo(XSD.DATETIME);
+	}
+
+	@Test
+	public void testLiteralTemporalPeriod() throws Exception {
+		Object obj = Period.ofWeeks(42);
+		Literal l = literal(obj);
+		assertThat(l).isNotNull();
+		assertThat(l.getDatatype()).isEqualTo(XSD.DURATION);
+		assertThat(l.temporalAmountValue()).isEqualTo(Period.ofWeeks(42));
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #3677 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- minor javadoc improvements
- let Values.literal accept  BigInteger, BigDecimal, TemporalAmount
- added tests for these types

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

