### PR TITLE
GH-4004 Make QueryTypes independend of HTTP and provide it in a reusable

### DIFF
--- a/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/EvaluateResultHttpResponse.java
+++ b/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/EvaluateResultHttpResponse.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.readonly;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.rdf4j.http.server.readonly.sparql.EvaluateResult;
+
+/**
+ * Encapsulated the {@link HttpServletResponse}.
+ */
+class EvaluateResultHttpResponse implements EvaluateResult {
+
+	private HttpServletResponse response;
+
+	public EvaluateResultHttpResponse(HttpServletResponse response) {
+		this.response = response;
+	}
+
+	@Override
+	public void setContentType(String contentType) {
+		response.setContentType(contentType);
+	}
+
+	@Override
+	public OutputStream getOutputstream() throws IOException {
+		return response.getOutputStream();
+	}
+}

--- a/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/EvaluateResultHttpResponse.java
+++ b/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/EvaluateResultHttpResponse.java
@@ -31,6 +31,11 @@ class EvaluateResultHttpResponse implements EvaluateResult {
 	}
 
 	@Override
+	public String getContentType() {
+		return response.getContentType();
+	}
+
+	@Override
 	public OutputStream getOutputstream() throws IOException {
 		return response.getOutputStream();
 	}

--- a/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/QueryResponder.java
+++ b/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/QueryResponder.java
@@ -11,36 +11,14 @@ import static org.springframework.http.HttpHeaders.ACCEPT;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 import java.io.IOException;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.rdf4j.common.annotation.Experimental;
-import org.eclipse.rdf4j.common.lang.FileFormat;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.query.BooleanQuery;
-import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.http.server.readonly.sparql.SparqlQueryEvaluator;
 import org.eclipse.rdf4j.query.MalformedQueryException;
-import org.eclipse.rdf4j.query.Query;
-import org.eclipse.rdf4j.query.QueryEvaluationException;
-import org.eclipse.rdf4j.query.QueryLanguage;
-import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.impl.SimpleDataset;
-import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriter;
-import org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriterFactory;
-import org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriterRegistry;
-import org.eclipse.rdf4j.query.resultio.QueryResultFormat;
-import org.eclipse.rdf4j.query.resultio.QueryResultIO;
-import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -58,6 +36,9 @@ public class QueryResponder {
 	private final Repository repository;
 
 	@Autowired
+	private SparqlQueryEvaluator sparqlQueryEvaluator;
+
+	@Autowired
 	public QueryResponder(Repository repository) {
 		this.repository = repository;
 	}
@@ -68,7 +49,13 @@ public class QueryResponder {
 			@RequestParam(value = "named-graph-uri", required = false) String namedGraphUri,
 			@RequestParam(value = "query") String query, @RequestHeader(ACCEPT) String acceptHeader,
 			HttpServletRequest request, HttpServletResponse response) throws IOException {
-		doSparql(request, query, acceptHeader, defaultGraphUri, namedGraphUri, response);
+		try {
+			EvaluateResultHttpResponse result = new EvaluateResultHttpResponse(response);
+			sparqlQueryEvaluator.evaluate(result, repository, query, acceptHeader, defaultGraphUri,
+					toArray(namedGraphUri));
+		} catch (MalformedQueryException | IllegalStateException | IOException e) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+		}
 	}
 
 	@RequestMapping(value = "/sparql", method = RequestMethod.GET)
@@ -76,158 +63,21 @@ public class QueryResponder {
 			@RequestParam(value = "named-graph-uri", required = false) String namedGraphUri,
 			@RequestParam(value = "query") String query, @RequestHeader(ACCEPT) String acceptHeader,
 			HttpServletRequest request, HttpServletResponse response) throws IOException {
-		doSparql(request, query, acceptHeader, defaultGraphUri, namedGraphUri, response);
-	}
 
-	private void doSparql(HttpServletRequest request, String query, String acceptHeader, String defaultGraphUri,
-			String namedGraphUri, HttpServletResponse response) throws IOException {
-
-		try (RepositoryConnection connection = repository.getConnection()) {
-			Query preparedQuery = connection.prepareQuery(QueryLanguage.SPARQL, query);
-			setQueryDataSet(preparedQuery, defaultGraphUri, namedGraphUri, connection);
-			for (QueryTypes qt : QueryTypes.values()) {
-				if (qt.accepts(preparedQuery, acceptHeader)) {
-					qt.evaluate(preparedQuery, acceptHeader, response, defaultGraphUri, namedGraphUri);
-				}
-			}
-		} catch (MalformedQueryException | MismatchingAcceptHeaderException mqe) {
-			response.sendError(HttpServletResponse.SC_BAD_REQUEST);
-		} catch (IllegalArgumentException e) {
-			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Bad IRI for default or namedGraphIri");
+		try {
+			EvaluateResultHttpResponse result = new EvaluateResultHttpResponse(response);
+			sparqlQueryEvaluator.evaluate(result, repository, query, acceptHeader, defaultGraphUri,
+					toArray(namedGraphUri));
+		} catch (MalformedQueryException | IllegalStateException | IOException e) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
 		}
 	}
 
-	/**
-	 * @see <a href="https://www.w3.org/TR/sparql11-protocol/#dataset">protocol dataset</a>
-	 * @param q               the query
-	 * @param defaultGraphUri
-	 * @param namedGraphUri
-	 * @param connection
-	 */
-	private void setQueryDataSet(Query q, String defaultGraphUri, String namedGraphUri,
-			RepositoryConnection connection) {
-		if (defaultGraphUri != null || namedGraphUri != null) {
-			SimpleDataset dataset = new SimpleDataset();
-
-			if (defaultGraphUri != null) {
-				IRI defaultIri = connection.getValueFactory().createIRI(defaultGraphUri);
-				dataset.addDefaultGraph(defaultIri);
-			}
-
-			if (namedGraphUri != null) {
-				IRI namedIri = connection.getValueFactory().createIRI(namedGraphUri);
-				dataset.addNamedGraph(namedIri);
-			}
-			q.setDataset(dataset);
+	private String[] toArray(String namedGraphUri) {
+		String[] namedGraphUris = new String[] {};
+		if (namedGraphUri != null) {
+			namedGraphUris = new String[] { namedGraphUri };
 		}
-	}
-
-	private enum QueryTypes {
-		CONSTRUCT_OR_DESCRIBE(q -> q instanceof GraphQuery, RDFFormat.TURTLE, RDFFormat.NTRIPLES, RDFFormat.JSONLD,
-				RDFFormat.RDFXML) {
-			@Override
-			protected void evaluate(Query q, String acceptHeader, HttpServletResponse response, String defaultGraphUri,
-					String namedGraphUri)
-					throws QueryEvaluationException, RDFHandlerException, UnsupportedRDFormatException, IOException {
-				GraphQuery gq = (GraphQuery) q;
-				RDFFormat format = (RDFFormat) bestFormat(acceptHeader);
-				response.setContentType(format.getDefaultMIMEType());
-				gq.evaluate(Rio.createWriter(format, response.getOutputStream()));
-			}
-		},
-		SELECT(q -> q instanceof TupleQuery, TupleQueryResultFormat.JSON, TupleQueryResultFormat.SPARQL,
-				TupleQueryResultFormat.CSV, TupleQueryResultFormat.TSV) {
-			@Override
-			protected void evaluate(Query q, String acceptHeader, HttpServletResponse response, String defaultGraphUri,
-					String namedGraphUri)
-					throws QueryEvaluationException, RDFHandlerException, UnsupportedRDFormatException, IOException {
-				TupleQuery tq = (TupleQuery) q;
-				QueryResultFormat format = (QueryResultFormat) bestFormat(acceptHeader);
-				response.setContentType(format.getDefaultMIMEType());
-				tq.evaluate(QueryResultIO.createTupleWriter(format, response.getOutputStream()));
-			}
-		},
-
-		ASK(q -> q instanceof BooleanQuery, BooleanQueryResultFormat.TEXT, BooleanQueryResultFormat.JSON,
-				BooleanQueryResultFormat.SPARQL) {
-			@Override
-			protected void evaluate(Query q, String acceptHeader, HttpServletResponse response, String defaultGraphUri,
-					String namedGraphUri)
-					throws QueryEvaluationException, RDFHandlerException, UnsupportedRDFormatException, IOException {
-				BooleanQuery bq = (BooleanQuery) q;
-				QueryResultFormat format = (QueryResultFormat) bestFormat(acceptHeader);
-				response.setContentType(format.getDefaultMIMEType());
-				final Optional<BooleanQueryResultWriterFactory> optional = BooleanQueryResultWriterRegistry
-						.getInstance()
-						.get(format);
-				if (optional.isPresent()) {
-
-					BooleanQueryResultWriter writer = optional.get().getWriter(response.getOutputStream());
-					writer.handleBoolean(bq.evaluate());
-				}
-
-			}
-		};
-
-		private final FileFormat[] formats;
-		private final Predicate<Query> typeChecker;
-
-		QueryTypes(Predicate<Query> typeChecker, FileFormat... formats) {
-			this.typeChecker = typeChecker;
-			this.formats = formats;
-		}
-
-		/**
-		 * Test if the query is of a type that can be answered. And that the accept headers allow for the response to be
-		 * send.
-		 *
-		 * @param preparedQuery
-		 * @param acceptHeader
-		 * @return true if the query is of the right type and acceptHeaders are acceptable.
-		 * @throws MismatchingAcceptHeaderException
-		 */
-		protected boolean accepts(Query preparedQuery, String acceptHeader) throws MismatchingAcceptHeaderException {
-			if (accepts(preparedQuery)) {
-				if (acceptHeader == null || acceptHeader.isEmpty()) {
-					return true;
-				} else {
-					for (FileFormat format : formats) {
-						for (String mimeType : format.getMIMETypes()) {
-							if (acceptHeader.contains(mimeType))
-								return true;
-						}
-					}
-				}
-				throw new MismatchingAcceptHeaderException();
-			}
-			return false;
-		}
-
-		protected abstract void evaluate(Query q, String acceptHeader, HttpServletResponse response,
-				String defaultGraphUri, String namedGraphUri)
-				throws QueryEvaluationException, RDFHandlerException, UnsupportedRDFormatException, IOException;
-
-		protected boolean accepts(Query q) {
-			return typeChecker.test(q);
-		};
-
-		protected FileFormat bestFormat(String acceptHeader) {
-			if (acceptHeader == null || acceptHeader.isEmpty()) {
-				return formats[0];
-			} else {
-				for (FileFormat format : formats) {
-					for (String mimeType : format.getMIMETypes()) {
-						if (acceptHeader.contains(mimeType))
-							return format;
-					}
-				}
-			}
-			return formats[0];
-		}
-	}
-
-	private static class MismatchingAcceptHeaderException extends Exception {
-		private static final long serialVersionUID = 1L;
-
+		return namedGraphUris;
 	}
 }

--- a/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/EvaluateResult.java
+++ b/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/EvaluateResult.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.readonly.sparql;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * In/Out Parameter for {@link SparqlQueryEvaluator} to make it independend from things like the serlvet api.
+ */
+public interface EvaluateResult {
+	void setContentType(String contentType);
+
+	OutputStream getOutputstream() throws IOException;
+}

--- a/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/EvaluateResult.java
+++ b/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/EvaluateResult.java
@@ -16,5 +16,7 @@ import java.io.OutputStream;
 public interface EvaluateResult {
 	void setContentType(String contentType);
 
+	String getContentType();
+
 	OutputStream getOutputstream() throws IOException;
 }

--- a/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/QueryTypes.java
+++ b/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/QueryTypes.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.readonly.sparql;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.eclipse.rdf4j.common.lang.FileFormat;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.Query;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriter;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriterFactory;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriterRegistry;
+import org.eclipse.rdf4j.query.resultio.QueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultIO;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
+
+enum QueryTypes {
+	CONSTRUCT_OR_DESCRIBE(q -> q instanceof GraphQuery, RDFFormat.TURTLE, RDFFormat.NTRIPLES, RDFFormat.JSONLD,
+			RDFFormat.RDFXML) {
+		@Override
+		protected void evaluate(EvaluateResult result, Query q, String acceptHeader)
+				throws QueryEvaluationException, RDFHandlerException, UnsupportedRDFormatException, IOException {
+			GraphQuery gq = (GraphQuery) q;
+			RDFFormat format = (RDFFormat) bestFormat(acceptHeader);
+			result.setContentType(format.getDefaultMIMEType());
+			gq.evaluate(Rio.createWriter(format, result.getOutputstream()));
+		}
+	},
+	SELECT(q -> q instanceof TupleQuery, TupleQueryResultFormat.JSON, TupleQueryResultFormat.SPARQL,
+			TupleQueryResultFormat.CSV, TupleQueryResultFormat.TSV) {
+		@Override
+		protected void evaluate(EvaluateResult result, Query q, String acceptHeader)
+				throws QueryEvaluationException, RDFHandlerException, UnsupportedRDFormatException, IOException {
+			TupleQuery tq = (TupleQuery) q;
+			QueryResultFormat format = (QueryResultFormat) bestFormat(acceptHeader);
+			result.setContentType(format.getDefaultMIMEType());
+			tq.evaluate(QueryResultIO.createTupleWriter(format, result.getOutputstream()));
+		}
+	},
+
+	ASK(q -> q instanceof BooleanQuery, BooleanQueryResultFormat.TEXT, BooleanQueryResultFormat.JSON,
+			BooleanQueryResultFormat.SPARQL) {
+		@Override
+		protected void evaluate(EvaluateResult result, Query q, String acceptHeader)
+				throws QueryEvaluationException, RDFHandlerException, UnsupportedRDFormatException, IOException {
+			BooleanQuery bq = (BooleanQuery) q;
+			QueryResultFormat format = (QueryResultFormat) bestFormat(acceptHeader);
+			result.setContentType(format.getDefaultMIMEType());
+			final Optional<BooleanQueryResultWriterFactory> optional = BooleanQueryResultWriterRegistry
+					.getInstance()
+					.get(format);
+			if (optional.isPresent()) {
+				BooleanQueryResultWriter writer = optional.get().getWriter(result.getOutputstream());
+				writer.handleBoolean(bq.evaluate());
+			}
+		}
+	};
+
+	private final FileFormat[] formats;
+	private final Predicate<Query> typeChecker;
+
+	QueryTypes(Predicate<Query> typeChecker, FileFormat... formats) {
+		this.typeChecker = typeChecker;
+		this.formats = formats;
+	}
+
+	/**
+	 * Test if the query is of a type that can be answered. And that the accept headers allow for the response to be
+	 * send.
+	 *
+	 * @param preparedQuery
+	 * @param acceptHeader
+	 * @return true if the query is of the right type and acceptHeaders are acceptable.
+	 * @throws IllegalStateException if no acceptHeader is present
+	 */
+	public boolean accepts(Query preparedQuery, String acceptHeader) throws IllegalStateException {
+		if (accepts(preparedQuery)) {
+			if (acceptHeader == null || acceptHeader.isEmpty()) {
+				return true;
+			} else {
+				for (FileFormat format : formats) {
+					for (String mimeType : format.getMIMETypes()) {
+						if (acceptHeader.contains(mimeType))
+							return true;
+					}
+				}
+			}
+			throw new IllegalStateException("acceptHeader is mandatory.");
+		}
+		return false;
+	}
+
+	protected abstract void evaluate(EvaluateResult result, Query q, String acceptHeader)
+			throws QueryEvaluationException, RDFHandlerException, UnsupportedRDFormatException, IOException;
+
+	protected boolean accepts(Query q) {
+		return typeChecker.test(q);
+	};
+
+	protected FileFormat bestFormat(String acceptHeader) {
+		if (acceptHeader == null || acceptHeader.isEmpty()) {
+			return formats[0];
+		} else {
+			for (FileFormat format : formats) {
+				for (String mimeType : format.getMIMETypes()) {
+					if (acceptHeader.contains(mimeType))
+						return format;
+				}
+			}
+		}
+		return formats[0];
+	}
+}

--- a/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/SparqlQueryEvaluator.java
+++ b/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/SparqlQueryEvaluator.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.readonly.sparql;
+
+import java.io.IOException;
+
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.repository.Repository;
+
+public interface SparqlQueryEvaluator {
+	/**
+	 * Evaluates/Execute the passed query against the passed repository usimg the passed arguments.
+	 * 
+	 * @param result          in/out parameter for returning the contentType and the result stream.
+	 * @param repository      the repository against which the query is to be executed
+	 * @param query           The query to be evaluated
+	 * @param acceptHeader    needed to find the best response format.
+	 * @param defaultGraphUri see {@link Dataset#getDefaultGraphs()}
+	 * @param namedGraphUris  see {@link Dataset#getNamedGraphs()}
+	 * @throws MalformedQueryException If the supplied query is malformed.
+	 * @throws IOException             if there is a problem with the {@link EvaluateResult#getOutputstream()}
+	 * @throws IllegalStateException   if no acceptHeader is present
+	 */
+	void evaluate(EvaluateResult result, Repository repository, String query, String acceptHeader,
+			String defaultGraphUri,
+			String[] namedGraphUris) throws MalformedQueryException, IllegalStateException, IOException;
+}

--- a/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/SparqlQueryEvaluatorDefault.java
+++ b/spring-components/spring-boot-sparql-web/src/main/java/org/eclipse/rdf4j/http/server/readonly/sparql/SparqlQueryEvaluatorDefault.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.readonly.sparql;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.Query;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.impl.SimpleDataset;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.springframework.stereotype.Component;
+
+@Component
+class SparqlQueryEvaluatorDefault implements SparqlQueryEvaluator {
+
+	@Override
+	public void evaluate(EvaluateResult result, Repository repository, String query,
+			String acceptHeader, String defaultGraphUri, String[] namedGraphUris)
+			throws MalformedQueryException, IOException, IllegalStateException {
+		try (RepositoryConnection connection = repository.getConnection()) {
+			Query preparedQuery = connection.prepareQuery(QueryLanguage.SPARQL, query);
+			preparedQuery.setDataset(getQueryDataSet(defaultGraphUri, namedGraphUris, connection));
+			for (QueryTypes qt : QueryTypes.values()) {
+				if (qt.accepts(preparedQuery, acceptHeader)) {
+					qt.evaluate(result, preparedQuery, acceptHeader);
+				}
+			}
+		}
+	}
+
+	/**
+	 * @see <a href="https://www.w3.org/TR/sparql11-protocol/#dataset">protocol dataset</a>
+	 * @param q               the query
+	 * @param defaultGraphUri
+	 * @param namedGraphUris
+	 * @param connection
+	 */
+	private Dataset getQueryDataSet(String defaultGraphUri, String[] namedGraphUris, RepositoryConnection connection) {
+		SimpleDataset dataset = new SimpleDataset();
+
+		if (defaultGraphUri != null) {
+			IRI defaultIri = connection.getValueFactory().createIRI(defaultGraphUri);
+			dataset.addDefaultGraph(defaultIri);
+		}
+
+		Arrays.stream(namedGraphUris).forEach(namedGraphUri -> {
+			IRI namedIri = connection.getValueFactory().createIRI(namedGraphUri);
+			dataset.addNamedGraph(namedIri);
+		});
+		return dataset;
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #4004

Briefly describe the changes proposed in this PR:

Providing a SparqlQueryEvaluator that can be used independently of the servlet api and can therefore also be used in other contexts such as apache-camel, etc. Seperation of Concerns.

----

PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made. 
   - [x] Just refactoring, no new functionality, so the test stays the same!
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

