### PR TITLE
GH-3817: fix all-uppercase and typo in FileOutputStream

### DIFF
--- a/site/content/documentation/programming/rdfstar.md
+++ b/site/content/documentation/programming/rdfstar.md
@@ -64,12 +64,12 @@ A Turtle-star file that contains an annotation with a certainty score, on a stat
 If we wish to read this data into an RDF4J Model object, we can do so using the Rio Turtle-star parser:
 
 ```java
-Model model = Rio.parse(new FileInputStream("/path/to/file.ttls"), "", RDFFORMAT.TURTLESTAR);
+Model model = Rio.parse(new FileInputStream("/path/to/file.ttls"), "", RDFFormat.TURTLESTAR);
 ```
 
 Similarly, Rio can be used to write RDF-star models to file:
 ```java
-Rio.write(model, new FileOuputStream("/path/to/file.ttls"), "", RDFFORMAT.TURTLESTAR);
+Rio.write(model, new FileOutputStream("/path/to/file.ttls"), "", RDFFormat.TURTLESTAR);
 ```
 
 ## Storing and retrieving RDF-star in a Repository


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #3817 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- fix type in FileOutputStream
- use correct casing in RDFFormat

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

