### PR TITLE
GH-3948 Serializable CoreDatatype.NONE

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatype.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/CoreDatatype.java
@@ -17,9 +17,7 @@ import org.eclipse.rdf4j.model.IRI;
 
 public interface CoreDatatype {
 
-	CoreDatatype NONE = () -> {
-		throw new IllegalStateException();
-	};
+	CoreDatatype NONE = DefaultDatatype.NONE;
 
 	/**
 	 * Checks whether the supplied datatype is an XML Schema Datatype.
@@ -220,7 +218,6 @@ public interface CoreDatatype {
 		 * and/or times.
 		 *
 		 * @return true if it is a calendar type
-		 *
 		 * @see XMLGregorianCalendar
 		 */
 		public boolean isCalendarDatatype() {
@@ -232,7 +229,6 @@ public interface CoreDatatype {
 		 * These are the datatypes that represents durations.
 		 *
 		 * @return true if it is a duration type
-		 *
 		 * @see Duration
 		 */
 		public boolean isDurationDatatype() {
@@ -353,4 +349,16 @@ public interface CoreDatatype {
 		}
 	}
 
+}
+
+/**
+ * This needs to be its own enum because we need it to be serializable.
+ */
+enum DefaultDatatype implements CoreDatatype {
+	NONE;
+
+	@Override
+	public IRI getIri() {
+		throw new IllegalStateException();
+	}
 }

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
@@ -12,8 +12,15 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.DateTimeException;
@@ -79,7 +86,6 @@ public abstract class LiteralTest {
 	 * Creates a test literal instance.
 	 *
 	 * @param label the label of the literal
-	 *
 	 * @return a new instance of the concrete literal class under test
 	 */
 	protected abstract Literal literal(String label);
@@ -89,7 +95,6 @@ public abstract class LiteralTest {
 	 *
 	 * @param label    the label of the literal
 	 * @param language the language of the literal
-	 *
 	 * @return a new instance of the concrete literal class under test
 	 */
 	protected abstract Literal literal(String label, String language);
@@ -99,7 +104,6 @@ public abstract class LiteralTest {
 	 *
 	 * @param label    the label of the literal
 	 * @param datatype the datatype of the literal
-	 *
 	 * @return a new instance of the concrete literal class under test
 	 */
 	protected abstract Literal literal(String label, IRI datatype);
@@ -109,7 +113,6 @@ public abstract class LiteralTest {
 	 *
 	 * @param label    the label of the literal
 	 * @param datatype the CoreDatatype of the literal
-	 *
 	 * @return a new instance of the concrete literal class under test
 	 */
 	protected abstract Literal literal(String label, CoreDatatype datatype);
@@ -118,7 +121,6 @@ public abstract class LiteralTest {
 	 * Creates a test datatype IRI instance.
 	 *
 	 * @param iri the IRI of the datatype
-	 *
 	 * @return a new instance of the concrete datatype class under test
 	 */
 	protected abstract IRI datatype(String iri);
@@ -1499,6 +1501,69 @@ public abstract class LiteralTest {
 
 		assertThat(plain).isEqualTo(typed);
 		assertThat(plain.hashCode()).isEqualTo(typed.hashCode());
+	}
+
+	@Test
+	public final void testSerializationWithCoreDatatypeXsd() {
+		Literal literal = literal("1", datatype(XSD_INT));
+
+		byte[] bytes = objectToBytes(literal);
+		Literal roundTrip = (Literal) bytesToObject(bytes);
+
+		assertEquals(CoreDatatype.XSD.INT, roundTrip.getCoreDatatype());
+	}
+
+	@Test
+	public final void testSerializationWithCoreDatatypeRdfLangString() {
+		Literal literal = literal("hei", "no");
+		assertEquals(CoreDatatype.RDF.LANGSTRING, literal.getCoreDatatype());
+
+		byte[] bytes = objectToBytes(literal);
+		Literal roundTrip = (Literal) bytesToObject(bytes);
+
+		assertEquals(CoreDatatype.RDF.LANGSTRING, roundTrip.getCoreDatatype());
+	}
+
+	@Test
+	public final void testSerializationWithCoreDatatypeGEO() {
+		Literal literal = literal("1", CoreDatatype.GEO.WKT_LITERAL);
+
+		byte[] bytes = objectToBytes(literal);
+		Literal roundTrip = (Literal) bytesToObject(bytes);
+
+		assertEquals(CoreDatatype.GEO.WKT_LITERAL, roundTrip.getCoreDatatype());
+	}
+
+	@Test
+	public final void testSerializationWithCoreDatatype4() {
+		Literal literal = literal("1", datatype("http://example.org/dt1"));
+		assertEquals(CoreDatatype.XSD.NONE, literal.getCoreDatatype());
+
+		byte[] bytes = objectToBytes(literal);
+		Literal roundTrip = (Literal) bytesToObject(bytes);
+
+		assertEquals(CoreDatatype.XSD.NONE, roundTrip.getCoreDatatype());
+	}
+
+	private byte[] objectToBytes(Serializable object) {
+		try (var byteArrayOutputStream = new ByteArrayOutputStream()) {
+			try (var objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+				objectOutputStream.writeObject(object);
+			}
+			return byteArrayOutputStream.toByteArray();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Object bytesToObject(byte[] str) {
+		try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(str)) {
+			try (ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
+				return objectInputStream.readObject();
+			}
+		} catch (IOException | ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 }

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/SimpleLiteral.java
@@ -49,6 +49,8 @@ public class SimpleLiteral extends AbstractLiteral {
 	 * The literal's language tag.
 	 */
 	private String language;
+	// Cache Optional instance for the language, or null if not yet computed. Marked as transient because Optional is
+	// not serializable.
 	transient private Optional<String> optionalLanguageCache = null;
 
 	/**
@@ -56,6 +58,7 @@ public class SimpleLiteral extends AbstractLiteral {
 	 */
 	private IRI datatype;
 
+	// Cached CoreDatatype, or null if not yet computed.
 	private CoreDatatype coreDatatype = null;
 
 	/*--------------*


### PR DESCRIPTION
GitHub issue resolved: #3948 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - SimpleLiteral could not be serialized when the CoreDatatype was NONE, fix is to make CoreDatatype.NONE an enum
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

