### PR TITLE
GH-3843 remove method from sail interface

### DIFF
--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/Sail.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/Sail.java
@@ -96,13 +96,4 @@ public interface Sail {
 	 */
 	IsolationLevel getDefaultIsolationLevel();
 
-	/**
-	 * Gets a Collection factory that may return optimised collections that may spill to disk.
-	 * 
-	 * @return a CollectionFactory
-	 */
-	default CollectionFactory getCollectionFactory() {
-		return new DefaultCollectionFactory();
-	}
-
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailWrapper.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/SailWrapper.java
@@ -133,9 +133,4 @@ public class SailWrapper implements StackableSail, FederatedServiceResolverClien
 		return baseSail.getDefaultIsolationLevel();
 	}
 
-	@Override
-	public CollectionFactory getCollectionFactory() {
-		verifyBaseSailSet();
-		return baseSail.getCollectionFactory();
-	}
 }

--- a/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/ExtensibleStore.java
+++ b/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/ExtensibleStore.java
@@ -158,8 +158,7 @@ public abstract class ExtensibleStore<T extends DataStructureInterface, N extend
 		return ExtensibleStatementHelper.getDefaultImpl();
 	}
 
-	@Override
-	public CollectionFactory getCollectionFactory() {
+	CollectionFactory getCollectionFactory() {
 		return new MapDbCollectionFactory(getIterationCacheSyncThreshold());
 	}
 }

--- a/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/ExtensibleStoreConnection.java
+++ b/core/sail/extensible-store/src/main/java/org/eclipse/rdf4j/sail/extensiblestore/ExtensibleStoreConnection.java
@@ -11,6 +11,9 @@ import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.base.SailSourceConnection;
 import org.eclipse.rdf4j.sail.helpers.DefaultSailChangedEvent;
@@ -97,4 +100,10 @@ public class ExtensibleStoreConnection<E extends ExtensibleStore> extends SailSo
 		sailChangedEvent.setStatementsRemoved(true);
 	}
 
+	@Override
+	protected EvaluationStrategy getEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
+		EvaluationStrategy evaluationStrategy = super.getEvaluationStrategy(dataset, tripleSource);
+		evaluationStrategy.setCollectionFactory(sail.getCollectionFactory());
+		return evaluationStrategy;
+	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
@@ -392,8 +392,7 @@ public class LmdbStore extends AbstractNotifyingSail implements FederatedService
 		return true;
 	}
 
-	@Override
-	public CollectionFactory getCollectionFactory() {
+	CollectionFactory getCollectionFactory() {
 		return new LmdbCollectionFactory((ValueStore) getBackingStore().getValueFactory(),
 				getIterationCacheSyncThreshold());
 	}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStore.java
@@ -494,8 +494,7 @@ public class NativeStore extends AbstractNotifyingSail implements FederatedServi
 		}
 	}
 
-	@Override
-	public CollectionFactory getCollectionFactory() {
+	CollectionFactory getCollectionFactory() {
 		return new MapDbCollectionFactory(getIterationCacheSyncThreshold());
 	}
 }

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnection.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnection.java
@@ -14,6 +14,9 @@ import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
 import org.eclipse.rdf4j.sail.base.SailSourceConnection;
@@ -158,4 +161,10 @@ public class NativeStoreConnection extends SailSourceConnection implements Threa
 		return getTransactionIsolation() != null && getTransactionIsolation() != IsolationLevels.SERIALIZABLE;
 	}
 
+	@Override
+	protected EvaluationStrategy getEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
+		EvaluationStrategy evaluationStrategy = super.getEvaluationStrategy(dataset, tripleSource);
+		evaluationStrategy.setCollectionFactory(nativeStore.getCollectionFactory());
+		return evaluationStrategy;
+	}
 }


### PR DESCRIPTION
@JervenBolleman would your approach still work if we just removed the new method from the Sail interface like I've done here?

No need to merge this PR. I can commit this directly onto [GH-3843-collection-factory](https://github.com/eclipse/rdf4j/tree/GH-3843-collection-factory).