### PR TITLE
GH-3590 Use Cleaner instead of Map for closing unreachable iterations

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPTupleQueryResultTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPTupleQueryResultTest.java
@@ -9,14 +9,15 @@ package org.eclipse.rdf4j.repository.http;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.testsuite.repository.TupleQueryResultTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
 public class HTTPTupleQueryResultTest extends TupleQueryResultTest {
 
 	private static HTTPMemServer server;
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new HTTPMemServer();
 		try {
@@ -27,7 +28,7 @@ public class HTTPTupleQueryResultTest extends TupleQueryResultTest {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 	}
@@ -37,4 +38,9 @@ public class HTTPTupleQueryResultTest extends TupleQueryResultTest {
 		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
 	}
 
+	@Override
+	@Disabled
+	public void testNotClosingResultThrowsException() {
+
+	}
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/CleanerIteration.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/CleanerIteration.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.helpers;
+
+import java.lang.ref.Cleaner;
+
+import org.eclipse.rdf4j.common.concurrent.locks.diagnostics.ConcurrentCleaner;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class CleanerIteration<E, X extends Exception> implements CloseableIteration<E, X> {
+
+	private static final Logger logger = LoggerFactory.getLogger(CleanerIteration.class);
+
+	private final CloseableIteration<E, X> delegate;
+	private final Cleaner.Cleanable cleanable;
+	private final CleanableState<E, X> state;
+
+	public CleanerIteration(CloseableIteration<E, X> delegate, ConcurrentCleaner cleaner) {
+		this.delegate = delegate;
+		this.state = new CleanableState<>(delegate);
+		this.cleanable = cleaner.register(this, state);
+	}
+
+	@Override
+	public void close() throws X {
+		state.close();
+		cleanable.clean();
+	}
+
+	@Override
+	public boolean hasNext() throws X {
+		return delegate.hasNext();
+	}
+
+	@Override
+	public E next() throws X {
+		return delegate.next();
+	}
+
+	@Override
+	public void remove() throws X {
+		delegate.remove();
+	}
+
+	private final static class CleanableState<E, X extends Exception> implements Runnable {
+
+		private final CloseableIteration<E, X> iteration;
+		private boolean closed = false;
+
+		public CleanableState(CloseableIteration<E, X> iteration) {
+			this.iteration = iteration;
+		}
+
+		@Override
+		public void run() {
+			if (!closed) {
+				try {
+					logger.warn(
+							"Forced closing of unclosed iteration. Set the system property 'org.eclipse.rdf4j.repository.debug' to 'true' to get stack traces.");
+					iteration.close();
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+			}
+		}
+
+		public void close() throws X {
+			closed = true;
+			iteration.close();
+		}
+	}
+
+}

--- a/core/sail/api/src/test/java/org/eclipse/rdf4j/common/concurrent/locks/TestHelper.java
+++ b/core/sail/api/src/test/java/org/eclipse/rdf4j/common/concurrent/locks/TestHelper.java
@@ -13,7 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.concurrent.CountDownLatch;
 
+import org.eclipse.rdf4j.common.concurrent.locks.diagnostics.ConcurrentCleaner;
+
 public class TestHelper {
+
+	private final static ConcurrentCleaner cleaner = new ConcurrentCleaner();
 
 	public static void callGC(AbstractReadWriteLockManager lockManager) throws InterruptedException {
 		while (lockManager.isReaderActive() || lockManager.isWriterActive()) {

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreTupleQueryResultIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreTupleQueryResultIT.java
@@ -18,8 +18,8 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.TupleQueryResultTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class ElasticsearchStoreTupleQueryResultIT extends TupleQueryResultTest {
 
@@ -27,13 +27,13 @@ public class ElasticsearchStoreTupleQueryResultIT extends TupleQueryResultTest {
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbTupleQueryResultTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbTupleQueryResultTest.java
@@ -7,21 +7,22 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.repository.TupleQueryResultTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LmdbTupleQueryResultTest extends TupleQueryResultTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+
+	@TempDir
+	File tempDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new LmdbStore(tmpDir.getRoot(), new LmdbStoreConfig("spoc")));
+		return new SailRepository(new LmdbStore(tempDir, new LmdbStoreConfig("spoc")));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeTupleQueryResultTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeTupleQueryResultTest.java
@@ -7,20 +7,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.testsuite.repository.TupleQueryResultTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeTupleQueryResultTest extends TupleQueryResultTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+
+	@TempDir
+	File tempDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
+		return new SailRepository(new NativeStore(tempDir, "spoc"));
 	}
 }

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/TupleQueryResultTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/TupleQueryResultTest.java
@@ -8,9 +8,6 @@
 package org.eclipse.rdf4j.testsuite.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -18,7 +15,6 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Random;
 
-import org.eclipse.rdf4j.common.concurrent.locks.Properties;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -35,27 +31,16 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class TupleQueryResultTest {
 
 	private final Logger logger = LoggerFactory.getLogger(TupleQueryResultTest.class);
-
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
-	}
-
-	@AfterClass
-	public static void afterClass() throws Exception {
-		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
-	}
 
 	private Repository rep;
 
@@ -67,8 +52,9 @@ public abstract class TupleQueryResultTest {
 
 	private final Random random = new Random(43252333);
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
+		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 		rep = createRepository();
 		con = rep.getConnection();
 
@@ -76,12 +62,16 @@ public abstract class TupleQueryResultTest {
 		addData();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
+		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
+
 		try {
 			con.close();
 			con = null;
 		} finally {
+			System.gc();
+			Thread.sleep(1);
 			rep.shutDown();
 			rep = null;
 		}
@@ -135,7 +125,7 @@ public abstract class TupleQueryResultTest {
 	}
 
 	@Test
-	public void testGetBindingNames() throws Exception {
+	public void testGetBindingNames() {
 		try (TupleQueryResult result = con.prepareTupleQuery(multipleResultQuery).evaluate()) {
 			List<String> headers = result.getBindingNames();
 
@@ -145,7 +135,7 @@ public abstract class TupleQueryResultTest {
 	}
 
 	@Test
-	public void testIterator() throws Exception {
+	public void testIterator() {
 
 		try (TupleQueryResult result = con.prepareTupleQuery(multipleResultQuery).evaluate()) {
 			int count = 0;
@@ -154,28 +144,28 @@ public abstract class TupleQueryResultTest {
 				count++;
 			}
 
-			assertTrue("query should have multiple results.", count > 1);
+			Assertions.assertTrue(count > 1, "query should have multiple results.");
 		}
 	}
 
 	@Test
-	public void testIsEmpty() throws Exception {
+	public void testIsEmpty() {
 
 		try (TupleQueryResult result = con.prepareTupleQuery(emptyResultQuery).evaluate()) {
-			assertFalse("Query result should be empty", result.hasNext());
+			Assertions.assertFalse(result.hasNext(), "Query result should be empty");
 		}
 	}
 
 	@Test
-	public void testCountMatchesAllSelect() throws Exception {
+	public void testCountMatchesAllSelect() {
 		try (TupleQueryResult result = con.prepareTupleQuery("SELECT * WHERE {?s ?p ?o}").evaluate()) {
 			long size = con.size();
 			for (int i = 0; i < size; i++) {
-				assertTrue(result.hasNext());
+				Assertions.assertTrue(result.hasNext());
 				BindingSet next = result.next();
-				assertNotNull(next);
+				Assertions.assertNotNull(next);
 			}
-			assertFalse("Query result should be empty", result.hasNext());
+			Assertions.assertFalse(result.hasNext(), "Query result should be empty");
 		}
 	}
 
@@ -253,5 +243,48 @@ public abstract class TupleQueryResultTest {
 				tupleQuery.evaluate();
 			}
 		}
+	}
+
+	@Test
+	public void testNotClosingResultWithoutDebug() {
+		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
+
+		con.begin();
+		con.add(RDF.TYPE, RDF.TYPE, RDF.PROPERTY);
+		con.commit();
+
+		for (int i = 0; i < 100; i++) {
+			try (RepositoryConnection repCon = rep.getConnection()) {
+				String queryString = "select * where {?s ?p ?o}";
+				TupleQuery tupleQuery = repCon.prepareTupleQuery(QueryLanguage.SPARQL, queryString);
+
+				// see if open results hangs test
+				// DO NOT CLOSE THIS
+				tupleQuery.evaluate();
+			}
+		}
+
+	}
+
+	@Test
+	public void testNotClosingResultThrowsException() {
+		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
+
+		con.begin();
+		con.add(RDF.TYPE, RDF.TYPE, RDF.PROPERTY);
+		con.commit();
+
+		Assertions.assertThrows(SailException.class, () -> {
+			TupleQueryResult evaluate = null;
+			try (RepositoryConnection repCon = rep.getConnection()) {
+				String queryString = "select * where {?s ?p ?o}";
+				TupleQuery tupleQuery = repCon.prepareTupleQuery(QueryLanguage.SPARQL, queryString);
+
+				evaluate = tupleQuery.evaluate();
+			} finally {
+				evaluate.close();
+			}
+		});
+
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #3590 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Instead of tracking all iterations in a map we instead tell the JVM to automatically close them if the users has forgotten. We register the iterations with the [Java Cleaner](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/ref/Cleaner.html) (introduced in Java 9 as a better alternative to finalize) together with a Runnable that closes the iteration. The Cleaner executes the runnable when the iteration has become phantom reachable (e.g. eligible for GC). We use our existing ConcurrentCleaner which wraps an array of Cleaner instances to spread the load when objects are registered from multiple threads.

I've retained the tracking functionality for debugging purposes and it can be enabled the same way as we would previously have enabled tracking with stack traces.

A change for users will be that a connection will now `throw new SailException("Connection closed before all iterations were closed.")` if there are unclosed iterations. Before throwing this exception we call `System.gc()` multiple times to hopefully trigger the closing of any "lost" iterations. 

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

