### PR TITLE
GH-3809 introduce a method to state that each invocation of a query

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
@@ -51,4 +51,16 @@ public interface Function {
 	default Value evaluate(TripleSource tripleSource, Value... args) throws ValueExprEvaluationException {
 		return evaluate(tripleSource.getValueFactory(), args);
 	}
+
+	/**
+	 * UUID() and STRUUID() must return a different result for each invocation.
+	 * 
+	 * @see https://www.w3.org/TR/sparql11-query/#func-uuid
+	 * @see https://www.w3.org/TR/sparql11-query/#func-struuid
+	 * @see https://www.w3.org/TR/sparql11-query/#func-numerics
+	 * @return if each invocation must return a different result.
+	 */
+	default boolean mustReturnDifferentResult() {
+		return false;
+	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/numeric/Rand.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/numeric/Rand.java
@@ -35,4 +35,9 @@ public class Rand implements Function {
 		return valueFactory.createLiteral(Math.random());
 	}
 
+	@Override
+	public boolean mustReturnDifferentResult() {
+		return true;
+	}
+
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/rdfterm/STRUUID.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/rdfterm/STRUUID.java
@@ -37,4 +37,8 @@ public class STRUUID implements Function {
 		return literal;
 	}
 
+	@Override
+	public boolean mustReturnDifferentResult() {
+		return true;
+	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/rdfterm/UUID.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/rdfterm/UUID.java
@@ -37,4 +37,8 @@ public class UUID implements Function {
 		return uri;
 	}
 
+	@Override
+	public boolean mustReturnDifferentResult() {
+		return true;
+	}
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -894,7 +894,8 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 		} else if (expr instanceof BNodeGenerator) {
 			return new QueryValueEvaluationStep.Minimal(this, expr);
 		} else if (expr instanceof Bound) {
-			return new QueryValueEvaluationStep.Minimal(this, expr);
+			return prepare((Bound) expr, context);
+//			return new QueryValueEvaluationStep.Minimal(this, expr);
 		} else if (expr instanceof Str) {
 			return new QueryValueEvaluationStep.Minimal(this, expr);
 		} else if (expr instanceof Label) {
@@ -1117,6 +1118,28 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 			return BooleanLiteral.valueOf(argValue != null);
 		} catch (ValueExprEvaluationException e) {
 			return BooleanLiteral.FALSE;
+		}
+	}
+
+	private QueryValueEvaluationStep prepare(Bound node, QueryEvaluationContext context)
+			throws QueryEvaluationException {
+		try {
+			QueryValueEvaluationStep arg = precompile(node.getArg(), context);
+			return new QueryValueEvaluationStep() {
+
+				@Override
+				public Value evaluate(BindingSet bindings)
+						throws ValueExprEvaluationException, QueryEvaluationException {
+					try {
+						Value argValue = arg.evaluate(bindings);
+						return BooleanLiteral.valueOf(argValue != null);
+					} catch (ValueExprEvaluationException e) {
+						return BooleanLiteral.FALSE;
+					}
+				}
+			};
+		} catch (QueryEvaluationException e) {
+			return new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
 		}
 	}
 
@@ -1529,13 +1552,7 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 
 		QueryValueEvaluationStep[] argSteps = new QueryValueEvaluationStep[args.size()];
 
-		boolean allConstant = true;
-		for (int i = 0; i < args.size(); i++) {
-			argSteps[i] = precompile(args.get(i), context);
-			if (!argSteps[i].isConstant()) {
-				allConstant = false;
-			}
-		}
+		boolean allConstant = determineIfFunctionCallWillBeAConstant(context, function, args, argSteps);
 		if (allConstant) {
 			Value[] argValues = evaluateAllArguments(args, argSteps, EmptyBindingSet.getInstance());
 			Value res = function.evaluate(tripleSource, argValues);
@@ -1551,6 +1568,34 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 				}
 			};
 		}
+	}
+
+	/**
+	 * If all input is constant normally the function call output will be constant as well.
+	 * 
+	 * @param context  used to precompile arguments of the function
+	 * @param function that might be constant
+	 * @param args     that the function must evaluate
+	 * @param argSteps side effect this array is filled
+	 * @return if this function resolves to a constant value
+	 */
+	private boolean determineIfFunctionCallWillBeAConstant(QueryEvaluationContext context, Function function,
+			List<ValueExpr> args, QueryValueEvaluationStep[] argSteps) {
+		boolean allConstant = true;
+		if (function.mustReturnDifferentResult()) {
+			allConstant = false;
+			for (int i = 0; i < args.size(); i++) {
+				argSteps[i] = precompile(args.get(i), context);
+			}
+		} else {
+			for (int i = 0; i < args.size(); i++) {
+				argSteps[i] = precompile(args.get(i), context);
+				if (!argSteps[i].isConstant()) {
+					allConstant = false;
+				}
+			}
+		}
+		return allConstant;
 	}
 
 	private Value[] evaluateAllArguments(List<ValueExpr> args, QueryValueEvaluationStep[] argSteps,

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/numeric/RandTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/numeric/RandTest.java
@@ -8,15 +8,31 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.function.numeric;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.FunctionCall;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +73,45 @@ public class RandTest {
 
 			assertTrue(randomValue >= 0.0d);
 			assertTrue(randomValue < 1.0d);
+		} catch (ValueExprEvaluationException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testPrepare() {
+		QueryValueEvaluationStep precompile = new StrictEvaluationStrategy(new TripleSource() {
+
+			@Override
+			public ValueFactory getValueFactory() {
+				return SimpleValueFactory.getInstance();
+			}
+
+			@Override
+			public CloseableIteration<? extends Statement, QueryEvaluationException> getStatements(Resource subj,
+					IRI pred, Value obj, Resource... contexts) throws QueryEvaluationException {
+				// TODO Auto-generated method stub
+				return null;
+			}
+		}, null).precompile(new FunctionCall(new Rand().getURI()), new QueryEvaluationContext.Minimal(null));
+		try {
+			Set<Double> previous = new HashSet<>();
+			for (int i = 0; i < 100; i++) {
+				Value random = precompile.evaluate(EmptyBindingSet.getInstance());
+
+				assertNotNull(random);
+				assertTrue(random instanceof Literal);
+				Literal randomL = (Literal) random;
+				assertEquals(XSD.DOUBLE, randomL.getDatatype());
+
+				double randomValue = randomL.doubleValue();
+
+				assertTrue(randomValue >= 0.0d);
+				assertTrue(randomValue < 1.0d);
+				assertFalse(previous.contains(randomValue));
+				previous.add(randomValue);
+			}
 		} catch (ValueExprEvaluationException e) {
 			e.printStackTrace();
 			fail(e.getMessage());

--- a/core/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/GenerateUUID.java
+++ b/core/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/GenerateUUID.java
@@ -26,4 +26,9 @@ public class GenerateUUID implements Function {
 	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
 		return valueFactory.createLiteral(UUID.randomUUID().toString());
 	}
+
+	@Override
+	public boolean mustReturnDifferentResult() {
+		return true;
+	}
 }

--- a/core/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/Random.java
+++ b/core/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/Random.java
@@ -24,4 +24,9 @@ public class Random implements Function {
 	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
 		return valueFactory.createLiteral(Math.random());
 	}
+
+	@Override
+	public boolean mustReturnDifferentResult() {
+		return true;
+	}
 }


### PR DESCRIPTION
GitHub issue resolved: #3809 

Briefly describe the changes proposed in this PR:

If we prepare/precompile a functioncall then functions may be turned into constant values. This is never valid for a number of functions such as UUID or RAND(). A new method is added to the Function interface that is used to mark such cases, and avoids constant folding.



----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

