### PR TITLE
GH-4187 and GH-4184 clone Var object at origin to prevent reuse

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/TupleExprBuilder.java
@@ -275,11 +275,13 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 	 */
 	protected Var mapValueExprToVar(Object valueExpr) {
 		if (valueExpr instanceof Var) {
-			return (Var) valueExpr;
+			// Return a clone to prevent the Var object from being used in more than one place.
+			return ((Var) valueExpr).clone();
 		} else if (valueExpr instanceof ValueConstant) {
 			return TupleExprs.createConstVar(((ValueConstant) valueExpr).getValue());
 		} else if (valueExpr instanceof TripleRef) {
-			return ((TripleRef) valueExpr).getExprVar();
+			// Return a clone to prevent the Var object from being used in more than one place.
+			return ((TripleRef) valueExpr).getExprVar().clone();
 		} else if (valueExpr == null) {
 			throw new IllegalArgumentException("valueExpr is null");
 		} else {
@@ -1480,9 +1482,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 			}
 			pathElementExpression = createTupleExprForNegatedPropertySets(psElems, pathSequenceContext);
 		} else {
-			final ValueExpr pred = (ValueExpr) pathElement.jjtGetChild(0).jjtAccept(this, pathSequenceContext);
-			final Var predVar = mapValueExprToVar(pred);
-			pathElementExpression = new StatementPattern(pathSequenceContext.scope, startVar.clone(), predVar, endVar,
+			Var predVar = mapValueExprToVar(pathElement.jjtGetChild(0).jjtAccept(this, pathSequenceContext));
+			pathElementExpression = new StatementPattern(pathSequenceContext.scope, startVar.clone(), predVar,
+					endVar.clone(),
 					pathSequenceContext.contextVar != null ? pathSequenceContext.contextVar.clone() : null);
 		}
 
@@ -1719,8 +1721,8 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 		for (int i = 0; i < childCount; i++) {
 			ValueExpr childValue = (ValueExpr) node.jjtGetChild(i).jjtAccept(this, null);
 
-			Var childVar = mapValueExprToVar(childValue);
-			graphPattern.addRequiredSP(listVar.clone(), TupleExprs.createConstVar(RDF.FIRST), childVar.clone());
+			graphPattern.addRequiredSP(listVar.clone(), TupleExprs.createConstVar(RDF.FIRST),
+					mapValueExprToVar(childValue));
 
 			Var nextListVar;
 			if (i == childCount - 1) {
@@ -2619,9 +2621,9 @@ public class TupleExprBuilder extends AbstractASTVisitor {
 	@Override
 	public TupleExpr visit(ASTTripleRef node, Object data) throws VisitorException {
 		TripleRef ret = new TripleRef();
-		ret.setSubjectVar(mapValueExprToVar(node.getSubj().jjtAccept(this, ret)).clone());
-		ret.setPredicateVar(mapValueExprToVar(node.getPred().jjtAccept(this, ret)).clone());
-		ret.setObjectVar(mapValueExprToVar(node.getObj().jjtAccept(this, ret)).clone());
+		ret.setSubjectVar(mapValueExprToVar(node.getSubj().jjtAccept(this, ret)));
+		ret.setPredicateVar(mapValueExprToVar(node.getPred().jjtAccept(this, ret)));
+		ret.setObjectVar(mapValueExprToVar(node.getObj().jjtAccept(this, ret)));
 		ret.setExprVar(createAnonVar());
 		graphPattern.addRequiredTE(ret);
 


### PR DESCRIPTION
GitHub issue resolved: #4187 and resolved #4184 and resolved #4189 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - fix a general problem with potential Var object reuse by cloning at the origin of the issue
 - add tests
 - cleanup and fix existing tests

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

