### PR TITLE
GH-4290 fix for count and order by with an implicit group clause

### DIFF
--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
@@ -11,12 +11,11 @@
 package org.eclipse.rdf4j.testsuite.sparql.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
+import static org.eclipse.rdf4j.model.util.Literals.getIntValue;
+import static org.eclipse.rdf4j.model.util.Values.bnode;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import java.math.BigDecimal;
 import java.time.ZoneId;
@@ -27,10 +26,7 @@ import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
-import org.eclipse.rdf4j.model.util.Literals;
-import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -139,10 +135,10 @@ public class AggregateTest extends AbstractComplianceTest {
 	public void testSES2361UndefMin() {
 		String query = "SELECT (MIN(?v) as ?min) WHERE { VALUES ?v { 1 2 undef 3 4 }}";
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
-			assertNotNull(result);
-			assertTrue(result.hasNext());
-			assertEquals("1", result.next().getValue("min").stringValue());
-			assertFalse(result.hasNext());
+			assertThat(result).isNotNull();
+			assertThat(result.hasNext()).isTrue();
+			assertThat(result.next().getValue("min").stringValue()).isEqualTo("1");
+			assertThat(result.hasNext()).isFalse();
 		}
 	}
 
@@ -150,10 +146,10 @@ public class AggregateTest extends AbstractComplianceTest {
 	public void testSES2361UndefMax() {
 		String query = "SELECT (MAX(?v) as ?max) WHERE { VALUES ?v { 1 2 7 undef 3 4 }}";
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
-			assertNotNull(result);
-			assertTrue(result.hasNext());
-			assertEquals("7", result.next().getValue("max").stringValue());
-			assertFalse(result.hasNext());
+			assertThat(result).isNotNull();
+			assertThat(result.hasNext()).isTrue();
+			assertThat(result.next().getValue("max").stringValue()).isEqualTo("7");
+			assertThat(result).isEmpty();
 		}
 	}
 
@@ -161,10 +157,10 @@ public class AggregateTest extends AbstractComplianceTest {
 	public void testSES2361UndefCount() {
 		String query = "SELECT (COUNT(?v) as ?c) WHERE { VALUES ?v { 1 2 undef 3 4 }}";
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
-			assertNotNull(result);
-			assertTrue(result.hasNext());
-			assertEquals("4", result.next().getValue("c").stringValue());
-			assertFalse(result.hasNext());
+			assertThat(result).isNotNull();
+			assertThat(result.hasNext()).isTrue();
+			assertThat(result.next().getValue("c").stringValue()).isEqualTo("4");
+			assertThat(result).isEmpty();
 		}
 	}
 
@@ -172,10 +168,10 @@ public class AggregateTest extends AbstractComplianceTest {
 	public void testSES2361UndefCountWildcard() {
 		String query = "SELECT (COUNT(*) as ?c) WHERE { VALUES ?v { 1 2 undef 3 4 }}";
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
-			assertNotNull(result);
-			assertTrue(result.hasNext());
-			assertEquals("4", result.next().getValue("c").stringValue());
-			assertFalse(result.hasNext());
+			assertThat(result).isNotNull();
+			assertThat(result.hasNext()).isTrue();
+			assertThat(result.next().getValue("c").stringValue()).isEqualTo("4");
+			assertThat(result).isEmpty();
 		}
 	}
 
@@ -183,10 +179,10 @@ public class AggregateTest extends AbstractComplianceTest {
 	public void testSES2361UndefSum() {
 		String query = "SELECT (SUM(?v) as ?s) WHERE { VALUES ?v { 1 2 undef 3 4 }}";
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
-			assertNotNull(result);
-			assertTrue(result.hasNext());
-			assertEquals("10", result.next().getValue("s").stringValue());
-			assertFalse(result.hasNext());
+			assertThat(result).isNotNull();
+			assertThat(result.hasNext()).isTrue();
+			assertThat(result.next().getValue("s").stringValue()).isEqualTo("10");
+			assertThat(result).isEmpty();
 		}
 	}
 
@@ -195,16 +191,13 @@ public class AggregateTest extends AbstractComplianceTest {
 		loadTestData("/testdata-query/dataset-ses1979.trig");
 		String query = "prefix : <http://example.org/> select (min(?o) as ?min) (max(?o) as ?max) where { ?s :float ?o }";
 
-		ValueFactory vf = conn.getValueFactory();
 		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
 
 		try (TupleQueryResult evaluate = tq.evaluate()) {
 			List<BindingSet> result = QueryResults.asList(evaluate);
-			assertNotNull(result);
-			assertEquals(1, result.size());
-
-			assertEquals(vf.createLiteral(Float.NEGATIVE_INFINITY), result.get(0).getValue("min"));
-			assertEquals(vf.createLiteral(Float.POSITIVE_INFINITY), result.get(0).getValue("max"));
+			assertThat(result).isNotNull().hasSize(1);
+			assertThat(result.get(0).getValue("min")).isEqualTo(literal(Float.NEGATIVE_INFINITY));
+			assertThat(result.get(0).getValue("max")).isEqualTo(literal(Float.POSITIVE_INFINITY));
 		} catch (QueryEvaluationException e) {
 			e.printStackTrace();
 			fail(e.getMessage());
@@ -223,26 +216,26 @@ public class AggregateTest extends AbstractComplianceTest {
 		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
 
 		try (TupleQueryResult result = tq.evaluate()) {
-			assertNotNull(result);
+			assertThat(result).isNotNull();
 
 			while (result.hasNext()) {
 				BindingSet bs = result.next();
-				assertNotNull(bs);
+				assertThat(bs).isNotNull();
 
 				Value concat = bs.getValue("concat");
 
-				assertTrue(concat instanceof Literal);
+				assertThat(concat).isInstanceOf(Literal.class);
 
 				String lexValue = ((Literal) concat).getLabel();
 
 				int occ = countCharOccurrences(lexValue, 'a');
-				assertEquals(1, occ);
+				assertThat(occ).isEqualTo(1);
 				occ = countCharOccurrences(lexValue, 'b');
-				assertEquals(1, occ);
+				assertThat(occ).isEqualTo(1);
 				occ = countCharOccurrences(lexValue, 'c');
-				assertEquals(1, occ);
+				assertThat(occ).isEqualTo(1);
 				occ = countCharOccurrences(lexValue, 'd');
-				assertEquals(1, occ);
+				assertThat(occ).isEqualTo(1);
 			}
 		} catch (QueryEvaluationException e) {
 			e.printStackTrace();
@@ -261,26 +254,26 @@ public class AggregateTest extends AbstractComplianceTest {
 		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
 
 		try (TupleQueryResult result = tq.evaluate()) {
-			assertNotNull(result);
+			assertThat(result).isNotNull();
 
 			while (result.hasNext()) {
 				BindingSet bs = result.next();
-				assertNotNull(bs);
+				assertThat(bs).isNotNull();
 
 				Value concat = bs.getValue("concat");
 
-				assertTrue(concat instanceof Literal);
+				assertThat(concat).isInstanceOf(Literal.class);
 
 				String lexValue = ((Literal) concat).getLabel();
 
 				int occ = countCharOccurrences(lexValue, 'a');
-				assertEquals(1, occ);
+				assertThat(occ).isEqualTo(1);
 				occ = countCharOccurrences(lexValue, 'b');
-				assertEquals(2, occ);
+				assertThat(occ).isEqualTo(2);
 				occ = countCharOccurrences(lexValue, 'c');
-				assertEquals(2, occ);
+				assertThat(occ).isEqualTo(2);
 				occ = countCharOccurrences(lexValue, 'd');
-				assertEquals(1, occ);
+				assertThat(occ).isEqualTo(1);
 			}
 		} catch (QueryEvaluationException e) {
 			e.printStackTrace();
@@ -298,14 +291,11 @@ public class AggregateTest extends AbstractComplianceTest {
 		TupleQuery tq = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
 
 		try (TupleQueryResult result = tq.evaluate()) {
-			assertNotNull(result);
+			assertThat(result).isNotNull();
 
-			assertTrue(result.hasNext());
+			assertThat(result.hasNext()).isTrue();
 			BindingSet s = result.next();
-			Literal count = (Literal) s.getValue("c");
-			assertNotNull(count);
-
-			assertEquals(3, count.intValue());
+			assertThat(getIntValue(s.getValue("c"), 0)).isEqualTo(3);
 		} catch (QueryEvaluationException e) {
 			e.printStackTrace();
 			fail(e.getMessage());
@@ -314,22 +304,22 @@ public class AggregateTest extends AbstractComplianceTest {
 
 	@Test
 	public void testCountHaving() {
-		BNode bnode1 = Values.bnode();
-		BNode bnode2 = Values.bnode();
-		BNode bnode3 = Values.bnode();
+		BNode bnode1 = bnode();
+		BNode bnode2 = bnode();
+		BNode bnode3 = bnode();
 
-		conn.add(bnode3, FOAF.KNOWS, Values.bnode());
-		conn.add(bnode1, FOAF.KNOWS, Values.bnode());
-		conn.add(bnode1, FOAF.KNOWS, Values.bnode());
-		conn.add(bnode2, FOAF.KNOWS, Values.bnode());
-		conn.add(bnode3, FOAF.KNOWS, Values.bnode());
-		conn.add(bnode3, FOAF.KNOWS, Values.bnode());
-		conn.add(bnode1, FOAF.KNOWS, Values.bnode());
+		conn.add(bnode3, FOAF.KNOWS, bnode());
+		conn.add(bnode1, FOAF.KNOWS, bnode());
+		conn.add(bnode1, FOAF.KNOWS, bnode());
+		conn.add(bnode2, FOAF.KNOWS, bnode());
+		conn.add(bnode3, FOAF.KNOWS, bnode());
+		conn.add(bnode3, FOAF.KNOWS, bnode());
+		conn.add(bnode1, FOAF.KNOWS, bnode());
 
 		String query = "SELECT ?a WHERE { ?a ?b ?c } GROUP BY ?a HAVING( (COUNT(?c) > 1 ) && ( COUNT(?c)  != 0 ) ) ";
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
 			List<BindingSet> collect = QueryResults.asList(result);
-			assertEquals(2, collect.size());
+			assertThat(collect).hasSize(2);
 		}
 	}
 
@@ -341,12 +331,12 @@ public class AggregateTest extends AbstractComplianceTest {
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
 			List<BindingSet> collect = QueryResults.asList(result);
 			int i = 0;
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(30.11), collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(new BigDecimal("89.4786576482391284723864721567342354783275234")),
-					collect.get(i++).getValue("aggregate"));
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal(30.11));
+			assertThat(collect.get(i++).getValue("aggregate"))
+					.isEqualTo(literal(new BigDecimal("89.4786576482391284723864721567342354783275234")));
 
 		}
 
@@ -360,12 +350,12 @@ public class AggregateTest extends AbstractComplianceTest {
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
 			List<BindingSet> collect = QueryResults.asList(result);
 			int i = 0;
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(30.11), collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(new BigDecimal("55.4786576482391284723864721567342354783275234")),
-					collect.get(i++).getValue("aggregate"));
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal(30.11));
+			assertThat(collect.get(i++).getValue("aggregate"))
+					.isEqualTo(literal(new BigDecimal("55.4786576482391284723864721567342354783275234")));
 		}
 
 	}
@@ -378,14 +368,13 @@ public class AggregateTest extends AbstractComplianceTest {
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
 			List<BindingSet> collect = QueryResults.asList(result);
 			int i = 0;
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(15.055), collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(new BigDecimal("17.89573152964782569447729443134684709566550468")),
-					collect.get(i++).getValue("aggregate"));
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal(15.055));
+			assertThat(collect.get(i++).getValue("aggregate"))
+					.isEqualTo(literal(new BigDecimal("17.89573152964782569447729443134684709566550468")));
 		}
-
 	}
 
 	@Test
@@ -396,14 +385,14 @@ public class AggregateTest extends AbstractComplianceTest {
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
 			List<BindingSet> collect = QueryResults.asList(result);
 			int i = 0;
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertNull(collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(15.055), collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(new BigDecimal("18.492885882746376157462157")),
-					collect.get(i++).getValue("aggregate"));
-		}
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
+			assertThat(collect.get(i++).getValue("aggregate")).isNull();
 
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal(15.055));
+			assertThat(collect.get(i++).getValue("aggregate"))
+					.isEqualTo(literal(new BigDecimal("18.492885882746376157462157")));
+		}
 	}
 
 	@Test
@@ -414,13 +403,13 @@ public class AggregateTest extends AbstractComplianceTest {
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
 			List<BindingSet> collect = QueryResults.asList(result);
 			int i = 0;
-			assertEquals(Values.literal(new BigDecimal("19.4786576482391284723864721567342354783275234")),
-					collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(23), collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(23), collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal("2022-01-01T01:01:01.000000001Z", CoreDatatype.XSD.DATETIME),
-					collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal("3"), collect.get(i++).getValue("aggregate"));
+			assertThat(collect.get(i++).getValue("aggregate"))
+					.isEqualTo(literal(new BigDecimal("19.4786576482391284723864721567342354783275234")));
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal(23));
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal(23));
+			assertThat(collect.get(i++).getValue("aggregate"))
+					.isEqualTo(literal("2022-01-01T01:01:01.000000001Z", CoreDatatype.XSD.DATETIME));
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal("3"));
 		}
 
 	}
@@ -433,22 +422,21 @@ public class AggregateTest extends AbstractComplianceTest {
 		try (TupleQueryResult result = conn.prepareTupleQuery(QueryLanguage.SPARQL, query).evaluate()) {
 			List<BindingSet> collect = QueryResults.asList(result);
 			int i = 0;
-			assertEquals(Values.literal(new BigDecimal("19.4786576482391284723864721567342354783275234")),
-					collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(23), collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal(23), collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal("2022-01-01T01:01:01.000000001Z", CoreDatatype.XSD.DATETIME),
-					collect.get(i++).getValue("aggregate"));
-			assertEquals(Values.literal("3"), collect.get(i++).getValue("aggregate"));
+			assertThat(collect.get(i++).getValue("aggregate"))
+					.isEqualTo(literal(new BigDecimal("19.4786576482391284723864721567342354783275234")));
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal(23));
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal(23));
+			assertThat(collect.get(i++).getValue("aggregate"))
+					.isEqualTo(literal("2022-01-01T01:01:01.000000001Z", CoreDatatype.XSD.DATETIME));
+			assertThat(collect.get(i++).getValue("aggregate")).isEqualTo(literal("3"));
 		}
-
 	}
 
 	/**
 	 * @see https://github.com/eclipse/rdf4j/issues/4290
 	 */
 	@Test
-	public void testCountOrderBy() {
+	public void testCountOrderBy_ImplicitGroup() {
 		mixedDataForNumericAggregates();
 
 		String query = "select (count(*) as ?c) where { \n"
@@ -456,48 +444,49 @@ public class AggregateTest extends AbstractComplianceTest {
 				+ "} \n"
 				+ "order by (?s)";
 
-		try (var result = conn.prepareTupleQuery(query).evaluate()) {
-			assertThat(result).hasSize(1);
+		TupleQuery preparedQuery = conn.prepareTupleQuery(query);
 
-			BindingSet bs = result.next();
-			assertThat(bs.size()).isEqualTo(1);
-			assertThat(Literals.getIntValue(bs.getValue("c"), 0)).isEqualTo(19);
-		}
+		List<BindingSet> result = QueryResults.asList(preparedQuery.evaluate());
+		assertThat(result).hasSize(1);
+
+		BindingSet bs = result.get(0);
+		assertThat(bs.size()).isEqualTo(1);
+		assertThat(getIntValue(bs.getValue("c"), 0)).isEqualTo(19);
 	}
 
 	// private methods
 
 	private void mixedDataForNumericAggregates() {
-		IRI node1 = Values.iri("http://example.com/1");
-		IRI node2 = Values.iri("http://example.com/2");
-		IRI node3 = Values.iri("http://example.com/3");
-		IRI node4 = Values.iri("http://example.com/4");
-		IRI node5 = Values.iri("http://example.com/5");
+		IRI node1 = iri("http://example.com/1");
+		IRI node2 = iri("http://example.com/2");
+		IRI node3 = iri("http://example.com/3");
+		IRI node4 = iri("http://example.com/4");
+		IRI node5 = iri("http://example.com/5");
 
-		conn.add(node3, FOAF.AGE, Values.bnode());
-		conn.add(node1, FOAF.AGE, Values.literal("3"));
-		conn.add(node1, FOAF.AGE, Values.literal(5));
-		conn.add(node2, FOAF.AGE, Values.literal(7.11));
-		conn.add(node3, FOAF.AGE, Values.literal(13));
-		conn.add(node3, FOAF.AGE, Values.literal(17));
-		conn.add(node1, FOAF.AGE, Values.literal(19));
-		conn.add(node2, FOAF.AGE, Values.literal(23));
+		conn.add(node3, FOAF.AGE, bnode());
+		conn.add(node1, FOAF.AGE, literal("3"));
+		conn.add(node1, FOAF.AGE, literal(5));
+		conn.add(node2, FOAF.AGE, literal(7.11));
+		conn.add(node3, FOAF.AGE, literal(13));
+		conn.add(node3, FOAF.AGE, literal(17));
+		conn.add(node1, FOAF.AGE, literal(19));
+		conn.add(node2, FOAF.AGE, literal(23));
 
-		conn.add(node4, FOAF.AGE, Values.literal(19));
-		conn.add(node4, FOAF.AGE, Values.literal(ZonedDateTime.of(2022, 01, 01, 01, 01, 01, 01, ZoneId.of("UTC"))));
+		conn.add(node4, FOAF.AGE, literal(19));
+		conn.add(node4, FOAF.AGE, literal(ZonedDateTime.of(2022, 01, 01, 01, 01, 01, 01, ZoneId.of("UTC"))));
 
-		conn.add(node1, FOAF.AGE, Values.literal(23));
-		conn.add(node2, FOAF.AGE, Values.literal(23));
-		conn.add(node3, FOAF.AGE, Values.literal(23));
-		conn.add(node4, FOAF.AGE, Values.literal(23));
+		conn.add(node1, FOAF.AGE, literal(23));
+		conn.add(node2, FOAF.AGE, literal(23));
+		conn.add(node3, FOAF.AGE, literal(23));
+		conn.add(node4, FOAF.AGE, literal(23));
 
 		conn.add(node3, FOAF.KNOWS, node1);
 
-		conn.add(node5, FOAF.AGE, Values.literal(17));
-		conn.add(node5, FOAF.PHONE, Values.literal(17));
-		conn.add(node5, FOAF.DNA_CHECKSUM, Values.literal(17));
-		conn.add(node5, FOAF.DNA_CHECKSUM, Values.literal(19));
-		conn.add(node5, FOAF.PHONE, Values.literal(new BigDecimal("19.4786576482391284723864721567342354783275234")));
+		conn.add(node5, FOAF.AGE, literal(17));
+		conn.add(node5, FOAF.PHONE, literal(17));
+		conn.add(node5, FOAF.DNA_CHECKSUM, literal(17));
+		conn.add(node5, FOAF.DNA_CHECKSUM, literal(19));
+		conn.add(node5, FOAF.PHONE, literal(new BigDecimal("19.4786576482391284723864721567342354783275234")));
 	}
 
 	private int countCharOccurrences(String string, char ch) {

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
@@ -29,6 +29,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
+import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -442,6 +443,29 @@ public class AggregateTest extends AbstractComplianceTest {
 		}
 
 	}
+
+	/**
+	 * @see https://github.com/eclipse/rdf4j/issues/4290
+	 */
+	@Test
+	public void testCountOrderBy() {
+		mixedDataForNumericAggregates();
+
+		String query = "select (count(*) as ?c) where { \n"
+				+ "	?s ?p ?o .\n"
+				+ "} \n"
+				+ "order by (?s)";
+
+		try (var result = conn.prepareTupleQuery(query).evaluate()) {
+			assertThat(result).hasSize(1);
+
+			BindingSet bs = result.next();
+			assertThat(bs.size()).isEqualTo(1);
+			assertThat(Literals.getIntValue(bs.getValue("c"), 0)).isEqualTo(19);
+		}
+	}
+
+	// private methods
 
 	private void mixedDataForNumericAggregates() {
 		IRI node1 = Values.iri("http://example.com/1");


### PR DESCRIPTION
GitHub issue resolved: #4290  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- the logic to reorder extensions for SELECT expressions and the order clause now takes into account that a new implicit group node may have been introduced
- added regression test
- rewrote all tests in AggregateTest to use AssertJ.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

