### PR TITLE
GH-4131 Introduce Variance & Standard Deviation aggregate functions

### DIFF
--- a/core/queryalgebra/evaluation/pom.xml
+++ b/core/queryalgebra/evaluation/pom.xml
@@ -51,6 +51,11 @@
 			<artifactId>mapdb</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
+			<version>3.6.1</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/StatisticCollector.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/StatisticCollector.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate;
+
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector;
+
+/**
+ * {@link AggregateCollector} implementation that processes SPARQL statistical functions based on input {@link Literal}
+ * values.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+@Experimental
+public abstract class StatisticCollector implements AggregateCollector {
+	protected static final Literal ZERO = SimpleValueFactory.getInstance().createLiteral("0", CoreDatatype.XSD.INTEGER);
+
+	protected final SummaryStatistics statistics;
+	protected final boolean population;
+	protected ValueExprEvaluationException typeError;
+
+	public StatisticCollector(boolean population) {
+		this.population = population;
+		this.statistics = new SummaryStatistics();
+	}
+
+	@Override
+	public Value getFinalValue() throws ValueExprEvaluationException {
+		if (typeError != null) {
+			// a type error occurred while processing the aggregate, throw it now.
+			throw typeError;
+		}
+		// for statistical functions at least two literal values are needed
+		return computeValue();
+	}
+
+	public void setTypeError(ValueExprEvaluationException typeError) {
+		this.typeError = typeError;
+	}
+
+	public boolean hasError() {
+		return typeError != null;
+	}
+
+	public void addValue(Literal val) {
+		var type = val.getCoreDatatype()
+				.asXSDDatatype()
+				.orElseThrow(() -> new IllegalArgumentException(val + " is not an XSD type literal"));
+		if (type == CoreDatatype.XSD.DOUBLE) {
+			statistics.addValue(val.doubleValue());
+		} else if (type == CoreDatatype.XSD.FLOAT) {
+			statistics.addValue(val.floatValue());
+		} else {
+			statistics.addValue(Double.parseDouble(val.getLabel()));
+		}
+	}
+
+	protected abstract Literal computeValue();
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/StatisticalAggregateFunction.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/StatisticalAggregateFunction.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunction;
+
+/**
+ * {@link AggregateFunction} used for processing of extended statistical aggregate operations through SPARQL.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+@Experimental
+public class StatisticalAggregateFunction extends AggregateFunction<StatisticCollector, Value> {
+
+	public StatisticalAggregateFunction(Function<BindingSet, Value> evaluationStep) {
+		super(evaluationStep);
+	}
+
+	@Override
+	public void processAggregate(BindingSet bindingSet, Predicate<Value> distinctValue, StatisticCollector collector)
+			throws QueryEvaluationException {
+		if (collector.hasError()) {
+			// Prevent calculating the aggregate further if a type error has occurred.
+			return;
+		}
+		Value v = evaluate(bindingSet);
+		if (distinctValue.test(v)) {
+			if (v instanceof Literal) {
+				Literal nextLiteral = (Literal) v;
+				// check if the literal is numeric.
+				if (((Literal) v).getCoreDatatype()
+						.asXSDDatatype()
+						.orElseThrow(() -> new ValueExprEvaluationException("not an XSD type literal: " + v))
+						.isNumericDatatype()) {
+					collector.addValue(nextLiteral);
+				} else {
+					collector.setTypeError(new ValueExprEvaluationException("not a number: " + v));
+				}
+			} else if (v != null) {
+				// we do not actually throw the exception yet, but record it and
+				// stop further processing. The exception will be thrown when
+				// getValue() is invoked.
+				collector.setTypeError(new ValueExprEvaluationException("not a literal: " + v));
+			}
+		}
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/stdev/PopulationStandardDeviationAggregateFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/stdev/PopulationStandardDeviationAggregateFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.stdev;
+
+import java.util.function.Function;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.StatisticalAggregateFunction;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunction;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunctionFactory;
+
+/**
+ * {@link AggregateFunctionFactory} implementation that provides {@link AggregateFunction} used for processing
+ * population standard deviation.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+@Experimental
+public class PopulationStandardDeviationAggregateFactory implements AggregateFunctionFactory {
+
+	@Override
+	public String getIri() {
+		return "http://rdf4j.org/aggregate#stdev_population";
+	}
+
+	@Override
+	public AggregateFunction buildFunction(Function<BindingSet, Value> evaluationStep) {
+		return new StatisticalAggregateFunction(evaluationStep);
+	}
+
+	@Override
+	public AggregateCollector getCollector() {
+		return new StandardDeviationCollector(true);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/stdev/StandardDeviationAggregateFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/stdev/StandardDeviationAggregateFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.stdev;
+
+import java.util.function.Function;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.StatisticalAggregateFunction;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunction;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunctionFactory;
+
+/**
+ * {@link AggregateFunctionFactory} implementation that provides {@link AggregateFunction} used for processing sample
+ * standard deviation.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+@Experimental
+public class StandardDeviationAggregateFactory implements AggregateFunctionFactory {
+
+	@Override
+	public String getIri() {
+		return "http://rdf4j.org/aggregate#stdev";
+	}
+
+	@Override
+	public AggregateFunction buildFunction(Function<BindingSet, Value> evaluationStep) {
+		return new StatisticalAggregateFunction(evaluationStep);
+	}
+
+	@Override
+	public AggregateCollector getCollector() {
+		return new StandardDeviationCollector(false);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/stdev/StandardDeviationCollector.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/stdev/StandardDeviationCollector.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.stdev;
+
+import org.apache.commons.math3.util.FastMath;
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.StatisticCollector;
+
+/**
+ * {@link org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector} that can compute both sample and
+ * population standard deviation based on input of numeric {@link Literal}s.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+@Experimental
+public class StandardDeviationCollector extends StatisticCollector {
+	public StandardDeviationCollector(boolean population) {
+		super(population);
+	}
+
+	@Override
+	protected Literal computeValue() {
+		double stDev;
+		if (population) {
+			stDev = FastMath.sqrt(statistics.getPopulationVariance());
+		} else {
+			stDev = statistics.getStandardDeviation();
+		}
+		if (Double.isNaN(stDev)) {
+			// no value has been added
+			return ZERO;
+		}
+		return SimpleValueFactory.getInstance().createLiteral(stDev);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/variance/PopulationVarianceAggregateFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/variance/PopulationVarianceAggregateFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.variance;
+
+import java.util.function.Function;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.StatisticalAggregateFunction;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunction;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunctionFactory;
+
+/**
+ * {@link AggregateFunctionFactory} implementation that provides {@link AggregateFunction} used for processing
+ * population variance.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+@Experimental
+public class PopulationVarianceAggregateFactory implements AggregateFunctionFactory {
+
+	@Override
+	public String getIri() {
+		return "http://rdf4j.org/aggregate#variance_population";
+	}
+
+	@Override
+	public AggregateFunction buildFunction(Function<BindingSet, Value> evaluationStep) {
+		return new StatisticalAggregateFunction(evaluationStep);
+	}
+
+	@Override
+	public AggregateCollector getCollector() {
+		return new VarianceCollector(true);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/variance/VarianceAggregateFactory.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/variance/VarianceAggregateFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.variance;
+
+import java.util.function.Function;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.StatisticalAggregateFunction;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunction;
+import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunctionFactory;
+
+/**
+ * {@link AggregateFunctionFactory} implementation that provides {@link AggregateFunction} used for processing sample
+ * variance.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+@Experimental
+public class VarianceAggregateFactory implements AggregateFunctionFactory {
+
+	@Override
+	public String getIri() {
+		return "http://rdf4j.org/aggregate#variance";
+	}
+
+	@Override
+	public AggregateFunction buildFunction(Function<BindingSet, Value> evaluationStep) {
+		return new StatisticalAggregateFunction(evaluationStep);
+	}
+
+	@Override
+	public AggregateCollector getCollector() {
+		return new VarianceCollector(false);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/variance/VarianceCollector.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/variance/VarianceCollector.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.variance;
+
+import org.eclipse.rdf4j.common.annotation.Experimental;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.StatisticCollector;
+
+/**
+ * {@link org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector} that can compute both sample and
+ * population variance based on input of numeric {@link Literal}s.
+ *
+ * @author Tomas Kovachev t.kovachev1996@gmail.com
+ */
+@Experimental
+public class VarianceCollector extends StatisticCollector {
+
+	public VarianceCollector(boolean population) {
+		super(population);
+	}
+
+	@Override
+	protected Literal computeValue() {
+		double variance;
+		if (population) {
+			variance = statistics.getPopulationVariance();
+		} else {
+			variance = statistics.getVariance();
+		}
+		if (Double.isNaN(variance)) {
+			// no value has been added
+			return ZERO;
+		}
+		return SimpleValueFactory.getInstance().createLiteral(variance);
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/MathUtil.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/MathUtil.java
@@ -18,6 +18,7 @@ import java.math.RoundingMode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -192,5 +193,4 @@ public class MathUtil {
 	public static void setDecimalExpansionScale(int decimalExpansionScale) {
 		MathUtil.decimalExpansionScale = decimalExpansionScale;
 	}
-
 }

--- a/core/queryalgebra/evaluation/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunctionFactory
+++ b/core/queryalgebra/evaluation/src/main/resources/META-INF/services/org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunctionFactory
@@ -1,0 +1,4 @@
+org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.stdev.PopulationStandardDeviationAggregateFactory
+org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.stdev.StandardDeviationAggregateFactory
+org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.variance.PopulationVarianceAggregateFactory
+org.eclipse.rdf4j.query.algebra.evaluation.function.aggregate.variance.VarianceAggregateFactory


### PR DESCRIPTION
GitHub issue resolved: #4131

Briefly describe the changes proposed in this PR:

Introduce support for custom Variance & Standard Deviation aggregate functions through magic predicates.

In total 4 magic predicates have been added with support for standard deviation & variance calculation based on sample & population formulas.

 The added magic predicates and subsequent functions include:
- <http://rdf4j.org/aggregate#variance_sample> - used to calculate variance based on sample assumption (e.g. N-1 variation)
- <http://rdf4j.org/aggregate#variance> - used to calculate variance based on population assumption 
-  <http://rdf4j.org/aggregate#stdev> - used to calculate standard deviation based on population assumption 
-  <http://rdf4j.org/aggregate#stdev_sample> - used to calculate standard deviation based on sample assumption 
