### PR TITLE
GH-4110: use multi-stage build to reduce image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,35 +1,35 @@
-FROM tomcat:8.5-jre11-temurin
-MAINTAINER Bart Hanssens (bart.hanssens@bosa.fgov.be)
+# Temp to reduce image size
+FROM ubuntu:jammy AS temp
 
-ENV JAVA_OPTS="-Xmx2g"
-ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"
-
-RUN apt update
-RUN apt install unzip
-RUN adduser --system tomcat
+RUN apt update && apt install unzip
 
 COPY ignore/rdf4j.zip /tmp/rdf4j.zip
 
 WORKDIR /tmp
 
-RUN	unzip -q /tmp/rdf4j.zip && \
-	rm -rf /usr/local/tomcat/webapps/* && \
-	cp /tmp/eclipse-rdf4j*/war/*.war /usr/local/tomcat/webapps && \
-	rm -rf /tmp/eclipse && \
-	rm /tmp/rdf4j.zip && \
+RUN unzip -q /tmp/rdf4j.zip
+
+# Final workbench
+FROM tomcat:8.5-jre11-temurin AS wb
+MAINTAINER Bart Hanssens (bart.hanssens@bosa.fgov.be)
+
+ENV JAVA_OPTS="-Xmx2g"
+ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"
+
+RUN adduser --system tomcat
+
+RUN	rm -rf /usr/local/tomcat/webapps/* && \
 	mkdir -p /var/rdf4j && \
 	chown -R tomcat /var/rdf4j /usr/local/tomcat && \
 	chmod a+x /usr/local/tomcat /usr/local/tomcat/bin /usr/local/tomcat/bin/catalina.sh
+
+COPY --from=temp /tmp/eclipse-rdf4j*/war/*.war /usr/local/tomcat/webapps
 
 COPY web.xml /usr/local/tomcat/conf/web.xml
 
 USER tomcat
 
 WORKDIR /usr/local/tomcat/
-
-# never got this syntax to work with docker-compose
-#VOLUME /var/rdf4j
-#VOLUME /usr/local/tomcat/logs
 
 EXPOSE 8080
 


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #4110 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- use multi-stage build: move copy/unzip part from build to a temp docker image
- don't use apt update in final image (was only needed to add unzip tool, which is only needed in temp image)
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

