### PR TITLE
GH-4028 ShaclSail Performance

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/NodeShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/NodeShape.java
@@ -206,11 +206,14 @@ public class NodeShape extends Shape {
 				.reduce(UnionNode::getInstanceDedupe)
 				.orElse(EmptyNode.getInstance());
 
-		planNode = UnionNode.getInstanceDedupe(planNode,
-				getTargetChain()
-						.getEffectiveTarget(Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner(),
-								stableRandomVariableProvider)
-						.getPlanNode(connectionsGroup, dataGraph, Scope.nodeShape, true, null));
+		if (connectionsGroup.getStats().hasRemoved()) {
+			PlanNode planNodeEffectiveTarget = getTargetChain()
+					.getEffectiveTarget(Scope.nodeShape, connectionsGroup.getRdfsSubClassOfReasoner(),
+							stableRandomVariableProvider)
+					.getPlanNode(connectionsGroup, dataGraph, Scope.nodeShape, true, null);
+
+			planNode = UnionNode.getInstanceDedupe(planNode, planNodeEffectiveTarget);
+		}
 
 		if (scope == Scope.propertyShape) {
 			planNode = Unique.getInstance(new ShiftToPropertyShape(planNode), true);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
@@ -241,11 +241,14 @@ public class PropertyShape extends Shape {
 				.reduce(UnionNode::getInstanceDedupe)
 				.orElse(EmptyNode.getInstance());
 
-		planNode = UnionNode.getInstanceDedupe(planNode,
-				getTargetChain()
-						.getEffectiveTarget(Scope.propertyShape,
-								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider)
-						.getPlanNode(connectionsGroup, dataGraph, Scope.propertyShape, true, null));
+		if (connectionsGroup.getStats().hasRemoved()) {
+			PlanNode planNodeEffectiveTarget = getTargetChain()
+					.getEffectiveTarget(Scope.propertyShape, connectionsGroup.getRdfsSubClassOfReasoner(),
+							stableRandomVariableProvider)
+					.getPlanNode(connectionsGroup, dataGraph, Scope.propertyShape, true, null);
+
+			planNode = UnionNode.getInstanceDedupe(planNode, planNodeEffectiveTarget);
+		}
 
 		if (scope == Scope.propertyShape) {
 			planNode = Unique.getInstance(new TargetChainPopper(planNode), true);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
@@ -130,11 +130,20 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 							validationSettings.getDataGraph())
 			);
 
+			PlanNode falseNode = joined;
+			if (connectionsGroup.getAddedStatements() != null) {
+				// filter by type against the added statements
+				falseNode = new ExternalPredicateObjectFilter(
+						connectionsGroup.getAddedStatements(),
+						validationSettings.getDataGraph(), RDF.TYPE, Collections.singleton(clazz),
+						falseNode, false, ExternalPredicateObjectFilter.FilterOn.value);
+			}
+
 			// filter by type against the base sail
-			PlanNode falseNode = new ExternalPredicateObjectFilter(
+			falseNode = new ExternalPredicateObjectFilter(
 					connectionsGroup.getBaseConnection(),
 					validationSettings.getDataGraph(), RDF.TYPE, Collections.singleton(clazz),
-					joined, false, ExternalPredicateObjectFilter.FilterOn.value);
+					falseNode, false, ExternalPredicateObjectFilter.FilterOn.value);
 
 			return falseNode;
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/ClassConstraintComponent.java
@@ -33,7 +33,6 @@ import org.eclipse.rdf4j.sail.shacl.ast.planNodes.TrimToTarget;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.UnionNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.Unique;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.UnorderedSelect;
-import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ValidationTuple;
 import org.eclipse.rdf4j.sail.shacl.ast.targets.EffectiveTarget;
 import org.eclipse.rdf4j.sail.shacl.wrapper.data.ConnectionsGroup;
 import org.eclipse.rdf4j.sail.shacl.wrapper.data.RdfsSubClassOfReasoner;
@@ -126,8 +125,7 @@ public class ClassConstraintComponent extends AbstractConstraintComponent {
 							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 					false,
 					null,
-					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
-							validationSettings.getDataGraph())
+					BulkedExternalInnerJoin.getMapper("a", "c", scope, validationSettings.getDataGraph())
 			);
 
 			PlanNode falseNode = joined;

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
@@ -117,8 +117,6 @@ public class DashHasValueInConstraintComponent extends AbstractConstraintCompone
 					validationSettings.getDataGraph(),
 					path.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
 							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-					false,
-					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 							validationSettings.getDataGraph())
 			);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/HasValueConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/HasValueConstraintComponent.java
@@ -108,8 +108,6 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 					validationSettings.getDataGraph(),
 					path.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
 							connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-					false,
-					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 							validationSettings.getDataGraph())
 			);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MaxCountConstraintComponent.java
@@ -109,8 +109,7 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 					false,
 					null,
-					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
-							validationSettings.getDataGraph())
+					BulkedExternalInnerJoin.getMapper("a", "c", scope, validationSettings.getDataGraph())
 			);
 		} else {
 			relevantTargetsWithPath = new BulkedExternalLeftOuterJoin(
@@ -121,8 +120,6 @@ public class MaxCountConstraintComponent extends AbstractConstraintComponent {
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 									new StatementMatcher.Variable("c"),
 									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-					false,
-					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 							validationSettings.getDataGraph())
 			);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
@@ -66,10 +66,7 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 
 		StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider = new StatementMatcher.StableRandomVariableProvider();
 
-		PlanNode target = getTargetChain()
-				.getEffectiveTarget(scope, connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider)
-				.getPlanNode(connectionsGroup, validationSettings.getDataGraph(), scope, true, null);
-
+		PlanNode target;
 		if (overrideTargetNode != null) {
 			target = getTargetChain()
 					.getEffectiveTarget(scope, connectionsGroup.getRdfsSubClassOfReasoner(),
@@ -80,6 +77,11 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 		} else {
 			// we can assume that we are not doing bulk validation, so it is worth checking our added statements before
 			// we go to the base sail
+
+			target = getTargetChain()
+					.getEffectiveTarget(scope, connectionsGroup.getRdfsSubClassOfReasoner(),
+							stableRandomVariableProvider)
+					.getPlanNode(connectionsGroup, validationSettings.getDataGraph(), scope, true, null);
 
 			PlanNode addedByPath = getTargetChain().getPath()
 					.get()

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/MinCountConstraintComponent.java
@@ -97,8 +97,6 @@ public class MinCountConstraintComponent extends AbstractConstraintComponent {
 						.get()
 						.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
 								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-				false,
-				null,
 				(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 						validationSettings.getDataGraph())
 		);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/OrConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/OrConstraintComponent.java
@@ -117,7 +117,8 @@ public class OrConstraintComponent extends LogicalOperatorConstraintComponent {
 		} else {
 			planNodeProvider = new BufferedSplitter(
 					getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
-							stableRandomVariableProvider));
+							stableRandomVariableProvider),
+					false);
 		}
 
 		PlanNode orPlanNodes = or.stream()

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
@@ -149,10 +149,12 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 
 		PlanNodeProvider planNodeProvider = () -> {
 
-			PlanNode target = getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
-					stableRandomVariableProvider);
+			PlanNode target;
 
-			if (overrideTargetNode != null) {
+			if (overrideTargetNode == null) {
+				target = getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
+						stableRandomVariableProvider);
+			} else {
 				target = getTargetChain()
 						.getEffectiveTarget(scope, connectionsGroup.getRdfsSubClassOfReasoner(),
 								stableRandomVariableProvider)
@@ -193,10 +195,12 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 
 		PlanNode invalid = Unique.getInstance(planNode, false);
 
-		PlanNode allTargetsPlan = getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
-				stableRandomVariableProvider);
+		PlanNode allTargetsPlan;
 
-		if (overrideTargetNode != null) {
+		if (overrideTargetNode == null) {
+			allTargetsPlan = getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
+					stableRandomVariableProvider);
+		} else {
 			allTargetsPlan = getTargetChain()
 					.getEffectiveTarget(scope, connectionsGroup.getRdfsSubClassOfReasoner(),
 							stableRandomVariableProvider)

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMaxCountConstraintComponent.java
@@ -173,8 +173,6 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 									new StatementMatcher.Variable("c"),
 									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-					false,
-					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 							validationSettings.getDataGraph())
 			);
@@ -218,8 +216,6 @@ public class QualifiedMaxCountConstraintComponent extends AbstractConstraintComp
 						.get()
 						.getTargetQueryFragment(new StatementMatcher.Variable("a"), new StatementMatcher.Variable("c"),
 								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-				false,
-				null,
 				(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 						validationSettings.getDataGraph())
 		);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMinCountConstraintComponent.java
@@ -180,8 +180,6 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 									new StatementMatcher.Variable("c"),
 									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-					false,
-					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 							validationSettings.getDataGraph())
 			);
@@ -230,8 +228,6 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
 									new StatementMatcher.Variable("c"),
 									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-					false,
-					null,
 					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 							validationSettings.getDataGraph())
 			);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMinCountConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/QualifiedMinCountConstraintComponent.java
@@ -152,10 +152,12 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 
 		PlanNodeProvider planNodeProvider = () -> {
 
-			PlanNode target = getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
-					stableRandomVariableProvider);
+			PlanNode target;
 
-			if (overrideTargetNode != null) {
+			if (overrideTargetNode == null) {
+				target = getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
+						stableRandomVariableProvider);
+			} else {
 				PlanNode planNode = overrideTargetNode.getPlanNode();
 				if (planNode instanceof AllTargetsPlanNode) {
 					return planNode;
@@ -200,10 +202,11 @@ public class QualifiedMinCountConstraintComponent extends AbstractConstraintComp
 
 		PlanNode invalid = Unique.getInstance(planNode, false);
 
-		PlanNode allTargetsPlan = getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
-				stableRandomVariableProvider);
-
-		if (overrideTargetNode != null) {
+		PlanNode allTargetsPlan;
+		if (overrideTargetNode == null) {
+			allTargetsPlan = getAllTargetsPlan(connectionsGroup, validationSettings.getDataGraph(), scope,
+					stableRandomVariableProvider);
+		} else {
 			allTargetsPlan = getTargetChain()
 					.getEffectiveTarget(scope, connectionsGroup.getRdfsSubClassOfReasoner(),
 							stableRandomVariableProvider)

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/SimpleAbstractConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/SimpleAbstractConstraintComponent.java
@@ -113,7 +113,6 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 				PlanNode overrideTargetPlanNode = overrideTargetNode.getPlanNode();
 
 				if (overrideTargetPlanNode instanceof AllTargetsPlanNode) {
-
 					// We are cheating a bit here by retrieving all the targets and values at the same time by
 					// pretending to be in node shape scope and then shifting the results back to property shape scope
 					PlanNode allTargets = targetChain
@@ -139,8 +138,8 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 											new StatementMatcher.Variable("c"),
 											connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 							false, null,
-							(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
-									validationSettings.getDataGraph()));
+							BulkedExternalInnerJoin.getMapper("a", "c", scope, validationSettings.getDataGraph())
+					);
 				}
 			}
 
@@ -183,11 +182,12 @@ public abstract class SimpleAbstractConstraintComponent extends AbstractConstrai
 					effectiveTarget.getPlanNode(connectionsGroup, validationSettings.getDataGraph(), scope, false,
 							null),
 					connectionsGroup.getBaseConnection(),
-					validationSettings.getDataGraph(), path.get()
+					validationSettings.getDataGraph(),
+					path.get()
 							.getTargetQueryFragment(new StatementMatcher.Variable("a"),
-									new StatementMatcher.Variable("c"),
-									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
-					true,
+									new StatementMatcher.Variable("c"), connectionsGroup.getRdfsSubClassOfReasoner(),
+									stableRandomVariableProvider),
+					connectionsGroup.hasPreviousStateConnection(),
 					connectionsGroup.getPreviousStateConnection(),
 					b -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
 							validationSettings.getDataGraph()));

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/UniqueLangConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/UniqueLangConstraintComponent.java
@@ -34,7 +34,6 @@ import org.eclipse.rdf4j.sail.shacl.ast.planNodes.TrimToTarget;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.UnBufferedPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.UnionNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.Unique;
-import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ValidationTuple;
 import org.eclipse.rdf4j.sail.shacl.ast.targets.EffectiveTarget;
 import org.eclipse.rdf4j.sail.shacl.wrapper.data.ConnectionsGroup;
 
@@ -133,8 +132,8 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 									connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 					false,
 					null,
-					(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
-							validationSettings.getDataGraph())
+					BulkedExternalInnerJoin.getMapper("a", "c", scope, validationSettings.getDataGraph())
+
 			);
 
 			PlanNode nonUniqueTargetLang = new NonUniqueTargetLang(relevantTargetsWithPath);
@@ -179,8 +178,8 @@ public class UniqueLangConstraintComponent extends AbstractConstraintComponent {
 								connectionsGroup.getRdfsSubClassOfReasoner(), stableRandomVariableProvider),
 				false,
 				null,
-				(b) -> new ValidationTuple(b.getValue("a"), b.getValue("c"), scope, true,
-						validationSettings.getDataGraph())
+				BulkedExternalInnerJoin.getMapper("a", "c", scope, validationSettings.getDataGraph())
+
 		);
 
 		PlanNode nonUniqueTargetLang = new NonUniqueTargetLang(relevantTargetsWithPath);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AbstractBulkJoinPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/AbstractBulkJoinPlanNode.java
@@ -46,8 +46,7 @@ public abstract class AbstractBulkJoinPlanNode implements PlanNode {
 
 	void runQuery(ArrayDeque<ValidationTuple> left, ArrayDeque<ValidationTuple> right, SailConnection connection,
 			ParsedQuery parsedQuery, Dataset dataset, Resource[] dataGraph, boolean skipBasedOnPreviousConnection,
-			SailConnection previousStateConnection,
-			Function<BindingSet, ValidationTuple> mapper) {
+			SailConnection previousStateConnection, Function<BindingSet, ValidationTuple> mapper) {
 		List<BindingSet> newBindindingset = buildBindingSets(left, connection, skipBasedOnPreviousConnection,
 				previousStateConnection, dataGraph);
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BindSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BindSelect.java
@@ -73,6 +73,7 @@ public class BindSelect implements PlanNode {
 			List<String> varNames, ConstraintComponent.Scope scope, int bulkSize, EffectiveTarget.Extend direction,
 			boolean includePropertyShapeValues) {
 		this.connection = connection;
+		assert this.connection != null;
 		this.mapper = (bindingSet) -> new ValidationTuple(bindingSet, varNames, scope, includePropertyShapeValues,
 				dataGraph);
 		this.varNames = varNames;
@@ -367,7 +368,7 @@ public class BindSelect implements PlanNode {
 		} else {
 			return bulkSize == that.bulkSize &&
 					includePropertyShapeValues == that.includePropertyShapeValues &&
-					connection.equals(that.connection) &&
+					Objects.equals(connection, that.connection) &&
 					varNames.equals(that.varNames) &&
 					scope.equals(that.scope) &&
 					query.equals(that.query) &&

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BufferedSplitter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BufferedSplitter.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -29,13 +30,28 @@ import org.slf4j.LoggerFactory;
  */
 public class BufferedSplitter implements PlanNodeProvider {
 
+	private static final AtomicLong idCounter = new AtomicLong();
+
 	private final Logger logger = LoggerFactory.getLogger(getClass());
 
-	PlanNode parent;
+	private final PlanNode parent;
+	private final boolean cached;
 	private volatile List<ValidationTuple> tuplesBuffer;
+	private long id = -1;
 
-	public BufferedSplitter(PlanNode planNode) {
-		parent = planNode;
+	public BufferedSplitter(PlanNode parent, boolean cached) {
+		this.parent = parent;
+		this.cached = cached;
+	}
+
+	public BufferedSplitter(PlanNode parent, boolean cached, boolean createId) {
+		this.parent = parent;
+		this.cached = cached;
+		id = idCounter.incrementAndGet();
+	}
+
+	public BufferedSplitter(PlanNode parent) {
+		this(parent, true);
 	}
 
 	private synchronized void init() {
@@ -51,9 +67,14 @@ public class BufferedSplitter implements PlanNodeProvider {
 
 	}
 
+	public String getId() {
+		int length = (idCounter.get() + "").length();
+		return String.format("%0" + length + "d", id);
+	}
+
 	@Override
 	public PlanNode getPlanNode() {
-		return new BufferedSplitterPlaneNode(this);
+		return new BufferedSplitterPlaneNode(this, cached);
 	}
 
 	@Override
@@ -73,14 +94,16 @@ public class BufferedSplitter implements PlanNodeProvider {
 		return Objects.hash(parent);
 	}
 
-	static class BufferedSplitterPlaneNode implements PlanNode {
+	public static class BufferedSplitterPlaneNode implements PlanNode {
 		private final BufferedSplitter bufferedSplitter;
+		public final boolean cached;
 		private boolean printed = false;
 
 		private ValidationExecutionLogger validationExecutionLogger;
 
-		public BufferedSplitterPlaneNode(BufferedSplitter bufferedSplitter) {
+		public BufferedSplitterPlaneNode(BufferedSplitter bufferedSplitter, boolean cached) {
 			this.bufferedSplitter = bufferedSplitter;
+			this.cached = cached;
 		}
 
 		@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalInnerJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalInnerJoin.java
@@ -56,6 +56,7 @@ public class BulkedExternalInnerJoin extends AbstractBulkJoinPlanNode {
 		this.query = StatementMatcher.StableRandomVariableProvider.normalize(query);
 
 		this.connection = connection;
+		assert this.connection != null;
 		this.skipBasedOnPreviousConnection = skipBasedOnPreviousConnection;
 		this.mapper = mapper;
 		this.previousStateConnection = previousStateConnection;
@@ -230,7 +231,8 @@ public class BulkedExternalInnerJoin extends AbstractBulkJoinPlanNode {
 			return false;
 		}
 		BulkedExternalInnerJoin that = (BulkedExternalInnerJoin) o;
-		return skipBasedOnPreviousConnection == that.skipBasedOnPreviousConnection && connection.equals(that.connection)
+		return skipBasedOnPreviousConnection == that.skipBasedOnPreviousConnection
+				&& Objects.equals(connection, that.connection)
 				&& leftNode.equals(that.leftNode)
 				&& Objects.equals(dataset, that.dataset)
 				&& Objects.equals(previousStateConnection, that.previousStateConnection) && query.equals(that.query);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalLeftOuterJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalLeftOuterJoin.java
@@ -49,6 +49,7 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 		this.leftNode = leftNode;
 		this.query = StatementMatcher.StableRandomVariableProvider.normalize(query);
 		this.connection = connection;
+		assert this.connection != null;
 		this.skipBasedOnPreviousConnection = skipBasedOnPreviousConnection;
 		this.previousStateConnection = previousStateConnection;
 		this.mapper = mapper;
@@ -213,7 +214,8 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 			return false;
 		}
 		BulkedExternalLeftOuterJoin that = (BulkedExternalLeftOuterJoin) o;
-		return skipBasedOnPreviousConnection == that.skipBasedOnPreviousConnection && connection.equals(that.connection)
+		return skipBasedOnPreviousConnection == that.skipBasedOnPreviousConnection
+				&& Objects.equals(connection, that.connection)
 				&& leftNode.equals(that.leftNode)
 				&& Objects.equals(dataset, that.dataset)
 				&& Objects.equals(previousStateConnection, that.previousStateConnection) && query.equals(that.query);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalLeftOuterJoin.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/BulkedExternalLeftOuterJoin.java
@@ -36,22 +36,17 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 	private final Dataset dataset;
 	private final Resource[] dataGraph;
 	private ParsedQuery parsedQuery;
-	private final boolean skipBasedOnPreviousConnection;
-	private final SailConnection previousStateConnection;
 	private final String query;
 	private boolean printed = false;
 
 	public BulkedExternalLeftOuterJoin(PlanNode leftNode, SailConnection connection, Resource[] dataGraph,
 			String query,
-			boolean skipBasedOnPreviousConnection, SailConnection previousStateConnection,
 			Function<BindingSet, ValidationTuple> mapper) {
 		leftNode = PlanNodeHelper.handleSorting(this, leftNode);
 		this.leftNode = leftNode;
 		this.query = StatementMatcher.StableRandomVariableProvider.normalize(query);
 		this.connection = connection;
 		assert this.connection != null;
-		this.skipBasedOnPreviousConnection = skipBasedOnPreviousConnection;
-		this.previousStateConnection = previousStateConnection;
 		this.mapper = mapper;
 		this.dataset = PlanNodeHelper.asDefaultGraphDataset(dataGraph);
 		this.dataGraph = dataGraph;
@@ -85,8 +80,7 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 					parsedQuery = parseQuery(query);
 				}
 
-				runQuery(left, right, connection, parsedQuery, dataset, dataGraph, skipBasedOnPreviousConnection,
-						previousStateConnection, mapper);
+				runQuery(left, right, connection, parsedQuery, dataset, dataGraph, false, null, mapper);
 
 			}
 
@@ -173,14 +167,6 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 					.append("\n");
 		}
 
-		if (skipBasedOnPreviousConnection) {
-			stringBuilder
-					.append(System.identityHashCode(previousStateConnection) + " -> " + getId()
-							+ " [label=\"skip if not present\"]")
-					.append("\n");
-
-		}
-
 		stringBuilder.append(leftNode.getId() + " -> " + getId() + " [label=\"left\"]").append("\n");
 
 	}
@@ -214,16 +200,14 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 			return false;
 		}
 		BulkedExternalLeftOuterJoin that = (BulkedExternalLeftOuterJoin) o;
-		return skipBasedOnPreviousConnection == that.skipBasedOnPreviousConnection
-				&& Objects.equals(connection, that.connection)
+		return Objects.equals(connection, that.connection)
 				&& leftNode.equals(that.leftNode)
 				&& Objects.equals(dataset, that.dataset)
-				&& Objects.equals(previousStateConnection, that.previousStateConnection) && query.equals(that.query);
+				&& query.equals(that.query);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.hashCode(), connection, dataset, leftNode, skipBasedOnPreviousConnection,
-				previousStateConnection, query);
+		return Objects.hash(super.hashCode(), connection, dataset, leftNode, query);
 	}
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByPredicate.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByPredicate.java
@@ -9,13 +9,17 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
@@ -50,13 +54,41 @@ public class ExternalFilterByPredicate implements PlanNode {
 
 	@Override
 	public CloseableIteration<? extends ValidationTuple, SailException> iterator() {
+
 		return new LoggingCloseableIteration(this, validationExecutionLogger) {
 
 			ValidationTuple next = null;
 
 			final CloseableIteration<? extends ValidationTuple, SailException> parentIterator = parent.iterator();
 
+			List<IRI> filterOnPredicates = null;
+
 			void calculateNext() {
+				if (filterOnPredicates == null) {
+					if (!parentIterator.hasNext()) {
+						return;
+					}
+
+					filterOnPredicates = ExternalFilterByPredicate.this.filterOnPredicates.stream()
+							.map(predicate -> {
+								try (var stream = connection
+										.getStatements(null, predicate, null, true, dataGraph)
+										.stream()) {
+									return stream.map(Statement::getPredicate)
+											.findAny()
+											.orElse(null);
+								}
+							}
+							)
+							.filter(Objects::nonNull)
+							.collect(Collectors.toList());
+
+				}
+
+				if (filterOnPredicates.isEmpty()) {
+					return;
+				}
+
 				while (next == null && parentIterator.hasNext()) {
 					ValidationTuple temp = parentIterator.next();
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByPredicate.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByPredicate.java
@@ -48,6 +48,7 @@ public class ExternalFilterByPredicate implements PlanNode {
 		this.dataGraph = dataGraph;
 		this.parent = PlanNodeHelper.handleSorting(this, parent);
 		this.connection = connection;
+		assert this.connection != null;
 		this.filterOnPredicates = filterOnPredicates;
 		this.on = on;
 	}
@@ -222,7 +223,7 @@ public class ExternalFilterByPredicate implements PlanNode {
 
 		}
 
-		return connection.equals(that.connection) && filterOnPredicates.equals(that.filterOnPredicates) &&
+		return Objects.equals(connection, that.connection) && filterOnPredicates.equals(that.filterOnPredicates) &&
 				Arrays.equals(dataGraph, that.dataGraph)
 				&& parent.equals(that.parent) && on == that.on;
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByQuery.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByQuery.java
@@ -49,6 +49,7 @@ public class ExternalFilterByQuery extends FilterPlanNode {
 			Function<ValidationTuple, Value> filterOn) {
 		super(parent);
 		this.connection = connection;
+		assert this.connection != null;
 		this.queryVariable = queryVariable;
 		this.filterOn = filterOn;
 
@@ -114,7 +115,7 @@ public class ExternalFilterByQuery extends FilterPlanNode {
 					&& queryString.equals(that.queryString);
 		}
 
-		return connection.equals(that.connection) && queryVariable.equals(that.queryVariable)
+		return Objects.equals(connection, that.connection) && queryVariable.equals(that.queryVariable)
 				&& Objects.equals(dataset, that.dataset)
 				&& filterOn.equals(that.filterOn) && queryString.equals(that.queryString);
 	}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterTargetIsObject.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterTargetIsObject.java
@@ -27,6 +27,7 @@ public class ExternalFilterTargetIsObject extends FilterPlanNode {
 	public ExternalFilterTargetIsObject(SailConnection connection, Resource[] dataGraph, PlanNode parent) {
 		super(parent);
 		this.connection = connection;
+		assert this.connection != null;
 		this.dataGraph = dataGraph;
 	}
 
@@ -60,7 +61,7 @@ public class ExternalFilterTargetIsObject extends FilterPlanNode {
 					.equals(((MemoryStoreConnection) that.connection).getSail())
 					&& Arrays.equals(dataGraph, that.dataGraph);
 		}
-		return connection.equals(that.connection) && Arrays.equals(dataGraph, that.dataGraph);
+		return Objects.equals(connection, that.connection) && Arrays.equals(dataGraph, that.dataGraph);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterTargetIsSubject.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterTargetIsSubject.java
@@ -27,6 +27,7 @@ public class ExternalFilterTargetIsSubject extends FilterPlanNode {
 	public ExternalFilterTargetIsSubject(SailConnection connection, Resource[] dataGraph, PlanNode parent) {
 		super(parent);
 		this.connection = connection;
+		assert this.connection != null;
 		this.dataGraph = dataGraph;
 	}
 
@@ -67,7 +68,7 @@ public class ExternalFilterTargetIsSubject extends FilterPlanNode {
 					.equals(((MemoryStoreConnection) that.connection).getSail())
 					&& Arrays.equals(dataGraph, that.dataGraph);
 		}
-		return connection.equals(that.connection) && Arrays.equals(dataGraph, that.dataGraph);
+		return Objects.equals(connection, that.connection) && Arrays.equals(dataGraph, that.dataGraph);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalPredicateObjectFilter.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalPredicateObjectFilter.java
@@ -47,6 +47,7 @@ public class ExternalPredicateObjectFilter implements PlanNode {
 		this.parent = PlanNodeHelper.handleSorting(this, parent);
 
 		this.connection = connection;
+		assert this.connection != null;
 		this.filterOnPredicate = filterOnPredicate;
 		this.filterOnObject = filterOnObject;
 		this.filterOn = filterOn;
@@ -260,7 +261,7 @@ public class ExternalPredicateObjectFilter implements PlanNode {
 					&& filterOn == that.filterOn && Arrays.equals(dataGraph, that.dataGraph)
 					&& parent.equals(that.parent);
 		} else {
-			return returnMatching == that.returnMatching && connection.equals(that.connection)
+			return returnMatching == that.returnMatching && Objects.equals(connection, that.connection)
 					&& filterOnObject.equals(that.filterOnObject) && filterOnPredicate.equals(that.filterOnPredicate)
 					&& filterOn == that.filterOn && Arrays.equals(dataGraph, that.dataGraph)
 					&& parent.equals(that.parent);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Select.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Select.java
@@ -50,6 +50,7 @@ public class Select implements PlanNode {
 	public Select(SailConnection connection, String queryFregment, String orderBy,
 			Function<BindingSet, ValidationTuple> mapper, Resource[] dataGraph) {
 		this.connection = connection;
+		assert this.connection != null;
 		this.mapper = mapper;
 		if (queryFregment.trim().equals("")) {
 			logger.error("Query is empty", new Throwable("This throwable is just to log the stack trace"));
@@ -77,6 +78,7 @@ public class Select implements PlanNode {
 		assert query.trim().toLowerCase().startsWith("select") : "Expected query to start with select.";
 
 		this.connection = connection;
+		assert this.connection != null;
 		this.mapper = mapper;
 		this.query = StatementMatcher.StableRandomVariableProvider.normalize(query);
 		this.dataset = PlanNodeHelper.asDefaultGraphDataset(dataGraph);
@@ -191,23 +193,23 @@ public class Select implements PlanNode {
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
-		Select select = (Select) o;
+		Select that = (Select) o;
 		// added/removed connections are always newly minted per plan node, so we instead need to compare the underlying
 		// sail
-		if (connection instanceof MemoryStoreConnection && select.connection instanceof MemoryStoreConnection) {
-			return sorted == select.sorted &&
+		if (connection instanceof MemoryStoreConnection && that.connection instanceof MemoryStoreConnection) {
+			return sorted == that.sorted &&
 					((MemoryStoreConnection) connection).getSail()
-							.equals(((MemoryStoreConnection) select.connection).getSail())
+							.equals(((MemoryStoreConnection) that.connection).getSail())
 					&&
-					mapper.equals(select.mapper) &&
-					dataset.equals(select.dataset) &&
-					query.equals(select.query);
+					mapper.equals(that.mapper) &&
+					dataset.equals(that.dataset) &&
+					query.equals(that.query);
 		} else {
-			return sorted == select.sorted &&
-					connection.equals(select.connection) &&
-					mapper.equals(select.mapper) &&
-					dataset.equals(select.dataset) &&
-					query.equals(select.query);
+			return sorted == that.sorted &&
+					Objects.equals(connection, that.connection) &&
+					mapper.equals(that.mapper) &&
+					dataset.equals(that.dataset) &&
+					query.equals(that.query);
 		}
 	}
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnBufferedPlanNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnBufferedPlanNode.java
@@ -123,7 +123,7 @@ public class UnBufferedPlanNode<T extends PlanNode & MultiStreamPlanNode> implem
 
 	@Override
 	public String toString() {
-		return "UnBufferedPlanNode";
+		return "UnBufferedPlanNode(" + parent.getClass().getSimpleName() + ")";
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnorderedSelect.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnorderedSelect.java
@@ -46,6 +46,7 @@ public class UnorderedSelect implements PlanNode {
 	public UnorderedSelect(SailConnection connection, Resource subject, IRI predicate, Value object,
 			Resource[] dataGraph, Function<Statement, ValidationTuple> mapper) {
 		this.connection = connection;
+		assert this.connection != null;
 		this.subject = subject;
 		this.predicate = predicate;
 		this.object = object;
@@ -155,7 +156,7 @@ public class UnorderedSelect implements PlanNode {
 					Arrays.equals(dataGraph, that.dataGraph) &&
 					mapper.equals(that.mapper);
 		} else {
-			return connection.equals(that.connection) &&
+			return Objects.equals(connection, that.connection) &&
 					Objects.equals(subject, that.subject) &&
 					Objects.equals(predicate, that.predicate) &&
 					Objects.equals(object, that.object) &&

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetChainRetriever.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/targets/TargetChainRetriever.java
@@ -171,8 +171,6 @@ public class TargetChainRetriever implements PlanNode {
 
 						}
 
-						MapBindingSet bindings = new MapBindingSet();
-
 						while (statements == null || !statements.hasNext()) {
 							calculateNextStatementMatcher();
 							if (statements == null) {
@@ -185,6 +183,8 @@ public class TargetChainRetriever implements PlanNode {
 						}
 
 						Statement next = statements.next();
+
+						MapBindingSet bindings = new MapBindingSet();
 
 						if (currentStatementMatcher.getSubjectValue() == null
 								&& !currentStatementMatcher.subjectIsWildcard()) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/data/ConnectionsGroup.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/data/ConnectionsGroup.java
@@ -8,8 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.wrapper.data;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
@@ -21,6 +21,8 @@ import org.eclipse.rdf4j.sail.shacl.ast.planNodes.BufferedSplitter;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.UnBufferedPlanNode;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.UnorderedSelect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -30,6 +32,8 @@ import org.eclipse.rdf4j.sail.shacl.ast.planNodes.UnorderedSelect;
  */
 @InternalUseOnly
 public class ConnectionsGroup implements AutoCloseable {
+
+	private static final Logger logger = LoggerFactory.getLogger(ConnectionsGroup.class);
 
 	private final SailConnection baseConnection;
 	private final SailConnection previousStateConnection;
@@ -45,7 +49,7 @@ public class ConnectionsGroup implements AutoCloseable {
 	private final boolean sparqlValidation;
 
 	// used to cache Select plan nodes so that we don't query a store for the same data during the same validation step.
-	private final Map<PlanNode, BufferedSplitter> nodeCache = new HashMap<>();
+	private final Map<PlanNode, BufferedSplitter> nodeCache = new ConcurrentHashMap<>();
 
 	public ConnectionsGroup(SailConnection baseConnection,
 			SailConnection previousStateConnection, Sail addedStatements, Sail removedStatements,
@@ -104,19 +108,34 @@ public class ConnectionsGroup implements AutoCloseable {
 		return baseConnection;
 	}
 
-	synchronized public PlanNode getCachedNodeFor(PlanNode planNode) {
+	public PlanNode getCachedNodeFor(PlanNode planNode) {
 
 		if (!transactionSettings.isCacheSelectNodes()) {
 			return planNode;
 		}
 
-		if (planNode instanceof UnorderedSelect || planNode instanceof UnBufferedPlanNode) {
+		if (planNode instanceof UnorderedSelect || planNode instanceof UnBufferedPlanNode
+				|| (planNode instanceof BufferedSplitter.BufferedSplitterPlaneNode
+						&& ((BufferedSplitter.BufferedSplitterPlaneNode) planNode).cached)) {
 			return planNode;
 		}
 
-		BufferedSplitter bufferedSplitter = nodeCache.computeIfAbsent(planNode, BufferedSplitter::new);
+		if (logger.isDebugEnabled()) {
+			boolean[] matchedCache = { true };
 
-		return bufferedSplitter.getPlanNode();
+			BufferedSplitter bufferedSplitter = nodeCache.computeIfAbsent(planNode, parent -> {
+				matchedCache[0] = false;
+				return new BufferedSplitter(parent, true, true);
+			});
+
+			logger.debug("Found in cache: {} {}  -  {} : {}", matchedCache[0] ? " TRUE" : "FALSE",
+					bufferedSplitter.getId(), planNode.getClass().getSimpleName(), planNode.getId());
+
+			return bufferedSplitter.getPlanNode();
+		} else {
+			return nodeCache.computeIfAbsent(planNode, BufferedSplitter::new).getPlanNode();
+		}
+
 	}
 
 	public RdfsSubClassOfReasoner getRdfsSubClassOfReasoner() {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/data/ConnectionsGroup.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/wrapper/data/ConnectionsGroup.java
@@ -82,6 +82,10 @@ public class ConnectionsGroup implements AutoCloseable {
 		return previousStateConnection;
 	}
 
+	public boolean hasPreviousStateConnection() {
+		return previousStateConnection != null;
+	}
+
 	public SailConnection getAddedStatements() {
 		return addedStatements;
 	}


### PR DESCRIPTION
GitHub issue resolved: #4028 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

 - add benchmark
 - when caching a plan node use ConcurrentHashMap and add debug logging
 - skip reasoning when the input class is the only inferred class and also try to return the existing statement and value as often as possible
 - reduce use of EffectiveTarget when no data has been removed
 - retrieve Resource/IRI from connection if it will be used many times
 - improve plan node caching
 - when filtering by predicate and object against the base sail we can filter against added statements first
 - fix for when addedStatements connection is null
 - reduce use of previousStateConnection and serializableConnection
 - fix for potential deadlock

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

