### PR TITLE
GH-2749 Include Namespaces in Statement imports from NamespaceAware collections

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
@@ -257,6 +257,13 @@ public class SPARQLStoreConnectionTest extends RepositoryConnectionTest {
 
 	@Override
 	@Ignore
+	public void testImportNamespacesFromIterable() throws Exception {
+		System.err
+				.println("disabled testImportNamespacesFromIterable() as namespace setting is not supported by SPARQL");
+	}
+
+	@Override
+	@Ignore
 	public void testTransactionIsolation() throws Exception {
 		System.err.println("temporarily disabled testTransactionIsolation() for SPARQLRepository");
 	}

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -940,7 +940,9 @@ public interface RepositoryConnection extends AutoCloseable {
 	/**
 	 * Adds the supplied statements to this repository, optionally to one or more named contexts.
 	 *
-	 * @param statements The statements that should be added.
+	 * @param statements The statements that should be added. In case the iterable is
+	 *                   {@link org.eclipse.rdf4j.model.NamespaceAware} and the target repository supports it, the
+	 *                   iterable's namespaces are also added to the repository, without overwriting existing ones.
 	 * @param contexts   The contexts to add the statements to. Note that this parameter is a vararg and as such is
 	 *                   optional. If no contexts are specified, each statement is added to any context specified in the
 	 *                   statement, or if the statement contains no context, it is added without context. If one or more

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/AbstractRepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/AbstractRepositoryConnection.java
@@ -15,9 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.rdf4j.common.iteration.Iteration;
@@ -370,20 +368,19 @@ public abstract class AbstractRepositoryConnection implements RepositoryConnecti
 				"contexts argument may not be null; either the value should be cast to Resource or an empty array should be supplied");
 
 		boolean localTransaction = startLocalTransaction();
-		Set<Namespace> newNamespaces = new HashSet<>();
 
 		try {
 			for (Statement st : statements) {
-				if (st instanceof NamespaceAware) {
-					newNamespaces.addAll(((NamespaceAware) st).getNamespaces());
-				}
 				addWithoutCommit(st, contexts);
 			}
 
-			for (Namespace newNamespace : newNamespaces) {
-				String nsPrefix = newNamespace.getPrefix();
-				if (getNamespace(nsPrefix) == null) {
-					setNamespace(nsPrefix, newNamespace.getName());
+			if (statements instanceof NamespaceAware) {
+				var newNamespaces = ((NamespaceAware) statements).getNamespaces();
+				for (Namespace newNamespace : newNamespaces) {
+					String nsPrefix = newNamespace.getPrefix();
+					if (getNamespace(nsPrefix) == null) {
+						setNamespace(nsPrefix, newNamespace.getName());
+					}
 				}
 			}
 
@@ -426,15 +423,6 @@ public abstract class AbstractRepositoryConnection implements RepositoryConnecti
 				"contexts argument may not be null; either the value should be cast to Resource or an empty array should be supplied");
 
 		addWithoutCommit(st, contexts);
-
-		if (st instanceof NamespaceAware) {
-			for (Namespace newNamespace : ((NamespaceAware) st).getNamespaces()) {
-				String nsPrefix = newNamespace.getPrefix();
-				if (getNamespace(nsPrefix) == null) {
-					setNamespace(nsPrefix, newNamespace.getName());
-				}
-			}
-		}
 
 		conditionalCommit(localTransaction);
 	}

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -643,6 +643,32 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 	}
 
 	@Override
+	public void add(Statement st, Resource... contexts) throws RepositoryException {
+		boolean localTransaction = startLocalTransaction();
+		addWithoutCommit(st, contexts);
+		try {
+			conditionalCommit(localTransaction);
+		} catch (RepositoryException e) {
+			conditionalRollback(localTransaction);
+			throw e;
+		}
+	}
+
+	@Override
+	public void add(Iterable<? extends Statement> statements, Resource... contexts) throws RepositoryException {
+		boolean localTransaction = startLocalTransaction();
+		for (Statement st : statements) {
+			addWithoutCommit(st, contexts);
+		}
+		try {
+			conditionalCommit(localTransaction);
+		} catch (RepositoryException e) {
+			conditionalRollback(localTransaction);
+			throw e;
+		}
+	}
+
+	@Override
 	public void clear(Resource... contexts) throws RepositoryException {
 		Objects.requireNonNull(contexts,
 				"contexts argument may not be null; either the value should be cast to Resource or an empty array should be supplied");

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -643,32 +643,6 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 	}
 
 	@Override
-	public void add(Statement st, Resource... contexts) throws RepositoryException {
-		boolean localTransaction = startLocalTransaction();
-		addWithoutCommit(st, contexts);
-		try {
-			conditionalCommit(localTransaction);
-		} catch (RepositoryException e) {
-			conditionalRollback(localTransaction);
-			throw e;
-		}
-	}
-
-	@Override
-	public void add(Iterable<? extends Statement> statements, Resource... contexts) throws RepositoryException {
-		boolean localTransaction = startLocalTransaction();
-		for (Statement st : statements) {
-			addWithoutCommit(st, contexts);
-		}
-		try {
-			conditionalCommit(localTransaction);
-		} catch (RepositoryException e) {
-			conditionalRollback(localTransaction);
-			throw e;
-		}
-	}
-
-	@Override
 	public void clear(Resource... contexts) throws RepositoryException {
 		Objects.requireNonNull(contexts,
 				"contexts argument may not be null; either the value should be cast to Resource or an empty array should be supplied");

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/RepositoryConnectionTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/RepositoryConnectionTest.java
@@ -1127,6 +1127,22 @@ public abstract class RepositoryConnectionTest {
 		assertThat(map.get(RDF_PREFIX)).isEqualTo("http://www.w3.org/1999/02/22-rdf-syntax-ns#");
 	}
 
+	@Test
+	public void testImportNamespacesFromIterable() throws Exception {
+		Model nsAwareModel = new LinkedHashModel();
+		nsAwareModel.setNamespace(RDFS_PREFIX, RDFS_NS);
+		nsAwareModel.setNamespace(EXAMPLE, EXAMPLE_NS);
+
+		testCon.add(nsAwareModel);
+		assertThat(testCon.getNamespace(RDFS_PREFIX)).isEqualTo(RDFS_NS);
+		assertThat(testCon.getNamespace(EXAMPLE)).isEqualTo(EXAMPLE_NS);
+
+		// Test that existing namespaces are not overwritten
+		nsAwareModel.setNamespace(EXAMPLE, "http://something.else/");
+		testCon.add(nsAwareModel);
+		assertThat(testCon.getNamespace(EXAMPLE)).isEqualTo(EXAMPLE_NS);
+	}
+
 	private void setupNamespaces() throws IOException, RDFParseException, RepositoryException {
 		testCon.setNamespace(EXAMPLE, EXAMPLE_NS);
 		testCon.setNamespace(RDF_PREFIX, "http://www.w3.org/1999/02/22-rdf-syntax-ns#");


### PR DESCRIPTION
Signed-off-by: Dzerom Dzenkins <dzeri96@proton.me>


GitHub issue resolved: #2749

Briefly describe the changes proposed in this PR:

As suggested by @jeenbroekstra, I've added a call to `setNamespace` for all new namespaces coming from the imported `Statement`s, and I've removed the appropriate overrides in the SPARQL repository, as it seems like the code was almost identical. Please correct me if I'm wrong.

Since this is a WIP, there are some things to clear up:
1. Where do I put the unit tests for this? I couldn't find an appropriate place with similar tests.
2. What should we do with the deprecated `Iteration` overload of the `add` method? I suspect this might get removed with the next release so I haven't added any changes there.
3. What about the `remove` method? Should we prune unused `Namespace`s?

As soon as these questions are cleared up, and the flaky tests are fixed, I'll continue working on this PR!

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

