### PR TITLE
Update Apache Felix Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -708,7 +708,7 @@
 				<plugin>
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
-					<version>5.1.1</version>
+					<version>5.1.8</version>
 					<extensions>true</extensions>
 					<configuration>
 						<instructions>


### PR DESCRIPTION
RDF4J currently uses an old version of the apache felix plugin, this is just a dependency update for this.

By the way maybe you want enable https://github.com/dependabot for this repository to get such notifications automatically?