### PR TITLE
GH-4197 use null instead of EmptyIteration to signal when PathIteration is finished

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
@@ -279,6 +279,9 @@ public class StatementPatternQueryEvaluationStep implements QueryEvaluationStep 
 		CloseableIteration<? extends Statement, QueryEvaluationException> iteration = null;
 		try {
 			iteration = tripleSource.getStatements((Resource) subject, (IRI) predicate, object, contexts);
+			if (iteration instanceof EmptyIteration) {
+				return null;
+			}
 			iteration = handleFilter(contexts, (Resource) subject, (IRI) predicate, object, iteration);
 
 			// Return an iterator that converts the statements to var bindings

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
@@ -94,16 +94,16 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 	@Override
 	protected BindingSet getNextElement() throws QueryEvaluationException {
 		again: while (true) {
-			while (!currentIter.hasNext()) {
+			while (currentIter != null && !currentIter.hasNext()) {
 				Iterations.closeCloseable(currentIter);
 				createIteration();
 				// stop condition: if the iter is an EmptyIteration
-				if (currentIter instanceof EmptyIteration<?, ?>) {
+				if (currentIter == null) {
 					break;
 				}
 			}
 
-			while (currentIter.hasNext()) {
+			while (currentIter != null && currentIter.hasNext()) {
 				BindingSet potentialNextElement = currentIter.next();
 				MutableBindingSet nextElement;
 				// if it is not a compatible type of BindingSet
@@ -256,7 +256,7 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 
 		if (isUnbound(startVar, bindings) || isUnbound(endVar, bindings)) {
 			// the variable must remain unbound for this solution see https://www.w3.org/TR/sparql11-query/#assignment
-			currentIter = new EmptyIteration<>();
+			currentIter = null;
 		} else if (currentLength == 0L) {
 			ZeroLengthPath zlp = new ZeroLengthPath(scope, startVar.clone(), endVar.clone(),
 					contextVar != null ? contextVar.clone() : null);
@@ -316,7 +316,7 @@ public class PathIteration extends LookAheadIteration<BindingSet, QueryEvaluatio
 
 				currentIter = this.strategy.evaluate(pathExprClone, bindings);
 			} else {
-				currentIter = new EmptyIteration<>();
+				currentIter = null;
 			}
 			currentLength++;
 


### PR DESCRIPTION
GitHub issue resolved: #4197 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
 - use null instead of EmptyIteration to signal when PathIteration is finished
<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

