### PR TITLE
GH-3940 add fuzzy prefix option to lucene sail

### DIFF
--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -334,6 +335,11 @@ public class LuceneSail extends NotifyingSailWrapper {
 	public static final String EVALUATION_MODE_KEY = "evaluationMode";
 
 	/**
+	 * Set this key as sail parameter to influence the fuzzy prefix length.
+	 */
+	public static final String FUZZY_PREFIX_LENGTH_KEY = "fuzzyPrefixLength";
+
+	/**
 	 * The LuceneIndex holding the indexed literals.
 	 */
 	private volatile SearchIndex luceneIndex;
@@ -448,6 +454,9 @@ public class LuceneSail extends NotifyingSailWrapper {
 			if (parameters.containsKey(EVALUATION_MODE_KEY)) {
 				setEvaluationMode(TupleFunctionEvaluationMode.valueOf(parameters.getProperty(EVALUATION_MODE_KEY)));
 			}
+			if (parameters.containsKey(FUZZY_PREFIX_LENGTH_KEY)) {
+				setFuzzyPrefixLength(NumberUtils.toInt(parameters.getProperty(FUZZY_PREFIX_LENGTH_KEY), 0));
+			}
 			if (luceneIndex == null) {
 				initializeLuceneIndex();
 			}
@@ -552,6 +561,10 @@ public class LuceneSail extends NotifyingSailWrapper {
 		Objects.requireNonNull(mode);
 		this.setParameter(INDEX_TYPE_BACKTRACE_MODE, mode.name());
 		this.indexBacktraceMode = mode;
+	}
+
+	public void setFuzzyPrefixLength(int fuzzyPrefixLength) {
+		setParameter(FUZZY_PREFIX_LENGTH_KEY, String.valueOf(fuzzyPrefixLength));
 	}
 
 	public TupleFunctionRegistry getTupleFunctionRegistry() {

--- a/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndex.java
+++ b/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndex.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene.impl;
 
+import static org.eclipse.rdf4j.sail.lucene.LuceneSail.FUZZY_PREFIX_LENGTH_KEY;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -24,6 +26,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -136,6 +139,8 @@ public class LuceneIndex extends AbstractLuceneIndex {
 
 	private volatile Similarity similarity;
 
+	private volatile int fuzzyPrefixLength;
+
 	/**
 	 * The IndexWriter that can be used to alter the index' contents. Created lazily.
 	 */
@@ -192,6 +197,10 @@ public class LuceneIndex extends AbstractLuceneIndex {
 		// Map<Object,Object>
 		// even though it is effectively Map<String,String>
 		this.geoStrategyMapper = createSpatialStrategyMapper((Map<String, String>) (Map<?, ?>) parameters);
+
+		if (parameters.containsKey(FUZZY_PREFIX_LENGTH_KEY)) {
+			this.fuzzyPrefixLength = NumberUtils.toInt(parameters.getProperty(FUZZY_PREFIX_LENGTH_KEY), 0);
+		}
 
 		postInit();
 	}
@@ -913,19 +922,20 @@ public class LuceneIndex extends AbstractLuceneIndex {
 	}
 
 	private QueryParser getQueryParser(IRI propertyURI) {
+		String fieldName;
 		// check out which query parser to use, based on the given property URI
-		if (propertyURI == null)
-		// if we have no property given, we create a default query parser
-		// which
-		// has the TEXT_FIELD_NAME as the default field
-		{
-			return new QueryParser(SearchFields.TEXT_FIELD_NAME, this.queryAnalyzer);
-		} else
-		// otherwise we create a query parser that has the given property as
-		// the default field
-		{
-			return new QueryParser(SearchFields.getPropertyField(propertyURI), this.queryAnalyzer);
+		if (propertyURI == null) {
+			// if we have no property given, we create a default query parser which has the TEXT_FIELD_NAME as the
+			// default field
+			fieldName = SearchFields.TEXT_FIELD_NAME;
+		} else {
+			// otherwise we create a query parser that has the given property as the default field
+			fieldName = SearchFields.getPropertyField(propertyURI);
 		}
+
+		QueryParser queryParser = new QueryParser(fieldName, queryAnalyzer);
+		queryParser.setFuzzyPrefixLength(fuzzyPrefixLength);
+		return queryParser;
 	}
 
 	/**

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneFuzzinessPrefixTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneFuzzinessPrefixTest.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.query.QueryLanguage.SPARQL;
+import static org.eclipse.rdf4j.sail.lucene.LuceneSail.FUZZY_PREFIX_LENGTH_KEY;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.evaluation.TupleFunctionEvaluationMode;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+public class LuceneFuzzinessPrefixTest {
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+	private static final String NAMESPACE = "http://example.org/";
+	private static final String PREFIXES = joinLines(
+			"PREFIX search: <http://www.openrdf.org/contrib/lucenesail#>",
+			"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
+			"PREFIX ex: <" + NAMESPACE + ">");
+
+	private static IRI iri(String name) {
+		return VF.createIRI(NAMESPACE + name);
+	}
+
+	private static String joinLines(String... lines) {
+		return String.join(" \n", lines);
+	}
+
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	private LuceneSail sail;
+	private MemoryStore memoryStore;
+	private SailRepository repository;
+	private File dataDir;
+
+	@Before
+	public void setup() throws IOException {
+		dataDir = tmpFolder.newFolder();
+		memoryStore = new MemoryStore();
+		sail = new LuceneSail();
+		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, "lucene-index");
+		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
+	}
+
+	private void initSail() {
+		sail.setBaseSail(memoryStore);
+		repository = new SailRepository(sail);
+		repository.setDataDir(dataDir);
+		repository.init();
+
+		add(
+				VF.createStatement(iri("element1"), iri("text"), VF.createLiteral("eclipse")),
+				VF.createStatement(iri("element2"), iri("text"), VF.createLiteral("foundation")),
+				VF.createStatement(iri("element3"), iri("text"), VF.createLiteral("ide"))
+		);
+	}
+
+	private void add(Statement... statements) {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			for (Statement stmt : statements) {
+				connection.add(stmt);
+			}
+		}
+	}
+
+	@Test
+	public void testFuzzinessPrefixLength_default() {
+		// Arrange
+		initSail();
+
+		// Act
+		List<String> results = executeQuery();
+
+		// Assert
+		assertThat(results).containsExactlyInAnyOrder("element1");
+	}
+
+	@Test
+	public void testFuzzinessPrefixLength_custom() {
+		// Arrange
+		sail.setParameter(FUZZY_PREFIX_LENGTH_KEY, "1");
+		initSail();
+
+		// Act
+		List<String> results = executeQuery();
+
+		// Assert
+		assertThat(results).containsExactlyInAnyOrder("element1");
+	}
+
+	@Test
+	public void testFuzzinessPrefixLength_custom_shouldExcludeResult() {
+		// Arrange
+		sail.setParameter(FUZZY_PREFIX_LENGTH_KEY, "2");
+		initSail();
+
+		// Act
+		List<String> results = executeQuery();
+
+		// Assert
+		assertThat(results).isEmpty();
+	}
+
+	private List<String> executeQuery() {
+		List<String> results = new ArrayList<>();
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			TupleQuery query = connection.prepareTupleQuery(SPARQL, PREFIXES + "\n" + joinLines(
+					"SELECT ?result {",
+					"  ?result search:matches ?match .",
+					"  ?match search:query 'eXlipse~1' .",
+					"}"));
+
+			try (TupleQueryResult result = query.evaluate()) {
+				for (BindingSet set : result) {
+					String element = set.getValue("result").stringValue().substring(NAMESPACE.length());
+					results.add(element);
+				}
+			}
+		}
+		return results;
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #3940

Add an option to configure the fuzzy prefix length of the lucene sail

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [X] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

