### PR TITLE
GH-3826 update tutorial, add default impl for deprecated method

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
@@ -35,12 +35,11 @@ public interface Function {
 	 * @param args         the function input arguments.
 	 * @return the function result value.
 	 * @throws ValueExprEvaluationException
-	 * @deprecated since 3.3.0. Use {@link #evaluate(TripleSource, Value...)} instead.
+	 * @deprecated since 3.3.0. Use {@link #evaluate(TripleSource, Value...)} instead. A reference to a ValueFactory can
+	 *             be retrieved using {@link TripleSource#getValueFactory()} if needed.
 	 */
 	@Deprecated
-	default Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
-		throw new UnsupportedOperationException("use evaluate(TripleSource, Value...) instead");
-	}
+	Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException;
 
 	/**
 	 * Evaluate the function over the supplied input arguments.

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/Function.java
@@ -35,11 +35,12 @@ public interface Function {
 	 * @param args         the function input arguments.
 	 * @return the function result value.
 	 * @throws ValueExprEvaluationException
-	 * @deprecated since 3.3.0. Use {@link #evaluate(TripleSource, Value...)} instead. A reference to a ValueFactory can
-	 *             be retrieved using {@link TripleSource#getValueFactory()} if needed.
+	 * @deprecated since 3.3.0. Use {@link #evaluate(TripleSource, Value...)} instead.
 	 */
 	@Deprecated
-	Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException;
+	default Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
+		throw new UnsupportedOperationException("use evaluate(TripleSource, Value...) instead");
+	}
 
 	/**
 	 * Evaluate the function over the supplied input arguments.

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/function/ExistingPalindromeFunction.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/function/ExistingPalindromeFunction.java
@@ -72,15 +72,11 @@ public class ExistingPalindromeFunction implements Function {
 		// a string is a palindrome if it is equal to its own inverse
 		boolean palindrome = inverted.equalsIgnoreCase(label);
 
-		// check if a triple with the rdfs:label predicate and this palindrome as its value exists in the database
+		// check if a triple with the rdfs:label predicate and this palindrome as its value already exists in the
+		// database
 		boolean existing = !QueryResults.asList(tripleSource.getStatements(null, RDFS.LABEL, (Literal) arg)).isEmpty();
 
 		// return a new boolean literal that is true if the input argument is a palindrome and exists as a label
 		return tripleSource.getValueFactory().createLiteral(palindrome && existing);
-	}
-
-	@Override
-	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
-		throw new UnsupportedOperationException("this function needs a TripleSource");
 	}
 }

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/function/ExistingPalindromeFunction.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/function/ExistingPalindromeFunction.java
@@ -79,4 +79,9 @@ public class ExistingPalindromeFunction implements Function {
 		// return a new boolean literal that is true if the input argument is a palindrome and exists as a label
 		return tripleSource.getValueFactory().createLiteral(palindrome && existing);
 	}
+
+	@Override
+	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/function/PalindromeFunction.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/function/PalindromeFunction.java
@@ -14,6 +14,7 @@ import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
@@ -73,5 +74,10 @@ public class PalindromeFunction implements Function {
 		// a function is always expected to return a Value object, so we
 		// return our boolean result as a Literal
 		return literal(palindrome);
+	}
+
+	@Override
+	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/examples/src/main/java/org/eclipse/rdf4j/examples/function/PalindromeFunction.java
+++ b/examples/src/main/java/org/eclipse/rdf4j/examples/function/PalindromeFunction.java
@@ -10,9 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.examples.function;
 
+import static org.eclipse.rdf4j.model.util.Values.literal;
+
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
@@ -42,7 +44,7 @@ public class PalindromeFunction implements Function {
 	 *                                      literal.
 	 */
 	@Override
-	public Value evaluate(ValueFactory valueFactory, Value... args)
+	public Value evaluate(TripleSource tripleSource, Value... args)
 			throws ValueExprEvaluationException {
 		// our palindrome function expects only a single argument, so throw an error
 		// if there's more than one
@@ -70,6 +72,6 @@ public class PalindromeFunction implements Function {
 
 		// a function is always expected to return a Value object, so we
 		// return our boolean result as a Literal
-		return valueFactory.createLiteral(palindrome);
+		return literal(palindrome);
 	}
 }

--- a/site/content/documentation/tutorials/custom-sparql-functions.md
+++ b/site/content/documentation/tutorials/custom-sparql-functions.md
@@ -81,9 +81,10 @@ The real proof of the pudding is in the `evaluate()` method: this is where the f
 ```java
 package org.eclipse.rdf4j.examples.function;
 
+import static org.eclipse.rdf4j.model.util.Values.literal;
+
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
@@ -114,7 +115,7 @@ public class PalindromeFunction implements Function {
      *         if more than one argument is supplied or if the supplied argument
      *         is not a literal.
      */
-    public Value evaluate(ValueFactory valueFactory, Value... args)
+    public Value evaluate(TripleSource tripleSource, Value... args)
 	throws ValueExprEvaluationException
 	{
 	    // our palindrome function expects only a single argument, so throw an error
@@ -144,14 +145,14 @@ public class PalindromeFunction implements Function {
 
 	    // a function is always expected to return a Value object, so we
 	    // return our boolean result as a Literal
-	    return valueFactory.createLiteral(palindrome);
+	    return literal(palindrome);
 	}
 }
 ```
 
 You are completely free to implement your function logic: in the above example, we have created a function that only returns `true` or `false`, but since the actual return type of an RDF4J function is {{< javadoc "Value" "model/Value.html" >}}, you can create functions that return string literals, numbers, dates, or even IRIs or blank nodes.
 
-In addition, since RDF4J release 3.3, the `evaluate` method also accepts a `TripleSource` as input parameter, which you can use to inspect the underlying database, and query it for further information (for a simple/silly example see the {{< example "Existing Palindrome function" "function/ExstingPalindromeFunction.java" >}}).
+In addition, the `evaluate` method accepts a `TripleSource` as input parameter, which you can use to inspect the underlying database, and query it for further information (for a simple/silly example see the {{< example "Existing Palindrome function" "function/ExstingPalindromeFunction.java" >}}, which in addition to checking that the argument is a palindrome, also checks if that palindrome already exists in the database).
 
 There are two important things to keep in mind though:
 


### PR DESCRIPTION
GitHub issue resolved: #3826  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- ~added default implementation of deprecated `evaluate` method (to allow implementations to avoid overriding it if they already implement the new variant with a `TripleSource` argument)~
- slightly updated the tutorial and example code

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

