### PR TITLE
Update security policy wrt supported patch releases

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,12 +6,15 @@ Eclipse RDF4J follows the [Eclipse Vulnerability Reporting Policy](https://www.e
 
 Eclipse RDF4J supports security updates for the following releases:
 
+
 | Version | Supported          |
 | ------- | ------------------ |
-| 4.1.x   | ✅ |
-| 4.0.x   | ✅                 |
-| 3.7.x   | ✅                 |
-| < 3.7   | :x:                |
+| current release   | ✅ |
+| latest minor release before the current   | ✅(on request only) |
+| latest major release before the current   | ✅(on request only) |
+| anything older   | :x:                |
+
+For example if the current release is 4.1, we support security patches for 4.1.x (the current release) and 4.0.x (latest minor before current), as well as for 3.7.x (latest major before current), but not for 3.6.x or older. Security patches for the current release are provided proactively by the team, while patches for older supported releases are provided on request only.
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,10 @@ Eclipse RDF4J supports security updates for the following releases:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.7.x   | :white_check_mark: |
-| 3.6.x   | :white_check_mark: |
-| < 3.6   | :x:                |
+| 4.1.x   | ✅ |
+| 4.0.x   | ✅                 |
+| 3.7.x   | ✅                 |
+| < 3.7   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Briefly describe the changes proposed in this PR:

Update the list of supported versions for security patch releases.

## open questions:

1. is this the correct list (in particular do we actually want to support doing security patch release for RDF4J 3.7.x?)
2. is this generic replacement easy enough to understand (intent is to make it easier for us to maintain without losing clarity for our users)?


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

