### PR TITLE
GH-2990 remove redundant Extension when alias mapping is var->var

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -591,12 +591,14 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 					}
 				}
 
-				// add extension element reference to the projection element and
-				// to
-				// the extension
-				ExtensionElem extElem = new ExtensionElem(valueExpr, alias);
-				extension.addElement(extElem);
-				elem.setSourceExpression(extElem);
+				if (!(child instanceof ASTVar)) {
+					// source of the aliased projection is not a simple variable:
+					// add extension element reference to the projection element and
+					// to the extension
+					ExtensionElem extElem = new ExtensionElem(valueExpr, alias);
+					extension.addElement(extElem);
+					elem.setSourceExpression(extElem);
+				}
 			} else if (child instanceof ASTVar) {
 				Var projVar = (Var) child.jjtAccept(this, null);
 				ProjectionElem elem = new ProjectionElem(projVar.getName());


### PR DESCRIPTION
GitHub issue resolved: #2990  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

When a projection alias involves a simple variable-to-variable mapping, an Extension node is redundant.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

