### PR TITLE
GH-3781 Accept only valid SPARQL prefixes

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceController.java
@@ -131,7 +131,7 @@ public class NamespaceController extends AbstractController {
 		}
 
 		if (!isValidPrefix(prefix)) {
-			throw new ClientHTTPException(SC_BAD_REQUEST, "Prefix not alphanumeric");
+			throw new ClientHTTPException(SC_BAD_REQUEST, "Prefix not valid");
 		}
 
 		if (!isValidNamespaceIri(namespace)) {

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceControllerTest.java
@@ -71,7 +71,7 @@ class NamespaceControllerTest {
 
 		// Act & Assert
 		assertThatThrownBy(() -> controller.handleRequest(request, response)).isInstanceOf(ClientHTTPException.class)
-				.hasMessageContaining("Prefix not alphanumeric");
+				.hasMessageContaining("Prefix not valid");
 	}
 
 	@ParameterizedTest

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/namespaces/NamespaceControllerTest.java
@@ -46,7 +46,7 @@ class NamespaceControllerTest {
 
 	@ParameterizedTest
 	@EmptySource
-	@ValueSource(strings = { "a", "1", "rdf", "rdf4j", "22" })
+	@ValueSource(strings = { "a", "rdf", "rdf4j", "wn-6", "t_1", "t_", "a2", "a.3" })
 	void addNamespace_prefix_ok(String prefix) throws Exception {
 		// Arrange
 		request.setRequestURI("/repositories/" + REPO_ID + "/namespaces/" + prefix);
@@ -62,7 +62,7 @@ class NamespaceControllerTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = { "  ", "\t", "\n", "-", "rdf 4j", "rdf-4j" })
+	@ValueSource(strings = { "  ", "\t", "\n", "-", "rdf 4j", "_", "_t", "2a", "a+a", "a*a", "a@a" })
 	void addNamespace_prefix_invalid(String prefix) {
 		// Arrange
 		request.setRequestURI("/repositories/" + REPO_ID + "/namespaces/" + prefix);


### PR DESCRIPTION
Signed-off-by: damyan.ognyanov <damyan.ognyanov@ontotext.com>


GitHub issue resolved: #3781

Briefly describe the changes proposed in this PR:

Validate prefixes according SPARL grammar spec

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

