### PR TITLE
Add support for custom query analyzers in Lucene and ES

### DIFF
--- a/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -174,7 +174,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 
 	private String analyzer;
 
-	private final String queryAnalyzer = "standard";
+	private String queryAnalyzer = DEFAULT_ANALYZER;
 
 	private Function<? super String, ? extends SpatialContext> geoContextMapper;
 
@@ -200,6 +200,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		indexName = parameters.getProperty(INDEX_NAME_KEY, DEFAULT_INDEX_NAME);
 		documentType = parameters.getProperty(DOCUMENT_TYPE_KEY, DEFAULT_DOCUMENT_TYPE);
 		analyzer = parameters.getProperty(LuceneSail.ANALYZER_CLASS_KEY, DEFAULT_ANALYZER);
+		queryAnalyzer = parameters.getProperty(LuceneSail.QUERY_ANALYZER_CLASS_KEY, DEFAULT_ANALYZER);
 		// slightly hacky cast to cope with the fact that Properties is
 		// Map<Object,Object>
 		// even though it is effectively Map<String,String>

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -320,6 +320,12 @@ public class LuceneSail extends NotifyingSailWrapper {
 	public static final String ANALYZER_CLASS_KEY = "analyzer";
 
 	/**
+	 * Set this key as sail parameter to configure the Lucene analyzer class implementation used for query analysis. In
+	 * most cases this should be set to the same value as {@link #ANALYZER_CLASS_KEY}
+	 */
+	public static final String QUERY_ANALYZER_CLASS_KEY = "queryAnalyzer";
+
+	/**
 	 * Set this key as sail parameter to configure {@link org.apache.lucene.search.similarities.Similarity} class
 	 * implementation to use for text analysis.
 	 */

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndexTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndexTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -405,6 +406,19 @@ public class LuceneIndexTest {
 		assertEquals("Is the second literal accepted?", true, index.accept(literal2));
 		assertEquals("Is the third literal accepted?", true, index.accept(literal3));
 		assertEquals("Is the fourth literal accepted?", false, index.accept(literal4));
+	}
+
+	@Test
+	public void testInstantiatesCustomQueryAnalyzer() throws Exception {
+		LuceneIndex index = new LuceneIndex();
+		java.util.Properties props = new java.util.Properties();
+		props.put(LuceneSail.QUERY_ANALYZER_CLASS_KEY, EnglishAnalyzer.class.getName());
+		props.put(LuceneSail.ANALYZER_CLASS_KEY, EnglishAnalyzer.class.getName());
+		props.put(LuceneSail.LUCENE_RAMDIR_KEY, "true");
+		index.initialize(props);
+
+		assertTrue(index.getAnalyzer() instanceof EnglishAnalyzer);
+		assertTrue(index.getQueryAnalyzer() instanceof EnglishAnalyzer);
 	}
 
 	private void assertStatement(Statement statement) throws Exception {


### PR DESCRIPTION
GitHub issue resolved: #4235


Briefly describe the changes proposed in this PR:

The indexing analyzer is configurable, however, this is only half the
problem because if we query with a different analyzer than what's
indexed, we will end up missing a number of results (particularly as it
pertains to stopwords and stemming). For the cases where you want
to configure the indexing analyzer, we should also be allowed to
configure the query analyzer.


<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

