### PR TITLE
GH-4047 simplify iteratios to reduce JVM generated itable stubs

### DIFF
--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/AbstractCloseableIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/AbstractCloseableIteration.java
@@ -11,9 +11,10 @@ package org.eclipse.rdf4j.common.iteration;
 /**
  * Base class for {@link CloseableIteration}s offering common functionality. This class keeps track of whether the
  * iteration has been closed and handles multiple calls to {@link #close()} by ignoring all but the first call.
- * 
+ *
  * Instances of this class is not safe to be accessed from multiple threads at the same time.
  */
+@Deprecated(since = "4.1.0")
 public abstract class AbstractCloseableIteration<E, X extends Exception> implements CloseableIteration<E, X> {
 
 	/*-----------*

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/CloseableIteratorIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/CloseableIteratorIteration.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 /**
  * An Iteration that can convert an {@link Iterator} to a {@link CloseableIteration}.
  */
+@Deprecated(since = "4.1.0")
 public class CloseableIteratorIteration<E, X extends Exception> extends AbstractCloseableIteration<E, X> {
 
 	private Iterator<? extends E> iter;

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/DualUnionIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/DualUnionIteration.java
@@ -13,6 +13,7 @@ import java.util.NoSuchElementException;
 /**
  * Provides a bag union of the two provided iterations.
  */
+@Deprecated(since = "4.1.0")
 public class DualUnionIteration<E, X extends Exception> implements CloseableIteration<E, X> {
 
 	private CloseableIteration<? extends E, X> iteration1;

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/DualUnionIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/DualUnionIteration.java
@@ -8,13 +8,20 @@
 
 package org.eclipse.rdf4j.common.iteration;
 
+import java.util.NoSuchElementException;
+
 /**
  * Provides a bag union of the two provided iterations.
  */
-public class DualUnionIteration<E, X extends Exception> extends LookAheadIteration<E, X> {
+public class DualUnionIteration<E, X extends Exception> implements CloseableIteration<E, X> {
 
 	private CloseableIteration<? extends E, X> iteration1;
 	private CloseableIteration<? extends E, X> iteration2;
+	private E nextElement;
+	/**
+	 * Flag indicating whether this iteration has been closed.
+	 */
+	private boolean closed = false;
 
 	private DualUnionIteration(CloseableIteration<? extends E, X> iteration1,
 			CloseableIteration<? extends E, X> iteration2) {
@@ -46,7 +53,6 @@ public class DualUnionIteration<E, X extends Exception> extends LookAheadIterati
 		}
 	}
 
-	@Override
 	public E getNextElement() throws X {
 		if (iteration1 == null && iteration2 != null) {
 			if (iteration2.hasNext()) {
@@ -74,16 +80,68 @@ public class DualUnionIteration<E, X extends Exception> extends LookAheadIterati
 	}
 
 	@Override
-	protected final void handleClose() throws X {
-		try {
-			if (iteration1 != null) {
-				iteration1.close();
-			}
-		} finally {
-			if (iteration2 != null) {
-				iteration2.close();
-			}
+	public final boolean hasNext() throws X {
+		if (closed) {
+			return false;
+		}
+
+		return lookAhead() != null;
+	}
+
+	@Override
+	public final E next() throws X {
+		if (closed) {
+			throw new NoSuchElementException("The iteration has been closed.");
+		}
+		E result = lookAhead();
+
+		if (result != null) {
+			nextElement = null;
+			return result;
+		} else {
+			throw new NoSuchElementException();
 		}
 	}
 
+	/**
+	 * Fetches the next element if it hasn't been fetched yet and stores it in {@link #nextElement}.
+	 *
+	 * @return The next element, or null if there are no more results.
+	 * @throws X If there is an issue getting the next element or closing the iteration.
+	 */
+	private E lookAhead() throws X {
+		if (nextElement == null) {
+			nextElement = getNextElement();
+
+			if (nextElement == null) {
+				close();
+			}
+		}
+		return nextElement;
+	}
+
+	/**
+	 * Throws an {@link UnsupportedOperationException}.
+	 */
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public final void close() throws X {
+		if (!closed) {
+			closed = true;
+			nextElement = null;
+			try {
+				if (iteration1 != null) {
+					iteration1.close();
+				}
+			} finally {
+				if (iteration2 != null) {
+					iteration2.close();
+				}
+			}
+		}
+	}
 }

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/EmptyIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/EmptyIteration.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
  * @implNote In the future this class will stop extending AbstractCloseableIteration and instead implement
  *           CloseableIteration directly.
  */
+@Deprecated(since = "4.1.0")
 public final class EmptyIteration<E, X extends Exception> extends AbstractCloseableIteration<E, X> {
 
 	/*--------------*

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/Iterations.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/Iterations.java
@@ -22,6 +22,7 @@ import java.util.stream.StreamSupport;
  * This class consists exclusively of static methods that operate on or return Iterations. It is the
  * Iteration-equivalent of <var>java.util.Collections</var>.
  */
+@Deprecated(since = "4.1.0")
 public class Iterations {
 
 	/**

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/LookAheadIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/LookAheadIteration.java
@@ -92,10 +92,6 @@ public abstract class LookAheadIteration<E, X extends Exception> extends Abstrac
 
 	@Override
 	protected void handleClose() throws X {
-		try {
-			super.handleClose();
-		} finally {
-			nextElement = null;
-		}
+		nextElement = null;
 	}
 }

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/LookAheadIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/LookAheadIteration.java
@@ -15,6 +15,7 @@ import java.util.NoSuchElementException;
  * super class for Iterations that have no easy way to tell if there are any more results, but still should implement
  * the <var>java.util.Iteration</var> interface.
  */
+@Deprecated(since = "4.1.0")
 public abstract class LookAheadIteration<E, X extends Exception> extends AbstractCloseableIteration<E, X> {
 
 	/*-----------*

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/QueueIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/QueueIteration.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author James Leigh
  */
+@Deprecated(since = "4.1.0")
 public abstract class QueueIteration<E, T extends Exception> extends LookAheadIteration<E, T> {
 
 	private final AtomicBoolean done = new AtomicBoolean(false);

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/SingletonIteration.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/SingletonIteration.java
@@ -13,6 +13,7 @@ import java.util.NoSuchElementException;
 /**
  * An Iteration that contains exactly one element.
  */
+@Deprecated(since = "4.1.0")
 public class SingletonIteration<E, X extends Exception> extends AbstractCloseableIteration<E, X> {
 
 	/*-----------*

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Var.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Var.java
@@ -154,7 +154,7 @@ public class Var extends AbstractQueryModelNode implements ValueExpr {
 		}
 		Var var = (Var) o;
 
-if (cachedHashCode != 0 && var.cachedHashCode != 0 && cachedHashCode != var.cachedHashCode) {
+		if (cachedHashCode != 0 && var.cachedHashCode != 0 && cachedHashCode != var.cachedHashCode) {
 			return false;
 		}
 

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Var.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Var.java
@@ -153,11 +153,13 @@ public class Var extends AbstractQueryModelNode implements ValueExpr {
 			return false;
 		}
 		Var var = (Var) o;
-		if (cachedHashCode != 0 && var.cachedHashCode != 0 && cachedHashCode != var.cachedHashCode) {
+
+if (cachedHashCode != 0 && var.cachedHashCode != 0 && cachedHashCode != var.cachedHashCode) {
 			return false;
 		}
 
-		return anonymous == var.anonymous && Objects.equals(name, var.name) && Objects.equals(value, var.value);
+		return anonymous == var.anonymous && !(name == null && var.name != null || value == null && var.value != null)
+				&& Objects.equals(name, var.name) && Objects.equals(value, var.value);
 	}
 
 	@Override

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/TripleSourceIterationWrapper.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/TripleSourceIterationWrapper.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+
+@InternalUseOnly
+public class TripleSourceIterationWrapper<T> implements CloseableIteration<T, QueryEvaluationException> {
+
+	private final CloseableIteration<? extends T, SailException> delegate;
+	private boolean closed = false;
+
+	public TripleSourceIterationWrapper(CloseableIteration<? extends T, SailException> delegate) {
+		this.delegate = Objects.requireNonNull(delegate, "The iterator was null");
+	}
+
+	/**
+	 * Checks whether the underlying iteration contains more elements.
+	 *
+	 * @return <var>true</var> if the underlying iteration contains more elements, <var>false</var> otherwise.
+	 * @throws QueryEvaluationException
+	 */
+	@Override
+	public boolean hasNext() throws QueryEvaluationException {
+		if (closed) {
+			return false;
+		}
+		try {
+			boolean result = delegate.hasNext();
+			if (!result) {
+				close();
+			}
+			return result;
+		} catch (QueryEvaluationException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new QueryEvaluationException(e);
+		}
+	}
+
+	/**
+	 * Returns the next element from the wrapped iteration.
+	 *
+	 * @throws QueryEvaluationException
+	 * @throws NoSuchElementException   If all elements have been returned.
+	 * @throws IllegalStateException    If the iteration has been closed.
+	 */
+	@Override
+	public T next() throws QueryEvaluationException {
+		if (closed) {
+			throw new NoSuchElementException("The iteration has been closed.");
+		}
+		try {
+			return delegate.next();
+		} catch (NoSuchElementException e) {
+			close();
+			throw e;
+		} catch (IllegalStateException | QueryEvaluationException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new QueryEvaluationException(e);
+		}
+	}
+
+	/**
+	 * Calls <var>remove()</var> on the underlying iteration.
+	 *
+	 * @throws UnsupportedOperationException If the wrapped iteration does not support the <var>remove</var> operation.
+	 * @throws IllegalStateException         If the Iteration has been closed, or if {@link #next} has not yet been
+	 *                                       called, or {@link #remove} has already been called after the last call to
+	 *                                       {@link #next}.
+	 */
+	@Override
+	public void remove() throws QueryEvaluationException {
+		if (closed) {
+			throw new IllegalStateException("The iteration has been closed.");
+		}
+		try {
+			delegate.remove();
+		} catch (UnsupportedOperationException | IllegalStateException | QueryEvaluationException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new QueryEvaluationException(e);
+		}
+	}
+
+	@Override
+	public final void close() throws QueryEvaluationException {
+		if (!closed) {
+			closed = true;
+			delegate.close();
+		}
+	}
+}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -266,30 +266,6 @@ class MemorySailStore implements SailStore {
 		return getMemStatementIterator(memSubj, memPred, memObj, explicit, snapshot, memContexts, smallestList);
 	}
 
-	private CloseableIteration<MemStatement, SailException> createStatementIterator(MemResource subj, MemIRI pred,
-			MemValue obj, Boolean explicit, int snapshot, MemResource... contexts) throws InterruptedException {
-
-		if (statements.isEmpty()) {
-			return EMPTY_ITERATION;
-		}
-
-		MemResource[] memContexts;
-		MemStatementList smallestList;
-
-		if (contexts.length == 0) {
-			memContexts = EMPTY_CONTEXT;
-			smallestList = statements;
-		} else if (contexts.length == 1 && contexts[0] != null) {
-			memContexts = contexts;
-			smallestList = contexts[0].getContextStatementList();
-		} else {
-			memContexts = contexts;
-			smallestList = statements;
-		}
-
-		return getMemStatementIterator(subj, pred, obj, explicit, snapshot, memContexts, smallestList);
-	}
-
 	private CloseableIteration<MemStatement, SailException> getMemStatementIterator(MemResource subj, MemIRI pred,
 			MemValue obj, Boolean explicit, int snapshot, MemResource[] memContexts, MemStatementList statementList)
 			throws InterruptedException {
@@ -307,6 +283,8 @@ class MemorySailStore implements SailStore {
 			smallestList = statementList;
 		} else if (smallestList.isEmpty()) {
 			return EMPTY_ITERATION;
+		} else if (smallestList.size() > statementList.size()) {
+			smallestList = statementList;
 		}
 
 		return MemStatementIterator.cacheAwareInstance(smallestList, subj, pred, obj, explicit, snapshot, memContexts,
@@ -1064,8 +1042,8 @@ class MemorySailStore implements SailStore {
 
 			// Filter more thoroughly by considering snapshot and read-mode
 			// parameters
-			try (MemStatementIterator<SailException> iter = new MemStatementIterator<>(contextStatements, null, null,
-					null, null, snapshot)) {
+			try (MemStatementIterator iter = new MemStatementIterator(contextStatements, null, null,
+					null, null, snapshot, null)) {
 				return iter.hasNext();
 			}
 		}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatement.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/model/MemStatement.java
@@ -46,6 +46,7 @@ public class MemStatement extends GenericStatement<MemResource, MemIRI, MemValue
 	/**
 	 * Identifies the snapshot in which this statement was revoked, defaults to {@link Integer#MAX_VALUE}.
 	 */
+	@SuppressWarnings("FieldMayBeFinal")
 	private volatile int tillSnapshot = Integer.MAX_VALUE;
 	private static final VarHandle TILL_SNAPSHOT;
 
@@ -137,17 +138,12 @@ public class MemStatement extends GenericStatement<MemResource, MemIRI, MemValue
 	}
 
 	public boolean matchesContext(MemResource[] memContexts) {
-		if (memContexts != null && memContexts.length > 0) {
-			for (MemResource context : memContexts) {
-				if (context == this.context) {
-					return true;
-				}
+		for (MemResource context : memContexts) {
+			if (context == this.context) {
+				return true;
 			}
-			return false;
-		} else {
-			// there is no context to check so we can return this statement
-			return true;
 		}
+		return false;
 	}
 
 	public boolean exactMatch(MemResource subject, MemIRI predicate, MemValue object, MemResource context) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnionNode.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/UnionNode.java
@@ -10,8 +10,6 @@ package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -102,9 +100,10 @@ public class UnionNode implements PlanNode {
 
 		return new LoggingCloseableIteration(this, validationExecutionLogger) {
 
-			final List<CloseableIteration<? extends ValidationTuple, SailException>> iterators = Arrays.stream(nodes)
+			final CloseableIteration<? extends ValidationTuple, SailException>[] iterators = Arrays
+					.stream(nodes)
 					.map(PlanNode::iterator)
-					.collect(Collectors.toList());
+					.toArray(CloseableIteration[]::new);
 
 			final ValidationTuple[] peekList = new ValidationTuple[nodes.length];
 
@@ -119,7 +118,7 @@ public class UnionNode implements PlanNode {
 
 				for (int i = 0; i < peekList.length; i++) {
 					if (peekList[i] == null) {
-						CloseableIteration<? extends ValidationTuple, SailException> iterator = iterators.get(i);
+						var iterator = iterators[i];
 						if (iterator.hasNext()) {
 							peekList[i] = iterator.next();
 						}
@@ -156,15 +155,17 @@ public class UnionNode implements PlanNode {
 			@Override
 			public void localClose() throws SailException {
 				Throwable thrown = null;
-				for (CloseableIteration<? extends ValidationTuple, SailException> iterator : iterators) {
+				for (int i = 0; i < iterators.length; i++) {
 					try {
-						iterator.close();
+						iterators[i].close();
 					} catch (Throwable t) {
 						if (thrown != null) {
 							thrown.addSuppressed(t);
 						} else {
 							thrown = t;
 						}
+					} finally {
+						iterators[i] = null;
 					}
 				}
 


### PR DESCRIPTION
GitHub issue resolved: #4047 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

