### PR TITLE
GH-4243: update and align the docker documentation

### DIFF
--- a/docker/README_DEV.md
+++ b/docker/README_DEV.md
@@ -1,51 +1,106 @@
 # Eclipse RDF4J server and workbench
 
-Documentation for building and distributing the Server and Workbench image
+Documentation for building and distributing the docker image containing the Server and Workbench.
 
 ## Getting started
 
-Run `./run.sh` to build and start the server and workbench.
+Run `./run.sh` to build and start the server and workbench. This will invoke the `build.sh` script.
 
-## Full build
-Before building the docker image we need to get hold of the WAR files. These are built when 
-the maven project is assembled and packed in the sdk ZIP-file under `assembly/target`.
+### Full build (build.sh)
 
-The Dockerfile expects that the sdk ZIP-file is copied and renamed as `ignore/rdf4j.zip`.
+The simplest way to build the image and tag it, is to run the `build.sh` script.
 
-Building the docker image can be done with a docker command directly, but it's easier to use 
-docker-compose instead. 
+This script will perform the following tasks:
 
-Once the image is built it needs to be tagged as `eclipse/rdf4j-workbench:${maven.project.version}`.
+1. Before building the docker image the WAR files need to be available. These are built when 
+the maven project is assembled and the result is packed in the SDK ZIP-file under `assembly/target`.
 
-The simplest way to accomplish all of the above is to run the `build.sh` script.
+2. The SDK ZIP-file is copied and renamed as `ignore/rdf4j.zip` (as required by the Dockerfile script).
 
-## Running up the docker container
+3. Building the docker image can be done with a docker command directly, 
+but the script takes an alternative approach and uses docker-compose instead. 
+
+4. Once the image is built, it is tagged as `eclipse/rdf4j-workbench:${maven.project.version}`.
+
+
+### Running up the docker container (docker-compose)
 
 Use docker-compose to run up the container. This uses the `docker-compose.yml` file to start
 a container with the port mapped to 8080 and persistence using docker volumes.
 
 `docker-compose up -d`
 
-### Other useful commands
+#### Other useful docker-compose commands
 
-#### Stop
+Stop:
+
 `docker-compose stop`
 
-#### Follow logs
+Follow logs:
+
 `docker-compose logs -f`
 
-#### Show all logs
+Show all logs:
+
 `docker-compose logs --tail="all"`
 
-#### Start containers in foreground (prints logs and stops containers with Ctrl-C)
+Start containers in foreground (prints logs and stops containers with Ctrl-C):
+
 `docker-compose up`
 
-#### Stop and remove all containers and delete all my volumes (for all containers and all volumes)
+Stop and remove all containers and delete all my volumes (for all containers and all volumes):
+
 `docker stop $(docker ps -a -q); docker rm $(docker ps -a -q); docker system prune -f --volumes`
 
-## Deploy
+List all versions on the local machine:
 
- * login: `docker login --username=yourhubusername --email=youremail@company.com`
- * push: `docker push eclipse/rdf4j-workbench:VERSION_GOES_HERE`
-   * VERSION_GOES_HERE is the version (tag) you want to push.
-   * to list all versions you have locally: `docker images | grep "eclipse/rdf4j-workbench"` 
+`docker images | grep "eclipse/rdf4j-workbench"`
+
+## Deploy the image on hub.docker.com
+
+The docker images on hub.docker.com are stored as part of the Eclipse organizational account. 
+
+Since this account is managed separately by the Eclipse Foundation,
+only a limited number of committers will be granted access by the EMO.
+
+### Method 1: using the build script and docker push
+
+Build the SDK ZIP file and docker image using the `build.sh` script mentioned above.
+Both the Workbench and the server will be part of the same image.
+
+Log into hub.docker.com:
+
+`docker login --username=yourhubusername`
+
+Push the image:
+
+`docker push eclipse/rdf4j-workbench:VERSION_TAG`
+ 
+`VERSION_TAG` is the version (tag) you want to push, e.g. `4.3.0`
+
+Note that hub.docker.com does not update the `latest` tag automatically,
+the newly created image has also to be tagged `latest` and pushed to hub.docker.com.
+
+### Method 2: multi-platform docker image using buildx
+
+Since the base image being used is available for multiple architectures,
+it is quite easy to build a [multi-platform image](https://docs.docker.com/build/building/multi-platform/).
+Currently the Workbench/Server image is made available for 64-bit AMD/Intel and ARM v8.
+
+Check if [Docker Buildx](https://docs.docker.com/build/buildx/install/) is installed on your system.
+
+Build the SDK ZIP file using the `build.sh` script mentioned above,
+or download the SDK from https://rdf4j.org/download/ and store the ZIP as `ignore/rdf4j.zip`.
+
+Log into hub.docker.com using your username and password.
+
+`docker login --username=yourhubusername`
+
+Build and push the image (note the `.` at the end of the command):
+
+`docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag eclipse/rdf4j-workbench:VERSION_TAG .`
+
+`VERSION_TAG` is the version (tag) you want to push, e.g. `4.3.0`
+ 
+Note that hub.docker.com does not update the `latest` tag automatically,
+the newly created image has also to be tagged `latest` and pushed to hub.docker.com.

--- a/site/content/documentation/developer/releases.md
+++ b/site/content/documentation/developer/releases.md
@@ -224,36 +224,50 @@ Once a minor release is published the `develop` minor version should be incremen
 version and any approved features that are scheduled for this next minor
 version should be merged into `develop` branch.
 
-## Optional: publishing docker images
+## Optional: publish a docker image
 
-Occasionally a docker server/workbench image could be built
-and pushed to `https:/hub.docker.com/eclipse/rdf4j-workbench`,
-which is part of the Eclipse organizational account.
+The docker images on hub.docker.com are stored as part of the Eclipse organizational account. 
+
 Since this account is managed separately by the Eclipse Foundation,
 only a limited number of committers will be granted access by the EMO.
 
-The Dockerfiles are stored in `rdf4j-tools/assembly/src/main/dist/docker`,
-and currently there are two supported architectures: `amd64` (Intel/AMD x86-64) and `arm64v8`.
+### Method 1: using the build script and docker push
 
-Note that docker does not support building cross-architecture out of the box,
-so either two systems or some additional software (e.g. QEMU) will be needed. See also
-https://www.ecliptik.com/Cross-Building-and-Running-Multi-Arch-Docker-Images.
+Build the SDK ZIP file and docker image using the `docker/build.sh` script.
+Both the Workbench and the server will be part of the same image.
+
+Log into hub.docker.com:
+
+`docker login --username=yourhubusername`
+
+Push the image:
+
+`docker push eclipse/rdf4j-workbench:VERSION_TAG`
+ 
+`VERSION_TAG` is the version (tag) you want to push, e.g. `4.3.0`
+
+Note that hub.docker.com does not update the `latest` tag automatically,
+the newly created image has also to be tagged `latest` and pushed to hub.docker.com.
 
 
-Go to the previously mentioned docker directory and build the image(s):
+### Method 2: multi-platform docker image using buildx
 
-    docker build --build-arg VERSION=2.5.0 --file Dockerfile.amd64 \
-                 --tag eclipse/rdf4j-workbench:amd64-2.5.0-testing .
+Since the base image being used is available for multiple architectures,
+it is quite easy to build a [multi-platform image](https://docs.docker.com/build/building/multi-platform/).
+Currently the Workbench/Server image is made available for 64-bit AMD/Intel and ARM v8.
 
-Verify the image by running it:
+Check if [Docker Buildx](https://docs.docker.com/build/buildx/install/) is installed on your system.
 
-    docker run -p 8080:8080 eclipse/rdf4j-workbench:amd64-2.5.0-testing
+Build the SDK ZIP file using the `docker/build.sh` script mentioned above,
+or download the SDK from https://rdf4j.org/download/ and store the ZIP as `ignore/rdf4j.zip`.
 
-After a fews seconds, the workbench should be avaible on `http://localhost:8080/rdf4j-workbench`.
-Check the RDF4J version in System / Information.
+Log into hub.docker.com:
 
-Log in on `hub.docker.com`, and push the image:
+`docker login --username=yourhubusername`
 
-    docker login
-    docker push eclipse/rdf4j-workbench:amd64-2.5.0-testing
+Build and push the image (note the `.` at the end of the command):
+
+`docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag eclipse/rdf4j-workbench:VERSION_TAG .`
+
+`VERSION_TAG` is the version (tag) you want to push, e.g. `4.3.0`
 


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #4243 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- align info on RDF4J website and Readme in docker directory
- added section on building/pushing multi-platform docker images

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

