### PR TITLE
Gh 3601 filter no new bindingset per iteraration next

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryEvaluationStep.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.DelayedIteration;
+import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.Iteration;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -57,6 +58,15 @@ public interface QueryEvaluationStep {
 			@Override
 			public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(BindingSet bs) {
 				return strategy.evaluate(expr, bs);
+			}
+		};
+	}
+
+	public static QueryEvaluationStep empty() {
+		return new QueryEvaluationStep() {
+			@Override
+			public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(BindingSet bs) {
+				return new EmptyIteration<BindingSet, QueryEvaluationException>();
 			}
 		};
 	}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/FilterIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/FilterIterator.java
@@ -7,83 +7,36 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
-import java.util.Set;
-
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.FilterIteration;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.Filter;
-import org.eclipse.rdf4j.query.algebra.QueryModelNode;
-import org.eclipse.rdf4j.query.algebra.SubQueryValueOperator;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
-import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 
 public class FilterIterator extends FilterIteration<BindingSet, QueryEvaluationException> {
 
-	/*-----------*
-	 * Constants *
-	 *-----------*/
-
-	private final Filter filter;
-
-	private final EvaluationStrategy strategy;
-
-	/**
-	 * The set of binding names that are "in scope" for the filter. The filter must not include bindings that are (only)
-	 * included because of the depth-first evaluation strategy in the evaluation of the constraint.
-	 */
-	private final Set<String> scopeBindingNames;
-
 	private final QueryValueEvaluationStep condition;
+	private final EvaluationStrategy strategy;
 
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
 
 	public FilterIterator(Filter filter, CloseableIteration<BindingSet, QueryEvaluationException> iter,
-			QueryValueEvaluationStep ves, EvaluationStrategy strategy) throws QueryEvaluationException {
+			QueryValueEvaluationStep condition, EvaluationStrategy strategy) throws QueryEvaluationException {
 		super(iter);
-		this.filter = filter;
+		this.condition = condition;
 		this.strategy = strategy;
-		this.condition = ves;
-		this.scopeBindingNames = filter.getBindingNames();
 
-	}
-
-	/*---------*
-	 * Methods *
-	 *---------*/
-
-	private boolean isPartOfSubQuery(QueryModelNode node) {
-		if (node instanceof SubQueryValueOperator) {
-			return true;
-		}
-
-		QueryModelNode parent = node.getParentNode();
-		if (parent == null) {
-			return false;
-		} else {
-			return isPartOfSubQuery(parent);
-		}
 	}
 
 	@Override
 	protected boolean accept(BindingSet bindings) throws QueryEvaluationException {
 		try {
-			// Limit the bindings to the ones that are in scope for this filter
-			QueryBindingSet scopeBindings = new QueryBindingSet(bindings);
-
-			// FIXME J1 scopeBindingNames should include bindings from superquery if the filter
-			// is part of a subquery. This is a workaround: we should fix the settings of scopeBindingNames,
-			// rather than skipping the limiting of bindings.
-			if (!isPartOfSubQuery(filter)) {
-				scopeBindings.retainAll(scopeBindingNames);
-			}
-
-			return strategy.isTrue(condition, scopeBindings);
+			return strategy.isTrue(condition, bindings);
 		} catch (ValueExprEvaluationException e) {
 			// failed to evaluate condition
 			return false;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/FilterIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/FilterIterator.java
@@ -76,9 +76,9 @@ public class FilterIterator extends FilterIteration<BindingSet, QueryEvaluationE
 		private final Filter node;
 		private final QueryEvaluationContext context;
 
-		public RetainedVariableFilteredQueryEvaluationContext(Filter node, QueryEvaluationContext context) {
+		public RetainedVariableFilteredQueryEvaluationContext(Filter node, QueryEvaluationContext contextToFilter) {
 			this.node = node;
-			this.context = context;
+			this.context = contextToFilter;
 		}
 
 		@Override
@@ -94,9 +94,9 @@ public class FilterIterator extends FilterIteration<BindingSet, QueryEvaluationE
 		@Override
 		public Predicate<BindingSet> hasBinding(String variableName) {
 			if (isVariableInScope(variableName)) {
-				return QueryEvaluationContext.super.hasBinding(variableName);
+				return context.hasBinding(variableName);
 			} else {
-				return null;
+				return (bs) -> false;
 			}
 		}
 
@@ -107,28 +107,24 @@ public class FilterIterator extends FilterIteration<BindingSet, QueryEvaluationE
 		@Override
 		public java.util.function.Function<BindingSet, Binding> getBinding(String variableName) {
 			if (isVariableInScope(variableName)) {
-				return QueryEvaluationContext.super.getBinding(variableName);
+				return context.getBinding(variableName);
 			} else {
-				return null;
+				return (bs) -> null;
 			}
 		}
 
 		@Override
 		public java.util.function.Function<BindingSet, Value> getValue(String variableName) {
 			if (isVariableInScope(variableName)) {
-				return QueryEvaluationContext.super.getValue(variableName);
+				return context.getValue(variableName);
 			} else {
-				return null;
+				return (bs) -> null;
 			}
 		}
 
 		@Override
 		public BiConsumer<Value, MutableBindingSet> setBinding(String variableName) {
-			if (isVariableInScope(variableName)) {
-				return QueryEvaluationContext.super.setBinding(variableName);
-			} else {
-				return null;
-			}
+			return context.setBinding(variableName);
 		}
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #3601

Briefly describe the changes proposed in this PR:

In the FilterIterator a new QueryBindingSet was made to hide few potential bindings. Which might have been a problem in subquery cases. Now we just hide access to the fields by introducing a new FilteredQueryContext. 
This patch series also prepares the `Exist` to show the benefit in the two benchmarks.

From the memory sail benchmarks.

| Benchmark | before | after |
|----------------|---------|-------|
| QueryBenchmark.lots_of_optional | 349.636 | 303.136 |
| QueryBenchmark.simple_filter_not | 18.268  | 14.130 |


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

