### PR TITLE
GH-4230 Make isolation-level setting to be compatible with different versions of client and server side

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartController.java
@@ -32,6 +32,7 @@ import org.eclipse.rdf4j.http.server.ClientHTTPException;
 import org.eclipse.rdf4j.http.server.ProtocolUtil;
 import org.eclipse.rdf4j.http.server.ServerHTTPException;
 import org.eclipse.rdf4j.http.server.repository.RepositoryInterceptor;
+import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.slf4j.Logger;
@@ -81,10 +82,10 @@ public class TransactionStartController extends AbstractController {
 		ArrayList<TransactionSetting> transactionSettings = new ArrayList<>();
 		final String isolationLevelString = request.getParameter(Protocol.ISOLATION_LEVEL_PARAM_NAME);
 		if (isolationLevelString != null) {
-
+			final String isolationLevelConverted = isolationLevelString.replace(SESAME.NAMESPACE, "");
 			for (IsolationLevel standardLevel : IsolationLevels.values()) {
-				if (standardLevel.getValue().equals(isolationLevelString)) {
-					transactionSettings.add(IsolationLevels.valueOf(isolationLevelString));
+				if (standardLevel.getValue().equals(isolationLevelConverted)) {
+					transactionSettings.add(IsolationLevels.valueOf(isolationLevelConverted));
 					break;
 				}
 			}

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionStartControllerTest.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.http.server.repository.transaction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.fail;
+import static org.eclipse.rdf4j.common.transaction.IsolationLevels.READ_COMMITTED;
 import static org.eclipse.rdf4j.common.transaction.IsolationLevels.SNAPSHOT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -130,6 +131,23 @@ class TransactionStartControllerTest {
 		// Act
 		controller.handleRequest(request, response);
 		verify(tx).begin(SNAPSHOT);
+	}
+
+	@Test
+	void createTransactionLocation_withIsolationOldPath() throws Exception {
+		TransactionStartController controller = spy(TransactionStartController.class);
+		Transaction tx = mock(Transaction.class);
+		// Arrange
+		controller.setExternalUrl(null);
+
+		request.addParameter("isolation-level", "http://www.openrdf.org/schema/sesame#READ_COMMITTED");
+		Repository repository = RepositoryInterceptor.getRepository(request);
+
+		when(controller.createTransaction(repository)).thenReturn(tx);
+		when(tx.getID()).thenReturn(UUID.randomUUID());
+		// Act
+		controller.handleRequest(request, response);
+		verify(tx).begin(READ_COMMITTED);
 	}
 
 	@Test


### PR DESCRIPTION
GH-4230: Refactor isolation-level settings in TransactionStartController in order to check the correct request parameter


GitHub issue resolved: #4230 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

