### PR TITLE
GH-4149 Check for ill-typed literals during SHACL datatype validation

### DIFF
--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/RSX.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/RSX.java
@@ -39,6 +39,7 @@ public class RSX {
 	public final static IRI targetShape = create("targetShape");
 	public final static IRI dataGraph = create("dataGraph");
 	public final static IRI shapesGraph = create("shapesGraph");
+	public final static IRI valueConformsToXsdDatatypeFunction = create("valueConformsToXsdDatatypeFunction");
 
 	private static IRI create(String localName) {
 		return Vocabularies.createIRI(RSX.NAMESPACE, localName);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/XmlDatatypeUtilFunction.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/XmlDatatypeUtilFunction.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.ast;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.model.vocabulary.RSX;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
+
+/**
+ * A custom SPARQL function that checks that a literal conforms to a given datatype by checking the datatype of the
+ * literal and also checking if the literal is ill-typed if the datatype is a supported XSD datatype.
+ */
+public class XmlDatatypeUtilFunction implements Function {
+
+	public String getURI() {
+		return RSX.valueConformsToXsdDatatypeFunction.stringValue();
+	}
+
+	@Override
+	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Value evaluate(TripleSource tripleSource, Value... args) {
+		if (args.length != 2) {
+			throw new ValueExprEvaluationException(
+					"valueConformsToXsdDatatypeFunction requires exactly 2 arguments, got " + args.length);
+		}
+
+		assert Arrays.stream(args).noneMatch(Objects::isNull);
+
+		if (!(args[0].isLiteral())) {
+			throw new ValueExprEvaluationException("invalid first argument (literal expected): " + args[0]);
+		}
+
+		if (!(args[1].isIRI())) {
+			throw new ValueExprEvaluationException("invalid second argument (IRI expected): " + args[1]);
+		}
+
+		Literal literal = (Literal) args[0];
+		CoreDatatype coreDatatype = CoreDatatype.from((IRI) args[1]);
+		if (literal.getCoreDatatype() != coreDatatype) {
+			return BooleanLiteral.FALSE;
+		} else if (coreDatatype == CoreDatatype.NONE && !args[1].equals(literal.getDatatype())) {
+			return BooleanLiteral.FALSE;
+		}
+
+		if (coreDatatype.isXSDDatatype()) {
+			return BooleanLiteral.valueOf(XMLDatatypeUtil.isValidValue(literal.stringValue(), coreDatatype));
+		}
+
+		return BooleanLiteral.TRUE;
+	}
+
+}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DatatypeConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DatatypeConstraintComponent.java
@@ -17,6 +17,8 @@ import java.util.function.Function;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.vocabulary.RSX;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ast.planNodes.DatatypeFilter;
@@ -25,10 +27,12 @@ import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
 
 public class DatatypeConstraintComponent extends SimpleAbstractConstraintComponent {
 
-	IRI datatype;
+	private final CoreDatatype coreDatatype;
+	private final IRI datatype;
 
 	public DatatypeConstraintComponent(IRI datatype) {
 		this.datatype = datatype;
+		this.coreDatatype = CoreDatatype.from(datatype);
 	}
 
 	@Override
@@ -53,11 +57,26 @@ public class DatatypeConstraintComponent extends SimpleAbstractConstraintCompone
 
 	@Override
 	String getSparqlFilterExpression(String varName, boolean negated) {
+		String checkDatatypeConformance = "<" + RSX.valueConformsToXsdDatatypeFunction + ">(?" + varName + ", <"
+				+ datatype + ">)";
 		if (negated) {
-			return "isLiteral(?" + varName + ") && datatype(?" + varName + ") = <" + datatype.stringValue() + ">";
+			return "isLiteral(?" + varName + ") && datatype(?" + varName + ") = <" + datatype + ">"
+					+ (coreDatatype.isXSDDatatype() ? " && " + checkDatatypeConformance : "");
 		} else {
-			return "!isLiteral(?" + varName + ") || datatype(?" + varName + ") != <" + datatype.stringValue() + ">";
+			return "!isLiteral(?" + varName + ") || datatype(?" + varName + ") != <" + datatype + ">"
+					+ (coreDatatype.isXSDDatatype() ? " || !" + checkDatatypeConformance : "");
 		}
 	}
+
+	// @formatter:off
+	/*
+	// This an attempt at an alternate approach using casting instead of a custom function. One issue with this is that we don't have an xsd:date constructor function which would be required to have parity with the reference SHACL validator.
+	if (negated) {
+		return "isLiteral(?" + varName + ") && datatype(?" + varName + ") = <" + datatype + ">" + (coreDatatype != null && coreDatatype.isPrimitiveDatatype() ? " && xsd:"+coreDatatype.getIri().getLocalName()+"(?"+varName+")":"");
+	} else {
+		return "!isLiteral(?" + varName + ") || datatype(?" + varName + ") != <" + datatype + "> "+ (coreDatatype != null && coreDatatype.isPrimitiveDatatype() ? " || !sameTerm(xsd:"+coreDatatype.getIri().getLocalName()+"(?"+varName+"), ?"+varName+")":"");
+	}
+	*/
+	// @formatter:on
 
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByPredicate.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/ExternalFilterByPredicate.java
@@ -12,7 +12,6 @@
 package org.eclipse.rdf4j.sail.shacl.ast.planNodes;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;

--- a/core/sail/shacl/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.algebra.evaluation.function.Function
+++ b/core/sail/shacl/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.algebra.evaluation.function.Function
@@ -1,0 +1,1 @@
+org.eclipse.rdf4j.sail.shacl.ast.XmlDatatypeUtilFunction

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case6/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case6/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:age "test"^^xsd:integer.
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case6/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case6/report.ttl
@@ -1,0 +1,25 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:shapesGraph rdf4j:SHACLShapeGraph;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:age;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:DatatypeConstraintComponent;
+      sh:sourceShape ex:PersonPropertyShape;
+      sh:value "test"^^xsd:integer
+    ] .
+
+ex:PersonPropertyShape a sh:PropertyShape;
+  sh:datatype xsd:integer;
+  sh:path ex:age .

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case7/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case7/query1.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:dateOfBirth "1980-12-12"^^xsd:date, "1980-13-13"^^xsd:date.
+}

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case7/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case7/report.ttl
@@ -1,0 +1,25 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:shapesGraph rdf4j:SHACLShapeGraph;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:dateOfBirth;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:DatatypeConstraintComponent;
+      sh:sourceShape ex:PersonDateOfBirthShape;
+      sh:value "1980-13-13"^^xsd:date
+    ] .
+
+ex:PersonDateOfBirthShape a sh:PropertyShape;
+  sh:datatype xsd:date;
+  sh:path ex:dateOfBirth .

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case8/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case8/query1.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:dateTimeOfBirth "1980-12-12T01:01:01.000Z"^^xsd:dateTime, "1980-13-13T01:01:01.000Z"^^xsd:dateTime.
+}

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case8/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/simple/invalid/case8/report.ttl
@@ -1,0 +1,25 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:shapesGraph rdf4j:SHACLShapeGraph;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:dateTimeOfBirth;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:DatatypeConstraintComponent;
+      sh:sourceShape ex:PersonDateTimeOfBirthShape;
+      sh:value "1980-13-13T01:01:01.000Z"^^xsd:dateTime
+    ] .
+
+ex:PersonDateTimeOfBirthShape a sh:PropertyShape;
+  sh:datatype xsd:dateTime;
+  sh:path ex:dateTimeOfBirth .

--- a/core/sail/shacl/src/test/resources/test-cases/datatype/simple/shacl.trig
+++ b/core/sail/shacl/src/test/resources/test-cases/datatype/simple/shacl.trig
@@ -9,8 +9,14 @@
 rdf4j:SHACLShapeGraph {
   ex:PersonShape a sh:NodeShape;
     sh:targetClass ex:Person;
-    sh:property ex:PersonPropertyShape .
-  
+    sh:property ex:PersonPropertyShape, ex:PersonDateOfBirthShape, ex:PersonDateTimeOfBirthShape .
+
   ex:PersonPropertyShape sh:path ex:age;
     sh:datatype xsd:integer .
+
+  ex:PersonDateOfBirthShape sh:path ex:dateOfBirth;
+    sh:datatype xsd:date .
+
+  ex:PersonDateTimeOfBirthShape sh:path ex:dateTimeOfBirth;
+    sh:datatype xsd:dateTime .
 }


### PR DESCRIPTION
GitHub issue resolved: #4149 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

SHACL spec says that we should check for ill-typed literals if they are the datatype is one of the supported XSD datatypes. Easiest way to do this is to use the `XMLDatatypeUtil.isValidValue(...)` method. To allow this to be used in the SPARQL query we also introduce a custom function in the RSX namespace that calls this method.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

