### PR TITLE
GH-3695 improved BCP47 language tag normalization

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -38,6 +38,18 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
 public class Literals {
 
 	/**
+	 * matches language subtags of two letters preceded by at least one subtag that is not a singleton, and followed by
+	 * either end-of-tag or another subtags
+	 */
+	private static final Pattern TWO_LETTER_SUBTAGS_REGEX = Pattern.compile("(\\w\\w-)(\\w\\w)($|-)");
+
+	/**
+	 * matches language subtags of four letters preceded by at least one subtag that is not a singleton, and followed by
+	 * either end-of-tag or another subtags.
+	 */
+	private static final Pattern FOUR_LETTER_SUBTAGS_REGEX = Pattern.compile("(\\w\\w-)(\\w)(\\w\\w\\w)($|-)");
+
+	/**
 	 * Gets the label of the supplied literal. The fallback value is returned in case the supplied literal is
 	 * <var>null</var>.
 	 *
@@ -517,12 +529,12 @@ public class Literals {
 
 		// all subtags are case-insensitive
 		String normalizedTag = languageTag.toLowerCase();
+
 		StringBuilder sb = new StringBuilder();
 
 		// exception 1: two-letter subtags not preceeded by a singleton and followed by either the end of the tag or
 		// another subtag are fully uppercase
-		Pattern twoLetterSubtags = Pattern.compile("(\\w\\w-)(\\w\\w)($|-)");
-		Matcher matcher = twoLetterSubtags.matcher(normalizedTag);
+		Matcher matcher = TWO_LETTER_SUBTAGS_REGEX.matcher(normalizedTag);
 		while (matcher.find()) {
 			matcher.appendReplacement(sb, matcher.group(1) + matcher.group(2).toUpperCase() + matcher.group(3));
 		}
@@ -532,8 +544,7 @@ public class Literals {
 		sb = new StringBuilder();
 
 		// exception 2: four-letter subtags are title case
-		Pattern fourLetterSubtags = Pattern.compile("(\\w\\w-)(\\w)(\\w\\w\\w)($|-)");
-		matcher = fourLetterSubtags.matcher(normalizedTag);
+		matcher = FOUR_LETTER_SUBTAGS_REGEX.matcher(normalizedTag);
 		while (matcher.find()) {
 			matcher.appendReplacement(sb,
 					matcher.group(1) + matcher.group(2).toUpperCase() + matcher.group(3) + matcher.group(4));
@@ -544,7 +555,7 @@ public class Literals {
 	}
 
 	/**
-	 * Checks if the given string is a <a href="https://tools.ietf.org/html/bcp47">BCP47</a> language tag language tag
+	 * Checks if the given string is a well-formed <a href="https://tools.ietf.org/html/bcp47">BCP47</a> language tag
 	 * according to the rules defined in <a href="https://www.rfc-editor.org/rfc/rfc5646.html#section-2.1.1">RFC 5646,
 	 * section 2.1.1</a>.
 	 *

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -27,6 +27,7 @@ import javax.xml.datatype.Duration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -45,6 +46,65 @@ public class LiteralsTest {
 	private static final Model model = new LinkedHashModel();
 	private static final IRI foo = vf.createIRI("http://example.org/foo");
 	private static final IRI bar = vf.createIRI("http://example.org/bar");
+
+	private static final String[][] expectedTagNormalizations = {
+			{ "en", "en" },
+			{ "EN", "en" },
+			{ "AR-Latn", "ar-Latn" },
+			{ "AZ-latn-x-LATN", "az-Latn-x-latn" },
+			{ "Az-latn-X-Latn", "az-Latn-x-latn" },
+			{ "BER-LATN-x-Dialect", "ber-Latn-x-dialect" },
+			{ "BNT", "bnt" },
+			{ "Egy-Latn", "egy-Latn" },
+			{ "en-ca-x-ca", "en-CA-x-ca" },
+			{ "EN-ca-X-Ca", "en-CA-x-ca" },
+			{ "En-Ca-X-Ca", "en-CA-x-ca" },
+			{ "en-GB", "en-GB" },
+			{ "EN-UK", "en-UK" },
+			{ "EN-US", "en-US" },
+			{ "FA-LATN-X-MIDDLE", "fa-Latn-x-middle" },
+			{ "FA-X-middle", "fa-x-middle" },
+			{ "Grc-latn-x-liturgic", "grc-Latn-x-liturgic" },
+			{ "Grc-x-liturgic", "grc-x-liturgic" },
+			{ "He-Latn", "he-Latn" },
+			{ "Ja-Latn", "ja-Latn" },
+			{ "Ko-Latn", "ko-Latn" },
+			{ "La-x-liturgic", "la-x-liturgic" },
+			{ "La-x-medieval", "la-x-medieval" },
+			{ "NN", "nn" },
+			{ "QQQ-002", "qqq-002" },
+			{ "qqq-142", "qqq-142" },
+			{ "QQQ-ET", "qqq-ET" },
+			{ "ru-Latn-UA", "ru-Latn-UA" },
+			{ "ru-Latn-ua", "ru-Latn-UA" },
+			{ "RU-LATN-UA", "ru-Latn-UA" },
+			{ "SGN-BE-FR", "sgn-BE-FR" },
+			{ "sgn-be-fr", "sgn-BE-FR" },
+			{ "UND", "und" },
+			{ "X-BYZANTIN-LATN", "x-byzantin-Latn" },
+			{ "X-Frisian", "x-frisian" },
+			{ "X-KHASIAN", "x-khasian" },
+			{ "x-local", "x-local" },
+			{ "zh-Hant", "zh-Hant" },
+			{ "zh-Latn-pinyin", "zh-Latn-pinyin" },
+			{ "Zh-latn-PINYIN-X-NoTone", "zh-Latn-pinyin-x-notone" },
+			{ "zh-Latn-wadegile", "zh-Latn-wadegile" }
+	};
+
+	/**
+	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#normalizeLanguageTag(String)} .
+	 */
+	@Test
+	public void testNormaliseBCP47Tag() throws Exception {
+
+		for (String[] expectedNormalization : expectedTagNormalizations) {
+			assertThat(Literals.normalizeLanguageTag(expectedNormalization[0])).isEqualTo(expectedNormalization[1]);
+		}
+
+		// invalid
+		assertThatExceptionOfType(IllformedLocaleException.class)
+				.isThrownBy(() -> Literals.normalizeLanguageTag("ru-ua-latn"));
+	}
 
 	/**
 	 * Test method for
@@ -815,50 +875,6 @@ public class LiteralsTest {
 	}
 
 	/**
-	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#normalizeLanguageTag(String)} .
-	 */
-	@Test
-	public void testNormaliseBCP47Tag() throws Exception {
-		// language
-		assertThat(Literals.normalizeLanguageTag("en")).isEqualTo("en");
-
-		// language-region
-		assertThat(Literals.normalizeLanguageTag("en-AU")).isEqualTo("en-AU");
-		assertThat(Literals.normalizeLanguageTag("en-au")).isEqualTo("en-AU");
-		assertThat(Literals.normalizeLanguageTag("EN-AU")).isEqualTo("en-AU");
-		assertThat(Literals.normalizeLanguageTag("EN-au")).isEqualTo("en-AU");
-		assertThat(Literals.normalizeLanguageTag("fr-FR")).isEqualTo("fr-FR");
-		assertThat(Literals.normalizeLanguageTag("fr-fr")).isEqualTo("fr-FR");
-		assertThat(Literals.normalizeLanguageTag("FR-FR")).isEqualTo("fr-FR");
-		assertThat(Literals.normalizeLanguageTag("Fr-fr")).isEqualTo("fr-FR");
-
-		// language-script-region
-		assertThat(Literals.normalizeLanguageTag("ru-latn-ua")).isEqualTo("ru-Latn-UA");
-		assertThat(Literals.normalizeLanguageTag("ru-LATN-ua")).isEqualTo("ru-Latn-UA");
-
-		// language-region-variant
-		assertThat(Literals.normalizeLanguageTag("ru-ua-latin")).isEqualTo("ru-UA-latin");
-		assertThat(Literals.normalizeLanguageTag("ru-ua-LATIN")).isEqualTo("ru-UA-latin");
-
-		// valid but unusual
-		assertThat(Literals.normalizeLanguageTag("x-byzantin-Latn")).isEqualTo("x-byzantin-Latn");
-		assertThat(Literals.normalizeLanguageTag("X-BYZANTIN-Latn")).isEqualTo("x-byzantin-Latn");
-		assertThat(Literals.normalizeLanguageTag("qqq-002")).isEqualTo("qqq-002");
-		assertThat(Literals.normalizeLanguageTag("QQQ-002")).isEqualTo("qqq-002");
-		assertThat(Literals.normalizeLanguageTag("qqq-ET")).isEqualTo("qqq-ET");
-		assertThat(Literals.normalizeLanguageTag("QQQ-ET")).isEqualTo("qqq-ET");
-		assertThat(Literals.normalizeLanguageTag("QQQ-et")).isEqualTo("qqq-ET");
-		assertThat(Literals.normalizeLanguageTag("grc-Latn-x-liturgic")).isEqualTo("grc-Latn-x-liturgic");
-		assertThat(Literals.normalizeLanguageTag("grc-latn-X-LITURGIC")).isEqualTo("grc-Latn-x-liturgic");
-		assertThat(Literals.normalizeLanguageTag("zh-Latn-pinyin-x-notone")).isEqualTo("zh-Latn-pinyin-x-notone");
-		assertThat(Literals.normalizeLanguageTag("zh-Latn-Pinyin-x-NOTONE")).isEqualTo("zh-Latn-pinyin-x-notone");
-
-		// invalid
-		assertThatExceptionOfType(IllformedLocaleException.class)
-				.isThrownBy(() -> Literals.normalizeLanguageTag("ru-ua-latn"));
-	}
-
-	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getLabel(Optional, String)}} .
 	 */
 	@Test
@@ -867,7 +883,7 @@ public class LiteralsTest {
 		Literal lit = vf.createLiteral(1.0);
 		model.add(foo, bar, lit);
 
-		Optional result = Models.object(model);
+		Optional<Value> result = Models.object(model);
 		String label = Literals.getLabel(result, "fallback");
 		assertNotNull(label);
 		assertTrue(label.equals("1.0"));
@@ -882,8 +898,8 @@ public class LiteralsTest {
 		Literal lit = vf.createLiteral(1.0);
 		model.add(foo, bar, lit);
 
-		Optional result = Models.object(model);
-		String label = Literals.getLabel((Optional) null, "fallback");
+		Optional<Value> result = Models.object(model);
+		String label = Literals.getLabel((Optional<Value>) null, "fallback");
 		assertNotNull(label);
 		assertTrue(label.equals("fallback"));
 	}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -7,14 +7,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.model.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.IllformedLocaleException;
 import java.util.Optional;
 
 import javax.xml.datatype.DatatypeConfigurationException;
@@ -28,8 +31,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link Literals}.
@@ -47,7 +50,7 @@ public class LiteralsTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getLabel(org.eclipse.rdf4j.model.Literal, java.lang.String)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetLabelLiteralString() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -57,7 +60,7 @@ public class LiteralsTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getLabel(org.eclipse.rdf4j.model.Value, java.lang.String)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetLabelValueString() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -67,7 +70,7 @@ public class LiteralsTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getByteValue(org.eclipse.rdf4j.model.Literal, byte)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetByteValueLiteralByte() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -76,7 +79,7 @@ public class LiteralsTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getByteValue(org.eclipse.rdf4j.model.Value, byte)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetByteValueValueByte() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -86,7 +89,7 @@ public class LiteralsTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getShortValue(org.eclipse.rdf4j.model.Literal, short)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetShortValueLiteralShort() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -96,7 +99,7 @@ public class LiteralsTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getShortValue(org.eclipse.rdf4j.model.Value, short)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetShortValueValueShort() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -105,7 +108,7 @@ public class LiteralsTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getIntValue(org.eclipse.rdf4j.model.Literal, int)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetIntValueLiteralInt() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -114,7 +117,7 @@ public class LiteralsTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getIntValue(org.eclipse.rdf4j.model.Value, int)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetIntValueValueInt() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -124,7 +127,7 @@ public class LiteralsTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getLongValue(org.eclipse.rdf4j.model.Literal, long)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetLongValueLiteralLong() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -133,7 +136,7 @@ public class LiteralsTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getLongValue(org.eclipse.rdf4j.model.Value, long)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetLongValueValueLong() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -144,7 +147,7 @@ public class LiteralsTest {
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getIntegerValue(org.eclipse.rdf4j.model.Literal, java.math.BigInteger)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetIntegerValueLiteralBigInteger() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -155,7 +158,7 @@ public class LiteralsTest {
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getIntegerValue(org.eclipse.rdf4j.model.Value, java.math.BigInteger)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetIntegerValueValueBigInteger() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -166,7 +169,7 @@ public class LiteralsTest {
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getDecimalValue(org.eclipse.rdf4j.model.Literal, java.math.BigDecimal)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetDecimalValueLiteralBigDecimal() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -177,7 +180,7 @@ public class LiteralsTest {
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getDecimalValue(org.eclipse.rdf4j.model.Value, java.math.BigDecimal)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetDecimalValueValueBigDecimal() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -187,7 +190,7 @@ public class LiteralsTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getFloatValue(org.eclipse.rdf4j.model.Literal, float)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetFloatValueLiteralFloat() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -197,7 +200,7 @@ public class LiteralsTest {
 	 * Test method for {@link org.eclipse.rdf4j.model.util.Literals#getFloatValue(org.eclipse.rdf4j.model.Value, float)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetFloatValueValueFloat() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -207,7 +210,7 @@ public class LiteralsTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getDoubleValue(org.eclipse.rdf4j.model.Literal, double)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetDoubleValueLiteralDouble() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -217,7 +220,7 @@ public class LiteralsTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getDoubleValue(org.eclipse.rdf4j.model.Value, double)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetDoubleValueValueDouble() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -227,7 +230,7 @@ public class LiteralsTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getBooleanValue(org.eclipse.rdf4j.model.Literal, boolean)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetBooleanValueLiteralBoolean() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -237,7 +240,7 @@ public class LiteralsTest {
 	 * Test method for
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getBooleanValue(org.eclipse.rdf4j.model.Value, boolean)} .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetBooleanValueValueBoolean() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -248,7 +251,7 @@ public class LiteralsTest {
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getCalendarValue(org.eclipse.rdf4j.model.Literal, javax.xml.datatype.XMLGregorianCalendar)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetCalendarValueLiteralXMLGregorianCalendar() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -259,7 +262,7 @@ public class LiteralsTest {
 	 * {@link org.eclipse.rdf4j.model.util.Literals#getCalendarValue(org.eclipse.rdf4j.model.Value, javax.xml.datatype.XMLGregorianCalendar)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testGetCalendarValueValueXMLGregorianCalendar() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -816,15 +819,43 @@ public class LiteralsTest {
 	 */
 	@Test
 	public void testNormaliseBCP47Tag() throws Exception {
-		assertEquals("en", Literals.normalizeLanguageTag("en"));
-		assertEquals("en-AU", Literals.normalizeLanguageTag("en-AU"));
-		assertEquals("en-AU", Literals.normalizeLanguageTag("en-au"));
-		assertEquals("en-AU", Literals.normalizeLanguageTag("EN-AU"));
-		assertEquals("en-AU", Literals.normalizeLanguageTag("EN-au"));
-		assertEquals("fr-FR", Literals.normalizeLanguageTag("fr-FR"));
-		assertEquals("fr-FR", Literals.normalizeLanguageTag("fr-fr"));
-		assertEquals("fr-FR", Literals.normalizeLanguageTag("FR-FR"));
-		assertEquals("fr-FR", Literals.normalizeLanguageTag("FR-fr"));
+		// language
+		assertThat(Literals.normalizeLanguageTag("en")).isEqualTo("en");
+
+		// language-region
+		assertThat(Literals.normalizeLanguageTag("en-AU")).isEqualTo("en-AU");
+		assertThat(Literals.normalizeLanguageTag("en-au")).isEqualTo("en-AU");
+		assertThat(Literals.normalizeLanguageTag("EN-AU")).isEqualTo("en-AU");
+		assertThat(Literals.normalizeLanguageTag("EN-au")).isEqualTo("en-AU");
+		assertThat(Literals.normalizeLanguageTag("fr-FR")).isEqualTo("fr-FR");
+		assertThat(Literals.normalizeLanguageTag("fr-fr")).isEqualTo("fr-FR");
+		assertThat(Literals.normalizeLanguageTag("FR-FR")).isEqualTo("fr-FR");
+		assertThat(Literals.normalizeLanguageTag("Fr-fr")).isEqualTo("fr-FR");
+
+		// language-script-region
+		assertThat(Literals.normalizeLanguageTag("ru-latn-ua")).isEqualTo("ru-Latn-UA");
+		assertThat(Literals.normalizeLanguageTag("ru-LATN-ua")).isEqualTo("ru-Latn-UA");
+
+		// language-region-variant
+		assertThat(Literals.normalizeLanguageTag("ru-ua-latin")).isEqualTo("ru-UA-latin");
+		assertThat(Literals.normalizeLanguageTag("ru-ua-LATIN")).isEqualTo("ru-UA-latin");
+
+		// valid but unusual
+		assertThat(Literals.normalizeLanguageTag("x-byzantin-Latn")).isEqualTo("x-byzantin-Latn");
+		assertThat(Literals.normalizeLanguageTag("X-BYZANTIN-Latn")).isEqualTo("x-byzantin-Latn");
+		assertThat(Literals.normalizeLanguageTag("qqq-002")).isEqualTo("qqq-002");
+		assertThat(Literals.normalizeLanguageTag("QQQ-002")).isEqualTo("qqq-002");
+		assertThat(Literals.normalizeLanguageTag("qqq-ET")).isEqualTo("qqq-ET");
+		assertThat(Literals.normalizeLanguageTag("QQQ-ET")).isEqualTo("qqq-ET");
+		assertThat(Literals.normalizeLanguageTag("QQQ-et")).isEqualTo("qqq-ET");
+		assertThat(Literals.normalizeLanguageTag("grc-Latn-x-liturgic")).isEqualTo("grc-Latn-x-liturgic");
+		assertThat(Literals.normalizeLanguageTag("grc-latn-X-LITURGIC")).isEqualTo("grc-Latn-x-liturgic");
+		assertThat(Literals.normalizeLanguageTag("zh-Latn-pinyin-x-notone")).isEqualTo("zh-Latn-pinyin-x-notone");
+		assertThat(Literals.normalizeLanguageTag("zh-Latn-Pinyin-x-NOTONE")).isEqualTo("zh-Latn-pinyin-x-notone");
+
+		// invalid
+		assertThatExceptionOfType(IllformedLocaleException.class)
+				.isThrownBy(() -> Literals.normalizeLanguageTag("ru-ua-latn"));
 	}
 
 	/**

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/LanguageHandler.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/LanguageHandler.java
@@ -40,16 +40,17 @@ public interface LanguageHandler {
 
 	/**
 	 * Checks if the given language tag is recognized by this language handler, including cases where the language tag
-	 * is recognized, but is not yet normalized.
+	 * is considered syntactically well-formed, but is not yet normalized.
 	 *
 	 * @param languageTag The language tag to check.
-	 * @return True if the language tag is syntactically valid and could be used with
+	 * @return True if the language tag is syntactically well-formed and could be used with
 	 *         {@link #verifyLanguage(String, String)} and {@link #normalizeLanguage(String, String, ValueFactory)}.
 	 */
 	boolean isRecognizedLanguage(String languageTag);
 
 	/**
-	 * Verifies that the language tag is valid, optionally including an automated check on the literal value.
+	 * Verifies that the language tag is syntactically well-formed, optionally including an automated check on the
+	 * literal value being a match for the given tag.
 	 * <p>
 	 * This method must only be called after verifying that {@link #isRecognizedLanguage(String)} returns true for the
 	 * given language tag.

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettings.java
@@ -105,8 +105,7 @@ public class BasicParserSettings {
 			"org.eclipse.rdf4j.rio.verify_language_tags", "Verify language tags", Boolean.TRUE);
 
 	/**
-	 * Boolean setting for parser to determine whether languages need to be normalized, and to which format they should
-	 * be normalized.
+	 * Boolean setting for parser to determine whether languages need to be normalized.
 	 * <p>
 	 * Normalization is performed using registered {@link LanguageHandler}s.
 	 * <p>
@@ -121,7 +120,7 @@ public class BasicParserSettings {
 	 * Setting used to specify which {@link LanguageHandler} implementations are to be used for a given parser
 	 * configuration.
 	 * <p>
-	 * Defaults to an RFC3066 LanguageHandler implementation based on {@link LanguageHandler#RFC3066}.
+	 * Defaults to an BCP47 LanguageHandler implementation based on {@link LanguageHandler#BCP47}.
 	 */
 	public static final RioSetting<List<LanguageHandler>> LANGUAGE_HANDLERS;
 


### PR DESCRIPTION
GitHub issue resolved: #3695  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
 
- full normalization according to rules in RFC 5646 (section 2.1.1) implemented
- extended test coverage
- clarified javadoc in language handlers and parser settings

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

