### PR TITLE
Gh 4146 rest isolation fixes

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartController.java
@@ -74,7 +74,7 @@ public class TransactionStartController extends AbstractController {
 	}
 
 	@Deprecated
-	ArrayList<TransactionSetting> getIsolationLevel(HttpServletRequest request) {
+	ArrayList<TransactionSetting> getIsolationLevel(HttpServletRequest request) throws IllegalArgumentException {
 		// process legacy isolation level param for backward compatibility with older clients
 
 		ArrayList<TransactionSetting> transactionSettings = new ArrayList<>();
@@ -87,6 +87,8 @@ public class TransactionStartController extends AbstractController {
 					break;
 				}
 			}
+			if (transactionSettings.isEmpty())
+				throw new IllegalArgumentException("Unknown isolation value " + isolationLevelString);
 		}
 
 		return transactionSettings;
@@ -94,8 +96,6 @@ public class TransactionStartController extends AbstractController {
 
 	ArrayList<TransactionSetting> getTransactionSettings(HttpServletRequest request) {
 
-		// currently does not work.  need to revisit to get a better idea of the approach
-		
 		ArrayList<TransactionSetting> transactionSettings = new ArrayList<>();
 		request.getParameterMap().forEach((k, v) -> {
 			if (k.startsWith(Protocol.TRANSACTION_SETTINGS_PREFIX)) {

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartController.java
@@ -13,10 +13,7 @@ package org.eclipse.rdf4j.http.server.repository.transaction;
 import static javax.servlet.http.HttpServletResponse.SC_CREATED;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -76,28 +73,30 @@ public class TransactionStartController extends AbstractController {
 		return result;
 	}
 
-	private ModelAndView startTransaction(Repository repository, HttpServletRequest request,
-			HttpServletResponse response) throws IOException, ClientHTTPException, ServerHTTPException {
-		ProtocolUtil.logRequestParameters(request);
-		Map<String, Object> model = new HashMap<>();
+	@Deprecated
+	ArrayList<TransactionSetting> getIsolationLevel(HttpServletRequest request) {
+		// process legacy isolation level param for backward compatibility with older clients
 
 		ArrayList<TransactionSetting> transactionSettings = new ArrayList<>();
-
-		final IsolationLevel[] isolationLevel = { null };
-
-		// process legacy isolation level param for backward compatibility with older clients
 		final String isolationLevelString = request.getParameter(Protocol.ISOLATION_LEVEL_PARAM_NAME);
 		if (isolationLevelString != null) {
-			final IRI level = Values.iri(isolationLevelString);
 
 			for (IsolationLevel standardLevel : IsolationLevels.values()) {
-				if (standardLevel.getName().equals(level.getLocalName())) {
-					isolationLevel[0] = standardLevel;
+				if (standardLevel.toString().equals(isolationLevelString)) {
+					transactionSettings.add(IsolationLevels.valueOf(isolationLevelString));
 					break;
 				}
 			}
 		}
 
+		return transactionSettings;
+	}
+
+	ArrayList<TransactionSetting> getTransactionSettings(HttpServletRequest request) {
+
+		// currently does not work.  need to revisit to get a better idea of the approach
+		
+		ArrayList<TransactionSetting> transactionSettings = new ArrayList<>();
 		request.getParameterMap().forEach((k, v) -> {
 			if (k.startsWith(Protocol.TRANSACTION_SETTINGS_PREFIX)) {
 				String settingsName = k.replace(Protocol.TRANSACTION_SETTINGS_PREFIX, "");
@@ -105,8 +104,7 @@ public class TransactionStartController extends AbstractController {
 				// FIXME we should make the isolation level an SPI impl as well so that it will work with non-standard
 				// isolation levels
 				if (settingsName.equals(IsolationLevels.NONE.getName())) {
-					isolationLevel[0] = IsolationLevels.valueOf(v[0]);
-					transactionSettings.add(isolationLevel[0]);
+					transactionSettings.add(IsolationLevels.valueOf(v[0]));
 				} else {
 					TransactionSettingRegistry.getInstance()
 							.get(settingsName)
@@ -116,17 +114,28 @@ public class TransactionStartController extends AbstractController {
 			}
 		});
 
+		return transactionSettings;
+	}
+
+	Transaction createTransaction(Repository repository) throws ExecutionException, InterruptedException {
+		return new Transaction(repository);
+	}
+
+	private ModelAndView startTransaction(Repository repository, HttpServletRequest request,
+			HttpServletResponse response) throws IOException, ClientHTTPException, ServerHTTPException {
+		ProtocolUtil.logRequestParameters(request);
+		Map<String, Object> model = new HashMap<>();
+
+		ArrayList<TransactionSetting> transactionSettings = getIsolationLevel(request);
+		transactionSettings.addAll(getTransactionSettings(request));
+
 		Transaction txn = null;
 		boolean allGood = false;
 		try {
-			txn = new Transaction(repository);
+			txn = createTransaction(repository);
 
 			if (transactionSettings.isEmpty()) {
-				if (isolationLevel[0] == null) {
-					txn.begin();
-				} else {
-					txn.begin(isolationLevel[0]);
-				}
+				txn.begin();
 			} else {
 				txn.begin(transactionSettings.toArray(new TransactionSetting[0]));
 			}

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
@@ -112,7 +112,6 @@ class TransactionStartControllerTest {
 
 	@Test
 	void createTransactionLocation_withPositiveIsolationOldPath() throws Exception {
-
 		TransactionStartController controller = spy(TransactionStartController.class);
 		Transaction tx = mock(Transaction.class);
 		// Arrange
@@ -131,7 +130,6 @@ class TransactionStartControllerTest {
 
 	@Test
 	void createTransactionLocation_withNegativeIsolationOldPath() throws Exception {
-
 		TransactionStartController controller = spy(TransactionStartController.class);
 		Transaction tx = mock(Transaction.class);
 
@@ -142,9 +140,8 @@ class TransactionStartControllerTest {
 
 		when(controller.createTransaction(repository)).thenReturn(tx);
 		when(tx.getID()).thenReturn(UUID.randomUUID());
-		
-		assertThatIllegalArgumentException().isThrownBy(()->controller.handleRequest(request, response));
 
+		assertThatIllegalArgumentException().isThrownBy(()->controller.handleRequest(request, response));
 	}
 
 }

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
@@ -12,13 +12,22 @@ package org.eclipse.rdf4j.http.server.repository.transaction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.eclipse.rdf4j.common.transaction.IsolationLevels.SNAPSHOT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
+import java.util.UUID;
 
+import org.eclipse.rdf4j.common.transaction.IsolationLevel;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.http.server.repository.RepositoryInterceptor;
+import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -87,4 +96,59 @@ class TransactionStartControllerTest {
 
 		return (HashMap<String, String>) result.getModel().get("headers");
 	}
+
+	@Test
+	void positiveIsolationEnumsOldPath() {
+		for (IsolationLevel level : IsolationLevels.values()) {
+			request.addParameter("isolation-level", level.toString());
+
+			assertThat(controller.getIsolationLevel(request).size() == 1);
+		}
+
+	}
+
+	@Test
+	void negativeIsolationEnumsOldPath() {
+		request.addParameter("isolation-level", "GARBAGE");
+		assertThat(controller.getIsolationLevel(request).size() == 0);
+	}
+
+	@Test
+	void createTransactionLocation_withPositiveIsolationOldPath() throws Exception {
+
+		TransactionStartController controller = spy(TransactionStartController.class);
+		Transaction tx = mock(Transaction.class);
+		// Arrange
+		controller.setExternalUrl(null);
+
+		request.addParameter("isolation-level", "SNAPSHOT");
+		Repository repository = RepositoryInterceptor.getRepository(request);
+
+		when(controller.createTransaction(repository)).thenReturn(tx);
+		when(tx.getID()).thenReturn(UUID.randomUUID());
+		// Act
+		controller.handleRequest(request, response);
+
+		verify(tx).begin(SNAPSHOT);
+	}
+
+	@Test
+	void createTransactionLocation_withNegativeIsolationOldPath() throws Exception {
+
+		TransactionStartController controller = spy(TransactionStartController.class);
+		Transaction tx = mock(Transaction.class);
+		// Arrange
+		controller.setExternalUrl(null);
+
+		request.addParameter("isolation-level", "GARBAGE");
+		Repository repository = RepositoryInterceptor.getRepository(request);
+
+		when(controller.createTransaction(repository)).thenReturn(tx);
+		when(tx.getID()).thenReturn(UUID.randomUUID());
+		// Act
+		controller.handleRequest(request, response);
+
+		verify(tx).begin();
+	}
+
 }

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
@@ -134,7 +134,7 @@ class TransactionStartControllerTest {
 
 		TransactionStartController controller = spy(TransactionStartController.class);
 		Transaction tx = mock(Transaction.class);
-		// Arrange
+
 		controller.setExternalUrl(null);
 
 		request.addParameter("isolation-level", "GARBAGE");
@@ -142,8 +142,8 @@ class TransactionStartControllerTest {
 
 		when(controller.createTransaction(repository)).thenReturn(tx);
 		when(tx.getID()).thenReturn(UUID.randomUUID());
-		// Act
-		controller.handleRequest(request, response);
+		
+		assertThatIllegalArgumentException().isThrownBy(()->controller.handleRequest(request, response));
 
 	}
 

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
@@ -10,10 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.server.repository.transaction;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.eclipse.rdf4j.common.transaction.IsolationLevels.SNAPSHOT;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
@@ -27,7 +25,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -110,7 +107,7 @@ class TransactionStartControllerTest {
 	@Test
 	void negativeIsolationEnumsOldPath() {
 		request.addParameter("isolation-level", "GARBAGE");
-		assertThat(controller.getIsolationLevel(request).size() == 0);
+		assertThatIllegalArgumentException().isThrownBy(() -> controller.getIsolationLevel(request));
 	}
 
 	@Test
@@ -148,7 +145,6 @@ class TransactionStartControllerTest {
 		// Act
 		controller.handleRequest(request, response);
 
-		verify(tx).begin();
 	}
 
 }


### PR DESCRIPTION
patches to get /transactions?isolation-level=xxx to work as well as unit tests for it.  left transaction_settings__xxxx logic in tact (moved to its own function for easier unit testing) for subsequent design conversation clarity.