### PR TITLE
GH-3982 Rework cardinality computation for LMDB triple store.

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Statistics.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Statistics.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+/**
+ * Helper class for computing cardinalities within triple store.
+ */
+class Statistics {
+
+	/**
+	 * Number of buckets used to sample average distances of keys.
+	 */
+	static final int MAX_BUCKETS = 3;
+
+	/**
+	 * Number of samples for each bucket.
+	 */
+	static final int MAX_SAMPLES_PER_BUCKET = 100;
+
+	final long[][] startValues = new long[MAX_BUCKETS + 1][4];
+	final long[][] lastValues = new long[MAX_BUCKETS][4];
+	final long[] values = new long[4];
+	final long[] minValues = new long[4];
+	final long[] maxValues = new long[4];
+	final double[] avgRowsPerValue = new double[4];
+	final long[] avgRowsPerValueCounts = new long[4];
+	final long[] counts = new long[4];
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/CardinalityTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/CardinalityTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+
+import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.eclipse.rdf4j.sail.lmdb.model.LmdbValue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Low-level tests for {@link TripleStore}.
+ */
+public class CardinalityTest {
+	final static Logger logger = LoggerFactory.getLogger(CardinalityTest.class);
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	protected TripleStore tripleStore;
+
+	@Before
+	public void before() throws Exception {
+		File dataDir = tempFolder.newFolder("triplestore");
+		tripleStore = new TripleStore(dataDir, new LmdbStoreConfig("spoc,posc"));
+	}
+
+	int count(RecordIterator it) throws IOException {
+		int count = 0;
+		while (it.next() != null) {
+			count++;
+		}
+		return count;
+	}
+
+	@Test
+	public void testCardinalities() throws Exception {
+		Random random = new Random();
+
+		int nrOfResources = 1000;
+
+		tripleStore.startTransaction();
+		for (int resource = 1; resource <= nrOfResources; resource++) {
+			int nrOfTriples = 20 + random.nextInt(100);
+			for (int i = 0; i < nrOfTriples; i++) {
+				tripleStore.storeTriple(resource, 2, random.nextInt(100000) * (long) Math.pow(10, random.nextInt(4)), 1,
+						true);
+				tripleStore.storeTriple(resource, 2 + random.nextInt(1000) + 1,
+						random.nextInt(100000) * (long) Math.pow(10, random.nextInt(4)), 1, true);
+			}
+		}
+		tripleStore.commit();
+
+		try (Txn txn = tripleStore.getTxnManager().createReadTxn()) {
+			logger.info(tripleStore.cardinality(LmdbValue.UNKNOWN_ID, 2, LmdbValue.UNKNOWN_ID, 1) + " --- " +
+					count(tripleStore.getTriples(txn, LmdbValue.UNKNOWN_ID, 2, LmdbValue.UNKNOWN_ID, 1, true)));
+
+			for (int resource = 1; resource <= nrOfResources; resource++) {
+				logger.info(tripleStore.cardinality(resource, 2, LmdbValue.UNKNOWN_ID, 1) + " --- " +
+						count(tripleStore.getTriples(txn, resource, 2, LmdbValue.UNKNOWN_ID, 1, true)));
+			}
+
+			logger.info(tripleStore.cardinality(LmdbValue.UNKNOWN_ID, LmdbValue.UNKNOWN_ID, 3, 1) + " --- " +
+					count(tripleStore.getTriples(txn, LmdbValue.UNKNOWN_ID, LmdbValue.UNKNOWN_ID, 3, 1, true)));
+		}
+	}
+
+	@After
+	public void after() throws Exception {
+		tripleStore.close();
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #3982 

Briefly describe the changes proposed in this PR:

The computation now uses several buckets to collect samples at multiple locations within the possible key range.
The cardinality estimate is based on the average distance of the sampled keys.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

