### PR TITLE
GH-3667: Optimize subqueries and bind statements 

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -88,6 +88,17 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 			node.setResultSizeEstimate(Math.max(statistics.getCardinality(node), node.getResultSizeEstimate()));
 		}
 
+		private void optimizePriorityJoin(Set<String> origBoundVars, TupleExpr join) {
+
+			Set<String> saveBoundVars = boundVars;
+			try {
+				boundVars = new HashSet<>(origBoundVars);
+				join.visit(this);
+			} finally {
+				boundVars = saveBoundVars;
+			}
+		}
+
 		@Override
 		public void meet(Join node) {
 
@@ -173,6 +184,7 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 					}
 
 					if (priorityJoins != null) {
+						optimizePriorityJoin(origBoundVars, priorityJoins);
 						replacement = new Join(priorityJoins, replacement);
 					}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -184,12 +184,18 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 					}
 
 					if (priorityJoins != null) {
-						optimizePriorityJoin(origBoundVars, priorityJoins);
 						replacement = new Join(priorityJoins, replacement);
 					}
 
 					// Replace old join hierarchy
 					node.replaceWith(replacement);
+
+					// we optimize after the replacement call above in case the optimize call below
+					// recurses back into this function and we need all the node's parent/child pointers
+					// set up correctly for replacement to work on subsequent calls
+					if (priorityJoins != null) {
+						optimizePriorityJoin(origBoundVars, priorityJoins);
+					}
 
 				} else {
 					// only subselect/priority joins involved in this query.


### PR DESCRIPTION
GitHub issue resolved: #3667

Briefly describe the changes proposed in this PR:

Optimize the graph when a subquery/optional/bind clause is present in the SPARQL.

