### PR TITLE
GH-3765 add support for rdf-star triple persistence in memorystore

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/FileIO.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/FileIO.java
@@ -32,9 +32,11 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.base.SailDataset;
 import org.eclipse.rdf4j.sail.base.SailSink;
@@ -60,7 +62,8 @@ class FileIO {
 	// Version 1: initial version
 	// Version 2: don't use read/writeUTF() to remove 64k limit on strings,
 	// removed dummy "up-to-date status" boolean for namespace records
-	private static final int BMSF_VERSION = 2;
+	// Version 3: introduced RDF-star triple record type
+	private static final int BMSF_VERSION = 3;
 
 	/* RECORD TYPES */
 	public static final int NAMESPACE_MARKER = 1;
@@ -82,6 +85,8 @@ class FileIO {
 	public static final int LANG_LITERAL_MARKER = 9;
 
 	public static final int DATATYPE_LITERAL_MARKER = 10;
+
+	public static final int RDFSTAR_TRIPLE_MARKER = 11;
 
 	public static final int EOF_MARKER = 127;
 
@@ -260,13 +265,13 @@ class FileIO {
 	}
 
 	private void writeValue(Value value, DataOutputStream dataOut) throws IOException {
-		if (value instanceof IRI) {
+		if (value.isIRI()) {
 			dataOut.writeByte(URI_MARKER);
-			writeString(((IRI) value).toString(), dataOut);
-		} else if (value instanceof BNode) {
+			writeString(((IRI) value).stringValue(), dataOut);
+		} else if (value.isBNode()) {
 			dataOut.writeByte(BNODE_MARKER);
 			writeString(((BNode) value).getID(), dataOut);
-		} else if (value instanceof Literal) {
+		} else if (value.isLiteral()) {
 			Literal lit = (Literal) value;
 
 			String label = lit.getLabel();
@@ -281,6 +286,9 @@ class FileIO {
 				writeString(label, dataOut);
 				writeValue(datatype, dataOut);
 			}
+		} else if (value.isTriple()) {
+			dataOut.writeByte(RDFSTAR_TRIPLE_MARKER);
+			writeValue(RDFStarUtil.toRDFEncodedValue(value), dataOut);
 		} else {
 			throw new IllegalArgumentException("unexpected value type: " + value.getClass());
 		}
@@ -306,6 +314,9 @@ class FileIO {
 			String label = readString(dataIn);
 			IRI datatype = (IRI) readValue(dataIn);
 			return vf.createLiteral(label, datatype);
+		} else if (valueTypeMarker == RDFSTAR_TRIPLE_MARKER) {
+			IRI rdfStarEncodedTriple = (IRI) readValue(dataIn);
+			return RDFStarUtil.fromRDFEncodedValue(rdfStarEncodedTriple);
 		} else {
 			throw new IOException("Invalid value type marker: " + valueTypeMarker);
 		}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryRDFStarSupportTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryRDFStarSupportTest.java
@@ -7,9 +7,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory;
 
+import java.io.File;
+
 import org.eclipse.rdf4j.repository.RDFStarSupportTest;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author jeen
@@ -17,9 +20,12 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
  */
 public class MemoryRDFStarSupportTest extends RDFStarSupportTest {
 
+	@TempDir
+	File tempDir;
+
 	@Override
 	protected Repository createRepository() {
-		return new SailRepository(new MemoryStore());
+		return new SailRepository(new MemoryStore(tempDir));
 	}
 
 }

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/repository/RDFStarSupportTest.java
@@ -25,11 +25,10 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test cases for RDF-star support in the Repository.
@@ -37,12 +36,8 @@ import org.junit.rules.Timeout;
  * @author Jeen Broekstra
  *
  */
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
 public abstract class RDFStarSupportTest {
-	/**
-	 * Timeout all individual tests after 10 minutes.
-	 */
-	@Rule
-	public Timeout to = new Timeout(10, TimeUnit.MINUTES);
 
 	private Repository testRepository;
 
@@ -68,7 +63,7 @@ public abstract class RDFStarSupportTest {
 
 	private IRI context2;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		testRepository = createRepository();
 
@@ -93,7 +88,7 @@ public abstract class RDFStarSupportTest {
 		context2 = vf.createIRI("urn:x-local:graph2");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			testCon.close();


### PR DESCRIPTION
GitHub issue resolved: #3765  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added support for reading/writing RDF-star triples in memory store custom persistence format
- extended rdf-star tests to explicitly run with a persistence-enabled memory store

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

