### PR TITLE
GH-3763 update spring to 5.3.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
 		<solr.version>7.7.3</solr.version>
 		<elasticsearch.version>6.8.18</elasticsearch.version>
 		<jetty.version>9.4.43.v20210629</jetty.version>
-		<spring.version>5.3.14</spring.version>
+		<spring.version>5.3.18</spring.version>
 		<guava.version>30.1.1-jre</guava.version>
 		<jmhVersion>1.33</jmhVersion>
 		<servlet.version>3.1.0</servlet.version>


### PR DESCRIPTION
GitHub issue resolved: #3763  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Bump version of Spring framework to 5.3.18 to address possible security vulnerability.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

