### PR TITLE
GH-3781 add namespace validation

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
@@ -10,7 +10,11 @@ package org.eclipse.rdf4j.http.server.repository.namespaces;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
+import static org.apache.commons.lang3.StringUtils.isAlphanumeric;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -18,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.rdf4j.common.io.IOUtil;
+import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.common.webapp.views.EmptySuccessView;
 import org.eclipse.rdf4j.common.webapp.views.SimpleResponseView;
 import org.eclipse.rdf4j.http.server.ClientHTTPException;
@@ -38,11 +43,10 @@ import org.springframework.web.servlet.mvc.AbstractController;
  * @author Arjohn Kampman
  */
 public class NamespaceController extends AbstractController {
-
 	private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
 	public NamespaceController() throws ApplicationContextException {
-		setSupportedMethods(new String[] { METHOD_GET, METHOD_HEAD, "PUT", "DELETE" });
+		setSupportedMethods(METHOD_GET, METHOD_HEAD, "PUT", "DELETE");
 	}
 
 	@Override
@@ -97,10 +101,7 @@ public class NamespaceController extends AbstractController {
 		String namespace = IOUtil.readString(request.getReader());
 		namespace = namespace.trim();
 
-		if (namespace.length() == 0) {
-			throw new ClientHTTPException(SC_BAD_REQUEST, "No namespace name found in request body");
-		}
-		// FIXME: perform some sanity checks on the namespace string
+		validateUpdateNamespaceData(prefix, namespace);
 
 		try (RepositoryConnection repositoryCon = RepositoryInterceptor.getRepositoryConnection(request)) {
 			repositoryCon.setNamespace(prefix, namespace);
@@ -120,5 +121,28 @@ public class NamespaceController extends AbstractController {
 		}
 
 		return new ModelAndView(EmptySuccessView.getInstance());
+	}
+
+	private void validateUpdateNamespaceData(String prefix, String namespace) throws ClientHTTPException {
+		if (namespace.length() == 0) {
+			throw new ClientHTTPException(SC_BAD_REQUEST, "No namespace name found in request body");
+		}
+
+		if (!isEmpty(prefix) && !isAlphanumeric(prefix)) {
+			throw new ClientHTTPException(SC_BAD_REQUEST, "Prefix not alphanumeric");
+		}
+
+		if (!isValidNamespaceIri(namespace)) {
+			throw new ClientHTTPException(SC_BAD_REQUEST, "Namespace not valid");
+		}
+	}
+
+	private boolean isValidNamespaceIri(String namespace) {
+		try {
+			return new ParsedIRI(namespace).isAbsolute();
+		} catch (URISyntaxException e) {
+			logger.debug("Namespace: {} isn't parseable.", namespace, e);
+			return false;
+		}
 	}
 }

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceControllerTest.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository.namespaces;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.eclipse.rdf4j.common.webapp.views.EmptySuccessView;
+import org.eclipse.rdf4j.http.server.ClientHTTPException;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.ModelAndView;
+
+class NamespaceControllerTest {
+	private final static String REPO_ID = "test-repo";
+	private final NamespaceController controller = new NamespaceController();
+
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		request = new MockHttpServletRequest();
+		request.setAttribute("repositoryID", REPO_ID);
+		request.setAttribute("repository", new SailRepository(new MemoryStore()));
+		request.setMethod(HttpMethod.PUT.name());
+		response = new MockHttpServletResponse();
+	}
+
+	@ParameterizedTest
+	@EmptySource
+	@ValueSource(strings = { "a", "1", "rdf", "rdf4j", "22" })
+	void addNamespace_prefix_ok(String prefix) throws Exception {
+		// Arrange
+		request.setRequestURI("/repositories/" + REPO_ID + "/namespaces/" + prefix);
+		request.setPathInfo(REPO_ID + "/namespaces/" + prefix);
+		request.setContent("http://www.w3.org/1999/02/22-rdf-syntax-ns#".getBytes(UTF_8));
+
+		// Act
+		final ModelAndView result = controller.handleRequest(request, response);
+
+		// Assert
+		assertThat(result).isNotNull();
+		assertThat(result.getView()).isInstanceOf(EmptySuccessView.class);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "  ", "\t", "\n", "-", "rdf 4j", "rdf-4j" })
+	void addNamespace_prefix_invalid(String prefix) {
+		// Arrange
+		request.setRequestURI("/repositories/" + REPO_ID + "/namespaces/" + prefix);
+		request.setPathInfo(REPO_ID + "/namespaces/" + prefix);
+		request.setContent("http://www.w3.org/1999/02/22-rdf-syntax-ns#".getBytes(UTF_8));
+
+		// Act & Assert
+		assertThatThrownBy(() -> controller.handleRequest(request, response)).isInstanceOf(ClientHTTPException.class)
+				.hasMessageContaining("Prefix not alphanumeric");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+			"http://www.w3.org/2001/XMLSchema-instance",
+			"http://purl.org/dc/elements/1.1/",
+			"http://rdfs.org/ns/void#",
+			"https://rdfs.org/ns/void#",
+			"ftp://rdfs.org/ns/void",
+			"ftps://rdfs.org/ns/void",
+			"http://example.org/with%20whitespace",
+			"http://",
+			"tttt://tttt.ttt",
+			"t://tttt",
+			"t:tttt",
+			"t:"
+	})
+	void addNamespace_namespaceUri_ok(String namespaceUrl) throws Exception {
+		// Arrange
+		request.setRequestURI("/repositories/" + REPO_ID + "/namespaces/rdf4j");
+		request.setPathInfo(REPO_ID + "/namespaces/rdf4j");
+		request.setContent(namespaceUrl.getBytes(UTF_8));
+
+		// Act
+		final ModelAndView result = controller.handleRequest(request, response);
+
+		// Assert
+		assertThat(result).isNotNull();
+		assertThat(result.getView()).isInstanceOf(EmptySuccessView.class);
+	}
+
+	@ParameterizedTest
+	@EmptySource
+	@ValueSource(strings = { "  ", "\t", "\n" })
+	void addNamespace_namespaceUri_empty(String namespaceUrl) {
+		// Arrange
+		request.setRequestURI("/repositories/" + REPO_ID + "/namespaces/rdf4j");
+		request.setPathInfo(REPO_ID + "/namespaces/rdf4j");
+		request.setContent(namespaceUrl.getBytes(UTF_8));
+
+		// Act & Assert
+		assertThatThrownBy(() -> controller.handleRequest(request, response)).isInstanceOf(ClientHTTPException.class)
+				.hasMessageContaining("No namespace name found in request body");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "wwww3org", "httpwwww3org", "www.rdf4j.org/ns/void", "t", ":", " :", "\n:\n",
+			"http://example.org/with whitespace" })
+	void addNamespace_namespaceUri_invalid(String namespaceUrl) {
+		// Arrange
+		request.setRequestURI("/repositories/" + REPO_ID + "/namespaces/rdf4j");
+		request.setPathInfo(REPO_ID + "/namespaces/rdf4j");
+		request.setContent(namespaceUrl.getBytes(UTF_8));
+
+		// Act & Assert
+		assertThatThrownBy(() -> controller.handleRequest(request, response)).isInstanceOf(ClientHTTPException.class)
+				.hasMessageContaining("Namespace not valid");
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #3781

The NamespaceController is now validating the prefix and namespace before updating it.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [X] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [X] I've added tests for the changes I made
 - [X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

