### PR TITLE
GH-3798 Prepare the FunctionCall and And operators.

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/CustomAggregateFunctionEvaluationTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/CustomAggregateFunctionEvaluationTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.query.parser.sparql.function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -484,8 +485,8 @@ public class CustomAggregateFunctionEvaluationTest {
 		String query = "select (<http://example.org/doesNotExist>(?o) as ?m) where { ?s <urn:n> ?o . }";
 		try (RepositoryConnection conn = rep.getConnection()) {
 			try (TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
-				QueryEvaluationException queryEvaluationException = Assertions
-						.assertThrows(QueryEvaluationException.class, result::next);
+				fail();
+			} catch (QueryEvaluationException queryEvaluationException) {
 				Assertions.assertFalse(queryEvaluationException.toString().contains("aggregate"));
 			}
 		}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryValueEvaluationStep.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
+import java.util.function.Function;
+
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -75,6 +77,43 @@ public interface QueryValueEvaluationStep {
 		@Override
 		public Value evaluate(BindingSet bindings) throws QueryEvaluationException {
 			return strategy.evaluate(ve, bindings);
+		}
+	}
+
+	/**
+	 * A minimal implementation that falls is known to throw an ValueExprEvaluationException. This can't be a constant
+	 * as the downstream code needs to catch and deal with it and that needs re-evaluation.
+	 */
+	public static final class Fail implements QueryValueEvaluationStep {
+
+		private final String message;
+
+		public Fail(String message) {
+			super();
+			this.message = message;
+		}
+
+		@Override
+		public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+			throw new ValueExprEvaluationException(message);
+		}
+	}
+
+	/**
+	 * A minimal implementation that falls calls a function that should return a value per passed in bindingsets.
+	 */
+	public static final class ApplyFunctionForEachBinding implements QueryValueEvaluationStep {
+
+		private final Function<BindingSet, Value> function;
+
+		public ApplyFunctionForEachBinding(Function<BindingSet, Value> function) {
+			super();
+			this.function = function;
+		}
+
+		@Override
+		public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+			return function.apply(bindings);
 		}
 	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DefaultEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DefaultEvaluationStrategy.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -146,6 +147,16 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.SliceQuer
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.StatementPatternQueryEvaluationStep;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.UnionQueryEvaluationStep;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.ZeroLengthPathEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.AndValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.CompareAllQueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.CompareAnyValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.ExistsQueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.IfValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.InValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.ListMemberValueOperationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.OrValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.QueryValueEvaluationStepSupplier;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values.ValueExprTripleRefEvaluationStep;
 import org.eclipse.rdf4j.query.algebra.evaluation.iterator.DescribeIteration;
 import org.eclipse.rdf4j.query.algebra.evaluation.iterator.ExtensionIterator;
 import org.eclipse.rdf4j.query.algebra.evaluation.iterator.FilterIterator;
@@ -1029,48 +1040,48 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 		} else if (expr instanceof ValueConstant) {
 			return prepare((ValueConstant) expr, context);
 		} else if (expr instanceof BNodeGenerator) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((BNodeGenerator) expr, context);
 		} else if (expr instanceof Bound) {
 			return prepare((Bound) expr, context);
 //			return new QueryValueEvaluationStep.Minimal(this, expr);
 		} else if (expr instanceof Str) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Str) expr, context);
 		} else if (expr instanceof Label) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Label) expr, context);
 		} else if (expr instanceof Lang) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Lang) expr, context);
 		} else if (expr instanceof LangMatches) {
 			return prepare((LangMatches) expr, context);
 		} else if (expr instanceof Datatype) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Datatype) expr, context);
 		} else if (expr instanceof Namespace) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Namespace) expr, context);
 		} else if (expr instanceof LocalName) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((LocalName) expr, context);
 		} else if (expr instanceof IsResource) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((IsResource) expr, context);
 		} else if (expr instanceof IsURI) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((IsURI) expr, context);
 		} else if (expr instanceof IsBNode) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((IsBNode) expr, context);
 		} else if (expr instanceof IsLiteral) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((IsLiteral) expr, context);
 		} else if (expr instanceof IsNumeric) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((IsNumeric) expr, context);
 		} else if (expr instanceof IRIFunction) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((IRIFunction) expr, context);
 		} else if (expr instanceof Regex) {
 			return prepare((Regex) expr, context);
 		} else if (expr instanceof Coalesce) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Coalesce) expr, context);
 		} else if (expr instanceof Like) {
 			return new QueryValueEvaluationStep.Minimal(this, expr);
 		} else if (expr instanceof FunctionCall) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((FunctionCall) expr, context);
 		} else if (expr instanceof And) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((And) expr, context);
 		} else if (expr instanceof Or) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Or) expr, context);
 		} else if (expr instanceof Not) {
 			return prepare((Not) expr, context);
 		} else if (expr instanceof SameTerm) {
@@ -1080,19 +1091,19 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 		} else if (expr instanceof MathExpr) {
 			return prepare((MathExpr) expr, context);
 		} else if (expr instanceof In) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((In) expr, context);
 		} else if (expr instanceof CompareAny) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((CompareAny) expr, context);
 		} else if (expr instanceof CompareAll) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((CompareAll) expr, context);
 		} else if (expr instanceof Exists) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Exists) expr, context);
 		} else if (expr instanceof If) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((If) expr, context);
 		} else if (expr instanceof ListMemberOperator) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((ListMemberOperator) expr, context);
 		} else if (expr instanceof ValueExprTripleRef) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((ValueExprTripleRef) expr, context);
 		} else if (expr == null) {
 			throw new IllegalArgumentException("expr must not be null");
 		} else {
@@ -1104,79 +1115,7 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	@Override
 	public Value evaluate(ValueExpr expr, BindingSet bindings)
 			throws QueryEvaluationException {
-		if (expr instanceof Var) {
-			return evaluate((Var) expr, bindings);
-		} else if (expr instanceof ValueConstant) {
-			return evaluate((ValueConstant) expr, bindings);
-		} else if (expr instanceof BNodeGenerator) {
-			return evaluate((BNodeGenerator) expr, bindings);
-		} else if (expr instanceof Bound) {
-			return evaluate((Bound) expr, bindings);
-		} else if (expr instanceof Str) {
-			return evaluate((Str) expr, bindings);
-		} else if (expr instanceof Label) {
-			return evaluate((Label) expr, bindings);
-		} else if (expr instanceof Lang) {
-			return evaluate((Lang) expr, bindings);
-		} else if (expr instanceof LangMatches) {
-			return evaluate((LangMatches) expr, bindings);
-		} else if (expr instanceof Datatype) {
-			return evaluate((Datatype) expr, bindings);
-		} else if (expr instanceof Namespace) {
-			return evaluate((Namespace) expr, bindings);
-		} else if (expr instanceof LocalName) {
-			return evaluate((LocalName) expr, bindings);
-		} else if (expr instanceof IsResource) {
-			return evaluate((IsResource) expr, bindings);
-		} else if (expr instanceof IsURI) {
-			return evaluate((IsURI) expr, bindings);
-		} else if (expr instanceof IsBNode) {
-			return evaluate((IsBNode) expr, bindings);
-		} else if (expr instanceof IsLiteral) {
-			return evaluate((IsLiteral) expr, bindings);
-		} else if (expr instanceof IsNumeric) {
-			return evaluate((IsNumeric) expr, bindings);
-		} else if (expr instanceof IRIFunction) {
-			return evaluate((IRIFunction) expr, bindings);
-		} else if (expr instanceof Regex) {
-			return evaluate((Regex) expr, bindings);
-		} else if (expr instanceof Coalesce) {
-			return evaluate((Coalesce) expr, bindings);
-		} else if (expr instanceof Like) {
-			return evaluate((Like) expr, bindings);
-		} else if (expr instanceof FunctionCall) {
-			return evaluate((FunctionCall) expr, bindings);
-		} else if (expr instanceof And) {
-			return evaluate((And) expr, bindings);
-		} else if (expr instanceof Or) {
-			return evaluate((Or) expr, bindings);
-		} else if (expr instanceof Not) {
-			return evaluate((Not) expr, bindings);
-		} else if (expr instanceof SameTerm) {
-			return evaluate((SameTerm) expr, bindings);
-		} else if (expr instanceof Compare) {
-			return evaluate((Compare) expr, bindings);
-		} else if (expr instanceof MathExpr) {
-			return evaluate((MathExpr) expr, bindings);
-		} else if (expr instanceof In) {
-			return evaluate((In) expr, bindings);
-		} else if (expr instanceof CompareAny) {
-			return evaluate((CompareAny) expr, bindings);
-		} else if (expr instanceof CompareAll) {
-			return evaluate((CompareAll) expr, bindings);
-		} else if (expr instanceof Exists) {
-			return evaluate((Exists) expr, bindings);
-		} else if (expr instanceof If) {
-			return evaluate((If) expr, bindings);
-		} else if (expr instanceof ListMemberOperator) {
-			return evaluate((ListMemberOperator) expr, bindings);
-		} else if (expr instanceof ValueExprTripleRef) {
-			return evaluate((ValueExprTripleRef) expr, bindings);
-		} else if (expr == null) {
-			throw new IllegalArgumentException("expr must not be null");
-		} else {
-			throw new QueryEvaluationException("Unsupported value expr type: " + expr.getClass());
-		}
+		return precompile(expr, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
 	}
 
 	@Deprecated(forRemoval = true)
@@ -1231,50 +1170,32 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	}
 
 	@Deprecated(forRemoval = true)
-	public Value evaluate(BNodeGenerator node, BindingSet bindings)
+	public Value evaluate(BNodeGenerator node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
+
+	protected QueryValueEvaluationStep prepare(BNodeGenerator node, QueryEvaluationContext context)
 			throws QueryEvaluationException {
+		ValueFactory vf = tripleSource.getValueFactory();
 		ValueExpr nodeIdExpr = node.getNodeIdExpr();
-
 		if (nodeIdExpr != null) {
-			Value nodeId = evaluate(nodeIdExpr, bindings);
-
-			if (nodeId instanceof Literal) {
-				String nodeLabel = ((Literal) nodeId).getLabel() + (bindings.toString().hashCode());
-				return tripleSource.getValueFactory().createBNode(nodeLabel);
-			} else {
-				throw new ValueExprEvaluationException("BNODE function argument must be a literal");
-			}
+			QueryValueEvaluationStep nodeVes = precompile(nodeIdExpr, context);
+			return QueryValueEvaluationStepSupplier.bnode(nodeVes, vf);
+		} else {
+			return new QueryValueEvaluationStep.ApplyFunctionForEachBinding((bs) -> vf.createBNode());
 		}
-		return tripleSource.getValueFactory().createBNode();
 	}
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(Bound node, BindingSet bindings) throws QueryEvaluationException {
-		try {
-			Value argValue = evaluate(node.getArg(), bindings);
-			return BooleanLiteral.valueOf(argValue != null);
-		} catch (ValueExprEvaluationException e) {
-			return BooleanLiteral.FALSE;
-		}
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
 	}
 
-	private QueryValueEvaluationStep prepare(Bound node, QueryEvaluationContext context)
+	protected QueryValueEvaluationStep prepare(Bound node, QueryEvaluationContext context)
 			throws QueryEvaluationException {
 		try {
 			QueryValueEvaluationStep arg = precompile(node.getArg(), context);
-			return new QueryValueEvaluationStep() {
-
-				@Override
-				public Value evaluate(BindingSet bindings)
-						throws ValueExprEvaluationException, QueryEvaluationException {
-					try {
-						Value argValue = arg.evaluate(bindings);
-						return BooleanLiteral.valueOf(argValue != null);
-					} catch (ValueExprEvaluationException e) {
-						return BooleanLiteral.FALSE;
-					}
-				}
-			};
+			return QueryValueEvaluationStepSupplier.prepareBound(arg, context);
 		} catch (QueryEvaluationException e) {
 			return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
 		}
@@ -1282,104 +1203,65 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(Str node, BindingSet bindings) throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
 
-		if (argValue instanceof IRI) {
-			return tripleSource.getValueFactory().createLiteral(argValue.toString());
-		} else if (argValue instanceof Literal) {
-			Literal literal = (Literal) argValue;
-
-			if (QueryEvaluationUtility.isSimpleLiteral(literal)) {
-				return literal;
-			} else {
-				return tripleSource.getValueFactory().createLiteral(literal.getLabel());
-			}
-		} else if (argValue instanceof Triple) {
-			return tripleSource.getValueFactory().createLiteral(argValue.toString());
-		} else {
-			throw new ValueExprEvaluationException();
-		}
+	protected QueryValueEvaluationStep prepare(Str node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		ValueFactory valueFactory = tripleSource.getValueFactory();
+		return QueryValueEvaluationStepSupplier.prepareStr(arg, valueFactory);
 	}
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(Label node, BindingSet bindings)
 			throws QueryEvaluationException {
-		// FIXME: deprecate Label in favour of Str(?)
-		Value argValue = evaluate(node.getArg(), bindings);
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
 
-		if (argValue instanceof Literal) {
-			Literal literal = (Literal) argValue;
-
-			if (QueryEvaluationUtility.isSimpleLiteral(literal)) {
-				return literal;
-			} else {
-				return tripleSource.getValueFactory().createLiteral(literal.getLabel());
-			}
-		} else {
-			throw new ValueExprEvaluationException();
-		}
+	protected QueryValueEvaluationStep prepare(Label node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareLabel(arg, tripleSource.getValueFactory());
 	}
 
 	@Deprecated(forRemoval = true)
-	public Value evaluate(Lang node, BindingSet bindings)
-			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
+	public Value evaluate(Lang node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
 
-		if (argValue instanceof Literal) {
-			Literal literal = (Literal) argValue;
-			return tripleSource.getValueFactory().createLiteral(literal.getLanguage().orElse(""));
-		}
+	protected QueryValueEvaluationStep prepare(Lang node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareLang(arg, tripleSource.getValueFactory());
+	}
 
-		throw new ValueExprEvaluationException();
+	public Value evaluate(Datatype node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
+
+	protected QueryValueEvaluationStep prepare(Datatype node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareDatatype(arg, context);
 	}
 
 	@Deprecated(forRemoval = true)
-	public Value evaluate(Datatype node, BindingSet bindings)
-			throws QueryEvaluationException {
-		Value v = evaluate(node.getArg(), bindings);
+	public Value evaluate(Namespace node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
 
-		if (v instanceof Literal) {
-			Literal literal = (Literal) v;
-
-			if (literal.getDatatype() != null) {
-				// literal with datatype
-				return literal.getDatatype();
-			} else if (literal.getLanguage().isPresent()) {
-				return CoreDatatype.RDF.LANGSTRING.getIri();
-			} else {
-				// simple literal
-				return CoreDatatype.XSD.STRING.getIri();
-			}
-
-		}
-
-		throw new ValueExprEvaluationException();
+	protected QueryValueEvaluationStep prepare(Namespace node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareNamespace(arg, tripleSource.getValueFactory());
 	}
 
 	@Deprecated(forRemoval = true)
-	public Value evaluate(Namespace node, BindingSet bindings)
-			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
-
-		if (argValue instanceof IRI) {
-			IRI uri = (IRI) argValue;
-			return tripleSource.getValueFactory().createIRI(uri.getNamespace());
-		} else {
-			throw new ValueExprEvaluationException();
-		}
+	public Value evaluate(LocalName node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
 	}
 
-	@Deprecated(forRemoval = true)
-	public Value evaluate(LocalName node, BindingSet bindings)
-			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
-
-		if (argValue instanceof IRI) {
-			IRI uri = (IRI) argValue;
-			return tripleSource.getValueFactory().createLiteral(uri.getLocalName());
-		} else {
-			throw new ValueExprEvaluationException();
-		}
+	protected QueryValueEvaluationStep prepare(LocalName node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareLocalName(arg, tripleSource.getValueFactory());
 	}
 
 	/**
@@ -1388,10 +1270,13 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	 * @return <var>true</var> if the operand contains a Resource, <var>false</var> otherwise.
 	 */
 	@Deprecated(forRemoval = true)
-	public Value evaluate(IsResource node, BindingSet bindings)
-			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
-		return BooleanLiteral.valueOf(argValue instanceof Resource);
+	public Value evaluate(IsResource node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
+
+	protected QueryValueEvaluationStep prepare(IsResource node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareIs(arg, v -> v instanceof Resource);
 	}
 
 	/**
@@ -1400,10 +1285,13 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	 * @return <var>true</var> if the operand contains a URI, <var>false</var> otherwise.
 	 */
 	@Deprecated(forRemoval = true)
-	public Value evaluate(IsURI node, BindingSet bindings)
-			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
-		return BooleanLiteral.valueOf(argValue instanceof IRI);
+	public Value evaluate(IsURI node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
+
+	protected QueryValueEvaluationStep prepare(IsURI node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareIs(arg, v -> v instanceof IRI);
 	}
 
 	/**
@@ -1412,10 +1300,13 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	 * @return <var>true</var> if the operand contains a BNode, <var>false</var> otherwise.
 	 */
 	@Deprecated(forRemoval = true)
-	public Value evaluate(IsBNode node, BindingSet bindings)
-			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
-		return BooleanLiteral.valueOf(argValue instanceof BNode);
+	public Value evaluate(IsBNode node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
+
+	protected QueryValueEvaluationStep prepare(IsBNode node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareIs(arg, v -> v instanceof BNode);
 	}
 
 	/**
@@ -1424,10 +1315,13 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	 * @return <var>true</var> if the operand contains a Literal, <var>false</var> otherwise.
 	 */
 	@Deprecated(forRemoval = true)
-	public Value evaluate(IsLiteral node, BindingSet bindings)
-			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
-		return BooleanLiteral.valueOf(argValue instanceof Literal);
+	public Value evaluate(IsLiteral node, BindingSet bindings) throws QueryEvaluationException {
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
+
+	protected QueryValueEvaluationStep prepare(IsLiteral node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareIs(arg, v -> v instanceof Literal);
 	}
 
 	/**
@@ -1440,17 +1334,22 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	@Deprecated(forRemoval = true)
 	public Value evaluate(IsNumeric node, BindingSet bindings)
 			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
 
+	protected QueryValueEvaluationStep prepare(IsNumeric node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareIs(arg, DefaultEvaluationStrategy::isNumeric);
+	}
+
+	private static boolean isNumeric(Value argValue) {
 		if (argValue instanceof Literal) {
 			Literal lit = (Literal) argValue;
 			IRI datatype = lit.getDatatype();
-
-			return BooleanLiteral.valueOf(XMLDatatypeUtil.isNumericDatatype(datatype));
+			return XMLDatatypeUtil.isNumericDatatype(datatype);
 		} else {
-			return BooleanLiteral.FALSE;
+			return false;
 		}
-
 	}
 
 	/**
@@ -1464,38 +1363,12 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	@Deprecated(forRemoval = true)
 	public IRI evaluate(IRIFunction node, BindingSet bindings)
 			throws QueryEvaluationException {
-		Value argValue = evaluate(node.getArg(), bindings);
+		return (IRI) prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
 
-		if (argValue instanceof Literal) {
-			final Literal lit = (Literal) argValue;
-
-			String uriString = lit.getLabel();
-			final String baseURI = node.getBaseURI();
-			try {
-				ParsedIRI iri = ParsedIRI.create(uriString);
-				if (!iri.isAbsolute() && baseURI != null) {
-					// uri string may be a relative reference.
-					uriString = ParsedIRI.create(baseURI).resolve(iri).toString();
-				} else if (!iri.isAbsolute()) {
-					throw new ValueExprEvaluationException("not an absolute IRI reference: " + uriString);
-				}
-			} catch (IllegalArgumentException e) {
-				throw new ValueExprEvaluationException("not a valid IRI reference: " + uriString);
-			}
-
-			IRI result;
-
-			try {
-				result = tripleSource.getValueFactory().createIRI(uriString);
-			} catch (IllegalArgumentException e) {
-				throw new ValueExprEvaluationException(e.getMessage());
-			}
-			return result;
-		} else if (argValue instanceof IRI) {
-			return ((IRI) argValue);
-		}
-
-		throw new ValueExprEvaluationException();
+	protected QueryValueEvaluationStep prepare(IRIFunction node, QueryEvaluationContext context) {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		return QueryValueEvaluationStepSupplier.prepareIriFunction(node, arg, tripleSource.getValueFactory());
 	}
 
 	/**
@@ -1691,9 +1564,13 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 
 		boolean allConstant = determineIfFunctionCallWillBeAConstant(context, function, args, argSteps);
 		if (allConstant) {
-			Value[] argValues = evaluateAllArguments(args, argSteps, EmptyBindingSet.getInstance());
-			Value res = function.evaluate(tripleSource, argValues);
-			return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(res);
+			try {
+				Value[] argValues = evaluateAllArguments(args, argSteps, EmptyBindingSet.getInstance());
+				Value res = function.evaluate(tripleSource, argValues);
+				return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(res);
+			} catch (QueryEvaluationException ex) {
+				return new QueryValueEvaluationStep.Fail("Constant failure: " + ex.getMessage());
+			}
 		} else {
 			return new QueryValueEvaluationStep() {
 
@@ -1746,54 +1623,38 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(And node, BindingSet bindings) throws QueryEvaluationException {
-		try {
-			Value leftValue = evaluate(node.getLeftArg(), bindings);
-			if (QueryEvaluationUtility.getEffectiveBooleanValue(leftValue) == QueryEvaluationUtility.Result._false) {
-				// Left argument evaluates to false, we don't need to look any
-				// further
-				return BooleanLiteral.FALSE;
-			}
-		} catch (ValueExprEvaluationException e) {
-			// Failed to evaluate the left argument. Result is 'false' when
-			// the right argument evaluates to 'false', failure otherwise.
-			Value rightValue = evaluate(node.getRightArg(), bindings);
-			if (QueryEvaluationUtility.getEffectiveBooleanValue(rightValue) == QueryEvaluationUtility.Result._false) {
-				return BooleanLiteral.FALSE;
-			} else {
-				throw new ValueExprEvaluationException();
-			}
-		}
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
 
-		// Left argument evaluated to 'true', result is determined
-		// by the evaluation of the right argument.
-		Value rightValue = evaluate(node.getRightArg(), bindings);
-		return BooleanLiteral.valueOf(QueryEvaluationUtil.getEffectiveBooleanValue(rightValue));
+	private QueryValueEvaluationStep prepare(And node, QueryEvaluationContext context) throws QueryEvaluationException {
+		QueryValueEvaluationStep leftStep = precompile(node.getLeftArg(), context);
+		QueryValueEvaluationStep rightStep = precompile(node.getRightArg(), context);
+
+		return AndValueEvaluationStep.supply(leftStep, rightStep);
 	}
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(Or node, BindingSet bindings) throws QueryEvaluationException {
-		try {
-			Value leftValue = evaluate(node.getLeftArg(), bindings);
-			if (QueryEvaluationUtil.getEffectiveBooleanValue(leftValue)) {
-				// Left argument evaluates to true, we don't need to look any
-				// further
-				return BooleanLiteral.TRUE;
-			}
-		} catch (ValueExprEvaluationException e) {
-			// Failed to evaluate the left argument. Result is 'true' when
-			// the right argument evaluates to 'true', failure otherwise.
-			Value rightValue = evaluate(node.getRightArg(), bindings);
-			if (QueryEvaluationUtil.getEffectiveBooleanValue(rightValue)) {
-				return BooleanLiteral.TRUE;
-			} else {
-				throw new ValueExprEvaluationException();
-			}
-		}
+		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+	}
 
-		// Left argument evaluated to 'false', result is determined
-		// by the evaluation of the right argument.
-		Value rightValue = evaluate(node.getRightArg(), bindings);
-		return BooleanLiteral.valueOf(QueryEvaluationUtil.getEffectiveBooleanValue(rightValue));
+	protected QueryValueEvaluationStep prepare(Or node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryValueEvaluationStep leftArg = null;
+		QueryValueEvaluationStep rightArg = null;
+		try {
+			try {
+				leftArg = precompile(node.getLeftArg(), context);
+			} catch (ValueExprEvaluationException e) {
+				// leftArg would always be false in this case so no need to evaluate it.
+				return precompile(node.getRightArg(), context);
+			}
+			rightArg = precompile(node.getRightArg(), context);
+		} catch (ValueExprEvaluationException e) {
+			// Both failed to compile so we know we will always throw an exception
+			return new QueryValueEvaluationStep.Fail("Value Expressions in OR both failed to prepare/precompile");
+		}
+		return new OrValueEvaluationStep(leftArg, rightArg);
 	}
 
 	@Deprecated(forRemoval = true)
@@ -1844,25 +1705,40 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(Coalesce node, BindingSet bindings) throws ValueExprEvaluationException {
-		Value result = null;
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
+	}
 
-		for (ValueExpr expr : node.getArguments()) {
+	protected QueryValueEvaluationStep prepare(Coalesce node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		List<ValueExpr> args = node.getArguments();
+		List<QueryValueEvaluationStep> compiledArgs = new ArrayList<>(args.size());
+		for (ValueExpr arg : args) {
 			try {
-				result = evaluate(expr, bindings);
-
-				// return first result that does not produce an error on
-				// evaluation.
-				break;
-			} catch (QueryEvaluationException ignored) {
+				compiledArgs.add(precompile(arg, context));
+			} catch (QueryEvaluationException e) {
+				// no need to add as it would have been ignored anyway.
 			}
 		}
 
-		if (result == null) {
-			throw new ValueExprEvaluationException(
-					"COALESCE arguments do not evaluate to a value: " + node.getSignature());
-		}
+		return new QueryValueEvaluationStep() {
 
-		return result;
+			@Override
+			public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+
+				for (QueryValueEvaluationStep expr : compiledArgs) {
+					try {
+						// return first result that does not produce an error on
+						// evaluation.
+						return expr.evaluate(bindings);
+
+					} catch (QueryEvaluationException ignored) {
+					}
+				}
+
+				throw new ValueExprEvaluationException(
+						"COALESCE arguments do not evaluate to a value: " + node.getSignature());
+			}
+		};
 	}
 
 	@Deprecated(forRemoval = true)
@@ -1927,147 +1803,92 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(If node, BindingSet bindings) throws QueryEvaluationException {
-		Value result;
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
+	}
 
-		boolean conditionIsTrue;
-
+	protected QueryValueEvaluationStep prepare(If node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryValueEvaluationStep condition;
 		try {
-			Value value = evaluate(node.getCondition(), bindings);
-			conditionIsTrue = QueryEvaluationUtil.getEffectiveBooleanValue(value);
+			condition = precompile(node.getCondition(), context);
 		} catch (ValueExprEvaluationException e) {
 			// in case of type error, if-construction should result in empty
 			// binding.
-			return null;
+			return new QueryValueEvaluationStep.ApplyFunctionForEachBinding(bs -> null);
 		}
-
-		if (conditionIsTrue) {
-			result = evaluate(node.getResult(), bindings);
-		} else {
-			result = evaluate(node.getAlternative(), bindings);
-		}
-		return result;
+		QueryValueEvaluationStep result = precompile(node.getResult(), context);
+		QueryValueEvaluationStep alternative = precompile(node.getAlternative(), context);
+		return new IfValueEvaluationStep(result, condition, alternative);
 	}
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(In node, BindingSet bindings) throws QueryEvaluationException {
-		Value leftValue = evaluate(node.getArg(), bindings);
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
+	}
 
-		// Result is false until a match has been found
-		boolean result = false;
-
-		// Use first binding name from tuple expr to compare values
-		String bindingName = node.getSubQuery().getBindingNames().iterator().next();
-
-		try (CloseableIteration<BindingSet, QueryEvaluationException> iter = evaluate(node.getSubQuery(), bindings)) {
-			while (!result && iter.hasNext()) {
-				BindingSet bindingSet = iter.next();
-
-				Value rightValue = bindingSet.getValue(bindingName);
-
-				result = leftValue == null && rightValue == null || leftValue != null && leftValue.equals(rightValue);
-			}
-		}
-
-		return BooleanLiteral.valueOf(result);
+	protected QueryValueEvaluationStep prepare(In node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryValueEvaluationStep left = precompile(node.getArg(), context);
+		QueryEvaluationStep subquery = precompile(node.getSubQuery(), context);
+		return new InValueEvaluationStep(node, subquery, left);
 	}
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(ListMemberOperator node, BindingSet bindings)
 			throws QueryEvaluationException {
-		List<ValueExpr> args = node.getArguments();
-		Value leftValue = evaluate(args.get(0), bindings);
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
+	}
 
-		boolean result = false;
-		ValueExprEvaluationException typeError = null;
-		for (int i = 1; i < args.size(); i++) {
-			ValueExpr arg = args.get(i);
+	protected QueryValueEvaluationStep prepare(ListMemberOperator node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		List<ValueExpr> args = node.getArguments();
+		List<QueryValueEvaluationStep> compiledArgs = new ArrayList<>(args.size());
+		for (ValueExpr arg : args) {
 			try {
-				Value rightValue = evaluate(arg, bindings);
-				result = leftValue == null && rightValue == null;
-				if (!result) {
-					result = QueryEvaluationUtil.compare(leftValue, rightValue, CompareOp.EQ);
-				}
-				if (result) {
-					break;
-				}
-			} catch (ValueExprEvaluationException caught) {
-				typeError = caught;
+				compiledArgs.add(precompile(arg, context));
+			} catch (ValueExprEvaluationException e) {
+				compiledArgs.add(new QueryValueEvaluationStep.Fail(""));
 			}
 		}
-
-		if (typeError != null && !result) {
-			// cf. SPARQL spec a type error is thrown if the value is not in the
-			// list and one of the list members caused a type error in the
-			// comparison.
-			throw typeError;
-		}
-
-		return BooleanLiteral.valueOf(result);
+		return new ListMemberValueOperationStep(compiledArgs);
 	}
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(CompareAny node, BindingSet bindings)
 			throws QueryEvaluationException {
-		Value leftValue = evaluate(node.getArg(), bindings);
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
+	}
 
-		// Result is false until a match has been found
-		boolean result = false;
-
-		// Use first binding name from tuple expr to compare values
-		String bindingName = node.getSubQuery().getBindingNames().iterator().next();
-
-		try (CloseableIteration<BindingSet, QueryEvaluationException> iter = evaluate(node.getSubQuery(), bindings)) {
-			while (!result && iter.hasNext()) {
-				BindingSet bindingSet = iter.next();
-
-				Value rightValue = bindingSet.getValue(bindingName);
-
-				try {
-					result = QueryEvaluationUtil.compare(leftValue, rightValue, node.getOperator());
-				} catch (ValueExprEvaluationException e) {
-					// ignore, maybe next value will match
-				}
-			}
-		}
-
-		return BooleanLiteral.valueOf(result);
+	protected QueryValueEvaluationStep prepare(CompareAny node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		QueryEvaluationStep subquery = precompile(node.getSubQuery(), context);
+		return new CompareAnyValueEvaluationStep(arg, node, subquery, context);
 	}
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(CompareAll node, BindingSet bindings)
 			throws QueryEvaluationException {
-		Value leftValue = evaluate(node.getArg(), bindings);
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
+	}
 
-		// Result is true until a mismatch has been found
-		boolean result = true;
-
-		// Use first binding name from tuple expr to compare values
-		String bindingName = node.getSubQuery().getBindingNames().iterator().next();
-
-		try (CloseableIteration<BindingSet, QueryEvaluationException> iter = evaluate(node.getSubQuery(), bindings)) {
-			while (result && iter.hasNext()) {
-				BindingSet bindingSet = iter.next();
-
-				Value rightValue = bindingSet.getValue(bindingName);
-
-				try {
-					result = QueryEvaluationUtil.compare(leftValue, rightValue, node.getOperator());
-				} catch (ValueExprEvaluationException e) {
-					// Exception thrown by ValueCompare.isTrue(...)
-					result = false;
-				}
-			}
-		}
-
-		return BooleanLiteral.valueOf(result);
+	protected QueryValueEvaluationStep prepare(CompareAll node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+		QueryEvaluationStep subquery = precompile(node.getSubQuery(), context);
+		return new CompareAllQueryValueEvaluationStep(arg, node, subquery, context);
 	}
 
 	@Deprecated(forRemoval = true)
 	public Value evaluate(Exists node, BindingSet bindings)
 			throws QueryEvaluationException {
-		try (CloseableIteration<BindingSet, QueryEvaluationException> iter = evaluate(node.getSubQuery(), bindings)) {
-			return BooleanLiteral.valueOf(iter.hasNext());
-		}
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
+	}
+
+	protected QueryValueEvaluationStep prepare(Exists node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryEvaluationStep subquery = precompile(node.getSubQuery(), context);
+		return new ExistsQueryValueEvaluationStep(subquery);
 	}
 
 	@Override
@@ -2119,19 +1940,16 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	@Deprecated(forRemoval = true)
 	public Value evaluate(ValueExprTripleRef node, BindingSet bindings)
 			throws QueryEvaluationException {
-		Value subj = evaluate(node.getSubjectVar(), bindings);
-		if (!(subj instanceof Resource)) {
-			throw new ValueExprEvaluationException("no subject value");
-		}
-		Value pred = evaluate(node.getPredicateVar(), bindings);
-		if (!(pred instanceof IRI)) {
-			throw new ValueExprEvaluationException("no predicate value");
-		}
-		Value obj = evaluate(node.getObjectVar(), bindings);
-		if (obj == null) {
-			throw new ValueExprEvaluationException("no object value");
-		}
-		return tripleSource.getValueFactory().createTriple((Resource) subj, (IRI) pred, obj);
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
+	}
+
+	protected QueryValueEvaluationStep prepare(ValueExprTripleRef node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		QueryValueEvaluationStep subject = precompile(node.getSubjectVar(), context);
+		QueryValueEvaluationStep predicate = precompile(node.getPredicateVar(), context);
+		QueryValueEvaluationStep object = precompile(node.getObjectVar(), context);
+		ValueFactory valueFactory = tripleSource.getValueFactory();
+		return new ValueExprTripleRefEvaluationStep(subject, valueFactory, predicate, object);
 
 	}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/RegexValueEvaluationStepSupplier.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/RegexValueEvaluationStepSupplier.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtility;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 
+//TODO: at 5.0 move to subpackage values
 public class RegexValueEvaluationStepSupplier {
 	/**
 	 * Returns value evaluation steps that determines whether the two operands match according to the <code>regex</code>

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/AndValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/AndValueEvaluationStep.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtility;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtility.Result;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+
+public class AndValueEvaluationStep implements QueryValueEvaluationStep {
+
+	private final QueryValueEvaluationStep leftStep;
+	private final QueryValueEvaluationStep rightStep;
+
+	public AndValueEvaluationStep(QueryValueEvaluationStep leftStep, QueryValueEvaluationStep rightStep) {
+		super();
+		this.leftStep = leftStep;
+		this.rightStep = rightStep;
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		try {
+
+			if (QueryEvaluationUtility
+					.getEffectiveBooleanValue(leftStep.evaluate(bindings)) == QueryEvaluationUtility.Result._false) {
+				// Left argument evaluates to false, we don't need to look any
+				// further
+				return BooleanLiteral.FALSE;
+			}
+		} catch (ValueExprEvaluationException e) {
+			// Failed to evaluate the left argument. Result is 'false' when
+			// the right argument evaluates to 'false', failure otherwise.
+			Value rightValue = rightStep.evaluate(bindings);
+			if (QueryEvaluationUtility.getEffectiveBooleanValue(rightValue) == QueryEvaluationUtility.Result._false) {
+				return BooleanLiteral.FALSE;
+			} else {
+				throw new ValueExprEvaluationException();
+			}
+		}
+
+		// Left argument evaluated to 'true', result is determined
+		// by the evaluation of the right argument.
+		Value rightValue = rightStep.evaluate(bindings);
+		return BooleanLiteral.valueOf(QueryEvaluationUtil.getEffectiveBooleanValue(rightValue));
+	}
+
+	public static QueryValueEvaluationStep supply(QueryValueEvaluationStep leftStep,
+			QueryValueEvaluationStep rightStep) {
+		if (leftStep.isConstant()) {
+			Result constantLeftValue = QueryEvaluationUtility
+					.getEffectiveBooleanValue(leftStep.evaluate(EmptyBindingSet.getInstance()));
+			if (constantLeftValue == QueryEvaluationUtility.Result._false) {
+				return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
+			} else if (constantLeftValue == QueryEvaluationUtility.Result._true && rightStep.isConstant()) {
+				Result constantRightValue = QueryEvaluationUtility
+						.getEffectiveBooleanValue(rightStep.evaluate(EmptyBindingSet.getInstance()));
+				if (constantRightValue == QueryEvaluationUtility.Result._false) {
+					return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
+				} else if (constantRightValue == QueryEvaluationUtility.Result._true) {
+					return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.TRUE);
+				}
+			}
+		}
+		if (rightStep.isConstant()) {
+			Result constantRightValue = QueryEvaluationUtility
+					.getEffectiveBooleanValue(rightStep.evaluate(EmptyBindingSet.getInstance()));
+			if (constantRightValue == QueryEvaluationUtility.Result._false) {
+				return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
+			}
+		}
+		return new AndValueEvaluationStep(leftStep, rightStep);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/CompareAllQueryValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/CompareAllQueryValueEvaluationStep.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import java.util.function.Function;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.CompareAll;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+
+public final class CompareAllQueryValueEvaluationStep implements QueryValueEvaluationStep {
+	private final QueryValueEvaluationStep arg;
+	private final CompareAll node;
+	private final QueryEvaluationStep subquery;
+	private final Function<BindingSet, Value> getValue;
+
+	public CompareAllQueryValueEvaluationStep(QueryValueEvaluationStep arg, CompareAll node,
+			QueryEvaluationStep subquery, QueryEvaluationContext context) {
+		this.arg = arg;
+		this.node = node;
+		this.subquery = subquery;
+		String bindingName = node.getSubQuery().getBindingNames().iterator().next();
+		this.getValue = context.getValue(bindingName);
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		Value leftValue = arg.evaluate(bindings);
+		// Result is true until a mismatch has been found
+		boolean result = true;
+		try (CloseableIteration<BindingSet, QueryEvaluationException> iter = subquery.evaluate(bindings)) {
+			while (result && iter.hasNext()) {
+				BindingSet bindingSet = iter.next();
+				Value rightValue = getValue.apply(bindingSet);
+				try {
+					result = QueryEvaluationUtil.compare(leftValue, rightValue, node.getOperator());
+				} catch (ValueExprEvaluationException e) {
+					// Exception thrown by ValueCompare.isTrue(...)
+					result = false;
+				}
+			}
+		}
+		return BooleanLiteral.valueOf(result);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/CompareAnyValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/CompareAnyValueEvaluationStep.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.CompareAny;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+
+public final class CompareAnyValueEvaluationStep implements QueryValueEvaluationStep {
+	private final QueryValueEvaluationStep arg;
+	private final CompareAny node;
+	private final QueryEvaluationStep subquery;
+
+	private final Function<BindingSet, Value> getValue;
+
+	public CompareAnyValueEvaluationStep(QueryValueEvaluationStep arg, CompareAny node,
+			QueryEvaluationStep subquery, QueryEvaluationContext context) {
+		this.arg = arg;
+		this.node = node;
+		this.subquery = subquery;
+		String bindingName = node.getSubQuery().getBindingNames().iterator().next();
+		this.getValue = context.getValue(bindingName);
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		Value leftValue = arg.evaluate(bindings);
+		// Result is false until a match has been found
+		boolean result = false;
+
+		try (CloseableIteration<BindingSet, QueryEvaluationException> iter = subquery.evaluate(bindings)) {
+			while (!result && iter.hasNext()) {
+				BindingSet bindingSet = iter.next();
+				Value rightValue = getValue.apply(bindingSet);
+				try {
+					result = QueryEvaluationUtil.compare(leftValue, rightValue, node.getOperator());
+				} catch (ValueExprEvaluationException e) {
+					// ignore, maybe next value will match
+				}
+			}
+		}
+		return BooleanLiteral.valueOf(result);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/ExistsQueryValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/ExistsQueryValueEvaluationStep.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+
+public final class ExistsQueryValueEvaluationStep implements QueryValueEvaluationStep {
+	private final QueryEvaluationStep subquery;
+
+	public ExistsQueryValueEvaluationStep(QueryEvaluationStep subquery) {
+		this.subquery = subquery;
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		try (CloseableIteration<BindingSet, QueryEvaluationException> iter = subquery.evaluate(bindings)) {
+			return BooleanLiteral.valueOf(iter.hasNext());
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/IfValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/IfValueEvaluationStep.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+
+public final class IfValueEvaluationStep implements QueryValueEvaluationStep {
+	private final QueryValueEvaluationStep result;
+	private final QueryValueEvaluationStep condition;
+	private final QueryValueEvaluationStep alternative;
+
+	public IfValueEvaluationStep(QueryValueEvaluationStep result, QueryValueEvaluationStep condition,
+			QueryValueEvaluationStep alternative) {
+		this.result = result;
+		this.condition = condition;
+		this.alternative = alternative;
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		boolean conditionIsTrue;
+
+		try {
+			Value value = condition.evaluate(bindings);
+			conditionIsTrue = QueryEvaluationUtil.getEffectiveBooleanValue(value);
+		} catch (ValueExprEvaluationException e) {
+			// in case of type error, if-construction should result in empty
+			// binding.
+			return null;
+		}
+
+		if (conditionIsTrue) {
+			return result.evaluate(bindings);
+		} else {
+			return alternative.evaluate(bindings);
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/InValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/InValueEvaluationStep.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.In;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+
+public final class InValueEvaluationStep implements QueryValueEvaluationStep {
+	private final In node;
+	private final QueryEvaluationStep subquery;
+	private final QueryValueEvaluationStep left;
+
+	public InValueEvaluationStep(In node, QueryEvaluationStep subquery,
+			QueryValueEvaluationStep left) {
+		this.node = node;
+		this.subquery = subquery;
+		this.left = left;
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		Value leftValue = left.evaluate(bindings);
+
+		// Result is false until a match has been found
+		boolean result = false;
+		// Use first binding name from tuple expr to compare values
+		String bindingName = node.getSubQuery().getBindingNames().iterator().next();
+		try (CloseableIteration<BindingSet, QueryEvaluationException> iter = subquery.evaluate(bindings)) {
+			while (!result && iter.hasNext()) {
+				BindingSet bindingSet = iter.next();
+				Value rightValue = bindingSet.getValue(bindingName);
+				result = leftValue == null && rightValue == null
+						|| leftValue != null && leftValue.equals(rightValue);
+			}
+		}
+		return BooleanLiteral.valueOf(result);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/ListMemberValueOperationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/ListMemberValueOperationStep.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.Compare.CompareOp;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+
+public final class ListMemberValueOperationStep implements QueryValueEvaluationStep {
+	private final List<QueryValueEvaluationStep> compiledArgs;
+
+	public ListMemberValueOperationStep(List<QueryValueEvaluationStep> compiledArgs) {
+		this.compiledArgs = compiledArgs;
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		Value leftValue = compiledArgs.get(0).evaluate(bindings);
+		boolean result = false;
+		ValueExprEvaluationException typeError = null;
+		for (int i = 1; i < compiledArgs.size(); i++) {
+			QueryValueEvaluationStep arg = compiledArgs.get(i);
+			try {
+				Value rightValue = arg.evaluate(bindings);
+				result = leftValue == null && rightValue == null;
+				if (!result) {
+					result = QueryEvaluationUtil.compare(leftValue, rightValue, CompareOp.EQ);
+				}
+				if (result) {
+					break;
+				}
+			} catch (ValueExprEvaluationException caught) {
+				typeError = caught;
+			}
+		}
+
+		if (typeError != null && !result) {
+			// cf. SPARQL spec a type error is thrown if the value is not in the
+			// list and one of the list members caused a type error in the
+			// comparison.
+			throw typeError;
+		}
+
+		return BooleanLiteral.valueOf(result);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/OrValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/OrValueEvaluationStep.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+
+public class OrValueEvaluationStep implements QueryValueEvaluationStep {
+	private final QueryValueEvaluationStep leftArg;
+	private final QueryValueEvaluationStep rightArg;
+
+	public OrValueEvaluationStep(QueryValueEvaluationStep leftArg, QueryValueEvaluationStep rightArg) {
+		this.leftArg = leftArg;
+		this.rightArg = rightArg;
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		try {
+			Value leftValue = leftArg.evaluate(bindings);
+			if (QueryEvaluationUtil.getEffectiveBooleanValue(leftValue)) {
+				// Left argument evaluates to true, we don't need to look any
+				// further
+				return BooleanLiteral.TRUE;
+			}
+		} catch (ValueExprEvaluationException e) {
+			Value rightValue = rightArg.evaluate(bindings);
+			if (QueryEvaluationUtil.getEffectiveBooleanValue(rightValue)) {
+				return BooleanLiteral.TRUE;
+			} else {
+				throw new ValueExprEvaluationException();
+			}
+		}
+		// Left argument evaluated to 'false', result is determined
+		// by the evaluation of the right argument.
+		Value rightValue = rightArg.evaluate(bindings);
+		return BooleanLiteral.valueOf(QueryEvaluationUtil.getEffectiveBooleanValue(rightValue));
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/QueryValueEvaluationStepSupplier.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/QueryValueEvaluationStepSupplier.java
@@ -1,0 +1,317 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.eclipse.rdf4j.common.net.ParsedIRI;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.IRIFunction;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep.ConstantQueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtility;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtility.Result;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+
+public class QueryValueEvaluationStepSupplier {
+	private static Value bound(QueryValueEvaluationStep arg, BindingSet bindings)
+			throws ValueExprEvaluationException, QueryEvaluationException {
+		try {
+			Value argValue = arg.evaluate(bindings);
+			return BooleanLiteral.valueOf(argValue != null);
+		} catch (ValueExprEvaluationException e) {
+			return BooleanLiteral.FALSE;
+		}
+	}
+
+	private QueryValueEvaluationStepSupplier() {
+
+	}
+
+	public static QueryValueEvaluationStep prepareStr(QueryValueEvaluationStep arg, ValueFactory valueFactory) {
+		return make(arg, "Unkown constant argument for STR()", bs -> str(arg, valueFactory, bs));
+	}
+
+	private static Value str(QueryValueEvaluationStep arg, ValueFactory valueFactory, BindingSet bindings) {
+		Value argValue = arg.evaluate(bindings);
+
+		if (argValue instanceof IRI || argValue instanceof Triple) {
+			return valueFactory.createLiteral(argValue.toString());
+		} else if (argValue instanceof Literal) {
+			Literal literal = (Literal) argValue;
+
+			if (QueryEvaluationUtility.isSimpleLiteral(literal)) {
+				return literal;
+			} else {
+				return valueFactory.createLiteral(literal.getLabel());
+			}
+		} else {
+			throw new ValueExprEvaluationException("Unkown constant argument for STR()");
+		}
+	}
+
+	public static QueryValueEvaluationStep prepareBound(QueryValueEvaluationStep arg, QueryEvaluationContext context) {
+		return make(arg, "bound called on constant argument that throws", bs -> bound(arg, bs));
+	}
+
+	public static QueryValueEvaluationStep prepareDatatype(QueryValueEvaluationStep arg,
+			QueryEvaluationContext context) {
+		return make(arg, "datatype called on constant that throws", (bs) -> datatype(arg, bs));
+	}
+
+	public static QueryValueEvaluationStep prepareLabel(QueryValueEvaluationStep arg, ValueFactory vf) {
+		return make(arg, "label called on constant that throws", (bs) -> label(arg, bs, vf));
+	}
+
+	private static QueryValueEvaluationStep make(QueryValueEvaluationStep arg, String errorMessage,
+			Function<BindingSet, Value> function) {
+		if (arg.isConstant()) {
+			try {
+				Value datatype = function.apply(EmptyBindingSet.getInstance());
+				return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(datatype);
+			} catch (ValueExprEvaluationException e) {
+				return new QueryValueEvaluationStep.Fail(errorMessage);
+			}
+
+		}
+		return new QueryValueEvaluationStep.ApplyFunctionForEachBinding(function);
+	}
+
+	private static Value label(QueryValueEvaluationStep arg, BindingSet bindings, ValueFactory vf) {
+		Value argValue = arg.evaluate(bindings);
+
+		if (argValue instanceof Literal) {
+			Literal literal = (Literal) argValue;
+
+			if (QueryEvaluationUtility.isSimpleLiteral(literal)) {
+				return literal;
+			} else {
+				return vf.createLiteral(literal.getLabel());
+			}
+		} else {
+			throw new ValueExprEvaluationException();
+		}
+	}
+
+	private static Value datatype(QueryValueEvaluationStep arg, BindingSet bindings) {
+		Value v = arg.evaluate(bindings);
+
+		if (v instanceof Literal) {
+			Literal literal = (Literal) v;
+
+			if (literal.getDatatype() != null) {
+				// literal with datatype
+				return literal.getDatatype();
+			} else if (literal.getLanguage().isPresent()) {
+				return CoreDatatype.RDF.LANGSTRING.getIri();
+			} else {
+				// simple literal
+				return CoreDatatype.XSD.STRING.getIri();
+			}
+
+		}
+		throw new ValueExprEvaluationException();
+	}
+
+	public static QueryValueEvaluationStep prepareVar(Var var, QueryEvaluationContext context) {
+		if (var.getValue() != null) {
+			return new ConstantQueryValueEvaluationStep(var.getValue());
+		} else {
+			Function<BindingSet, Value> getValue = context.getValue(var.getName());
+			return new QueryValueEvaluationStep.ApplyFunctionForEachBinding(bindings -> {
+				Value val = getValue.apply(bindings);
+				if (val == null) {
+					throw new ValueExprEvaluationException();
+				}
+				return val;
+			});
+		}
+	}
+
+	public static QueryValueEvaluationStep prepareNamespace(QueryValueEvaluationStep arg, ValueFactory vf) {
+		return make(arg, "namespace called on constant that throws", bs -> namespace(arg, bs, vf));
+	}
+
+	private static Value namespace(QueryValueEvaluationStep arg, BindingSet bindings, ValueFactory valueFactory) {
+		Value argValue = arg.evaluate(bindings);
+
+		if (argValue instanceof IRI) {
+			IRI uri = (IRI) argValue;
+			return valueFactory.createIRI(uri.getNamespace());
+		} else {
+			throw new ValueExprEvaluationException();
+		}
+	}
+
+	public static QueryValueEvaluationStep prepareLocalName(QueryValueEvaluationStep arg, ValueFactory vf) {
+		return make(arg, "localName called on constant that throws", bs -> localName(arg, bs, vf));
+	}
+
+	private static Value localName(QueryValueEvaluationStep arg, BindingSet bindings, ValueFactory valueFactory) {
+		Value argValue = arg.evaluate(bindings);
+		if (argValue instanceof IRI) {
+			IRI uri = (IRI) argValue;
+			return valueFactory.createLiteral(uri.getLocalName());
+		} else {
+			throw new ValueExprEvaluationException();
+		}
+	}
+
+	public static QueryValueEvaluationStep prepareLang(QueryValueEvaluationStep arg, ValueFactory vf) {
+		return make(arg, "lang called on constant that throws", bs -> lang(arg, bs, vf));
+	}
+
+	private static Value lang(QueryValueEvaluationStep arg, BindingSet bindings, ValueFactory valueFactory) {
+		Value argValue = arg.evaluate(bindings);
+
+		if (argValue instanceof Literal) {
+			Literal literal = (Literal) argValue;
+			return valueFactory.createLiteral(literal.getLanguage().orElse(""));
+		}
+
+		throw new ValueExprEvaluationException();
+	}
+
+	public static QueryValueEvaluationStep bnode(QueryValueEvaluationStep nodeVes, ValueFactory vf) {
+		try {
+			if (nodeVes.isConstant()) {
+				Value nodeId = nodeVes.evaluate(EmptyBindingSet.getInstance());
+				if (nodeId instanceof Literal) {
+					String nodeLabel = nodeId.stringValue();
+					return new QueryValueEvaluationStep.ApplyFunctionForEachBinding(
+							(bs) -> vf.createBNode(nodeLabel + (bs.toString().hashCode())));
+				} else {
+					return new QueryValueEvaluationStep.Fail("BNODE function argument must be a literal");
+				}
+			} else {
+				return new QueryValueEvaluationStep.ApplyFunctionForEachBinding(
+						(bs) -> vf.createBNode(nodeVes.evaluate(bs).stringValue() + bs.toString().hashCode()));
+			}
+		} catch (ValueExprEvaluationException e) {
+			return new QueryValueEvaluationStep.Fail("BNODE function argument must be a literal");
+		}
+	}
+
+	public static QueryValueEvaluationStep prepareIs(QueryValueEvaluationStep arg, Predicate<Value> is) {
+		return make(arg, "isResource called on constant that throws", bs -> {
+			Value argValue = arg.evaluate(bs);
+			return BooleanLiteral.valueOf(is.test(argValue));
+		});
+	}
+
+	public static QueryValueEvaluationStep prepareAnd(QueryValueEvaluationStep leftStep,
+			QueryValueEvaluationStep rightStep) {
+
+		if (leftStep.isConstant()) {
+			Result constantLeftValue = QueryEvaluationUtility
+					.getEffectiveBooleanValue(leftStep.evaluate(EmptyBindingSet.getInstance()));
+			if (constantLeftValue == QueryEvaluationUtility.Result._false) {
+				return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
+			} else if (constantLeftValue == QueryEvaluationUtility.Result._true && rightStep.isConstant()) {
+				Result constantRightValue = QueryEvaluationUtility
+						.getEffectiveBooleanValue(rightStep.evaluate(EmptyBindingSet.getInstance()));
+				if (constantRightValue == QueryEvaluationUtility.Result._false) {
+					return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
+				} else if (constantRightValue == QueryEvaluationUtility.Result._true) {
+					return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.TRUE);
+				}
+			}
+		}
+		if (rightStep.isConstant()) {
+			Result constantRightValue = QueryEvaluationUtility
+					.getEffectiveBooleanValue(rightStep.evaluate(EmptyBindingSet.getInstance()));
+			if (constantRightValue == QueryEvaluationUtility.Result._false) {
+				return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
+			}
+		}
+		return new QueryValueEvaluationStep() {
+
+			@Override
+			public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+				try {
+
+					if (QueryEvaluationUtility.getEffectiveBooleanValue(
+							leftStep.evaluate(bindings)) == QueryEvaluationUtility.Result._false) {
+						// Left argument evaluates to false, we don't need to look any
+						// further
+						return BooleanLiteral.FALSE;
+					}
+				} catch (ValueExprEvaluationException e) {
+					// Failed to evaluate the left argument. Result is 'false' when
+					// the right argument evaluates to 'false', failure otherwise.
+					Value rightValue = rightStep.evaluate(bindings);
+					if (QueryEvaluationUtility
+							.getEffectiveBooleanValue(rightValue) == QueryEvaluationUtility.Result._false) {
+						return BooleanLiteral.FALSE;
+					} else {
+						throw new ValueExprEvaluationException();
+					}
+				}
+
+				// Left argument evaluated to 'true', result is determined
+				// by the evaluation of the right argument.
+				Value rightValue = rightStep.evaluate(bindings);
+				return BooleanLiteral.valueOf(QueryEvaluationUtil.getEffectiveBooleanValue(rightValue));
+			}
+		};
+	}
+
+	public static QueryValueEvaluationStep prepareIriFunction(IRIFunction node, QueryValueEvaluationStep arg,
+			ValueFactory valueFactory) {
+		return make(arg, "IRI() called on constant that throws",
+				bs -> iriFunction(node.getBaseURI(), arg.evaluate(bs), valueFactory));
+	}
+
+	private static IRI iriFunction(String baseURI, Value argValue, ValueFactory vf) {
+		if (argValue instanceof Literal) {
+			final Literal lit = (Literal) argValue;
+
+			String uriString = lit.getLabel();
+			try {
+				ParsedIRI iri = ParsedIRI.create(uriString);
+				if (!iri.isAbsolute() && baseURI != null) {
+					// uri string may be a relative reference.
+					uriString = ParsedIRI.create(baseURI).resolve(iri).toString();
+				} else if (!iri.isAbsolute()) {
+					throw new ValueExprEvaluationException("not an absolute IRI reference: " + uriString);
+				}
+			} catch (IllegalArgumentException e) {
+				throw new ValueExprEvaluationException("not a valid IRI reference: " + uriString);
+			}
+
+			IRI result;
+
+			try {
+				result = vf.createIRI(uriString);
+			} catch (IllegalArgumentException e) {
+				throw new ValueExprEvaluationException(e.getMessage());
+			}
+			return result;
+		} else if (argValue instanceof IRI) {
+			return ((IRI) argValue);
+		}
+
+		throw new ValueExprEvaluationException();
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/ValueExprTripleRefEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/values/ValueExprTripleRefEvaluationStep.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.values;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+
+public final class ValueExprTripleRefEvaluationStep implements QueryValueEvaluationStep {
+	private final QueryValueEvaluationStep subject;
+	private final ValueFactory valueFactory;
+	private final QueryValueEvaluationStep predicate;
+	private final QueryValueEvaluationStep object;
+
+	public ValueExprTripleRefEvaluationStep(QueryValueEvaluationStep subject, ValueFactory valueFactory,
+			QueryValueEvaluationStep predicate, QueryValueEvaluationStep object) {
+		this.subject = subject;
+		this.valueFactory = valueFactory;
+		this.predicate = predicate;
+		this.object = object;
+	}
+
+	@Override
+	public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		Value subj = subject.evaluate(bindings);
+		if (!(subj instanceof Resource)) {
+			throw new ValueExprEvaluationException("no subject value");
+		}
+		Value pred = predicate.evaluate(bindings);
+		if (!(pred instanceof IRI)) {
+			throw new ValueExprEvaluationException("no predicate value");
+		}
+		Value obj = object.evaluate(bindings);
+		if (obj == null) {
+			throw new ValueExprEvaluationException("no object value");
+		}
+		return valueFactory.createTriple((Resource) subj, (IRI) pred, obj);
+	}
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,8 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
@@ -181,6 +184,47 @@ public class StrictEvaluationStrategyTest {
 			assertTrue(nowValue.isLiteral());
 			Literal nowLiteral = (Literal) nowValue;
 			assertEquals(CoreDatatype.XSD.DATETIME, nowLiteral.getCoreDatatype());
+		}
+	}
+
+	@Test
+	public void testDatetimeCast() {
+		String query = "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT (xsd:date(\"2022-09-xx\") AS ?date) { }";
+		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, query, null);
+		QueryEvaluationStep prepared = strategy.precompile(pq.getTupleExpr());
+		assertNotNull(prepared);
+		try (CloseableIteration<BindingSet, QueryEvaluationException> result = prepared
+				.evaluate(EmptyBindingSet.getInstance())) {
+			assertNotNull(result);
+			assertTrue(result.hasNext());
+			assertFalse(
+					result.next().hasBinding("date"),
+					"There should be no binding because the cast should have failed.");
+			assertFalse(result.hasNext());
+		}
+	}
+
+	@Test
+	public void testSES1991NOWEvaluation() throws Exception {
+		String query = "PREFIX ex:<http://example.org> SELECT ?d WHERE {VALUES(?s ?p ?o) {(ex:type rdf:type ex:type)(ex:type ex:type ex:type)} . BIND(NOW() as ?d) } LIMIT 2";
+		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, query, null);
+		QueryEvaluationStep prepared = strategy.precompile(pq.getTupleExpr());
+
+		try (CloseableIteration<BindingSet, QueryEvaluationException> result = prepared
+				.evaluate(EmptyBindingSet.getInstance())) {
+			assertNotNull(result);
+			assertTrue(result.hasNext());
+
+			Literal d1 = (Literal) result.next().getValue("d");
+			assertTrue(result.hasNext());
+			Literal d2 = (Literal) result.next().getValue("d");
+			assertFalse(result.hasNext());
+			assertNotNull(d1);
+			assertEquals(d1, d2);
+			assertTrue(d1 == d2);
+		} catch (QueryEvaluationException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
 		}
 	}
 }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BuiltinFunctionTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BuiltinFunctionTest.java
@@ -82,10 +82,11 @@ public class BuiltinFunctionTest extends AbstractComplianceTest {
 
 		try (TupleQueryResult result = tq.evaluate()) {
 			assertNotNull(result);
-
+			assertTrue(result.hasNext());
 			Literal d1 = (Literal) result.next().getValue("d");
+			assertTrue(result.hasNext());
 			Literal d2 = (Literal) result.next().getValue("d");
-
+			assertFalse(result.hasNext());
 			assertNotNull(d1);
 			assertEquals(d1, d2);
 		} catch (QueryEvaluationException e) {


### PR DESCRIPTION
GitHub issue resolved: #3798 
Briefly describe the changes proposed in this PR:

Start precompiling the binary operators. Taking into account constant propagation.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

