### PR TITLE
GH-3830 re-enable japicmp checks, new version no longer needs exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -863,7 +863,7 @@
 				<plugin>
 					<groupId>com.github.siom79.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.15.3</version>
+					<version>0.15.7</version>
 					<configuration>
 						<oldVersion>
 							<dependency>
@@ -880,8 +880,7 @@
 						</newVersion>
 						<parameter>
 							<onlyModified>true</onlyModified>
-							<breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
-							<breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
+							<breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
 							<ignoreMissingOldVersion>true</ignoreMissingOldVersion>
 							<excludes>
 								<exclude>@org.eclipse.rdf4j.common.annotation.InternalUseOnly</exclude>
@@ -889,21 +888,8 @@
 								<exclude>org.eclipse.rdf4j.common.annotation.InternalUseOnly</exclude>
 								<exclude>org.eclipse.rdf4j.common.annotation.Experimental</exclude>
 							</excludes>
-							<overrideCompatibilityChangeParameters>
-								<overrideCompatibilityChangeParameter>
-									<compatibilityChange>METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE</compatibilityChange>
-									<binaryCompatible>true</binaryCompatible>
-									<sourceCompatible>true</sourceCompatible>
-								</overrideCompatibilityChangeParameter>
-								<overrideCompatibilityChangeParameter>
-									<compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
-									<binaryCompatible>true</binaryCompatible>
-									<sourceCompatible>true</sourceCompatible>
-								</overrideCompatibilityChangeParameter>
-							</overrideCompatibilityChangeParameters>
 						</parameter>
 					</configuration>
-					<!-- API compatibility checks disabled for major release. Should be re-enabled after 4.0.0 is final
 					<executions>
 						<execution>
 							<phase>verify</phase>
@@ -912,7 +898,6 @@
 							</goals>
 						</execution>
 					</executions>
-					-->
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
GitHub issue resolved: #3830 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- re-enable japicmp plugin for compatibility checks against 4.0.0
- bumped version of plugin which fixes several issues we had to put exceptions in for earlier
- removed exceptions and simplified config


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

