### PR TITLE
GH-3687 add external url configuration property

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartController.java
@@ -47,6 +47,7 @@ import org.springframework.web.servlet.mvc.AbstractController;
 public class TransactionStartController extends AbstractController {
 
 	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+	private String externalUrl;
 
 	public TransactionStartController() throws ApplicationContextException {
 		setSupportedMethods(METHOD_POST);
@@ -130,7 +131,7 @@ public class TransactionStartController extends AbstractController {
 			UUID txnId = txn.getID();
 
 			model.put(SimpleResponseView.SC_KEY, SC_CREATED);
-			final StringBuffer txnURL = request.getRequestURL();
+			final StringBuffer txnURL = getUrlBasePath(request);
 			txnURL.append("/" + txnId.toString());
 			Map<String, String> customHeaders = new HashMap<>();
 			customHeaders.put("Location", txnURL.toString());
@@ -153,4 +154,23 @@ public class TransactionStartController extends AbstractController {
 		}
 	}
 
+	private StringBuffer getUrlBasePath(final HttpServletRequest request) {
+		if (externalUrl == null) {
+			return request.getRequestURL();
+		}
+
+		final StringBuffer url = new StringBuffer();
+		if (externalUrl.endsWith("/")) {
+			url.append(externalUrl, 0, externalUrl.length() - 1);
+		} else {
+			url.append(externalUrl);
+		}
+
+		url.append(request.getRequestURI());
+		return url;
+	}
+
+	public void setExternalUrl(final String externalUrl) {
+		this.externalUrl = externalUrl;
+	}
 }

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
@@ -1,0 +1,80 @@
+package org.eclipse.rdf4j.http.server.repository.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.HashMap;
+
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.ModelAndView;
+
+class TransactionStartControllerTest {
+	private final static String REPO_ID = "test-repo";
+	private final TransactionStartController controller = new TransactionStartController();
+
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		request = new MockHttpServletRequest();
+		request.setRequestURI("/repositories/" + REPO_ID + "/transactions");
+		request.setAttribute("repositoryID", REPO_ID);
+		request.setAttribute("repository", new SailRepository(new MemoryStore()));
+		request.setMethod(HttpMethod.POST.name());
+		response = new MockHttpServletResponse();
+	}
+
+	@Test
+	void createTransactionLocation_default() throws Exception {
+		// Arrange
+		controller.setExternalUrl(null);
+
+		// Act
+		final ModelAndView result = controller.handleRequest(request, response);
+
+		// Assert
+		assertThat(getHeaders(result).get("Location"))
+				.startsWith("http://localhost/repositories/test-repo/transactions/");
+	}
+
+	@Test
+	void createTransactionLocation_overrideExternalUrl() throws Exception {
+		// Arrange
+		controller.setExternalUrl("https://external-url.com/subpath/");
+
+		// Act
+		final ModelAndView result = controller.handleRequest(request, response);
+
+		// Assert
+		assertThat(getHeaders(result).get("Location")).startsWith(
+				"https://external-url.com/subpath/repositories/test-repo/transactions/");
+	}
+
+	@Test
+	void createTransactionLocation_overrideExternalUrl_withoutEndingSlash() throws Exception {
+		// Arrange
+		controller.setExternalUrl("https://external-url.com/subpath");
+
+		// Act
+		final ModelAndView result = controller.handleRequest(request, response);
+
+		// Assert
+		assertThat(getHeaders(result).get("Location")).startsWith(
+				"https://external-url.com/subpath/repositories/test-repo/transactions/");
+	}
+
+	private HashMap<String, String> getHeaders(final ModelAndView result) {
+		if (result == null) {
+			return fail("Result is null");
+		}
+
+		return (HashMap<String, String>) result.getModel().get("headers");
+	}
+}

--- a/tools/server/src/main/resources/org/eclipse/rdf4j/http/server/application.properties
+++ b/tools/server/src/main/resources/org/eclipse/rdf4j/http/server/application.properties
@@ -1,0 +1,2 @@
+## Override the external url of the server
+#rdf4j.externalurl=https://my-server.com/path/

--- a/tools/server/src/main/webapp/WEB-INF/rdf4j-http-server-servlet.xml
+++ b/tools/server/src/main/webapp/WEB-INF/rdf4j-http-server-servlet.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aop="http://www.springframework.org/schema/aop" xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aop="http://www.springframework.org/schema/aop" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
+	<!-- PROPERTIES -->
+	<bean class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+		<property name="locations">
+			<list>
+				<value>classpath:org/eclipse/rdf4j/http/server/application.properties</value>
+			</list>
+		</property>
+		<property name="ignoreUnresolvablePlaceholders" value="true"/>
+	</bean>
 	<!-- RESOURCES -->
 	<bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
 		<property name="basenames">
@@ -118,5 +127,7 @@
 	<bean id="rdf4jRepositoryStatementsController" class="org.eclipse.rdf4j.http.server.repository.statements.StatementsController"/>
 	<bean id="rdf4jRepositoryGraphController" class="org.eclipse.rdf4j.http.server.repository.graph.GraphController"/>
 	<bean id="rdf4jRepositoryTransactionController" class="org.eclipse.rdf4j.http.server.repository.transaction.TransactionController"/>
-	<bean id="rdf4jRepositoryTransactionStartController" class="org.eclipse.rdf4j.http.server.repository.transaction.TransactionStartController"/>
+	<bean id="rdf4jRepositoryTransactionStartController" class="org.eclipse.rdf4j.http.server.repository.transaction.TransactionStartController">
+		<property name="externalUrl" value="${rdf4j.externalurl:#{null}}"/>
+	</bean>
 </beans>


### PR DESCRIPTION
GitHub issue resolved: #3687

Briefly describe the changes proposed in this PR:

I have added an optional property to configure the external base URL of the server. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [X] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

