### PR TITLE
GH-4065 public api deprecation fixes

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResult.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResult.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.query;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iterator.CloseableIterationIterator;
@@ -19,7 +20,8 @@ import org.eclipse.rdf4j.common.iterator.CloseableIterationIterator;
  * @author Jeen Broekstra
  * @author Arjohn Kampman
  */
-public interface QueryResult<T> extends CloseableIteration<T, QueryEvaluationException>, Iterable<T> {
+public interface QueryResult<T>
+		extends AutoCloseable, CloseableIteration<T, QueryEvaluationException>, Iterable<T> {
 
 	@Override
 	default Iterator<T> iterator() {
@@ -43,4 +45,16 @@ public interface QueryResult<T> extends CloseableIteration<T, QueryEvaluationExc
 	 * @throws QueryEvaluationException if an error occurs while executing the query.
 	 */
 	T next() throws QueryEvaluationException;
+
+	/**
+	 *
+	 * Convert the result elements to a Java {@link Stream}. Note that the consumer should take care to close the stream
+	 * (by calling Stream#close() or using try-with-resource) if it is not fully consumed.
+	 *
+	 * @return stream a {@link Stream} of query result elements.
+	 */
+	default Stream<T> stream() {
+		return QueryResults.stream(this);
+	}
+
 }

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResult.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResult.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iterator.CloseableIterationIterator;
@@ -25,4 +26,21 @@ public interface QueryResult<T> extends CloseableIteration<T, QueryEvaluationExc
 		return new CloseableIterationIterator<>(this);
 	}
 
+	/**
+	 * Returns {@code true} if the query result has more elements. (In other words, returns {@code true} if
+	 * {@link #next} would return an element rather than throwing a {@link NoSuchElementException}.)
+	 *
+	 * @return {@code true} if the iteration has more elements.
+	 * @throws QueryEvaluationException if an error occurs while executing the query.
+	 */
+	boolean hasNext() throws QueryEvaluationException;
+
+	/**
+	 * Returns the next element in the query result.
+	 *
+	 * @return the next element in the query result.
+	 * @throws NoSuchElementException   if the iteration has no more elements or if it has been closed.
+	 * @throws QueryEvaluationException if an error occurs while executing the query.
+	 */
+	T next() throws QueryEvaluationException;
 }

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResults.java
@@ -86,6 +86,32 @@ public class QueryResults extends Iterations {
 	}
 
 	/**
+	 * Get a List containing all elements obtained from the specified {@link QueryResult}.
+	 *
+	 * @param queryResult the {@link QueryResult} to get the elements from
+	 * @return a List containing all elements obtained from the specified query result.
+	 */
+	public static <T> List<T> asList(QueryResult<T> queryResult) throws QueryEvaluationException {
+		// stream.collect is slightly slower than addAll for lists
+		List<T> list = new ArrayList<>();
+
+		// addAll closes the iteration
+		return addAll(queryResult, list);
+	}
+
+	/**
+	 * Get a Set containing all elements obtained from the specified {@link QueryResult}.
+	 *
+	 * @param queryResult the {@link QueryResult} to get the elements from
+	 * @return a Set containing all elements obtained from the specified query result.
+	 */
+	public static <T> Set<T> asSet(QueryResult<T> queryResult) throws QueryEvaluationException {
+		try (Stream<T> stream = queryResult.stream()) {
+			return stream.collect(Collectors.toSet());
+		}
+	}
+
+	/**
 	 * Returns a list of values of a particular variable out of the QueryResult.
 	 *
 	 * @param result


### PR DESCRIPTION
GitHub issue resolved: #4065  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- redefine method previously inherited from now deprecated classes to avoid deprecation warnings in places we don't want them. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

