### PR TITLE
GH-3969 ConcurrentCleaner buffer

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/diagnostics/LockCleaner.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/diagnostics/LockCleaner.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 @InternalUseOnly
 public class LockCleaner<T extends Lock> implements LockMonitoring<T> {
 
-	private final static ConcurrentCleaner cleaner = new ConcurrentCleaner();
+	private final static ConcurrentCleaner cleaner = ConcurrentCleaner.create();
 	private final Logger logger;
 	private final Lock.ExtendedSupplier<T> supplier;
 	private final String alias;

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/diagnostics/LockTracking.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/diagnostics/LockTracking.java
@@ -35,7 +35,7 @@ public class LockTracking<T extends Lock> implements LockMonitoring<T> {
 
 	private final Logger logger;
 
-	private final static ConcurrentCleaner cleaner = new ConcurrentCleaner();
+	private final static ConcurrentCleaner cleaner = ConcurrentCleaner.create();
 	private final static AtomicLong seq = new AtomicLong();
 
 	private final ReentrantLock staleLoggingLock = new ReentrantLock();
@@ -110,6 +110,7 @@ public class LockTracking<T extends Lock> implements LockMonitoring<T> {
 							// if something should fail we don't want to perform a new cleanup immediately
 							previousCleanup = 0;
 
+							cleaner.flush();
 							System.gc();
 							long activeLocksSignature = getActiveLocksSignature();
 							if (previousActiveLocksSignature == activeLocksSignature) {

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractSailConnection implements SailConnection {
 
-	private static final ConcurrentCleaner cleaner = new ConcurrentCleaner();
+	private static final ConcurrentCleaner cleaner = ConcurrentCleaner.create();
 
 	/**
 	 * Size of write queue before auto flushing changes within write operation

--- a/core/sail/api/src/test/java/org/eclipse/rdf4j/common/concurrent/locks/TestHelper.java
+++ b/core/sail/api/src/test/java/org/eclipse/rdf4j/common/concurrent/locks/TestHelper.java
@@ -17,9 +17,10 @@ import org.eclipse.rdf4j.common.concurrent.locks.diagnostics.ConcurrentCleaner;
 
 public class TestHelper {
 
-	private final static ConcurrentCleaner cleaner = new ConcurrentCleaner();
+	private final static ConcurrentCleaner cleaner = ConcurrentCleaner.create();
 
 	public static void callGC(AbstractReadWriteLockManager lockManager) throws InterruptedException {
+		cleaner.flush();
 		while (lockManager.isReaderActive() || lockManager.isWriterActive()) {
 			System.gc();
 			Thread.sleep(1);
@@ -27,6 +28,7 @@ public class TestHelper {
 	}
 
 	public static void callGC(ExclusiveLockManager lockManager) throws InterruptedException {
+		cleaner.flush();
 		while (lockManager.isActiveLock()) {
 			System.gc();
 			Thread.sleep(1);
@@ -34,6 +36,7 @@ public class TestHelper {
 	}
 
 	public static void callGC(LockManager lockManager) throws InterruptedException {
+		cleaner.flush();
 		while (lockManager.isActiveLock()) {
 			System.gc();
 			Thread.sleep(1);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -163,7 +163,7 @@ public class ShaclSail extends ShaclSailBaseConfiguration {
 	private static final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();
 
 	private static final Logger logger = LoggerFactory.getLogger(ShaclSail.class);
-	private static final ConcurrentCleaner cleaner = new ConcurrentCleaner();
+	private static final ConcurrentCleaner cleaner = ConcurrentCleaner.create();
 
 	/**
 	 * an initialized {@link Repository} for storing/retrieving Shapes data

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShutdownTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShutdownTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.rdf4j.common.concurrent.locks.diagnostics.ConcurrentCleaner;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
@@ -218,6 +219,7 @@ public class ShutdownTest {
 		Assertions.assertFalse(executorServices.isShutdown());
 
 		for (int i = 0; i < 100; i++) {
+			ConcurrentCleaner.flush();
 			System.gc();
 			if (executorServices.isShutdown()) {
 				return;


### PR DESCRIPTION
GitHub issue resolved: #3969 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - add a buffer to the ConcurrentCleaner 
 - thread that flushes the buffer periodically

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

