### PR TITLE
GH-4089: remove whitespace in javadoc link

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
@@ -152,7 +152,7 @@ public class Statements {
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple}
+	 * Create a {@link Statement} from the supplied {@link Triple RDF-star triple}
 	 *
 	 * @param triple an RDF-star triple to convert to a {@link Statement}.
 	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and no context.
@@ -164,7 +164,7 @@ public class Statements {
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple}
+	 * Create a {@link Statement} from the supplied {@link Triple RDF-star triple}
 	 *
 	 * @param triple an RDF-star triple to convert to a {@link Statement}.
 	 * @return an {@link Statement} with the same subject, predicate and object as the input triple, and no context.
@@ -175,7 +175,7 @@ public class Statements {
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple} and context.
+	 * Create a {@link Statement} from the supplied {@link Triple RDF-star triple} and context.
 	 *
 	 * @param triple  an RDF-star triple to convert to a {@link Statement}.
 	 * @param context the context to assign to the {@link Statement}.
@@ -188,7 +188,7 @@ public class Statements {
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple} and context.
+	 * Create a {@link Statement} from the supplied {@link Triple RDF-star triple} and context.
 	 *
 	 * @param triple  an RDF-star triple to convert to a {@link Statement}.
 	 * @param context the context to assign to the {@link Statement}.
@@ -202,7 +202,7 @@ public class Statements {
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple} and context.
+	 * Create a {@link Statement} from the supplied {@link Triple RDF-star triple} and context.
 	 *
 	 * @param vf      the {@link ValueFactory} to use for creating the {@link Statement} object.
 	 * @param triple  an RDF-star triple to convert to a {@link Statement}.
@@ -217,7 +217,7 @@ public class Statements {
 	}
 
 	/**
-	 * Create a {@link Statement} from the supplied { @link Triple RDF-star triple} and context.
+	 * Create a {@link Statement} from the supplied {@link Triple RDF-star triple} and context.
 	 *
 	 * @param vf      the {@link ValueFactory} to use for creating the {@link Statement} object.
 	 * @param triple  an RDF-star triple to convert to a {@link Statement}.


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #4089 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- no code changes, just removed incorrect whitespaces

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/.github/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

