### PR TITLE
GH-3867 improve generic flushing performance

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractNotifyingSailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractNotifyingSailConnection.java
@@ -33,37 +33,28 @@ public abstract class AbstractNotifyingSailConnection extends AbstractSailConnec
 
 	@Override
 	public void addConnectionListener(SailConnectionListener listener) {
-		synchronized (listeners) {
-			listeners.add(listener);
-		}
+		listeners.add(listener);
 	}
 
 	@Override
 	public void removeConnectionListener(SailConnectionListener listener) {
-		synchronized (listeners) {
-			listeners.remove(listener);
-		}
+		listeners.remove(listener);
 	}
 
 	protected boolean hasConnectionListeners() {
-		synchronized (listeners) {
-			return !listeners.isEmpty();
-		}
+		return !listeners.isEmpty();
 	}
 
 	protected void notifyStatementAdded(Statement st) {
-		synchronized (listeners) {
-			for (SailConnectionListener listener : listeners) {
-				listener.statementAdded(st);
-			}
+		for (SailConnectionListener listener : listeners) {
+			listener.statementAdded(st);
 		}
+
 	}
 
 	protected void notifyStatementRemoved(Statement st) {
-		synchronized (listeners) {
-			for (SailConnectionListener listener : listeners) {
-				listener.statementRemoved(st);
-			}
+		for (SailConnectionListener listener : listeners) {
+			listener.statementRemoved(st);
 		}
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #3867 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
 - improve change tracking to reduce unneeded flushing
 - reduce use of synchronization

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

