### PR TITLE
GH-3992 add sparql parser default prefixes

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserFactory.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserFactory.java
@@ -7,6 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser.sparql;
 
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.parser.QueryParser;
 import org.eclipse.rdf4j.query.parser.QueryParserFactory;
@@ -34,5 +38,17 @@ public class SPARQLParserFactory implements QueryParserFactory {
 	@Override
 	public QueryParser getParser() {
 		return singleton;
+	}
+
+	/**
+	 * @param customPrefixes the default prefixes
+	 * @return a parser with predefined custom default prefixes.
+	 */
+	public QueryParser getParser(Set<Namespace> customPrefixes) {
+		Objects.requireNonNull(customPrefixes, "customPrefixes can't be null!");
+		if (customPrefixes.isEmpty()) {
+			return singleton;
+		}
+		return new SPARQLParser(customPrefixes);
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #3992

Briefly describe the changes proposed in this PR:

This PR add a constructor to the SPARQLParser class and a new method in the SPARQLParserFactory to add custom default prefixes to the parser.

```java
// SPARQLParser
SPARQLParser(Set<Namespace> customDefaultPrefixes)

// SPARQLParserFactory
QueryParser getParser(Set<Namespace> customDefaultPrefixes);
```

Example

```java
// create a set with the ex namespace 
Set<Namespace> customDefaultPrefixes = new HashSet<>();
customDefaultPrefixes.add(Values.namespace("ex", "http://example.org/"));

// create a parser with the default prefixes
SPARQLParser parser = new SPARQLParser(customDefaultPrefixes);

// we can use the default prefix without having to specify it
parser.parseQuery("SELECT ?s {?s ex:aaa ex:ooo}", null);

// we can redefine the prefix in the query if we want another one (this is not an error)
parser.parseQuery("PREFIX ex: <http://example2.org/> SELECT ?s {?s ex:aaa ex:ooo}", null);


// we cannot redefine a prefix in the same request (this is still an excepted error)
parser.parseQuery("PREFIX ex: <http://example.org/> PREFIX ex: <http://example2.org/> SELECT ?s {?s ex:aaa ex:ooo}", null);
```

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

