### PR TITLE
GH-3682 stop using Elasticsearch TimeValue

### DIFF
--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchHelper.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchHelper.java
@@ -14,7 +14,6 @@ import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -25,18 +24,18 @@ class ElasticsearchHelper {
 	static CloseableIteration<SearchHit, RuntimeException> getScrollingIterator(QueryBuilder queryBuilder,
 			Client client, String index, int scrollTimeout) {
 
-		return new CloseableIteration<SearchHit, RuntimeException>() {
+		return new CloseableIteration<>() {
 
 			Iterator<SearchHit> items;
 			String scrollId;
 			long itemsRetrieved = 0;
-			int size = 1000;
+			final int size = 1000;
 
 			{
 
 				SearchResponse scrollResp = client.prepareSearch(index)
 						.addSort(FieldSortBuilder.DOC_FIELD_NAME, SortOrder.ASC)
-						.setScroll(new TimeValue(scrollTimeout))
+						.setScroll(scrollTimeout + "ms")
 						.setQuery(queryBuilder)
 						.setSize(size)
 						.get();
@@ -66,7 +65,7 @@ class ElasticsearchHelper {
 						scrollIsEmpty();
 					} else {
 						SearchResponse scrollResp = client.prepareSearchScroll(scrollId)
-								.setScroll(new TimeValue(scrollTimeout))
+								.setScroll(scrollTimeout + "ms")
 								.execute()
 								.actionGet();
 


### PR DESCRIPTION
GitHub issue resolved: #3682 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - use string instead of TimeValue so that our code becomes compatible with future minor versions of Elasticsearch
 
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

