### PR TITLE
GH-4112 fix query regression for CONSTRUCT query with RDF*

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
@@ -417,13 +417,14 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 			if (toBeReplaced.equals(var) || (toBeReplaced.isAnonymous() && var.isAnonymous()
 					&& (toBeReplaced.hasValue() && toBeReplaced.getValue().equals(var.getValue())))) {
 				QueryModelNode parent = var.getParentNode();
+				Var replacement = this.replacement.clone();
 				parent.replaceChildNode(var, replacement);
-				replacement.setParentNode(parent);
+				assert replacement.getParentNode() == parent;
 			} else if (replaceAnons && var.isAnonymous() && !var.hasValue()) {
 				Var replacementVar = createAnonVar("anon-replace-" + var.getName() + index);
 				QueryModelNode parent = var.getParentNode();
 				parent.replaceChildNode(var, replacementVar);
-				replacementVar.setParentNode(parent);
+				assert replacementVar.getParentNode() == parent;
 			}
 		}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIteration.java
@@ -86,7 +86,7 @@ public class ZeroLengthPathIteration extends LookAheadIteration<BindingSet, Quer
 
 		StatementPattern subjects;
 		if (contextVar != null) {
-			subjects = new StatementPattern(Scope.NAMED_CONTEXTS, startVar, predicate, endVar, contextVar);
+			subjects = new StatementPattern(Scope.NAMED_CONTEXTS, startVar, predicate, endVar, contextVar.clone());
 		} else {
 			subjects = new StatementPattern(startVar, predicate, endVar);
 		}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/CompareOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/CompareOptimizer.java
@@ -57,7 +57,7 @@ public class CompareOptimizer implements QueryOptimizer {
 				boolean rightIsResource = isResource(rightArg);
 
 				if (leftIsVar && rightIsResource || leftIsResource && rightIsVar || leftIsResource && rightIsResource) {
-					SameTerm sameTerm = new SameTerm(leftArg, rightArg);
+					SameTerm sameTerm = new SameTerm(leftArg.clone(), rightArg.clone());
 					compare.replaceWith(sameTerm);
 				}
 			}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/ConstantOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/ConstantOptimizer.java
@@ -146,14 +146,14 @@ public class ConstantOptimizer implements QueryOptimizer {
 					if (leftIsTrue) {
 						or.replaceWith(new ValueConstant(BooleanLiteral.TRUE));
 					} else {
-						or.replaceWith(or.getRightArg());
+						or.replaceWith(or.getRightArg().clone());
 					}
 				} else if (isConstant(or.getRightArg())) {
 					boolean rightIsTrue = strategy.isTrue(or.getRightArg(), EmptyBindingSet.getInstance());
 					if (rightIsTrue) {
 						or.replaceWith(new ValueConstant(BooleanLiteral.TRUE));
 					} else {
-						or.replaceWith(or.getLeftArg());
+						or.replaceWith(or.getLeftArg().clone());
 					}
 				}
 			} catch (ValueExprEvaluationException e) {
@@ -176,14 +176,14 @@ public class ConstantOptimizer implements QueryOptimizer {
 				} else if (isConstant(and.getLeftArg())) {
 					boolean leftIsTrue = strategy.isTrue(and.getLeftArg(), EmptyBindingSet.getInstance());
 					if (leftIsTrue) {
-						and.replaceWith(and.getRightArg());
+						and.replaceWith(and.getRightArg().clone());
 					} else {
 						and.replaceWith(new ValueConstant(BooleanLiteral.FALSE));
 					}
 				} else if (isConstant(and.getRightArg())) {
 					boolean rightIsTrue = strategy.isTrue(and.getRightArg(), EmptyBindingSet.getInstance());
 					if (rightIsTrue) {
-						and.replaceWith(and.getLeftArg());
+						and.replaceWith(and.getLeftArg().clone());
 					} else {
 						and.replaceWith(new ValueConstant(BooleanLiteral.FALSE));
 					}
@@ -310,7 +310,7 @@ public class ConstantOptimizer implements QueryOptimizer {
 					if (strategy.isTrue(node.getCondition(), EmptyBindingSet.getInstance())) {
 						node.replaceWith(node.getResult());
 					} else {
-						node.replaceWith(node.getAlternative());
+						node.replaceWith(node.getAlternative().clone());
 					}
 				} catch (ValueExprEvaluationException e) {
 					logger.debug("Failed to evaluate UnaryValueOperator with a constant argument", e);

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/ParentReferenceChecker.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/ParentReferenceChecker.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.query.algebra.evaluation.optimizer;
+
+import java.util.ArrayDeque;
+
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checks {@link QueryModelNode#getParentNode()} references that have become inconsistent with the actual algebra tree
+ * structure due to optimization operations. Used during testing.
+ *
+ * @author Jeen Broekstra
+ * @author Håvard Ottestad
+ */
+@InternalUseOnly
+public class ParentReferenceChecker implements QueryOptimizer {
+
+	private static final Logger logger = LoggerFactory.getLogger(ParentReferenceChecker.class);
+	private final QueryOptimizer previousOptimizerInPipeline;
+
+	public ParentReferenceChecker(QueryOptimizer previousOptimizerInPipeline) {
+		this.previousOptimizerInPipeline = previousOptimizerInPipeline;
+	}
+
+	@Override
+	public void optimize(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings) {
+		tupleExpr.visit(new ParentCheckingVisitor());
+	}
+
+	private class ParentCheckingVisitor extends AbstractQueryModelVisitor<RuntimeException> {
+
+		private final ArrayDeque<QueryModelNode> ancestors = new ArrayDeque<>();
+
+		@Override
+		protected void meetNode(QueryModelNode node) throws RuntimeException {
+			QueryModelNode expectedParent = ancestors.peekLast();
+			if (node.getParentNode() != expectedParent) {
+				String previousOptimizer;
+				if (ParentReferenceChecker.this.previousOptimizerInPipeline != null) {
+					previousOptimizer = ParentReferenceChecker.this.previousOptimizerInPipeline.getClass()
+							.getSimpleName();
+				} else {
+					previousOptimizer = "query parsing";
+				}
+				String message = "After " + previousOptimizer + " there was an unexpected parent for node " + node
+						+ ": " + node.getParentNode() + " (expected " + expectedParent + ")";
+
+				assert node.getParentNode() == expectedParent : message;
+			}
+
+			ancestors.addLast(node);
+			super.meetNode(node);
+			ancestors.pollLast();
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/ParentReferenceChecker.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/ParentReferenceChecker.java
@@ -5,7 +5,9 @@
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
- ******************************************************************************/
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
 
 package org.eclipse.rdf4j.query.algebra.evaluation.optimizer;
 
@@ -32,6 +34,7 @@ import org.slf4j.LoggerFactory;
 public class ParentReferenceChecker implements QueryOptimizer {
 
 	private static final Logger logger = LoggerFactory.getLogger(ParentReferenceChecker.class);
+
 	private final QueryOptimizer previousOptimizerInPipeline;
 
 	public ParentReferenceChecker(QueryOptimizer previousOptimizerInPipeline) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/RegexAsStringFunctionOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/RegexAsStringFunctionOptimizer.java
@@ -84,7 +84,8 @@ public class RegexAsStringFunctionOptimizer implements QueryOptimizer {
 
 		private void containsCandidate(Regex node, String potential) {
 			if (plain(potential)) {
-				node.replaceWith(new FunctionCall(FN.CONTAINS.stringValue(), node.getArg(), node.getPatternArg()));
+				node.replaceWith(new FunctionCall(FN.CONTAINS.stringValue(), node.getArg().clone(),
+						node.getPatternArg().clone()));
 			}
 		}
 
@@ -104,7 +105,7 @@ public class RegexAsStringFunctionOptimizer implements QueryOptimizer {
 			final String potential = regex.substring(0, regex.length() - 1);
 			if (plain(potential)) {
 				ValueConstant vc = new ValueConstant(vf.createLiteral(potential));
-				node.replaceWith(new FunctionCall(FN.ENDS_WITH.stringValue(), node.getArg(), vc));
+				node.replaceWith(new FunctionCall(FN.ENDS_WITH.stringValue(), node.getArg().clone(), vc));
 			}
 		}
 
@@ -112,7 +113,7 @@ public class RegexAsStringFunctionOptimizer implements QueryOptimizer {
 			final String potential = regex.substring(1, regex.length());
 			if (plain(potential)) {
 				ValueConstant vc = new ValueConstant(vf.createLiteral(potential));
-				node.replaceWith(new FunctionCall(FN.STARTS_WITH.stringValue(), node.getArg(), vc));
+				node.replaceWith(new FunctionCall(FN.STARTS_WITH.stringValue(), node.getArg().clone(), vc));
 			}
 		}
 
@@ -120,7 +121,7 @@ public class RegexAsStringFunctionOptimizer implements QueryOptimizer {
 			final String potential = regex.substring(1, regex.length() - 1);
 			if (plain(potential)) {
 				ValueConstant vc = new ValueConstant(vf.createLiteral(potential));
-				node.replaceWith(new Compare(node.getArg(), vc, Compare.CompareOp.EQ));
+				node.replaceWith(new Compare(node.getArg().clone(), vc, Compare.CompareOp.EQ));
 			}
 		}
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
@@ -58,10 +58,10 @@ public class FilterOptimizerTest extends QueryOptimizerTest {
 		Var o2 = new Var("o2");
 		ValueConstant two = new ValueConstant(SimpleValueFactory.getInstance().createLiteral(2));
 		ValueConstant four = new ValueConstant(SimpleValueFactory.getInstance().createLiteral(4));
-		Compare oSmallerThanTwo = new Compare(o, two, CompareOp.GT);
-		Filter spo = new Filter(new StatementPattern(s, p, o), oSmallerThanTwo);
-		Compare o2SmallerThanFour = new Compare(o2, four, CompareOp.LT);
-		Filter spo2 = new Filter(new StatementPattern(s, p, o2), o2SmallerThanFour);
+		Compare oSmallerThanTwo = new Compare(o.clone(), two, CompareOp.GT);
+		Filter spo = new Filter(new StatementPattern(s.clone(), p.clone(), o.clone()), oSmallerThanTwo);
+		Compare o2SmallerThanFour = new Compare(o2.clone(), four, CompareOp.LT);
+		Filter spo2 = new Filter(new StatementPattern(s.clone(), p.clone(), o2.clone()), o2SmallerThanFour);
 		TupleExpr expected = new QueryRoot(
 				new Projection(new Join(spo, spo2), new ProjectionElemList(new ProjectionElem("s"),
 						new ProjectionElem("p"), new ProjectionElem("o"), new ProjectionElem("o2"))));
@@ -81,12 +81,13 @@ public class FilterOptimizerTest extends QueryOptimizerTest {
 		ValueConstant four = new ValueConstant(SimpleValueFactory.getInstance().createLiteral(4));
 		ValueConstant five = new ValueConstant(SimpleValueFactory.getInstance().createLiteral(5));
 
-		And firstAnd = new And(new Compare(o, five, CompareOp.LT), new Compare(o, two, CompareOp.GT));
-		Filter spo = new Filter(new StatementPattern(s, p, o), firstAnd);
+		And firstAnd = new And(new Compare(o.clone(), five, CompareOp.LT), new Compare(o.clone(), two, CompareOp.GT));
+		Filter spo = new Filter(new StatementPattern(s.clone(), p.clone(), o.clone()), firstAnd);
 
-		And secondAnd = new And(new And(new Compare(o2, two, CompareOp.NE), new Compare(o2, one, CompareOp.GT)),
-				new Compare(o2, four, CompareOp.LT));
-		Filter spo2 = new Filter(new StatementPattern(s, p, o2), secondAnd);
+		And secondAnd = new And(
+				new And(new Compare(o2.clone(), two, CompareOp.NE), new Compare(o2.clone(), one, CompareOp.GT)),
+				new Compare(o2.clone(), four, CompareOp.LT));
+		Filter spo2 = new Filter(new StatementPattern(s.clone(), p.clone(), o2.clone()), secondAnd);
 
 		TupleExpr expected = new QueryRoot(
 				new Projection(new Join(spo, spo2), new ProjectionElemList(new ProjectionElem("s"),

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ValueExprTripleRef.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ValueExprTripleRef.java
@@ -14,33 +14,34 @@ package org.eclipse.rdf4j.query.algebra;
 public class ValueExprTripleRef extends AbstractQueryModelNode implements ValueExpr {
 
 	private final String exprVarName;
-	private final org.eclipse.rdf4j.query.algebra.Var subjectVar;
-	private final org.eclipse.rdf4j.query.algebra.Var predicateVar;
-	private final org.eclipse.rdf4j.query.algebra.Var objectVar;
+	private Var subjectVar;
+	private Var predicateVar;
+	private Var objectVar;
 
-	public ValueExprTripleRef(String extName,
-			org.eclipse.rdf4j.query.algebra.Var s,
-			org.eclipse.rdf4j.query.algebra.Var p,
-			org.eclipse.rdf4j.query.algebra.Var o) {
+	public ValueExprTripleRef(String extName, Var s, Var p, Var o) {
 		this.exprVarName = extName;
 		subjectVar = s;
 		predicateVar = p;
 		objectVar = o;
+
+		subjectVar.setParentNode(this);
+		predicateVar.setParentNode(this);
+		objectVar.setParentNode(this);
 	}
 
 	public String getExtVarName() {
 		return exprVarName;
 	}
 
-	public org.eclipse.rdf4j.query.algebra.Var getSubjectVar() {
+	public Var getSubjectVar() {
 		return subjectVar;
 	}
 
-	public org.eclipse.rdf4j.query.algebra.Var getPredicateVar() {
+	public Var getPredicateVar() {
 		return predicateVar;
 	}
 
-	public org.eclipse.rdf4j.query.algebra.Var getObjectVar() {
+	public Var getObjectVar() {
 		return objectVar;
 	}
 
@@ -86,4 +87,16 @@ public class ValueExprTripleRef extends AbstractQueryModelNode implements ValueE
 		// visitChildren(visitor);
 	}
 
+	@Override
+	public void replaceChildNode(QueryModelNode current, QueryModelNode replacement) {
+		if (subjectVar == current) {
+			subjectVar = (Var) replacement;
+		} else if (predicateVar == current) {
+			predicateVar = (Var) replacement;
+		} else if (objectVar == current) {
+			objectVar = (Var) replacement;
+		} else {
+			super.replaceChildNode(current, replacement);
+		}
+	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Var.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Var.java
@@ -109,6 +109,7 @@ public class Var extends AbstractQueryModelNode implements ValueExpr {
 
 	@Override
 	public void setParentNode(QueryModelNode parent) {
+		assert this.parent == null;
 		this.parent = parent;
 	}
 

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
@@ -32,7 +32,6 @@ import org.eclipse.rdf4j.query.algebra.Var;
  * A graph pattern consisting of (required and optional) tuple expressions, binding assignments and boolean constraints.
  *
  * @author Arjohn Kampman
- *
  * @apiNote This feature is for internal use only: its existence, signature or behavior may change without warning from
  *          one release to the next.
  */
@@ -100,7 +99,9 @@ public class GraphPattern {
 	}
 
 	public void addRequiredSP(Var subjVar, Var predVar, Var objVar) {
-		addRequiredTE(new StatementPattern(spScope, subjVar, predVar, objVar, contextVar));
+
+		addRequiredTE(new StatementPattern(spScope, subjVar, predVar, objVar,
+				contextVar != null ? contextVar.clone() : null));
 	}
 
 	public List<TupleExpr> getRequiredTEs() {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/EmptyStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/EmptyStatementPattern.java
@@ -24,7 +24,8 @@ public class EmptyStatementPattern extends StatementPattern implements EmptyResu
 	private static final long serialVersionUID = 1026901522434201643L;
 
 	public EmptyStatementPattern(StatementPattern node) {
-		super(node.getSubjectVar(), node.getPredicateVar(), node.getObjectVar(), node.getContextVar());
+		super(node.getSubjectVar().clone(), node.getPredicateVar().clone(), node.getObjectVar().clone(),
+				node.getContextVar() != null ? node.getContextVar().clone() : null);
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveArbitraryLengthPath.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/ExclusiveArbitraryLengthPath.java
@@ -40,8 +40,8 @@ public class ExclusiveArbitraryLengthPath extends ArbitraryLengthPath
 	private final List<String> freeVars;
 
 	public ExclusiveArbitraryLengthPath(ArbitraryLengthPath path, StatementSource owner, QueryInfo queryInfo) {
-		super(path.getScope(), path.getSubjectVar(), path.getPathExpression(), path.getObjectVar(),
-				path.getContextVar(), path.getMinLength());
+		super(path.getScope(), path.getSubjectVar().clone(), path.getPathExpression(), path.getObjectVar().clone(),
+				path.getContextVar() != null ? path.getContextVar().clone() : null, path.getMinLength());
 		this.owner = owner;
 		this.queryInfo = queryInfo;
 		this.freeVars = computeFreeVars();

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXStatementPattern.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/algebra/FedXStatementPattern.java
@@ -48,7 +48,8 @@ public abstract class FedXStatementPattern extends StatementPattern
 	protected long upperLimit = -1; // if set to a positive number, this upper limit is applied to any subquery
 
 	public FedXStatementPattern(StatementPattern node, QueryInfo queryInfo) {
-		super(node.getScope(), node.getSubjectVar(), node.getPredicateVar(), node.getObjectVar(), node.getContextVar());
+		super(node.getScope(), node.getSubjectVar().clone(), node.getPredicateVar().clone(),
+				node.getObjectVar().clone(), node.getContextVar() != null ? node.getContextVar().clone() : null);
 		this.id = NodeFactory.getNextId();
 		this.queryInfo = queryInfo;
 		initFreeVars();


### PR DESCRIPTION
GitHub issue resolved: #4112 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - add test
 - add missing replaceChild method (which was the main issue)
 - remove the parent reference cleaner from the standard query optimizers
 - add a parent reference checker to the standard query optimizers if assertions are enabled (so that our tests fail)
 - prevent sharing or reuse of a Var object by checking (assert) that the parent ref was null before setting it

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

