### PR TITLE
GH-3902 fix MemEvaluationStatistics regression

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemEvaluationStatistics.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemEvaluationStatistics.java
@@ -71,63 +71,71 @@ class MemEvaluationStatistics extends EvaluationStatistics {
 
 			if (subj == null && pred == null && obj == null && context == null) {
 				return memStatementList.size();
+			} else {
+				return minStatementCount(subj, pred, obj, context);
 			}
 
+		}
+
+		private int minStatementCount(Value subj, Value pred, Value obj, Value context) {
 			int minListSizes = Integer.MAX_VALUE;
-			boolean found = false;
 
 			if (subj != null) {
-				// Perform look-ups for value-equivalents of the specified values
 				MemResource memSubj = valueFactory.getMemResource((Resource) subj);
 				if (memSubj != null) {
-					found = true;
 					minListSizes = memSubj.getSubjectStatementCount();
 					if (minListSizes == 0) {
 						return 0;
 					}
+				} else {
+					// couldn't find the value in the value factory, which means that there are no statements with that
+					// value
+					return 0;
 				}
 			}
 
 			if (pred != null) {
 				MemIRI memPred = valueFactory.getMemURI((IRI) pred);
 				if (memPred != null) {
-					found = true;
-
 					minListSizes = Math.min(minListSizes, memPred.getPredicateStatementCount());
 					if (minListSizes == 0) {
 						return 0;
 					}
+				} else {
+					// couldn't find the value in the value factory, which means that there are no statements with that
+					// value
+					return 0;
 				}
 			}
 
 			if (obj != null) {
 				MemValue memObj = valueFactory.getMemValue(obj);
 				if (memObj != null) {
-					found = true;
 					minListSizes = Math.min(minListSizes, memObj.getObjectStatementCount());
 					if (minListSizes == 0) {
 						return 0;
 					}
+				} else {
+					// couldn't find the value in the value factory, which means that there are no statements with that
+					// value
+					return 0;
 				}
 			}
 
 			if (context != null) {
 				MemResource memContext = valueFactory.getMemResource((Resource) context);
 				if (memContext != null) {
-					found = true;
 					minListSizes = Math.min(minListSizes, memContext.getContextStatementCount());
-					if (minListSizes == 0) {
-						return 0;
-					}
+				} else {
+					// couldn't find the value in the value factory, which means that there are no statements with that
+					// value
+					return 0;
 				}
 			}
 
-			if (found) {
-				return minListSizes;
-			} else {
-				return 0;
-			}
+			assert minListSizes != Integer.MAX_VALUE : "minListSizes should have been updated before this point";
 
+			return minListSizes;
 		}
 
 		protected Value getConstantValue(Var var) {
@@ -138,4 +146,5 @@ class MemEvaluationStatistics extends EvaluationStatistics {
 			return null;
 		}
 	}
-} // end inner class MemCardinalityCalculator
+
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/BenchmarkIT.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/BenchmarkIT.java
@@ -8,7 +8,6 @@
 
 package org.eclipse.rdf4j.sail.shacl.benchmark;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -29,7 +28,6 @@ import org.openjdk.jmh.runner.options.TimeValue;
 public class BenchmarkIT {
 
 	@Test
-	@Disabled
 	public void test() throws RunnerException {
 		Options opt = new OptionsBuilder()
 				.include("")


### PR DESCRIPTION
GitHub issue resolved: #3902 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Original code first looked up all four S,P,O,C in the memory value factory before finding out what the smallest statement list size was. I rewrote it to look up one value at a time instead of all four at once, that way we could return earlier if the statement list size was 0. 

I forgot to take account of that the memory value factory returns null when the value is unknown, which entails that there can't be any statements with the value. Fixed that now.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

