### PR TITLE
GH-4066 re-introduce use of Extension for all select expressions

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ArrayBindingBasedQueryEvaluationContext.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ArrayBindingBasedQueryEvaluationContext.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -271,8 +270,8 @@ public final class ArrayBindingBasedQueryEvaluationContext implements QueryEvalu
 			@Override
 			public void meet(ProjectionElem node) throws QueryEvaluationException {
 				super.meet(node);
-				node.setSourceName(varNames.computeIfAbsent(node.getSourceName(), k -> k));
-				node.setTargetName(varNames.computeIfAbsent(node.getTargetName(), k -> k));
+				node.setName(varNames.computeIfAbsent(node.getName(), k -> k));
+				node.setProjectionAlias(varNames.computeIfAbsent(node.getProjectionAlias().orElse(null), k -> k));
 			}
 
 			@Override

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ConstantOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ConstantOptimizer.java
@@ -84,7 +84,7 @@ public class ConstantOptimizer implements QueryOptimizer {
 			varsBefore.removeAll(varsAfter);
 			for (ProjectionElemList projElems : visitor.projElemLists) {
 				for (ProjectionElem projElem : projElems.getElements()) {
-					String name = projElem.getSourceName();
+					String name = projElem.getName();
 					if (varsBefore.contains(name)) {
 						UnaryTupleOperator proj = (UnaryTupleOperator) projElems.getParentNode();
 						Extension ext = new Extension(proj.getArg());

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/OrderLimitOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/OrderLimitOptimizer.java
@@ -75,9 +75,7 @@ public class OrderLimitOptimizer implements QueryOptimizer {
 			if (projection != null) {
 				boolean projected = false;
 				for (ProjectionElem e : projection.getProjectionElemList().getElements()) {
-					String source = e.getSourceName();
-					String target = e.getTargetName();
-					if (node.getName().equals(source) && node.getName().equals(target)) {
+					if (node.getName().equals(e.getName())) {
 						projected = true;
 						break;
 					}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SameTermFilterOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SameTermFilterOptimizer.java
@@ -187,8 +187,8 @@ public class SameTermFilterOptimizer implements QueryOptimizer {
 
 		@Override
 		public void meet(ProjectionElem projElem) throws RuntimeException {
-			if (projElem.getSourceName().equals(oldVar.getName())) {
-				projElem.setSourceName(newVar.getName());
+			if (projElem.getName().equals(oldVar.getName())) {
+				projElem.setName(newVar.getName());
 			}
 		}
 	}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ProjectionIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ProjectionIterator.java
@@ -52,10 +52,9 @@ public class ProjectionIterator extends ConvertingIteration<BindingSet, BindingS
 
 		BiConsumer<MutableBindingSet, BindingSet> consumer = null;
 		for (ProjectionElem pe : projectionElemList.getElements()) {
-			String sourceName = pe.getSourceName();
-			String targetName = pe.getTargetName();
-			Function<BindingSet, Value> valueWithSourceName = context.getValue(sourceName);
-			BiConsumer<Value, MutableBindingSet> setTarget = context.setBinding(targetName);
+			String projectionName = pe.getProjectionAlias().orElse(pe.getName());
+			Function<BindingSet, Value> valueWithSourceName = context.getValue(pe.getName());
+			BiConsumer<Value, MutableBindingSet> setTarget = context.setBinding(projectionName);
 			BiConsumer<MutableBindingSet, BindingSet> next = (resultBindings, sourceBindings) -> {
 				Value targetValue = valueWithSourceName.apply(sourceBindings);
 				if (!includeAllParentBindings && targetValue == null) {
@@ -120,12 +119,12 @@ public class ProjectionIterator extends ConvertingIteration<BindingSet, BindingS
 		final QueryBindingSet resultBindings = makeNewQueryBindings(parentBindings, includeAllParentBindings);
 
 		for (ProjectionElem pe : projElemList.getElements()) {
-			Value targetValue = sourceBindings.getValue(pe.getSourceName());
+			Value targetValue = sourceBindings.getValue(pe.getName());
 			if (!includeAllParentBindings && targetValue == null) {
-				targetValue = parentBindings.getValue(pe.getSourceName());
+				targetValue = parentBindings.getValue(pe.getName());
 			}
 			if (targetValue != null) {
-				resultBindings.setBinding(pe.getTargetName(), targetValue);
+				resultBindings.setBinding(pe.getProjectionAlias().orElse(pe.getName()), targetValue);
 			}
 		}
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/ConstantOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/ConstantOptimizer.java
@@ -88,7 +88,7 @@ public class ConstantOptimizer implements QueryOptimizer {
 			for (ProjectionElemList projElems : visitor.projElemLists) {
 				for (ProjectionElem projElem : projElems.getElements()) {
 
-					String name = projElem.getSourceName();
+					String name = projElem.getName();
 
 					if (varsBefore.contains(name)) {
 						UnaryTupleOperator proj = (UnaryTupleOperator) projElems.getParentNode();

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/OrderLimitOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/OrderLimitOptimizer.java
@@ -79,9 +79,7 @@ public class OrderLimitOptimizer implements QueryOptimizer {
 			if (projection != null) {
 				boolean projected = false;
 				for (ProjectionElem e : projection.getProjectionElemList().getElements()) {
-					String source = e.getSourceName();
-					String target = e.getTargetName();
-					if (node.getName().equals(source) && node.getName().equals(target)) {
+					if (node.getName().equals(e.getName())) {
 						projected = true;
 						break;
 					}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/SameTermFilterOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/SameTermFilterOptimizer.java
@@ -191,8 +191,8 @@ public class SameTermFilterOptimizer implements QueryOptimizer {
 
 		@Override
 		public void meet(ProjectionElem projElem) throws RuntimeException {
-			if (projElem.getSourceName().equals(oldVar.getName())) {
-				projElem.setSourceName(newVar.getName());
+			if (projElem.getName().equals(oldVar.getName())) {
+				projElem.setName(newVar.getName());
 			}
 		}
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/MultiProjection.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/MultiProjection.java
@@ -76,7 +76,7 @@ public class MultiProjection extends UnaryTupleOperator {
 		Set<String> bindingNames = new HashSet<>();
 
 		for (ProjectionElemList projElemList : projections) {
-			bindingNames.addAll(projElemList.getTargetNames());
+			bindingNames.addAll(projElemList.getProjectedNames());
 		}
 
 		return bindingNames;
@@ -89,10 +89,10 @@ public class MultiProjection extends UnaryTupleOperator {
 		if (projections.size() >= 1) {
 			Set<String> assuredSourceNames = getArg().getAssuredBindingNames();
 
-			bindingNames.addAll(projections.get(0).getTargetNamesFor(assuredSourceNames));
+			bindingNames.addAll(projections.get(0).getProjectedNamesFor(assuredSourceNames));
 
 			for (int i = 1; i < projections.size(); i++) {
-				bindingNames.retainAll(projections.get(i).getTargetNamesFor(assuredSourceNames));
+				bindingNames.retainAll(projections.get(i).getProjectedNamesFor(assuredSourceNames));
 			}
 		}
 

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Projection.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Projection.java
@@ -65,14 +65,14 @@ public class Projection extends UnaryTupleOperator {
 
 	@Override
 	public Set<String> getBindingNames() {
-		return projElemList.getTargetNames();
+		return projElemList.getProjectedNames();
 	}
 
 	@Override
 	public Set<String> getAssuredBindingNames() {
 		// Return all target binding names for which the source binding is assured
 		// by the argument
-		return projElemList.getTargetNamesFor(getArg().getAssuredBindingNames());
+		return projElemList.getProjectedNamesFor(getArg().getAssuredBindingNames());
 	}
 
 	@Override

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ProjectionElem.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ProjectionElem.java
@@ -10,56 +10,135 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Projection elements control which of the selected expressions (produced by the WHERE clause of a query) are returned
+ * in the solution, and the order in which they appear.
+ * <p>
+ * In SPARQL SELECT queries, projection elements are the variables determined by the algorithm for finding SELECT
+ * expressions (see <a href="https://www.w3.org/TR/sparql11-query/#sparqlSelectExpressions">SPARQL 1.1 Query Language
+ * Recommendation, section 18.2.4.4</a>). Each projection element will be a single variable name (any aliasing is
+ * handled by the use of {@link Extension}s).
+ * <p>
+ * In SPARQL CONSTRUCT queries, the projection elements are used to map the variables obtained from the SELECT
+ * expressions to the required statement patterns. In this case, each projection element will have an additional
+ * {@link #getProjectionAlias() target name} that maps each projection variable name to one of {@code subject},
+ * {@code predicate}, {@code object} or {@code context}.
+ * 
+ * @author Jeen Broekstra
+ */
 public class ProjectionElem extends AbstractQueryModelNode {
 
-	/*-----------*
-	 * Variables *
-	 *-----------*/
+	private static final long serialVersionUID = -8129811335486478066L;
 
-	private String sourceName;
+	private String name;
 
-	private String targetName;
+	private String projectionAlias;
 
 	private boolean aggregateOperatorInExpression;
 
 	private ExtensionElem sourceExpression;
 
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
-
+	/**
+	 * Create a new empty {@link ProjectionElem}.
+	 */
 	public ProjectionElem() {
 	}
 
+	/**
+	 * Create a new {@link ProjectionElem} with a variable name.
+	 * 
+	 * @param name The name of the projection element (typically the name of the variable in the select expressions).
+	 *             May not be <code>null</code>.
+	 */
 	public ProjectionElem(String name) {
-		this(name, name);
+		this(name, null);
 	}
 
-	public ProjectionElem(String sourceName, String targetName) {
-		setSourceName(sourceName);
-		setTargetName(targetName);
+	/**
+	 * Create a new {@link ProjectionElem} with a variable name and an additional mapped {@link #getProjectionAlias()
+	 * target name}
+	 * 
+	 * @param name       The name of the projection element (typically the name of the variable in the select
+	 *                   expressions). May not be <code>null</code>.
+	 * @param targetName The name of the variable the projection element value should be mapped to, to produce the
+	 *                   projection. Used in CONSTRUCT queries for mapping select expressions to statement patterns. May
+	 *                   be <code>null</code>.
+	 */
+	public ProjectionElem(String name, String targetName) {
+		setName(name);
+		setProjectionAlias(targetName);
 	}
 
-	/*---------*
-	 * Methods *
-	 *---------*/
+	/**
+	 * Get the name of the projection element (typically the name of the variable in the select expressions)
+	 * 
+	 */
+	public String getName() {
+		return name;
+	}
 
+	/**
+	 * @deprecated since 4.1.1. Use {@link #getName()} instead.
+	 */
+	@Deprecated(since = "4.1.1", forRemoval = true)
 	public String getSourceName() {
-		return sourceName;
+		return getName();
 	}
 
+	/**
+	 * @deprecated since 4.1.1. Use {@link #setName(String)} instead.
+	 */
+	@Deprecated(since = "4.1.1", forRemoval = true)
 	public void setSourceName(String sourceName) {
-		assert sourceName != null : "sourceName must not be null";
-		this.sourceName = sourceName;
+		setName(sourceName);
 	}
 
-	public String getTargetName() {
-		return targetName;
+	/**
+	 * Set the name of the projection element (typically the name of the variable in the select expressions)
+	 * 
+	 * @param name the projection variable name. May not be {@code null}.
+	 */
+	public void setName(String name) {
+		this.name = Objects.requireNonNull(name);
 	}
 
+	/**
+	 * Get the alias the projection element value should be mapped to. Used in CONSTRUCT queries for mapping select
+	 * expressions to statement patterns.
+	 * 
+	 * @return an optionally empty projection alias.
+	 */
+	public Optional<String> getProjectionAlias() {
+		return Optional.ofNullable(projectionAlias);
+	}
+
+	/**
+	 * Set the alias the projection element value should be mapped to. Used in CONSTRUCT queries for mapping select
+	 * expressions to statement patterns.
+	 * 
+	 * @param alias the projection alias.
+	 */
+	public void setProjectionAlias(String alias) {
+		this.projectionAlias = alias;
+	}
+
+	/**
+	 * @deprecated since 4.1.1. Use {@link #setProjectionAlias(String)} instead.
+	 */
+	@Deprecated(since = "4.1.1", forRemoval = true)
 	public void setTargetName(String targetName) {
-		assert targetName != null : "targetName must not be null";
-		this.targetName = targetName;
+		setProjectionAlias(targetName);
+	}
+
+	/**
+	 * @deprecated since 4.1.1. Use {@link #getProjectionAlias()} instead.
+	 */
+	@Deprecated(since = "4.1.1", forRemoval = true)
+	public String getTargetName() {
+		return getProjectionAlias().orElse(null);
 	}
 
 	@Override
@@ -78,11 +157,11 @@ public class ProjectionElem extends AbstractQueryModelNode {
 		sb.append(super.getSignature());
 
 		sb.append(" \"");
-		sb.append(sourceName);
+		sb.append(name);
 		sb.append("\"");
 
-		if (!sourceName.equals(targetName)) {
-			sb.append(" AS \"").append(targetName).append("\"");
+		if (projectionAlias != null) {
+			sb.append(" AS \"").append(projectionAlias).append("\"");
 		}
 
 		return sb.toString();
@@ -92,15 +171,14 @@ public class ProjectionElem extends AbstractQueryModelNode {
 	public boolean equals(Object other) {
 		if (other instanceof ProjectionElem) {
 			ProjectionElem o = (ProjectionElem) other;
-			return sourceName.equals(o.getSourceName()) && targetName.equals(o.getTargetName());
+			return name.equals(o.getName()) && Objects.equals(getProjectionAlias(), o.getProjectionAlias());
 		}
 		return false;
 	}
 
 	@Override
 	public int hashCode() {
-		// Note: don't xor source and target since they will often be equal
-		return targetName.hashCode();
+		return Objects.hash(name, projectionAlias);
 	}
 
 	@Override

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ProjectionElemList.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/ProjectionElemList.java
@@ -23,16 +23,10 @@ import java.util.stream.StreamSupport;
  */
 public class ProjectionElemList extends AbstractQueryModelNode {
 
-	/*-----------*
-	 * Variables *
-	 *-----------*/
+	private static final long serialVersionUID = 167331362220688635L;
 
 	private ProjectionElem[] elements = {};
 	private List<ProjectionElem> elementsList = Collections.emptyList();
-
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
 
 	public ProjectionElemList() {
 	}
@@ -44,10 +38,6 @@ public class ProjectionElemList extends AbstractQueryModelNode {
 	public ProjectionElemList(Iterable<ProjectionElem> elements) {
 		addElements(elements);
 	}
-
-	/*---------*
-	 * Methods *
-	 *---------*/
 
 	public List<ProjectionElem> getElements() {
 		return elementsList;
@@ -90,26 +80,44 @@ public class ProjectionElemList extends AbstractQueryModelNode {
 		pe.setParentNode(this);
 	}
 
+	/**
+	 *
+	 * @deprecated since 4.1.1. Use {@link #getProjectedNames()} instead.
+	 */
+	@Deprecated(since = "4.1.1", forRemoval = true)
 	public Set<String> getTargetNames() {
-		Set<String> targetNames = new LinkedHashSet<>(elementsList.size());
-
-		for (ProjectionElem pe : elementsList) {
-			targetNames.add(pe.getTargetName());
-		}
-
-		return targetNames;
+		return getProjectedNames();
 	}
 
-	public Set<String> getTargetNamesFor(Collection<String> sourceNames) {
-		Set<String> targetNames = new LinkedHashSet<>(elementsList.size());
+	public Set<String> getProjectedNames() {
+		Set<String> projectedNames = new LinkedHashSet<>(elementsList.size());
 
 		for (ProjectionElem pe : elementsList) {
-			if (sourceNames.contains(pe.getSourceName())) {
-				targetNames.add(pe.getTargetName());
+			projectedNames.add(pe.getProjectionAlias().orElse(pe.getName()));
+		}
+
+		return projectedNames;
+	}
+
+	/**
+	 *
+	 * @deprecated since 4.1.1. Use {@link #getProjectedNamesFor(Collection)} instead.
+	 */
+	@Deprecated(since = "4.1.1", forRemoval = true)
+	public Set<String> getTargetNamesFor(Collection<String> sourceNames) {
+		return getProjectedNamesFor(sourceNames);
+	}
+
+	public Set<String> getProjectedNamesFor(Collection<String> sourceNames) {
+		Set<String> projectedNames = new LinkedHashSet<>(elementsList.size());
+
+		for (ProjectionElem pe : elementsList) {
+			if (sourceNames.contains(pe.getName())) {
+				projectedNames.add(pe.getProjectionAlias().orElse(pe.getName()));
 			}
 		}
 
-		return targetNames;
+		return projectedNames;
 	}
 
 	@Override

--- a/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/ProjectionElemListTest.java
+++ b/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/ProjectionElemListTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php 
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.query.algebra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public class ProjectionElemListTest {
+
+	private ProjectionElem elem_a = new ProjectionElem("a");
+	private ProjectionElem elem_b = new ProjectionElem("b");
+	private ProjectionElem elem_ac = new ProjectionElem("a", "c");
+	private ProjectionElem elem_de = new ProjectionElem("d", "e");
+
+	private ProjectionElemList subject = new ProjectionElemList(elem_a, elem_b, elem_ac, elem_de);
+
+	@Test
+	public void testGetProjectedNames() {
+		assertThat(subject.getProjectedNames()).containsExactly("a", "b", "c", "e");
+	}
+
+	@Test
+	public void testGetProjectedNamesFor() {
+		Set<String> sourceNames = new HashSet<>(Arrays.asList("a", "d"));
+		assertThat(subject.getProjectedNamesFor(sourceNames)).containsExactly("a", "c", "e");
+
+		sourceNames = new HashSet<>(Arrays.asList("b"));
+		assertThat(subject.getProjectedNamesFor(sourceNames)).containsExactly("b");
+	}
+
+}

--- a/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/ProjectionElemTest.java
+++ b/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/ProjectionElemTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php 
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.query.algebra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeen Broekstra
+ *
+ */
+public class ProjectionElemTest {
+
+	private ProjectionElem elem_a = new ProjectionElem("a");
+	private ProjectionElem elem_b = new ProjectionElem("b");
+	private ProjectionElem elem_a2 = new ProjectionElem("a");
+
+	private ProjectionElem elem_ab = new ProjectionElem("a", "b");
+	private ProjectionElem elem_aa = new ProjectionElem("a", "a");
+	private ProjectionElem elem_ba = new ProjectionElem("b", "a");
+	private ProjectionElem elem_ab2 = new ProjectionElem("a", "b");
+
+	@Test
+	public void testEquals() {
+		assertThat(elem_a).isEqualTo(elem_a2);
+		assertThat(elem_a).isNotEqualTo(elem_aa).isNotEqualTo(elem_b).isNotEqualTo(elem_ab).isNotEqualTo(elem_ba);
+		assertThat(elem_ab).isNotEqualTo(elem_aa).isNotEqualTo(elem_ba);
+		assertThat(elem_ab).isEqualTo(elem_ab2);
+	}
+
+	@Test
+	public void testSignature() {
+		assertThat(elem_a.getSignature()).isEqualTo("ProjectionElem \"a\"");
+		assertThat(elem_aa.getSignature()).isEqualTo("ProjectionElem \"a\" AS \"a\"");
+		assertThat(elem_ab.getSignature()).isEqualTo("ProjectionElem \"a\" AS \"b\"");
+	}
+}

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -551,11 +551,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 					throw new VisitorException("Either TripleRef or Expression expected in projection.");
 				}
 
-				String sourceName = alias;
-				if (child instanceof ASTVar) {
-					sourceName = ((ASTVar) child).getName();
-				}
-				ProjectionElem elem = new ProjectionElem(sourceName, alias);
+				ProjectionElem elem = new ProjectionElem(alias);
 				projElemList.addElement(elem);
 
 				AggregateCollector collector = new AggregateCollector();
@@ -637,8 +633,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 							throw new VisitorException("non-aggregate expression '" + expr
 									+ "' not allowed in projection when using GROUP BY.");
 						}
-					} else if (!groupNames.contains(elem.getTargetName())) {
-						throw new VisitorException("variable '" + elem.getTargetName()
+					} else if (!groupNames.contains(elem.getName())) {
+						throw new VisitorException("variable '" + elem.getName()
 								+ "' in projection not present in GROUP BY.");
 					}
 				}
@@ -690,7 +686,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			String prev = varName;
 
 			for (ProjectionElem element : elements) {
-				if (element.getTargetName().equals(varName)) {
+				if (element.getName().equals(varName)) {
 					if (element.hasAggregateOperatorInExpression()) {
 						return false;
 					} else {
@@ -702,7 +698,7 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 							}
 						}
 
-						varName = element.getSourceName();
+						varName = element.getName();
 						break;
 					}
 				}
@@ -1658,9 +1654,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 
 		@Override
 		public void meet(ProjectionElem node) throws VisitorException {
-			if (node.getSourceName().equals(toBeReplaced.getName())) {
-				node.setSourceName(replacement.getName());
-				node.setTargetName(replacement.getName());
+			if (node.getName().equals(toBeReplaced.getName())) {
+				node.setName(replacement.getName());
 			}
 		}
 	}

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLParserTest.java
@@ -248,6 +248,27 @@ public class SPARQLParserTest {
 	}
 
 	@Test
+	public void testOrderByWithAliases2() throws Exception {
+		String queryString = "SELECT (?l AS ?v)\n"
+				+ "WHERE { ?s rdfs:label ?l. }\n"
+				+ "ORDER BY ?v";
+
+		ParsedQuery query = parser.parseQuery(queryString, null);
+
+		TupleExpr te = query.getTupleExpr();
+		assertThat(te).isInstanceOf(QueryRoot.class);
+		te = ((QueryRoot) te).getArg();
+		assertThat(te).isInstanceOf(Projection.class);
+
+		te = ((Projection) te).getArg();
+		assertThat(te).isInstanceOf(Order.class);
+
+		te = ((Order) te).getArg();
+		assertThat(te).isInstanceOf(Extension.class);
+
+	}
+
+	@Test
 	public void testSES1927UnequalLiteralValueConstants1() throws Exception {
 
 		StringBuilder qb = new StringBuilder();
@@ -457,7 +478,7 @@ public class SPARQLParserTest {
 				+ "} GROUP BY ?p";
 
 		assertThatExceptionOfType(MalformedQueryException.class).isThrownBy(() -> parser.parseQuery(query, null))
-				.withMessageStartingWith("variable 'o' in projection not present in GROUP BY.");
+				.withMessageStartingWith("non-aggregate expression 'Var (name=o)");
 	}
 
 	@Test

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestSparqlStarParser.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestSparqlStarParser.java
@@ -248,7 +248,7 @@ public class TestSparqlStarParser {
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
-			listNames.add(el.getTargetName());
+			listNames.add(el.getName());
 		});
 		assertEquals("expect all bindings", 4, list.size());
 		assertTrue("expect s", listNames.contains("s"));
@@ -311,7 +311,7 @@ public class TestSparqlStarParser {
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
-			listNames.add(el.getTargetName());
+			listNames.add(el.getName());
 		});
 		assertEquals("expect all bindings", 4, list.size());
 		assertTrue("expect s", listNames.contains("s"));
@@ -381,7 +381,7 @@ public class TestSparqlStarParser {
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
-			listNames.add(el.getTargetName());
+			listNames.add(el.getName());
 		});
 		assertEquals("expect all bindings", 6, list.size());
 		assertTrue("expect s", listNames.contains("s"));
@@ -461,7 +461,7 @@ public class TestSparqlStarParser {
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listTargetNames = new ArrayList<>();
 		list.forEach(el -> {
-			listTargetNames.add(el.getTargetName());
+			listTargetNames.add(el.getProjectionAlias().orElse(null));
 		});
 		assertEquals("expect all bindings", 3, list.size());
 		assertTrue("expect target subject", listTargetNames.contains("subject"));
@@ -470,7 +470,7 @@ public class TestSparqlStarParser {
 
 		final ArrayList<String> listSourceNames = new ArrayList<>();
 		list.forEach(el -> {
-			listSourceNames.add(el.getSourceName());
+			listSourceNames.add(el.getName());
 		});
 
 		assertTrue("expect extension", proj.getArg() instanceof Extension);
@@ -665,8 +665,8 @@ public class TestSparqlStarParser {
 	 *                Var (name=_anon_3ddeacea_c54c_4db0_bb6e_2f699772e5f8, anonymous)
 	 *          GroupElem
 	 *             Count (Distinct)
-	 *                Var (name=p)	 * @throws Exception
-	 *
+	 *                Var (name=p)
+	 *                	 
 	 * @throws Exception
 	 */
 	@Test
@@ -684,7 +684,7 @@ public class TestSparqlStarParser {
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
-			listNames.add(el.getTargetName());
+			listNames.add(el.getName());
 		});
 		assertEquals("expect all bindings", 2, list.size());
 		assertTrue("expect ref", listNames.contains("ref"));
@@ -767,7 +767,7 @@ public class TestSparqlStarParser {
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
-			listNames.add(el.getTargetName());
+			listNames.add(el.getName());
 		});
 		assertEquals("expect all bindings", 3, list.size());
 		assertTrue("expect s", listNames.contains("s"));
@@ -833,7 +833,7 @@ public class TestSparqlStarParser {
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
-			listNames.add(el.getTargetName());
+			listNames.add(el.getName());
 		});
 		assertEquals("expect one binding", 1, list.size());
 		assertTrue("expect str", listNames.contains("str"));

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilderTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilderTest.java
@@ -19,13 +19,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.Order;
 import org.eclipse.rdf4j.query.algebra.Projection;
-import org.eclipse.rdf4j.query.algebra.ProjectionElem;
 import org.eclipse.rdf4j.query.algebra.Service;
 import org.eclipse.rdf4j.query.algebra.SingletonSet;
 import org.eclipse.rdf4j.query.algebra.Slice;
-import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTQueryContainer;
@@ -55,11 +54,12 @@ public class TupleExprBuilderTest {
 			assertThat(result instanceof Projection).isTrue();
 
 			Projection p = (Projection) result;
-			assertThat(p.getArg()).isInstanceOf(StatementPattern.class);
+			assertThat(p.getArg()).isInstanceOf(Extension.class);
+			Extension extension = (Extension) p.getArg();
 
-			ProjectionElem alias = p.getProjectionElemList().getElements().get(0);
-			assertThat(alias.getSourceName()).isEqualTo("a");
-			assertThat(alias.getTargetName()).isEqualTo("b");
+			assertThat(extension.getElements()).hasSize(1)
+					.allMatch(elem -> elem.getName().equals("b") && ((Var) elem.getExpr()).getName().equals("a"));
+
 		} catch (Exception e) {
 			e.printStackTrace();
 			fail("should parse simple select query");

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/BaseTupleExprRenderer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/BaseTupleExprRenderer.java
@@ -158,15 +158,15 @@ public abstract class BaseTupleExprRenderer extends AbstractQueryModelVisitor<Ex
 		ProjectionElem aObj = theList.getElements().get(2);
 
 		return new StatementPattern(
-				mExtensions.containsKey(aSubj.getSourceName())
-						? new Var(scrubVarName(aSubj.getSourceName()), asValue(mExtensions.get(aSubj.getSourceName())))
-						: new Var(scrubVarName(aSubj.getSourceName())),
-				mExtensions.containsKey(aPred.getSourceName())
-						? new Var(scrubVarName(aPred.getSourceName()), asValue(mExtensions.get(aPred.getSourceName())))
-						: new Var(scrubVarName(aPred.getSourceName())),
-				mExtensions.containsKey(aObj.getSourceName())
-						? new Var(scrubVarName(aObj.getSourceName()), asValue(mExtensions.get(aObj.getSourceName())))
-						: new Var(scrubVarName(aObj.getSourceName())));
+				mExtensions.containsKey(aSubj.getName())
+						? new Var(scrubVarName(aSubj.getName()), asValue(mExtensions.get(aSubj.getName())))
+						: new Var(scrubVarName(aSubj.getName())),
+				mExtensions.containsKey(aPred.getName())
+						? new Var(scrubVarName(aPred.getName()), asValue(mExtensions.get(aPred.getName())))
+						: new Var(scrubVarName(aPred.getName())),
+				mExtensions.containsKey(aObj.getName())
+						? new Var(scrubVarName(aObj.getName()), asValue(mExtensions.get(aObj.getName())))
+						: new Var(scrubVarName(aObj.getName())));
 	}
 
 	/**
@@ -227,9 +227,9 @@ public abstract class BaseTupleExprRenderer extends AbstractQueryModelVisitor<Ex
 	 */
 	public static boolean isSPOElemList(ProjectionElemList theList) {
 		return theList.getElements().size() == 3
-				&& theList.getElements().get(0).getTargetName().equalsIgnoreCase("subject")
-				&& theList.getElements().get(1).getTargetName().equalsIgnoreCase("predicate")
-				&& theList.getElements().get(2).getTargetName().equalsIgnoreCase("object");
+				&& theList.getElements().get(0).getProjectionAlias().get().equalsIgnoreCase("subject")
+				&& theList.getElements().get(1).getProjectionAlias().get().equalsIgnoreCase("predicate")
+				&& theList.getElements().get(2).getProjectionAlias().get().equalsIgnoreCase("object");
 	}
 
 	/**

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SPARQLQueryRenderer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/SPARQLQueryRenderer.java
@@ -103,7 +103,7 @@ public class SPARQLQueryRenderer implements QueryRenderer {
 							aFirst = false;
 						}
 
-						aQuery.append("?" + aElem.getSourceName());
+						aQuery.append("?" + aElem.getName());
 					}
 				}
 			}

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/PreprocessedQuerySerializer.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/PreprocessedQuerySerializer.java
@@ -954,15 +954,15 @@ class PreprocessedQuerySerializer extends AbstractQueryModelVisitor<RuntimeExcep
 
 		for (ProjectionElemList proj : node.getProjections()) {
 			for (ProjectionElem elem : proj.getElements()) {
-				if (valueMap.containsKey(elem.getSourceName())) {
-					ValueExpr expr = valueMap.get(elem.getSourceName());
+				if (valueMap.containsKey(elem.getName())) {
+					ValueExpr expr = valueMap.get(elem.getName());
 					if (expr instanceof BNodeGenerator) {
-						builder.append("_:" + elem.getSourceName());
+						builder.append("_:" + elem.getName());
 					} else {
-						valueMap.get(elem.getSourceName()).visit(this);
+						valueMap.get(elem.getName()).visit(this);
 					}
 				} else {
-					builder.append("?" + elem.getSourceName());
+					builder.append("?" + elem.getName());
 				}
 				builder.append(" ");
 				// elem.getSourceExpression().getExpr().visit(this);
@@ -1034,31 +1034,30 @@ class PreprocessedQuerySerializer extends AbstractQueryModelVisitor<RuntimeExcep
 
 	@Override
 	public void meet(ProjectionElem node) throws RuntimeException {
-
 		if (node.getSourceExpression() == null) {
 			boolean isDescribe = false;
 			if ((this.currentQueryProfile instanceof SerializableParsedConstructQuery)) {
 				isDescribe = ((SerializableParsedConstructQuery) this.currentQueryProfile).describe;
 			}
 
-			if (node.getSourceName() == null || node.getTargetName().equals(node.getSourceName())) {
-				if (isDescribe && this.currentQueryProfile.extensionElements.containsKey(node.getTargetName())) {
-					ExtensionElem elem = this.currentQueryProfile.extensionElements.get(node.getTargetName());
+			if (node.getProjectionAlias().isEmpty() || node.getProjectionAlias().get().equals(node.getName())) {
+				if (isDescribe && this.currentQueryProfile.extensionElements.containsKey(node.getName())) {
+					ExtensionElem elem = this.currentQueryProfile.extensionElements.get(node.getName());
 					elem.getExpr().visit(this);
 					builder.append(" ");
 				} else {
 					builder.append("?");
-					builder.append(node.getTargetName());
+					builder.append(node.getName());
 					builder.append(" ");
 				}
 			} else {
 				builder.append("(");
 				builder.append("?");
-				builder.append(node.getSourceName());
+				builder.append(node.getName());
 				builder.append(" ");
 				builder.append("AS ");
 				builder.append("?");
-				builder.append(node.getTargetName());
+				builder.append(node.getProjectionAlias());
 				builder.append(" ");
 				builder.append(") ");
 			}
@@ -1069,7 +1068,7 @@ class PreprocessedQuerySerializer extends AbstractQueryModelVisitor<RuntimeExcep
 				builder.append(") ");
 			} else {
 				builder.append("?");
-				builder.append(node.getTargetName());
+				builder.append(node.getName());
 				builder.append(" ");
 			}
 		}

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/SerializableParsedConstructQuery.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/SerializableParsedConstructQuery.java
@@ -48,7 +48,7 @@ class SerializableParsedConstructQuery extends AbstractSerializableParsedQuery {
 		List<String> res = Lists.newArrayList();
 		for (ProjectionElemList proj : projection.getProjections()) {
 			for (ProjectionElem elem : proj.getElements()) {
-				res.add(elem.getTargetName());
+				res.add(elem.getProjectionAlias().orElse(elem.getName()));
 			}
 		}
 		return res;

--- a/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/SerializableParsedTupleQuery.java
+++ b/core/queryrender/src/main/java/org/eclipse/rdf4j/queryrender/sparql/experimental/SerializableParsedTupleQuery.java
@@ -56,7 +56,7 @@ class SerializableParsedTupleQuery extends AbstractSerializableParsedQuery {
 				projection.getProjectionElemList().getElements().size());
 
 		for (ProjectionElem elem : projection.getProjectionElemList().getElements()) {
-			res.add(elem.getTargetName());
+			res.add(elem.getProjectionAlias().orElse(elem.getName()));
 		}
 
 		return res;

--- a/core/spin/src/main/java/org/eclipse/rdf4j/spin/SpinParser.java
+++ b/core/spin/src/main/java/org/eclipse/rdf4j/spin/SpinParser.java
@@ -1027,9 +1027,6 @@ public class SpinParser {
 					} else {
 						valueExpr = new Var(varName);
 					}
-					if (projName == null) {
-						projName = varName;
-					}
 				} else {
 					// resource
 					if (projName == null) {
@@ -1050,7 +1047,7 @@ public class SpinParser {
 					group = new Group();
 				}
 				for (AggregateOperator op : aggregates) {
-					group.addGroupElement(new GroupElem(projName, op));
+					group.addGroupElement(new GroupElem(projElem.getProjectionAlias().orElse(varName), op));
 				}
 			}
 			aggregates = oldAggregates;

--- a/core/spin/src/main/java/org/eclipse/rdf4j/spin/SpinRenderer.java
+++ b/core/spin/src/main/java/org/eclipse/rdf4j/spin/SpinRenderer.java
@@ -367,11 +367,11 @@ public class SpinRenderer {
 			if (isSubQuery) {
 				super.meet(node);
 			} else {
-				String varName = node.getSourceName();
+				String varName = node.getName();
 				ValueExpr valueExpr = inlineBindings.getValueExpr(varName);
 				Value value = (valueExpr instanceof ValueConstant) ? ((ValueConstant) valueExpr).getValue()
 						: getVar(varName);
-				String targetName = node.getTargetName();
+				String targetName = node.getProjectionAlias().orElse(null);
 				IRI pred;
 				if ("subject".equals(targetName)) {
 					pred = SP.SUBJECT_PROPERTY;
@@ -611,10 +611,10 @@ public class SpinRenderer {
 		public void meet(ProjectionElem node) throws RDFHandlerException {
 			ValueExpr valueExpr = null;
 			if (inlineBindings != null) {
-				String varName = node.getSourceName();
+				String varName = node.getName();
 				valueExpr = inlineBindings.getValueExpr(varName);
 			}
-			Resource targetVar = getVar(node.getTargetName());
+			Resource targetVar = getVar(node.getProjectionAlias().orElse(node.getName()));
 			listEntry(targetVar);
 			if (valueExpr != null && !(valueExpr instanceof Var)) {
 				Resource currentSubj = subject;


### PR DESCRIPTION
GitHub issue resolved: #4066  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- re-introduce use of Extension for all non-var SELECT expressions
- refactor of ProjectionElem and ProjectionElemList to clarify use of name vs targetName

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

