### PR TITLE
GH-4214: fix DESCRIBE queries in FedX when targeting a single source

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSourceBase.java
@@ -88,6 +88,7 @@ public abstract class TripleSourceBase implements TripleSource {
 				}
 				return;
 			case CONSTRUCT:
+			case DESCRIBE:
 				monitorRemoteRequest();
 				GraphQuery gQuery = conn.prepareGraphQuery(QueryLanguage.SPARQL, preparedQuery, baseURI);
 				applyBindings(gQuery, queryBindings);

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/BasicTests.java
@@ -476,4 +476,12 @@ public class BasicTests extends SPARQLBaseTest {
 		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl", "/tests/basic/data01endpoint2.ttl"));
 		execute("/tests/basic/query_describe2.rq", "/tests/basic/query_describe2.ttl", false, true);
 	}
+
+	@Test
+	public void testDescribe_SingleSource() throws Exception {
+
+		/* test DESCRIBE query for a single resource (one federation member to simulate single source) */
+		prepareTest(Arrays.asList("/tests/basic/data01endpoint1.ttl"));
+		execute("/tests/basic/query_describe1.rq", "/tests/basic/query_describe1_singleSource.ttl", false, true);
+	}
 }

--- a/tools/federation/src/test/resources/tests/basic/query_describe1_singleSource.ttl
+++ b/tools/federation/src/test/resources/tests/basic/query_describe1_singleSource.ttl
@@ -1,0 +1,4 @@
+@prefix : <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+:a foaf:name "Alan" .


### PR DESCRIPTION
GitHub issue resolved: #4214

Previously DESCRIBE queries (when targeting a single source, i.e. a single federation member) could run into a QueryEvaluationException.

This change now completes the code path for evaluating single source DESCRIBE queries in the the TripleSource by treating them in the same way as CONSTRUCT queries.

Scenario covered with a simulated unit test.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

