### PR TITLE
GH-3737 use release flag to compile for Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,49 @@
 			</build>
 		</profile>
 		<profile>
+			<id>java8-compiler-flags</id>
+			<activation>
+				<jdk>1.8</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<configuration>
+								<fork>true</fork>
+								<source>1.8</source>
+								<target>1.8</target>
+								<encoding>utf8</encoding>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+		<profile>
+			<id>java9-compiler-flags</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<configuration>
+								<fork>true</fork>
+								<release>8</release>
+								<encoding>utf8</encoding>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
 				<jdk>1.8</jdk>
@@ -685,7 +728,6 @@
 					<version>3.8.1</version>
 					<configuration>
 						<fork>true</fork>
-						<release>8</release>
 						<encoding>utf8</encoding>
 					</configuration>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -685,8 +685,7 @@
 					<version>3.8.1</version>
 					<configuration>
 						<fork>true</fork>
-						<source>1.8</source>
-						<target>1.8</target>
+						<release>8</release>
 						<encoding>utf8</encoding>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
GitHub issue resolved: #3737  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Replace the use of of the `source` and `target` compiler arguments with the (new since Java 9) `release` argument. This will ensure that when we do 3.7.x releases, the produced artifacts will be compatible with Java 8 (even if the artifacts are compiled using a newer JVM).

A potential downside: this flag will cause an error if you are _actually_ using Java 8 to compile the code, as the `release` argument was only introduced in Java 9. However, given that we are all running more modern Javas on our machines, and that our Jenkins deployment jobs also have been configured to use Java 11, I think  this may be the simplest way to fix the issue.


See https://stackoverflow.com/questions/43102787/what-is-the-release-flag-in-the-java-9-compiler

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

