### PR TITLE
GH-3954 fix for query regression with group by

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -99,6 +99,7 @@ import org.eclipse.rdf4j.query.algebra.ZeroLengthPath;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.algebra.helpers.StatementPatternCollector;
 import org.eclipse.rdf4j.query.algebra.helpers.TupleExprs;
+import org.eclipse.rdf4j.query.algebra.helpers.VarNameCollector;
 import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTAbs;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTAnd;
@@ -227,7 +228,6 @@ import org.eclipse.rdf4j.query.parser.sparql.ast.VisitorException;
  * A SPARQL AST visitor implementation that creates a query algebra representation of the query.
  *
  * @author Arjohn Kampman
- *
  * @apiNote This feature is for internal use only: its existence, signature or behavior may change without warning from
  *          one release to the next.
  */
@@ -274,8 +274,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		if (valueExpr instanceof Var) {
 			return (Var) valueExpr;
 		} else if (valueExpr instanceof ValueConstant) {
-			Var v = TupleExprs.createConstVar(((ValueConstant) valueExpr).getValue());
-			return v;
+			return TupleExprs.createConstVar(((ValueConstant) valueExpr).getValue());
 		} else if (valueExpr instanceof TripleRef) {
 			return ((TripleRef) valueExpr).getExprVar();
 		} else if (valueExpr == null) {
@@ -348,7 +347,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	@Override
 	public TupleExpr visit(ASTSelectQuery node, Object data) throws VisitorException {
-		GraphPattern parentGP = graphPattern;
+		final GraphPattern parentGP = graphPattern;
 
 		// Start with building the graph pattern
 		graphPattern = new GraphPattern(parentGP);
@@ -413,11 +412,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			tupleExpr = new Slice(tupleExpr, offset, limit);
 		}
 
-		if (parentGP != null) {
-
-			parentGP.addRequiredTE(tupleExpr);
-			graphPattern = parentGP;
-		}
+		parentGP.addRequiredTE(tupleExpr);
+		graphPattern = parentGP;
 		return tupleExpr;
 	}
 
@@ -554,12 +550,11 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 					throw new VisitorException("Either TripleRef or Expression expected in projection.");
 				}
 
-				String targetName = alias;
 				String sourceName = alias;
 				if (child instanceof ASTVar) {
 					sourceName = ((ASTVar) child).getName();
 				}
-				ProjectionElem elem = new ProjectionElem(sourceName, targetName);
+				ProjectionElem elem = new ProjectionElem(sourceName, alias);
 				projElemList.addElement(elem);
 
 				AggregateCollector collector = new AggregateCollector();
@@ -633,36 +628,39 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 		result = new Projection(result, projElemList);
 		if (group != null) {
-			for (ProjectionElem elem : projElemList.getElements()) {
+			Set<String> groupNames = group.getBindingNames();
+			List<ProjectionElem> elements = projElemList.getElements();
+
+			for (ProjectionElem elem : elements) {
 				if (!elem.hasAggregateOperatorInExpression()) {
 					// non-aggregate projection elem is only allowed to be a constant or a simple expression (see
 					// https://www.w3.org/TR/sparql11-query/#aggregateRestrictions)
 					ExtensionElem extElem = elem.getSourceExpression();
 					if (extElem != null) {
 						ValueExpr expr = extElem.getExpr();
-						if (!(expr instanceof ValueConstant)) {
-							throw new VisitorException(
-									"non-aggregate expression '" + expr
-											+ "' not allowed in projection when using GROUP BY.");
+						if (isIllegalCombinedWithGroupByExpression(expr, elements, groupNames)) {
+							throw new VisitorException("non-aggregate expression '" + expr
+									+ "' not allowed in projection when using GROUP BY.");
 						}
 
 					} else {
-						Set<String> groupNames = group.getBindingNames();
 
 						if (!elem.getSourceName().equals(elem.getTargetName())) {
-							// projection element is a SELECT expression using a simple var (e.g. (?a AS ?b)).
+							// Projection element is a SELECT expression using a simple var (e.g. (?a AS ?b)).
 							// Source var must be present in GROUP BY.
 							if (!groupNames.contains(elem.getSourceName())) {
-								throw new VisitorException(
-										"variable '" + elem.getSourceName()
-												+ "' in projection not present in GROUP BY.");
+								if (isIllegalCombinedWithGroupByExpression(elem.getSourceName(), elements,
+										groupNames)) {
+									throw new VisitorException("variable '" + elem.getSourceName()
+											+ "' in projection not present in GROUP BY.");
+								}
+
 							}
 						} else {
 							// projection element is simple var. Must be present in GROUP BY.
 							if (!groupNames.contains(elem.getTargetName())) {
-								throw new VisitorException(
-										"variable '" + elem.getTargetName()
-												+ "' in projection not present in GROUP BY.");
+								throw new VisitorException("variable '" + elem.getTargetName()
+										+ "' in projection not present in GROUP BY.");
 							}
 						}
 					}
@@ -686,7 +684,59 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		return result;
 	}
 
-	private class GroupFinder extends AbstractQueryModelVisitor<VisitorException> {
+	private static boolean isIllegalCombinedWithGroupByExpression(ValueExpr expr, List<ProjectionElem> elements,
+			Set<String> groupNames) {
+		if (expr instanceof ValueConstant)
+			return false;
+
+		VarNameCollector varNameCollector = new VarNameCollector();
+		expr.visit(varNameCollector);
+		Set<String> varNames = varNameCollector.getVarNames();
+
+		for (String varName : varNames) {
+			if (isIllegalCombinedWithGroupByExpression(varName, elements, groupNames)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static boolean isIllegalCombinedWithGroupByExpression(String varName, List<ProjectionElem> elements,
+			Set<String> groupNames) {
+		do {
+			String prev = varName;
+
+			for (ProjectionElem element : elements) {
+				if (element.getTargetName().equals(varName)) {
+					if (element.hasAggregateOperatorInExpression()) {
+						return false;
+					} else {
+						ExtensionElem sourceExpression = element.getSourceExpression();
+						if (sourceExpression != null) {
+							if (sourceExpression.getExpr() != null) {
+								return isIllegalCombinedWithGroupByExpression(sourceExpression.getExpr(), elements,
+										groupNames);
+							}
+						}
+
+						varName = element.getSourceName();
+						break;
+					}
+				}
+			}
+
+			// check if we didn't find a new element
+			if (prev.equals(varName)) {
+				return true;
+			}
+
+		} while (!groupNames.contains(varName));
+
+		return false;
+	}
+
+	private static class GroupFinder extends AbstractQueryModelVisitor<VisitorException> {
 
 		private Group group;
 
@@ -721,7 +771,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			tupleExpr = (TupleExpr) groupNode.jjtAccept(this, tupleExpr);
 		}
 
-		Group group = null;
+		Group group;
 		if (tupleExpr instanceof Group) {
 			group = (Group) tupleExpr;
 		} else {
@@ -1083,14 +1133,14 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		Group group = (Group) data;
 		TupleExpr arg = group.getArg();
 
-		Extension extension = null;
+		Extension extension;
 		if (arg instanceof Extension) {
 			extension = (Extension) arg;
 		} else {
 			extension = new Extension();
 		}
 
-		String name = null;
+		String name;
 		ValueExpr ve = castToValueExpr(node.jjtGetChild(0).jjtAccept(this, data));
 
 		boolean aliased = false;
@@ -1535,7 +1585,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 	}
 
 	private TupleExpr handlePathModifiers(Scope scope, Var subjVar, TupleExpr te, Var endVar, Var contextVar,
-			long lowerBound, long upperBound) throws VisitorException {
+			long lowerBound, long upperBound) {
 
 		// * and + modifiers
 		if (upperBound == Long.MAX_VALUE) {
@@ -1599,11 +1649,11 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	}
 
-	private class VarReplacer extends AbstractQueryModelVisitor<VisitorException> {
+	private static class VarReplacer extends AbstractQueryModelVisitor<VisitorException> {
 
-		private Var toBeReplaced;
+		private final Var toBeReplaced;
 
-		private Var replacement;
+		private final Var replacement;
 
 		public VarReplacer(Var toBeReplaced, Var replacement) {
 			this.toBeReplaced = toBeReplaced;
@@ -1631,7 +1681,6 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	@Override
 	public Object visit(ASTPropertyListPath propListNode, Object data) throws VisitorException {
-		Object subject = data;
 		Object verbPath = propListNode.getVerb().jjtAccept(this, data);
 
 		if (verbPath instanceof Var) {
@@ -1639,7 +1688,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			@SuppressWarnings("unchecked")
 			List<ValueExpr> objectList = (List<ValueExpr>) propListNode.getObjectList().jjtAccept(this, null);
 
-			Var subjVar = mapValueExprToVar(subject);
+			Var subjVar = mapValueExprToVar(data);
 
 			Var predVar = mapValueExprToVar(verbPath);
 			for (ValueExpr object : objectList) {
@@ -1652,7 +1701,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 		ASTPropertyListPath nextPropList = propListNode.getNextPropertyList();
 		if (nextPropList != null) {
-			nextPropList.jjtAccept(this, subject);
+			nextPropList.jjtAccept(this, data);
 		}
 
 		return null;
@@ -2092,9 +2141,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			}
 		}
 
-		BindingSet result = new ListBindingSet(names, values);
-
-		return result;
+		return new ListBindingSet(names, values);
 	}
 
 	@Override
@@ -2202,7 +2249,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	@Override
 	public If visit(ASTIf node, Object data) throws VisitorException {
-		If result = null;
+		If result;
 
 		if (node.jjtGetNumChildren() < 3) {
 			throw new VisitorException("IF construction missing required number of arguments");
@@ -2227,7 +2274,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	@Override
 	public ValueExpr visit(ASTIn node, Object data) throws VisitorException {
-		ValueExpr result = null;
+		ValueExpr result;
 		ValueExpr leftArg = (ValueExpr) data;
 		int listItemCount = node.jjtGetNumChildren();
 
@@ -2252,7 +2299,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	@Override
 	public ValueExpr visit(ASTNotIn node, Object data) throws VisitorException {
-		ValueExpr result = null;
+		ValueExpr result;
 		ValueExpr leftArg = (ValueExpr) data;
 
 		int listItemCount = node.jjtGetNumChildren();
@@ -2330,7 +2377,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		Extension extension = new Extension();
 		extension.addElement(new ExtensionElem(ve, alias));
 
-		TupleExpr result = null;
+		TupleExpr result;
 		TupleExpr arg = graphPattern.buildTupleExpr();
 
 		// check if alias is not previously used.
@@ -2477,7 +2524,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	static class AggregateCollector extends AbstractQueryModelVisitor<VisitorException> {
 
-		private Collection<AggregateOperator> operators = new ArrayList<>();
+		private final Collection<AggregateOperator> operators = new ArrayList<>();
 
 		public Collection<AggregateOperator> getOperators() {
 			return operators;
@@ -2533,9 +2580,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 	static class AggregateOperatorReplacer extends AbstractQueryModelVisitor<VisitorException> {
 
-		private Var replacement;
+		private final Var replacement;
 
-		private AggregateOperator operator;
+		private final AggregateOperator operator;
 
 		public AggregateOperatorReplacer(AggregateOperator operator, Var replacement) {
 			this.operator = operator;

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -441,7 +441,6 @@ public class SPARQLParserTest {
 
 		// should parse without error
 		parser.parseQuery(query, null);
-
 	}
 
 	@Test
@@ -453,7 +452,6 @@ public class SPARQLParserTest {
 
 		// should parse without error
 		parser.parseQuery(query, null);
-
 	}
 
 	@Test
@@ -465,7 +463,16 @@ public class SPARQLParserTest {
 
 		// should parse without error
 		parser.parseQuery(query, null);
+	}
 
+	@Test
+	public void testGroupByProjectionHandling_effectivelyConstant() {
+		String query = "SELECT  (2  AS ?constant1) (?constant1  AS ?constant2) (?constant2/2  AS ?constant3){\n" +
+				"    ?o ?p ?o .\n" +
+				"} GROUP BY ?o";
+
+		// should parse without error
+		parser.parseQuery(query, null);
 	}
 
 	@Test
@@ -476,7 +483,6 @@ public class SPARQLParserTest {
 
 		// should parse without error
 		parser.parseQuery(query, null);
-
 	}
 
 	@Test
@@ -487,6 +493,38 @@ public class SPARQLParserTest {
 
 		// should parse without error
 		parser.parseQuery(query, null);
-
 	}
+
+//	@Test
+//	public void testGroupByProjectionHandling_recursion1() {
+//		String query = "SELECT (?a  AS ?b) (?b/2  AS ?c)   (?c/2  AS ?d)  (?d  AS ?a){\n" +
+//			"    ?o ?p ?o .\n" +
+//			"} GROUP BY ?o";
+//
+//		// should parse without error
+//		parser.parseQuery(query, null);
+//
+//	}
+//
+//	@Test
+//	public void testGroupByProjectionHandling_recursion2() {
+//		String query = "SELECT (?a  AS ?b) (?b/2  AS ?c)   (?c/2  AS ?a)  {\n" +
+//			"    ?o ?p ?o .\n" +
+//			"} GROUP BY ?o";
+//
+//		// should parse without error
+//		parser.parseQuery(query, null);
+//
+//	}
+//
+//	@Test
+//	public void testGroupByProjectionHandling_recursion3() {
+//		String query = "SELECT (?a  AS ?b) (?b  AS ?c)   (?c/2  AS ?a)  {\n" +
+//			"    ?o ?p ?o .\n" +
+//			"} GROUP BY ?o";
+//
+//		// should parse without error
+//		parser.parseQuery(query, null);
+//
+//	}
 }

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -495,36 +495,4 @@ public class SPARQLParserTest {
 		parser.parseQuery(query, null);
 	}
 
-//	@Test
-//	public void testGroupByProjectionHandling_recursion1() {
-//		String query = "SELECT (?a  AS ?b) (?b/2  AS ?c)   (?c/2  AS ?d)  (?d  AS ?a){\n" +
-//			"    ?o ?p ?o .\n" +
-//			"} GROUP BY ?o";
-//
-//		// should parse without error
-//		parser.parseQuery(query, null);
-//
-//	}
-//
-//	@Test
-//	public void testGroupByProjectionHandling_recursion2() {
-//		String query = "SELECT (?a  AS ?b) (?b/2  AS ?c)   (?c/2  AS ?a)  {\n" +
-//			"    ?o ?p ?o .\n" +
-//			"} GROUP BY ?o";
-//
-//		// should parse without error
-//		parser.parseQuery(query, null);
-//
-//	}
-//
-//	@Test
-//	public void testGroupByProjectionHandling_recursion3() {
-//		String query = "SELECT (?a  AS ?b) (?b  AS ?c)   (?c/2  AS ?a)  {\n" +
-//			"    ?o ?p ?o .\n" +
-//			"} GROUP BY ?o";
-//
-//		// should parse without error
-//		parser.parseQuery(query, null);
-//
-//	}
 }

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -52,17 +52,11 @@ public class SPARQLParserTest {
 
 	private SPARQLParser parser;
 
-	/**
-	 * @throws java.lang.Exception
-	 */
 	@BeforeEach
 	public void setUp() throws Exception {
 		parser = new SPARQLParser();
 	}
 
-	/**
-	 * @throws java.lang.Exception
-	 */
 	@AfterEach
 	public void tearDown() throws Exception {
 		parser = null;
@@ -456,6 +450,40 @@ public class SPARQLParserTest {
 				+ "WHERE {\n"
 				+ "	?s ?p ?o \n"
 				+ "} GROUP BY ?o";
+
+		// should parse without error
+		parser.parseQuery(query, null);
+
+	}
+
+	@Test
+	public void testGroupByProjectionHandling_variableEffectivelyAggregationResult() {
+		String query = "SELECT (COUNT (*) AS ?count) (?count / ?count AS ?result) (?result AS ?temp) (?temp / 2 AS ?temp2) {\n"
+				+
+				"    ?s a ?o .\n" +
+				"}";
+
+		// should parse without error
+		parser.parseQuery(query, null);
+
+	}
+
+	@Test
+	public void testGroupByProjectionHandling_renameVariable() {
+		String query = "SELECT ?o (?o  AS ?o2) (?o2  AS ?o3) (?o3/2  AS ?o4){\n" +
+				"    ?o ?p ?o .\n" +
+				"} GROUP BY ?o";
+
+		// should parse without error
+		parser.parseQuery(query, null);
+
+	}
+
+	@Test
+	public void testGroupByProjectionHandling_renameVariableWithAggregation() {
+		String query = "SELECT ?o (?o  AS ?o2) (COUNT (*) AS ?count) (?o2/?count  AS ?newCount){\n" +
+				"    ?o ?p ?o .\n" +
+				"} GROUP BY ?o";
 
 		// should parse without error
 		parser.parseQuery(query, null);


### PR DESCRIPTION
GitHub issue resolved: #3954 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - use recursion to check if a projected variable is effectively a constant, an aggregation or declared in the group by expression

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

