### PR TITLE
GH-4337 assign new issues to new board automatically

### DIFF
--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -1,15 +1,15 @@
-name: Add new issue to Inbox
-on: [issues]
+name: Add new issue to project board
+on: 
+  issues:
+    types:
+      - opened
 jobs:
-  github-actions-automate-projects:
+  add-to-project:
+    name: Add issue to project
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
-    - name: add-new-issues-to-repository-based-project-column
-      uses: docker://takanabe/github-actions-automate-projects:latest
-      if: github.event_name == 'issues' && github.event.action == 'opened'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_PROJECT_URL: https://github.com/eclipse/rdf4j/projects/19
-        GITHUB_PROJECT_COLUMN_NAME: 📥 Inbox
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/eclipse/projects/36
+          github-token: ${{ secrets.GITHUB_TOKEN }}
  


### PR DESCRIPTION
GitHub issue resolved: #4337  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- replace and reconfigure github action to assign new issues to project board
- 
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

