### PR TITLE
GH-2524 : Added regex for handling inline binding expressions

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtil.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtil.java
@@ -18,7 +18,8 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLQueries;
 
 /**
- * Utility class to perfom query string manipulations as used in {@link SPARQLTupleQuery}, {@link SPARQLGraphQuery} and
+ * Utility class to perfom query string manipulations as used in
+ * {@link SPARQLTupleQuery}, {@link SPARQLGraphQuery} and
  * {@link SPARQLBooleanQuery}.
  *
  * @author Andreas Schwarte
@@ -31,7 +32,8 @@ public class QueryStringUtil {
 	// TODO maybe add BASE declaration here as well?
 
 	/**
-	 * Retrieve a modified queryString into which all bindings of the given argument are replaced.
+	 * Retrieve a modified queryString into which all bindings of the given argument
+	 * are replaced.
 	 *
 	 * @param queryString
 	 * @param bindings
@@ -44,7 +46,8 @@ public class QueryStringUtil {
 	}
 
 	/**
-	 * Retrieve a modified queryString into which all bindings of the given argument are replaced, with the binding
+	 * Retrieve a modified queryString into which all bindings of the given argument
+	 * are replaced, with the binding
 	 * names included in the SELECT clause.
 	 *
 	 * @param queryString
@@ -65,7 +68,9 @@ public class QueryStringUtil {
 			if (replacement != null) {
 				String pattern = "[\\?\\$]" + name + "(?=\\W)";
 				select = select.replaceAll(pattern, "(" + Matcher.quoteReplacement(replacement) + " as ?" + name + ")");
-
+				pattern = "[\\?\\$]" + name + "(?=\\s?\\)\\W)";
+				select = select.replaceAll(pattern, Matcher.quoteReplacement(replacement));
+				pattern = "[\\?\\$]" + name + "(?=\\W)";
 				// we use Matcher.quoteReplacement to make sure things like newlines
 				// in literal values
 				// are preserved
@@ -76,7 +81,8 @@ public class QueryStringUtil {
 	}
 
 	/**
-	 * Retrieve a modified queryString into which all bindings of the given argument are replaced with their value.
+	 * Retrieve a modified queryString into which all bindings of the given argument
+	 * are replaced with their value.
 	 *
 	 * @param queryString
 	 * @param bindings
@@ -87,7 +93,8 @@ public class QueryStringUtil {
 	}
 
 	/**
-	 * Retrieve a modified queryString into which all bindings of the given argument are replaced with their value.
+	 * Retrieve a modified queryString into which all bindings of the given argument
+	 * are replaced with their value.
 	 *
 	 * @param queryString
 	 * @param bindings
@@ -98,7 +105,8 @@ public class QueryStringUtil {
 	}
 
 	/**
-	 * Retrieve a modified queryString into which all bindings of the given argument are replaced with their value.
+	 * Retrieve a modified queryString into which all bindings of the given argument
+	 * are replaced with their value.
 	 *
 	 * @param queryString
 	 * @param bindings
@@ -135,7 +143,8 @@ public class QueryStringUtil {
 	}
 
 	/**
-	 * Converts a value to its SPARQL string representation and appends it to a StringBuilder.
+	 * Converts a value to its SPARQL string representation and appends it to a
+	 * StringBuilder.
 	 *
 	 * Null will be converted to UNDEF (may be used in VALUES only).
 	 *


### PR DESCRIPTION
GitHub issue resolved: #2524

Briefly describe the changes proposed in this PR:

The handling of binding substitution fails for queries of the form select (func(?x) as ?y). For a binding x=foo the output is select (func('foo' as ?x) as ?y) when it should be select (func('foo') as ?y). The current code only works for select ?x ?y ?z type queries. Regex has been modified to ignore patterns that are preceded by 'as'.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

