### PR TITLE
GH-3972 correctly close streams in the ShapeSource(s)

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/BackwardChainingShapeSource.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/BackwardChainingShapeSource.java
@@ -130,27 +130,11 @@ public class BackwardChainingShapeSource implements ShapeSource {
 	}
 
 	public Value getRdfFirst(Resource subject) {
-		assert context != null;
-
-		return connection.getStatements(subject, RDF.FIRST, null, true, context)
-				.stream()
-				.map(Statement::getObject)
-				.findAny()
-				.orElse(null);
-		// .orElseThrow(() -> new IllegalStateException("Corrupt rdf:list at rdf:first: " + subject));
+		return ShapeSourceHelper.getFirst(connection, subject, context);
 	}
 
 	public Resource getRdfRest(Resource subject) {
-		assert context != null;
-
-		Value value = connection.getStatements(subject, RDF.REST, null, true, context)
-				.stream()
-				.map(Statement::getObject)
-				.findAny()
-				.orElse(null);
-		// .orElseThrow(() -> new IllegalStateException("Corrupt rdf:list at rdf:rest: " + subject));
-
-		return ((Resource) value);
+		return ShapeSourceHelper.getRdfRest(connection, subject, context);
 	}
 
 	public boolean isType(Resource subject, IRI type) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/CombinedShapeSource.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/CombinedShapeSource.java
@@ -109,17 +109,13 @@ public class CombinedShapeSource implements ShapeSource {
 	public Value getRdfFirst(Resource subject) {
 		assert context != null;
 		Value rdfFirst1 = rdf4jShapesGraph.getRdfFirst(subject);
-		Value rdfFirst2 = baseSail.getRdfFirst(subject);
-		return rdfFirst1 != null ? rdfFirst1 : rdfFirst2;
+		return rdfFirst1 != null ? rdfFirst1 : baseSail.getRdfFirst(subject);
 	}
 
 	public Resource getRdfRest(Resource subject) {
 		assert context != null;
-
 		Value rdfRest1 = rdf4jShapesGraph.getRdfRest(subject);
-		Value rdfRest2 = baseSail.getRdfRest(subject);
-
-		return (Resource) (rdfRest1 != null ? rdfRest1 : rdfRest2);
+		return (Resource) (rdfRest1 != null ? rdfRest1 : baseSail.getRdfRest(subject));
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/ForwardChainingShapeSource.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/ForwardChainingShapeSource.java
@@ -27,13 +27,10 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencer;
-import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencerConnection;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 public class ForwardChainingShapeSource implements ShapeSource {
@@ -71,12 +68,11 @@ public class ForwardChainingShapeSource implements ShapeSource {
 				SchemaCachingRDFSInferencer.fastInstantiateFrom(shaclVocabulary, new MemoryStore(), false));
 		shapesRepoWithReasoning.init();
 
-		try (SailRepositoryConnection shapesRepoWithReasoningConnection = shapesRepoWithReasoning.getConnection()) {
+		try (var shapesRepoWithReasoningConnection = shapesRepoWithReasoning.getConnection()) {
 
 			shapesRepoWithReasoningConnection.begin(IsolationLevels.NONE);
 
-			try (RepositoryResult<Statement> statements = shapesRepoConnection.getStatements(null, null, null,
-					false)) {
+			try (var statements = shapesRepoConnection.getStatements(null, null, null, false)) {
 				shapesRepoWithReasoningConnection.add(statements);
 			}
 
@@ -91,7 +87,7 @@ public class ForwardChainingShapeSource implements ShapeSource {
 		try (InputStream in = getResourceAsStream("shacl-sparql-inference/shaclVocabulary.ttl")) {
 			SchemaCachingRDFSInferencer schemaCachingRDFSInferencer = new SchemaCachingRDFSInferencer(
 					new MemoryStore());
-			try (SchemaCachingRDFSInferencerConnection connection = schemaCachingRDFSInferencer.getConnection()) {
+			try (var connection = schemaCachingRDFSInferencer.getConnection()) {
 				connection.begin(IsolationLevels.NONE);
 				Model model = Rio.parse(in, "", RDFFormat.TURTLE);
 				model.forEach(s -> connection.addStatement(s.getSubject(), s.getPredicate(), s.getObject(),
@@ -128,7 +124,7 @@ public class ForwardChainingShapeSource implements ShapeSource {
 	}
 
 	private void implicitTargetClass(RepositoryConnection shaclSailConnection) {
-		try (Stream<Statement> stream = shaclSailConnection.getStatements(null, RDF.TYPE, RDFS.CLASS, false).stream()) {
+		try (var stream = shaclSailConnection.getStatements(null, RDF.TYPE, RDFS.CLASS, false).stream()) {
 			stream
 					.map(Statement::getSubject)
 					.filter(s ->
@@ -210,40 +206,15 @@ public class ForwardChainingShapeSource implements ShapeSource {
 
 	public Stream<Statement> getAllStatements(Resource id) {
 		assert context != null;
-		return connection.getStatements(id, null, null, true, context)
-				.stream();
+		return connection.getStatements(id, null, null, true, context).stream();
 	}
 
 	public Value getRdfFirst(Resource subject) {
-		assert context != null;
-
-		try (Stream<Statement> stream = connection.getStatements(subject, RDF.FIRST, null, true, context).stream()) {
-			return stream
-					.map(Statement::getObject)
-					.findAny()
-					.orElse(null);
-		}
-		// .orElseThrow(() -> new IllegalStateException("Corrupt rdf:list at rdf:first: " + subject));
+		return ShapeSourceHelper.getFirst(connection, subject, context);
 	}
 
 	public Resource getRdfRest(Resource subject) {
-		assert context != null;
-
-		try (Stream<Statement> stream = connection.getStatements(subject, RDF.REST, null, true, context).stream()) {
-			return (Resource) stream
-					.map(Statement::getObject)
-					.findAny()
-					.orElse(null);
-		}
-
-		// .orElseThrow(() -> new IllegalStateException("Corrupt rdf:list at rdf:rest: " + subject));
-
-//		if (value.isResource()) {
-//			return ((Resource) value);
-//		} else {
-//			throw new IllegalStateException("Corrupt rdf:list at rdf:rest: " + subject);
-//		}
-
+		return ShapeSourceHelper.getRdfRest(connection, subject, context);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/RepositoryConnectionShapeSource.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/RepositoryConnectionShapeSource.java
@@ -108,27 +108,11 @@ public class RepositoryConnectionShapeSource implements ShapeSource {
 	}
 
 	public Value getRdfFirst(Resource subject) {
-		assert context != null;
-
-		return connection.getStatements(subject, RDF.FIRST, null, true, context)
-				.stream()
-				.map(Statement::getObject)
-				.findAny()
-				.orElse(null);
-		// .orElseThrow(() -> new IllegalStateException("Corrupt rdf:list at rdf:first: " + subject));
+		return ShapeSourceHelper.getFirst(connection, subject, context);
 	}
 
 	public Resource getRdfRest(Resource subject) {
-		assert context != null;
-
-		Value value = connection.getStatements(subject, RDF.REST, null, true, context)
-				.stream()
-				.map(Statement::getObject)
-				.findAny()
-				.orElse(null);
-		// .orElseThrow(() -> new IllegalStateException("Corrupt rdf:list at rdf:rest: " + subject));
-
-		return ((Resource) value);
+		return ShapeSourceHelper.getRdfRest(connection, subject, context);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/SailConnectionShapeSource.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/SailConnectionShapeSource.java
@@ -107,27 +107,11 @@ public class SailConnectionShapeSource implements ShapeSource {
 	}
 
 	public Value getRdfFirst(Resource subject) {
-		assert context != null;
-
-		return connection.getStatements(subject, RDF.FIRST, null, true, context)
-				.stream()
-				.map(Statement::getObject)
-				.findAny()
-				.orElse(null);
-		// .orElseThrow(() -> new IllegalStateException("Corrupt rdf:list at rdf:first: " + subject));
+		return ShapeSourceHelper.getFirst(connection, subject, context);
 	}
 
 	public Resource getRdfRest(Resource subject) {
-		assert context != null;
-
-		Value value = connection.getStatements(subject, RDF.REST, null, true, context)
-				.stream()
-				.map(Statement::getObject)
-				.findAny()
-				.orElse(null);
-		// .orElseThrow(() -> new IllegalStateException("Corrupt rdf:list at rdf:rest: " + subject));
-
-		return ((Resource) value);
+		return ShapeSourceHelper.getRdfRest(connection, subject, context);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/ShapeSourceHelper.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/shape/ShapeSourceHelper.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.wrapper.shape;
+
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.sail.SailConnection;
+
+class ShapeSourceHelper {
+
+	static Value getFirst(SailConnection connection, Resource subject, Resource[] context) {
+		assert context != null;
+		try (var stream = connection.getStatements(subject, RDF.FIRST, null, true, context).stream()) {
+			return getObject(stream);
+		}
+	}
+
+	static Value getFirst(RepositoryConnection connection, Resource subject, Resource[] context) {
+		assert context != null;
+		try (var stream = connection.getStatements(subject, RDF.FIRST, null, true, context).stream()) {
+			return getObject(stream);
+		}
+	}
+
+	static Resource getRdfRest(RepositoryConnection connection, Resource subject, Resource[] context) {
+		assert context != null;
+		try (var stream = connection.getStatements(subject, RDF.REST, null, true, context).stream()) {
+			return (Resource) getObject(stream);
+		}
+	}
+
+	static Resource getRdfRest(SailConnection connection, Resource subject, Resource[] context) {
+		assert context != null;
+		try (var stream = connection.getStatements(subject, RDF.REST, null, true, context).stream()) {
+			return (Resource) getObject(stream);
+		}
+	}
+
+	private static Value getObject(Stream<? extends Statement> stream) {
+		return stream
+				.map(Statement::getObject)
+				.findAny()
+				.orElse(null);
+	}
+
+}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SerializableTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SerializableTest.java
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 


### PR DESCRIPTION
GitHub issue resolved: #3972 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - introduce a helper class so that we don't forget to close streams 
 
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

