### PR TITLE
GH-4245 fix SPARQL COUNT hashCode() NullPointerException

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryEvaluationStep.java
@@ -15,7 +15,6 @@ import java.util.function.Function;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.DelayedIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
-import org.eclipse.rdf4j.common.iteration.Iteration;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/StatisticalAggregateFunction.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/aggregate/StatisticalAggregateFunction.java
@@ -16,7 +16,6 @@ import java.util.function.Predicate;
 import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/LeftJoinQueryEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/LeftJoinQueryEvaluationStep.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps;
 
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/PathIteration.java
@@ -14,7 +14,6 @@ import java.util.Queue;
 import java.util.Set;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
-import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
 import org.eclipse.rdf4j.model.Value;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/MathUtil.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/MathUtil.java
@@ -18,7 +18,6 @@ import java.math.RoundingMode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/OrderComparator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/OrderComparator.java
@@ -21,7 +21,6 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.Order;
-import org.eclipse.rdf4j.query.algebra.OrderElem;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.algebra.evaluation.ArrayBindingSet;

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
@@ -28,7 +28,6 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
-import org.eclipse.rdf4j.model.base.CoreDatatype.XSD;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BinaryTupleOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/BinaryTupleOperator.java
@@ -12,8 +12,6 @@ package org.eclipse.rdf4j.query.algebra;
 
 import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
-import org.eclipse.rdf4j.query.BindingSet;
-import org.eclipse.rdf4j.query.QueryEvaluationException;
 
 /**
  * An abstract superclass for binary tuple operators which, by definition, has two arguments.

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
@@ -17,18 +17,10 @@ import java.util.Set;
  */
 public abstract class UnaryTupleOperator extends AbstractQueryModelNode implements TupleExpr {
 
-	/*-----------*
-	 * Variables *
-	 *-----------*/
-
 	/**
 	 * The operator's argument.
 	 */
 	protected TupleExpr arg;
-
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
 
 	protected UnaryTupleOperator() {
 	}
@@ -41,10 +33,6 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 	protected UnaryTupleOperator(TupleExpr arg) {
 		setArg(arg);
 	}
-
-	/*---------*
-	 * Methods *
-	 *---------*/
 
 	/**
 	 * Gets the argument of this unary tuple operator.

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryTupleOperator.java
@@ -90,13 +90,17 @@ public abstract class UnaryTupleOperator extends AbstractQueryModelNode implemen
 	}
 
 	@Override
-	public boolean equals(Object other) {
-		if (other instanceof UnaryTupleOperator) {
-			UnaryTupleOperator o = (UnaryTupleOperator) other;
-			return arg.equals(o.getArg());
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof UnaryTupleOperator)) {
+			return false;
 		}
 
-		return false;
+		UnaryTupleOperator that = (UnaryTupleOperator) o;
+
+		return arg.equals(that.arg);
 	}
 
 	@Override

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryValueOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryValueOperator.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import java.util.Objects;
+
 /**
  * An abstract superclass for unary value operators which, by definition, has one argument.
  */
@@ -82,25 +84,29 @@ public abstract class UnaryValueOperator extends AbstractQueryModelNode implemen
 	}
 
 	@Override
-	public boolean equals(Object other) {
-		if (other instanceof UnaryValueOperator) {
-			UnaryValueOperator o = (UnaryValueOperator) other;
-			return (arg == null && o.getArg() == null) || (arg != null && arg.equals(o.getArg()));
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof UnaryValueOperator)) {
+			return false;
 		}
 
-		return false;
+		UnaryValueOperator that = (UnaryValueOperator) o;
+
+		return Objects.equals(arg, that.arg);
 	}
 
 	@Override
 	public int hashCode() {
-		return arg.hashCode();
+		return arg != null ? arg.hashCode() : 97;
 	}
 
 	@Override
 	public UnaryValueOperator clone() {
 		UnaryValueOperator clone = (UnaryValueOperator) super.clone();
-		if (getArg() != null) {
-			clone.setArg(getArg().clone());
+		if (arg != null) {
+			clone.setArg(arg.clone());
 		}
 		return clone;
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryValueOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/UnaryValueOperator.java
@@ -13,26 +13,16 @@ package org.eclipse.rdf4j.query.algebra;
 import java.util.Objects;
 
 /**
- * An abstract superclass for unary value operators which, by definition, has one argument.
+ * An abstract superclass for unary value operators which, by definition, has one argument. In special cases the
+ * argument can be null, for instance to represent the argument * in COUNT(*).
  */
 public abstract class UnaryValueOperator extends AbstractQueryModelNode implements ValueExpr {
-
-	/*-----------*
-	 * Variables *
-	 *-----------*/
 
 	/**
 	 * The operator's argument.
 	 */
 	protected ValueExpr arg;
 
-	/*--------------*
-	 * Constructors *
-	 *--------------*/
-
-	/**
-	 * Creates a new empty unary value operator.
-	 */
 	protected UnaryValueOperator() {
 	}
 
@@ -44,10 +34,6 @@ public abstract class UnaryValueOperator extends AbstractQueryModelNode implemen
 	protected UnaryValueOperator(ValueExpr arg) {
 		setArg(arg);
 	}
-
-	/*---------*
-	 * Methods *
-	 *---------*/
 
 	/**
 	 * Gets the argument of this unary value operator.
@@ -78,6 +64,7 @@ public abstract class UnaryValueOperator extends AbstractQueryModelNode implemen
 
 	@Override
 	public void replaceChildNode(QueryModelNode current, QueryModelNode replacement) {
+		assert current != null;
 		if (arg == current) {
 			setArg((ValueExpr) replacement);
 		}

--- a/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/impl/AbstractParserQuery.java
+++ b/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/impl/AbstractParserQuery.java
@@ -79,4 +79,23 @@ public abstract class AbstractParserQuery extends AbstractQuery {
 			throw new QueryInterruptedException("Query evaluation took too long");
 		}
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		AbstractParserQuery that = (AbstractParserQuery) o;
+
+		return parsedQuery.equals(that.parsedQuery);
+	}
+
+	@Override
+	public int hashCode() {
+		return parsedQuery.hashCode();
+	}
 }

--- a/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/impl/AbstractParserUpdate.java
+++ b/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/impl/AbstractParserUpdate.java
@@ -124,4 +124,23 @@ public abstract class AbstractParserUpdate extends AbstractUpdate {
 
 		return mergedDataset;
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		AbstractParserUpdate that = (AbstractParserUpdate) o;
+
+		return parsedUpdate.equals(that.parsedUpdate);
+	}
+
+	@Override
+	public int hashCode() {
+		return parsedUpdate.hashCode();
+	}
 }

--- a/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/parser/ParsedQuery.java
+++ b/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/parser/ParsedQuery.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser;
 
+import java.util.Objects;
+
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 
@@ -125,4 +127,27 @@ public abstract class ParsedQuery extends ParsedOperation {
 		}
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ParsedQuery that = (ParsedQuery) o;
+
+		if (!tupleExpr.equals(that.tupleExpr)) {
+			return false;
+		}
+		return Objects.equals(dataset, that.dataset);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = tupleExpr.hashCode();
+		result = 31 * result + (dataset != null ? dataset.hashCode() : 0);
+		return result;
+	}
 }

--- a/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/parser/ParsedUpdate.java
+++ b/core/queryparser/api/src/main/java/org/eclipse/rdf4j/query/parser/ParsedUpdate.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.query.parser;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.UpdateExpr;
@@ -30,7 +30,7 @@ public class ParsedUpdate extends ParsedOperation {
 	 * Variables *
 	 *-----------*/
 
-	private Map<String, String> namespaces;
+	private final Map<String, String> namespaces;
 
 	private final List<UpdateExpr> updateExprs = new ArrayList<>();
 
@@ -46,15 +46,17 @@ public class ParsedUpdate extends ParsedOperation {
 	 */
 	public ParsedUpdate() {
 		super();
+		this.namespaces = Map.of();
 	}
 
 	public ParsedUpdate(String sourceString) {
 		super(sourceString);
+		this.namespaces = Map.of();
 	}
 
 	public ParsedUpdate(String sourceString, Map<String, String> namespaces) {
 		super(sourceString);
-		this.namespaces = namespaces;
+		this.namespaces = Objects.requireNonNull(namespaces);
 	}
 
 	/**
@@ -66,7 +68,7 @@ public class ParsedUpdate extends ParsedOperation {
 	 */
 	public ParsedUpdate(Map<String, String> namespaces) {
 		super();
-		this.namespaces = namespaces;
+		this.namespaces = Objects.requireNonNull(namespaces);
 	}
 
 	/*---------*
@@ -74,11 +76,7 @@ public class ParsedUpdate extends ParsedOperation {
 	 *---------*/
 
 	public Map<String, String> getNamespaces() {
-		if (namespaces != null) {
-			return namespaces;
-		} else {
-			return Collections.emptyMap();
-		}
+		return namespaces;
 	}
 
 	public void addUpdateExpr(UpdateExpr updateExpr) {
@@ -113,5 +111,35 @@ public class ParsedUpdate extends ParsedOperation {
 			stringBuilder.append("; ");
 		}
 		return stringBuilder.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ParsedUpdate that = (ParsedUpdate) o;
+
+		if (!namespaces.equals(that.namespaces)) {
+			return false;
+		}
+		if (!updateExprs.equals(that.updateExprs)) {
+			return false;
+		}
+		return datasetMapping.equals(that.datasetMapping);
+	}
+
+	@Override
+	public int hashCode() {
+		assert updateExprs.stream().noneMatch(expr -> expr.hashCode() == System.identityHashCode(expr));
+
+		int result = namespaces.hashCode();
+		result = 31 * result + updateExprs.hashCode();
+		result = 31 * result + datasetMapping.hashCode();
+		return result;
 	}
 }

--- a/core/repository/dataset/src/main/java/org/eclipse/rdf4j/repository/dataset/DatasetQuery.java
+++ b/core/repository/dataset/src/main/java/org/eclipse/rdf4j/repository/dataset/DatasetQuery.java
@@ -102,4 +102,28 @@ abstract class DatasetQuery implements Query {
 	public Explanation explain(Explanation.Level level) {
 		throw new UnsupportedOperationException();
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		DatasetQuery that = (DatasetQuery) o;
+
+		if (!con.equals(that.con)) {
+			return false;
+		}
+		return sailQuery.equals(that.sailQuery);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = con.hashCode();
+		result = 31 * result + sailQuery.hashCode();
+		return result;
+	}
 }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11UpdateComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11UpdateComplianceTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -56,7 +58,6 @@ import org.slf4j.LoggerFactory;
  * A test suite that runs the W3C Approved SPARQL 1.1 update compliance tests.
  *
  * @author Jeen Broekstra
- *
  * @see <a href="https://www.w3.org/2009/sparql/docs/tests/">sparql docs tests</a>
  */
 @RunWith(Parameterized.class)
@@ -359,6 +360,15 @@ public abstract class SPARQL11UpdateComplianceTest extends SPARQLComplianceTest 
 			con.begin();
 
 			Update update = con.prepareUpdate(QueryLanguage.SPARQL, updateString, requestFile);
+
+			assertThatNoException().isThrownBy(() -> {
+				int hashCode = update.hashCode();
+				if (hashCode == System.identityHashCode(update)) {
+					throw new UnsupportedOperationException(
+							"hashCode() result is the same as  the identityHashCode in " + update.getClass().getName());
+				}
+			});
+
 			update.setDataset(dataset);
 			update.execute();
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryComplianceTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
@@ -27,7 +28,6 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.common.iteration.Iterations;
-import org.eclipse.rdf4j.common.text.StringUtil;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
@@ -69,7 +69,6 @@ import org.slf4j.LoggerFactory;
  * Base functionality for SPARQL query compliance test suites .
  *
  * @author Jeen Broekstra
- *
  */
 public abstract class SPARQLQueryComplianceTest extends SPARQLComplianceTest {
 
@@ -141,6 +140,15 @@ public abstract class SPARQLQueryComplianceTest extends SPARQLComplianceTest {
 
 			String queryString = readQueryString();
 			Query query = conn.prepareQuery(QueryLanguage.SPARQL, queryString, queryFileURL);
+
+			assertThatNoException().isThrownBy(() -> {
+				int hashCode = query.hashCode();
+				if (hashCode == System.identityHashCode(query)) {
+					throw new UnsupportedOperationException(
+							"hashCode() result is the same as  the identityHashCode in " + query.getClass().getName());
+				}
+			});
+
 			if (dataset != null) {
 				query.setDataset(dataset);
 			}

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLSyntaxComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLSyntaxComplianceTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -52,7 +53,6 @@ import org.slf4j.LoggerFactory;
  * A test suite that runs SPARQL syntax tests.
  *
  * @author Jeen Broekstra
- *
  */
 public abstract class SPARQLSyntaxComplianceTest extends SPARQLComplianceTest {
 
@@ -185,6 +185,14 @@ public abstract class SPARQLSyntaxComplianceTest extends SPARQLComplianceTest {
 
 		try {
 			ParsedOperation operation = parseOperation(query, queryFileURL);
+
+			assertThatNoException().isThrownBy(() -> {
+				int hashCode = operation.hashCode();
+				if (hashCode == System.identityHashCode(operation)) {
+					throw new UnsupportedOperationException("hashCode() result is the same as  the identityHashCode in "
+							+ operation.getClass().getName());
+				}
+			});
 
 			if (!positiveTest) {
 				boolean dataBlockUpdate = false;

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/AbstractComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/AbstractComplianceTest.java
@@ -10,15 +10,40 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sparql;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.net.URL;
 
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.Iteration;
+import org.eclipse.rdf4j.common.transaction.IsolationLevel;
+import org.eclipse.rdf4j.common.transaction.TransactionSetting;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.query.BooleanQuery;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.Query;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.RepositoryResult;
+import org.eclipse.rdf4j.repository.UnknownTransactionStateException;
+import org.eclipse.rdf4j.rio.ParserConfig;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandler;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
@@ -31,7 +56,6 @@ import org.slf4j.LoggerFactory;
  * Abstract base class for tests included in the {@link RepositorySPARQLComplianceTestSuite}.
  *
  * @author Jeen Broekstra
- *
  */
 public abstract class AbstractComplianceTest {
 
@@ -43,7 +67,7 @@ public abstract class AbstractComplianceTest {
 	@Before
 	public void setUp() throws Exception {
 		repo = RepositorySPARQLComplianceTestSuite.getEmptyInitializedRepository(this.getClass());
-		conn = repo.getConnection();
+		conn = new RepositoryConnectionWrapper(repo.getConnection());
 	}
 
 	@After
@@ -75,5 +99,398 @@ public abstract class AbstractComplianceTest {
 				"PREFIX foaf: <" + FOAF.NAMESPACE + "> \n" +
 				"PREFIX ex: <" + EX.NAMESPACE + "> \n" +
 				"\n";
+	}
+
+	private static class RepositoryConnectionWrapper implements RepositoryConnection {
+
+		private final RepositoryConnection delegate;
+
+		public RepositoryConnectionWrapper(RepositoryConnection delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Repository getRepository() {
+			return delegate.getRepository();
+		}
+
+		@Override
+		public void setParserConfig(ParserConfig config) {
+			delegate.setParserConfig(config);
+		}
+
+		@Override
+		public ParserConfig getParserConfig() {
+			return delegate.getParserConfig();
+		}
+
+		@Override
+		public ValueFactory getValueFactory() {
+			return delegate.getValueFactory();
+		}
+
+		@Override
+		public boolean isOpen() throws RepositoryException {
+			return delegate.isOpen();
+		}
+
+		@Override
+		public void close() throws RepositoryException {
+			delegate.close();
+		}
+
+		private <T> T checkThatHashCodeWorks(T prepareQuery) {
+			assert prepareQuery.hashCode() == prepareQuery.hashCode();
+			assert prepareQuery.hashCode() != System.identityHashCode(prepareQuery);
+
+			return prepareQuery;
+		}
+
+		@Override
+		public Query prepareQuery(String query) throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareQuery(query));
+		}
+
+		@Override
+		public Query prepareQuery(QueryLanguage ql, String query) throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareQuery(ql, query));
+		}
+
+		@Override
+		public Query prepareQuery(QueryLanguage ql, String query, String baseURI)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareQuery(ql, query, baseURI));
+		}
+
+		@Override
+		public TupleQuery prepareTupleQuery(String query) throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareTupleQuery(query));
+		}
+
+		@Override
+		public TupleQuery prepareTupleQuery(QueryLanguage ql, String query)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareTupleQuery(ql, query));
+		}
+
+		@Override
+		public TupleQuery prepareTupleQuery(QueryLanguage ql, String query, String baseURI)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareTupleQuery(ql, query, baseURI));
+		}
+
+		@Override
+		public GraphQuery prepareGraphQuery(String query) throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareGraphQuery(query));
+		}
+
+		@Override
+		public GraphQuery prepareGraphQuery(QueryLanguage ql, String query)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareGraphQuery(ql, query));
+		}
+
+		@Override
+		public GraphQuery prepareGraphQuery(QueryLanguage ql, String query, String baseURI)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareGraphQuery(ql, query, baseURI));
+		}
+
+		@Override
+		public BooleanQuery prepareBooleanQuery(String query) throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareBooleanQuery(query));
+		}
+
+		@Override
+		public BooleanQuery prepareBooleanQuery(QueryLanguage ql, String query)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareBooleanQuery(ql, query));
+		}
+
+		@Override
+		public BooleanQuery prepareBooleanQuery(QueryLanguage ql, String query, String baseURI)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareBooleanQuery(ql, query, baseURI));
+		}
+
+		@Override
+		public Update prepareUpdate(String update) throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareUpdate(update));
+		}
+
+		@Override
+		public Update prepareUpdate(QueryLanguage ql, String update)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareUpdate(ql, update));
+		}
+
+		@Override
+		public Update prepareUpdate(QueryLanguage ql, String update, String baseURI)
+				throws RepositoryException, MalformedQueryException {
+			return checkThatHashCodeWorks(delegate.prepareUpdate(ql, update, baseURI));
+		}
+
+		@Override
+		public RepositoryResult<Resource> getContextIDs() throws RepositoryException {
+			return delegate.getContextIDs();
+		}
+
+		@Override
+		public RepositoryResult<Statement> getStatements(Resource subj, IRI pred, Value obj, Resource... contexts)
+				throws RepositoryException {
+			return delegate.getStatements(subj, pred, obj, contexts);
+		}
+
+		@Override
+		public RepositoryResult<Statement> getStatements(Resource subj, IRI pred, Value obj, boolean includeInferred,
+				Resource... contexts) throws RepositoryException {
+			return delegate.getStatements(subj, pred, obj, includeInferred, contexts);
+		}
+
+		@Override
+		public boolean hasStatement(Resource subj, IRI pred, Value obj, boolean includeInferred, Resource... contexts)
+				throws RepositoryException {
+			return delegate.hasStatement(subj, pred, obj, includeInferred, contexts);
+		}
+
+		@Override
+		public boolean hasStatement(Statement st, boolean includeInferred, Resource... contexts)
+				throws RepositoryException {
+			return delegate.hasStatement(st, includeInferred, contexts);
+		}
+
+		@Override
+		public void exportStatements(Resource subj, IRI pred, Value obj, boolean includeInferred, RDFHandler handler,
+				Resource... contexts) throws RepositoryException, RDFHandlerException {
+			delegate.exportStatements(subj, pred, obj, includeInferred, handler, contexts);
+		}
+
+		@Override
+		public void export(RDFHandler handler, Resource... contexts) throws RepositoryException, RDFHandlerException {
+			delegate.export(handler, contexts);
+		}
+
+		@Override
+		public long size(Resource... contexts) throws RepositoryException {
+			return delegate.size(contexts);
+		}
+
+		@Override
+		public boolean isEmpty() throws RepositoryException {
+			return delegate.isEmpty();
+		}
+
+		@Override
+		@Deprecated
+		public void setAutoCommit(boolean autoCommit) throws RepositoryException {
+			delegate.setAutoCommit(autoCommit);
+		}
+
+		@Override
+		@Deprecated
+		public boolean isAutoCommit() throws RepositoryException {
+			return delegate.isAutoCommit();
+		}
+
+		@Override
+		public boolean isActive() throws UnknownTransactionStateException, RepositoryException {
+			return delegate.isActive();
+		}
+
+		@Override
+		public void setIsolationLevel(IsolationLevel level) throws IllegalStateException {
+			delegate.setIsolationLevel(level);
+		}
+
+		@Override
+		public IsolationLevel getIsolationLevel() {
+			return delegate.getIsolationLevel();
+		}
+
+		@Override
+		public void begin() throws RepositoryException {
+			delegate.begin();
+		}
+
+		@Override
+		public void begin(IsolationLevel level) throws RepositoryException {
+			delegate.begin(level);
+		}
+
+		@Override
+		public void begin(TransactionSetting... settings) {
+			delegate.begin(settings);
+		}
+
+		@Override
+		public void prepare() throws RepositoryException {
+			delegate.prepare();
+		}
+
+		@Override
+		public void commit() throws RepositoryException {
+			delegate.commit();
+		}
+
+		@Override
+		public void rollback() throws RepositoryException {
+			delegate.rollback();
+		}
+
+		@Override
+		public void add(InputStream in, RDFFormat dataFormat, Resource... contexts)
+				throws IOException, RDFParseException, RepositoryException {
+			delegate.add(in, dataFormat, contexts);
+		}
+
+		@Override
+		public void add(InputStream in, String baseURI, RDFFormat dataFormat, Resource... contexts)
+				throws IOException, RDFParseException, RepositoryException {
+			delegate.add(in, baseURI, dataFormat, contexts);
+		}
+
+		@Override
+		public void add(Reader reader, RDFFormat dataFormat, Resource... contexts)
+				throws IOException, RDFParseException, RepositoryException {
+			delegate.add(reader, dataFormat, contexts);
+		}
+
+		@Override
+		public void add(Reader reader, String baseURI, RDFFormat dataFormat, Resource... contexts)
+				throws IOException, RDFParseException, RepositoryException {
+			delegate.add(reader, baseURI, dataFormat, contexts);
+		}
+
+		@Override
+		public void add(URL url, Resource... contexts) throws IOException, RDFParseException, RepositoryException {
+			delegate.add(url, contexts);
+		}
+
+		@Override
+		public void add(URL url, RDFFormat dataFormat, Resource... contexts)
+				throws IOException, RDFParseException, RepositoryException {
+			delegate.add(url, dataFormat, contexts);
+		}
+
+		@Override
+		public void add(URL url, String baseURI, RDFFormat dataFormat, Resource... contexts)
+				throws IOException, RDFParseException, RepositoryException {
+			delegate.add(url, baseURI, dataFormat, contexts);
+		}
+
+		@Override
+		public void add(File file, Resource... contexts) throws IOException, RDFParseException, RepositoryException {
+			delegate.add(file, contexts);
+		}
+
+		@Override
+		public void add(File file, RDFFormat dataFormat, Resource... contexts)
+				throws IOException, RDFParseException, RepositoryException {
+			delegate.add(file, dataFormat, contexts);
+		}
+
+		@Override
+		public void add(File file, String baseURI, RDFFormat dataFormat, Resource... contexts)
+				throws IOException, RDFParseException, RepositoryException {
+			delegate.add(file, baseURI, dataFormat, contexts);
+		}
+
+		@Override
+		public void add(Resource subject, IRI predicate, Value object, Resource... contexts)
+				throws RepositoryException {
+			delegate.add(subject, predicate, object, contexts);
+		}
+
+		@Override
+		public void add(Statement st, Resource... contexts) throws RepositoryException {
+			delegate.add(st, contexts);
+		}
+
+		@Override
+		public void add(Iterable<? extends Statement> statements, Resource... contexts) throws RepositoryException {
+			delegate.add(statements, contexts);
+		}
+
+		@Override
+		@Deprecated(since = "4.1.0", forRemoval = true)
+		public <E extends Exception> void add(Iteration<? extends Statement, E> statements, Resource... contexts)
+				throws RepositoryException, E {
+			delegate.add(statements, contexts);
+		}
+
+		@Override
+		public <E extends Exception> void add(CloseableIteration<? extends Statement, E> statements,
+				Resource... contexts) throws RepositoryException, E {
+			delegate.add(statements, contexts);
+		}
+
+		@Override
+		public void add(RepositoryResult<Statement> statements, Resource... contexts) throws RepositoryException {
+			delegate.add(statements, contexts);
+		}
+
+		@Override
+		public void remove(Resource subject, IRI predicate, Value object, Resource... contexts)
+				throws RepositoryException {
+			delegate.remove(subject, predicate, object, contexts);
+		}
+
+		@Override
+		public void remove(Statement st, Resource... contexts) throws RepositoryException {
+			delegate.remove(st, contexts);
+		}
+
+		@Override
+		public void remove(Iterable<? extends Statement> statements, Resource... contexts) throws RepositoryException {
+			delegate.remove(statements, contexts);
+		}
+
+		@Override
+		@Deprecated(since = "4.1.0", forRemoval = true)
+		public <E extends Exception> void remove(Iteration<? extends Statement, E> statements, Resource... contexts)
+				throws RepositoryException, E {
+			delegate.remove(statements, contexts);
+		}
+
+		@Override
+		public <E extends Exception> void remove(CloseableIteration<? extends Statement, E> statements,
+				Resource... contexts) throws RepositoryException, E {
+			delegate.remove(statements, contexts);
+		}
+
+		@Override
+		public void remove(RepositoryResult<Statement> statements, Resource... contexts) throws RepositoryException {
+			delegate.remove(statements, contexts);
+		}
+
+		@Override
+		public void clear(Resource... contexts) throws RepositoryException {
+			delegate.clear(contexts);
+		}
+
+		@Override
+		public RepositoryResult<Namespace> getNamespaces() throws RepositoryException {
+			return delegate.getNamespaces();
+		}
+
+		@Override
+		public String getNamespace(String prefix) throws RepositoryException {
+			return delegate.getNamespace(prefix);
+		}
+
+		@Override
+		public void setNamespace(String prefix, String name) throws RepositoryException {
+			delegate.setNamespace(prefix, name);
+		}
+
+		@Override
+		public void removeNamespace(String prefix) throws RepositoryException {
+			delegate.removeNamespace(prefix);
+		}
+
+		@Override
+		public void clearNamespaces() throws RepositoryException {
+			delegate.clearNamespaces();
+		}
 	}
 }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
@@ -19,11 +19,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.List;
 
 import org.eclipse.rdf4j.model.BNode;
@@ -40,9 +37,6 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.junit.Test;
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OrderByTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OrderByTest.java
@@ -10,25 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sparql.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.StringReader;
-import java.util.List;
 import java.util.stream.Stream;
 
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
-import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
-import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.junit.Test;


### PR DESCRIPTION
GitHub issue resolved: #4245 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - add hashCode() checks into the main query parsing/evaluating tests
 - implement hashCode() and equals() in various classes so that the tests work
 - fix the NullPointerException by first checking if the arg is null

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

