### PR TITLE
GH-4182 Add complex Lucene queries

### DIFF
--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailSchema.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailSchema.java
@@ -35,6 +35,8 @@ public class LuceneSailSchema {
 
 	public static final IRI INDEXID;
 
+	public static final IRI BOOST;
+
 	/**
 	 * "Magic property" (TupleFunction) IRI.
 	 */
@@ -61,6 +63,8 @@ public class LuceneSailSchema {
 		MATCHES = factory.createIRI(NAMESPACE + "matches");
 
 		INDEXID = factory.createIRI(NAMESPACE + "indexid");
+
+		BOOST = factory.createIRI(NAMESPACE + "boost");
 
 		SEARCH = factory.createIRI(NAMESPACE + "search");
 		ALL_MATCHES = factory.createIRI(NAMESPACE + "allMatches");

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilder.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilder.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.sail.lucene;
 
 import static org.eclipse.rdf4j.model.vocabulary.RDF.TYPE;
+import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.BOOST;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.INDEXID;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.LUCENE_QUERY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.MATCHES;
@@ -22,12 +23,15 @@ import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SNIPPET;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.algebra.Join;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
@@ -149,11 +153,12 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 			}
 
 			// find the relevant outgoing patterns
-			StatementPattern typePattern, queryPattern, propertyPattern, scorePattern, snippetPattern;
+			StatementPattern typePattern, propertyPattern, scorePattern, snippetPattern;
+			List<StatementPattern> queryPatterns;
 
 			try {
 				typePattern = getPattern(matchesVar, filter.typePatterns);
-				queryPattern = getPattern(matchesVar, filter.queryPatterns);
+				queryPatterns = getQueryVar(matchesVar, filter.queryPatterns);
 				propertyPattern = getPattern(matchesVar, filter.propertyPatterns);
 				scorePattern = getPattern(matchesVar, filter.scorePatterns);
 				snippetPattern = getPattern(matchesVar, filter.snippetPatterns);
@@ -164,19 +169,100 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 
 			// fetch the query String
 			String queryString = null;
+			List<QuerySpec.QueryParam> queries = new ArrayList<>();
+			StatementPattern litQueryPattern = null;
+			boolean multiFieldQuery = false;
 
-			if (queryPattern != null) {
-				Var queryVar = queryPattern.getObjectVar();
-				Value queryValue = queryVar.hasValue() ? queryVar.getValue() : bindings.getValue(queryVar.getName());
+			if (!queryPatterns.isEmpty()) {
+				Var queryVar = queryPatterns.get(0).getObjectVar();
+				Value firstQueryValue = queryVar.hasValue() ? queryVar.getValue()
+						: bindings.getValue(queryVar.getName());
+				multiFieldQuery = firstQueryValue == null || !firstQueryValue.isLiteral();
 
-				if (queryValue instanceof Literal) {
-					queryString = ((Literal) queryValue).getLabel();
+				if (multiFieldQuery) {
+					// multiple queries
+					for (StatementPattern queryPattern : queryPatterns) {
+						Var queryPatternVar = queryPattern.getObjectVar();
+						StatementPattern fieldQueryQueryPattern = getPattern(queryPatternVar, filter.queryPatterns);
+						StatementPattern fieldQueryBoostPattern = getPattern(queryPatternVar, filter.boostPatterns);
+						StatementPattern fieldQueryPropertyPattern = getPattern(queryPatternVar,
+								filter.propertyPatterns);
+						StatementPattern fieldQuerySnippetPattern = getPattern(queryPatternVar, filter.snippetPatterns);
+						StatementPattern fieldTypePattern = getPattern(queryPatternVar, filter.typePatterns);
+
+						String query = null;
+						IRI property = null;
+						Float boost = null;
+						Var snippetVar = fieldQuerySnippetPattern == null ? null
+								: fieldQuerySnippetPattern.getObjectVar();
+
+						if (fieldQueryQueryPattern != null) {
+							Var fieldQueryQueryVar = fieldQueryQueryPattern.getObjectVar();
+							Value queryValue = fieldQueryQueryVar.hasValue() ? fieldQueryQueryVar.getValue()
+									: bindings.getValue(fieldQueryQueryVar.getName());
+
+							if (queryValue instanceof Literal) {
+								query = ((Literal) queryValue).getLabel();
+							}
+						}
+
+						if (fieldQueryBoostPattern != null) {
+							Var fieldQueryBoostVar = fieldQueryBoostPattern.getObjectVar();
+							Value boostValue = fieldQueryBoostVar.hasValue() ? fieldQueryBoostVar.getValue()
+									: bindings.getValue(fieldQueryBoostVar.getName());
+
+							if (boostValue instanceof Literal) {
+								boost = ((Literal) boostValue).floatValue();
+							}
+						}
+
+						if (fieldQueryPropertyPattern != null) {
+							Var propertyVar = fieldQueryPropertyPattern.getObjectVar();
+							Value propertyValue = propertyVar.hasValue() ? propertyVar.getValue()
+									: bindings.getValue(propertyVar.getName());
+
+							// if property is a restriction, it should be an URI
+							if (propertyValue instanceof IRI) {
+								property = (IRI) propertyValue;
+							}
+							// otherwise, it should be a variable
+							else if (propertyValue != null) {
+								failOrWarn(PROPERTY + " should have a property URI or a variable as object: "
+										+ propertyVar.getValue());
+								continue;
+							}
+						}
+
+						// check the snippet variable, if any
+						if (snippetVar != null && snippetVar.hasValue()) {
+							failOrWarn(SNIPPET + " should have a variable as object: " + snippetVar.getValue());
+							continue;
+						}
+
+						// check type pattern
+						if (fieldTypePattern == null) {
+							logger.debug("Query variable '{}' has not rdf:type, assuming {}", fieldTypePattern,
+									LUCENE_QUERY);
+						}
+
+						queries.add(new QuerySpec.QueryParam(queryPattern, fieldQueryQueryPattern,
+								fieldQueryPropertyPattern, fieldQuerySnippetPattern, fieldQueryBoostPattern,
+								fieldTypePattern, query, property, boost));
+					}
+				} else {
+					// using literal query
+					queryString = ((Literal) firstQueryValue).getLabel();
+					litQueryPattern = queryPatterns.get(0);
 				}
 			}
 
 			// check property restriction or variable
 			IRI propertyURI = null;
 			if (propertyPattern != null) {
+				if (multiFieldQuery) {
+					failOrWarn(PROPERTY + " can't be used with " + MATCHES + " for non literal query");
+					continue;
+				}
 				Var propertyVar = propertyPattern.getObjectVar();
 				Value propertyValue = propertyVar.hasValue() ? propertyVar.getValue()
 						: bindings.getValue(propertyVar.getName());
@@ -212,8 +298,12 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 				logger.debug("Query variable '{}' has not rdf:type, assuming {}", subject, LUCENE_QUERY);
 			}
 
-			QuerySpec querySpec = new QuerySpec(matchesPattern, queryPattern, propertyPattern, scorePattern,
-					snippetPattern, typePattern, idPattern, subject, queryString, propertyURI);
+			if (!multiFieldQuery) {
+				queries.add(new QuerySpec.QueryParam(litQueryPattern, propertyPattern, snippetPattern, null,
+						queryString, propertyURI, null));
+			}
+
+			QuerySpec querySpec = new QuerySpec(matchesPattern, queries, scorePattern, typePattern, idPattern, subject);
 
 			if (querySpec.isEvaluable()) {
 				// constant optimizer
@@ -222,7 +312,13 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 				// evaluate later
 				TupleFunctionCall funcCall = new TupleFunctionCall();
 				funcCall.setURI(LuceneSailSchema.SEARCH.toString());
-				funcCall.addArg(queryPattern.getObjectVar());
+				if (multiFieldQuery) {
+					funcCall.addArg(new ValueConstant(QUERY));
+					funcCall.addArg(new ValueConstant(Values.literal(queryPatterns.size())));
+					queryPatterns.stream().map(StatementPattern::getObjectVar).forEach(funcCall::addArg);
+				} else {
+					funcCall.addArg(queryPatterns.get(0).getObjectVar());
+				}
 				if (subject != null) {
 					funcCall.addArg(matchesPattern.getSubjectVar());
 				} else {
@@ -301,6 +397,57 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 		return result;
 	}
 
+	/**
+	 * Return all the var of the patterns with the subject subjectVar, if a pattern is a literal, it will return a
+	 * singleton list, otherwise it will return an empty list or a list without any literal var
+	 */
+	private List<StatementPattern> getQueryVar(Var subjectVar, ArrayList<StatementPattern> patterns)
+			throws IllegalArgumentException {
+		StatementPattern litResult = null;
+		List<StatementPattern> objectResult = null;
+
+		for (StatementPattern pattern : patterns) {
+			// ignore other subject
+			if (!pattern.getSubjectVar().equals(subjectVar)) {
+				continue;
+			}
+
+			Var queryPatternVar = pattern.getObjectVar();
+			if (queryPatternVar.hasValue() && queryPatternVar.getValue().isLiteral()) {
+				if (objectResult != null) {
+					throw new IllegalArgumentException("query can't be done over both literal and resource!");
+				}
+				if (litResult != null) {
+					throw new IllegalArgumentException(
+							"multiple StatementPatterns with the same subject: " + litResult + ", " + pattern);
+				} else {
+					litResult = pattern;
+				}
+			} else {
+				if (litResult != null) {
+					throw new IllegalArgumentException("query can't be done over both literal and resource!");
+				}
+				if (objectResult == null) {
+					objectResult = new ArrayList<>();
+				}
+				objectResult.add(pattern);
+			}
+		}
+		// remove the result from the list, to filter out superflous patterns
+		// we have one literal
+		if (litResult != null) {
+			patterns.remove(litResult);
+			return List.of(litResult);
+		}
+		// we have resources
+		if (objectResult != null) {
+			patterns.removeAll(objectResult);
+			return objectResult;
+		}
+		// no query
+		return List.of();
+	}
+
 	private static class PatternFilter extends AbstractQueryModelVisitor<RuntimeException> {
 
 		public ArrayList<StatementPattern> typePatterns = new ArrayList<>();
@@ -316,6 +463,8 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 		public ArrayList<StatementPattern> snippetPatterns = new ArrayList<>();
 
 		public ArrayList<StatementPattern> idPatterns = new ArrayList<>();
+
+		public ArrayList<StatementPattern> boostPatterns = new ArrayList<>();
 
 		/**
 		 * Method implementing the visitor pattern that gathers all statements using a predicate from the LuceneSail's
@@ -337,6 +486,8 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 				snippetPatterns.add(node);
 			} else if (INDEXID.equals(predicate)) {
 				idPatterns.add(node);
+			} else if (BOOST.equals(predicate)) {
+				boostPatterns.add(node);
 			} else if (TYPE.equals(predicate)) {
 				Value object = node.getObjectVar().getValue();
 				if (LUCENE_QUERY.equals(object)) {

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/LangSpecTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/LangSpecTest.java
@@ -69,7 +69,7 @@ public class LangSpecTest {
 		}
 
 		@Override
-		protected Iterable<? extends DocumentScore> query(Resource subject, String q, IRI property, boolean highlight) {
+		protected Iterable<? extends DocumentScore> query(Resource subject, QuerySpec spec) {
 			throw new RuntimeException("not implemented");
 		}
 

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilderTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilderTest.java
@@ -11,13 +11,16 @@
 package org.eclipse.rdf4j.sail.lucene;
 
 import static org.eclipse.rdf4j.model.vocabulary.RDF.TYPE;
+import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.BOOST;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.LUCENE_QUERY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.MATCHES;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.QUERY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SCORE;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SNIPPET;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -46,47 +49,47 @@ public class QuerySpecBuilderTest {
 	}
 
 	@Test
-	public void testQueryInterpretation() throws Exception {
-		StringBuilder buffer = new StringBuilder();
-		buffer.append("SELECT ?Subject ?Score ?Snippet ");
-		buffer.append("WHERE { ?Subject <" + MATCHES + "> [ ");
-		buffer.append("<" + TYPE + "> <" + LUCENE_QUERY + ">; ");
-		buffer.append("<" + QUERY + "> \"my Lucene query\"; ");
-		buffer.append("<" + SCORE + "> ?Score; ");
-		buffer.append("<" + SNIPPET + "> ?Snippet ]. } ");
-		ParsedQuery query = parser.parseQuery(buffer.toString(), null);
+	public void testQueryInterpretation() {
+		String buffer = "SELECT ?Subject ?Score ?Snippet " +
+				"WHERE { ?Subject <" + MATCHES + "> [ " +
+				"<" + TYPE + "> <" + LUCENE_QUERY + ">; " +
+				"<" + QUERY + "> \"my Lucene query\"; " +
+				"<" + SCORE + "> ?Score; " +
+				"<" + SNIPPET + "> ?Snippet ]. } ";
+		ParsedQuery query = parser.parseQuery(buffer, null);
 		TupleExpr tupleExpr = query.getTupleExpr();
 		Collection<SearchQueryEvaluator> queries = process(interpreter, tupleExpr);
 		assertEquals(1, queries.size());
 
 		QuerySpec querySpec = (QuerySpec) queries.iterator().next();
 		assertEquals("Subject", querySpec.getMatchesPattern().getSubjectVar().getName());
-		assertEquals("my Lucene query", ((Literal) querySpec.getQueryPattern().getObjectVar().getValue()).getLabel());
+		assertEquals(1, querySpec.getQueryPatterns().size());
+		QuerySpec.QueryParam param = querySpec.getQueryPatterns().iterator().next();
+		assertEquals("my Lucene query", ((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
 		assertEquals("Score", querySpec.getScorePattern().getObjectVar().getName());
-		assertEquals("Snippet", querySpec.getSnippetPattern().getObjectVar().getName());
+		assertEquals("Snippet", param.getSnippetPattern().getObjectVar().getName());
 		assertEquals(LUCENE_QUERY, querySpec.getTypePattern().getObjectVar().getValue());
-		assertEquals("my Lucene query", querySpec.getQueryString());
+		assertEquals("my Lucene query", param.getQuery());
 		assertNull(querySpec.getSubject());
 	}
 
 	@Test
-	public void testMultipleQueriesInterpretation() throws Exception {
-		StringBuilder buffer = new StringBuilder();
-		buffer.append("SELECT ?sub1 ?score1 ?snippet1 ?sub2 ?score2 ?snippet2 ?x ?p1 ?p2 ");
-		buffer.append("WHERE { ?sub1 <" + MATCHES + "> [ ");
-		buffer.append("<" + TYPE + "> <" + LUCENE_QUERY + ">; ");
-		buffer.append("<" + QUERY + "> \"my Lucene query\"; ");
-		buffer.append("<" + SCORE + "> ?score1; ");
-		buffer.append("<" + SNIPPET + "> ?snippet1 ]. ");
-		buffer.append(" ?sub2 <" + MATCHES + "> [ ");
-		buffer.append("<" + TYPE + "> <" + LUCENE_QUERY + ">; ");
-		buffer.append("<" + QUERY + "> \"second lucene query\"; ");
-		buffer.append("<" + SCORE + "> ?score2; ");
-		buffer.append("<" + SNIPPET + "> ?snippet2 ]. ");
-		// and connect them both via any X in between, just as salt to make the
-		// parser do something
-		buffer.append(" ?sub1 ?p1 ?x . ?x ?p2 ?sub2 .} ");
-		ParsedQuery query = parser.parseQuery(buffer.toString(), null);
+	public void testMultipleQueriesInterpretation() {
+		String buffer = "SELECT ?sub1 ?score1 ?snippet1 ?sub2 ?score2 ?snippet2 ?x ?p1 ?p2 " +
+				"WHERE { ?sub1 <" + MATCHES + "> [ " +
+				"<" + TYPE + "> <" + LUCENE_QUERY + ">; " +
+				"<" + QUERY + "> \"my Lucene query\"; " +
+				"<" + SCORE + "> ?score1; " +
+				"<" + SNIPPET + "> ?snippet1 ]. " +
+				" ?sub2 <" + MATCHES + "> [ " +
+				"<" + TYPE + "> <" + LUCENE_QUERY + ">; " +
+				"<" + QUERY + "> \"second lucene query\"; " +
+				"<" + SCORE + "> ?score2; " +
+				"<" + SNIPPET + "> ?snippet2 ]. " +
+				// and connect them both via any X in between, just as salt to make the
+				// parser do something
+				" ?sub1 ?p1 ?x . ?x ?p2 ?sub2 .} ";
+		ParsedQuery query = parser.parseQuery(buffer, null);
 		TupleExpr tupleExpr = query.getTupleExpr();
 
 		Collection<SearchQueryEvaluator> queries = process(interpreter, tupleExpr);
@@ -99,27 +102,31 @@ public class QuerySpecBuilderTest {
 			if ("sub1".equals(querySpec.getMatchesVariableName())) {
 				// Matched the first
 				assertEquals("sub1", querySpec.getMatchesPattern().getSubjectVar().getName());
+				assertEquals(1, querySpec.getQueryPatterns().size());
+				QuerySpec.QueryParam param = querySpec.getQueryPatterns().iterator().next();
 				assertEquals("my Lucene query",
-						((Literal) querySpec.getQueryPattern().getObjectVar().getValue()).getLabel());
+						((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
 				assertEquals("score1", querySpec.getScorePattern().getObjectVar().getName());
-				assertEquals("snippet1", querySpec.getSnippetPattern().getObjectVar().getName());
+				assertEquals("snippet1", param.getSnippetPattern().getObjectVar().getName());
 				assertEquals(LUCENE_QUERY, querySpec.getTypePattern().getObjectVar().getValue());
-				assertEquals("my Lucene query", querySpec.getQueryString());
+				assertEquals("my Lucene query", param.getQuery());
 				assertNull(querySpec.getSubject());
 				matched1 = true;
 			} else if ("sub2".equals(querySpec.getMatchesVariableName())) {
 				// and the second
 				assertEquals("sub2", querySpec.getMatchesPattern().getSubjectVar().getName());
+				assertEquals(1, querySpec.getQueryPatterns().size());
+				QuerySpec.QueryParam param = querySpec.getQueryPatterns().iterator().next();
 				assertEquals("second lucene query",
-						((Literal) querySpec.getQueryPattern().getObjectVar().getValue()).getLabel());
+						((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
 				assertEquals("score2", querySpec.getScorePattern().getObjectVar().getName());
-				assertEquals("snippet2", querySpec.getSnippetPattern().getObjectVar().getName());
+				assertEquals("snippet2", param.getSnippetPattern().getObjectVar().getName());
 				assertEquals(LUCENE_QUERY, querySpec.getTypePattern().getObjectVar().getValue());
-				assertEquals("second lucene query", querySpec.getQueryString());
+				assertEquals("second lucene query", param.getQuery());
 				assertNull(querySpec.getSubject());
 				matched2 = true;
 			} else {
-				fail("Found unexpected query spec: " + querySpec.toString());
+				fail("Found unexpected query spec: " + querySpec);
 			}
 		}
 		if (!matched1) {
@@ -128,6 +135,161 @@ public class QuerySpecBuilderTest {
 		if (!matched2) {
 			fail("did not find query patter sub2");
 		}
+	}
+
+	@Test
+	public void testQueryInterpretation2() {
+		String buffer = "SELECT ?Subject ?Score ?Snippet " +
+				"WHERE { ?Subject <" + MATCHES + "> [ " +
+				"<" + TYPE + "> <" + LUCENE_QUERY + ">; " +
+				"<" + QUERY + ">" + "[ <" + QUERY + "> \"my Lucene query\"; " +
+				"<" + SNIPPET + "> ?Snippet ] ;" +
+				"<" + SCORE + "> ?Score ]. } ";
+		ParsedQuery query = parser.parseQuery(buffer, null);
+		TupleExpr tupleExpr = query.getTupleExpr();
+		Collection<SearchQueryEvaluator> queries = process(interpreter, tupleExpr);
+		assertEquals(1, queries.size());
+
+		QuerySpec querySpec = (QuerySpec) queries.iterator().next();
+		assertEquals("Subject", querySpec.getMatchesPattern().getSubjectVar().getName());
+		assertEquals(1, querySpec.getQueryPatterns().size());
+		QuerySpec.QueryParam param = querySpec.getQueryPatterns().iterator().next();
+		assertEquals("my Lucene query", ((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
+		assertEquals("Score", querySpec.getScorePattern().getObjectVar().getName());
+		assertEquals("Snippet", param.getSnippetPattern().getObjectVar().getName());
+		assertEquals(LUCENE_QUERY, querySpec.getTypePattern().getObjectVar().getValue());
+		assertEquals("my Lucene query", param.getQuery());
+		assertNull(querySpec.getSubject());
+	}
+
+	@Test
+	public void testMultipleQueriesInterpretation2() {
+		String buffer = "SELECT ?sub1 ?score1 ?snippet1 ?sub2 ?score2 ?snippet2 ?x ?p1 ?p2 " +
+				"WHERE { ?sub1 <" + MATCHES + "> [ " +
+				"<" + TYPE + "> <" + LUCENE_QUERY + ">; " +
+				"<" + SCORE + "> ?score1; " +
+				"<" + QUERY + "> [ <" + QUERY + "> \"my Lucene query\"; " +
+				"<" + SNIPPET + "> ?snippet1 ]]. " +
+				" ?sub2 <" + MATCHES + "> [ " +
+				"<" + TYPE + "> <" + LUCENE_QUERY + ">; " +
+				"<" + SCORE + "> ?score2; " +
+				"<" + QUERY + "> [ <" + QUERY + "> \"second lucene query\"; " +
+				"<" + SNIPPET + "> ?snippet2 ] ]. " +
+				// and connect them both via any X in between, just as salt to make the
+				// parser do something
+				" ?sub1 ?p1 ?x . ?x ?p2 ?sub2 .} ";
+		ParsedQuery query = parser.parseQuery(buffer, null);
+		TupleExpr tupleExpr = query.getTupleExpr();
+
+		Collection<SearchQueryEvaluator> queries = process(interpreter, tupleExpr);
+		assertEquals(2, queries.size());
+		Iterator<SearchQueryEvaluator> i = queries.iterator();
+		boolean matched1 = false;
+		boolean matched2 = false;
+		while (i.hasNext()) {
+			QuerySpec querySpec = (QuerySpec) i.next();
+			if ("sub1".equals(querySpec.getMatchesVariableName())) {
+				// Matched the first
+				assertEquals("sub1", querySpec.getMatchesPattern().getSubjectVar().getName());
+				assertEquals(1, querySpec.getQueryPatterns().size());
+				QuerySpec.QueryParam param = querySpec.getQueryPatterns().iterator().next();
+				assertEquals("my Lucene query",
+						((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
+				assertEquals("score1", querySpec.getScorePattern().getObjectVar().getName());
+				assertEquals("snippet1", param.getSnippetPattern().getObjectVar().getName());
+				assertEquals(LUCENE_QUERY, querySpec.getTypePattern().getObjectVar().getValue());
+				assertEquals("my Lucene query", param.getQuery());
+				assertNull(querySpec.getSubject());
+				matched1 = true;
+			} else if ("sub2".equals(querySpec.getMatchesVariableName())) {
+				// and the second
+				assertEquals("sub2", querySpec.getMatchesPattern().getSubjectVar().getName());
+				assertEquals(1, querySpec.getQueryPatterns().size());
+				QuerySpec.QueryParam param = querySpec.getQueryPatterns().iterator().next();
+				assertEquals("second lucene query",
+						((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
+				assertEquals("score2", querySpec.getScorePattern().getObjectVar().getName());
+				assertEquals("snippet2", param.getSnippetPattern().getObjectVar().getName());
+				assertEquals(LUCENE_QUERY, querySpec.getTypePattern().getObjectVar().getValue());
+				assertEquals("second lucene query", param.getQuery());
+				assertNull(querySpec.getSubject());
+				matched2 = true;
+			} else {
+				fail("Found unexpected query spec: " + querySpec);
+			}
+		}
+		if (!matched1) {
+			fail("did not find query patter sub1");
+		}
+		if (!matched2) {
+			fail("did not find query patter sub2");
+		}
+	}
+
+	@Test
+	public void testQueryInterpretationMulti() {
+		String buffer = "SELECT ?sub1 ?sub2 ?sub3 ?Subject ?Score ?Snippet ?Snippet2 " +
+				"WHERE { ?Subject <" + MATCHES + "> [ " +
+				"<" + TYPE + "> <" + LUCENE_QUERY + ">; " +
+				"<" + QUERY + "> ?sub1, ?sub2, ?sub3;" +
+				"<" + SCORE + "> ?Score ]. " +
+				"?sub1 <" + QUERY + "> \"my Lucene query\"; <" + SNIPPET + "> ?Snippet ; <" + BOOST + "> 0.8 ." +
+				"?sub2 <" + QUERY + "> \"my Lucene query2\"; <" + SNIPPET + "> ?Snippet2 ; <" + BOOST + "> 0.2 ." +
+				"?sub3 <" + QUERY + "> \"my Lucene query3\"." +
+				// and connect them both via any X in between, just as salt to make the
+				// parser do something
+				" ?sub1 ?p1 ?x . ?x ?p2 ?sub2 . ?x ?p3 ?sub3 } ";
+		ParsedQuery query = parser.parseQuery(buffer, null);
+		TupleExpr tupleExpr = query.getTupleExpr();
+		Collection<SearchQueryEvaluator> queries = process(interpreter, tupleExpr);
+		assertEquals(1, queries.size());
+
+		QuerySpec querySpec = (QuerySpec) queries.iterator().next();
+		assertEquals("Subject", querySpec.getMatchesPattern().getSubjectVar().getName());
+		assertEquals(3, querySpec.getQueryPatterns().size());
+
+		boolean read1 = false, read2 = false, read3 = false;
+		for (QuerySpec.QueryParam param : querySpec.getQueryPatterns()) {
+			switch (param.getFieldPattern().getObjectVar().getName()) {
+			case "sub1": {
+				assertEquals("my Lucene query", param.getQuery());
+				assertEquals("my Lucene query",
+						((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
+				assertEquals("Snippet", param.getSnippetPattern().getObjectVar().getName());
+				assertNotNull(param.getBoost());
+				assertEquals(0.8f, param.getBoost(), 0.0001f);
+				read1 = true;
+			}
+				break;
+			case "sub2": {
+				assertEquals("my Lucene query2", param.getQuery());
+				assertEquals("my Lucene query2",
+						((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
+				assertEquals("Snippet2", param.getSnippetPattern().getObjectVar().getName());
+				assertNotNull(param.getBoost());
+				assertEquals(0.2f, param.getBoost(), 0.0001f);
+				read2 = true;
+			}
+				break;
+			case "sub3": {
+				assertEquals("my Lucene query3", param.getQuery());
+				assertEquals("my Lucene query3",
+						((Literal) param.getQueryPattern().getObjectVar().getValue()).getLabel());
+				assertNull(param.getBoost());
+				assertNull(param.getSnippetPattern());
+				read3 = true;
+			}
+				break;
+			default:
+				fail("unknown query var name: " + param.getFieldPattern().getObjectVar().getName());
+			}
+		}
+		assertEquals(LUCENE_QUERY, querySpec.getTypePattern().getObjectVar().getValue());
+		assertEquals("Score", querySpec.getScorePattern().getObjectVar().getName());
+		assertTrue("lucene query 1 not read", read1);
+		assertTrue("lucene query 2 not read", read2);
+		assertTrue("lucene query 3 not read", read3);
+		assertNull(querySpec.getSubject());
 	}
 
 	/**

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/MultiParamTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/MultiParamTest.java
@@ -1,0 +1,467 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import static org.eclipse.rdf4j.model.util.Values.literal;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.evaluation.TupleFunctionEvaluationMode;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class MultiParamTest {
+	private static final String NAMESPACE = "http://example.org/";
+	private static final String PREFIXES = joinLines(
+			"PREFIX search: <http://www.openrdf.org/contrib/lucenesail#>",
+			"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
+			"PREFIX ex: <" + NAMESPACE + ">");
+
+	private static IRI iri(String name) {
+		return Values.iri(NAMESPACE + name);
+	}
+
+	private static String joinLines(String... lines) {
+		return String.join(" \n", lines);
+	}
+
+	private static final IRI elem1 = iri("elem1");
+	private static final IRI elem2 = iri("elem2");
+	private static final IRI elem3 = iri("elem3");
+	private static final IRI elem4 = iri("elem4");
+	private static final IRI elem5 = iri("elem5");
+	private static final IRI elem6 = iri("elem6");
+	private static final IRI elem7 = iri("elem7");
+
+	private static final IRI p1 = iri("p1");
+	private static final IRI p2 = iri("p2");
+	private static final IRI p3 = iri("p3");
+
+	@Rule
+	public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	LuceneSail luceneSail;
+	SailRepository repository;
+	SailRepositoryConnection conn;
+
+	@Before
+	public void setup() throws IOException {
+		MemoryStore memoryStore = new MemoryStore();
+		// sail with the ex:text1 filter
+		luceneSail = new LuceneSail();
+		luceneSail.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
+		luceneSail.setEvaluationMode(TupleFunctionEvaluationMode.NATIVE);
+		luceneSail.setBaseSail(memoryStore);
+		luceneSail.setDataDir(tmpFolder.newFolder());
+		repository = new SailRepository(luceneSail);
+		repository.init();
+
+		// add test elements
+		conn = repository.getConnection();
+		conn.begin();
+
+		conn.add(elem1, p1, literal("aaa"));
+		conn.add(elem1, p2, literal("bbb"));
+		conn.add(elem1, p3, literal("ccc"));
+
+		conn.add(elem2, p1, literal("aaa"));
+		conn.add(elem2, p2, literal("ddd"));
+		conn.add(elem2, p3, literal("ccc"));
+
+		conn.add(elem3, p1, literal("ddd"));
+		conn.add(elem3, p2, literal("bbb"));
+		conn.add(elem3, p3, literal("fff"));
+
+		conn.add(elem4, p1, literal("ddd"));
+		conn.add(elem4, p2, literal("ggg"));
+		conn.add(elem4, p3, literal("ccc"));
+
+		conn.add(elem5, p1, literal("hhh"));
+		conn.add(elem5, p2, literal("eee"));
+		conn.add(elem5, p3, literal("aaa"));
+
+		conn.add(elem6, p1, literal("iii zzz yyy"));
+		conn.add(elem6, p2, literal("jjj zzz"));
+		conn.add(elem6, p3, literal("kkk"));
+
+		conn.add(elem7, p1, literal("iii zzz"));
+		conn.add(elem7, p2, literal("jjj zzz yyy"));
+		conn.add(elem7, p3, literal("kkk"));
+
+		conn.commit();
+	}
+
+	@After
+	public void complete() {
+		try {
+			conn.close();
+		} finally {
+			repository.shutDown();
+		}
+	}
+
+	@Test
+	public void testPredicateSimple() {
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query \"aaa\"",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			Set<String> values = new HashSet<>(Set.of(
+					elem1.toString(),
+					elem2.toString(),
+					elem5.toString()
+			));
+
+			while (result.hasNext()) {
+				Value next = result.next().getValue("subj");
+				assertTrue("unknown value: " + next, values.remove(next.toString()));
+			}
+			assertTrue("missing value" + values, values.isEmpty());
+		}
+	}
+
+	@Test
+	public void testPredicateMulti() {
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query [ ",
+				"       search:query \"aaa\"",
+				"    ]",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			Set<String> values = new HashSet<>(Set.of(
+					elem1.toString(),
+					elem2.toString(),
+					elem5.toString()
+			));
+
+			while (result.hasNext()) {
+				Value next = result.next().getValue("subj");
+				assertTrue("unknown value: " + next, values.remove(next.toString()));
+			}
+			assertTrue("missing value" + values, values.isEmpty());
+		}
+	}
+
+	@Test
+	public void testMultiPredicate() {
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query [ ",
+				"       search:query \"aaa\" ;",
+				"       search:property ex:p1",
+				"    ]",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			Set<String> values = new HashSet<>(Set.of(
+					elem1.toString(),
+					elem2.toString()
+			));
+
+			while (result.hasNext()) {
+				Value next = result.next().getValue("subj");
+				assertTrue("unknown value: " + next, values.remove(next.toString()));
+			}
+			assertTrue("missing value" + values, values.isEmpty());
+		}
+	}
+
+	@Test
+	public void testMultiQuery() {
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query",
+				"    [",
+				"       search:query \"aaa\" ;",
+				"       search:property ex:p1",
+				"    ] , [",
+				"       search:query \"bbb\" ;",
+				"       search:property ex:p2",
+				"    ]",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			Set<String> values = new HashSet<>(Set.of(
+					elem1.toString(),
+					elem2.toString(),
+					elem3.toString()
+			));
+
+			while (result.hasNext()) {
+				BindingSet binding = result.next();
+				Value next = binding.getValue("subj");
+				assertTrue("unknown value: " + next, values.remove(next.toString()));
+			}
+			assertTrue("missing value" + values, values.isEmpty());
+		}
+	}
+
+	@Test
+	public void testMultiSnippetQuery() {
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query",
+				"    [",
+				"       search:query \"aaa\" ;",
+				"       search:property ex:p1 ;",
+				"       search:snippet ?sp1 ;",
+				"    ] , [",
+				"       search:query \"bbb\" ;",
+				"       search:property ex:p2 ;",
+				"       search:snippet ?sp2 ;",
+				"    ]",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			Set<String> values = new HashSet<>(Set.of(
+					elem1 + ":\"<B>aaa</B>\":\"<B>bbb</B>\"",
+					elem2 + ":\"<B>aaa</B>\":null",
+					elem3 + ":null:\"<B>bbb</B>\""
+			));
+
+			while (result.hasNext()) {
+				BindingSet bindings = result.next();
+				Value next = bindings.getValue("subj");
+				Value snippet1 = bindings.getValue("sp1");
+				Value snippet2 = bindings.getValue("sp2");
+				String obj = next + ":" + snippet1 + ":" + snippet2;
+				assertTrue("unknown value: " + obj, values.remove(obj));
+			}
+			assertTrue("missing value" + values, values.isEmpty());
+		}
+	}
+
+	@Test
+	public void testMultiOrderQuery() {
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query",
+				"    [",
+				"       search:query \"iii\" ;",
+				"       search:property ex:p1 ;",
+				"       search:boost 0.2 ;",
+				"    ] , [",
+				"       search:query \"jjj\" ;",
+				"       search:property ex:p2 ;",
+				"       search:boost 0.8 ;",
+				"    ] ;",
+				"    search:score ?score",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			String[] values = new String[] {
+					elem6.toString(),
+					elem7.toString()
+			};
+			Iterator<String> it = Arrays.stream(values).iterator();
+
+			while (result.hasNext()) {
+				if (!it.hasNext()) {
+					do {
+						System.out.println(result.next());
+					} while (result.hasNext());
+					fail("too many binding");
+				}
+				BindingSet bindings = result.next();
+				String exceptedValue = it.next();
+				Value next = bindings.getValue("subj");
+				assertEquals(exceptedValue, next.toString());
+			}
+			if (it.hasNext()) {
+				do {
+					System.out.println(it.next());
+				} while (it.hasNext());
+				fail();
+			}
+		}
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query",
+				"    [",
+				"       search:query \"iii\" ;",
+				"       search:property ex:p1 ;",
+				"       search:boost 0.8 ;",
+				"    ] , [",
+				"       search:query \"jjj\" ;",
+				"       search:property ex:p2 ;",
+				"       search:boost 0.2 ;",
+				"    ] ;",
+				"    search:score ?score",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			String[] values = new String[] {
+					elem7.toString(),
+					elem6.toString()
+			};
+			Iterator<String> it = Arrays.stream(values).iterator();
+
+			while (result.hasNext()) {
+				if (!it.hasNext()) {
+					do {
+						System.out.println(result.next());
+					} while (result.hasNext());
+					fail("too many binding");
+				}
+				BindingSet bindings = result.next();
+				String exceptedValue = it.next();
+				Value next = bindings.getValue("subj");
+				assertEquals(exceptedValue, next.toString());
+			}
+			if (it.hasNext()) {
+				do {
+					System.out.println(it.next());
+				} while (it.hasNext());
+				fail();
+			}
+		}
+	}
+
+	@Test
+	public void testMultiOrderSnippetQuery() {
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query",
+				"    [",
+				"       search:query \"iii\" ;",
+				"       search:property ex:p1 ;",
+				"       search:boost 0.2 ;",
+				"       search:snippet ?sp1 ;",
+				"    ] , [",
+				"       search:query \"jjj\" ;",
+				"       search:property ex:p2 ;",
+				"       search:boost 0.8 ;",
+				"       search:snippet ?sp2 ;",
+				"    ] ;",
+				"    search:score ?score",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			String[] values = new String[] {
+					elem6 + ":<B>iii</B> zzz yyy:<B>jjj</B> zzz",
+					elem7 + ":<B>iii</B> zzz:<B>jjj</B> zzz yyy"
+			};
+			Iterator<String> it = Arrays.stream(values).iterator();
+
+			while (result.hasNext()) {
+				if (!it.hasNext()) {
+					do {
+						System.out.println(result.next());
+					} while (result.hasNext());
+					fail("too many binding");
+				}
+				String exceptedValue = it.next();
+				BindingSet bindings = result.next();
+				Value snippetValue1 = bindings.getValue("sp1");
+				String snippet1 = snippetValue1 == null ? "" : snippetValue1.stringValue();
+				Value snippetValue2 = bindings.getValue("sp2");
+				String snippet2 = snippetValue2 == null ? "" : snippetValue2.stringValue();
+				Value next = bindings.getValue("subj");
+				String actualValue = next + ":" + snippet1 + ":" + snippet2;
+				assertEquals(exceptedValue, actualValue);
+			}
+			if (it.hasNext()) {
+				do {
+					System.out.println(it.next());
+				} while (it.hasNext());
+				fail();
+			}
+		}
+		try (TupleQueryResult result = conn.prepareTupleQuery(joinLines(
+				PREFIXES,
+				"SELECT * {",
+				"  ?subj search:matches [",
+				"    search:query",
+				"    [",
+				"       search:query \"iii\" ;",
+				"       search:property ex:p1 ;",
+				"       search:boost 0.8 ;",
+				"       search:snippet ?sp1 ;",
+				"    ] , [",
+				"       search:query \"jjj\" ;",
+				"       search:property ex:p2 ;",
+				"       search:boost 0.2 ;",
+				"       search:snippet ?sp2 ;",
+				"    ] ;",
+				"    search:score ?score",
+				"  ]",
+				"}"
+		)).evaluate()) {
+			String[] values = new String[] {
+					elem7 + ":<B>iii</B> zzz:<B>jjj</B> zzz yyy",
+					elem6 + ":<B>iii</B> zzz yyy:<B>jjj</B> zzz"
+			};
+			Iterator<String> it = Arrays.stream(values).iterator();
+
+			while (result.hasNext()) {
+				if (!it.hasNext()) {
+					do {
+						System.out.println(result.next());
+					} while (result.hasNext());
+					fail("too many binding");
+				}
+				BindingSet bindings = result.next();
+				String exceptedValue = it.next();
+				Value snippetValue1 = bindings.getValue("sp1");
+				String snippet1 = snippetValue1 == null ? "" : snippetValue1.stringValue();
+				Value snippetValue2 = bindings.getValue("sp2");
+				String snippet2 = snippetValue2 == null ? "" : snippetValue2.stringValue();
+				Value next = bindings.getValue("subj");
+				String actualValue = next + ":" + snippet1 + ":" + snippet2;
+				assertEquals(exceptedValue, actualValue);
+			}
+			if (it.hasNext()) {
+				do {
+					System.out.println(it.next());
+				} while (it.hasNext());
+				fail();
+			}
+		}
+	}
+}

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
@@ -39,6 +39,7 @@ import org.eclipse.rdf4j.sail.lucene.DocumentDistance;
 import org.eclipse.rdf4j.sail.lucene.DocumentResult;
 import org.eclipse.rdf4j.sail.lucene.DocumentScore;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
+import org.eclipse.rdf4j.sail.lucene.QuerySpec;
 import org.eclipse.rdf4j.sail.lucene.SearchDocument;
 import org.eclipse.rdf4j.sail.lucene.SearchFields;
 import org.eclipse.rdf4j.sail.lucene.util.GeoUnits;
@@ -282,16 +283,22 @@ public class SolrIndex extends AbstractSearchIndex {
 	 * Parse the passed query.
 	 *
 	 * @param subject
-	 * @param query       string
-	 * @param propertyURI
-	 * @param highlight
+	 * @param spec    query to process
 	 * @return the parsed query
 	 * @throws MalformedQueryException
 	 * @throws IOException
+	 * @throws IllegalArgumentException if the spec contains a multi-param query
 	 */
 	@Override
-	protected Iterable<? extends DocumentScore> query(Resource subject, String query, IRI propertyURI,
-			boolean highlight) throws MalformedQueryException, IOException {
+	protected Iterable<? extends DocumentScore> query(Resource subject, QuerySpec spec)
+			throws MalformedQueryException, IOException {
+		if (spec.getQueryPatterns().size() != 1) {
+			throw new IllegalArgumentException("Multi-param query not implemented!");
+		}
+		QuerySpec.QueryParam param = spec.getQueryPatterns().iterator().next();
+		IRI propertyURI = param.getProperty();
+		boolean highlight = param.isHighlight();
+		String query = param.getQuery();
 		SolrQuery q = prepareQuery(propertyURI, new SolrQuery(query));
 		if (highlight) {
 			q.setHighlight(true);

--- a/site/content/documentation/programming/lucene.md
+++ b/site/content/documentation/programming/lucene.md
@@ -134,15 +134,55 @@ results.forEach(res -> {
 });
 ```
 
+## Complex query (Field boosting and per-field search)
+
+*This feature might no be available for your implementation, see [SearchIndex implementations](#searchindex-implementations).*
+
+During the search, it might be important to boost the value of a single field while using multiple fields, to do that, you can use complex query:
+
+
+```sparql
+PREFIX search: <http://www.openrdf.org/contrib/lucenesail#>
+
+?subj search:matches [
+          search:query 
+          [
+              search:query "search terms over my:property1...";
+              search:property my:property1;
+              search:boost 0.8;
+              search:snippet ?snippet1;
+          ] ,
+          [
+              search:query "search terms over my:property2...";
+              search:property my:property2;
+              search:boost 0.2;
+              search:snippet ?snippet2;
+          ];
+          search:score ?score
+] .
+```
+
+The 'virtual' properties in the `search:` namespace have the following meaning:
+
+- `search:matches` – links the resource to be found with the following query statements (required)
+- `search:query` – specifies the Lucene query object(s), you can put as much query object as you want (required)
+  - `search:query` – specifies the Lucene query (required)
+  - `search:property` – specifies the property to search. If omitted all properties are searched (optional)
+  - `search:boost` – (float number) specifies the boost for the property to search. If omitted, no boost is applied (optional)
+  - `search:snippet` – specifies a variable for a highlighted snippet (optional)
+- `search:score` – specifies a variable for the score (optional)
+
+**You can use complex queries with a literal query!**
+
 ## SearchIndex implementations
 
 The LuceneSail can currently be used with three SearchIndex implementations:
 
-|                   |  SearchIndex implementation                 | Maven module                          |
-|------------------ |---------------------------------------------|---------------------|
-| Apache Lucene     | `org.eclipse.rdf4j.sail.lucene.impl.LuceneIndex` | `rdf4j-sail-lucene` |
-| ElasticSearch     | `org.eclipse.rdf4j.sail.elasticsearch.ElasticsearchIndex` | `rdf4j-sail-elasticsearch` |
-| Apache Solr       | `org.eclipse.rdf4j.sail.solr.SolrIndex`     | `rdf4j-sail-solr`   |
+|                   |  SearchIndex implementation                               | Maven module                          | Complex query support ? |
+|------------------ |-----------------------------------------------------------|---------------------------------------|-------------------------|
+| Apache Lucene     | `org.eclipse.rdf4j.sail.lucene.impl.LuceneIndex`          | `rdf4j-sail-lucene`                   | yes                      |
+| ElasticSearch     | `org.eclipse.rdf4j.sail.elasticsearch.ElasticsearchIndex` | `rdf4j-sail-elasticsearch`            | no                      |
+| Apache Solr       | `org.eclipse.rdf4j.sail.solr.SolrIndex`                   | `rdf4j-sail-solr`                     | no                      |
 
 Each SearchIndex implementation can easily be extended if you need to add extra features or store/access data with a different schema.
 


### PR DESCRIPTION
GitHub issue resolved: #4182

Briefly describe the changes proposed in this PR:

I've added a new format for the Lucene query, instead of putting one query in a Lucene request, we can add more complex per-field queries.

It's the same format as the one presented in #4182.

```SPARQL
PREFIX search: <http://www.openrdf.org/contrib/lucenesail#>
SELECT * {
  ?subj search:matches [
      search:query [
          search:property my:property1
          search:query "search terms for my:property1..."
          search:boost 0.8;
          search:snippet ?snippetp1
      ] , [
          search:property my:property2
          search:query "search terms for my:property2..."
          search:boost 0.2;
          search:snippet ?snippetp2
      ] ;
      search:score ?score
  ] .
}
```

It adds a new predicate `search:boost` to boost a field compared to another one, it can be useful if the query is the same on 2 different fields (to boost a search in a title compared to the content of a document)

The maximum of sub-queries depends on the index implementation.

I've also updated the Full-text search documentation page to explain the new format.

It is only implemented for the Lucene index, trying to use a complex query with a Solr or Elasticsearch Index will create a IllegalArgumentException. To wait the implementation, it was added in the documentation.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

