### PR TITLE
GH-3811 ensure thread safety of the shared now value.

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryValueEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryValueEvaluationStep.java
@@ -19,12 +19,12 @@ import org.eclipse.rdf4j.query.algebra.ValueExpr;
  */
 public interface QueryValueEvaluationStep {
 	Value evaluate(BindingSet bindings)
-			throws ValueExprEvaluationException, QueryEvaluationException;
+			throws QueryEvaluationException;
 
 	/**
 	 * If an value expression results in a constant then it may be executed once per query invocation. This can reduce
 	 * computation time significantly.
-	 * 
+	 *
 	 * @return if this ValueExpresionStep will always return the same value
 	 */
 	default boolean isConstant() {
@@ -35,7 +35,7 @@ public interface QueryValueEvaluationStep {
 	 * A QueryValueEvalationStep that will return the same constant value throughout the query execution. As these
 	 * rather result just in a value we set the value at precompile time.
 	 */
-	public static class ConstantQueryValueEvaluationStep implements QueryValueEvaluationStep {
+	class ConstantQueryValueEvaluationStep implements QueryValueEvaluationStep {
 		private final Value value;
 
 		public ConstantQueryValueEvaluationStep(ValueConstant valueConstant) {
@@ -47,7 +47,7 @@ public interface QueryValueEvaluationStep {
 		}
 
 		@Override
-		public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		public Value evaluate(BindingSet bindings) throws QueryEvaluationException {
 			return value;
 		}
 
@@ -59,7 +59,7 @@ public interface QueryValueEvaluationStep {
 	/**
 	 * A minimal implementation that falls back to calling evaluate in the strategy.
 	 */
-	public static final class Minimal implements QueryValueEvaluationStep {
+	final class Minimal implements QueryValueEvaluationStep {
 		private final ValueExpr ve;
 		private final EvaluationStrategy strategy;
 
@@ -70,7 +70,7 @@ public interface QueryValueEvaluationStep {
 		}
 
 		@Override
-		public Value evaluate(BindingSet bindings) throws ValueExprEvaluationException, QueryEvaluationException {
+		public Value evaluate(BindingSet bindings) throws QueryEvaluationException {
 			return strategy.evaluate(ve, bindings);
 		}
 	}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryEvaluationContext.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryEvaluationContext.java
@@ -33,26 +33,31 @@ public interface QueryEvaluationContext {
 	public class Minimal implements QueryEvaluationContext {
 		public Minimal(Literal now, Dataset dataset) {
 			super();
-			this.now = now;
+			this.nowL = now;
+			// This is valid because the now field will never be read.
+			this.now = 0L;
 			this.dataset = dataset;
 		}
 
 		public Minimal(Dataset dataset) {
+			this.now = System.currentTimeMillis();
 			this.dataset = dataset;
 		}
 
-		private Literal now;
+		private final long now;
+		private Literal nowL;
 		private final Dataset dataset;
 
 		@Override
 		public Literal getNow() {
 			// creating a new date is expensive because it uses the XMLGregorianCalendar implementation which is very
-			// complex
-			if (now == null) {
-				now = SimpleValueFactory.getInstance().createLiteral(new Date());
+			// complex. This is thread safe even without a volatile because the literal is instantiated to the same
+			// value.
+			if (nowL == null) {
+				nowL = SimpleValueFactory.getInstance().createLiteral(new Date(now));
 			}
 
-			return now;
+			return nowL;
 		}
 
 		@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryEvaluationContext.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryEvaluationContext.java
@@ -31,33 +31,47 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
 public interface QueryEvaluationContext {
 
 	public class Minimal implements QueryEvaluationContext {
+		// The now time in the unix epoch or zero
+		private final long nowInMillis;
+		// The now time as a literal, lazy set if not yet known.
+		private Literal nowInLiteral;
+
+		private final Dataset dataset;
+
+		/**
+		 * Set the shared now value to an prexisting object
+		 * 
+		 * @param now     that is shared.
+		 * @param dataset that a query should use to the evaluate
+		 */
 		public Minimal(Literal now, Dataset dataset) {
 			super();
-			this.nowL = now;
+			this.nowInLiteral = now;
 			// This is valid because the now field will never be read.
-			this.now = 0L;
+			this.nowInMillis = 0L;
 			this.dataset = dataset;
 		}
 
+		/**
+		 * @param dataset that a query should use to the evaluate
+		 */
 		public Minimal(Dataset dataset) {
-			this.now = System.currentTimeMillis();
+			this.nowInMillis = System.currentTimeMillis();
 			this.dataset = dataset;
 		}
-
-		private final long now;
-		private Literal nowL;
-		private final Dataset dataset;
 
 		@Override
 		public Literal getNow() {
 			// creating a new date is expensive because it uses the XMLGregorianCalendar implementation which is very
-			// complex. This is thread safe even without a volatile because the literal is instantiated to the same
+			// complex. So if the nowInLiteral value is null, then we construct a new one based on the long value set
+			// nowInMillis.
+			// This is thread safe even without a volatile because the literal is instantiated to the same
 			// value.
-			if (nowL == null) {
-				nowL = SimpleValueFactory.getInstance().createLiteral(new Date(now));
+			if (nowInLiteral == null) {
+				nowInLiteral = SimpleValueFactory.getInstance().createLiteral(new Date(nowInMillis));
 			}
 
-			return nowL;
+			return nowInLiteral;
 		}
 
 		@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -174,7 +174,7 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 	// shared return value for successive calls of the NOW() function within the
 	// same query. Will be reset upon each new query being evaluated. See
 	// SES-869.
-	private Value sharedValueOfNow;
+	private Literal sharedValueOfNow;
 
 	private final long iterationCacheSyncThreshold;
 
@@ -314,7 +314,7 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 
 	@Override
 	public QueryEvaluationStep precompile(TupleExpr expr) {
-		QueryEvaluationContext context = new QueryEvaluationContext.Minimal(dataset);
+		QueryEvaluationContext context = new QueryEvaluationContext.Minimal(dataset, tripleSource.getValueFactory());
 		if (expr instanceof QueryRoot) {
 			String[] allVariables = ArrayBindingBasedQueryEvaluationContext
 					.findAllVariablesUsedInQuery((QueryRoot) expr);
@@ -1370,7 +1370,7 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 	@Deprecated(forRemoval = true)
 	public Value evaluate(Regex node, BindingSet bindings)
 			throws QueryEvaluationException {
-		return prepare(node, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+		return prepare(node, new QueryEvaluationContext.Minimal(sharedValueOfNow, dataset)).evaluate(bindings);
 	}
 
 	/**

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/NowTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/NowTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.datetime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author jeen
+ */
+public class NowTest {
+
+	private Now now;
+
+	private ValueFactory f = SimpleValueFactory.getInstance();
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		now = new Now();
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	@Test
+	public void testEvaluate() {
+		try {
+			Literal nowL = now.evaluate(f);
+
+			assertNotNull(nowL);
+			assertEquals(XSD.DATETIME, nowL.getDatatype());
+
+		} catch (ValueExprEvaluationException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/MinimalContextNowTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/MinimalContextNowTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.junit.Test;
+
+public class MinimalContextNowTest {
+
+	@Test
+	public void testNow() {
+
+		// Tests that the now value is correctly initialized.
+		QueryEvaluationContext.Minimal context = new QueryEvaluationContext.Minimal(null);
+		QueryValueEvaluationStep prepared = new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(
+				context.getNow());
+		assertNotNull(prepared);
+		Value nowValue = prepared.evaluate(EmptyBindingSet.getInstance());
+		assertTrue(nowValue.isLiteral());
+		Literal nowLiteral = (Literal) nowValue;
+		assertEquals(CoreDatatype.XSD.DATETIME, nowLiteral.getCoreDatatype());
+	}
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/MinimalContextNowTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/MinimalContextNowTest.java
@@ -7,16 +7,22 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryValueEvaluationStep;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MinimalContextNowTest {
 
@@ -27,10 +33,56 @@ public class MinimalContextNowTest {
 		QueryEvaluationContext.Minimal context = new QueryEvaluationContext.Minimal(null);
 		QueryValueEvaluationStep prepared = new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(
 				context.getNow());
-		assertNotNull(prepared);
+
+		Assertions.assertNotNull(prepared);
+
 		Value nowValue = prepared.evaluate(EmptyBindingSet.getInstance());
-		assertTrue(nowValue.isLiteral());
-		Literal nowLiteral = (Literal) nowValue;
-		assertEquals(CoreDatatype.XSD.DATETIME, nowLiteral.getCoreDatatype());
+
+		Assertions.assertTrue(nowValue.isLiteral());
+		Assertions.assertEquals(CoreDatatype.XSD.DATETIME, ((Literal) nowValue).getCoreDatatype());
+	}
+
+	@Test
+	public void testConcurrentAccessToNow() throws ExecutionException, InterruptedException {
+		int numberOfIterations = 100;
+		int numberOfThreads = 10;
+
+		ExecutorService executorService = Executors.newCachedThreadPool();
+		try {
+
+			for (int i = 0; i < numberOfIterations; i++) {
+				QueryEvaluationContext.Minimal context = new QueryEvaluationContext.Minimal(null);
+
+				CountDownLatch countDownLatch = new CountDownLatch(numberOfThreads);
+
+				List<? extends Future<Literal>> futures = IntStream.range(0, numberOfThreads)
+						.mapToObj(j -> executorService.submit(() -> {
+							try {
+								countDownLatch.countDown();
+								countDownLatch.await();
+								return context.getNow();
+							} catch (InterruptedException e) {
+								throw new RuntimeException(e);
+							}
+						}))
+						.collect(Collectors.toList());
+
+				Literal prev = null;
+				for (Future<Literal> future : futures) {
+					Literal now = future.get();
+					Assertions.assertNotNull(now);
+					if (prev != null) {
+						Assertions.assertSame(prev, now);
+					}
+					prev = now;
+				}
+
+			}
+
+		} finally {
+			List<Runnable> runnables = executorService.shutdownNow();
+			Assertions.assertTrue(runnables.isEmpty());
+		}
+
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/MinimalContextNowTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/MinimalContextNowTest.java
@@ -28,7 +28,6 @@ public class MinimalContextNowTest {
 
 	@Test
 	public void testNow() {
-
 		// Tests that the now value is correctly initialized.
 		QueryEvaluationContext.Minimal context = new QueryEvaluationContext.Minimal(null);
 		QueryValueEvaluationStep prepared = new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIterationTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIterationTest.java
@@ -12,6 +12,11 @@ import static org.junit.Assert.assertFalse;
 
 import java.util.Arrays;
 
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -19,6 +24,7 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.junit.Test;
@@ -30,7 +36,20 @@ public class HashJoinIterationTest {
 
 	private final ValueFactory vf = SimpleValueFactory.getInstance();
 
-	private final EvaluationStrategy evaluator = new StrictEvaluationStrategy(null, null);
+	private final EvaluationStrategy evaluator = new StrictEvaluationStrategy(new TripleSource() {
+
+		@Override
+		public ValueFactory getValueFactory() {
+			return SimpleValueFactory.getInstance();
+		}
+
+		@Override
+		public CloseableIteration<? extends Statement, QueryEvaluationException> getStatements(Resource subj, IRI pred,
+				Value obj, Resource... contexts) throws QueryEvaluationException {
+			// TODO Auto-generated method stub
+			return null;
+		}
+	}, null);
 
 	@Test
 	public void testCartesianJoin() throws QueryEvaluationException {

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/JoinIteratorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/JoinIteratorTest.java
@@ -15,7 +15,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -24,6 +29,7 @@ import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
@@ -36,7 +42,20 @@ public class JoinIteratorTest {
 
 	private final ValueFactory vf = SimpleValueFactory.getInstance();
 
-	private final EvaluationStrategy evaluator = new StrictEvaluationStrategy(null, null);
+	private final EvaluationStrategy evaluator = new StrictEvaluationStrategy(new TripleSource() {
+
+		@Override
+		public ValueFactory getValueFactory() {
+			return SimpleValueFactory.getInstance();
+		}
+
+		@Override
+		public CloseableIteration<? extends Statement, QueryEvaluationException> getStatements(Resource subj, IRI pred,
+				Value obj, Resource... contexts) throws QueryEvaluationException {
+			// TODO Auto-generated method stub
+			return null;
+		}
+	}, null);
 	private final QueryEvaluationContext context = new QueryEvaluationContext.Minimal(
 			vf.createLiteral(Date.from(Instant.now())), null);
 


### PR DESCRIPTION
GitHub issue resolved: #3811 

Briefly describe the changes proposed in this PR:

Ensure the now value is instantiated to the same value but lazily at a low cost.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

