### PR TITLE
GH-4256 sparql exists filter scope

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategy.java
@@ -517,18 +517,12 @@ public class StrictEvaluationStrategy implements EvaluationStrategy, FederatedSe
 	}
 
 	protected QueryEvaluationStep prepare(Filter node, QueryEvaluationContext context) throws QueryEvaluationException {
-
-		if (FilterIterator.isPartOfSubQuery(node)) {
-			context = new FilterIterator.RetainedVariableFilteredQueryEvaluationContext(node, context);
-		}
 		QueryEvaluationStep arg = precompile(node.getArg(), context);
 		QueryValueEvaluationStep ves;
 		try {
 			ves = precompile(node.getCondition(), context);
 		} catch (QueryEvaluationException e) {
-			// If we have a failed compilation we always return false.
-			// Which means empty. so let's short circuit that.
-//			ves = new QueryValueEvaluationStep.ConstantQueryValueEvaluationStep(BooleanLiteral.FALSE);
+			// If we have a failed compilation we always return false. Which means empty.
 			return QueryEvaluationStep.EMPTY;
 		}
 		// if the query evaluation is constant it is either FILTER(true) or FILTER(false)

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/FilterIterator.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/FilterIterator.java
@@ -58,6 +58,7 @@ public class FilterIterator extends FilterIteration<BindingSet, QueryEvaluationE
 		}
 	}
 
+	@Deprecated(forRemoval = true, since = "4.2.1")
 	public static boolean isPartOfSubQuery(QueryModelNode node) {
 		if (node instanceof SubQueryValueOperator) {
 			return true;

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/CompareAll.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/CompareAll.java
@@ -12,8 +12,7 @@ package org.eclipse.rdf4j.query.algebra;
 
 import org.eclipse.rdf4j.query.algebra.Compare.CompareOp;
 
-/**
- */
+@Deprecated(forRemoval = true, since = "4.2.1")
 public class CompareAll extends CompareSubQueryValueOperator {
 
 	/*-----------*

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/CompareAny.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/CompareAny.java
@@ -12,8 +12,7 @@ package org.eclipse.rdf4j.query.algebra;
 
 import org.eclipse.rdf4j.query.algebra.Compare.CompareOp;
 
-/**
- */
+@Deprecated(forRemoval = true, since = "4.2.1")
 public class CompareAny extends CompareSubQueryValueOperator {
 
 	/*-----------*

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/CompareSubQueryValueOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/CompareSubQueryValueOperator.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+@Deprecated(forRemoval = true, since = "4.2.1")
 public abstract class CompareSubQueryValueOperator extends SubQueryValueOperator {
 
 	/*-----------*

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Filter.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Filter.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -58,10 +59,10 @@ public class Filter extends UnaryTupleOperator {
 	@Override
 	public Set<String> getBindingNames() {
 		Set<String> result = getArg().getBindingNames();
-		if (condition instanceof SubQueryValueOperator) {
+		if (condition instanceof Exists) {
 			result = Stream
 					.concat(result.stream(),
-							((SubQueryValueOperator) condition).getSubQuery().getBindingNames().stream())
+							((Exists) condition).getSubQuery().getBindingNames().stream())
 					.collect(Collectors.toSet());
 		}
 		return result;

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/SubQueryValueOperator.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/SubQueryValueOperator.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
+@Deprecated(forRemoval = true, since = "4.2.1")
 public abstract class SubQueryValueOperator extends AbstractQueryModelNode implements ValueExpr {
 
 	/*-----------*

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/RepositorySPARQLComplianceTestSuite.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/RepositorySPARQLComplianceTestSuite.java
@@ -31,6 +31,7 @@ import org.eclipse.rdf4j.testsuite.sparql.tests.DescribeTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.ExistsTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.GroupByTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.InTest;
+import org.eclipse.rdf4j.testsuite.sparql.tests.MinusTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.OptionalTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.OrderByTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.PropertyPathTest;
@@ -77,16 +78,16 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ AggregateTest.class, ArbitraryLengthPathTest.class, BasicTest.class, BindTest.class,
 		BuiltinFunctionTest.class, ConstructTest.class, DefaultGraphTest.class, DescribeTest.class, GroupByTest.class,
 		InTest.class, OptionalTest.class, PropertyPathTest.class, SubselectTest.class, UnionTest.class,
-		ValuesTest.class, OrderByTest.class, ExistsTest.class })
+		ValuesTest.class, OrderByTest.class, ExistsTest.class, MinusTest.class })
 @Experimental
 public abstract class RepositorySPARQLComplianceTestSuite {
 	@BeforeClass
-	public static void setUpClass() throws Exception {
+	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
 	@AfterClass
-	public static void tearDownClass() throws Exception {
+	public static void tearDownClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/RepositorySPARQLComplianceTestSuite.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/RepositorySPARQLComplianceTestSuite.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.testsuite.sparql.tests.BuiltinFunctionTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.ConstructTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.DefaultGraphTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.DescribeTest;
+import org.eclipse.rdf4j.testsuite.sparql.tests.ExistsTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.GroupByTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.InTest;
 import org.eclipse.rdf4j.testsuite.sparql.tests.OptionalTest;
@@ -76,7 +77,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ AggregateTest.class, ArbitraryLengthPathTest.class, BasicTest.class, BindTest.class,
 		BuiltinFunctionTest.class, ConstructTest.class, DefaultGraphTest.class, DescribeTest.class, GroupByTest.class,
 		InTest.class, OptionalTest.class, PropertyPathTest.class, SubselectTest.class, UnionTest.class,
-		ValuesTest.class, OrderByTest.class })
+		ValuesTest.class, OrderByTest.class, ExistsTest.class })
 @Experimental
 public abstract class RepositorySPARQLComplianceTestSuite {
 	@BeforeClass

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
@@ -19,11 +19,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.List;
 
 import org.eclipse.rdf4j.model.BNode;
@@ -40,9 +37,6 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.junit.Test;
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ExistsTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ExistsTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.testsuite.sparql.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
+import org.junit.Test;
+
+/**
+ * Test for queries using EXISTS
+ *
+ * @author Håvard M. Ottestad
+ */
+public class ExistsTest extends AbstractComplianceTest {
+
+	@Test
+	public void testFilterNotExistsBindingToCurrentSolutionMapping() {
+
+		String ex = "http://example/";
+		IRI a1 = Values.iri(ex, "a1");
+		IRI a2 = Values.iri(ex, "a2");
+
+		IRI both = Values.iri(ex, "both");
+
+		IRI predicate1 = Values.iri(ex, "predicate1");
+		IRI predicate2 = Values.iri(ex, "predicate2");
+
+		conn.add(a1, predicate1, both);
+		conn.add(a1, predicate2, both);
+
+		conn.add(a2, predicate1, both);
+		conn.add(a2, predicate2, Values.bnode());
+
+		TupleQuery tupleQuery = conn.prepareTupleQuery(
+				"PREFIX : <http://example/>\n" +
+						"SELECT * WHERE {\n" +
+						"  ?a :predicate1 ?p1\n" +
+						"  FILTER NOT EXISTS {\n" +
+						"    ?a :predicate2 ?p2 .\n" +
+						"    FILTER(?p2 = ?p1)\n" +
+						"  }\n" +
+						"}\n");
+
+		try (Stream<BindingSet> stream = tupleQuery.evaluate().stream()) {
+			List<BindingSet> collect = stream.collect(Collectors.toList());
+			assertEquals(1, collect.size());
+			assertEquals(a2, collect.get(0).getValue("a"));
+		}
+
+	}
+
+}

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/MinusTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/MinusTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.testsuite.sparql.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
+import org.junit.Test;
+
+/**
+ * Test for queries using MINUS
+ *
+ * @author Håvard M. Ottestad
+ */
+public class MinusTest extends AbstractComplianceTest {
+
+	@Test
+	public void testScopingOfFilterInMinus() {
+
+		String ex = "http://example/";
+		IRI a1 = Values.iri(ex, "a1");
+		IRI a2 = Values.iri(ex, "a2");
+
+		IRI both = Values.iri(ex, "both");
+
+		IRI predicate1 = Values.iri(ex, "predicate1");
+		IRI predicate2 = Values.iri(ex, "predicate2");
+
+		conn.add(a1, predicate1, both);
+		conn.add(a1, predicate2, both);
+
+		conn.add(a2, predicate1, both);
+		conn.add(a2, predicate2, Values.bnode());
+
+		TupleQuery tupleQuery = conn.prepareTupleQuery(
+				"PREFIX : <http://example/>\n" +
+						"SELECT * WHERE {\n" +
+						"  ?a :predicate1 ?p1\n" +
+						"  MINUS {\n" +
+						"    ?a :predicate2 ?p2 .\n" +
+						"    FILTER(?p2 = ?p1)\n" +
+						"  }\n" +
+						"} ORDER BY ?a\n"
+		);
+
+		try (Stream<BindingSet> stream = tupleQuery.evaluate().stream()) {
+			List<BindingSet> collect = stream.collect(Collectors.toList());
+			assertEquals(2, collect.size());
+
+			List<Value> expectedValues = List.of(a1, a2);
+			List<Value> actualValues = collect
+					.stream()
+					.map(b -> b.getValue("a"))
+					.collect(Collectors.toList());
+
+			assertEquals(expectedValues, actualValues);
+		}
+
+	}
+
+}

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OrderByTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OrderByTest.java
@@ -10,25 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sparql.tests;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.StringReader;
-import java.util.List;
 import java.util.stream.Stream;
 
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
-import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
-import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.junit.Test;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlTripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlTripleSource.java
@@ -194,16 +194,21 @@ public class SparqlTripleSource extends TripleSourceBase {
 			monitorRemoteRequest();
 			RepositoryResult<Statement> repoResult = conn.getStatements(subj, pred, obj,
 					queryInfo.getIncludeInferred(), contexts);
-
-			resultHolder.set(new ExceptionConvertingIteration<>(repoResult) {
-				@Override
-				protected QueryEvaluationException convert(Exception ex) {
-					if (ex instanceof QueryEvaluationException) {
-						return (QueryEvaluationException) ex;
+			try {
+				resultHolder.set(new ExceptionConvertingIteration<>(repoResult) {
+					@Override
+					protected QueryEvaluationException convert(Exception ex) {
+						if (ex instanceof QueryEvaluationException) {
+							return (QueryEvaluationException) ex;
+						}
+						return new QueryEvaluationException(ex);
 					}
-					return new QueryEvaluationException(ex);
-				}
-			});
+				});
+			} catch (Throwable t) {
+				repoResult.close();
+				throw t;
+			}
+
 		});
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #4256 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

From the spec: 

> Variables in the pattern that are bound in the current [solution mapping](http://www.w3.org/TR/rdf-sparql-query/#defn_sparqlSolutionMapping) take the value that they have from the solution mapping. Variables in the pattern pattern that are not bound in the current solution mapping take part in pattern matching.

https://www.w3.org/TR/sparql11-query/#func-filter-exists

I've removed the check for `isPartOfSubQuery` because it seems to be related to some legacy code that is no longer in use. 



<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

