### PR TITLE
GH-4227 add config for spring repository manager username & password

### DIFF
--- a/site/content/documentation/programming/spring.md
+++ b/site/content/documentation/programming/spring.md
@@ -29,7 +29,12 @@ To configure the application to access an existing repository, set the following
 ```properties
  rdf4j.spring.repository.remote.manager-url=http://localhost:7200
  rdf4j.spring.repository.remote.name=myrepo
+
+ # Optional with username and password
+ rdf4j.spring.repository.remote.username=admin
+ rdf4j.spring.repository.remote.password=1234
 ```
+
 To use an in-memory repository (for example, for unit tests), use
 ```properties
 rdf4j.spring.repository.inmemory.enabled=true

--- a/spring-components/rdf4j-spring/pom.xml
+++ b/spring-components/rdf4j-spring/pom.xml
@@ -65,6 +65,11 @@
 			<artifactId>commons-pool2</artifactId>
 			<version>2.8.1</version>
 		</dependency>
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryConfig.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryConfig.java
@@ -12,7 +12,6 @@ import java.lang.invoke.MethodHandles;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.manager.RemoteRepositoryManager;
-import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.spring.support.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +38,15 @@ public class RemoteRepositoryConfig {
 		Repository repository;
 		logger.info("Using these repository properties: {}", repositoryProperties);
 		try {
-			RepositoryManager repositoryManager = new RemoteRepositoryManager(repositoryProperties.getManagerUrl());
+			RemoteRepositoryManager repositoryManager = new RemoteRepositoryManager(
+					repositoryProperties.getManagerUrl());
+
+			if (repositoryProperties.isUsernamePasswordConfigured()) {
+				logger.debug("Set username: {} and password: ****", repositoryProperties.getUsername());
+				repositoryManager.setUsernameAndPassword(repositoryProperties.getUsername(),
+						repositoryProperties.getPassword());
+			}
+
 			repositoryManager.init();
 			repository = repositoryManager.getRepository(repositoryProperties.getName());
 			logger.debug("Successfully initialized repository config: {}", repositoryProperties);

--- a/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryProperties.java
+++ b/spring-components/rdf4j-spring/src/main/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryProperties.java
@@ -21,11 +21,23 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "rdf4j.spring.repository.remote")
 public class RemoteRepositoryProperties {
-	/** URL of the SPARQL endpoint */
+	/**
+	 * URL of the SPARQL endpoint
+	 */
 	@NotBlank
 	@Pattern(regexp = "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]")
 	private String managerUrl = null;
-	/** Name of the repository */
+	/**
+	 * Optional username of the SPARQL endpoint
+	 */
+	private String username = null;
+	/**
+	 * Optional password of the SPARQL endpoint
+	 */
+	private String password = null;
+	/**
+	 * Name of the repository
+	 */
 	@NotBlank
 	@Length(min = 1)
 	private String name = null;
@@ -38,6 +50,22 @@ public class RemoteRepositoryProperties {
 		this.managerUrl = managerUrl;
 	}
 
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
 	public String getName() {
 		return name;
 	}
@@ -46,15 +74,16 @@ public class RemoteRepositoryProperties {
 		this.name = name;
 	}
 
+	public boolean isUsernamePasswordConfigured() {
+		return username != null && password != null;
+	}
+
 	@Override
 	public String toString() {
 		return "RemoteRepositoryConfig{"
-				+ "managerUrl='"
-				+ managerUrl
-				+ '\''
-				+ ", name='"
-				+ name
-				+ '\''
-				+ '}';
+				+ "managerUrl='" + managerUrl + "'"
+				+ (username != null ? ", username='" + username + "'" : "")
+				+ (password != null ? ", password='****'" : "")
+				+ ", name='" + name + "' }";
 	}
 }

--- a/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryConfigTest.java
+++ b/spring-components/rdf4j-spring/src/test/java/org/eclipse/rdf4j/spring/repository/remote/RemoteRepositoryConfigTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.spring.repository.remote;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.spring.support.ConfigurationException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+class RemoteRepositoryConfigTest {
+
+	private final RemoteRepositoryConfig remoteRepositoryConfig = new RemoteRepositoryConfig();
+	private static final WireMockServer wireMockServer = new WireMockServer(options()
+			.dynamicPort()
+			.usingFilesUnderClasspath("src/test/resources/"));
+
+	@BeforeAll
+	static void setUp() {
+		wireMockServer.start();
+		wireMockServer.stubFor(get(urlEqualTo("/repositories"))
+				.willReturn(aResponse().withStatus(200)
+						.withHeader("Content-Type", "application/sparql-results+json;charset=UTF-8")
+						.withBodyFile("repositories.srj")));
+	}
+
+	@Test
+	void getRemoteRepository() {
+		// Arrange
+		RemoteRepositoryProperties properties = new RemoteRepositoryProperties();
+		properties.setManagerUrl(wireMockServer.baseUrl());
+		properties.setName("test-repo");
+
+		// Act
+		Repository repository = remoteRepositoryConfig.getRemoteRepository(properties);
+
+		// Assert
+		assertThat(repository).isNotNull();
+		wireMockServer.verify(exactly(1), getRequestedFor(urlEqualTo("/repositories"))
+				.withoutHeader("Authorization"));
+	}
+
+	@Test
+	void getRemoteRepositoryWithUsernameAndPassword() {
+		// Arrange
+		RemoteRepositoryProperties properties = new RemoteRepositoryProperties();
+		properties.setManagerUrl(wireMockServer.baseUrl());
+		properties.setName("test-repo");
+		properties.setUsername("admin");
+		properties.setPassword("1234");
+
+		// Act
+		Repository repository = remoteRepositoryConfig.getRemoteRepository(properties);
+
+		// Assert
+		assertThat(repository).isNotNull();
+		wireMockServer.verify(exactly(1), getRequestedFor(urlEqualTo("/repositories"))
+				.withHeader("Authorization", equalTo("Basic YWRtaW46MTIzNA==")));
+	}
+
+	@Test
+	void getRemoteRepository_error() {
+		// Arrange
+		RemoteRepositoryProperties properties = new RemoteRepositoryProperties();
+		properties.setManagerUrl("https://unknown-host:8888");
+		properties.setName("test-repo");
+
+		// Act & Assert
+		assertThatExceptionOfType(ConfigurationException.class)
+				.isThrownBy(() -> remoteRepositoryConfig.getRemoteRepository(properties));
+	}
+
+	@AfterAll
+	static void tearDown() {
+		wireMockServer.stop();
+	}
+}

--- a/spring-components/rdf4j-spring/src/test/resources/__files/repositories.srj
+++ b/spring-components/rdf4j-spring/src/test/resources/__files/repositories.srj
@@ -1,0 +1,39 @@
+{
+  "head" : {
+    "vars" : [
+      "uri",
+      "id",
+      "title",
+      "readable",
+      "writable"
+    ]
+  },
+  "results" : {
+    "bindings" : [
+      {
+        "readable" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+          "type" : "literal",
+          "value" : "true"
+        },
+        "id" : {
+          "type" : "literal",
+          "value" : "test-repo"
+        },
+        "title" : {
+          "type" : "literal",
+          "value" : ""
+        },
+        "uri" : {
+          "type" : "uri",
+          "value" : "http://localhost:7200/repositories/test-repo"
+        },
+        "writable" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#boolean",
+          "type" : "literal",
+          "value" : "true"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
GitHub issue resolved: #4227 

Added spring config options for username & password of remote repositories

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [X] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [X] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [X] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [X] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

