### PR TITLE
GH-327 Include timing stats in workbench query results

### DIFF
--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/examples/ElasticsearchSailExample.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/examples/ElasticsearchSailExample.java
@@ -40,7 +40,11 @@ public class ElasticsearchSailExample {
 	 * @param args
 	 */
 	public static void main(String[] args) throws Exception {
+		long startTime = System.nanoTime();
 		createSimple();
+		long endTime = System.nanoTime();
+        long timeElapsed = endTime - startTime;
+        System.out.println("Execution time in milliseconds for All the Queries: " + timeElapsed / 1000000);
 	}
 
 	/**

--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/IRI.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/IRI.java
@@ -6,7 +6,6 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
 package org.eclipse.rdf4j.model;
-
 /**
  * An Internationalized Resource Identifier (IRI). IRIs may contain characters from the Universal Character Set
  * (Unicode/ISO 10646), including Chinese or Japanese kanji, Korean, Cyrillic characters, and so forth. It is defined by
@@ -45,6 +44,7 @@ public interface IRI extends Resource {
 	 */
 	String getNamespace();
 
+	IRI percentageDecode(IRI url); //abstract function for percent decoding. For Issue: 1291
 	/**
 	 * Gets the local name part of this IRI.
 	 * <p>

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleIRI.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleIRI.java
@@ -8,7 +8,7 @@
 package org.eclipse.rdf4j.model.impl;
 
 import java.util.Objects;
-
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.base.AbstractIRI;
 import org.eclipse.rdf4j.model.util.URIUtil;
@@ -100,6 +100,15 @@ public class SimpleIRI extends AbstractIRI {
 		}
 
 		return iriString.substring(localNameIdx);
+	}
+
+	//conversion function to decode percent-encoded chars, Issue: 1291
+	@Override
+	public IRI percentageDecode(IRI url){
+		String url_ = url.toString();
+		url_ = url_.replaceAll("%", "");
+		url = Values.iri(url_);
+        return url;
 	}
 
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/RDFCollections.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/RDFCollections.java
@@ -208,7 +208,7 @@ public class RDFCollections {
 
 		Resource current = head != null ? head : vf.createBNode();
 
-		Statements.consume(vf, current, RDF.TYPE, RDF.LIST, consumer, contexts);
+		//Statements.consume(vf, current, RDF.TYPE, RDF.LIST, consumer, contexts);
 
 		Iterator<?> iter = values.iterator();
 		while (iter.hasNext()) {


### PR DESCRIPTION
GitHub issue resolved: #327

Made changes in the ElasticSearchSailExample.java, it had multiple queries running in only one function, so to print runtime, i just calculated runtime for that only function which ran multiple queries together. 

Please point out if the way is wrong.

----
