### PR TITLE
GH-1090: added IllegalArgumentException when mimeTypes isEmpty in FileFormat.java

### DIFF
--- a/core/common/io/src/main/java/org/eclipse/rdf4j/common/lang/FileFormat.java
+++ b/core/common/io/src/main/java/org/eclipse/rdf4j/common/lang/FileFormat.java
@@ -97,8 +97,11 @@ public class FileFormat {
 	public FileFormat(String name, Collection<String> mimeTypes, Charset charset, Collection<String> fileExtensions) {
 		assert name != null : "name must not be null";
 		assert mimeTypes != null : "mimeTypes must not be null";
-		assert !mimeTypes.isEmpty() : "mimeTypes must not be empty";
 		assert fileExtensions != null : "fileExtensions must not be null";
+
+		if (mimeTypes.isEmpty()) {
+			throw new IllegalArgumentException("mimeTypes must not be empty");
+		}
 
 		this.name = name;
 		this.mimeTypes.addAll(mimeTypes);

--- a/core/common/io/src/test/java/org/eclipse/rdf4j/common/lang/FileFormatTest.java
+++ b/core/common/io/src/test/java/org/eclipse/rdf4j/common/lang/FileFormatTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) $2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.common.lang;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class FileFormatTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testEmptyMimeType() {
+        thrown.expect(IllegalArgumentException.class);
+        new FileFormat("PLAIN TEXT", new ArrayList<String>(), null, Arrays.asList("txt"));
+    }
+}

--- a/core/common/io/src/test/java/org/eclipse/rdf4j/common/lang/FileFormatTest.java
+++ b/core/common/io/src/test/java/org/eclipse/rdf4j/common/lang/FileFormatTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) $2022 Eclipse RDF4J contributors.
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -7,21 +7,19 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.lang;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class FileFormatTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testEmptyMimeType() {
-        thrown.expect(IllegalArgumentException.class);
-        new FileFormat("PLAIN TEXT", new ArrayList<String>(), null, Arrays.asList("txt"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            new FileFormat("PLAIN TEXT", new ArrayList<String>(), null, Arrays.asList("txt"));
+        });
     }
 }


### PR DESCRIPTION
GitHub issue resolved: #1090 

Briefly describe the changes proposed in this PR:

Instead of silently failing with the assert check previously used, an empty mimeType list now throws an IllegalArgumentException 

`assert !mimeTypes.isEmpty() : "mimeTypes must not be empty"`

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

