### PR TITLE
GH-3833 prefer writer over reader to avoid effective deadlock in WeakObjectRegistry

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/WeakObjectRegistry.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/WeakObjectRegistry.java
@@ -320,7 +320,9 @@ public class WeakObjectRegistry<E> extends AbstractSet<E> {
 				} else {
 					// Release our read lock so we don't block any writers.
 					readersUnlocked.increment();
-					Thread.onSpinWait();
+					while (lock.isWriteLocked()) {
+						Thread.onSpinWait();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
GitHub issue resolved: #3833 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

