### PR TITLE
GH-3782 clean up handling of GROUP BY projection element verification

### DIFF
--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -41,7 +41,6 @@ import org.eclipse.rdf4j.query.parser.ParsedGraphQuery;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
 import org.eclipse.rdf4j.query.parser.ParsedUpdate;
-import org.eclipse.rdf4j.query.parser.sparql.ast.VisitorException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -442,6 +441,18 @@ public class SPARQLParserTest {
 	@Test
 	public void testGroupByProjectionHandling_Aggregate_SimpleExpr2() {
 		String query = "SELECT (COUNT(?s) as ?count) ?o \n"
+				+ "WHERE {\n"
+				+ "	?s ?p ?o \n"
+				+ "} GROUP BY ?o";
+
+		// should parse without error
+		parser.parseQuery(query, null);
+
+	}
+
+	@Test
+	public void testGroupByProjectionHandling_Aggregate_Constant() {
+		String query = "SELECT (COUNT(?s) as ?count) (<foo:constant> as ?constant) \n"
 				+ "WHERE {\n"
 				+ "	?s ?p ?o \n"
 				+ "} GROUP BY ?o";


### PR DESCRIPTION
GitHub issue resolved: #3782  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

When a query has a GROUP BY clause, the projection may only contain:

 1. aggregate expressions
 2. constants
 3. simple expressions consisting of just a variable (if and only if that var is in the GROUP BY)

code changes: 

- check presence of all non-simple expression types in projeciton when using GROUP BY
- clearer errors are given
- added test cases

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

