### PR TITLE
GH-3984 improve caching of cardinality

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatistics.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.eclipse.rdf4j.query.algebra.AbstractQueryModelNode;
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.BinaryTupleOperator;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
@@ -50,6 +51,10 @@ public class EvaluationStatistics {
 			assert calculator != null;
 		}
 
+		if (expr instanceof AbstractQueryModelNode && ((AbstractQueryModelNode) expr).isCardinalitySet()) {
+			return ((AbstractQueryModelNode) expr).getCardinality();
+		}
+
 		expr.visit(calculator);
 		return calculator.getCardinality();
 	}
@@ -87,10 +92,7 @@ public class EvaluationStatistics {
 
 		@Override
 		public void meet(BindingSetAssignment node) {
-			// actual cardinality is node.getBindingSets().size() binding sets
-			// but cost is cheap as we don't need to query the triple store
-			// so effective cardinality is 1 or a very slowly increasing function of node.getBindingSets().size().
-			cardinality = 1.0;
+			cardinality = getCardinalityInternal(node);
 		}
 
 		@Override
@@ -117,9 +119,8 @@ public class EvaluationStatistics {
 			// single ?s ?p ?o ?c pattern where ?p is unbound, compensating for the fact that
 			// the length of the path is unknown but expected to be _at least_ twice that of a normal
 			// statement pattern.
-			cardinality = 2.0 * getCardinality(
-					new StatementPattern(node.getSubjectVar().clone(), pathVar, node.getObjectVar().clone(),
-							node.getContextVar() != null ? node.getContextVar().clone() : null));
+			cardinality = 2.0 * getCardinalityInternal(new StatementPattern(node.getSubjectVar().clone(), pathVar,
+					node.getObjectVar().clone(), node.getContextVar() != null ? node.getContextVar().clone() : null));
 		}
 
 		@Override
@@ -151,22 +152,51 @@ public class EvaluationStatistics {
 
 		@Override
 		public void meet(StatementPattern sp) {
-			cardinality = getCardinality(sp);
+			cardinality = getCardinalityInternal(sp);
 		}
 
 		@Override
 		public void meet(TripleRef tripleRef) {
-			cardinality = getSubjectCardinality(tripleRef.getSubjectVar())
-					* getPredicateCardinality(tripleRef.getPredicateVar())
-					* getObjectCardinality(tripleRef.getObjectVar());
+			cardinality = getCardinalityInternal(tripleRef);
+		}
+
+		private double getCardinalityInternal(StatementPattern node) {
+			if (!node.isCardinalitySet()) {
+				node.setCardinality(getCardinality(node));
+			}
+			return node.getCardinality();
+		}
+
+		private double getCardinalityInternal(TripleRef node) {
+			if (!node.isCardinalitySet()) {
+				node.setCardinality(getCardinality(node));
+			}
+			return node.getCardinality();
+		}
+
+		private double getCardinalityInternal(BindingSetAssignment node) {
+			if (!node.isCardinalitySet()) {
+				node.setCardinality(getCardinality(node));
+			}
+			return node.getCardinality();
 		}
 
 		protected double getCardinality(StatementPattern sp) {
-			if (!sp.isCardinalitySet()) {
-				sp.setCardinality(getSubjectCardinality(sp) * getPredicateCardinality(sp) * getObjectCardinality(sp)
-						* getContextCardinality(sp));
-			}
-			return sp.getCardinality();
+			return getSubjectCardinality(sp) * getPredicateCardinality(sp) * getObjectCardinality(sp)
+					* getContextCardinality(sp);
+		}
+
+		protected double getCardinality(BindingSetAssignment bindingSetAssignment) {
+			// actual cardinality is node.getBindingSets().size() binding sets
+			// but cost is cheap as we don't need to query the triple store
+			// so effective cardinality is 1 or a very slowly increasing function of node.getBindingSets().size().
+			return 1.0;
+		}
+
+		protected double getCardinality(TripleRef tripleRef) {
+			return getSubjectCardinality(tripleRef.getSubjectVar())
+					* getPredicateCardinality(tripleRef.getPredicateVar())
+					* getObjectCardinality(tripleRef.getObjectVar());
 		}
 
 		/**

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIteration.java
@@ -80,11 +80,14 @@ public class ZeroLengthPathIteration extends LookAheadIteration<BindingSet, Quer
 		Var startVar = createAnonVar(ANON_SUBJECT_VAR);
 		Var predicate = createAnonVar(ANON_PREDICATE_VAR);
 		Var endVar = createAnonVar(ANON_OBJECT_VAR);
-		StatementPattern subjects = new StatementPattern(startVar, predicate, endVar);
+
+		StatementPattern subjects;
 		if (contextVar != null) {
-			subjects.setScope(Scope.NAMED_CONTEXTS);
-			subjects.setContextVar(contextVar);
+			subjects = new StatementPattern(Scope.NAMED_CONTEXTS, startVar, predicate, endVar, contextVar);
+		} else {
+			subjects = new StatementPattern(startVar, predicate, endVar);
 		}
+
 		precompile = evaluationStrategy.precompile(subjects, context);
 		setSubject = context.addBinding(subjectVar.getName());
 		setObject = context.addBinding(objVar.getName());

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatisticsTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStatisticsTest.java
@@ -7,11 +7,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TripleRef;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.parser.ParsedTupleQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class EvaluationStatisticsTest {
@@ -34,6 +39,36 @@ public class EvaluationStatisticsTest {
 		checker.reset();
 		expr.visit(checker);
 		assertThat(checker.getInconsistentNodes()).isEmpty();
+	}
+
+	@Test
+	public void testCacheCardinalityStatementPattern() {
+		StatementPattern tupleExpr = new StatementPattern(new Var("a"), new Var("b"), new Var("c"));
+		Assertions.assertFalse(tupleExpr.isCardinalitySet());
+
+		double cardinality = new EvaluationStatistics().getCardinality(tupleExpr);
+		Assertions.assertTrue(tupleExpr.isCardinalitySet());
+		Assertions.assertEquals(cardinality, tupleExpr.getCardinality());
+	}
+
+	@Test
+	public void testCacheCardinalityTripleRef() {
+		TripleRef tupleExpr = new TripleRef(new Var("a"), new Var("b"), new Var("c"), new Var("expr"));
+		Assertions.assertFalse(tupleExpr.isCardinalitySet());
+
+		double cardinality = new EvaluationStatistics().getCardinality(tupleExpr);
+		Assertions.assertTrue(tupleExpr.isCardinalitySet());
+		Assertions.assertEquals(cardinality, tupleExpr.getCardinality());
+	}
+
+	@Test
+	public void testCacheCardinalityBindingSetAssignment() {
+		BindingSetAssignment tupleExpr = new BindingSetAssignment();
+		Assertions.assertFalse(tupleExpr.isCardinalitySet());
+
+		double cardinality = new EvaluationStatistics().getCardinality(tupleExpr);
+		Assertions.assertTrue(tupleExpr.isCardinalitySet());
+		Assertions.assertEquals(cardinality, tupleExpr.getCardinality());
 	}
 
 	private class ParentCheckingVisitor extends AbstractQueryModelVisitor<RuntimeException> {

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStrategyWithRDFStarTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStrategyWithRDFStarTest.java
@@ -166,11 +166,7 @@ public class EvaluationStrategyWithRDFStarTest {
 
 		baseSource = new CommonBaseSource();
 
-		tripleRefNode = new TripleRef();
-		tripleRefNode.setSubjectVar(new Var("s"));
-		tripleRefNode.setPredicateVar(new Var("p"));
-		tripleRefNode.setObjectVar(new Var("o"));
-		tripleRefNode.setExprVar(new Var("extern"));
+		tripleRefNode = new TripleRef(new Var("s"), new Var("p"), new Var("o"), new Var("extern"));
 
 		strategy = new StrictEvaluationStrategy(createSource(), null);
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNode.java
@@ -10,12 +10,15 @@ package org.eclipse.rdf4j.query.algebra;
 import java.util.List;
 import java.util.ListIterator;
 
+import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.query.algebra.helpers.QueryModelTreePrinter;
 
 /**
  * Base implementation of {@link QueryModelNode}.
  */
 public abstract class AbstractQueryModelNode implements QueryModelNode, VariableScopeChange, GraphPatternGroupable {
+
+	private static final double CARDINALITY_NOT_SET = Double.MIN_VALUE;
 
 	/*-----------*
 	 * Variables *
@@ -31,6 +34,8 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, Variable
 	private long resultSizeActual = -1;
 	private double costEstimate = -1;
 	private long totalTimeNanosActual = -1;
+
+	private double cardinality = CARDINALITY_NOT_SET;
 
 	/*---------*
 	 * Methods *
@@ -118,6 +123,7 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, Variable
 		try {
 			AbstractQueryModelNode clone = (AbstractQueryModelNode) super.clone();
 			clone.setVariableScopeChange(this.isVariableScopeChange());
+			clone.cardinality = CARDINALITY_NOT_SET;
 			return clone;
 		} catch (CloneNotSupportedException e) {
 			throw new RuntimeException("Query model nodes are required to be cloneable", e);
@@ -202,4 +208,31 @@ public abstract class AbstractQueryModelNode implements QueryModelNode, Variable
 
 		return humanReadbleString;
 	}
+
+	@Experimental
+	public double getCardinality() {
+		assert cardinality != CARDINALITY_NOT_SET;
+		return cardinality;
+	}
+
+	@Experimental
+	public void setCardinality(double cardinality) {
+		this.cardinality = cardinality;
+	}
+
+	@Experimental
+	public void resetCardinality() {
+		this.cardinality = CARDINALITY_NOT_SET;
+	}
+
+	@Experimental
+	public boolean isCardinalitySet() {
+		return shouldCacheCardinality() && cardinality != CARDINALITY_NOT_SET;
+	}
+
+	@Experimental
+	protected boolean shouldCacheCardinality() {
+		return false;
+	}
+
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ArbitraryLengthPath.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ArbitraryLengthPath.java
@@ -260,4 +260,5 @@ public class ArbitraryLengthPath extends AbstractQueryModelNode implements Tuple
 
 		return clone;
 	}
+
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BindingSetAssignment.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BindingSetAssignment.java
@@ -102,4 +102,9 @@ public class BindingSetAssignment extends AbstractQueryModelNode implements Tupl
 	public String getSignature() {
 		return super.getSignature() + " (" + this.getBindingSets().toString() + ")";
 	}
+
+	@Override
+	protected boolean shouldCacheCardinality() {
+		return true;
+	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
@@ -21,6 +21,7 @@ import java.util.Set;
  */
 public class StatementPattern extends AbstractQueryModelNode implements TupleExpr {
 
+	@Deprecated
 	public static final double CARDINALITY_NOT_SET = Double.MIN_VALUE;
 
 	/**
@@ -54,8 +55,6 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 
 	private Set<String> assuredBindingNames;
 	private List<Var> varList;
-
-	private double cardinality = CARDINALITY_NOT_SET;
 
 	/*--------------*
 	 * Constructors *
@@ -127,7 +126,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		this.scope = Objects.requireNonNull(scope);
 		assuredBindingNames = null;
 		varList = null;
-		cardinality = CARDINALITY_NOT_SET;
+		resetCardinality();
 	}
 
 	public Var getSubjectVar() {
@@ -140,7 +139,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		subjectVar = subject;
 		assuredBindingNames = null;
 		varList = null;
-		cardinality = CARDINALITY_NOT_SET;
+		resetCardinality();
 	}
 
 	public Var getPredicateVar() {
@@ -153,7 +152,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		predicateVar = predicate;
 		assuredBindingNames = null;
 		varList = null;
-		cardinality = CARDINALITY_NOT_SET;
+		resetCardinality();
 	}
 
 	public Var getObjectVar() {
@@ -166,7 +165,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		objectVar = object;
 		assuredBindingNames = null;
 		varList = null;
-		cardinality = CARDINALITY_NOT_SET;
+		resetCardinality();
 	}
 
 	/**
@@ -184,7 +183,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		contextVar = context;
 		assuredBindingNames = null;
 		varList = null;
-		cardinality = CARDINALITY_NOT_SET;
+		resetCardinality();
 	}
 
 	@Override
@@ -211,7 +210,8 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 		String[] values;
 
 		public SmallStringSet(Var var1, Var var2, Var var3, Var var4) {
-			String[] values = new String[4];
+			String[] values = new String[(var1 != null ? 1 : 0) + (var2 != null ? 1 : 0) + (var3 != null ? 1 : 0)
+					+ (var4 != null ? 1 : 0)];
 
 			int i = 0;
 			if (var1 != null) {
@@ -221,7 +221,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 			i = add(var3, values, i);
 			i = add(var4, values, i);
 
-			if (i == 4) {
+			if (i == values.length) {
 				this.values = values;
 			} else {
 				this.values = Arrays.copyOfRange(values, 0, i);
@@ -426,20 +426,13 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 
 		clone.assuredBindingNames = assuredBindingNames;
 		clone.varList = null;
-		clone.cardinality = CARDINALITY_NOT_SET;
 
 		return clone;
 	}
 
-	public double getCardinality() {
-		return cardinality;
+	@Override
+	protected boolean shouldCacheCardinality() {
+		return true;
 	}
 
-	public void setCardinality(double cardinality) {
-		this.cardinality = cardinality;
-	}
-
-	public boolean isCardinalitySet() {
-		return cardinality != CARDINALITY_NOT_SET;
-	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/TripleRef.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/TripleRef.java
@@ -16,36 +16,57 @@ import java.util.Set;
 /** Triple lookup reference. Allow retrieval of RDF-star triples **/
 public class TripleRef extends AbstractQueryModelNode implements TupleExpr {
 
-	private org.eclipse.rdf4j.query.algebra.Var exprVar;
-	private org.eclipse.rdf4j.query.algebra.Var subjectVar;
-	private org.eclipse.rdf4j.query.algebra.Var predicateVar;
-	private org.eclipse.rdf4j.query.algebra.Var objectVar;
+	private Var subjectVar;
+	private Var predicateVar;
+	private Var objectVar;
+	private Var exprVar;
 
-	public org.eclipse.rdf4j.query.algebra.Var getSubjectVar() {
+	public TripleRef() {
+	}
+
+	public TripleRef(Var subjectVar, Var predicateVar, Var objectVar, Var exprVar) {
+		assert subjectVar != null : "subject must not be null";
+		assert predicateVar != null : "predicate must not be null";
+		assert objectVar != null : "object must not be null";
+
+		subjectVar.setParentNode(this);
+		predicateVar.setParentNode(this);
+		objectVar.setParentNode(this);
+		if (exprVar != null) {
+			exprVar.setParentNode(this);
+		}
+
+		this.subjectVar = subjectVar;
+		this.predicateVar = predicateVar;
+		this.objectVar = objectVar;
+		this.exprVar = exprVar;
+	}
+
+	public Var getSubjectVar() {
 		return subjectVar;
 	}
 
-	public void setSubjectVar(org.eclipse.rdf4j.query.algebra.Var subject) {
+	public void setSubjectVar(Var subject) {
 		assert subject != null : "subject must not be null";
 		subject.setParentNode(this);
 		subjectVar = subject;
 	}
 
-	public org.eclipse.rdf4j.query.algebra.Var getPredicateVar() {
+	public Var getPredicateVar() {
 		return predicateVar;
 	}
 
-	public void setPredicateVar(org.eclipse.rdf4j.query.algebra.Var predicate) {
+	public void setPredicateVar(Var predicate) {
 		assert predicate != null : "predicate must not be null";
 		predicate.setParentNode(this);
 		predicateVar = predicate;
 	}
 
-	public org.eclipse.rdf4j.query.algebra.Var getObjectVar() {
+	public Var getObjectVar() {
 		return objectVar;
 	}
 
-	public void setObjectVar(org.eclipse.rdf4j.query.algebra.Var object) {
+	public void setObjectVar(Var object) {
 		assert object != null : "object must not be null";
 		object.setParentNode(this);
 		objectVar = object;
@@ -54,11 +75,11 @@ public class TripleRef extends AbstractQueryModelNode implements TupleExpr {
 	/**
 	 * Returns the context variable, if available.
 	 */
-	public org.eclipse.rdf4j.query.algebra.Var getExprVar() {
+	public Var getExprVar() {
 		return exprVar;
 	}
 
-	public void setExprVar(org.eclipse.rdf4j.query.algebra.Var context) {
+	public void setExprVar(Var context) {
 		if (context != null) {
 			context.setParentNode(this);
 		}
@@ -90,14 +111,14 @@ public class TripleRef extends AbstractQueryModelNode implements TupleExpr {
 		return bindingNames;
 	}
 
-	public List<org.eclipse.rdf4j.query.algebra.Var> getVarList() {
+	public List<Var> getVarList() {
 		return getVars(new ArrayList<>(4));
 	}
 
 	/**
 	 * Adds the variables of this statement pattern to the supplied collection.
 	 */
-	public <L extends Collection<org.eclipse.rdf4j.query.algebra.Var>> L getVars(L varCollection) {
+	public <L extends Collection<Var>> L getVars(L varCollection) {
 		if (subjectVar != null) {
 			varCollection.add(subjectVar);
 		}
@@ -138,13 +159,13 @@ public class TripleRef extends AbstractQueryModelNode implements TupleExpr {
 	@Override
 	public void replaceChildNode(QueryModelNode current, QueryModelNode replacement) {
 		if (subjectVar == current) {
-			setSubjectVar((org.eclipse.rdf4j.query.algebra.Var) replacement);
+			setSubjectVar((Var) replacement);
 		} else if (predicateVar == current) {
-			setPredicateVar((org.eclipse.rdf4j.query.algebra.Var) replacement);
+			setPredicateVar((Var) replacement);
 		} else if (objectVar == current) {
-			setObjectVar((org.eclipse.rdf4j.query.algebra.Var) replacement);
+			setObjectVar((Var) replacement);
 		} else if (exprVar == current) {
-			setExprVar((org.eclipse.rdf4j.query.algebra.Var) replacement);
+			setExprVar((Var) replacement);
 		}
 	}
 
@@ -191,4 +212,10 @@ public class TripleRef extends AbstractQueryModelNode implements TupleExpr {
 
 		return clone;
 	}
+
+	@Override
+	protected boolean shouldCacheCardinality() {
+		return true;
+	}
+
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Var.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Var.java
@@ -132,7 +132,7 @@ public class Var extends AbstractQueryModelNode implements ValueExpr {
 		sb.append(" (name=").append(name);
 
 		if (value != null) {
-			sb.append(", value=").append(value.toString());
+			sb.append(", value=").append(value);
 		}
 
 		if (anonymous) {
@@ -153,6 +153,10 @@ public class Var extends AbstractQueryModelNode implements ValueExpr {
 			return false;
 		}
 		Var var = (Var) o;
+		if (cachedHashCode != 0 && var.cachedHashCode != 0 && cachedHashCode != var.cachedHashCode) {
+			return false;
+		}
+
 		return anonymous == var.anonymous && Objects.equals(name, var.name) && Objects.equals(value, var.value);
 	}
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
-import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -32,10 +31,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -101,14 +97,28 @@ public class QueryBenchmark {
 	}
 
 	public static void main(String[] args) throws RunnerException, IOException, InterruptedException {
-		Options opt = new OptionsBuilder()
-				.include("QueryBenchmark.complexQueryFirst") // adapt to run other benchmark tests
-				.include("QueryBenchmark.lots_of_optionalFirst")
-				.include("QueryBenchmark.different_datasets_with_similar_distributionsFirst")
-				.forks(1)
-				.build();
+//		Options opt = new OptionsBuilder()
+//				.include("QueryBenchmark") // adapt to run other benchmark tests
+//				// .addProfiler("stack", "lines=20;period=1;top=20")
+//				.forks(1)
+//				.build();
+//
+//		new Runner(opt).run();
 
-		new Runner(opt).run();
+		QueryBenchmark queryBenchmark = new QueryBenchmark();
+		queryBenchmark.beforeClass();
+		for (int i = 0; i < 100; i++) {
+			System.out.println(i);
+			queryBenchmark.pathExpressionQuery1();
+			queryBenchmark.groupByQuery();
+			queryBenchmark.different_datasets_with_similar_distributions();
+			queryBenchmark.long_chain();
+			queryBenchmark.simple_filter_not();
+			queryBenchmark.complexQuery();
+			queryBenchmark.lots_of_optional();
+			queryBenchmark.nested_optionals();
+		}
+		queryBenchmark.afterClass();
 
 	}
 
@@ -149,15 +159,6 @@ public class QueryBenchmark {
 					.evaluate()
 					.stream()
 					.count();
-		}
-	}
-
-	@Benchmark
-	public boolean complexQueryFirst() {
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			try (TupleQueryResult evaluate = connection.prepareTupleQuery(query4).evaluate()) {
-				return evaluate.hasNext();
-			}
 		}
 	}
 
@@ -208,18 +209,6 @@ public class QueryBenchmark {
 	}
 
 	@Benchmark
-	public boolean different_datasets_with_similar_distributionsFirst() {
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			try (TupleQueryResult evaluate = connection
-					.prepareTupleQuery(different_datasets_with_similar_distributions)
-					.evaluate()) {
-				return evaluate.hasNext();
-			}
-
-		}
-	}
-
-	@Benchmark
 	public long long_chain() {
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			return connection
@@ -238,16 +227,6 @@ public class QueryBenchmark {
 					.evaluate()
 					.stream()
 					.count();
-		}
-	}
-
-	@Benchmark
-	public boolean lots_of_optionalFirst() {
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			try (TupleQueryResult evaluate = connection.prepareTupleQuery(lots_of_optional).evaluate()) {
-				return evaluate.hasNext();
-			}
-
 		}
 	}
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/benchmark/QueryBenchmark.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -31,7 +32,10 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  * @author Håvard Ottestad
@@ -97,28 +101,14 @@ public class QueryBenchmark {
 	}
 
 	public static void main(String[] args) throws RunnerException, IOException, InterruptedException {
-//		Options opt = new OptionsBuilder()
-//				.include("QueryBenchmark") // adapt to run other benchmark tests
-//				// .addProfiler("stack", "lines=20;period=1;top=20")
-//				.forks(1)
-//				.build();
-//
-//		new Runner(opt).run();
+		Options opt = new OptionsBuilder()
+				.include("QueryBenchmark.complexQueryFirst") // adapt to run other benchmark tests
+				.include("QueryBenchmark.lots_of_optionalFirst")
+				.include("QueryBenchmark.different_datasets_with_similar_distributionsFirst")
+				.forks(1)
+				.build();
 
-		QueryBenchmark queryBenchmark = new QueryBenchmark();
-		queryBenchmark.beforeClass();
-		for (int i = 0; i < 100; i++) {
-			System.out.println(i);
-			queryBenchmark.pathExpressionQuery1();
-			queryBenchmark.groupByQuery();
-			queryBenchmark.different_datasets_with_similar_distributions();
-			queryBenchmark.long_chain();
-			queryBenchmark.simple_filter_not();
-			queryBenchmark.complexQuery();
-			queryBenchmark.lots_of_optional();
-			queryBenchmark.nested_optionals();
-		}
-		queryBenchmark.afterClass();
+		new Runner(opt).run();
 
 	}
 
@@ -159,6 +149,15 @@ public class QueryBenchmark {
 					.evaluate()
 					.stream()
 					.count();
+		}
+	}
+
+	@Benchmark
+	public boolean complexQueryFirst() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			try (TupleQueryResult evaluate = connection.prepareTupleQuery(query4).evaluate()) {
+				return evaluate.hasNext();
+			}
 		}
 	}
 
@@ -209,6 +208,18 @@ public class QueryBenchmark {
 	}
 
 	@Benchmark
+	public boolean different_datasets_with_similar_distributionsFirst() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			try (TupleQueryResult evaluate = connection
+					.prepareTupleQuery(different_datasets_with_similar_distributions)
+					.evaluate()) {
+				return evaluate.hasNext();
+			}
+
+		}
+	}
+
+	@Benchmark
 	public long long_chain() {
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			return connection
@@ -227,6 +238,16 @@ public class QueryBenchmark {
 					.evaluate()
 					.stream()
 					.count();
+		}
+	}
+
+	@Benchmark
+	public boolean lots_of_optionalFirst() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			try (TupleQueryResult evaluate = connection.prepareTupleQuery(lots_of_optional).evaluate()) {
+				return evaluate.hasNext();
+			}
+
 		}
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #3984 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - add support for caching cardinality for StatementPattern, TripleRef and BindingSetAssignment
 - reduce the use of HashMap for caching cardinality in QueryJoinOptimizer

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

