### PR TITLE
GH-3421 use cleaner instead of weak reference

### DIFF
--- a/core/http/client/pom.xml
+++ b/core/http/client/pom.xml
@@ -105,6 +105,11 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sail-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/SPARQLProtocolSession.java
@@ -354,6 +354,10 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	 * Query evaluation *
 	 *------------------*/
 
+	/**
+	 * @deprecated WeakReference<?> callerRef argument will be removed
+	 */
+	@Deprecated(since = "4.1.2")
 	public TupleQueryResult sendTupleQuery(QueryLanguage ql, String query, Dataset dataset, boolean includeInferred,
 			WeakReference<?> callerRef,
 			Binding... bindings) throws IOException, RepositoryException, MalformedQueryException,
@@ -361,6 +365,10 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 		return sendTupleQuery(ql, query, null, dataset, includeInferred, 0, callerRef, bindings);
 	}
 
+	/**
+	 * @deprecated WeakReference<?> callerRef argument will be removed
+	 */
+	@Deprecated(since = "4.1.2")
 	public TupleQueryResult sendTupleQuery(QueryLanguage ql, String query, String baseURI, Dataset dataset,
 			boolean includeInferred, int maxQueryTime, WeakReference<?> callerRef, Binding... bindings)
 			throws IOException, RepositoryException,
@@ -397,6 +405,10 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 		}
 	}
 
+	/**
+	 * @deprecated WeakReference<?> callerRef argument will be removed
+	 */
+	@Deprecated(since = "4.1.2")
 	public GraphQueryResult sendGraphQuery(QueryLanguage ql, String query, Dataset dataset, boolean includeInferred,
 			WeakReference<?> callerRef,
 			Binding... bindings) throws IOException, RepositoryException, MalformedQueryException,
@@ -404,6 +416,10 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 		return sendGraphQuery(ql, query, null, dataset, includeInferred, 0, callerRef, bindings);
 	}
 
+	/**
+	 * @deprecated WeakReference<?> callerRef argument will be removed
+	 */
+	@Deprecated(since = "4.1.2")
 	public GraphQueryResult sendGraphQuery(QueryLanguage ql, String query, String baseURI, Dataset dataset,
 			boolean includeInferred, int maxQueryTime, WeakReference<?> callerRef, Binding... bindings)
 			throws IOException, RepositoryException,
@@ -641,7 +657,10 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	/**
 	 * Parse the response in a background thread. HTTP connections are dealt with in the {@link BackgroundTupleResult}
 	 * or (in the error-case) in this method.
+	 * 
+	 * @deprecated WeakReference<?> callerRef argument will be removed
 	 */
+	@Deprecated(since = "4.1.2")
 	protected TupleQueryResult getBackgroundTupleQueryResult(HttpUriRequest method, WeakReference<?> callerRef)
 			throws RepositoryException, QueryInterruptedException, MalformedQueryException, IOException {
 
@@ -771,7 +790,10 @@ public class SPARQLProtocolSession implements HttpClientDependent, AutoCloseable
 	/**
 	 * Parse the response in a background thread. HTTP connections are dealt with in the {@link BackgroundGraphResult}
 	 * or (in the error-case) in this method.
+	 * 
+	 * @deprecated WeakReference<?> callerRef argument will be removed
 	 */
+	@Deprecated(since = "4.1.2")
 	protected GraphQueryResult getRDFBackground(HttpUriRequest method, boolean requireContext,
 			WeakReference<?> callerRef)
 			throws IOException, RDFHandlerException, RepositoryException, MalformedQueryException,

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/BackgroundGraphResultHangTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/BackgroundGraphResultHangTest.java
@@ -16,7 +16,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
@@ -55,13 +54,12 @@ public class BackgroundGraphResultHangTest {
 
 	@Test
 	@Timeout(value = 1, unit = TimeUnit.SECONDS)
-	public void testBGRHang() throws Exception {
+	public void testBGRHang() {
 		String data = "@not-rdf";
 		Exception exception = assertThrows(QueryEvaluationException.class, () -> {
 			BackgroundGraphResult gRes = new BackgroundGraphResult(new DummyParser(),
 					new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8,
-					"http://base.org", new WeakReference<>(data));
-
+					"http://example.org", null);
 			gRes.run();
 			gRes.getNamespaces();
 			gRes.hasNext();

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/QueueCursor.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/QueueCursor.java
@@ -28,10 +28,23 @@ public class QueueCursor<E> extends QueueIteration<E, QueryEvaluationException> 
 	/**
 	 * Creates an <var>QueueCursor</var> with the given (fixed) capacity and default access policy.
 	 *
+	 * @param capacity the capacity of this queue
+	 */
+	public QueueCursor(int capacity) {
+		super(capacity, false);
+	}
+
+	/**
+	 * Creates an <var>QueueCursor</var> with the given (fixed) capacity and default access policy.
+	 *
 	 * @param capacity        the capacity of this queue
 	 * @param callerReference the thing that needs this cursor. Used to detect unexpected code failures and clean up in
 	 *                        those case
+	 * @deprecated WeakReference is no longer supported as a way to automatically close this iteration. The recommended
+	 *             approach to automatically closing an iteration on garbage collection is to use a
+	 *             {@link java.lang.ref.Cleaner}.
 	 */
+	@Deprecated(since = "4.1.2", forRemoval = true)
 	public QueueCursor(int capacity, WeakReference<?> callerReference) {
 		this(capacity, false, callerReference);
 	}
@@ -44,7 +57,11 @@ public class QueueCursor<E> extends QueueIteration<E, QueryEvaluationException> 
 	 *                        processed in FIFO order; if <var>false</var> the access order is unspecified.
 	 * @param callerReference the thing that needs this cursor. Used to detect unexpected code failures and clean up in
 	 *                        those case
+	 * @deprecated WeakReference is no longer supported as a way to automatically close this iteration. The recommended
+	 *             approach to automatically closing an iteration on garbage collection is to use a
+	 *             {@link java.lang.ref.Cleaner}.
 	 */
+	@Deprecated(since = "4.1.2", forRemoval = true)
 	public QueueCursor(int capacity, boolean fair, WeakReference<?> callerReference) {
 		super(capacity, fair, callerReference);
 	}
@@ -58,9 +75,28 @@ public class QueueCursor<E> extends QueueIteration<E, QueryEvaluationException> 
 	 *                        implementation for this cursor.
 	 * @param callerReference the thing that needs this cursor. Used to detect unexpected code failures and clean up in
 	 *                        those case
+	 * @deprecated WeakReference is no longer supported as a way to automatically close this iteration. The recommended
+	 *             approach to automatically closing an iteration on garbage collection is to use a
+	 *             {@link java.lang.ref.Cleaner}.
 	 */
+	@Deprecated(since = "4.1.2", forRemoval = true)
 	public QueueCursor(BlockingQueue<E> queue, WeakReference<?> callerReference) {
 		super(queue, callerReference);
+	}
+
+	/**
+	 * Creates an <var>QueueCursor</var> with the given {@link BlockingQueue} as its backing queue.<br>
+	 * It may not be threadsafe to modify or access the given {@link BlockingQueue} from other locations. This method
+	 * only enables the default {@link ArrayBlockingQueue} to be overridden.
+	 *
+	 * @param queue A BlockingQueue that is not used in other locations, but will be used as the backing Queue
+	 *              implementation for this cursor.
+	 * @deprecated WeakReference is no longer supported as a way to automatically close this iteration. The recommended
+	 *             approach to automatically closing an iteration on garbage collection is to use a
+	 *             {@link java.lang.ref.Cleaner}.
+	 */
+	public QueueCursor(BlockingQueue<E> queue) {
+		super(queue);
 	}
 
 	@Override

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateDataBlockParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateDataBlockParserTest.java
@@ -32,7 +32,7 @@ public class SPARQLUpdateDataBlockParserTest {
 		String[] blocksToCheck = new String[] { "graph <u:g1> {<u:1> <p:1> 1 } . <u:2> <p:2> 2.",
 				"graph <u:g1> {<u:1> <p:1> 1 .} . <u:2> <p:2> 2." };
 		for (String block : blocksToCheck) {
-			parser.parse(new StringReader(block), "http://base.org");
+			parser.parse(new StringReader(block), "http://example.org");
 		}
 	}
 
@@ -46,7 +46,7 @@ public class SPARQLUpdateDataBlockParserTest {
 				"@prefix u: <http://example.com/>.\n<< <a>  u:2<<<b> u:4 u:5>>>>u:6<< u:7 u:8<c>>>"
 		};
 		for (String block : blocksToCheck) {
-			parser.parse(new StringReader(block), "http://base.org");
+			parser.parse(new StringReader(block), "http://example.org");
 		}
 	}
 }

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestPropPathMisbehaviour.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestPropPathMisbehaviour.java
@@ -55,7 +55,7 @@ public class TestPropPathMisbehaviour {
 		String query1 = "select ?iri ?value where { \n" +
 				"    ?iri (<urn:p>+) / <urn:q> ?value .\n" +
 				"}";
-		ParsedQuery q = parser.parseQuery(query1, "http://base.org/");
+		ParsedQuery q = parser.parseQuery(query1, "http://example.org/");
 
 		assertNotNull(q);
 		TupleExpr tupleExpr = q.getTupleExpr();
@@ -83,7 +83,7 @@ public class TestPropPathMisbehaviour {
 		String query1 = "select ?value where { \n" +
 				"    <urn:non-existent> ^(<urn:p>*) / <urn:q>? ?value .\n" +
 				"}";
-		ParsedQuery q = parser.parseQuery(query1, "http://base.org/");
+		ParsedQuery q = parser.parseQuery(query1, "http://example.org/");
 
 		assertNotNull(q);
 		TupleExpr tupleExpr = q.getTupleExpr();

--- a/core/queryresultio/api/pom.xml
+++ b/core/queryresultio/api/pom.xml
@@ -25,6 +25,11 @@
 			<artifactId>rdf4j-rio-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sail-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/queryresultio/binary/src/test/java/org/eclipse/rdf4j/query/resultio/binary/SPARQLBinaryTupleBackgroundTest.java
+++ b/core/queryresultio/binary/src/test/java/org/eclipse/rdf4j/query/resultio/binary/SPARQLBinaryTupleBackgroundTest.java
@@ -46,7 +46,7 @@ public class SPARQLBinaryTupleBackgroundTest extends AbstractQueryResultIOTupleT
 	@Override
 	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
 			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTupleBackground(in, format, new WeakReference<>(this));
+		return QueryResultIO.parseTupleBackground(in, format, null);
 	}
 
 }

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleBackgroundTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleBackgroundTest.java
@@ -63,7 +63,7 @@ public class SPARQLJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTes
 	@Override
 	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
 			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTupleBackground(in, format, new WeakReference<>(this));
+		return QueryResultIO.parseTupleBackground(in, format, null);
 	}
 
 	@Test

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarJSONTupleBackgroundTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLStarJSONTupleBackgroundTest.java
@@ -45,6 +45,6 @@ public class SPARQLStarJSONTupleBackgroundTest extends AbstractQueryResultIOTupl
 	@Override
 	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
 			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTupleBackground(in, format, new WeakReference<>(this));
+		return QueryResultIO.parseTupleBackground(in, format, null);
 	}
 }

--- a/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarXMLTupleBackgroundTest.java
+++ b/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLStarXMLTupleBackgroundTest.java
@@ -46,7 +46,7 @@ public class SPARQLStarXMLTupleBackgroundTest extends AbstractQueryResultIOTuple
 	@Override
 	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
 			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTupleBackground(in, format, new WeakReference<>(this));
+		return QueryResultIO.parseTupleBackground(in, format, null);
 	}
 
 }

--- a/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleBackgroundTest.java
+++ b/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleBackgroundTest.java
@@ -46,7 +46,7 @@ public class SPARQLXMLTupleBackgroundTest extends AbstractQueryResultIOTupleTest
 	@Override
 	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
 			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTupleBackground(in, format, new WeakReference<>(this));
+		return QueryResultIO.parseTupleBackground(in, format, null);
 	}
 
 }

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleBackgroundTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLStarTSVTupleBackgroundTest.java
@@ -46,6 +46,6 @@ public class SPARQLStarTSVTupleBackgroundTest extends AbstractQueryResultIOTuple
 	@Override
 	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
 			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTupleBackground(in, format, new WeakReference<>(this));
+		return QueryResultIO.parseTupleBackground(in, format, null);
 	}
 }

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleBackgroundTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleBackgroundTest.java
@@ -61,7 +61,7 @@ public class SPARQLTSVTupleBackgroundTest extends AbstractQueryResultIOTupleTest
 	@Override
 	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
 			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTupleBackground(in, format, new WeakReference<>(this));
+		return QueryResultIO.parseTupleBackground(in, format, null);
 	}
 
 	@Test

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPGraphQuery.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPGraphQuery.java
@@ -50,7 +50,7 @@ public class HTTPGraphQuery extends AbstractHTTPQuery implements GraphQuery {
 		try {
 			conn.flushTransactionState(Protocol.Action.QUERY);
 			return client.sendGraphQuery(queryLanguage, queryString, baseURI, dataset, getIncludeInferred(),
-					getMaxExecutionTime(), new WeakReference<>(this), getBindingsArray());
+					getMaxExecutionTime(), ((WeakReference) null), getBindingsArray());
 		} catch (IOException | RepositoryException | MalformedQueryException e) {
 			throw new HTTPQueryEvaluationException(e.getMessage(), e);
 		}

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPTupleQuery.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPTupleQuery.java
@@ -48,8 +48,9 @@ public class HTTPTupleQuery extends AbstractHTTPQuery implements TupleQuery {
 		SPARQLProtocolSession client = getHttpClient();
 		try {
 			conn.flushTransactionState(Protocol.Action.QUERY);
+
 			return client.sendTupleQuery(queryLanguage, queryString, baseURI, dataset, getIncludeInferred(),
-					getMaxExecutionTime(), new WeakReference<>(this), getBindingsArray());
+					getMaxExecutionTime(), ((WeakReference) null), getBindingsArray());
 		} catch (IOException | RepositoryException | MalformedQueryException e) {
 			throw new HTTPQueryEvaluationException(e.getMessage(), e);
 		}

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/JoinExecutorBase.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/JoinExecutorBase.java
@@ -54,8 +54,7 @@ public abstract class JoinExecutorBase<T> extends LookAheadIteration<T, QueryEva
 	 */
 	protected volatile boolean finished = false;
 
-	protected final QueueCursor<CloseableIteration<T, QueryEvaluationException>> rightQueue = new QueueCursor<>(1024,
-			new WeakReference<>(this));
+	protected final QueueCursor<CloseableIteration<T, QueryEvaluationException>> rightQueue = new QueueCursor<>(1024);
 
 	protected JoinExecutorBase(CloseableIteration<T, QueryEvaluationException> leftIter, TupleExpr rightArg,
 			BindingSet bindings) throws QueryEvaluationException {

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLGraphQuery.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLGraphQuery.java
@@ -44,7 +44,7 @@ public class SPARQLGraphQuery extends AbstractHTTPQuery implements GraphQuery {
 			// TODO getQueryString() already inserts bindings, use emptybindingset
 			// as last argument?
 			return client.sendGraphQuery(queryLanguage, getQueryString(), baseURI, dataset, getIncludeInferred(),
-					getMaxExecutionTime(), new WeakReference<>(this), getBindingsArray());
+					getMaxExecutionTime(), ((WeakReference) null), getBindingsArray());
 		} catch (IOException | RepositoryException | MalformedQueryException e) {
 			throw new QueryEvaluationException(e.getMessage(), e);
 		}

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLTupleQuery.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLTupleQuery.java
@@ -45,7 +45,7 @@ public class SPARQLTupleQuery extends AbstractHTTPQuery implements TupleQuery {
 		SPARQLProtocolSession client = getHttpClient();
 		try {
 			return client.sendTupleQuery(QueryLanguage.SPARQL, getQueryString(), baseURI, dataset, getIncludeInferred(),
-					getMaxExecutionTime(), new WeakReference<>(this), getBindingsArray());
+					getMaxExecutionTime(), ((WeakReference) null), getBindingsArray());
 		} catch (IOException | RepositoryException | MalformedQueryException e) {
 			throw new QueryEvaluationException(e.getMessage(), e);
 		}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/ParserConfig.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/ParserConfig.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/WriterConfig.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/WriterConfig.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
-import java.io.Serializable;
-
 /**
  * A container object for easy setting and passing of {@link RDFWriter} configuration options.
  *

--- a/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
+++ b/core/rio/binary/src/test/java/org/eclipse/rdf4j/rio/binary/BinaryRDFWriterBackgroundTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.rio.binary;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -36,7 +35,7 @@ public class BinaryRDFWriterBackgroundTest extends RDFWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 	@Override

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -30,7 +30,6 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParser.java
@@ -26,7 +26,6 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.jsonld.JSONLDParser;
 
 import com.fasterxml.jackson.core.JsonFactory;

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriter.java
@@ -25,7 +25,6 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
@@ -17,7 +17,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -69,7 +68,7 @@ public class JSONLDWriterBackgroundTest extends RDFWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 	@Test

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/NQuadsWriterBackgroundTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/NQuadsWriterBackgroundTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.rio.nquads;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -30,7 +29,7 @@ public class NQuadsWriterBackgroundTest extends AbstractNQuadsWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 }

--- a/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
+++ b/core/rio/ntriples/src/main/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriter.java
@@ -28,7 +28,6 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterBackgroundTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/NTriplesWriterBackgroundTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.rio.ntriples;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -35,7 +34,7 @@ public class NTriplesWriterBackgroundTest extends AbstractNTriplesWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 }

--- a/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONStreamingWriterTest.java
+++ b/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONStreamingWriterTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.rdf4j.rio.rdfjson;
 
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -39,7 +38,7 @@ public class RDFJSONStreamingWriterTest extends RDFWriterTest {
 			throws RDFParseException, RDFHandlerException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 	@Override

--- a/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriterTest.java
+++ b/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriterTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.rio.rdfjson;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -39,7 +38,7 @@ public class RDFJSONWriterTest extends RDFWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 	@Override

--- a/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
+++ b/core/rio/rdfxml/src/main/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriter.java
@@ -34,7 +34,6 @@ import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterBackgroundTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterBackgroundTest.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -56,7 +55,7 @@ public class RDFXMLPrettyWriterBackgroundTest extends AbstractRDFXMLWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 	/**

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterBackgroundTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterBackgroundTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.rio.rdfxml;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -37,7 +36,7 @@ public class RDFXMLWriterBackgroundTest extends AbstractRDFXMLWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 }

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGPrettyWriterBackgroundTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGPrettyWriterBackgroundTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.rio.trig;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -42,7 +41,7 @@ public class TriGPrettyWriterBackgroundTest extends AbstractTriGWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 }

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGWriterBackgroundTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGWriterBackgroundTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.rio.trig;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.ref.WeakReference;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -40,7 +39,7 @@ public class TriGWriterBackgroundTest extends AbstractTriGWriterTest {
 			throws RDFParseException, RDFHandlerException, IOException {
 		return QueryResults
 				.asModel(QueryResults.parseGraphBackground(reader, baseURI, rdfParserFactory.getRDFFormat(),
-						new WeakReference<>(this)));
+						null));
 	}
 
 }

--- a/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
+++ b/core/rio/trix/src/main/java/org/eclipse/rdf4j/rio/trix/TriXWriter.java
@@ -36,7 +36,6 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
 

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -50,7 +50,6 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/diagnostics/CleanerGraphQueryResult.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/diagnostics/CleanerGraphQueryResult.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.common.concurrent.locks.diagnostics;
+
+import java.lang.ref.Cleaner;
+import java.util.Map;
+
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InternalUseOnly
+public class CleanerGraphQueryResult implements GraphQueryResult {
+
+	private static final Logger logger = LoggerFactory.getLogger(CleanerGraphQueryResult.class);
+
+	private final GraphQueryResult delegate;
+	private final Cleaner.Cleanable cleanable;
+	private final CleanableState state;
+
+	public CleanerGraphQueryResult(GraphQueryResult delegate, ConcurrentCleaner cleaner) {
+		this.delegate = delegate;
+		this.state = new CleanableState(delegate);
+		this.cleanable = cleaner.register(this, state);
+	}
+
+	@Override
+	public void close() {
+		state.close();
+		cleanable.clean();
+	}
+
+	@Override
+	public boolean hasNext() {
+		return delegate.hasNext();
+	}
+
+	@Override
+	public Statement next() {
+		return delegate.next();
+	}
+
+	@Override
+	public void remove() {
+		delegate.remove();
+	}
+
+	@Override
+	public Map<String, String> getNamespaces() throws QueryEvaluationException {
+		return delegate.getNamespaces();
+	}
+
+	private final static class CleanableState implements Runnable {
+
+		private final GraphQueryResult iteration;
+		private boolean closed = false;
+
+		public CleanableState(GraphQueryResult iteration) {
+			this.iteration = iteration;
+		}
+
+		@Override
+		public void run() {
+			if (!closed) {
+				try {
+					logger.warn(
+							"Forced closing of unclosed iteration. Set the system property 'org.eclipse.rdf4j.repository.debug' to 'true' to get stack traces.");
+					iteration.close();
+				} catch (Exception e) {
+					if (e instanceof InterruptedException) {
+						Thread.currentThread().interrupt();
+					}
+					throw new RuntimeException(e);
+				}
+			}
+		}
+
+		public void close() {
+			closed = true;
+			iteration.close();
+		}
+	}
+
+}

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/diagnostics/CleanerTupleQueryResult.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/common/concurrent/locks/diagnostics/CleanerTupleQueryResult.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.common.concurrent.locks.diagnostics;
+
+import java.lang.ref.Cleaner;
+import java.util.List;
+
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InternalUseOnly
+public class CleanerTupleQueryResult implements TupleQueryResult {
+
+	private static final Logger logger = LoggerFactory.getLogger(CleanerTupleQueryResult.class);
+
+	private final TupleQueryResult delegate;
+	private final Cleaner.Cleanable cleanable;
+	private final CleanableState state;
+
+	public CleanerTupleQueryResult(TupleQueryResult delegate, ConcurrentCleaner cleaner) {
+		this.delegate = delegate;
+		this.state = new CleanableState(delegate);
+		this.cleanable = cleaner.register(this, state);
+	}
+
+	@Override
+	public void close() {
+		state.close();
+		cleanable.clean();
+	}
+
+	@Override
+	public boolean hasNext() {
+		return delegate.hasNext();
+	}
+
+	@Override
+	public BindingSet next() {
+		return delegate.next();
+	}
+
+	@Override
+	public void remove() {
+		delegate.remove();
+	}
+
+	@Override
+	public List<String> getBindingNames() throws QueryEvaluationException {
+		return delegate.getBindingNames();
+	}
+
+	private final static class CleanableState implements Runnable {
+
+		private final TupleQueryResult iteration;
+		private boolean closed = false;
+
+		public CleanableState(TupleQueryResult iteration) {
+			this.iteration = iteration;
+		}
+
+		@Override
+		public void run() {
+			if (!closed) {
+				try {
+					logger.warn(
+							"Forced closing of unclosed iteration. Set the system property 'org.eclipse.rdf4j.repository.debug' to 'true' to get stack traces.");
+					iteration.close();
+				} catch (Exception e) {
+					if (e instanceof InterruptedException) {
+						Thread.currentThread().interrupt();
+					}
+					throw new RuntimeException(e);
+				}
+			}
+		}
+
+		public void close() {
+			closed = true;
+			iteration.close();
+		}
+	}
+
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
@@ -53,7 +53,7 @@ public class MemoryStoreTest extends RDFNotifyingStoreTest {
 						"    <http://unexisting_resource> (^(<http://predicate_a>)*) / <http://predicate_b>? ?resource\n"
 						+
 						"}",
-				"http://base.org/");
+				"http://example.org/");
 		CloseableIteration<? extends BindingSet, QueryEvaluationException> res = con.evaluate(tupleQuery.getTupleExpr(),
 				null, EmptyBindingSet.getInstance(), false);
 		assertTrue("expect a result", res.hasNext());

--- a/spring-components/spring-boot-sparql-web/src/test/java/org/eclipse/rdf4j/http/server/readonly/MemoryBackedOnlySparqlApplicationTest.java
+++ b/spring-components/spring-boot-sparql-web/src/test/java/org/eclipse/rdf4j/http/server/readonly/MemoryBackedOnlySparqlApplicationTest.java
@@ -68,7 +68,7 @@ public class MemoryBackedOnlySparqlApplicationTest {
 		try (
 				SPARQLProtocolSession session = rep.createSPARQLProtocolSession();
 				TupleQueryResult sendTupleQuery = session.sendTupleQuery(QueryLanguage.SPARQL, query, null, false,
-						new WeakReference<>(this))) {
+						null)) {
 
 			while (sendTupleQuery.hasNext()) {
 				assertNotNull(sendTupleQuery.next());

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractQueryResultIOTest {
 	 */
 	protected TupleQueryResult parseTupleInternal(TupleQueryResultFormat format, InputStream in) throws IOException,
 			QueryResultParseException, TupleQueryResultHandlerException, UnsupportedQueryResultFormatException {
-		return QueryResultIO.parseTuple(in, format, new WeakReference<>(this));
+		return QueryResultIO.parseTuple(in, format, null);
 	}
 
 	/**

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTupleTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTupleTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractQueryResultIOTupleTest extends AbstractQueryResult
 			QueryResultIO.writeTuple(new IteratingTupleQueryResult(bindingNames, bindings), getTupleFormat(), bos);
 			try (ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray())) {
 				TupleQueryResult parsedBindings = QueryResultIO.parseTuple(bis, getTupleFormat(),
-						new WeakReference<>(this));
+						null);
 				assertEquals(bindingNames, parsedBindings.getBindingNames());
 				List<BindingSet> actualBindings = new ArrayList<>();
 				parsedBindings.forEach(actualBindings::add);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/FedXQueueCursor.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/FedXQueueCursor.java
@@ -33,9 +33,14 @@ public class FedXQueueCursor<T> extends QueueCursor<CloseableIteration<T, QueryE
 	private static final Logger log = LoggerFactory.getLogger(FedXQueueCursor.class);
 
 	public static <T> FedXQueueCursor<T> create(int capacity, WeakReference<?> callerReference) {
+		assert callerReference == null;
+		return create(capacity);
+	}
+
+	public static <T> FedXQueueCursor<T> create(int capacity) {
 		BlockingQueue<CloseableIteration<T, QueryEvaluationException>> queue = new ArrayBlockingQueue<>(capacity,
 				false);
-		return new FedXQueueCursor<>(queue, callerReference);
+		return new FedXQueueCursor<>(queue);
 	}
 
 	/**
@@ -45,9 +50,8 @@ public class FedXQueueCursor<T> extends QueueCursor<CloseableIteration<T, QueryE
 	 */
 	private final BlockingQueue<CloseableIteration<T, QueryEvaluationException>> queueRef;
 
-	private FedXQueueCursor(BlockingQueue<CloseableIteration<T, QueryEvaluationException>> queue,
-			WeakReference<?> callerRef) {
-		super(queue, callerRef);
+	private FedXQueueCursor(BlockingQueue<CloseableIteration<T, QueryEvaluationException>> queue) {
+		super(queue);
 		this.queueRef = queue;
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelExecutorBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelExecutorBase.java
@@ -48,7 +48,7 @@ public abstract class ParallelExecutorBase<T> extends LookAheadIteration<T, Quer
 
 	/* Variables */
 	protected volatile Thread evaluationThread;
-	protected FedXQueueCursor<T> rightQueue = FedXQueueCursor.create(1024, new WeakReference<>(this));
+	protected FedXQueueCursor<T> rightQueue = FedXQueueCursor.create(1024);
 	protected volatile CloseableIteration<T, QueryEvaluationException> rightIter;
 	protected volatile boolean finished = false;
 

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ProtocolIT.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ProtocolIT.java
@@ -624,8 +624,7 @@ public class ProtocolIT {
 			// HTTP 200
 			if (responseCode == HttpURLConnection.HTTP_OK) {
 				// Process query results
-				return QueryResultIO.parseTuple(conn.getInputStream(), TupleQueryResultFormat.SPARQL,
-						new WeakReference<>(this));
+				return QueryResultIO.parseTuple(conn.getInputStream(), TupleQueryResultFormat.SPARQL, null);
 			} else {
 				String response = "location " + location + " responded: " + conn.getResponseMessage() + " ("
 						+ responseCode + ")";


### PR DESCRIPTION
GitHub issue resolved: #3421 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
 - The use of WeakReference was buggy because it was linked to objects that did not necessarily stick around for the entire time that the iteration was in use. 
 - Swapped out the main use case for the WeakReference with Java 9 Cleaner.
 - Due to our maven structure I had to duplicate some code.
 - Deprecated as many methods as I could and cleaned up our code to pass null instead of a WeakReference together with an assertion down the line to make sure we always pass in null.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

