### PR TITLE
GH-4279 FilterOptimizer should not modify the query tree above the node it is currently on

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/FilterOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/FilterOptimizer.java
@@ -110,15 +110,14 @@ public class FilterOptimizer implements QueryOptimizer {
 		@Override
 		public void meet(Filter filter) {
 			super.meet(filter);
-			if (filter.getParentNode() instanceof Filter && filter.getParentNode().getParentNode() != null) {
+			if (filter.getArg() instanceof Filter && filter.getParentNode() != null) {
 
-				Filter parentFilter = (Filter) filter.getParentNode();
-				QueryModelNode grandParent = parentFilter.getParentNode();
-				And merge = new And(filter.getCondition().clone(), parentFilter.getCondition().clone());
+				Filter childFilter = (Filter) filter.getArg();
+				QueryModelNode parent = filter.getParentNode();
+				And merge = new And(childFilter.getCondition().clone(), filter.getCondition().clone());
 
-				Filter newFilter = new Filter(filter.getArg().clone(), merge);
-				grandParent.replaceChildNode(parentFilter, newFilter);
-				meet(newFilter);
+				Filter newFilter = new Filter(childFilter.getArg().clone(), merge);
+				parent.replaceChildNode(filter, newFilter);
 			}
 		}
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
@@ -98,6 +98,15 @@ public class FilterOptimizerTest extends QueryOptimizerTest {
 		testOptimizer(expected, query);
 	}
 
+	@Test
+	public void testNestedFilter() {
+		String expectedQuery = "SELECT * WHERE {?s ?p ?o . ?o ?r ?z. ?z ?k ?m. FILTER( NOT EXISTS {{?o ?p2 ?v1. FILTER(?v1 < 4) }\n {?o ?p2 ?v2. FILTER(?v2 > 0 && ?v2 < 4)}\n ?o ?p2 ?v3.} && NOT EXISTS {?o ?p2 []}) }";
+
+		String query = "SELECT * WHERE {?s ?p ?o . ?o ?r ?z. FILTER NOT EXISTS {?o ?p2 []}\n ?z ?k ?m. FILTER NOT EXISTS {?o ?p2 ?v1, ?v2, ?v3. FILTER(?v2 < 4) FILTER(?v1 < 4) FILTER(?v2 > 0)} }";
+
+		testOptimizer(expectedQuery, query);
+	}
+
 	void testOptimizer(String expectedQuery, String actualQuery)
 			throws MalformedQueryException, UnsupportedQueryLanguageException {
 		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, actualQuery, null);


### PR DESCRIPTION
GitHub issue resolved: #4279 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

