### PR TITLE
GH-3847 skip japicmp and formatters when using the quick profile in maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,10 @@
 			<properties>
 				<skipTests>true</skipTests>
 				<skipITs>true</skipITs>
+				<formatter.skip>true</formatter.skip>
+				<impsort.skip>true</impsort.skip>
+				<xml-format.skip>true</xml-format.skip>
+				<japicmp.skip>true</japicmp.skip>
 			</properties>
 		</profile>
 		<profile>


### PR DESCRIPTION
GitHub issue resolved: #3847 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

