### PR TITLE
GH-3835 use full fence to ensure memory ordering for new LongAdder based locks

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/AbstractReadWriteLockManager.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/AbstractReadWriteLockManager.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.common.concurrent.locks;
 
+import java.lang.invoke.VarHandle;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.StampedLock;
@@ -393,6 +394,10 @@ public abstract class AbstractReadWriteLockManager implements ReadWriteLockManag
 				throw new IllegalMonitorStateException("Trying to release a lock that is not locked");
 			}
 
+			// Make sure that readers in other threads will be able to read the writes that were made by the user within
+			// the write-locked section. The stamped lock only guarantees that writes are visible to other threads if
+			// those threads use a stamped lock read-lock.
+			VarHandle.fullFence();
 			lock.unlockWrite(temp);
 		}
 	}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/WeakObjectRegistry.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/WeakObjectRegistry.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory.model;
 
+import java.lang.invoke.VarHandle;
 import java.lang.ref.WeakReference;
 import java.util.AbstractSet;
 import java.util.Arrays;
@@ -354,6 +355,10 @@ public class WeakObjectRegistry<E> extends AbstractSet<E> {
 
 		public void unlockWriter(long stamp) {
 			if (stamp != 0) {
+				// Make sure that readers in other threads will be able to read the writes that were made by the user
+				// within the write-locked section. The stamped lock only guarantees that writes are visible to other
+				// threads if those threads use a stamped lock read-lock.
+				VarHandle.fullFence();
 				lock.unlockWrite(stamp);
 			} else {
 				throw new IllegalMonitorStateException();


### PR DESCRIPTION
GitHub issue resolved: #3835 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

