### PR TITLE
GH-4267: use latest jetty dependencies

### DIFF
--- a/compliance/repository/pom.xml
+++ b/compliance/repository/pom.xml
@@ -70,12 +70,10 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/compliance/sparql/pom.xml
+++ b/compliance/sparql/pom.xml
@@ -200,12 +200,10 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<version>${jetty.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,6 @@
 		<lwjgl.version>3.3.1</lwjgl.version>
 		<solr.version>8.4.1</solr.version>
 		<elasticsearch.version>7.8.1</elasticsearch.version>
-		<jetty.version>9.4.48.v20220622</jetty.version>
 		<spring.version>5.3.21</spring.version>
 		<guava.version>30.1.1-jre</guava.version>
 		<jmhVersion>1.35</jmhVersion>
@@ -362,6 +361,14 @@
 				<groupId>com.fasterxml.jackson</groupId>
 				<artifactId>jackson-bom</artifactId>
 				<version>2.13.4.20221013</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<!-- fix dependencies for elastic/solr client libraries -->
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-bom</artifactId>
+				<version>9.4.49.v20220914</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -100,13 +100,11 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -73,19 +73,16 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<version>${jetty.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>apache-jsp</artifactId>
-			<version>${jetty.version}</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #4267 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- use jetty BOM in root pom to override older versions imported by e.g. elasticsearch dependencies
- don't use jetty.version variable anymore in other pom.xml files

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

