### PR TITLE
GH-4248 check for invalid triple context value

### DIFF
--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
@@ -731,6 +731,10 @@ public abstract class SailSourceConnection extends AbstractNotifyingSailConnecti
 			}
 		} else {
 			for (Resource ctx : contexts) {
+				if (ctx != null && ctx.isTriple()) {
+					throw new SailException("context argument can not be of type Triple: " + ctx.stringValue());
+				}
+
 				Resource[] contextsToCheck;
 				if (contexts.length == 1) {
 					contextsToCheck = contexts;

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStore.java
@@ -349,7 +349,7 @@ class LmdbSailStore implements SailStore {
 			for (Resource context : contexts) {
 				if (context == null) {
 					contextIDList.add(0L);
-				} else {
+				} else if (!context.isTriple()) {
 					long contextID = valueStore.getId(context);
 
 					if (contextID != LmdbValue.UNKNOWN_ID) {

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
@@ -250,7 +250,7 @@ class NativeSailStore implements SailStore {
 			for (Resource context : contexts) {
 				if (context == null) {
 					contextIDList.add(0);
-				} else {
+				} else if (!context.isTriple()) {
 					int contextID = valueStore.getID(context);
 
 					if (contextID != NativeValue.UNKNOWN_ID) {

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/RDFStarSupportTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/RDFStarSupportTest.java
@@ -34,6 +34,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -123,7 +124,7 @@ public abstract class RDFStarSupportTest {
 		try {
 			testCon.add(RDF.ALT, RDF.TYPE, RDF.ALT, rdfStarTriple);
 			Assertions.fail("RDF-star triple value should not be allowed by store as context identifier");
-		} catch (UnsupportedOperationException e) {
+		} catch (RepositoryException e) {
 			// fall through, expected behavior
 			testCon.rollback();
 		}


### PR DESCRIPTION
GitHub issue resolved: #4248  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added explicit check in SailSourceConnection to avoid adding Triple as a context value 
- added test coverage
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

