### PR TITLE
GH-4240 skip property shape if sh:path is not implemented/supported

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
@@ -136,6 +136,11 @@ public class PropertyShape extends Shape {
 			return ValidationQuery.Deactivated.getInstance();
 		}
 
+		if (!getPath().isSupported()) {
+			logger.error("Unsupported path detected. Shape ignored!\n{}", this);
+			return ValidationQuery.Deactivated.getInstance();
+		}
+
 		ValidationQuery validationQuery = constraintComponents.stream()
 				.map(c -> {
 					ValidationQuery validationQuery1 = c.generateSparqlValidationQuery(connectionsGroup,
@@ -177,6 +182,11 @@ public class PropertyShape extends Shape {
 			return EmptyNode.getInstance();
 		}
 
+		if (!getPath().isSupported()) {
+			logger.error("Unsupported path detected. Shape ignored!\n{}", this);
+			return EmptyNode.getInstance();
+		}
+
 		PlanNode union = EmptyNode.getInstance();
 
 //		if (negatePlan) {
@@ -205,10 +215,6 @@ public class PropertyShape extends Shape {
 //		}
 
 		for (ConstraintComponent constraintComponent : constraintComponents) {
-			if (!getPath().isSupported()) {
-				logger.error("Unsupported path detected. Shape ignored!\n" + this);
-				continue;
-			}
 
 			PlanNode validationPlanNode = constraintComponent
 					.generateTransactionalValidationPlan(connectionsGroup, validationSettings, overrideTargetNode,
@@ -274,6 +280,17 @@ public class PropertyShape extends Shape {
 
 	public Path getPath() {
 		return path;
+	}
+
+	@Override
+	public boolean requiresEvaluation(ConnectionsGroup connectionsGroup, Scope scope, Resource[] dataGraph,
+			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
+		if (!getPath().isSupported()) {
+			logger.error("Unsupported path detected. Shape ignored!\n{}", this);
+			return false;
+		}
+
+		return super.requiresEvaluation(connectionsGroup, scope, dataGraph, stableRandomVariableProvider);
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/PropertyShape.java
@@ -137,7 +137,7 @@ public class PropertyShape extends Shape {
 		}
 
 		if (!getPath().isSupported()) {
-			logger.error("Unsupported path detected. Shape ignored!\n{}", this);
+			logger.error("Unsupported SHACL feature detected: {}. Shape ignored!\n{}", path, this);
 			return ValidationQuery.Deactivated.getInstance();
 		}
 
@@ -183,36 +183,11 @@ public class PropertyShape extends Shape {
 		}
 
 		if (!getPath().isSupported()) {
-			logger.error("Unsupported path detected. Shape ignored!\n{}", this);
+			logger.error("Unsupported SHACL feature detected: {}. Shape ignored!\n{}", path, this);
 			return EmptyNode.getInstance();
 		}
 
 		PlanNode union = EmptyNode.getInstance();
-
-//		if (negatePlan) {
-//			assert overrideTargetNode == null : "Negated property shape with override target is not supported at the moment!";
-//
-//			PlanNode ret = EmptyNode.getInstance();
-//
-//			for (ConstraintComponent constraintComponent : constraintComponents) {
-//				PlanNode planNode = constraintComponent.generateTransactionalValidationPlan(connectionsGroup,
-//						logValidationPlans, () -> getAllLocalTargetsPlan(connectionsGroup, negatePlan), negateChildren,
-//						false, Scope.propertyShape);
-//
-//				PlanNode allTargetsPlan = getAllLocalTargetsPlan(connectionsGroup, negatePlan);
-//
-//				Unique invalid = Unique.getInstance(planNode);
-//
-//				PlanNode discardedLeft = new InnerJoin(allTargetsPlan, invalid)
-//						.getDiscardedLeft(BufferedPlanNode.class);
-//
-//				ret = UnionNode.getInstance(ret, discardedLeft);
-//
-//			}
-//
-//			return ret;
-//
-//		}
 
 		for (ConstraintComponent constraintComponent : constraintComponents) {
 
@@ -286,7 +261,7 @@ public class PropertyShape extends Shape {
 	public boolean requiresEvaluation(ConnectionsGroup connectionsGroup, Scope scope, Resource[] dataGraph,
 			StatementMatcher.StableRandomVariableProvider stableRandomVariableProvider) {
 		if (!getPath().isSupported()) {
-			logger.error("Unsupported path detected. Shape ignored!\n{}", this);
+			logger.error("Unsupported SHACL feature detected: {}. Shape ignored!\n{}", path, this);
 			return false;
 		}
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.rdf4j.sail.shacl;
 
 import org.eclipse.rdf4j.common.transaction.IsolationLevel;
-import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -30,7 +29,7 @@ public class ShaclTest extends AbstractShaclTest {
 	@ParameterizedTest
 	@MethodSource("testCases")
 	public void testSingleTransaction(TestCase testCase) {
-		runWithAutomaticLogging(() -> runTestCaseSingleTransaction(testCase, IsolationLevels.NONE));
+		runWithAutomaticLogging(() -> runTestCaseSingleTransaction(testCase));
 	}
 
 	@ParameterizedTest

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UnknownShapesTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UnknownShapesTest.java
@@ -12,34 +12,37 @@ package org.eclipse.rdf4j.sail.shacl;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
+import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 
 public class UnknownShapesTest {
+	private TestAppender appender;
+
+	@BeforeEach
+	public void beforeEach() {
+		appender = new TestAppender();
+
+		Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		root.addAppender(appender);
+	}
 
 	@Test
 	public void testPropertyShapes() throws IOException, InterruptedException {
-		ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory
-				.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
-
-		MyAppender newAppender = new MyAppender();
-		root.addAppender(newAppender);
-
 		SailRepository shaclRepository = Utils.getInitializedShaclRepository("unknownProperties.trig");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
@@ -50,7 +53,7 @@ public class UnknownShapesTest {
 
 		Thread.sleep(100);
 
-		List<String> relevantLog = newAppender.logged.stream()
+		List<String> relevantLog = appender.logged.stream()
 				.filter(m -> m.startsWith("Unsupported SHACL feature"))
 				.distinct()
 				.sorted(String::compareTo)
@@ -67,15 +70,8 @@ public class UnknownShapesTest {
 
 	}
 
-	@Disabled
 	@Test
 	public void testComplexPath() throws IOException, InterruptedException {
-		ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory
-				.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
-
-		MyAppender newAppender = new MyAppender();
-		root.addAppender(newAppender);
-
 		SailRepository shaclRepository = Utils.getInitializedShaclRepository("complexPath.trig");
 
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
@@ -86,25 +82,55 @@ public class UnknownShapesTest {
 
 		Thread.sleep(100);
 
-		Set<String> relevantLog = newAppender.logged.stream()
+		Set<String> relevantLog = appender.logged.stream()
 				.filter(m -> m.startsWith("Unsupported SHACL feature"))
 				.map(s -> s.replaceAll("\r\n|\r|\n", " "))
 				.map(String::trim)
 				.collect(Collectors.toSet());
 
-		Set<String> expected = new HashSet<>(Arrays.asList(
-				"Unsupported SHACL feature with complex path. Only single predicate paths, or single predicate inverse paths are supported. <http://example.com/ns#alternativePath> shape has been deactivated!  @prefix sh: <http://www.w3.org/ns/shacl#> .  <http://example.com/ns#alternativePath> sh:path [       sh:alternativePath <http://example.com/ns#father>     ] .",
-				"Unsupported SHACL feature with complex path. Only single predicate paths, or single predicate inverse paths are supported. <http://example.com/ns#pathSequence> shape has been deactivated!  @prefix sh: <http://www.w3.org/ns/shacl#> .  <http://example.com/ns#pathSequence> sh:path (<http://example.com/ns#parent> <http://example.com/ns#firstName>) .",
-				"Unsupported SHACL feature with complex path. Only single predicate paths, or single predicate inverse paths are supported. <http://example.com/ns#inverseOfWithComplex> shape has been deactivated!  @prefix sh: <http://www.w3.org/ns/shacl#> .  <http://example.com/ns#inverseOfWithComplex> sh:path [       sh:inversePath [           sh:zeroOrMorePath <http://example.com/ns#inverseThis>         ]     ] ."));
+		Set<String> expected = Set.of(
+				"Unsupported SHACL feature detected: InversePath{ ZeroOrMorePath{ SimplePath{ <http://example.com/ns#inverseThis> } } }. Shape ignored! <http://example.com/ns#inverseOfWithComplex> a sh:PropertyShape;   sh:path [       sh:inversePath [           sh:zeroOrMorePath <http://example.com/ns#inverseThis>         ]     ];   sh:minCount 1 .",
+				"Unsupported SHACL feature detected: InversePath{ ZeroOrMorePath{ SimplePath{ <http://example.com/ns#inverseThis> } } }. Shape ignored! <http://example.com/ns#inverseOfWithComplex> a sh:PropertyShape;   sh:path [       sh:inversePath [           sh:zeroOrMorePath <http://example.com/ns#inverseThis>         ]     ];   sh:datatype xsd:int .",
+				"Unsupported SHACL feature detected: AlternativePath{ SimplePath{ <http://example.com/ns#father> } }. Shape ignored! <http://example.com/ns#alternativePath> a sh:PropertyShape;   sh:path [       sh:alternativePath <http://example.com/ns#father>     ];   sh:minCount 1 .",
+				"Unsupported SHACL feature detected: SequencePath{ [SimplePath{ <http://example.com/ns#parent> }, SimplePath{ <http://example.com/ns#firstName> }] }. Shape ignored! <http://example.com/ns#pathSequence> a sh:PropertyShape;   sh:path (<http://example.com/ns#parent> <http://example.com/ns#firstName>);   sh:minCount 1 ."
+		);
 
 		Assertions.assertEquals(expected, relevantLog);
 
 		shaclRepository.shutDown();
 	}
 
-	static class MyAppender extends AppenderBase<ILoggingEvent> {
+	@Test
+	public void testThatUnknownPathsAreIgnored() throws IOException {
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("complexPath.trig");
 
-		List<String> logged = new ArrayList<>();
+		// trigger SPARQL based validation
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+			connection.begin();
+			connection.add(RDF.TYPE, RDF.TYPE, RDFS.RESOURCE);
+			connection.commit();
+		}
+
+		// trigger transactional validation
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+			connection.begin();
+			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
+			connection.commit();
+		}
+
+		// trigger requiresEvaluation(...) check
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+			connection.begin();
+			connection.add(RDFS.RESOURCE, Values.iri("http://example.com/ns#parent"), RDFS.RESOURCE);
+			connection.commit();
+		}
+
+		shaclRepository.shutDown();
+	}
+
+	private static class TestAppender extends AppenderBase<ILoggingEvent> {
+
+		private final List<String> logged = new ArrayList<>();
 
 		@Override
 		public synchronized void doAppend(ILoggingEvent eventObject) {

--- a/core/sail/shacl/src/test/resources/complexPath.trig
+++ b/core/sail/shacl/src/test/resources/complexPath.trig
@@ -14,16 +14,23 @@ ex:PersonShape
 	sh:targetClass rdfs:Resource ;
         rdfs:label "label" ;
         rdfs:subClassOf ex:HumanShape ;
-	sh:property ex:inverseOfWithComplex, ex:pathSequence, ex:alternativePath  .
+	sh:property ex:inverseOfWithComplex, ex:pathSequence, ex:alternativePath, ex:nestedSequencePath   .
 
 ex:inverseOfWithComplex
 		sh:path [ sh:inversePath [sh:zeroOrMorePath ex:inverseThis] ]  ;
+		sh:datatype xsd:int ;
 		sh:minCount 1 .
 
 
 ex:pathSequence
 		sh:path ( ex:parent ex:firstName )  ;
 		sh:minCount 1 .
+
+ex:nestedSequencePath
+		sh:path ex:parent ;
+		sh:maxCount 1 ;
+		sh:property ex:pathSequence ;
+		.
 
 ex:alternativePath
 		sh:path [ sh:alternativePath ex:father ]  ;


### PR DESCRIPTION
GitHub issue resolved: #4240 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - add tests
 - add checks to skip property shapes with unsupported path expressions

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

