### PR TITLE
GH-2642 improve support for sh:message and add support sh:resultMessage

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -316,6 +316,7 @@ public class ShaclSail extends ShaclSailBaseConfiguration {
 				SHACL.QUALIFIED_MIN_COUNT,
 				SHACL.QUALIFIED_VALUE_SHAPE,
 				SHACL.SHAPES_GRAPH,
+				SHACL.MESSAGE,
 				DASH.hasValueIn,
 				RSX.targetShape
 		);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailValidationException.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailValidationException.java
@@ -13,9 +13,12 @@ package org.eclipse.rdf4j.sail.shacl;
 
 import org.eclipse.rdf4j.common.exception.ValidationException;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.RSX;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
 
@@ -33,23 +36,23 @@ public class ShaclSailValidationException extends SailException implements Valid
 	 */
 	@Override
 	public Model validationReportAsModel() {
+		Model model = getValidationReport().asModel();
 
-		ValidationReport validationReport = getValidationReport();
-
-		Model model = validationReport.asModel();
 		model.setNamespace(RSX.NS);
 		model.setNamespace(RDF4J.NS);
 		model.setNamespace(SHACL.NS);
-		return model;
+		model.setNamespace(XSD.NS);
+		model.setNamespace(RDF.NS);
+		model.setNamespace(RDFS.NS);
 
+		return model;
 	}
 
 	/**
-	 * @deprecated The returned ValidationReport is planned to be moved to a different package and this method is
-	 *             planned to return that class.
-	 *
 	 * @return A ValidationReport Java object that describes what failed and can optionally be converted to a Model as
 	 *         specified by the SHACL Recommendation
+	 * @deprecated The returned ValidationReport is planned to be moved to a different package and this method is
+	 *             planned to return that class.
 	 */
 	@Deprecated
 	public ValidationReport getValidationReport() {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/Shape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/Shape.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.DynamicModel;
 import org.eclipse.rdf4j.model.impl.LinkedHashModelFactory;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
@@ -193,6 +194,10 @@ abstract public class Shape implements ConstraintComponent, Identifiable {
 
 		if (deactivated) {
 			modelBuilder.add(SHACL.DEACTIVATED, deactivated);
+		}
+
+		for (Literal literal : message) {
+			modelBuilder.add(SHACL.MESSAGE, literal);
 		}
 
 		target.forEach(t -> {
@@ -459,6 +464,10 @@ abstract public class Shape implements ConstraintComponent, Identifiable {
 				.reduce(ValidationApproach::reduceCompatible)
 				.orElse(ValidationApproach.MOST_COMPATIBLE);
 
+	}
+
+	public List<Literal> getMessage() {
+		return message;
 	}
 
 	public static class Factory {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationReport.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationReport.java
@@ -36,6 +36,8 @@ import org.eclipse.rdf4j.model.vocabulary.SHACL;
 @Deprecated
 public class ValidationReport {
 
+	private static final DynamicModelFactory DYNAMIC_MODEL_FACTORY = new DynamicModelFactory();
+
 	protected Resource id = null;
 
 	protected boolean conforms = true;
@@ -72,7 +74,7 @@ public class ValidationReport {
 	}
 
 	public Model asModel() {
-		return asModel(new DynamicModelFactory().createEmptyModel());
+		return asModel(DYNAMIC_MODEL_FACTORY.createEmptyModel());
 	}
 
 	public final Resource getId() {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
@@ -137,6 +138,9 @@ public class ValidationResult {
 
 		model.add(getId(), SHACL.SOURCE_CONSTRAINT_COMPONENT, getSourceConstraintComponent().getIri());
 		model.add(getId(), SHACL.RESULT_SEVERITY, severity.getIri());
+		for (Literal message : shape.getMessage()) {
+			model.add(getId(), SHACL.RESULT_MESSAGE, message);
+		}
 
 		// TODO: Figure out how sh:detail should work!
 //		if (detail != null) {

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -104,25 +104,26 @@ abstract public class AbstractShaclTest {
 			"test-cases/class/complexTargetShape",
 			"test-cases/class/complexTargetShape2",
 			"test-cases/class/multipleClass",
+			"test-cases/class/nestedNode",
 			"test-cases/class/not",
 			"test-cases/class/not2",
 			"test-cases/class/notAnd",
 			"test-cases/class/notNotSimple",
 			"test-cases/class/simple",
+			"test-cases/class/simpleNested",
 			"test-cases/class/simpleTargetShape",
-//		"test-cases/class/sparqlTarget",
-//		"test-cases/class/sparqlTargetNot",
 			"test-cases/class/subclass",
 			"test-cases/class/targetNode",
 			"test-cases/class/validateTarget",
 			"test-cases/class/validateTargetNot",
 			"test-cases/complex/dcat",
 			"test-cases/complex/foaf",
-			"test-cases/complex/targetShapeAndQualifiedShape",
 			"test-cases/complex/mms",
-//		"test-cases/complex/sparqlTarget",
+			"test-cases/complex/targetShapeAndQualifiedShape",
 			"test-cases/datatype/allObjects",
 			"test-cases/datatype/not",
+			"test-cases/datatype/notNestedPropertyShape",
+			"test-cases/datatype/notNestedPropertyShape2",
 			"test-cases/datatype/notNodeShape",
 			"test-cases/datatype/notNodeShapeAnd",
 			"test-cases/datatype/notNodeShapeTargetShape",
@@ -137,7 +138,6 @@ abstract public class AbstractShaclTest {
 			"test-cases/datatype/simpleNested2",
 			"test-cases/datatype/simpleNode",
 			"test-cases/datatype/simpleNodeNested",
-//		"test-cases/datatype/sparqlTarget",
 			"test-cases/datatype/targetNode",
 			"test-cases/datatype/targetNode2",
 			"test-cases/datatype/targetNodeLang",
@@ -151,28 +151,50 @@ abstract public class AbstractShaclTest {
 			"test-cases/functionalProperty/multipleFunctionalOr",
 			"test-cases/functionalProperty/singleFunctional",
 			"test-cases/hasValue/and",
+			"test-cases/hasValue/and2",
 			"test-cases/hasValue/not",
 			"test-cases/hasValue/not2",
+			"test-cases/hasValue/or",
+			"test-cases/hasValue/simple",
+			"test-cases/hasValue/targetNode",
+			"test-cases/hasValue/targetNode2",
+			"test-cases/hasValue/targetShapeAnd",
+			"test-cases/hasValue/targetShapeAnd2",
+			"test-cases/hasValue/targetShapeAnd3",
+			"test-cases/hasValue/targetShapeAndOr",
+			"test-cases/hasValue/targetShapeAndOr2",
+			"test-cases/hasValue/targetShapeAndOr3",
+			"test-cases/hasValue/targetShapeOr",
+			"test-cases/hasValueIn/and",
 			"test-cases/hasValueIn/and",
 			"test-cases/hasValueIn/not",
+			"test-cases/hasValueIn/not",
 			"test-cases/hasValueIn/not2",
+			"test-cases/hasValueIn/not2",
+			"test-cases/hasValueIn/or",
+			"test-cases/hasValueIn/simple",
 			"test-cases/hasValueIn/simple",
 			"test-cases/hasValueIn/targetNode",
+			"test-cases/hasValueIn/targetNode",
 			"test-cases/hasValueIn/targetNode2",
+			"test-cases/hasValueIn/targetNode2",
+			"test-cases/hasValueIn/targetNode2",
+			"test-cases/hasValueIn/targetShapeOr",
 			"test-cases/implicitTargetClass/simple",
 			"test-cases/implicitTargetClass/simpleDefaultGraph",
 			"test-cases/in/notAnd",
 			"test-cases/in/notOr",
 			"test-cases/in/simple",
 			"test-cases/languageIn/simple",
-			"test-cases/maxCount/not",
+			"test-cases/languageIn/subtags",
+			"test-cases/languageIn/subtags2",
 			"test-cases/maxCount/nested",
 			"test-cases/maxCount/nestedCombination",
+			"test-cases/maxCount/not",
 			"test-cases/maxCount/not2",
 			"test-cases/maxCount/notNot",
 			"test-cases/maxCount/simple",
 			"test-cases/maxCount/simpleInversePath",
-//		"test-cases/maxCount/sparqlTarget",
 			"test-cases/maxCount/targetNode",
 			"test-cases/maxCount/zeroAndNegative",
 			"test-cases/maxExclusive/simple",
@@ -204,7 +226,6 @@ abstract public class AbstractShaclTest {
 			"test-cases/or/datatypeNodeShape",
 			"test-cases/or/datatypeTargetNode",
 			"test-cases/or/implicitAnd",
-//		"test-cases/or/implicitAndSparqlTarget",
 			"test-cases/or/inheritance",
 			"test-cases/or/inheritance-deep",
 			"test-cases/or/inheritanceNodeShape",
@@ -218,47 +239,28 @@ abstract public class AbstractShaclTest {
 			"test-cases/pattern/multiple",
 			"test-cases/pattern/simple",
 			"test-cases/propertyShapeWithTarget/simple",
-			"test-cases/uniqueLang/not",
-			"test-cases/uniqueLang/simple",
-			"test-cases/datatype/notNestedPropertyShape",
-			"test-cases/datatype/notNestedPropertyShape2",
-			"test-cases/hasValue/simple",
-			"test-cases/hasValue/and2",
-			"test-cases/hasValue/targetNode",
-			"test-cases/hasValue/targetNode2",
-			"test-cases/hasValueIn/simple",
-			"test-cases/hasValueIn/and",
-			"test-cases/hasValueIn/not",
-			"test-cases/hasValueIn/not2",
-			"test-cases/hasValueIn/targetNode",
-			"test-cases/hasValueIn/targetNode2",
-			"test-cases/languageIn/subtags",
-			"test-cases/languageIn/subtags2",
-			"test-cases/hasValueIn/targetNode2",
-			"test-cases/hasValue/or",
-			"test-cases/hasValue/targetShapeOr",
-			"test-cases/hasValue/targetShapeAnd",
-			"test-cases/hasValue/targetShapeAnd2",
-			"test-cases/hasValue/targetShapeAnd3",
-			"test-cases/hasValue/targetShapeAndOr",
-			"test-cases/hasValue/targetShapeAndOr2",
-			"test-cases/hasValue/targetShapeAndOr3",
-			"test-cases/hasValueIn/targetShapeOr",
-			"test-cases/hasValueIn/or",
-			"test-cases/class/simpleNested",
-			"test-cases/class/nestedNode",
-			"test-cases/qualifiedShape/minCountSimple",
+			"test-cases/qualifiedShape/complex",
 			"test-cases/qualifiedShape/maxCountSimple",
+			"test-cases/qualifiedShape/minCountSimple",
 			"test-cases/uniqueLang/complex",
-			"test-cases/qualifiedShape/complex"
+			"test-cases/uniqueLang/not",
+			"test-cases/uniqueLang/simple"
+//			"test-cases/class/sparqlTarget",
+//			"test-cases/class/sparqlTargetNot",
+//			"test-cases/complex/sparqlTarget",
+//			"test-cases/datatype/sparqlTarget",
+//			"test-cases/maxCount/sparqlTarget",
+//			"test-cases/or/implicitAndSparqlTarget",
 	)
 			.distinct()
 			.sorted()
 			.collect(Collectors.toList());
+
 	public static final Set<IRI> SHAPE_GRAPHS = Set.of(RDF4J.SHACL_SHAPE_GRAPH, RDF4J.NIL,
 			Values.iri("http://example.com/ns#shapesGraph1"));
 
 	boolean fullLogging = false;
+
 	static List<TestCase> testCases = getTestsToRun();
 	static List<Arguments> testsToRun = getTestsToRunWithoutIsolationLevel(testCases);
 	static List<Arguments> testsToRunWithIsolationLevel = getTestsToRunWithIsolationLevel(testCases);
@@ -331,26 +333,21 @@ abstract public class AbstractShaclTest {
 	}
 
 	private static Stream<TestCase> findTestCases(String testCase, ExpectedResult baseCase) {
-		String shacl;
-
-		try (InputStream resourceAsStream = getResourceAsStream(testCase + "/shacl.trig")) {
-			assert Objects.nonNull(resourceAsStream) : "Could not find: " + testCase + "/shacl.trig";
-			shacl = IOUtils.toString(resourceAsStream, StandardCharsets.UTF_8);
-
-		} catch (IOException e) {
-			throw new IllegalStateException(e);
-		}
+		String shacl = readShaclFile(testCase);
 
 		URL resource = AbstractShaclTest.class.getClassLoader().getResource(testCase + "/" + baseCase + "/");
 		if (resource == null) {
 			return Stream.empty();
 		}
 
-		return Arrays.stream(Objects.requireNonNull(new File(resource.getFile()).list()))
+		String[] testCases = Objects.requireNonNull(new File(resource.getFile()).list(),
+			"Could not find test cases for: " + resource);
+
+		return Arrays.stream(testCases)
 				.filter(s -> !s.startsWith("."))
 				.sorted()
-				.map(caseName -> {
-					String fullTestCasePath = testCase + "/" + baseCase + "/" + caseName;
+				.map(caseName -> testCase + "/" + baseCase + "/" + caseName)
+				.map(fullTestCasePath -> {
 					URL fullTestCase = AbstractShaclTest.class.getClassLoader().getResource(fullTestCasePath);
 					if (fullTestCase != null) {
 						File[] files = new File(fullTestCase.getFile()).listFiles();
@@ -369,6 +366,16 @@ abstract public class AbstractShaclTest {
 					return null;
 				})
 				.filter(Objects::nonNull);
+	}
+
+	private static String readShaclFile(String testCase) {
+		try (InputStream resourceAsStream = AbstractShaclTest.class.getClassLoader()
+				.getResourceAsStream(testCase + "/shacl.trig")) {
+			assert Objects.nonNull(resourceAsStream) : "Could not find: " + testCase + "/shacl.trig";
+			return IOUtils.toString(resourceAsStream, StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
 	}
 
 	private static List<Arguments> getTestsToRunWithIsolationLevel(List<TestCase> testCases) {
@@ -408,7 +415,7 @@ abstract public class AbstractShaclTest {
 
 		printTestCase(testCase);
 
-		SailRepository shaclRepository = getShaclSail(testCase, true);
+		SailRepository shaclRepository = getShaclSail(testCase);
 
 		boolean containsShapesGraphStatements = testCase.getShacl().contains(null, SHACL.SHAPES_GRAPH, null);
 		boolean onlyContainsRdf4jShapesGraph = testCase.getShacl().contexts().equals(Set.of(RDF4J.SHACL_SHAPE_GRAPH));
@@ -905,7 +912,7 @@ abstract public class AbstractShaclTest {
 
 	void runTestCaseSingleTransaction(TestCase testCase) {
 
-		SailRepository shaclRepository = getShaclSail(testCase, true);
+		SailRepository shaclRepository = getShaclSail(testCase);
 
 		try {
 			boolean exception = false;
@@ -962,7 +969,7 @@ abstract public class AbstractShaclTest {
 
 	void runTestCaseRevalidate(TestCase testCase, IsolationLevel isolationLevel) {
 
-		SailRepository shaclRepository = getShaclSail(testCase, true);
+		SailRepository shaclRepository = getShaclSail(testCase);
 		try {
 
 			ValidationReport report = new ValidationReport(true);
@@ -1019,7 +1026,7 @@ abstract public class AbstractShaclTest {
 			return;
 		}
 
-		SailRepository shaclRepository = getShaclSail(testCase, true);
+		SailRepository shaclRepository = getShaclSail(testCase);
 		try {
 
 			List<ContextWithShapes> shapes = ((ShaclSail) shaclRepository.getSail()).getCachedShapes()
@@ -1095,7 +1102,7 @@ abstract public class AbstractShaclTest {
 		printResults(validationReport);
 	}
 
-	SailRepository getShaclSail(TestCase testCase, boolean loadInitialData) {
+	SailRepository getShaclSail(TestCase testCase) {
 
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 		SailRepository repository = new SailRepository(shaclSail);
@@ -1115,11 +1122,14 @@ abstract public class AbstractShaclTest {
 
 		try {
 			Utils.loadShapeData(repository, testCase.getShacl());
-			if (loadInitialData && testCase.hasInitialData()) {
+			if (testCase.hasInitialData()) {
 				Utils.loadInitialData(repository, testCase.getInitialData());
 			}
 		} catch (Exception e) {
 			repository.shutDown();
+			if (e instanceof RuntimeException) {
+				throw ((RuntimeException) e);
+			}
 			throw new RuntimeException(e);
 		}
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -341,7 +341,7 @@ abstract public class AbstractShaclTest {
 		}
 
 		String[] testCases = Objects.requireNonNull(new File(resource.getFile()).list(),
-			"Could not find test cases for: " + resource);
+				"Could not find test cases for: " + resource);
 
 		return Arrays.stream(testCases)
 				.filter(s -> !s.startsWith("."))

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTestWithoutRdfsReasonerTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTestWithoutRdfsReasonerTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @author Håvard Ottestad
  */
 @Tag("slow")
-public class ShaclTestWithoutRdfsReasoner extends AbstractShaclTest {
+public class ShaclTestWithoutRdfsReasonerTest extends AbstractShaclTest {
 
 	@ParameterizedTest
 	@MethodSource("testsToRunWithIsolationLevel")
@@ -50,7 +50,7 @@ public class ShaclTestWithoutRdfsReasoner extends AbstractShaclTest {
 		return testCase.getTestCasePath().contains("/subclass");
 	}
 
-	SailRepository getShaclSail(TestCase testCase, boolean loadInitialData) {
+	SailRepository getShaclSail(TestCase testCase) {
 
 		ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 		SailRepository repository = new SailRepository(shaclSail);
@@ -70,7 +70,7 @@ public class ShaclTestWithoutRdfsReasoner extends AbstractShaclTest {
 
 		try {
 			Utils.loadShapeData(repository, testCase.getShacl());
-			if (loadInitialData && testCase.hasInitialData()) {
+			if (testCase.hasInitialData()) {
 				Utils.loadInitialData(repository, testCase.getInitialData());
 			}
 		} catch (Exception e) {

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/targetNode2/invalid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/targetNode2/invalid/case1/report.ttl
@@ -13,6 +13,7 @@
   sh:result [ a sh:ValidationResult;
       rsx:shapesGraph rdf4j:SHACLShapeGraph;
       sh:focusNode ex:steve;
+      sh:resultMessage "This is a contradiction!";
       sh:resultSeverity sh:Violation;
       sh:sourceConstraintComponent sh:HasValueConstraintComponent;
       sh:sourceShape ex:PersonShape
@@ -20,4 +21,5 @@
 
 ex:PersonShape a sh:NodeShape;
   sh:hasValue ex:peter;
+  sh:message "This is a contradiction!";
   sh:targetNode ex:steve .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/targetNode2/shacl.trig
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/targetNode2/shacl.trig
@@ -10,5 +10,6 @@
 rdf4j:SHACLShapeGraph {
   ex:PersonShape a sh:NodeShape;
     sh:targetNode ex:steve;
-    sh:hasValue ex:peter .
+    sh:hasValue ex:peter ;
+    sh:message "This is a contradiction!" .
 }

--- a/core/sail/shacl/src/test/resources/test-cases/minCount/simple/invalid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/minCount/simple/invalid/case1/report.ttl
@@ -13,10 +13,13 @@
   sh:result [ a sh:ValidationResult;
       rsx:shapesGraph rdf4j:SHACLShapeGraph;
       sh:focusNode ex:validPerson1;
+      sh:resultMessage "Requires at least 2 social security numbers"@en, "Trenger minst 2 fødselsnummer"@no-nb, "Requires at least 2 social security numbers";
       sh:resultPath ex:ssn;
       sh:resultSeverity sh:Violation;
       sh:sourceConstraintComponent sh:MinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
+          sh:message "Requires at least 2 social security numbers"@en, "Trenger minst 2 fødselsnummer"@no-nb,
+            "Requires at least 2 social security numbers";
           sh:minCount 2;
           sh:path ex:ssn
         ]

--- a/core/sail/shacl/src/test/resources/test-cases/minCount/simple/invalid/case2/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/minCount/simple/invalid/case2/report.ttl
@@ -13,10 +13,13 @@
   sh:result [ a sh:ValidationResult;
       rsx:shapesGraph rdf4j:SHACLShapeGraph;
       sh:focusNode ex:validPerson2;
+      sh:resultMessage "Requires at least 2 social security numbers"@en, "Trenger minst 2 fødselsnummer"@no-nb, "Requires at least 2 social security numbers";
       sh:resultPath ex:ssn;
       sh:resultSeverity sh:Violation;
       sh:sourceConstraintComponent sh:MinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
+          sh:message "Requires at least 2 social security numbers"@en, "Trenger minst 2 fødselsnummer"@no-nb,
+            "Requires at least 2 social security numbers";
           sh:minCount 2;
           sh:path ex:ssn
         ]

--- a/core/sail/shacl/src/test/resources/test-cases/minCount/simple/invalid/case3/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/minCount/simple/invalid/case3/report.ttl
@@ -13,10 +13,13 @@
   sh:result [ a sh:ValidationResult;
       rsx:shapesGraph rdf4j:SHACLShapeGraph;
       sh:focusNode ex:validPerson1;
+      sh:resultMessage "Requires at least 2 social security numbers"@en, "Trenger minst 2 fødselsnummer"@no-nb, "Requires at least 2 social security numbers";
       sh:resultPath ex:ssn;
       sh:resultSeverity sh:Violation;
       sh:sourceConstraintComponent sh:MinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
+          sh:message "Requires at least 2 social security numbers"@en, "Trenger minst 2 fødselsnummer"@no-nb,
+            "Requires at least 2 social security numbers";
           sh:minCount 2;
           sh:path ex:ssn
         ]

--- a/core/sail/shacl/src/test/resources/test-cases/minCount/simple/invalid/case4/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/minCount/simple/invalid/case4/report.ttl
@@ -13,10 +13,13 @@
   sh:result [ a sh:ValidationResult;
       rsx:shapesGraph rdf4j:SHACLShapeGraph;
       sh:focusNode ex:validPerson1;
+      sh:resultMessage "Requires at least 2 social security numbers"@en, "Trenger minst 2 fødselsnummer"@no-nb, "Requires at least 2 social security numbers";
       sh:resultPath ex:ssn;
       sh:resultSeverity sh:Violation;
       sh:sourceConstraintComponent sh:MinCountConstraintComponent;
       sh:sourceShape [ a sh:PropertyShape;
+          sh:message "Requires at least 2 social security numbers"@en, "Trenger minst 2 fødselsnummer"@no-nb,
+            "Requires at least 2 social security numbers";
           sh:minCount 2;
           sh:path ex:ssn
         ]

--- a/core/sail/shacl/src/test/resources/test-cases/minCount/simple/shacl.trig
+++ b/core/sail/shacl/src/test/resources/test-cases/minCount/simple/shacl.trig
@@ -11,7 +11,8 @@
     sh:targetClass ex:Person;
     sh:property [
         sh:path ex:ssn;
-        sh:minCount 2
+        sh:minCount 2 ;
+        sh:message "Requires at least 2 social security numbers", "Trenger minst 2 fødselsnummer"@no-nb, "Requires at least 2 social security numbers"@en ;
       ] .
 
 }

--- a/site/content/documentation/programming/shacl.md
+++ b/site/content/documentation/programming/shacl.md
@@ -25,7 +25,8 @@ ex:PersonShape
     sh:targetClass ex:Person ;
     sh:property [
         sh:path ex:age ;
-        sh:datatype xsd:integer ;
+        sh:datatype xsd:int ;
+        sh:message "A person's age must be a number (xsd:int)." ;
     ] .
 ```
 
@@ -108,6 +109,7 @@ As of writing this documentation the following features are supported.
 - `sh:targetNode`
 - `sh:targetSubjectsOf`
 - `sh:targetObjectsOf`
+- `sh:message`
 - `sh:path`
 - `sh:inversePath`
 - `sh:property`
@@ -135,7 +137,7 @@ As of writing this documentation the following features are supported.
 - `sh:qualifiedMaxCount`
 - `sh:qualifiedMinCount`
 - `sh:qualifiedValueShape`
-- 'sh:shapesGraph'
+- `sh:shapesGraph`
 - `dash:hasValueIn`
 - `sh:target` for use with DASH targets
 - `rsx:targetShape`
@@ -180,10 +182,16 @@ The `validationReportModel` follows the report format specified by the W3C SHACL
     sh:result [
         a sh:ValidationResult ;
         sh:value "eighteen";
-        sh:focusNode <http://example.com/ns#pete> ;
-        sh:resultPath <http://example.com/ns#age> ;
+        sh:focusNode ex:pete ;
+        sh:resultPath ex:age ;
         sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
-        sh:sourceShape <http://example.com/ns#PersonShapeAgeProperty> ;
+        sh:resultSeverity sh:Violation;
+        sh:resultMessage "A person's age must be a number (xsd:int).";
+        sh:sourceShape [ a sh:PropertyShape;
+            sh:message "A persons age must be a number (xsd:int).";
+            sh:path ex:age;
+            sh:datatype xsd:int
+        ]
     ] .
 ```
 
@@ -252,7 +260,7 @@ ex:PersonShape
     sh:targetClass ex:Person ;
     sh:property [
         sh:path ex:age ;
-        sh:datatype xsd:integer ;
+        sh:datatype xsd:int ;
     ] .
 ```
 
@@ -306,35 +314,35 @@ SailRepository sailRepository = new SailRepository(shaclSail);
 
 try (SailRepositoryConnection connection = sailRepository.getConnection()) {
 
-	connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Bulk);
+    connection.begin(IsolationLevels.NONE, ShaclSail.TransactionSettings.ValidationApproach.Bulk);
 
-//	You can enable parallel validation and the intermediate cache for better performance if you have sufficient memory 
-//	connection.begin(
-//		IsolationLevels.NONE, 
-//		ShaclSail.TransactionSettings.ValidationApproach.Bulk, 
-//		ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled, 
-//		ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation
-//	);	
-	
-	// load shapes
-	try (InputStream inputStream = new FileInputStream("shacl.ttl")) {
-		connection.add(inputStream, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
-	}
+//    You can enable parallel validation and the intermediate cache for better performance if you have sufficient memory 
+//    connection.begin(
+//        IsolationLevels.NONE, 
+//        ShaclSail.TransactionSettings.ValidationApproach.Bulk, 
+//        ShaclSail.TransactionSettings.PerformanceHint.CacheEnabled, 
+//        ShaclSail.TransactionSettings.PerformanceHint.ParallelValidation
+//    );    
+    
+    // load shapes
+    try (InputStream inputStream = new FileInputStream("shacl.ttl")) {
+        connection.add(inputStream, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+    }
 
-	// load data
-	try (InputStream inputStream = new BufferedInputStream(new FileInputStream("data.ttl"))) {
-		connection.add(inputStream, "", RDFFormat.TURTLE);
-	}
+    // load data
+    try (InputStream inputStream = new BufferedInputStream(new FileInputStream("data.ttl"))) {
+        connection.add(inputStream, "", RDFFormat.TURTLE);
+    }
 
-	// commit transaction and catch any exception
-	try {
-		connection.commit();
-	} catch (RepositoryException e){
-		if(e.getCause() instanceof ValidationException){
-			Model model = ((ValidationException) e.getCause()).validationReportAsModel();
-			Rio.write(model, System.out, RDFFormat.TURTLE);
-		}
-	}
+    // commit transaction and catch any exception
+    try {
+        connection.commit();
+    } catch (RepositoryException e){
+        if(e.getCause() instanceof ValidationException){
+            Model model = ((ValidationException) e.getCause()).validationReportAsModel();
+            Rio.write(model, System.out, RDFFormat.TURTLE);
+        }
+    }
 
 }
 
@@ -393,7 +401,7 @@ ex:shapesGraph2 {
     ex:PersonShape       
         sh:property [
             sh:path ex:age ;
-            sh:datatype xsd:integer ;
+            sh:datatype xsd:int ;
         ] .
 
     rdf4j:nil sh:shapesGraph ex:shapesGraph1, ex:shapesGraph2.         
@@ -462,7 +470,7 @@ First step to debugging and understanding an unexpected violation is to enable `
 
 Validation plans are logged as Graphviz DOT. Validations plans are a form of query plan.
 
-Here is the validation plan for the example above: [Link](https://dreampuf.github.io/GraphvizOnline/#digraph%20%20%7B%0Alabelloc%3Dt%3B%0Afontsize%3D30%3B%0Alabel%3D%22DatatypePropertyShape%22%3B%0A1866229258%20%5Blabel%3D%22Base%20sail%22%20nodeShape%3Dpentagon%20fillcolor%3Dlightblue%20style%3Dfilled%5D%3B%0A1555990397%20%5Blabel%3D%22Added%20statements%22%20nodeShape%3Dpentagon%20fillcolor%3Dlightblue%20style%3Dfilled%5D%3B%0A1544078442%20%5Blabel%3D%22Removed%20statements%22%20nodeShape%3Dpentagon%20fillcolor%3Dlightblue%20style%3Dfilled%5D%3B%0A1337866219%20%5Blabel%3D%22Previous%20state%20connection%22%20nodeShape%3Dpentagon%20fillcolor%3Dlightblue%20style%3Dfilled%5D%3B%0A1291367132%20%5Blabel%3D%22DirectTupleFromFilter%22%5D%3B%0A1887699190%20%5Blabel%3D%22DatatypeFilter%7Bdatatype%3Dhttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23integer%7D%22%5D%3B%0A1479140596%20-%3E%201887699190%0A1887699190%20-%3E%201291367132%20%5Blabel%3D%22false%20values%22%5D%0A1479140596%20%5Blabel%3D%22UnionNode%22%5D%3B%0A1108889615%20-%3E%201479140596%0A1108889615%20%5Blabel%3D%22UnionNode%22%5D%3B%0A1275028674%20-%3E%201108889615%0A455888635%20%5Blabel%3D%22BufferedSplitter%22%5D%3B%0A204805934%20-%3E%20455888635%0A204805934%20%5Blabel%3D%22TrimTuple%7BnewLength%3D1%7D%22%5D%3B%0A204322447%20-%3E%20204805934%0A204322447%20%5Blabel%3D%22Select%7Bquery%3D%E2%80%99select%20*%20where%20%7B%20BIND(rdf%3Atype%20as%20%3Fb)%20%5Cn%20BIND(%3Chttp%3A%2F%2Fexample.com%2Fns%23Person%3E%20as%20%3Fc)%20%5Cn%20%3Fa%20%3Fb%20%3Fc.%7D%20order%20by%20%3Fa'%7D%22%5D%3B%0A1555990397%20-%3E%20204322447%0A1275028674%20%5Blabel%3D%22InnerJoin%22%5D%3B%0A455888635%20-%3E%201275028674%20%5Blabel%3D%22left%22%5D%3B%0A1019484860%20-%3E%201275028674%20%5Blabel%3D%22right%22%5D%3B%0A1019484860%20%5Blabel%3D%22DirectTupleFromFilter%22%5D%3B%0A1164365897%20%5Blabel%3D%22DatatypeFilter%7Bdatatype%3Dhttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23integer%7D%22%5D%3B%0A1640899500%20-%3E%201164365897%0A1164365897%20-%3E%201019484860%20%5Blabel%3D%22false%20values%22%5D%0A1640899500%20%5Blabel%3D%22Select%7Bquery%3D%E2%80%99select%20*%20where%20%7B%20%3Fa%20%3Chttp%3A%2F%2Fexample.com%2Fns%23age%3E%20%3Fc.%20%7D%20order%20by%20%3Fa'%7D%22%5D%3B%0A1555990397%20-%3E%201640899500%0A1275028674%20-%3E%203565780%20%5Blabel%3D%22discardedRight%22%5D%3B%0A473666452%20-%3E%201108889615%0A473666452%20%5Blabel%3D%22ExternalTypeFilterNode%7BfilterOnType%3Dhttp%3A%2F%2Fexample.com%2Fns%23Person%7D%22%5D%3B%0A3565780%20-%3E%20473666452%0A1337866219%20-%3E%20473666452%20%5Blabel%3D%22filter%20source%22%5D%0A3565780%20%5Blabel%3D%22BufferedTupleFromFilter%22%5D%3B%0A1865219266%20-%3E%201479140596%0A1865219266%20%5Blabel%3D%22BulkedExternalInnerJoin%7Bpredicate%3Dnull%2C%20query%3D'%3Fa%20%3Chttp%3A%2F%2Fexample.com%2Fns%23age%3E%20%3Fc.%20'%7D%22%5D%3B%0A455888635%20-%3E%201865219266%20%5Blabel%3D%22left%22%5D%0A1337866219%20-%3E%201865219266%20%5Blabel%3D%22right%22%5D%0A%7D%0A8)
+Here is the validation plan for the example above: [Link](https://dreampuf.github.io/GraphvizOnline/#digraph%20%20%7B%0Alabelloc%3Dt%3B%0Afontsize%3D30%3B%0Alabel%3D%22DatatypePropertyShape%22%3B%0A1866229258%20%5Blabel%3D%22Base%20sail%22%20nodeShape%3Dpentagon%20fillcolor%3Dlightblue%20style%3Dfilled%5D%3B%0A1555990397%20%5Blabel%3D%22Added%20statements%22%20nodeShape%3Dpentagon%20fillcolor%3Dlightblue%20style%3Dfilled%5D%3B%0A1544078442%20%5Blabel%3D%22Removed%20statements%22%20nodeShape%3Dpentagon%20fillcolor%3Dlightblue%20style%3Dfilled%5D%3B%0A1337866219%20%5Blabel%3D%22Previous%20state%20connection%22%20nodeShape%3Dpentagon%20fillcolor%3Dlightblue%20style%3Dfilled%5D%3B%0A1291367132%20%5Blabel%3D%22DirectTupleFromFilter%22%5D%3B%0A1887699190%20%5Blabel%3D%22DatatypeFilter%7Bdatatype%3Dhttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23int%7D%22%5D%3B%0A1479140596%20-%3E%201887699190%0A1887699190%20-%3E%201291367132%20%5Blabel%3D%22false%20values%22%5D%0A1479140596%20%5Blabel%3D%22UnionNode%22%5D%3B%0A1108889615%20-%3E%201479140596%0A1108889615%20%5Blabel%3D%22UnionNode%22%5D%3B%0A1275028674%20-%3E%201108889615%0A455888635%20%5Blabel%3D%22BufferedSplitter%22%5D%3B%0A204805934%20-%3E%20455888635%0A204805934%20%5Blabel%3D%22TrimTuple%7BnewLength%3D1%7D%22%5D%3B%0A204322447%20-%3E%20204805934%0A204322447%20%5Blabel%3D%22Select%7Bquery%3D%E2%80%99select%20*%20where%20%7B%20BIND(rdf%3Atype%20as%20%3Fb)%20%5Cn%20BIND(%3Chttp%3A%2F%2Fexample.com%2Fns%23Person%3E%20as%20%3Fc)%20%5Cn%20%3Fa%20%3Fb%20%3Fc.%7D%20order%20by%20%3Fa'%7D%22%5D%3B%0A1555990397%20-%3E%20204322447%0A1275028674%20%5Blabel%3D%22InnerJoin%22%5D%3B%0A455888635%20-%3E%201275028674%20%5Blabel%3D%22left%22%5D%3B%0A1019484860%20-%3E%201275028674%20%5Blabel%3D%22right%22%5D%3B%0A1019484860%20%5Blabel%3D%22DirectTupleFromFilter%22%5D%3B%0A1164365897%20%5Blabel%3D%22DatatypeFilter%7Bdatatype%3Dhttp%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%23int%7D%22%5D%3B%0A1640899500%20-%3E%201164365897%0A1164365897%20-%3E%201019484860%20%5Blabel%3D%22false%20values%22%5D%0A1640899500%20%5Blabel%3D%22Select%7Bquery%3D%E2%80%99select%20*%20where%20%7B%20%3Fa%20%3Chttp%3A%2F%2Fexample.com%2Fns%23age%3E%20%3Fc.%20%7D%20order%20by%20%3Fa'%7D%22%5D%3B%0A1555990397%20-%3E%201640899500%0A1275028674%20-%3E%203565780%20%5Blabel%3D%22discardedRight%22%5D%3B%0A473666452%20-%3E%201108889615%0A473666452%20%5Blabel%3D%22ExternalTypeFilterNode%7BfilterOnType%3Dhttp%3A%2F%2Fexample.com%2Fns%23Person%7D%22%5D%3B%0A3565780%20-%3E%20473666452%0A1337866219%20-%3E%20473666452%20%5Blabel%3D%22filter%20source%22%5D%0A3565780%20%5Blabel%3D%22BufferedTupleFromFilter%22%5D%3B%0A1865219266%20-%3E%201479140596%0A1865219266%20%5Blabel%3D%22BulkedExternalInnerJoin%7Bpredicate%3Dnull%2C%20query%3D'%3Fa%20%3Chttp%3A%2F%2Fexample.com%2Fns%23age%3E%20%3Fc.%20'%7D%22%5D%3B%0A455888635%20-%3E%201865219266%20%5Blabel%3D%22left%22%5D%0A1337866219%20-%3E%201865219266%20%5Blabel%3D%22right%22%5D%0A%7D%0A8)
 
 The structure of this log and its contents may change in the future, without warning.
 
@@ -503,8 +511,8 @@ Following on from the example above:
 
 
     1. [main] INFO  SHACL not valid. The following experimental debug results were produced:
-    2. 	NodeShape: http://example.com/ns#PersonShape
-    3. 		Tuple{line=[http://example.com/ns#pete, "eighteen"], propertyShapes= DatatypePropertyShape <_:node1d285h2ktx1>} -cause->  [ Tuple{line=[http://example.com/ns#pete, http://www.w3.org/1999/02/22-rdf-syntax-ns#type, http://example.com/ns#Person]} ]
+    2.     NodeShape: http://example.com/ns#PersonShape
+    3.         Tuple{line=[http://example.com/ns#pete, "eighteen"], propertyShapes= DatatypePropertyShape <_:node1d285h2ktx1>} -cause->  [ Tuple{line=[http://example.com/ns#pete, http://www.w3.org/1999/02/22-rdf-syntax-ns#type, http://example.com/ns#Person]} ]
 
 
 Line 2 shows the shape that triggered this violation. Line 3 shows the ultimate tuple produced and which PropertyShape produced the exception followed by a cause listing other tuples that caused the violation. In this case the existing type statement.
@@ -516,6 +524,7 @@ The structure of this log and its contents may change in the future, without war
 ```java
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import org.eclipse.rdf4j.common.exception.ValidationException;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -523,9 +532,10 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
-import org.eclipse.rdf4j.sail.shacl.ValidationException;
 import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
 import org.slf4j.LoggerFactory;
 
@@ -538,12 +548,11 @@ public class ShaclSampleCode {
 
         ShaclSail shaclSail = new ShaclSail(new MemoryStore());
 
-        //Logger root = (Logger) LoggerFactory.getLogger(ShaclSail.class.getName());
-        //root.setLevel(Level.INFO);
+//        Logger root = (Logger) LoggerFactory.getLogger(ShaclSail.class.getName());
+//        root.setLevel(Level.INFO);
+//
+//        shaclSail.setPerformanceLogging(true);
 
-        //shaclSail.setLogValidationPlans(true);
-        //shaclSail.setGlobalLogValidationExecution(true);
-        //shaclSail.setLogValidationViolations(true);
 
         SailRepository sailRepository = new SailRepository(shaclSail);
         sailRepository.init();
@@ -562,13 +571,23 @@ public class ShaclSampleCode {
                     "ex:PersonShape",
                     "  a sh:NodeShape  ;",
                     "  sh:targetClass foaf:Person ;",
-                    "  sh:property ex:PersonShapeProperty .",
+                    "  sh:property ex:PersonAgeIntShape, ex:PersonMustHaveAge, ex:PersonCanNotHaveMultipleAge  .",
 
-                    "ex:PersonShapeProperty ",
+                    "ex:PersonAgeIntShape ",
                     "  sh:path foaf:age ;",
-                    "  sh:datatype xsd:int ;",
-                    "  sh:maxCount 1 ;",
-                    "  sh:minCount 1 ."
+                    "  sh:message \"A person's age must be a number (xsd:int).\" ;",
+                    "  sh:datatype xsd:int .",
+
+                    "ex:PersonMustHaveAge ",
+                    "  sh:path foaf:age ;",
+                    "  sh:message \"A must have an age.\" ;",
+                    "  sh:minCount 1 .",
+
+                    "ex:PersonCanNotHaveMultipleAge ",
+                    "  sh:path foaf:age ;",
+                    "  sh:message \"A person can only have one age.\" ;",
+                    "  sh:maxCount 1 ."
+
                 ));
 
             connection.add(shaclRules, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
@@ -595,7 +614,12 @@ public class ShaclSampleCode {
                 if (cause instanceof ValidationException) {
                     Model validationReportModel = ((ValidationException) cause).validationReportAsModel();
 
-                    Rio.write(validationReportModel, System.out, RDFFormat.TURTLE);
+                    WriterConfig writerConfig = new WriterConfig()
+                        .set(BasicWriterSettings.INLINE_BLANK_NODES, true)
+                        .set(BasicWriterSettings.XSD_STRING_TO_PLAIN_LITERAL, true)
+                        .set(BasicWriterSettings.PRETTY_PRINT, true);
+
+                    Rio.write(validationReportModel, System.out, RDFFormat.TURTLE, writerConfig);
                 }
                 throw exception;
             }


### PR DESCRIPTION
GitHub issue resolved: #2642 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - sh:message is already read during parsing, but wasn't written out when the shape was converted to a model
 - sh:resultMessage is now added if there are any values for sh:message in the source shape

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

