### PR TITLE
GH-3911 LMDB store: do not use additional read transaction for removals

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
@@ -398,21 +398,14 @@ class LmdbSailStore implements SailStore {
 	private final class LmdbSailSink implements SailSink {
 
 		private final boolean explicit;
-		private final Txn txn;
 
 		public LmdbSailSink(boolean explicit) throws SailException {
 			this.explicit = explicit;
-			try {
-				this.txn = tripleStore.getTxnManager().createReadTxn();
-			} catch (IOException e) {
-				throw new SailException(e);
-			}
 		}
 
 		@Override
 		public void close() {
-			// close the associated txn
-			txn.close();
+			// do nothing
 		}
 
 		@Override
@@ -647,8 +640,7 @@ class LmdbSailStore implements SailStore {
 				throws IOException {
 			long removeCount = 0;
 			for (long contextId : contexts) {
-				Map<Long, Long> result = tripleStore.removeTriplesByContext(txn, subj, pred, obj, contextId,
-						explicit);
+				Map<Long, Long> result = tripleStore.removeTriplesByContext(subj, pred, obj, contextId, explicit);
 
 				for (Entry<Long, Long> entry : result.entrySet()) {
 					Long entryContextId = entry.getKey();

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -668,10 +668,9 @@ class TripleStore implements Closeable {
 	 * @return A mapping of each modified context to the number of statements removed in that context.
 	 * @throws IOException
 	 */
-	public Map<Long, Long> removeTriplesByContext(Txn txn, long subj, long pred, long obj, long context,
-			boolean explicit)
-			throws IOException {
-		RecordIterator records = getTriples(txn, subj, pred, obj, context, explicit);
+	public Map<Long, Long> removeTriplesByContext(long subj, long pred, long obj, long context,
+			boolean explicit) throws IOException {
+		RecordIterator records = getTriples(txnManager.createTxn(writeTxn), subj, pred, obj, context, explicit);
 		return removeTriples(records, explicit);
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #3911 

Briefly describe the changes proposed in this PR:

Use the active write transaction for reading the statements that should be removed.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

