### PR TITLE
GH-3729 allow setting a Lucene index id and select it

### DIFF
--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailSchema.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailSchema.java
@@ -30,6 +30,8 @@ public class LuceneSailSchema {
 
 	public static final IRI MATCHES;
 
+	public static final IRI INDEXID;
+
 	/**
 	 * "Magic property" (TupleFunction) IRI.
 	 */
@@ -54,6 +56,8 @@ public class LuceneSailSchema {
 		PROPERTY = factory.createIRI(NAMESPACE + "property");
 		SNIPPET = factory.createIRI(NAMESPACE + "snippet");
 		MATCHES = factory.createIRI(NAMESPACE + "matches");
+
+		INDEXID = factory.createIRI(NAMESPACE + "indexid");
 
 		SEARCH = factory.createIRI(NAMESPACE + "search");
 		ALL_MATCHES = factory.createIRI(NAMESPACE + "allMatches");

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/QuerySpec.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/QuerySpec.java
@@ -34,6 +34,8 @@ public class QuerySpec extends AbstractSearchQueryEvaluator {
 
 	private final StatementPattern typePattern;
 
+	private final StatementPattern idPattern;
+
 	private final Resource subject;
 
 	private final String queryString;
@@ -51,12 +53,20 @@ public class QuerySpec extends AbstractSearchQueryEvaluator {
 	public QuerySpec(StatementPattern matchesPattern, StatementPattern queryPattern, StatementPattern propertyPattern,
 			StatementPattern scorePattern, StatementPattern snippetPattern, StatementPattern typePattern,
 			Resource subject, String queryString, IRI propertyURI) {
+		this(matchesPattern, queryPattern, propertyPattern, scorePattern, snippetPattern, typePattern,
+				null, subject, queryString, propertyURI);
+	}
+
+	public QuerySpec(StatementPattern matchesPattern, StatementPattern queryPattern, StatementPattern propertyPattern,
+			StatementPattern scorePattern, StatementPattern snippetPattern, StatementPattern typePattern,
+			StatementPattern idPattern, Resource subject, String queryString, IRI propertyURI) {
 		this.matchesPattern = matchesPattern;
 		this.queryPattern = queryPattern;
 		this.propertyPattern = propertyPattern;
 		this.scorePattern = scorePattern;
 		this.snippetPattern = snippetPattern;
 		this.typePattern = typePattern;
+		this.idPattern = idPattern;
 		this.subject = subject;
 		this.queryString = queryString;
 		this.propertyURI = propertyURI;
@@ -94,6 +104,7 @@ public class QuerySpec extends AbstractSearchQueryEvaluator {
 		this.snippetPattern = null;
 		this.typePattern = null;
 		this.queryPattern = null;
+		this.idPattern = null;
 		this.subject = subject;
 		this.queryString = queryString;
 		this.propertyURI = propertyURI;
@@ -113,6 +124,7 @@ public class QuerySpec extends AbstractSearchQueryEvaluator {
 		replace(getPropertyPattern(), replacement);
 		replace(getSnippetPattern(), replacement);
 		replace(getTypePattern(), replacement);
+		replace(getIdPattern(), replacement);
 
 		final QueryModelNode placeholder = new SingletonSet();
 
@@ -152,6 +164,10 @@ public class QuerySpec extends AbstractSearchQueryEvaluator {
 
 	public StatementPattern getPropertyPattern() {
 		return propertyPattern;
+	}
+
+	public StatementPattern getIdPattern() {
+		return idPattern;
 	}
 
 	public String getPropertyVariableName() {

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexIdFilteringTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexIdFilteringTest.java
@@ -1,0 +1,432 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.evaluation.TupleFunctionEvaluationMode;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+public class LuceneIndexIdFilteringTest {
+	private static final Logger LOG = LoggerFactory.getLogger(LuceneIndexIdFilteringTest.class);
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+	private static final String NAMESPACE = "http://example.org/";
+	private static final String PREFIXES = joinLines(
+			"PREFIX search: <http://www.openrdf.org/contrib/lucenesail#>",
+			"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
+			"PREFIX ex: <" + NAMESPACE + ">");
+
+	private static IRI iri(String name) {
+		return VF.createIRI(NAMESPACE + name);
+	}
+
+	private static String joinLines(String... lines) {
+		return String.join(" \n", lines);
+	}
+
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	LuceneSail sailType1, sailType2, sailType3;
+	SailRepository repository;
+
+	@Before
+	public void setup() throws IOException {
+		// sails schema
+		// sailType1(LuceneSail) -> sailType2(LuceneSail) -> sailType3(LuceneSail) -> memoryStore(MemoryStore)
+
+		MemoryStore memoryStore = new MemoryStore();
+
+		// sail with the ex:text3 filter
+		sailType3 = new LuceneSail();
+		sailType3.setParameter(LuceneSail.INDEXEDFIELDS, "index.1=" + NAMESPACE + "text3");
+		sailType3.setParameter(LuceneSail.LUCENE_DIR_KEY, "lucene-index3");
+		sailType3.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
+		sailType3.setEvaluationMode(TupleFunctionEvaluationMode.TRIPLE_SOURCE);
+		sailType3.setBaseSail(memoryStore);
+
+		// sail with the ex:text2 filter
+		sailType2 = new LuceneSail();
+		sailType2.setParameter(LuceneSail.INDEXEDFIELDS, "index.1=" + NAMESPACE + "text2");
+		sailType2.setParameter(LuceneSail.LUCENE_DIR_KEY, "lucene-index2");
+		sailType2.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
+		sailType2.setEvaluationMode(TupleFunctionEvaluationMode.NATIVE);
+		sailType2.setBaseSail(sailType3);
+
+		// sail with the ex:text1 filter
+		sailType1 = new LuceneSail();
+		sailType1.setParameter(LuceneSail.INDEXEDFIELDS, "index.1=" + NAMESPACE + "text1");
+		sailType1.setParameter(LuceneSail.LUCENE_DIR_KEY, "lucene-index1");
+		sailType1.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
+		sailType1.setEvaluationMode(TupleFunctionEvaluationMode.NATIVE);
+		sailType1.setBaseSail(sailType2);
+		sailType1.setDataDir(tmpFolder.newFolder());
+	}
+
+	private void initSails() {
+		repository = new SailRepository(sailType1);
+		repository.init();
+
+		// add test elements
+		add(
+				VF.createStatement(iri("element1"), iri("text1"), VF.createLiteral("text")),
+				VF.createStatement(iri("element2"), iri("text1"), VF.createLiteral("text")),
+				VF.createStatement(iri("element2"), iri("text2"), VF.createLiteral("text")),
+				VF.createStatement(iri("element3"), iri("text3"), VF.createLiteral("text"))
+		);
+	}
+
+	private void add(Statement... statements) {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			for (Statement stmt : statements) {
+				connection.add(stmt);
+			}
+		}
+	}
+
+	private void assertSearchQuery(String queryStr, String... exceptedElements) {
+		// using a list for duplicates
+		List<String> exceptedDocSet = Lists.newArrayList(exceptedElements);
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			// fire a query with the subject pre-specified
+			TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL, PREFIXES + "\n" + queryStr);
+			try (TupleQueryResult result = query.evaluate()) {
+				while (result.hasNext()) {
+					BindingSet set = result.next();
+					String element = set.getValue("result").stringValue().substring(NAMESPACE.length());
+					if (!exceptedDocSet.remove(element)) {
+						LOG.error("Docs: " + exceptedDocSet);
+						LOG.error("Remaining:");
+						while (result.hasNext()) {
+							set = result.next();
+							LOG.error("- {}", set.getValue("result").stringValue().substring(NAMESPACE.length()));
+						}
+						Assert.fail("The element '" + element + "' was in the index, but wasn't excepted");
+					}
+				}
+			}
+
+			if (!exceptedDocSet.isEmpty()) {
+				Assert.fail("Unexpected docs: " + exceptedDocSet);
+			}
+		}
+	}
+
+	@Test
+	public void noConfigTest() {
+		// no config
+		initSails();
+
+		assertSearchQuery(joinLines(
+				"SELECT ?result {",
+				"  ?result search:matches ?match .",
+				"  ?match search:query 'text' .",
+				"}"
+		), "element1", "element2");
+	}
+
+	@Test
+	public void idConfigTest() {
+		sailType1.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene1");
+		sailType2.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene2");
+		sailType3.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene3");
+		initSails();
+
+		// try query on index 1
+		assertSearchQuery(joinLines(
+				"SELECT ?result {",
+				"  ?result search:matches ?match .",
+				"  ?match search:indexid ex:lucene1 .",
+				"  ?match search:query 'text' .",
+				"}"
+		), "element1", "element2");
+
+		// try query on index 2
+		assertSearchQuery(joinLines(
+				"SELECT ?result {",
+				"  ?result search:matches ?match .",
+				"  ?match search:indexid ex:lucene2 .",
+				"  ?match search:query 'text' .",
+				"}"
+		), "element2");
+
+		// try query on index 3
+		assertSearchQuery(joinLines(
+				"SELECT ?result {",
+				"  ?result search:matches ?match .",
+				"  ?match search:indexid ex:lucene3 .",
+				"  ?match search:query 'text' .",
+				"}"
+		), "element3");
+
+		// try query on index 2 and 3
+		assertSearchQuery(joinLines(
+				"SELECT ?result {",
+				"  {",
+				"    ?result search:matches ?match .",
+				"    ?match search:indexid ex:lucene2 .",
+				"    ?match search:query 'text' .",
+				"  } UNION {",
+				"    ?result search:matches ?match2 .",
+				"    ?match2 search:indexid ex:lucene3 .",
+				"    ?match2 search:query 'text' .",
+				"  }",
+				"}"
+		), "element2", "element3");
+
+		// try query on index 1 and 2
+		assertSearchQuery(joinLines(
+				"SELECT ?result {",
+				"  {",
+				"    ?result search:matches ?match .",
+				"    ?match search:indexid ex:lucene1 .",
+				"    ?match search:query 'text' .",
+				"  } UNION {",
+				"    ?result search:matches ?match2 .",
+				"    ?match2 search:indexid ex:lucene2 .",
+				"    ?match2 search:query 'text' .",
+				"  }",
+				"}"
+		), "element1", "element2", "element2");
+
+		// try query on index 1, 2 and 3
+		assertSearchQuery(joinLines(
+				"SELECT ?result {",
+				"  {",
+				"    ?result search:matches ?match .",
+				"    ?match search:indexid ex:lucene2 .",
+				"    ?match search:query 'text' .",
+				"  } UNION {",
+				"    ?result search:matches ?match2 .",
+				"    ?match2 search:indexid ex:lucene3 .",
+				"    ?match2 search:query 'text' .",
+				"  } UNION {",
+				"    ?result search:matches ?match3 .",
+				"    ?match3 search:indexid ex:lucene1 .",
+				"    ?match3 search:query 'text' .",
+				"  }",
+				"}"
+		), "element1", "element2", "element2", "element3");
+	}
+
+	private void assertSearchQuery(String queryStr, boolean union, QueryElement... exceptedElements) {
+		// using a list for duplicates
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			// fire a query with the subject pre-specified
+			TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL, PREFIXES + "\n" + queryStr);
+			try (TupleQueryResult result = query.evaluate()) {
+				while (result.hasNext()) {
+					BindingSet set = result.next();
+					Value elementValue = null;
+					for (QueryElement el : exceptedElements) {
+						// union lines shouldn't be containing multiple results
+						if (union && elementValue != null) {
+							Assert.assertNull("union test returns multiple results", set.getValue(el.resultName));
+							continue;
+						}
+						elementValue = set.getValue(el.resultName);
+						if (elementValue == null)
+							continue;
+
+						String element = elementValue.stringValue().substring(NAMESPACE.length());
+						if (!el.elements.remove(element)) {
+							LOG.error("Docs: " + el.elements);
+							LOG.error("Remaining:");
+							while (result.hasNext()) {
+								set = result.next();
+								LOG.error("- {}", set);
+							}
+							Assert.fail("The element '" + element + "' was in the index "
+									+ el.resultName + ", but wasn't excepted");
+						}
+					}
+					Assert.assertNotNull("No element for the set: " + set, elementValue);
+				}
+			}
+
+			List<QueryElement> missing = new ArrayList<>();
+
+			// check for missing elements
+			for (QueryElement el : exceptedElements) {
+				if (!el.elements.isEmpty()) {
+					missing.add(el);
+				}
+			}
+
+			if (!missing.isEmpty()) {
+				Assert.fail("Unexpected docs: " + missing);
+			}
+		}
+	}
+
+	private void assertUnionSearchQuery(String queryStr, QueryElement... exceptedElements) {
+		assertSearchQuery(queryStr, true, exceptedElements);
+	}
+
+	private void assertJoinSearchQuery(String queryStr, QueryElement... exceptedElements) {
+		assertSearchQuery(queryStr, false, exceptedElements);
+	}
+
+	@Test
+	public void idConfigUnionTest() {
+		sailType1.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene1");
+		sailType2.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene2");
+		sailType3.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene3");
+		initSails();
+
+		// try query on index 2 and 3
+		assertUnionSearchQuery(joinLines(
+				"SELECT ?result ?result2 {",
+				"  {",
+				"    ?result search:matches ?match .",
+				"    ?match search:indexid ex:lucene2 .",
+				"    ?match search:query 'text' .",
+				"  } UNION {",
+				"    ?result2 search:matches ?match2 .",
+				"    ?match2 search:indexid ex:lucene3 .",
+				"    ?match2 search:query 'text' .",
+				"  }",
+				"}"
+		),
+				new QueryElement("result", "element2"),
+				new QueryElement("result2", "element3"));
+
+		// try query on index 1 and 2
+		assertUnionSearchQuery(joinLines(
+				"SELECT ?result ?result2 {",
+				"  {",
+				"    ?result search:matches ?match .",
+				"    ?match search:indexid ex:lucene1 .",
+				"    ?match search:query 'text' .",
+				"  } UNION {",
+				"    ?result2 search:matches ?match2 .",
+				"    ?match2 search:indexid ex:lucene2 .",
+				"    ?match2 search:query 'text' .",
+				"  }",
+				"}"
+		),
+				new QueryElement("result", "element1", "element2"),
+				new QueryElement("result2", "element2"));
+
+		// try query on index 1, 2 and 3
+		assertUnionSearchQuery(joinLines(
+				"SELECT ?result ?result2 ?result3 {",
+				"  {",
+				"    ?result search:matches ?match .",
+				"    ?match search:indexid ex:lucene1 .",
+				"    ?match search:query 'text' .",
+				"  } UNION {",
+				"    ?result2 search:matches ?match2 .",
+				"    ?match2 search:indexid ex:lucene2 .",
+				"    ?match2 search:query 'text' .",
+				"  } UNION {",
+				"    ?result3 search:matches ?match3 .",
+				"    ?match3 search:indexid ex:lucene3 .",
+				"    ?match3 search:query 'text' .",
+				"  }",
+				"}"
+		),
+				new QueryElement("result", "element1", "element2"),
+				new QueryElement("result2", "element2"),
+				new QueryElement("result3", "element3"));
+	}
+
+	@Test
+	public void idConfigJoinTest() {
+		sailType1.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene1");
+		sailType2.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene2");
+		sailType3.setParameter(LuceneSail.INDEX_ID, NAMESPACE + "lucene3");
+		initSails();
+		add(
+				VF.createStatement(iri("element4"), iri("text2"), VF.createLiteral("text")),
+				VF.createStatement(iri("element5"), iri("text3"), VF.createLiteral("text")),
+				VF.createStatement(iri("element4"), iri("friend"), iri("element5"))
+		);
+
+		// try query on index 2 and 3
+		assertJoinSearchQuery(joinLines(
+				"SELECT ?result1 ?result2 {",
+				"  {",
+				"    ?result1 search:matches ?match .",
+				"    ?match search:indexid ex:lucene2 .",
+				"    ?match search:query 'text' .",
+				"",
+				"    ?result2 search:matches ?match2 .",
+				"    ?match2 search:indexid ex:lucene3 .",
+				"    ?match2 search:query 'text' .",
+				"  }",
+				"}"
+		),
+				// twice the elements because we are doing result1 x result2
+				new QueryElement("result1", "element2", "element4", "element2", "element4"),
+				new QueryElement("result2", "element3", "element5", "element3", "element5"));
+
+		// try query on index 2 and 3 with a join on the result
+		assertJoinSearchQuery(joinLines(
+				"SELECT ?result1 ?result2 {",
+				"  {",
+				"    ?result1 search:matches ?match .",
+				"    ?match search:indexid ex:lucene2 .",
+				"    ?match search:query 'text' .",
+				"",
+				"    ?result2 search:matches ?match2 .",
+				"    ?match2 search:indexid ex:lucene3 .",
+				"    ?match2 search:query 'text' .",
+				"",
+				"    ?result1 ex:friend ?result2 .",
+				"  }",
+				"}"
+		),
+				new QueryElement("result1", "element4"),
+				new QueryElement("result2", "element5"));
+	}
+
+	static class QueryElement {
+		List<String> elements;
+		String resultName;
+
+		/**
+		 * a result element of a query, shouldn't be used twice
+		 *
+		 * @param resultName       the result object to use
+		 * @param exceptedElements the excepted element
+		 */
+		QueryElement(String resultName, String... exceptedElements) {
+			this.resultName = resultName;
+			this.elements = Lists.newArrayList(exceptedElements);
+		}
+
+		@Override
+		public String toString() {
+			return elements + ": " + resultName;
+		}
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #3729 

Briefly describe the changes proposed in this PR:

In this pull request, I've added a new property to the LuceneSail ``search:indexid`` to select a LuceneSail by ID.

To set an ID, a new parameter was added: ``LuceneSail.INDEX_ID`` and configured with an IRI:

```java
luceneSail.setParameter(LuceneSail.INDEX_ID, "http://example.org/myluceneindex");
```

Now we can select the Lucene index in a SPARQL query by using ``search:indexid``:

```sparql
SELECT ?result {
  ?result search:matches ?match .
  ?match search:indexid ex:myluceneindex .
  ?match search:query 'text' .
}
```

This feature can be used with multiple LuceneSail, we create 3 sails, *ls1*, *ls2* and *ls3* and we chain them like this:

```java
// tripleSource is the next sail
// ...
ls3.setBaseSail(tripleSource);
// ...
ls2.setEvaluationMode(TupleFunctionEvaluationMode.NATIVE);
ls2.setBaseSail(ls3);
// ...
ls1.setEvaluationMode(TupleFunctionEvaluationMode.NATIVE);
ls1.setBaseSail(ls2);
// ls1 is the sail to query
```
Notice that the LuceneSails should have a NATIVE evaluation mode to use another LuceneSail as a base sail, it was added in the documentation.

Now we can join multiple queries over multiple indexes in one query like this on 3 indexes, ``lucene[1-3]`` are the index ids.

```sparql
SELECT ?result1 ?result2 ?result3 {
  {
    ?result1 search:matches ?match .
    ?match search:indexid ex:lucene1 .
    ?match search:query 'my query on lucene1' .

    ?result2 search:matches ?match2 .
    ?match2 search:indexid ex:lucene2 .
    ?match2 search:query 'my query on lucene2' .

    ?result3 search:matches ?match3 .
    ?match3 search:indexid ex:lucene3 .
    ?match3 search:query 'my query on lucene3' .

    ?result1 ex:myprop1 ?result2 .
    ?result2 ex:myprop2 ?result3 .
  }
}
```

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

