### PR TITLE
GH-3917 MemValueFactory should not validate on IRI creation

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactory.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.base.AbstractValueFactory;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.util.URIUtil;
 import org.eclipse.rdf4j.model.util.Values;
@@ -326,7 +327,7 @@ public class MemValueFactory extends AbstractValueFactory {
 
 	@Override
 	public IRI createIRI(String namespace, String localName) {
-		return iriRegistry.getOrAdd(Values.iri(namespace, localName), () -> {
+		return iriRegistry.getOrAdd(SimpleValueFactory.getInstance().createIRI(namespace, localName), () -> {
 
 			if (namespace.indexOf(':') == -1) {
 				throw new IllegalArgumentException("Not a valid (absolute) URI: " + namespace + localName);

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactoryTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/model/MemValueFactoryTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.junit.jupiter.api.Test;
+
+public class MemValueFactoryTest {
+
+	@Test
+	public void testCreateIRI_namespace_localName_whitespace() {
+		MemValueFactory factory = new MemValueFactory();
+
+		String namespace = "http://example.org/with whitespace/";
+		String localName = "example_iri";
+
+		// MemValueFactory should not do validation of whitespace, and just produce an IRI object
+		assertThat(factory.createIRI(namespace, localName)).isInstanceOf(IRI.class);
+	}
+
+}


### PR DESCRIPTION
GitHub issue resolved: #3917 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- Change MemValueFactory to use a SimpleValueFactory internally, instead of a (validating) `Values` utility method
- added regression test

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

