### PR TITLE
GH-4333: move 'since' info into 'Deprecated' annotation

### DIFF
--- a/core/common/io/src/main/java/org/eclipse/rdf4j/common/net/ParsedURI.java
+++ b/core/common/io/src/main/java/org/eclipse/rdf4j/common/net/ParsedURI.java
@@ -22,7 +22,7 @@ import java.util.StringTokenizer;
  *
  * @deprecated use {@link ParsedIRI} instead
  */
-@Deprecated
+@Deprecated(since = "2.3")
 public class ParsedURI implements java.lang.Cloneable {
 
 	/*

--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/IterationWrapper.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/IterationWrapper.java
@@ -30,7 +30,7 @@ public class IterationWrapper<E, X extends Exception> extends AbstractCloseableI
 	 *
 	 * @deprecated This will be changed to private, possibly with an accessor in future. Do not rely on it.
 	 */
-	@Deprecated
+	@Deprecated(since = "4.1.0")
 	protected final Iteration<? extends E, ? extends X> wrappedIter;
 
 	/*--------------*

--- a/core/common/text/src/main/java/org/eclipse/rdf4j/common/text/StringUtil.java
+++ b/core/common/text/src/main/java/org/eclipse/rdf4j/common/text/StringUtil.java
@@ -34,7 +34,7 @@ public class StringUtil {
 	 * @return The result String containing the substitutions; if no substitutions were made, the result is 'text'.
 	 * @deprecated use {@link String#replace(CharSequence, CharSequence) instead}.
 	 */
-	@Deprecated
+	@Deprecated(since = "4.0.0")
 	public static String gsub(String olds, String news, String text) {
 		if (olds == null || olds.length() == 0) {
 			// Nothing to substitute.

--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
@@ -122,9 +122,9 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 	private long pingDelay = PINGDELAY;
 
 	/**
-	 * @deprecated since 3.6.2 - use {@link #RDF4JProtocolSession(HttpClient, ExecutorService)} instead
+	 * @deprecated Use {@link #RDF4JProtocolSession(HttpClient, ExecutorService)} instead
 	 */
-	@Deprecated
+	@Deprecated(since = "3.6.2")
 	public RDF4JProtocolSession(HttpClient client, ScheduledExecutorService executor) {
 		this(client, (ExecutorService) executor);
 	}
@@ -844,7 +844,7 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 	 * @throws UnauthorizedException
 	 * @deprecated since 2.8.0
 	 */
-	@Deprecated
+	@Deprecated(since = "2.8.0")
 	public void sendTransaction(final Iterable<? extends TransactionOperation> txn)
 			throws IOException, RepositoryException, UnauthorizedException {
 		checkRepositoryURL();

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/Protocol.java
@@ -212,9 +212,9 @@ public abstract class Protocol {
 	 * Parameter name for the isolation level used in transactions.
 	 *
 	 * @see #TRANSACTION_SETTINGS_PREFIX
-	 * @deprecated since 3.3.0. Use <code>transaction-setting__isolation-level</code> instead.
+	 * @deprecated Use <code>transaction-setting__isolation-level</code> instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.3.0")
 	public static final String ISOLATION_LEVEL_PARAM_NAME = "isolation-level";
 
 	/**

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Literals.java
@@ -387,9 +387,9 @@ public class Literals {
 	 * @param object       an object to be converted to a typed literal.
 	 * @return a typed literal representation of the supplied object.
 	 * @throws NullPointerException If the object was null.
-	 * @deprecated since 3.5.0 - use {@link Values#literal(Object)} instead.
+	 * @deprecated Use {@link Values#literal(Object)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.5.0")
 	public static Literal createLiteral(ValueFactory valueFactory, Object object) {
 		try {
 			return createLiteral(valueFactory, object, false);
@@ -410,9 +410,9 @@ public class Literals {
 	 * @return a typed literal representation of the supplied object.
 	 * @throws LiteralUtilException If the literal could not be created.
 	 * @throws NullPointerException If the object was null.
-	 * @deprecated since 3.5.0 - use {@link Values#literal(Object, boolean)} instead.
+	 * @deprecated Use {@link Values#literal(Object, boolean)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.5.0")
 	public static Literal createLiteralOrFail(ValueFactory valueFactory, Object object) throws LiteralUtilException {
 		return createLiteral(valueFactory, object, true);
 	}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Models.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Models.java
@@ -734,10 +734,10 @@ public class Models {
 	 *           {@link #isomorphic(Iterable, Iterable)} implementation.
 	 * @see #isomorphic(Iterable, Iterable)
 	 * @since 3.6.0
-	 * @deprecated since 3.6.0 - use {@link #isomorphic(Iterable, Iterable)} instead.
+	 * @deprecated Use {@link #isomorphic(Iterable, Iterable)} instead.
 	 */
 	@Experimental
-	@Deprecated
+	@Deprecated(since = "3.6.0")
 	public static boolean legacyIsomorphic(Iterable<? extends Statement> model1, Iterable<? extends Statement> model2) {
 		if (model1 == model2) {
 			return true;

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Statements.java
@@ -130,9 +130,9 @@ public class Statements {
 	 * @param statement a statement to convert to an RDF-star triple
 	 * @return an {@link Triple RDF-star triple} with the same subject, predicate and object as the input statement.
 	 * @since 3.4.0
-	 * @deprecated since 3.5.0 - use {@link Values#triple(Statement)} instead
+	 * @deprecated Use {@link Values#triple(Statement)} instead
 	 */
-	@Deprecated
+	@Deprecated(since = "3.5.0")
 	public static Triple toTriple(Statement statement) {
 		return toTriple(SimpleValueFactory.getInstance(), statement);
 	}
@@ -144,9 +144,9 @@ public class Statements {
 	 * @param statement a statement to convert to an RDF-star triple
 	 * @return an {@link Triple RDF-star triple} with the same subject, predicate and object as the input statement.
 	 * @since 3.4.0
-	 * @deprecated since 3.5.0 - use {@link Values#triple(ValueFactory, Statement)} instead
+	 * @deprecated Use {@link Values#triple(ValueFactory, Statement)} instead
 	 */
-	@Deprecated
+	@Deprecated(since = "3.5.0")
 	public static Triple toTriple(ValueFactory vf, Statement statement) {
 		return vf.createTriple(statement.getSubject(), statement.getPredicate(), statement.getObject());
 	}

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/Query.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/Query.java
@@ -52,9 +52,9 @@ public interface Query extends Operation {
 	 *
 	 * @param maxQueryTime The maximum query time, measured in seconds. A negative or zero value indicates an unlimited
 	 *                     query time (which is the default).
-	 * @deprecated since 2.0. Use {@link Operation#setMaxExecutionTime(int)} instead.
+	 * @deprecated Use {@link Operation#setMaxExecutionTime(int)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	void setMaxQueryTime(int maxQueryTime);
 
 	/**
@@ -62,9 +62,9 @@ public interface Query extends Operation {
 	 *
 	 * @return The maximum query evaluation time, measured in seconds.
 	 * @see #setMaxQueryTime(int)
-	 * @deprecated since 2.0. Use {@link Operation#getMaxExecutionTime()} instead.
+	 * @deprecated Use {@link Operation#getMaxExecutionTime()} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	int getMaxQueryTime();
 
 	/**

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResultUtil.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/QueryResultUtil.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link QueryResults} instead.
+ * @deprecated Use {@link QueryResults} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public class QueryResultUtil extends QueryResults {
 
 }

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/TupleQueryResultHandlerBase.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/TupleQueryResultHandlerBase.java
@@ -14,7 +14,7 @@ package org.eclipse.rdf4j.query;
  * @author Jeen Broekstra
  * @deprecated since 2.0. Use {@link AbstractTupleQueryResultHandler} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public class TupleQueryResultHandlerBase extends AbstractTupleQueryResultHandler {
 
 }

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/BindingImpl.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/BindingImpl.java
@@ -14,9 +14,9 @@ import org.eclipse.rdf4j.model.Value;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link SimpleBinding} instead.
+ * @deprecated Use {@link SimpleBinding} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public class BindingImpl extends SimpleBinding {
 
 	private static final long serialVersionUID = 1L;

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/DatasetImpl.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/DatasetImpl.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query.impl;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link SimpleDataset} instead.
+ * @deprecated Use {@link SimpleDataset} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public class DatasetImpl extends SimpleDataset {
 
 	private static final long serialVersionUID = 1L;

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/GraphQueryResultImpl.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/GraphQueryResultImpl.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
  * @author Jeen Broekstra
  * @deprecated since 2.0. Use {@link IteratingGraphQueryResult} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public class GraphQueryResultImpl extends IteratingGraphQueryResult {
 
 	public GraphQueryResultImpl(Map<String, String> namespaces,

--- a/core/query/src/main/java/org/eclipse/rdf4j/query/impl/TupleQueryResultImpl.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/impl/TupleQueryResultImpl.java
@@ -18,9 +18,9 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link IteratingTupleQueryResult} instead.
+ * @deprecated Use {@link IteratingTupleQueryResult} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public class TupleQueryResultImpl extends IteratingTupleQueryResult {
 
 	public TupleQueryResultImpl(List<String> bindingNames,

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/FederatedServiceResolverBase.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/FederatedServiceResolverBase.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query.algebra.evaluation.federation;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 4.0. Use {@link AbstractFederatedServiceResolver} instead.
+ * @deprecated Use {@link AbstractFederatedServiceResolver} instead.
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public abstract class FederatedServiceResolverBase extends AbstractFederatedServiceResolver {
 
 }

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/JoinExecutorBase.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/JoinExecutorBase.java
@@ -22,9 +22,9 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
  * is synchronized).
  *
  * @author Andreas Schwarte
- * @deprecated since 2.3 use {@link org.eclipse.rdf4j.repository.sparql.federation.JoinExecutorBase}
+ * @deprecated Use {@link org.eclipse.rdf4j.repository.sparql.federation.JoinExecutorBase}
  */
-@Deprecated
+@Deprecated(since = "2.3")
 public abstract class JoinExecutorBase<T> extends org.eclipse.rdf4j.repository.sparql.federation.JoinExecutorBase<T> {
 
 	public JoinExecutorBase(CloseableIteration<T, QueryEvaluationException> leftIter, TupleExpr rightArg,

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/RepositoryFederatedService.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/RepositoryFederatedService.java
@@ -16,9 +16,9 @@ import org.eclipse.rdf4j.repository.Repository;
  * Federated Service wrapping the {@link Repository} to communicate with a SPARQL endpoint.
  *
  * @author Andreas Schwarte
- * @deprecated since 2.3 use {@link org.eclipse.rdf4j.repository.sparql.federation.RepositoryFederatedService}
+ * @deprecated Use {@link org.eclipse.rdf4j.repository.sparql.federation.RepositoryFederatedService}
  */
-@Deprecated
+@Deprecated(since = "2.3")
 public class RepositoryFederatedService
 		extends org.eclipse.rdf4j.repository.sparql.federation.RepositoryFederatedService {
 

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/SPARQLFederatedService.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/federation/SPARQLFederatedService.java
@@ -17,9 +17,9 @@ import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
  * Federated Service wrapping the {@link SPARQLRepository} to communicate with a SPARQL endpoint.
  *
  * @author Andreas Schwarte
- * @deprecated since 2.3 use {@link org.eclipse.rdf4j.repository.sparql.federation.SPARQLFederatedService}
+ * @deprecated Use {@link org.eclipse.rdf4j.repository.sparql.federation.SPARQLFederatedService}
  */
-@Deprecated
+@Deprecated(since = "2.3")
 public class SPARQLFederatedService extends org.eclipse.rdf4j.repository.sparql.federation.SPARQLFederatedService {
 
 	public SPARQLFederatedService(String serviceUrl, HttpClientSessionManager client) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStrategyImpl.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/EvaluationStrategyImpl.java
@@ -16,9 +16,9 @@ import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceRes
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 4.0. Use {@link StrictEvaluationStrategy} instead.
+ * @deprecated Use {@link StrictEvaluationStrategy} instead.
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public class EvaluationStrategyImpl extends StrictEvaluationStrategy {
 
 	public EvaluationStrategyImpl(TripleSource tripleSource, Dataset dataset,

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
@@ -31,7 +31,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.util.XMLDatatypeMathUtil;
  * comparison and mathematical operators to the minimally-conforming {@link StrictEvaluationStrategy}.
  *
  * @author Jeen Broekstra
- * @deprecated since 4.3.0. Use {@link DefaultEvaluationStrategy} instead.
+ * @deprecated Use {@link DefaultEvaluationStrategy} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ExtendedEvaluationStrategy extends TupleFunctionEvaluationStrategy {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/SilentIteration.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/SilentIteration.java
@@ -19,9 +19,9 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
  * Wrap an inner iteration and suppress exceptions silently
  *
  * @author Andreas Schwarte
- * @deprecated since 3.1.2. Use {@link org.eclipse.rdf4j.common.iteration.SilentIteration } instead.
+ * @deprecated Use {@link org.eclipse.rdf4j.common.iteration.SilentIteration } instead.
  */
-@Deprecated
+@Deprecated(since = "3.1.2")
 @InternalUseOnly
 public class SilentIteration
 		extends org.eclipse.rdf4j.common.iteration.SilentIteration<BindingSet, QueryEvaluationException> {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/Statements.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/Statements.java
@@ -14,7 +14,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.util;
 /**
  * @deprecated since 2.0. Use {@link TripleSources} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public final class Statements extends TripleSources {
 
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AggregateOperatorBase.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/AggregateOperatorBase.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query.algebra;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link AbstractAggregateOperator} instead.
+ * @deprecated Use {@link AbstractAggregateOperator} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public abstract class AggregateOperatorBase extends AbstractAggregateOperator {
 
 	private static final long serialVersionUID = 1L;

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/GraphPatternGroupable.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/GraphPatternGroupable.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query.algebra;
 
 /**
  * @author jeen
- * @deprecated since 3.2. Use {@link VariableScopeChange} instead.
+ * @deprecated Use {@link VariableScopeChange} instead.
  */
-@Deprecated
+@Deprecated(since = "3.2")
 public interface GraphPatternGroupable {
 
 	/**

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Join.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/Join.java
@@ -40,9 +40,9 @@ public class Join extends BinaryTupleOperator {
 
 	/**
 	 * @return <code>true</code> if the right argument of this Join contains a projection, <code>false</code> otherwise.
-	 * @deprecated since 2.0. Use {@link TupleExprs#containsProjection(TupleExpr)} instead.
+	 * @deprecated Use {@link TupleExprs#containsProjection(TupleExpr)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	public boolean hasSubSelectInRightArg() {
 		return TupleExprs.containsSubquery(rightArg);
 	}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNodeBase.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/QueryModelNodeBase.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query.algebra;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link AbstractQueryModelNode} instead.
+ * @deprecated Use {@link AbstractQueryModelNode} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public abstract class QueryModelNodeBase extends AbstractQueryModelNode {
 
 	private static final long serialVersionUID = 1L;

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelVisitorBase.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelVisitorBase.java
@@ -14,7 +14,7 @@ package org.eclipse.rdf4j.query.algebra.helpers;
  * @author Jeen Broekstra
  * @deprecated since 2.0. Use {@link AbstractQueryModelVisitor} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public abstract class QueryModelVisitorBase<X extends Exception> extends AbstractQueryModelVisitor<X> {
 
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprs.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprs.java
@@ -134,9 +134,9 @@ public class TupleExprs {
 	 * @param expr a {@link TupleExpr}
 	 * @return <code>true</code> if the {@link TupleExpr} is {@link GraphPatternGroupable} and has its graph pattern
 	 *         group flag set to <code>true</code>, <code>false</code> otherwise.
-	 * @deprecated since 3.2. Use {@link #isVariableScopeChange(TupleExpr)} instead.
+	 * @deprecated Use {@link #isVariableScopeChange(TupleExpr)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.2")
 	public static boolean isGraphPatternGroup(TupleExpr expr) {
 		if (expr instanceof GraphPatternGroupable) {
 			return ((GraphPatternGroupable) expr).isGraphPatternGroup();
@@ -151,9 +151,9 @@ public class TupleExprs {
 	 * @param t a tuple expression.
 	 * @return <code>true</code> if the TupleExpr contains a projection (outside of a Join), <code>false</code>
 	 *         otherwise.
-	 * @deprecated since 2.0. Use {@link #containsSubquery(TupleExpr)} instead.
+	 * @deprecated Use {@link #containsSubquery(TupleExpr)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	public static boolean containsProjection(TupleExpr t) {
 		Deque<TupleExpr> queue = new ArrayDeque<>();
 		queue.add(t);

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ASTVisitorBase.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/ASTVisitorBase.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query.parser.sparql;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link AbstractASTVisitor} instead.
+ * @deprecated Use {@link AbstractASTVisitor} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public abstract class ASTVisitorBase extends AbstractASTVisitor {
 
 }

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUtil.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUtil.java
@@ -16,13 +16,13 @@ package org.eclipse.rdf4j.query.parser.sparql;
  * @author Arjohn Kampman
  * @deprecated since 3.6.0 Use {@link SPARQLQueries} instead.
  */
-@Deprecated
+@Deprecated(since = "3.6.0")
 public class SPARQLUtil extends SPARQLQueries {
 
 	/**
 	 * @deprecated since 3.6.0. Use {@link SPARQLQueries#escape(String)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.6.0")
 	public static String encodeString(String string) {
 		return escape(string);
 	}
@@ -30,7 +30,7 @@ public class SPARQLUtil extends SPARQLQueries {
 	/**
 	 * @deprecated since 3.6.0. Use {@link SPARQLQueries#unescape(String)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.6.0")
 	public static String decodeString(String string) {
 		return unescape(string);
 	}

--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/WildcardProjectionProcessor.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/WildcardProjectionProcessor.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.query.parser.sparql;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTBind;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTConstraint;
@@ -35,10 +36,11 @@ import org.eclipse.rdf4j.query.parser.sparql.ast.VisitorException;
  *
  * @author arjohn
  * @author Jeen Broekstra
- * @deprecated since 3.0. This feature is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @deprecated This feature is for internal use only: its existence, signature or behavior may change without warning
+ *             from one release to the next.
  */
-@Deprecated
+@Deprecated(since = "3.0")
+@InternalUseOnly
 public class WildcardProjectionProcessor extends AbstractASTVisitor {
 
 	public static void process(ASTOperationContainer container) throws MalformedQueryException {

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONParserBase.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONParserBase.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link AbstractSPARQLJSONParser} instead.
+ * @deprecated Use {@link AbstractSPARQLJSONParser} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public abstract class SPARQLJSONParserBase extends AbstractSPARQLJSONParser {
 
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONParser.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONParser.java
@@ -11,9 +11,9 @@
 package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
 
 /**
- * @deprecated since 3.4.0 - moved to {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParser}
+ * @deprecated moved to {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParser}
  */
-@Deprecated
+@Deprecated(since = "3.4.0")
 public class SPARQLStarResultsJSONParser
 		extends org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParser {
 

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONParserFactory.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONParserFactory.java
@@ -11,10 +11,9 @@
 package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
 
 /**
- * @deprecated since 3.4.0 - moved to
- *             {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParserFactory}
+ * @deprecated Moved to {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParserFactory}
  */
-@Deprecated
+@Deprecated(since = "3.4.0")
 public class SPARQLStarResultsJSONParserFactory
 		extends org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONParserFactory {
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONWriter.java
@@ -13,9 +13,9 @@ package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
 import java.io.OutputStream;
 
 /**
- * @deprecated since 3.4.0 - moved to {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriter}
+ * @deprecated Moved to {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriter}
  */
-@Deprecated
+@Deprecated(since = "3.4.0")
 public class SPARQLStarResultsJSONWriter
 		extends org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriter {
 

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONWriterFactory.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlstarjson/SPARQLStarResultsJSONWriterFactory.java
@@ -11,10 +11,9 @@
 package org.eclipse.rdf4j.query.resultio.sparqlstarjson;
 
 /**
- * @deprecated since 3.4.0 - moved to
- *             {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriterFactory}
+ * @deprecated Moved to {@link org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriterFactory}
  */
-@Deprecated
+@Deprecated(since = "3.4.0")
 public class SPARQLStarResultsJSONWriterFactory
 		extends org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLStarResultsJSONWriterFactory {
 }

--- a/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLParserBase.java
+++ b/core/queryresultio/sparqlxml/src/main/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLParserBase.java
@@ -12,9 +12,9 @@ package org.eclipse.rdf4j.query.resultio.sparqlxml;
 
 /**
  * @author Jeen Broekstra
- * @deprecated since 2.0. Use {@link AbstractSPARQLXMLParser} instead.
+ * @deprecated Use {@link AbstractSPARQLXMLParser} instead.
  */
-@Deprecated
+@Deprecated(since = "2.0")
 public abstract class SPARQLXMLParserBase extends AbstractSPARQLXMLParser {
 
 }

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVMappingStrategy.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVMappingStrategy.java
@@ -17,9 +17,9 @@ import org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVMappingStrategy
  * Extends {@link SPARQLResultsTSVMappingStrategy} with support for parsing a {@link org.eclipse.rdf4j.model.Triple}.
  *
  * @author Pavel Mihaylov
- * @deprecated since 3.4.0 - functionality has been folded into {@link SPARQLResultsTSVMappingStrategy}
+ * @deprecated Functionality has been folded into {@link SPARQLResultsTSVMappingStrategy}
  */
-@Deprecated
+@Deprecated(since = "3.4.0")
 public class SPARQLStarResultsTSVMappingStrategy extends SPARQLResultsTSVMappingStrategy {
 	public SPARQLStarResultsTSVMappingStrategy(ValueFactory valueFactory) {
 		super(valueFactory);

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVParser.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVParser.java
@@ -11,8 +11,8 @@
 package org.eclipse.rdf4j.query.resultio.textstar.tsv;
 
 /**
- * @deprecated since 3.4.0 - moved to {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVParser}.
+ * @deprecated Moved to {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVParser}.
  */
-@Deprecated
+@Deprecated(since = "3.4.0")
 public class SPARQLStarResultsTSVParser extends org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVParser {
 }

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVWriter.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVWriter.java
@@ -13,9 +13,9 @@ package org.eclipse.rdf4j.query.resultio.textstar.tsv;
 import java.io.OutputStream;
 
 /**
- * @deprecated since 3.4.0 - moved to {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriter}.
+ * @deprecated Moved to {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriter}.
  */
-@Deprecated
+@Deprecated(since = "3.4.0")
 public class SPARQLStarResultsTSVWriter extends org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriter {
 
 	public SPARQLStarResultsTSVWriter(OutputStream out) {

--- a/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVWriterFactory.java
+++ b/core/queryresultio/text/src/main/java/org/eclipse/rdf4j/query/resultio/textstar/tsv/SPARQLStarResultsTSVWriterFactory.java
@@ -11,10 +11,9 @@
 package org.eclipse.rdf4j.query.resultio.textstar.tsv;
 
 /**
- * @deprecated since 3.4.0 - moved to
- *             {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriterFactory}.
+ * @deprecated Moved to {@link org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriterFactory}.
  */
-@Deprecated
+@Deprecated(since = "3.4.0")
 public class SPARQLStarResultsTSVWriterFactory
 		extends org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLStarResultsTSVWriterFactory {
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/RepositoryConnection.java
@@ -503,9 +503,9 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * @throws RepositoryException In case the mode switch failed, for example because a currently active transaction
 	 *                             failed to commit.
 	 * @see #commit()
-	 * @deprecated As of release 2.7.0, use {@link #begin()} instead.
+	 * @deprecated Use {@link #begin()} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.7.0")
 	void setAutoCommit(boolean autoCommit) throws RepositoryException;
 
 	/**
@@ -517,9 +517,9 @@ public interface RepositoryConnection extends AutoCloseable {
 	 * </ol>
 	 *
 	 * @throws RepositoryException If a repository access error occurs.
-	 * @deprecated since 2.0. Use {@link #isActive()} instead.
+	 * @deprecated Use {@link #isActive()} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	boolean isAutoCommit() throws RepositoryException;
 
 	/**

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/AbstractRepositoryConnection.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/AbstractRepositoryConnection.java
@@ -188,9 +188,9 @@ public abstract class AbstractRepositoryConnection implements RepositoryConnecti
 	}
 
 	/**
-	 * @deprecated since 2.0. Use {@link #begin()} instead.
+	 * @deprecated Use {@link #begin()} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	@Override
 	public void setAutoCommit(boolean autoCommit) throws RepositoryException {
 		if (isActive()) {
@@ -205,9 +205,9 @@ public abstract class AbstractRepositoryConnection implements RepositoryConnecti
 	}
 
 	/**
-	 * @deprecated since 2.0. Use {@link #isActive()} instead.
+	 * @deprecated Use {@link #isActive()} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	@Override
 	public boolean isAutoCommit() throws RepositoryException {
 		return !isActive();

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/RepositoryConnectionWrapper.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/base/RepositoryConnectionWrapper.java
@@ -292,10 +292,10 @@ public class RepositoryConnectionWrapper extends AbstractRepositoryConnection
 	}
 
 	/**
-	 * @deprecated since 2.0. Use {@link #isActive()} instead.
+	 * @deprecated Use {@link #isActive()} instead.
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.0")
 	public boolean isAutoCommit() throws RepositoryException {
 		return getDelegate().isAutoCommit();
 	}

--- a/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/RepositoryConnectionInterceptor.java
+++ b/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/RepositoryConnectionInterceptor.java
@@ -43,9 +43,9 @@ public interface RepositoryConnectionInterceptor {
 	 *                   on.
 	 * @param autoCommit
 	 * @return true if the interceptor has been denied access to the setAutoCommit operation, false otherwise.
-	 * @deprecated since 2.0. Use {@link #begin(RepositoryConnection)} instead.
+	 * @deprecated Use {@link #begin(RepositoryConnection)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	boolean setAutoCommit(RepositoryConnection conn, boolean autoCommit);
 
 	/**

--- a/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/RepositoryConnectionListener.java
+++ b/core/repository/event/src/main/java/org/eclipse/rdf4j/repository/event/RepositoryConnectionListener.java
@@ -29,9 +29,9 @@ public interface RepositoryConnectionListener {
 	/**
 	 * @param conn
 	 * @param autoCommit
-	 * @deprecated since 2.0. Use {@link #begin(RepositoryConnection)} instead.
+	 * @deprecated Use {@link #begin(RepositoryConnection)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	void setAutoCommit(RepositoryConnection conn, boolean autoCommit);
 
 	void begin(RepositoryConnection conn);

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RepositoryManager.java
@@ -444,17 +444,17 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	public abstract Collection<RepositoryInfo> getAllRepositoryInfos() throws RepositoryException;
 
 	/**
-	 * @deprecated since 4.0 - use {@link #getAllRepositoryInfos()} instead.
+	 * @deprecated Use {@link #getAllRepositoryInfos()} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "4.0")
 	public Collection<RepositoryInfo> getAllUserRepositoryInfos() throws RepositoryException {
 		return getAllRepositoryInfos();
 	}
 
 	/**
-	 * @deprecated since 4.0 - use {@link #getAllRepositoryInfos()} instead.
+	 * @deprecated Use {@link #getAllRepositoryInfos()} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "4.0")
 	public Collection<RepositoryInfo> getAllRepositoryInfos(boolean skipSystemRepo) throws RepositoryException {
 		return getAllRepositoryInfos();
 	}

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/RepositoryResolver.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/RepositoryResolver.java
@@ -18,9 +18,9 @@ import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
  * Gets local repositories using a simple identifier string.
  *
  * @author Dale Visser
- * @deprecated since 2.3 use {@link org.eclipse.rdf4j.repository.RepositoryResolver}
+ * @deprecated Use {@link org.eclipse.rdf4j.repository.RepositoryResolver}
  */
-@Deprecated
+@Deprecated(since = "2.3")
 public interface RepositoryResolver extends org.eclipse.rdf4j.repository.RepositoryResolver {
 
 	@Override

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/RepositoryResolverClient.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/RepositoryResolverClient.java
@@ -14,8 +14,8 @@ package org.eclipse.rdf4j.repository.sail.config;
  * Interface used by factory classes that need access to other repositories by their id's.
  *
  * @author Dale Visser
- * @deprecated since 2.3 use {@link org.eclipse.rdf4j.repository.RepositoryResolverClient}
+ * @deprecated Use {@link org.eclipse.rdf4j.repository.RepositoryResolverClient}
  */
-@Deprecated
+@Deprecated(since = "2.3")
 public interface RepositoryResolverClient extends org.eclipse.rdf4j.repository.RepositoryResolverClient {
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SPARQLUpdateDataBlockParser.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SPARQLUpdateDataBlockParser.java
@@ -13,9 +13,9 @@ package org.eclipse.rdf4j.repository.sail.helpers;
 import org.eclipse.rdf4j.model.ValueFactory;
 
 /**
- * @deprecated since 3.2.2. Use {@link org.eclipse.rdf4j.query.parser.sparql.SPARQLUpdateDataBlockParser} instead.
+ * @deprecated Use {@link org.eclipse.rdf4j.query.parser.sparql.SPARQLUpdateDataBlockParser} instead.
  */
-@Deprecated
+@Deprecated(since = "3.2.2")
 public class SPARQLUpdateDataBlockParser extends org.eclipse.rdf4j.query.parser.sparql.SPARQLUpdateDataBlockParser {
 
 	@Deprecated

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnection.java
@@ -173,9 +173,9 @@ public class SPARQLConnection extends AbstractRepositoryConnection implements Ht
 	 *
 	 * @param flag the value to set this to.
 	 * @see https://www.w3.org/TR/sparql11-update/#clear
-	 * @deprecated since 3.6.0 - use {@link #setSilentClear(boolean)} instead.
+	 * @deprecated Use {@link #setSilentClear(boolean)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.6.0")
 	public void enableSilentMode(boolean flag) {
 		setSilentClear(flag);
 	}

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtil.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtil.java
@@ -39,9 +39,9 @@ public class QueryStringUtil {
 	 * @param queryString
 	 * @param bindings
 	 * @return the modified queryString
-	 * @deprecated since 2.0.use {@link #getTupleQueryString(String, BindingSet)}
+	 * @deprecated Use {@link #getTupleQueryString(String, BindingSet)}
 	 */
-	@Deprecated
+	@Deprecated(since = "2.0")
 	public static String getQueryString(String queryString, BindingSet bindings) {
 		return getTupleQueryString(queryString, bindings);
 	}

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/RDFFormat.java
@@ -389,7 +389,7 @@ public class RDFFormat extends FileFormat {
 	 *                           <var>false</var> otherwise.
 	 * @deprecated since 3.2.0
 	 */
-	@Deprecated
+	@Deprecated(since = "3.2.0")
 	public RDFFormat(String name, String mimeType, Charset charset, String fileExtension, boolean supportsNamespaces,
 			boolean supportsContexts) {
 		this(name, mimeType, charset, fileExtension, supportsNamespaces, supportsContexts, NO_RDF_STAR);
@@ -434,7 +434,7 @@ public class RDFFormat extends FileFormat {
 	 *                           <var>false</var> otherwise.
 	 * @deprecated since 3.2.0
 	 */
-	@Deprecated
+	@Deprecated(since = "3.2.0")
 	public RDFFormat(String name, String mimeType, Charset charset, Collection<String> fileExtensions,
 			boolean supportsNamespaces, boolean supportsContexts) {
 		this(name, mimeType, charset, fileExtensions, supportsNamespaces, supportsContexts, NO_RDF_STAR);
@@ -480,7 +480,7 @@ public class RDFFormat extends FileFormat {
 	 *                           <var>false</var> otherwise.
 	 * @deprecated since 3.2.0
 	 */
-	@Deprecated
+	@Deprecated(since = "3.2.0")
 	public RDFFormat(String name, Collection<String> mimeTypes, Charset charset, Collection<String> fileExtensions,
 			boolean supportsNamespaces, boolean supportsContexts) {
 		this(name, mimeTypes, charset, fileExtensions, null, supportsNamespaces, supportsContexts, NO_RDF_STAR);
@@ -529,7 +529,7 @@ public class RDFFormat extends FileFormat {
 	 *                           <var>false</var> otherwise.
 	 * @deprecated since 3.2.0
 	 */
-	@Deprecated
+	@Deprecated(since = "3.2.0")
 	public RDFFormat(String name, Collection<String> mimeTypes, Charset charset, Collection<String> fileExtensions,
 			IRI standardURI, boolean supportsNamespaces, boolean supportsContexts) {
 		this(name, mimeTypes, charset, fileExtensions, standardURI, supportsNamespaces, supportsContexts, NO_RDF_STAR);

--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/ArrangedWriter.java
@@ -46,9 +46,9 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
  *
  * @author James Leigh
  * @since 2.3
- * @deprecated since 3.3.1. pretty printing / bnode inlining logic has been moved to {@link TurtleWriter} internally.
+ * @deprecated Pretty printing / bnode inlining logic has been moved to {@link TurtleWriter} internally.
  */
-@Deprecated
+@Deprecated(since = "3.3.1")
 public class ArrangedWriter extends AbstractRDFWriter {
 
 	private final static int DEFAULT_QUEUE_SIZE = 100;

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
@@ -428,11 +428,11 @@ public abstract class AbstractSailConnection implements SailConnection {
 	 * can use {@link AbstractSailConnection#verifyIsActive()} as a convenience method for this check.
 	 *
 	 * @throws SailException if no transaction is active.
-	 * @deprecated since 2.7.0. Use {@link #verifyIsActive()} instead. We should not automatically start a transaction
-	 *             at the sail level. Instead, an exception should be thrown when an update is executed without first
-	 *             starting a transaction.
+	 * @deprecated Use {@link #verifyIsActive()} instead. We should not automatically start a transaction at the sail
+	 *             level. Instead, an exception should be thrown when an update is executed without first starting a
+	 *             transaction.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.7.0")
 	protected void autoStartTransaction() throws SailException {
 		verifyIsActive();
 	}

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailSink.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/SailSink.java
@@ -134,8 +134,6 @@ public interface SailSink extends SailClosable {
 	/**
 	 * Removes a statement with the specified subject, predicate, object, and context. All four parameters may be
 	 * non-null.
-	 * <p>
-	 * Deprecated since 3.1.0 2019.
 	 *
 	 * @param subj The subject of the statement that should be removed
 	 * @param pred The predicate of the statement that should be removed
@@ -143,7 +141,7 @@ public interface SailSink extends SailClosable {
 	 * @param ctx  The context from which to remove the statement
 	 * @throws SailException If the statement could not be removed, for example because no transaction is active.
 	 */
-	@Deprecated
+	@Deprecated(since = "3.1.0")
 	default void deprecate(Resource subj, IRI pred, Value obj, Resource ctx) throws SailException {
 		deprecate(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, ctx));
 	}

--- a/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchQuery.java
+++ b/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchQuery.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Iterables;
 /**
  * To be removed, no longer used.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public class ElasticsearchQuery implements SearchQuery {
 
 	private final SearchRequestBuilder request;

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencer.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencer.java
@@ -21,10 +21,10 @@ import org.eclipse.rdf4j.sail.inferencer.InferencerConnection;
  * inferencer can be used to add RDF Schema semantics to any Sail that returns {@link InferencerConnection}s from their
  * {@link Sail#getConnection()} method.
  *
- * @deprecated since 2.5. This inferencer implementation will be phased out. Consider switching to the
+ * @deprecated This inferencer implementation will be phased out. Consider switching to the
  *             {@link SchemaCachingRDFSInferencer} instead.
  */
-@Deprecated
+@Deprecated(since = "2.5")
 public class ForwardChainingRDFSInferencer extends AbstractForwardChainingInferencer {
 	/*--------------*
 	 * Constructors *

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencerConnection.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencerConnection.java
@@ -32,10 +32,10 @@ import org.slf4j.LoggerFactory;
  * inferencer can be used to add RDF Schema semantics to any Sail that returns {@link InferencerConnection}s from their
  * {@link Sail#getConnection()} method.
  *
- * @deprecated since 2.5. This inferencer implementation will be phased out. Consider switching to the
+ * @deprecated This inferencer implementation will be phased out. Consider switching to the
  *             {@link SchemaCachingRDFSInferencer} instead.
  */
-@Deprecated
+@Deprecated(since = "2.5")
 class ForwardChainingRDFSInferencerConnection extends AbstractForwardChainingInferencerConnection {
 
 	static private final Logger logger = LoggerFactory.getLogger(ForwardChainingRDFSInferencerConnection.class);

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailBuffer.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailBuffer.java
@@ -30,10 +30,10 @@ import org.eclipse.rdf4j.model.Value;
  *
  * @author sauermann
  * @author andriy.nikolov
- * @deprecated since 3.0. This feature is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @deprecated This feature is for internal use only: its existence, signature or behavior may change without warning
+ *             from one release to the next.
  */
-@Deprecated
+@Deprecated(since = "3.0")
 @InternalUseOnly
 public class LuceneSailBuffer {
 

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/util/MapOfListMaps.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/util/MapOfListMaps.java
@@ -20,10 +20,10 @@ import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 
 /**
  * @author andriy.nikolov
- * @deprecated since 3.0. This feature is for internal use only: its existence, signature or behavior may change without
- *             warning from one release to the next.
+ * @deprecated This feature is for internal use only: its existence, signature or behavior may change without warning
+ *             from one release to the next.
  */
-@Deprecated
+@Deprecated(since = "3.0")
 @InternalUseOnly
 public class MapOfListMaps<Index1Type, Index2Type, DataType> {
 

--- a/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneDocument.java
+++ b/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneDocument.java
@@ -49,7 +49,7 @@ public class LuceneDocument implements SearchDocument {
 	/**
 	 * To be removed, no longer used.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public LuceneDocument() {
 		this(null);
 	}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TripleStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/TripleStore.java
@@ -740,9 +740,9 @@ class TripleStore implements Closeable {
 	 * @param context The context for the pattern, or <var>-1</var> for a wildcard.
 	 * @return The number of triples that were removed.
 	 * @throws IOException
-	 * @deprecated since 2.5.3. use {@link #removeTriplesByContext(int, int, int, int)} instead.
+	 * @deprecated Use {@link #removeTriplesByContext(int, int, int, int)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.5.3")
 	public int removeTriples(int subj, int pred, int obj, int context) throws IOException {
 		Map<Integer, Long> countPerContext = removeTriplesByContext(subj, pred, obj, context);
 		return (int) countPerContext.values().stream().mapToLong(Long::longValue).sum();
@@ -778,7 +778,7 @@ class TripleStore implements Closeable {
 	 * @throws IOException
 	 * @deprecated since 2.5.3. use {@link #removeTriplesByContext(int, int, int, int, boolean)} instead.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.5.3")
 	public int removeTriples(int subj, int pred, int obj, int context, boolean explicit) throws IOException {
 		Map<Integer, Long> countPerContext = removeTriplesByContext(subj, pred, obj, context, explicit);
 		return (int) countPerContext.values().stream().mapToLong(Long::longValue).sum();

--- a/core/spin/src/main/java/org/eclipse/rdf4j/spin/package-info.java
+++ b/core/spin/src/main/java/org/eclipse/rdf4j/spin/package-info.java
@@ -15,5 +15,5 @@
  *
  * @since 3.1.0 2019
  */
-@Deprecated
+@Deprecated(since = "3.1.0")
 package org.eclipse.rdf4j.spin;

--- a/testsuites/model/src/main/java/org/eclipse/rdf4j/testsuite/model/AbstractModelTest.java
+++ b/testsuites/model/src/main/java/org/eclipse/rdf4j/testsuite/model/AbstractModelTest.java
@@ -11,9 +11,9 @@
 package org.eclipse.rdf4j.testsuite.model;
 
 /**
- * @deprecated since 3.5.0. Use {@link ModelTest} instead.
+ * @deprecated Use {@link ModelTest} instead.
  */
-@Deprecated
+@Deprecated(since = "3.5.0")
 public abstract class AbstractModelTest extends ModelTest {
 
 }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11SyntaxTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQL11SyntaxTest.java
@@ -58,9 +58,9 @@ import junit.framework.TestSuite;
  * A SPARQL 1.1 syntax test, created by reading in a W3C working-group style manifest.
  *
  * @author Jeen Broekstra
- * @deprecated since 3.3.0 Use {@link SPARQL11SyntaxComplianceTest} instead.
+ * @deprecated Use {@link SPARQL11SyntaxComplianceTest} instead.
  */
-@Deprecated
+@Deprecated(since = "3.3.0")
 public abstract class SPARQL11SyntaxTest extends TestCase {
 
 	/*-----------*

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryTest.java
@@ -73,9 +73,9 @@ import junit.framework.TestSuite;
  * A SPARQL query test suite, created by reading in a W3C working-group style manifest.
  *
  * @author Jeen Broekstra
- * @deprecated since 3.3.0. Use {@link SPARQL11QueryComplianceTest} instead.
+ * @deprecated Use {@link SPARQL11QueryComplianceTest} instead.
  */
-@Deprecated
+@Deprecated(since = "3.3.0")
 public abstract class SPARQLQueryTest extends TestCase {
 
 	/*-----------*

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLUpdateConformanceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLUpdateConformanceTest.java
@@ -55,9 +55,9 @@ import junit.framework.TestSuite;
  *
  * @author Jeen Broekstra
  *
- * @deprecated since 3.3.0. Use {@link SPARQL11UpdateComplianceTest} instead.
+ * @deprecated Use {@link SPARQL11UpdateComplianceTest} instead.
  */
-@Deprecated
+@Deprecated(since = "3.3.0")
 public abstract class SPARQLUpdateConformanceTest extends TestCase {
 
 	/*-----------*

--- a/tools/config/src/main/java/org/eclipse/rdf4j/common/app/logging/base/LogConfigurationBase.java
+++ b/tools/config/src/main/java/org/eclipse/rdf4j/common/app/logging/base/LogConfigurationBase.java
@@ -13,10 +13,10 @@ package org.eclipse.rdf4j.common.app.logging.base;
 import java.io.IOException;
 
 /**
- * @deprecated since 4.0. Use {@link AbstractLogConfiguration} instead.
+ * @deprecated Use {@link AbstractLogConfiguration} instead.
  * @author Jeen Broekstra
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public abstract class LogConfigurationBase extends AbstractLogConfiguration {
 
 	/**

--- a/tools/config/src/main/java/org/eclipse/rdf4j/common/logging/base/LogReaderBase.java
+++ b/tools/config/src/main/java/org/eclipse/rdf4j/common/logging/base/LogReaderBase.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.common.logging.base;
 
 /**
- * @deprecated since 4.0. Use {@link AbstractLogReader} instead.
+ * @deprecated Use {@link AbstractLogReader} instead.
  * @author Jeen Broekstra
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public abstract class LogReaderBase extends AbstractLogReader {
 
 }

--- a/tools/config/src/main/java/org/eclipse/rdf4j/common/logging/base/LogRecordBase.java
+++ b/tools/config/src/main/java/org/eclipse/rdf4j/common/logging/base/LogRecordBase.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.common.logging.base;
 
 /**
- * @deprecated since 4.0. Use {@link SimpleLogRecord} instead.
+ * @deprecated Use {@link SimpleLogRecord} instead.
  * @author Jeen Broekstra
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public class LogRecordBase extends SimpleLogRecord {
 
 }

--- a/tools/config/src/main/java/org/eclipse/rdf4j/common/platform/PlatformBase.java
+++ b/tools/config/src/main/java/org/eclipse/rdf4j/common/platform/PlatformBase.java
@@ -14,7 +14,7 @@ package org.eclipse.rdf4j.common.platform;
  * @deprecated since 4.0. Use {@link AbstractPlatform} instead.
  * @author Jeen Broekstra
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public abstract class PlatformBase extends AbstractPlatform {
 
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/TripleSource.java
@@ -87,7 +87,7 @@ public interface TripleSource {
 	 * @Deprecated will be removed in 4.0. Replaced with
 	 *             {@link #getStatements(String, BindingSet, QueryType, QueryInfo)}
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	default CloseableIteration<BindingSet, QueryEvaluationException> getStatements(String preparedQuery,
 			QueryType queryType, QueryInfo queryInfo)
 			throws RepositoryException, MalformedQueryException, QueryEvaluationException {
@@ -194,7 +194,7 @@ public interface TripleSource {
 	 * @return true if a prepared query is to be used preferably, false otherwise
 	 * @deprecated replaced with {@link #usePreparedQuery(StatementPattern, QueryInfo)}, to be removed in 4.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	default boolean usePreparedQuery() {
 		return true;
 	}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ControlledWorkerScheduler.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ControlledWorkerScheduler.java
@@ -54,7 +54,7 @@ public class ControlledWorkerScheduler<T> implements Scheduler<T>, TaskWrapperAw
 	 *
 	 * @deprecated use {@link #ControlledWorkerScheduler(int, String)}. Scheduled to be removed in 4.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public ControlledWorkerScheduler() {
 		this(20, "FedX Worker");
 	}

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/common/webapp/navigation/NavigationNodeBase.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/common/webapp/navigation/NavigationNodeBase.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.common.webapp.navigation;
 
 /**
- * @deprecated since 4.0. Use {@link AbstractNavigationNode} instead.
+ * @deprecated Use {@link AbstractNavigationNode} instead.
  * @author Jeen Broekstra
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public abstract class NavigationNodeBase extends AbstractNavigationNode {
 
 	public NavigationNodeBase(String id) {

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/ActiveTransactionRegistry.java
@@ -44,17 +44,17 @@ public enum ActiveTransactionRegistry {
 	 * Configurable system property {@code rdf4j.server.txn.registry.timeout} for specifying the transaction cache
 	 * timeout (in seconds).
 	 *
-	 * @deprecated since 2.3 use {@link Protocol#CACHE_TIMEOUT_PROPERTY}
+	 * @deprecated Use {@link Protocol#CACHE_TIMEOUT_PROPERTY}
 	 */
-	@Deprecated
+	@Deprecated(since = "2.3")
 	public static final String CACHE_TIMEOUT_PROPERTY = Protocol.TIMEOUT.CACHE_PROPERTY;
 
 	/**
 	 * Default timeout setting for transaction cache entries (in seconds).
 	 *
-	 * @deprecated since 2.3 use {@link Protocol#DEFAULT_TIMEOUT}
+	 * @deprecated Use {@link Protocol#DEFAULT_TIMEOUT}
 	 */
-	@Deprecated
+	@Deprecated(since = "2.3")
 	public final static int DEFAULT_TIMEOUT = Protocol.TIMEOUT.DEFAULT;
 
 	/**

--- a/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/base/BaseRepositoryServlet.java
+++ b/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/base/BaseRepositoryServlet.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.workbench.base;
 
 /**
- * @deprecated since 4.0. Use {@link AbstractRepositoryServlet} instead.
+ * @deprecated Use {@link AbstractRepositoryServlet} instead.
  * @author Jeen Broekstra
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public abstract class BaseRepositoryServlet extends AbstractRepositoryServlet {
 
 }

--- a/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/base/BaseServlet.java
+++ b/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/base/BaseServlet.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.workbench.base;
 
 /**
- * @deprecated since 4.0. Use {@link AbstractServlet} instead.
+ * @deprecated Use {@link AbstractServlet} instead.
  * @author Jeen Broekstra
  */
-@Deprecated
+@Deprecated(since = "4.0")
 public abstract class BaseServlet extends AbstractServlet {
 
 }


### PR DESCRIPTION
Signed-off-by:Bart Hanssens <bart.hanssens@bosa.fgov.be>


GitHub issue resolved: #4333 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
- no code changes, only javadoc changes to include 'since' in annotation based on javadoc

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

