### PR TITLE
GH-3935 Remove SmartTransactionObject from TransactionObject

### DIFF
--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/BaseConcurrentBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/BaseConcurrentBenchmark.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Scope;
@@ -22,11 +23,11 @@ import org.openjdk.jmh.annotations.TearDown;
 @State(Scope.Benchmark)
 public class BaseConcurrentBenchmark {
 
-	ExecutorService executorService;
+	private ExecutorService executorService;
 
 	@Setup(Level.Trial)
 	public void setup() throws Exception {
-		executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+		executorService = Executors.newFixedThreadPool(8);
 	}
 
 	@TearDown(Level.Trial)
@@ -55,6 +56,10 @@ public class BaseConcurrentBenchmark {
 		latch.countDown();
 		latchDone.await();
 
+	}
+
+	Future<?> submit(Runnable runnable) {
+		return executorService.submit(runnable);
 	}
 
 	static InputStream getResourceAsStream(String filename) {

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/ConcurrentQueryBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/ConcurrentQueryBenchmark.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.memory.benchmark;
+
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * @author Håvard M. Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms1G", "-Xmx1G", })
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ConcurrentQueryBenchmark extends BaseConcurrentBenchmark {
+
+	private SailRepository repository;
+
+	public static void main(String[] args) throws RunnerException {
+		Options opt = new OptionsBuilder()
+				.include("ConcurrentQueryBenchmark.*") // adapt to run other benchmark tests
+				.forks(1)
+				.build();
+
+		new Runner(opt).run();
+	}
+
+	@Setup(Level.Trial)
+	public void setup() throws Exception {
+		super.setup();
+		repository = new SailRepository(new MemoryStore());
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(IsolationLevels.NONE);
+			try (InputStream resourceAsStream = getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl")) {
+				connection.add(resourceAsStream, RDFFormat.TURTLE);
+			}
+			connection.commit();
+
+		}
+
+	}
+
+	@TearDown(Level.Trial)
+	public void tearDown() throws Exception {
+		super.tearDown();
+		repository.shutDown();
+	}
+
+	@Benchmark
+	public void hasStatement(Blackhole blackhole) throws Exception {
+		threads(100, () -> {
+			try (SailRepositoryConnection connection = repository.getConnection()) {
+				for (int i = 0; i < 100; i++) {
+					boolean b = connection.hasStatement(null, null, null, true);
+					blackhole.consume(b);
+				}
+			}
+		});
+	}
+
+	@Benchmark
+	public void hasStatementSharedConnection(Blackhole blackhole) throws Exception {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			threads(100, () -> {
+				for (int i = 0; i < 100; i++) {
+					boolean b = connection.hasStatement(null, null, null, true);
+					blackhole.consume(b);
+				}
+			});
+		}
+	}
+
+	@Benchmark
+	public void getNamespaces(Blackhole blackhole) throws Exception {
+		threads(100, () -> {
+			try (SailRepositoryConnection connection = repository.getConnection()) {
+				for (int i = 0; i < 100; i++) {
+					blackhole.consume(connection.getNamespaces().stream().count());
+				}
+			}
+		});
+	}
+
+	@Benchmark
+	public void getNamespacesSharedConnection(Blackhole blackhole) throws Exception {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			threads(100, () -> {
+				for (int i = 0; i < 100; i++) {
+					blackhole.consume(connection.getNamespaces().stream().count());
+				}
+			});
+		}
+	}
+
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/LoadingBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/LoadingBenchmark.java
@@ -44,11 +44,11 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 20)
+@Warmup(iterations = 5)
 @BenchmarkMode({ Mode.AverageTime })
 //@Fork(value = 1, jvmArgs = {"-Xms4G", "-Xmx4G", "-XX:+UseSerialGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=5s,duration=60s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
 @Fork(value = 1, jvmArgs = { "-Xms4G", "-Xmx4G", "-XX:+UseSerialGC" })
-@Measurement(iterations = 10)
+@Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class LoadingBenchmark {
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/MemValueFactoryConcurrentBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/MemValueFactoryConcurrentBenchmark.java
@@ -53,10 +53,10 @@ import com.google.common.collect.Lists;
  * @author Håvard M. Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 20)
+@Warmup(iterations = 5)
 @BenchmarkMode({ Mode.AverageTime })
 @Fork(value = 1, jvmArgs = { "-Xms1G", "-Xmx1G", })
-@Measurement(iterations = 10)
+@Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class MemValueFactoryConcurrentBenchmark extends BaseConcurrentBenchmark {
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/NotifyingSailBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/NotifyingSailBenchmark.java
@@ -55,11 +55,11 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 20)
+@Warmup(iterations = 5)
 @BenchmarkMode({ Mode.AverageTime })
 //@Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=5s,duration=60s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
 @Fork(value = 1, jvmArgs = { "-Xms2G", "-Xmx2G" })
-@Measurement(iterations = 10)
+@Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class NotifyingSailBenchmark {
 
@@ -76,7 +76,6 @@ public class NotifyingSailBenchmark {
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
 				.include("NotifyingSailBenchmark.load") // adapt to run other benchmark tests
-				// .addProfiler("stack", "lines=20;period=1;top=20")
 				.forks(1)
 				.build();
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/ParallelMixedReadWriteBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/ParallelMixedReadWriteBenchmark.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- *******************************************************************************/
+ ******************************************************************************/
 
 package org.eclipse.rdf4j.sail.memory.benchmark;
 
@@ -24,10 +24,17 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -50,13 +57,13 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 5)
+@Warmup(iterations = 10)
 @BenchmarkMode({ Mode.AverageTime })
 @Fork(value = 1, jvmArgs = { "-Xms1G", "-Xmx1G" })
 //@Fork(value = 1, jvmArgs = { "-Xms1G", "-Xmx1G", "-XX:StartFlightRecording=delay=20s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
 @Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
+public class ParallelMixedReadWriteBenchmark extends BaseConcurrentBenchmark {
 
 	private static final String query1;
 	private static final String query4;
@@ -77,17 +84,18 @@ public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
 	}
 
 	private SailRepository repository;
+	private Model data;
 
 	@Setup(Level.Trial)
 	public void setup() throws Exception {
 		super.setup();
 		repository = new SailRepository(new MemoryStore());
-
+		try (InputStream resourceAsStream = getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl")) {
+			data = Rio.parse(resourceAsStream, RDFFormat.TURTLE);
+		}
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
-			try (InputStream resourceAsStream = getResourceAsStream("benchmarkFiles/datagovbe-valid.ttl")) {
-				connection.add(resourceAsStream, RDFFormat.TURTLE);
-			}
+			connection.add(data);
 			connection.commit();
 		}
 	}
@@ -98,9 +106,28 @@ public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
 		super.tearDown();
 	}
 
+	@TearDown(Level.Invocation)
+	public void clearAfterInvocation() throws Exception {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin(IsolationLevels.NONE);
+			try (RepositoryResult<Resource> contextIDs = connection.getContextIDs()) {
+				for (Resource contextID : contextIDs) {
+					if (contextID != null) {
+//						System.out.println("Clearing: " + contextID);
+						connection.clear(contextID);
+					}
+				}
+			}
+			connection.commit();
+		}
+		System.gc();
+		Thread.sleep(100);
+		System.gc();
+	}
+
 	public static void main(String[] args) throws Exception {
 		Options opt = new OptionsBuilder()
-				.include("ParallelQueryBenchmark.*") // adapt to run other benchmark tests
+				.include("ParallelMixedReadWriteBenchmark.*") // adapt to run other benchmark tests
 				.forks(1)
 				.build();
 
@@ -108,7 +135,7 @@ public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
 	}
 
 	@Benchmark
-	public void mixedQueriesAndReads(Blackhole blackhole) throws InterruptedException {
+	public void mixedQueriesAndReadsAndWrites(Blackhole blackhole) throws InterruptedException {
 		CountDownLatch startSignal = new CountDownLatch(1);
 
 		List<Future<?>> collect = getMixedWorkload(blackhole, startSignal, null)
@@ -126,6 +153,8 @@ public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
 			}
 		}
 
+//		System.out.println("\n\n\n");
+
 	}
 
 	private ArrayList<Runnable> getMixedWorkload(Blackhole blackhole, CountDownLatch startSignal,
@@ -141,10 +170,12 @@ public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
 						.count();
 
 				blackhole.consume(count);
+//				System.out.println("Finished query4");
+
 			}));
 		}
 
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < 30; i++) {
 			list.add(getRunnable(startSignal, connection, (localConnection) -> {
 				long count = localConnection
 						.prepareTupleQuery(query7_pathexpression1)
@@ -153,10 +184,12 @@ public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
 						.count();
 
 				blackhole.consume(count);
+//				System.out.println("Finished query7_pathexpression1");
+
 			}));
 		}
 
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < 30; i++) {
 			list.add(getRunnable(startSignal, connection, (localConnection) -> {
 				long count = localConnection
 						.prepareTupleQuery(query8_pathexpression2)
@@ -165,22 +198,28 @@ public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
 						.count();
 
 				blackhole.consume(count);
+//				System.out.println("Finished query8_pathexpression2");
+
 			}));
 		}
 
-		for (int i = 0; i < 100; i++) {
+		for (int i = 0; i < 400; i++) {
 			list.add(getRunnable(startSignal, connection, (localConnection) -> {
 				blackhole.consume(localConnection.hasStatement(null, RDF.TYPE, null, false));
+//				System.out.println("Finished hasStatement explicit");
+
 			}));
 		}
 
-		for (int i = 0; i < 100; i++) {
+		for (int i = 0; i < 400; i++) {
 			list.add(getRunnable(startSignal, connection, (localConnection) -> {
 				blackhole.consume(localConnection.hasStatement(null, RDF.TYPE, null, true));
+//				System.out.println("Finished hasStatement inferred");
+
 			}));
 		}
 
-		for (int i = 0; i < 5; i++) {
+		for (int i = 0; i < 20; i++) {
 			list.add(getRunnable(startSignal, connection, (localConnection) -> {
 				long count = localConnection
 						.prepareTupleQuery(query1)
@@ -189,8 +228,24 @@ public class ParallelQueryBenchmark extends BaseConcurrentBenchmark {
 						.count();
 
 				blackhole.consume(count);
+//				System.out.println("Finished query1");
 			}));
 		}
+
+		for (int i = 0; i < 200; i++) {
+			list.add(getRunnable(startSignal, connection, (localConnection) -> {
+				for (int j = 0; j < 100; j++) {
+					localConnection.add(Values.bnode(), RDFS.LABEL, Values.literal(j),
+							Values.iri("http://example.com/g1"));
+				}
+//				System.out.println("      ### WRITE ### Finished adding data");
+			}));
+		}
+
+		list.add(getRunnable(startSignal, connection, (localConnection) -> {
+			localConnection.add(data, Values.iri("http://example.com/g2"));
+//			System.out.println("      ### WRITE ### Finished loading file");
+		}));
 
 		Collections.shuffle(list, new Random(2948234));
 		return list;

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
@@ -40,11 +40,11 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 20)
+@Warmup(iterations = 5)
 @BenchmarkMode({ Mode.AverageTime })
 @Fork(value = 1, jvmArgs = { "-Xms1G", "-Xmx1G" })
 //@Fork(value = 1, jvmArgs = {"-Xms1G", "-Xmx1G", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
-@Measurement(iterations = 10)
+@Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class QueryBenchmark {
 
@@ -99,14 +99,30 @@ public class QueryBenchmark {
 		}
 	}
 
-	public static void main(String[] args) throws RunnerException {
-		Options opt = new OptionsBuilder()
-				.include("QueryBenchmark") // adapt to run other benchmark tests
-				// .addProfiler("stack", "lines=20;period=1;top=20")
-				.forks(1)
-				.build();
+	public static void main(String[] args) throws RunnerException, IOException, InterruptedException {
+//		Options opt = new OptionsBuilder()
+//				.include("QueryBenchmark") // adapt to run other benchmark tests
+//				// .addProfiler("stack", "lines=20;period=1;top=20")
+//				.forks(1)
+//				.build();
+//
+//		new Runner(opt).run();
 
-		new Runner(opt).run();
+		QueryBenchmark queryBenchmark = new QueryBenchmark();
+		queryBenchmark.beforeClass();
+		for (int i = 0; i < 100; i++) {
+			System.out.println(i);
+			queryBenchmark.pathExpressionQuery1();
+			queryBenchmark.groupByQuery();
+			queryBenchmark.different_datasets_with_similar_distributions();
+			queryBenchmark.long_chain();
+			queryBenchmark.simple_filter_not();
+			queryBenchmark.complexQuery();
+			queryBenchmark.lots_of_optional();
+			queryBenchmark.nested_optionals();
+		}
+		queryBenchmark.afterClass();
+
 	}
 
 	@Setup(Level.Trial)

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryWriteBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryWriteBenchmark.java
@@ -47,11 +47,11 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 20)
+@Warmup(iterations = 5)
 @BenchmarkMode({ Mode.AverageTime })
 @Fork(value = 1, jvmArgs = { "-Xms1G", "-Xmx1G" })
 //@Fork(value = 1, jvmArgs = {"-Xms1G", "-Xmx1G", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=60s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
-@Measurement(iterations = 10)
+@Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class QueryWriteBenchmark {
 
@@ -84,7 +84,6 @@ public class QueryWriteBenchmark {
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
 				.include("QueryWriteBenchmark") // adapt to run other benchmark tests
-				// .addProfiler("stack", "lines=20;period=1;top=20")
 				.forks(1)
 				.build();
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/SortBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/SortBenchmark.java
@@ -49,12 +49,12 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
-@Warmup(iterations = 10)
+@Warmup(iterations = 5)
 @BenchmarkMode({ Mode.AverageTime })
 // use UseSerialGC to make GC more evident
 @Fork(value = 1, jvmArgs = { "-Xms400M", "-Xmx400M", "-XX:+UseSerialGC" })
 //@Fork(value = 1, jvmArgs = {"-Xms400M", "-Xmx400M", "-XX:+UseSerialGC",  "-XX:StartFlightRecording=delay=60s,duration=240s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
-@Measurement(iterations = 10)
+@Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class SortBenchmark {
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/SparqlOverheadBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/SparqlOverheadBenchmark.java
@@ -70,7 +70,6 @@ public class SparqlOverheadBenchmark {
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
 				.include("SparqlOverheadBenchmark.*") // adapt to run other benchmark tests
-				// .addProfiler("stack", "lines=20;period=1;top=20")
 				.forks(1)
 				.build();
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/constraint/Expressions.java
@@ -15,8 +15,15 @@ import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.CEIL;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.COALESCE;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.CONCAT;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.REGEX;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.*;
+import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.EmptyPropertyPathBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.PropertyPathBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Assignable;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
@@ -318,6 +325,14 @@ public class Expressions {
 		return binaryExpression(BinaryOperator.NOT_EQUALS, left, right);
 	}
 
+	public static Expression<?> notEquals(Variable left, RdfValue right) {
+		return binaryExpression(BinaryOperator.NOT_EQUALS, left, right);
+	}
+
+	public static Expression<?> notEquals(Variable left, IRI right) {
+		return binaryExpression(BinaryOperator.NOT_EQUALS, left, iri(right));
+	}
+
 	/**
 	 * <code>left > right</code>
 	 *
@@ -593,8 +608,16 @@ public class Expressions {
 		return new NotIn(var, options);
 	}
 
+	public static Expression<?> notIn(Variable var, IRI... options) {
+		return notIn(var, parseIRIOptionsToRDFValueVarargs(options));
+	}
+
 	public static Expression<?> in(Variable var, RdfValue... options) {
 		return new In(var, options);
+	}
+
+	public static Expression<?> in(Variable var, IRI... options) {
+		return in(var, parseIRIOptionsToRDFValueVarargs(options));
 	}
 
 	public static Expression<?> strdt(Operand lexicalForm, Operand datatype) {
@@ -615,5 +638,19 @@ public class Expressions {
 
 	public static Expression<?> iff(Operand testExp, Operand thenExp, Operand elseExp) {
 		return function(SparqlFunction.IF, testExp, thenExp, elseExp);
+	}
+
+	/**
+	 * Parses IRI... options to RdfValue... options to give more flexibility in expressions use
+	 * 
+	 * @param options options as IRIs
+	 * @return options as RDFValues
+	 */
+	private static RdfValue[] parseIRIOptionsToRDFValueVarargs(IRI... options) {
+		List<RdfValue> rdfValueOptions = new ArrayList<>();
+		for (IRI option : options) {
+			rdfValueOptions.add(iri(option));
+		}
+		return rdfValueOptions.toArray(new RdfValue[0]);
 	}
 }

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilder.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/dao/support/RelationMapBuilder.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.spring.dao.support;
 
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 import static org.eclipse.rdf4j.spring.util.QueryResultUtils.getIRI;
 import static org.eclipse.rdf4j.spring.util.QueryResultUtils.getIRIOptional;
 
@@ -53,6 +54,11 @@ public class RelationMapBuilder {
 	public RelationMapBuilder(RDF4JTemplate rdf4JTemplate, RdfPredicate predicate) {
 		this.rdf4JTemplate = rdf4JTemplate;
 		this.predicate = predicate;
+	}
+
+	public RelationMapBuilder(RDF4JTemplate rdf4JTemplate, IRI predicate) {
+		this.rdf4JTemplate = rdf4JTemplate;
+		this.predicate = iri(predicate);
 	}
 
 	/**

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionObject.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/tx/TransactionObject.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.support.SmartTransactionObject;
  * @author ameingast@gmail.com
  * @author Florian Kleedorfer
  */
-public class TransactionObject implements SmartTransactionObject {
+public class TransactionObject {
 
 	private RepositoryConnection connection;
 
@@ -106,11 +106,6 @@ public class TransactionObject implements SmartTransactionObject {
 
 	public void setReadOnly(boolean readOnly) {
 		this.readOnly = readOnly;
-	}
-
-	@Override
-	public void flush() {
-		throw new UnsupportedOperationException("flush() is not supported");
 	}
 
 	@Override

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/ServiceLayerTests.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/dao/support/ServiceLayerTests.java
@@ -19,10 +19,13 @@ import org.eclipse.rdf4j.spring.domain.model.Artist;
 import org.eclipse.rdf4j.spring.domain.model.Painting;
 import org.eclipse.rdf4j.spring.domain.service.ArtService;
 import org.eclipse.rdf4j.spring.support.RDF4JTemplate;
+import org.eclipse.rdf4j.spring.tx.TransactionObject;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
@@ -66,6 +69,7 @@ public class ServiceLayerTests extends RDF4JSpringTestBase {
 				null));
 	}
 
+	// TODO
 	@Test
 	public void testRollbackOnException() {
 		transactionTemplate.execute(status -> {
@@ -87,7 +91,7 @@ public class ServiceLayerTests extends RDF4JSpringTestBase {
 					"oil on canvas",
 					null));
 			// now ascertain that the transaction will not commit because of the exception
-			assertTrue(status.isRollbackOnly());
+			assertTrue(((TransactionObject) ((DefaultTransactionStatus) status).getTransaction()).isRollbackOnly());
 			return null;
 		});
 	}


### PR DESCRIPTION
GitHub issue resolved: #3935 

Briefly describe the changes proposed in this PR:

Removing the `SmartTransactionObject` dependencie from `TransactionObject` and extend `Expressions`

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

