### PR TITLE
GH-3720 add Lucene language and type filtering

### DIFF
--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -142,6 +142,22 @@ import org.slf4j.LoggerFactory;
  * http\://xmlns.com/foaf/0.1/name=http\://www.w3.org/2000/01/rdf-schema#label
  * </pre>
  *
+ * <h2 name="indexedtypelangsyntax">Defining the indexed Types/Languages</h2> The properties {@link #INDEXEDTYPES} and
+ * {@link #INDEXEDLANG} are to configure which fields to index by their language or type. {@link #INDEXEDTYPES} Syntax:
+ *
+ * <pre>
+ * # only index object of rdf:type ex:mytype1, rdf:type ex:mytype2 or ex:mytypedef ex:mytype3
+ * http\://www.w3.org/1999/02/22-rdf-syntax-ns#type=http://example.org/mytype1 http://example.org/mytype2
+ * http\://example.org/mytypedef=http://example.org/mytype3
+ * </pre>
+ *
+ * {@link #INDEXEDLANG} Syntax:
+ *
+ * <pre>
+ * # syntax to index only French(fr) and English(en) literals
+ * fr en
+ * </pre>
+ *
  * <h2>Datatypes</h2> Datatypes are ignored in the LuceneSail.
  */
 public class LuceneSail extends NotifyingSailWrapper {
@@ -213,6 +229,21 @@ public class LuceneSail extends NotifyingSailWrapper {
 	 */
 	public static final String INDEXEDFIELDS = "indexedfields";
 
+	/**
+	 * Set the parameter "indexedtypes=..." to configure a selection of field type to index. Only the fields with the
+	 * specific type will be indexed. Syntax of indexedtypes - see <a href="#indexedtypelangsyntax">above</a>
+	 */
+	public static final String INDEXEDTYPES = "indexedtypes";
+
+	/**
+	 * Set the parameter "indexedlang=..." to configure a selection of field language to index. Only the fields with the
+	 * specific language will be indexed. Syntax of indexedlang - see <a href="#indexedtypelangsyntax">above</a>
+	 */
+	public static final String INDEXEDLANG = "indexedlang";
+	/**
+	 * See {@link org.eclipse.rdf4j.sail.lucene.TypeBacktraceMode}
+	 */
+	public static final String INDEX_TYPE_BACKTRACE_MODE = "indexBacktraceMode";
 	/**
 	 * Set the key "lucenedir=&lt;path&gt;" as sail parameter to configure the Lucene Directory on the filesystem where
 	 * to store the lucene index.
@@ -287,6 +318,8 @@ public class LuceneSail extends NotifyingSailWrapper {
 	private volatile boolean incompleteQueryFails = true;
 
 	private volatile TupleFunctionEvaluationMode evaluationMode = TupleFunctionEvaluationMode.TRIPLE_SOURCE;
+
+	private volatile TypeBacktraceMode indexBacktraceMode = TypeBacktraceMode.DEFAULT_TYPE_BACKTRACE_MODE;
 
 	private TupleFunctionRegistry tupleFunctionRegistry = TupleFunctionRegistry.getInstance();
 
@@ -470,6 +503,22 @@ public class LuceneSail extends NotifyingSailWrapper {
 		Objects.requireNonNull(mode);
 		this.setParameter(EVALUATION_MODE_KEY, mode.name());
 		this.evaluationMode = mode;
+	}
+
+	/**
+	 * See {@link #INDEX_TYPE_BACKTRACE_MODE} parameter.
+	 */
+	public TypeBacktraceMode getIndexBacktraceMode() {
+		return indexBacktraceMode;
+	}
+
+	/**
+	 * See {@link #INDEX_TYPE_BACKTRACE_MODE} parameter.
+	 */
+	public void setIndexBacktraceMode(TypeBacktraceMode mode) {
+		Objects.requireNonNull(mode);
+		this.setParameter(INDEX_TYPE_BACKTRACE_MODE, mode.name());
+		this.indexBacktraceMode = mode;
 	}
 
 	public TupleFunctionRegistry getTupleFunctionRegistry() {

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchIndex.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchIndex.java
@@ -10,8 +10,11 @@ package org.eclipse.rdf4j.sail.lucene;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -48,6 +51,36 @@ public interface SearchIndex {
 	 * @return boolean
 	 */
 	boolean isGeoField(String propertyName);
+
+	/**
+	 * Returns true if the given statement is a type statement, see {@link LuceneSail#INDEXEDTYPES} to use. This method
+	 * should return false if {@link #isTypeFilteringEnabled()} returns false.
+	 * 
+	 * @param statement statement
+	 * @return boolean
+	 */
+	boolean isTypeStatement(Statement statement);
+
+	/**
+	 * is the {@link LuceneSail#INDEXEDTYPES} parameter set for this index.
+	 * 
+	 * @return boolean
+	 */
+	boolean isTypeFilteringEnabled();
+
+	/**
+	 * Returns true if the given statement is a type statement of the right type, see {@link LuceneSail#INDEXEDTYPES} to
+	 * use. This method should return false if {@link #isTypeFilteringEnabled()} returns false.
+	 * 
+	 * @param statement statement
+	 * @return boolean
+	 */
+	boolean isIndexedTypeStatement(Statement statement);
+
+	/**
+	 * @return the accepted types for a particular predicate map (predicate -> [objects])
+	 */
+	Map<IRI, Set<IRI>> getIndexedTypeMapping();
 
 	/**
 	 * Begins a transaction.

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/TypeBacktraceMode.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/TypeBacktraceMode.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+/**
+ * Option to describe how the {@link org.eclipse.rdf4j.sail.lucene.LuceneSail} should handle the add of a new type
+ * statement in a connection if the {@link LuceneSail#INDEXEDTYPES} property is defined.
+ *
+ * <h2 id="backtrace_example">Backtrace example</h2> For example if we have the predicate my:text indexed by Lucene and
+ * (my:oftype my:type1) as an {@link LuceneSail#INDEXEDTYPES}, the previous store state is
+ *
+ * <pre>
+ * # Store triples:
+ * my:subj1 my:text   "demo 1" .
+ * my:subj2 my:oftype my:type1 .
+ * my:subj2 my:text   "demo 2" .
+ * # Lucene Indexed literals:
+ * my:subj2 "demo 2"
+ * </pre>
+ *
+ * The option will define how the Sail will handle the update:
+ *
+ * <pre>
+ * INSERT my:subj1 my:oftype my:type1 .
+ * DELETE my:subj2 my:oftype my:type1 .
+ * </pre>
+ */
+public enum TypeBacktraceMode {
+	/**
+	 * The sail will get all previous triples of the subject and add them (if required) in the Lucene index, this mode
+	 * is enabled by default.
+	 *
+	 * the future state of the Lucene index in the <a href="#backtrace_example">above example</a> would be:
+	 * 
+	 * <pre>
+	 * my:subj1 "demo 1"
+	 * </pre>
+	 */
+	COMPLETE(true, true),
+	/**
+	 * The sail won't get any previous triples of the subject in the Lucene index, this mode is useful if you won't
+	 * change the type and values of your subjects in multiple queries.
+	 *
+	 * the future state of the Lucene index in the <a href="#backtrace_example">above example</a> would be:
+	 * 
+	 * <pre>
+	 * my:subj2 "demo 2"
+	 * </pre>
+	 */
+	PARTIAL(false, false);
+
+	private final boolean shouldBackTraceInsert;
+	private final boolean shouldBackTraceDelete;
+
+	TypeBacktraceMode(boolean shouldBackTraceInsert, boolean shouldBackTraceDelete) {
+		this.shouldBackTraceInsert = shouldBackTraceInsert;
+		this.shouldBackTraceDelete = shouldBackTraceDelete;
+	}
+
+	/**
+	 * @return if the index should backtrace over the old properties on an add
+	 */
+	public boolean shouldBackTraceInsert() {
+		return shouldBackTraceInsert;
+	}
+
+	/**
+	 * @return if the index should backtrace over the old properties on a delete
+	 */
+	public boolean shouldBackTraceDelete() {
+		return shouldBackTraceDelete;
+	}
+
+	/**
+	 * Default backtrace mode
+	 */
+	public static final TypeBacktraceMode DEFAULT_TYPE_BACKTRACE_MODE = COMPLETE;
+}

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/LangSpecTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/LangSpecTest.java
@@ -66,12 +66,6 @@ public class LangSpecTest {
 		}
 
 		@Override
-		@SuppressWarnings("deprecated")
-		protected SearchQuery parseQuery(String q, IRI property) {
-			throw new RuntimeException("not implemented");
-		}
-
-		@Override
 		protected Iterable<? extends DocumentScore> query(Resource subject, String q, IRI property, boolean highlight) {
 			throw new RuntimeException("not implemented");
 		}
@@ -90,16 +84,6 @@ public class LangSpecTest {
 
 		@Override
 		protected BulkUpdater newBulkUpdate() {
-			throw new RuntimeException("not implemented");
-		}
-
-		@Override
-		public void beginReading() {
-			throw new RuntimeException("not implemented");
-		}
-
-		@Override
-		public void endReading() {
 			throw new RuntimeException("not implemented");
 		}
 

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/LangSpecTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/LangSpecTest.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import java.util.Properties;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Point;
+
+public class LangSpecTest {
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+
+	protected static class SearchIndexImpl extends AbstractSearchIndex {
+
+		@Override
+		protected SpatialContext getSpatialContext(String property) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected SearchDocument getDocument(String id) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected Iterable<? extends SearchDocument> getDocuments(String resourceId) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected SearchDocument newDocument(String id, String resourceId, String context) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected SearchDocument copyDocument(SearchDocument doc) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected void addDocument(SearchDocument doc) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected void updateDocument(SearchDocument doc) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected void deleteDocument(SearchDocument doc) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		@SuppressWarnings("deprecated")
+		protected SearchQuery parseQuery(String q, IRI property) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected Iterable<? extends DocumentScore> query(Resource subject, String q, IRI property, boolean highlight) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected Iterable<? extends DocumentDistance> geoQuery(IRI geoProperty, Point p, IRI units, double distance,
+				String distanceVar, Var context) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty, String wkt,
+				Var context) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		protected BulkUpdater newBulkUpdate() {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public void beginReading() {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public void endReading() {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public void shutDown() {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public void begin() {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public void commit() {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public void rollback() {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public void clearContexts(Resource... contexts) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public void clear() {
+			throw new RuntimeException("not implemented");
+		}
+	}
+
+	SearchIndex index;
+	Properties prop;
+
+	@Before
+	public void setup() {
+		index = new SearchIndexImpl();
+		prop = new Properties();
+	}
+
+	@Test
+	public void noLangTest() throws Exception {
+		index.initialize(prop);
+
+		// test that without setting the LuceneSail.INDEXEDLANG property, the accept method is still
+		// working as intended
+		Assert.assertTrue(index.accept(VF.createLiteral("my literal")));
+		Assert.assertTrue(index.accept(VF.createLiteral("my literal", "en")));
+		Assert.assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
+	}
+
+	@Test
+	public void langTest() throws Exception {
+		prop.setProperty(LuceneSail.INDEXEDLANG, "fr");
+		index.initialize(prop);
+
+		// test that with the LuceneSail.INDEXEDLANG property, we are only accepting literals of the right language
+		Assert.assertFalse(index.accept(VF.createLiteral("my literal")));
+		Assert.assertFalse(index.accept(VF.createLiteral("my literal", "en")));
+		Assert.assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
+	}
+
+	@Test
+	public void multipleLangTest() throws Exception {
+		prop.setProperty(LuceneSail.INDEXEDLANG, "fr  en");
+		index.initialize(prop);
+
+		// test that with the LuceneSail.INDEXEDLANG property, we are only accepting literals of the right languages
+		Assert.assertFalse(index.accept(VF.createLiteral("my literal")));
+		Assert.assertTrue(index.accept(VF.createLiteral("my literal", "en")));
+		Assert.assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
+		Assert.assertFalse(index.accept(VF.createLiteral("mi literal", "es")));
+	}
+}

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/SearchQueryEvaluatorTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/SearchQueryEvaluatorTest.java
@@ -11,9 +11,11 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -60,6 +62,26 @@ abstract class SearchQueryEvaluatorTest {
 		@Override
 		public boolean isGeoField(String propertyName) {
 			return (wktFields != null) && wktFields.contains(propertyName);
+		}
+
+		@Override
+		public boolean isTypeStatement(Statement statement) {
+			return false;
+		}
+
+		@Override
+		public boolean isTypeFilteringEnabled() {
+			return false;
+		}
+
+		@Override
+		public boolean isIndexedTypeStatement(Statement statement) {
+			return false;
+		}
+
+		@Override
+		public Map<IRI, Set<IRI>> getIndexedTypeMapping() {
+			return null;
 		}
 
 		@Override

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/TypeSpecTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/TypeSpecTest.java
@@ -86,7 +86,7 @@ public class TypeSpecTest {
 		sail.setBaseSail(memoryStore);
 		repository = new SailRepository(sail);
 		repository.setDataDir(dataDir);
-		repository.initialize();
+		repository.init();
 	}
 
 	private void add(Statement... statements) {

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/TypeSpecTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/TypeSpecTest.java
@@ -1,0 +1,494 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Sets;
+
+public class TypeSpecTest {
+	private static final Logger LOG = LoggerFactory.getLogger(TypeSpecTest.class);
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+	private static final String EX_NS = "http://example.org/";
+	private static final String PREDICATE_TYPEOF = EX_NS + "typeof";
+	private static final String PREDICATE_TEXT = EX_NS + "text";
+
+	private static Statement typeof(String subject) {
+		return VF.createStatement(
+				VF.createIRI(EX_NS + subject),
+				VF.createIRI(PREDICATE_TYPEOF),
+				VF.createIRI(EX_NS + "type1")
+		);
+	}
+
+	private static Statement typeRDF(String subject) {
+		return VF.createStatement(
+				VF.createIRI(EX_NS + subject),
+				RDF.TYPE,
+				VF.createIRI(EX_NS + "type2")
+		);
+	}
+
+	private static Statement literal(String subject, String value) {
+		return VF.createStatement(
+				VF.createIRI(EX_NS + subject),
+				VF.createIRI(PREDICATE_TEXT),
+				VF.createLiteral(value)
+		);
+	}
+
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	LuceneSail sail;
+	MemoryStore memoryStore;
+	SailRepository repository;
+	File dataDir;
+
+	@Before
+	public void setup() throws IOException {
+		dataDir = tmpFolder.newFolder();
+		memoryStore = new MemoryStore();
+		// enable lock tracking
+		sail = new LuceneSail();
+		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, "lucene-index");
+		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
+
+	}
+
+	private void initSail() {
+		sail.setBaseSail(memoryStore);
+		repository = new SailRepository(sail);
+		repository.setDataDir(dataDir);
+		repository.initialize();
+	}
+
+	private void add(Statement... statements) {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+			for (Statement s : statements) {
+				connection.add(s);
+			}
+			connection.commit();
+		}
+	}
+
+	private void remove(Statement... statements) {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+			for (Statement s : statements) {
+				connection.remove(s);
+			}
+			connection.commit();
+		}
+	}
+
+	private void addRemove(Statement[] toAdd, Statement[] toRemove) {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+			for (Statement s : toAdd) {
+				connection.add(s);
+			}
+			for (Statement s : toRemove) {
+				connection.remove(s);
+			}
+			connection.commit();
+		}
+	}
+
+	/**
+	 * assert the repository only contains the excepted documents
+	 * 
+	 * @param exceptedDocuments the excepted documents
+	 */
+	private void assertQuery(String... exceptedDocuments) {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			String queryStr = "";
+			queryStr += "PREFIX search: <http://www.openrdf.org/contrib/lucenesail#> ";
+			queryStr += "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> ";
+			queryStr += "SELECT DISTINCT ?result { ";
+			queryStr += "  ?result search:matches ?match . ";
+			queryStr += "  ?match search:query 'text' . }";
+
+			Set<String> exceptedDocSet = Sets.newHashSet(exceptedDocuments);
+
+			// fire a query with the subject pre-specified
+			TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL, queryStr);
+			try (TupleQueryResult result = query.evaluate()) {
+				while (result.hasNext()) {
+					BindingSet set = result.next();
+					String element = set.getValue("result").stringValue().substring(EX_NS.length());
+					if (!exceptedDocSet.remove(element)) {
+						LOG.error("Docs: " + exceptedDocSet);
+						LOG.error("Remaining:");
+						while (result.hasNext()) {
+							set = result.next();
+							LOG.error("- {}", set.getValue("result").stringValue().substring(EX_NS.length()));
+						}
+						Assert.fail("The element '" + element + "' was in the index, but wasn't excepted");
+					}
+				}
+			}
+
+			if (!exceptedDocSet.isEmpty()) {
+				Assert.fail("Unexpected docs: " + exceptedDocSet);
+			}
+		}
+	}
+
+	@Test
+	public void noConfigTest() {
+		// no config to add
+		initSail();
+
+		// initial data
+		add(
+				literal("aaa", "text aaa"),
+				literal("bbb", "text bbb"),
+				literal("ccc", "text ccc"),
+				typeof("bbb"),
+				typeof("eee")
+		);
+
+		assertQuery(
+				"aaa", "bbb", "ccc"
+		);
+
+		// test backtrace of add(aaa, typeof, type1) -> (aaa, text, "text aaa") add
+		add(
+				typeof("aaa")
+		);
+
+		assertQuery(
+				"aaa", "bbb", "ccc"
+		);
+
+		// test backtrace of remove(bbb, typeof, type1) -> (bbb, text, "text bbb") removed
+		remove(
+				typeof("bbb")
+		);
+
+		assertQuery(
+				"aaa", "bbb", "ccc"
+		);
+
+		// test add without calling sail (ddd, text, "text ddd") add
+		add(
+				typeof("ddd"),
+				literal("ddd", "text ddd")
+		);
+
+		assertQuery(
+				"aaa", "bbb", "ccc", "ddd"
+		);
+
+		// test add with calling sail (eee, text, "text eee") add
+		add(
+				literal("eee", "text eee")
+		);
+
+		assertQuery(
+				"aaa", "bbb", "ccc", "ddd", "eee"
+		);
+
+		// test adding and remove typeof in the same addRemove (eee, text, "text eee") shouldn't be added
+		addRemove(
+				// add
+				new Statement[] {
+						typeof("fff"),
+						literal("fff", "text fff")
+				},
+				// remove
+				new Statement[] {
+						typeof("fff")
+				}
+		);
+
+		assertQuery(
+				"aaa", "bbb", "ccc", "ddd", "eee", "fff"
+		);
+
+		remove(
+				literal("aaa", "text aaa")
+		);
+
+		assertQuery(
+				"bbb", "ccc", "ddd", "eee", "fff"
+		);
+
+	}
+
+	@Test
+	public void typeTest() {
+		sail.setParameter(LuceneSail.INDEXEDTYPES, (PREDICATE_TYPEOF + "=" + EX_NS + "type1")
+				.replaceAll("[:]", "\\\\:"));
+		initSail();
+
+		// initial data
+		add(
+				literal("aaa", "text aaa"),
+				literal("bbb", "text bbb"),
+				literal("ccc", "text ccc"),
+				typeof("bbb"),
+				typeof("eee")
+		);
+
+		assertQuery(
+				"bbb"
+		);
+
+		// test backtrace of add(aaa, typeof, type1) -> (aaa, text, "text aaa") add
+		add(
+				typeof("aaa")
+		);
+
+		assertQuery(
+				"aaa", "bbb"
+		);
+
+		// test backtrace of remove(bbb, typeof, type1) -> (bbb, text, "text bbb") removed
+		remove(
+				typeof("bbb")
+		);
+
+		assertQuery(
+				"aaa"
+		);
+
+		// test add without calling sail (ddd, text, "text ddd") add
+		add(
+				typeof("ddd"),
+				literal("ddd", "text ddd")
+		);
+
+		assertQuery(
+				"aaa", "ddd"
+		);
+
+		// test add with calling sail (eee, text, "text eee") add
+		add(
+				literal("eee", "text eee")
+		);
+
+		assertQuery(
+				"aaa", "ddd", "eee"
+		);
+
+		// test adding and remove typeof in the same addRemove (eee, text, "text eee") shouldn't be added
+		addRemove(
+				// add
+				new Statement[] {
+						typeof("fff"),
+						literal("fff", "text fff")
+				},
+				// remove
+				new Statement[] {
+						typeof("fff")
+				}
+		);
+
+		assertQuery(
+				"aaa", "ddd", "eee"
+		);
+
+		remove(
+				literal("aaa", "text aaa")
+		);
+
+		assertQuery(
+				"ddd", "eee"
+		);
+	}
+
+	@Test
+	public void typePartialModeTest() {
+		sail.setParameter(LuceneSail.INDEXEDTYPES, (PREDICATE_TYPEOF + "=" + EX_NS + "type1")
+				.replaceAll("[:]", "\\\\:"));
+		sail.setIndexBacktraceMode(TypeBacktraceMode.PARTIAL);
+		initSail();
+
+		// initial data
+		add(
+				literal("aaa", "text aaa"),
+				literal("bbb", "text bbb"),
+				literal("ccc", "text ccc"),
+				typeof("bbb"),
+				typeof("eee")
+		);
+
+		assertQuery(
+				"bbb"
+		);
+
+		// test backtrace of add(aaa, typeof, type1) -> (aaa, text, "text aaa") add
+		add(
+				typeof("aaa")
+		);
+
+		assertQuery(
+				"bbb"
+		);
+
+		// test backtrace of remove(bbb, typeof, type1) -> (bbb, text, "text bbb") removed
+		remove(
+				typeof("bbb")
+		);
+
+		assertQuery(
+				"bbb"
+		);
+
+		// test add without calling sail (ddd, text, "text ddd") add
+		add(
+				typeof("ddd"),
+				literal("ddd", "text ddd")
+		);
+
+		assertQuery(
+				"bbb", "ddd"
+		);
+
+		// test add with calling sail (eee, text, "text eee") add
+		add(
+				literal("eee", "text eee")
+		);
+
+		assertQuery(
+				"bbb", "ddd", "eee"
+		);
+
+		// test adding and remove typeof in the same addRemove (eee, text, "text eee") shouldn't be added
+		addRemove(
+				// add
+				new Statement[] {
+						typeof("fff"),
+						literal("fff", "text fff")
+				},
+				// remove
+				new Statement[] {
+						typeof("fff")
+				}
+		);
+
+		assertQuery(
+				"bbb", "ddd", "eee"
+		);
+
+		remove(
+				literal("aaa", "text aaa")
+		);
+
+		assertQuery(
+				"bbb", "ddd", "eee"
+		);
+	}
+
+	@Test
+	public void typeRDFTest() {
+		sail.setParameter(LuceneSail.INDEXEDTYPES, ("a=" + EX_NS + "type2")
+				.replaceAll("[:]", "\\\\:"));
+		initSail();
+
+		// initial data
+		add(
+				literal("aaa", "text aaa"),
+				literal("bbb", "text bbb"),
+				literal("ccc", "text ccc"),
+				typeRDF("bbb"),
+				typeRDF("eee")
+		);
+
+		assertQuery(
+				"bbb"
+		);
+
+		// test backtrace of add(aaa, typeof, type1) -> (aaa, text, "text aaa") add
+		add(
+				typeRDF("aaa")
+		);
+
+		assertQuery(
+				"aaa", "bbb"
+		);
+
+		// test backtrace of remove(bbb, typeof, type1) -> (bbb, text, "text bbb") removed
+		remove(
+				typeRDF("bbb")
+		);
+
+		assertQuery(
+				"aaa"
+		);
+
+		// test add without calling sail (ddd, text, "text ddd") add
+		add(
+				typeRDF("ddd"),
+				literal("ddd", "text ddd")
+		);
+
+		assertQuery(
+				"aaa", "ddd"
+		);
+
+		// test add with calling sail (eee, text, "text eee") add
+		add(
+				literal("eee", "text eee")
+		);
+
+		assertQuery(
+				"aaa", "ddd", "eee"
+		);
+
+		// test adding and remove typeof in the same addRemove (eee, text, "text eee") shouldn't be added
+		addRemove(
+				// add
+				new Statement[] {
+						typeRDF("fff"),
+						literal("fff", "text fff")
+				},
+				// remove
+				new Statement[] {
+						typeRDF("fff")
+				}
+		);
+
+		assertQuery(
+				"aaa", "ddd", "eee"
+		);
+
+		remove(
+				literal("aaa", "text aaa")
+		);
+
+		assertQuery(
+				"ddd", "eee"
+		);
+	}
+
+}

--- a/site/content/documentation/programming/lucene.md
+++ b/site/content/documentation/programming/lucene.md
@@ -40,6 +40,67 @@ lucenesail.setParameter(LuceneSail.LUCENE_RAMDIR_KEY, "true");
 lucenesail.setBaseSail(baseSail);
 ```
 
+### Language filtering
+
+You can add a filter to only index literals with particular languages, for example:
+
+```java
+// this sail will now will only index French literals
+lucenesail.setParameter(LuceneSail.INDEXEDLANG, "fr");
+```
+
+To use multiple languages, split them with spaces, for example:
+
+```java
+// this sail will now only index French and English literals
+lucenesail.setParameter(LuceneSail.INDEXEDLANG, "fr en");
+```
+
+### Type filtering
+
+You can add a filter to only index literals of subject with particular type, for example with the subject/literals
+
+```turle
+@prefix my: <http://example.org/> .
+
+my:subject1 my:oftype my:type1 ;
+            my:prop   "text"   .
+
+my:subject2 my:oftype my:type2 ;
+            my:prop   "text"   .
+```
+
+To only index the literals of the subjects with the type ``my:type1``, you can use the type filter parameter:
+
+```java
+// this sail will now only index literals of subjects ?s with the triple (?s ex:oftype ex:type1).
+lucenesail.setParameter(LuceneSail.INDEXEDTYPES, "http\\://example.org/oftype=http\\://example.org/type1");
+```
+
+You can specify multiple types for the same type predicate by splitting them with spaces, you can specify multiple type predicates by splitting them with new lines, example:
+
+```java
+// this sail will now only index literals of subjects ?s with the triple:
+// (?s ex:oftype1 ex:type11), (?s ex:oftype1 ex:type12), (?s ex:oftype2 ex:type21) 
+// or (?s ex:oftype2 ex:type22).
+lucenesail.setParameter(LuceneSail.INDEXEDTYPES, 
+		"http\\://example.org/oftype1=http\\://example.org/type11 http\\://example.org/type12\n"
+		"http\\://example.org/oftype2=http\\://example.org/type21 http\\://example.org/type22"
+);
+```
+
+You can use the special predicate ``a`` instead of ``rdf:type``.
+
+You can also reduce the usage of the base sail to set the type of backtracking:
+
+- ``TypeBacktraceMode.COMPLETE``: (**default**) will check every triples with ?s and try to add or remove them in the Lucene Index.
+- ``TypeBacktraceMode.PARTIAL``: won't check previous triples in the store, assume that the user would add new elements to the index after and with the add of a type triple and would remove elements to the index with the remove of type.
+
+```java
+// the sail won't search for the type a triple if the type isn't in the UPDATE request
+lucenesail.setIndexBacktraceMode(TypeBacktraceMode.PARTIAL);
+```
+
 ## Full text search
 
 Search is case-insensitive, wildcards and other modifiers can be used to broaden the search. For example, search all literals containing words starting with "alic" (e.g. persons named "Alice"):


### PR DESCRIPTION

GitHub issue resolved: #3720 

Briefly describe the changes proposed in this PR:

It add parameters in the LuceneSail to filter the indexed element by languages and types.

- ``INDEXEDLANG``: Check when we are indexing a Literal that the language of the literal is one of the elements in the parameters. 
  Example: ``INDEXEDLANG=fr en`` to filter only French and English literals.
- ``INDEXEDTYPES``: Check for the triple (?s my:pred my:type) in the store or update query before adding an element to the store, my:pred and my:type can be configured. 
  Example:``INDEXEDTYPES="http\\://example.org/oftype=http\\://example.org/type1"``, will filter all the subjects ?s without the triple (?s http://example.org/oftype, http://example.org/type1) in the store or the query.

Another parameter ``INDEX_TYPE_BACKTRACE_MODE`` can be set with the method ``setIndexBacktraceMode(TypeBacktraceMode)`` to define how Lucene should handle the add and a remove of a type triple (?s my:pred my:type):

- ``TypeBacktraceMode.COMPLETE``: will check every triples with ?s and try to add or remove them in the Lucene Index
- ``TypeBacktraceMode.PARTIAL``: won't check previous triples in the store, assume that the user would add new elements to the index after and with the add of a type triple and would remove elements to the index with the remove of type.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change
