### PR TITLE
GH-3708 Pass JSON-LD writer options to JSON-LD processor

### DIFF
--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -120,10 +120,6 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter, CharSi
 		checkWritingStarted();
 		final JSONLDInternalRDFParser serialiser = new JSONLDInternalRDFParser();
 		try {
-			Object output = JsonLdProcessor.fromRDF(model, serialiser);
-
-			final JSONLDMode mode = getWriterConfig().get(JSONLDSettings.JSONLD_MODE);
-
 			final JsonLdOptions opts = new JsonLdOptions();
 			// opts.addBlankNodeIDs =
 			// getWriterConfig().get(BasicParserSettings.PRESERVE_BNODE_IDS);
@@ -133,6 +129,10 @@ public class JSONLDWriter extends AbstractRDFWriter implements RDFWriter, CharSi
 			opts.setUseRdfType(writerConfig.get(JSONLDSettings.USE_RDF_TYPE));
 			opts.setUseNativeTypes(writerConfig.get(JSONLDSettings.USE_NATIVE_TYPES));
 			// opts.optimize = getWriterConfig().get(JSONLDSettings.OPTIMIZE);
+
+			Object output = JsonLdProcessor.fromRDF(model, opts, serialiser);
+
+			final JSONLDMode mode = getWriterConfig().get(JSONLDSettings.JSONLD_MODE);
 
 			if (writerConfig.get(JSONLDSettings.HIERARCHICAL_VIEW)) {
 				output = JSONLDHierarchicalProcessor.fromJsonLdObject(output);

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterTest.java
@@ -125,6 +125,29 @@ public class JSONLDWriterTest extends RDFWriterTest {
 		}
 	}
 
+	/**
+	 * Test if the JSON-LD writer honors the "native RDF type" setting.
+	 */
+	@Test
+	public void testNativeRDFTypes() {
+		IRI subject = vf.createIRI(exNs, "uri1");
+		IRI predicate = vf.createIRI(exNs, "uri2");
+		Literal object = vf.createLiteral(true);
+		Statement stmt = vf.createStatement(subject, predicate, object);
+
+		StringWriter w = new StringWriter();
+		RDFWriter rdfWriter = rdfWriterFactory.getWriter(w);
+		rdfWriter.getWriterConfig().set(JSONLDSettings.JSONLD_MODE, JSONLDMode.COMPACT);
+		rdfWriter.getWriterConfig().set(JSONLDSettings.COMPACT_ARRAYS, true);
+		rdfWriter.getWriterConfig().set(JSONLDSettings.USE_NATIVE_TYPES, true);
+
+		rdfWriter.startRDF();
+		rdfWriter.handleStatement(stmt);
+		rdfWriter.endRDF();
+
+		assertTrue("Does contain @type", !w.toString().contains("@type"));
+	}
+
 	@Override
 	protected RioSetting<?>[] getExpectedSupportedSettings() {
 		return new RioSetting[] {


### PR DESCRIPTION
Resolves issue: #3708 

Not only use the JSON-LD writer options for expand/flatten/compact but also for generating the JSON-LD output by passing them to `JsonLdProcessor.fromRDF()`. This will make sure that options like “use native types” will be honored.

----

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

