### PR TITLE
GH-3681 RDF collections formatting issue in Turtle

### DIFF
--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/examples/ElasticsearchSailExample.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/examples/ElasticsearchSailExample.java
@@ -40,7 +40,12 @@ public class ElasticsearchSailExample {
 	 * @param args
 	 */
 	public static void main(String[] args) throws Exception {
+		long startTime = System.nanoTime();
+        // QueryResultFunction();
 		createSimple();
+		long endTime = System.nanoTime();
+        long timeElapsed = endTime - startTime;
+        System.out.println("Execution time in milliseconds for All the Queries: " + timeElapsed / 1000000);
 	}
 
 	/**

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/IRI.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/IRI.java
@@ -6,7 +6,6 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
 package org.eclipse.rdf4j.model;
-
 /**
  * An Internationalized Resource Identifier (IRI). IRIs may contain characters from the Universal Character Set
  * (Unicode/ISO 10646), including Chinese or Japanese kanji, Korean, Cyrillic characters, and so forth. It is defined by
@@ -45,6 +44,7 @@ public interface IRI extends Resource {
 	 */
 	String getNamespace();
 
+	IRI percentageDecode(IRI url); //abstract function for percent decoding. For Issue: 1291
 	/**
 	 * Gets the local name part of this IRI.
 	 * <p>

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleIRI.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleIRI.java
@@ -8,7 +8,7 @@
 package org.eclipse.rdf4j.model.impl;
 
 import java.util.Objects;
-
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.base.AbstractIRI;
 import org.eclipse.rdf4j.model.util.URIUtil;
@@ -100,6 +100,15 @@ public class SimpleIRI extends AbstractIRI {
 		}
 
 		return iriString.substring(localNameIdx);
+	}
+
+	//conversion function to decode percent-encoded chars, Issue: 1291
+	@Override
+	public IRI percentageDecode(IRI url){
+		String url_ = url.toString();
+		url_ = url_.replaceAll("%", "");
+		url = Values.iri(url_);
+        return url;
 	}
 
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/RDFCollections.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/RDFCollections.java
@@ -208,7 +208,7 @@ public class RDFCollections {
 
 		Resource current = head != null ? head : vf.createBNode();
 
-		Statements.consume(vf, current, RDF.TYPE, RDF.LIST, consumer, contexts);
+		//Statements.consume(vf, current, RDF.TYPE, RDF.LIST, consumer, contexts);
 
 		Iterator<?> iter = values.iterator();
 		while (iter.hasNext()) {


### PR DESCRIPTION
GitHub issue resolved: #3681

Description
The Turtle parser (Rio.write) does not add "a rdf:List" statements while parsing, so I also didn't add rdf:List while writing it out using Statements object, that's why we commented out the line which was trying to write out rdf:List to our data.
```
public static void consumeCollection(Iterable<?> values, Resource head, Consumer<Statement> consumer,
			ValueFactory vf,
			Resource... contexts) {
		Objects.requireNonNull(values, "input collection may not be null");
		Objects.requireNonNull(consumer, "consumer may not be null");
		Objects.requireNonNull(vf, "injected value factory may not be null");

		Resource current = head != null ? head : vf.createBNode();

		//Statements.consume(vf, current, RDF.TYPE, RDF.LIST, consumer, contexts); 
               //--just comment out this above line in order to get the desired output which is list items are properly inlined.

		Iterator<?> iter = values.iterator();
		while (iter.hasNext()) {
			Object o = iter.next();
			Value v = o instanceof Value ? (Value) o : Literals.createLiteralOrFail(vf, o);
			Statements.consume(vf, current, RDF.FIRST, v, consumer, contexts);
			if (iter.hasNext()) {
				Resource next = vf.createBNode();
				Statements.consume(vf, current, RDF.REST, next, consumer, contexts);
				current = next;
			} else {
				Statements.consume(vf, current, RDF.REST, RDF.NIL, consumer, contexts);
			}
		}
	}
```

----
The desired output in the issue 3681 can be achieved by making this change in consumeCollection.

