### PR TITLE
GH-3396 upgrade solr and lucene

### DIFF
--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -59,7 +59,23 @@
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpcore</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>${httpcore.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>2.1</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/compliance/solr/solr/cores/embedded/conf/solrconfig.xml
+++ b/compliance/solr/solr/cores/embedded/conf/solrconfig.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-	<luceneMatchVersion>8.5.0</luceneMatchVersion>
+	<luceneMatchVersion>8.9.0</luceneMatchVersion>
 	<dataDir>target/test-data</dataDir>
 	<requestHandler name="/select" class="solr.SearchHandler"/>
 	<requestHandler name="/get" class="solr.RealTimeGetHandler"/>
+	<directoryFactory class="org.apache.solr.core.RAMDirectoryFactory"/>
+	<indexConfig>
+		<lockType>single</lockType>
+	</indexConfig>
 </config>

--- a/core/sail/elasticsearch-store/pom.xml
+++ b/core/sail/elasticsearch-store/pom.xml
@@ -12,6 +12,27 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>elasticsearch-rest-high-level-client</artifactId>
+			<version>${elasticsearch.version}</version>
+			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpcore</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>${httpcore.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>transport</artifactId>
 			<version>${elasticsearch.version}</version>
 			<optional>true</optional>
@@ -43,18 +64,6 @@
 			<artifactId>rdf4j-repository-sail</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.codelibs</groupId>
-			<artifactId>elasticsearch-cluster-runner</artifactId>
-			<version>${elasticsearch.version}.0</version>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -102,6 +111,26 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<id>jdk11-securitymanager</id>
+			<activation>
+				<jdk>11</jdk>
+			</activation>
+			<properties>
+				<java.sec.mgr/>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk-securitymanager</id>
+			<activation>
+				<jdk>[12,)</jdk>
+			</activation>
+			<properties>
+				<java.sec.mgr>-Djava.security.manager=allow</java.sec.mgr>
+			</properties>
+		</profile>
+	</profiles>
 	<build>
 		<plugins>
 			<plugin>
@@ -110,6 +139,43 @@
 				<configuration>
 					<forkCount>0</forkCount>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.github.alexcojocaru</groupId>
+				<artifactId>elasticsearch-maven-plugin</artifactId>
+				<version>6.26</version>
+				<configuration>
+					<version>${elasticsearch.version}</version>
+					<clusterName>test</clusterName>
+					<transportPort>9300</transportPort>
+					<httpPort>9200</httpPort>
+					<environmentVariables>
+						<ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
+						<ES_JAVA_OPTS>${java.sec.mgr}</ES_JAVA_OPTS>
+					</environmentVariables>
+					<instanceCount>1</instanceCount>
+					<instanceSettings>
+						<properties>
+							<ingest.geoip.downloader.enabled>false</ingest.geoip.downloader.enabled>
+						</properties>
+					</instanceSettings>
+				</configuration>
+				<executions>
+					<execution>
+						<id>start-elasticsearch</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>runforked</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>stop-elasticsearch</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStore.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStore.java
@@ -40,10 +40,16 @@ import org.slf4j.LoggerFactory;
  * <p>
  * This is an EXPERIMENTAL feature. Use at your own risk!
  * </p>
- *
+ * <p>
+ * Note that, while RDF4J is licensed under the EDL, several ElasticSearch dependencies are licensed under the Elastic
+ * License or the SSPL, which may have implications for some projects. <br/>
+ * Please consult the ElasticSearch website and Elastic license FAQ for more information.
+ * </p>
  * <p>
  * There is no write-ahead logging, so a failure during a transaction may result in partially persisted changes.
  * </p>
+ *
+ * @see <a href="https://www.elastic.co/licensing/elastic-license/faq">Elastic License FAQ</a>
  *
  * @author Håvard Mikkelsen Ottestad
  */

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/package-info.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/package-info.java
@@ -9,6 +9,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  *******************************************************************************/
 /**
- * Elasticsearch store for string triples
+ * Elasticsearch store for string triples.
+ *
+ * Note that, while RDF4J is licensed under the EDL, several ElasticSearch dependencies are licensed under the Elastic
+ * License or the SSPL, which may have implications for some projects.
+ *
+ * Please consult the ElasticSearch website and license FAQ for more information.
+ *
+ * @see <a href="https://www.elastic.co/licensing/elastic-license/faq">Elastic License FAQ</a>
  */
 package org.eclipse.rdf4j.sail.elasticsearchstore;

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/AbstractElasticsearchStoreIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/AbstractElasticsearchStoreIT.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.elasticsearchstore;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractElasticsearchStoreIT {
+
+	private static final Logger logger = LoggerFactory.getLogger(AbstractElasticsearchStoreIT.class);
+
+	@BeforeAll
+	public static void beforeClass() throws IOException, InterruptedException {
+		TestHelpers.openClient();
+	}
+
+	@AfterAll
+	public static void afterClass() throws IOException {
+		TestHelpers.closeClient();
+	}
+
+	@AfterEach
+	public void after() throws IOException {
+		TestHelpers.getClient().indices().refresh(Requests.refreshRequest("*"), RequestOptions.DEFAULT);
+		printAllDocs();
+		deleteAllIndexes();
+	}
+
+	protected void printAllDocs() throws IOException {
+		for (String index : getIndexes()) {
+			if (!index.equals(".geoip_databases")) {
+				logger.info("INDEX: " + index);
+				SearchResponse res = TestHelpers.getClient()
+						.search(Requests.searchRequest(index), RequestOptions.DEFAULT);
+				SearchHits hits = res.getHits();
+				for (SearchHit hit : hits) {
+					logger.info(" doc " + hit.getSourceAsString());
+				}
+			}
+		}
+	}
+
+	protected void deleteAllIndexes() throws IOException {
+		for (String index : getIndexes()) {
+			if (!index.equals(".geoip_databases")) {
+				logger.info("deleting index: " + index);
+				TestHelpers.getClient().indices().delete(Requests.deleteIndexRequest(index), RequestOptions.DEFAULT);
+			}
+		}
+	}
+
+	protected String[] getIndexes() {
+		Settings settings = Settings.builder().put("cluster.name", TestHelpers.CLUSTER).build();
+		try (TransportClient client = new PreBuiltTransportClient(settings)) {
+			client.addTransportAddress(
+					new TransportAddress(InetAddress.getByName("localhost"), TestHelpers.PORT));
+
+			return client.admin()
+					.indices()
+					.getIndex(new GetIndexRequest())
+					.actionGet()
+					.getIndices();
+		} catch (UnknownHostException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreWalIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreWalIT.java
@@ -13,93 +13,24 @@ package org.eclipse.rdf4j.sail.elasticsearchstore;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.client.Requests;
-import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // Tests transaction failures that the Write-Ahead-Log should be able to recover from
-public class ElasticsearchStoreWalIT {
+public class ElasticsearchStoreWalIT extends AbstractElasticsearchStoreIT {
 
 	private static final Logger logger = LoggerFactory.getLogger(ElasticsearchStoreWalIT.class);
-	private static ElasticsearchClusterRunner runner;
-	private static final SimpleValueFactory vf = SimpleValueFactory.getInstance();
 
-	@TempDir
-	static File installLocation;
-
-	@BeforeAll
-	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-	}
-
-	@AfterAll
-	public static void afterClass() throws IOException {
-		TestHelpers.stopElasticsearch(runner);
-	}
-
-	@AfterEach
-	public void after() throws UnknownHostException {
-		runner.admin().indices().refresh(Requests.refreshRequest("*")).actionGet();
-		deleteAllIndexes();
-
-	}
-
-	@BeforeEach
-	public void before() throws UnknownHostException {
-//		embeddedElastic.refreshIndices();
-//
-//		embeddedElastic.deleteIndices();
-
-	}
-
-	private void deleteAllIndexes() {
-		for (String index : getIndexes()) {
-			logger.info("deleting: " + index);
-			runner.admin().indices().delete(Requests.deleteIndexRequest(index)).actionGet();
-
-		}
-	}
-
-	private String[] getIndexes() {
-
-		Settings settings = Settings.builder().put("cluster.name", TestHelpers.CLUSTER).build();
-		try (TransportClient client = new PreBuiltTransportClient(settings)) {
-			client.addTransportAddress(
-					new TransportAddress(InetAddress.getByName("localhost"), TestHelpers.getPort(runner)));
-
-			return client.admin()
-					.indices()
-					.getIndex(new GetIndexRequest())
-					.actionGet()
-					.getIndices();
-		} catch (UnknownHostException e) {
-			throw new IllegalStateException(e);
-		}
-
-	}
+	/*
+	 * @After public void after() throws IOException { client.indices().refresh(Requests.refreshRequest("*"),
+	 * RequestOptions.DEFAULT); deleteAllIndexes(); }
+	 */
 
 	@Disabled // No WAL implemented yet
 	@Test
@@ -117,7 +48,7 @@ public class ElasticsearchStoreWalIT {
 		assertTrue(transactionFaild);
 
 		SailRepository elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex"));
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex"));
 
 		try (SailRepositoryConnection connection = elasticsearchStore.getConnection()) {
 
@@ -131,7 +62,7 @@ public class ElasticsearchStoreWalIT {
 
 	private void failedTransactionAdd(int count) {
 		ClientProviderWithDebugStats clientProvider = new ClientProviderWithDebugStats("localhost",
-				TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+				TestHelpers.PORT, TestHelpers.CLUSTER);
 
 		ElasticsearchStore es = new ElasticsearchStore(clientProvider, "testindex");
 		SailRepository elasticsearchStore = new SailRepository(es);
@@ -182,7 +113,7 @@ public class ElasticsearchStoreWalIT {
 		assertTrue(transactionFaild);
 
 		SailRepository elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex"));
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex"));
 
 		try (SailRepositoryConnection connection = elasticsearchStore.getConnection()) {
 
@@ -196,7 +127,7 @@ public class ElasticsearchStoreWalIT {
 
 	private void fill(int count) {
 		SailRepository elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex"));
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex"));
 
 		try (SailRepositoryConnection connection = elasticsearchStore.getConnection()) {
 
@@ -212,7 +143,7 @@ public class ElasticsearchStoreWalIT {
 
 	private void failedTransactionRemove() {
 		ClientProviderWithDebugStats clientProvider = new ClientProviderWithDebugStats("localhost",
-				TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+				TestHelpers.PORT, TestHelpers.CLUSTER);
 
 		ElasticsearchStore es = new ElasticsearchStore(clientProvider, "testindex");
 		SailRepository elasticsearchStore = new SailRepository(es);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/TestHelpers.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/TestHelpers.java
@@ -10,49 +10,28 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
-import org.elasticsearch.common.settings.Settings.Builder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 
 public class TestHelpers {
-	public static final String CLUSTER = "cluster1";
+	public static final String CLUSTER = "test";
+	public static final int PORT = 9300;
 
-	private static final Logger logger = LoggerFactory.getLogger(TestHelpers.class);
+	private static RestHighLevelClient CLIENT;
 
-	public static ElasticsearchClusterRunner startElasticsearch(File installLocation)
-			throws IOException, InterruptedException {
-
-		ElasticsearchClusterRunner runner = new ElasticsearchClusterRunner();
-		runner.onBuild(new ElasticsearchClusterRunner.Builder() {
-			@Override
-			public void build(int number, Builder settingsBuilder) {
-				// settingsBuilder.put("indices.breaker.total.limit", "1100m");
-			}
-		});
-		runner.build(ElasticsearchClusterRunner.newConfigs()
-				.numOfNode(1)
-				.basePath(installLocation.toString())
-				.clusterName(CLUSTER));
-
-		runner.ensureYellow();
-
-		return runner;
+	public static void openClient() {
+		CLIENT = new RestHighLevelClient(RestClient.builder(new HttpHost("localhost", 9200, "http")));
 	}
 
-	public static int getPort(ElasticsearchClusterRunner runner) {
-		return runner.node().settings().getAsInt("transport.port", 9300);
+	public static RestHighLevelClient getClient() {
+		return CLIENT;
 	}
 
-	public static void stopElasticsearch(ElasticsearchClusterRunner runner) {
-		try {
-			runner.close();
-		} catch (IOException ioe) {
-			logger.error("Error closing ES cluster", ioe);
-		}
-		runner.clean();
+	public static void closeClient() throws IOException {
+		CLIENT.close();
 	}
+
 }

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/AddBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/AddBenchmark.java
@@ -11,13 +11,10 @@
 
 package org.eclipse.rdf4j.sail.elasticsearchstore.benchmark;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 
-import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -50,8 +47,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class AddBenchmark {
 
-	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
 	private SailRepository elasticsearchStore;
 
 	@Setup(Level.Trial)
@@ -59,10 +54,9 @@ public class AddBenchmark {
 		// JMH does not correctly set JAVA_HOME. Change the JAVA_HOME below if you the following error:
 		// [EmbeddedElsHandler] INFO p.a.t.e.ElasticServer - could not find java; set JAVA_HOME or ensure java is in
 		// PATH
-		runner = TestHelpers.startElasticsearch(installLocation);
-
+		TestHelpers.getClient();
 		elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex",
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex",
 						ExtensibleStore.Cache.NONE));
 
 		System.gc();
@@ -74,10 +68,9 @@ public class AddBenchmark {
 	}
 
 	@TearDown(Level.Trial)
-	public void afterClass() {
-
+	public void afterClass() throws IOException {
 		elasticsearchStore.shutDown();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Benchmark

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/DeleteBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/DeleteBenchmark.java
@@ -11,12 +11,9 @@
 
 package org.eclipse.rdf4j.sail.elasticsearchstore.benchmark;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -54,8 +51,6 @@ public class DeleteBenchmark {
 	// @Param({ "100", "1000", "10000" })
 	public int NUMBER_OF_STATEMENTS = 10000;
 
-	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
 	private SailRepository elasticsearchStore;
 
 	@Setup(Level.Trial)
@@ -63,10 +58,10 @@ public class DeleteBenchmark {
 		// JMH does not correctly set JAVA_HOME. Change the JAVA_HOME below if you the following error:
 		// [EmbeddedElsHandler] INFO p.a.t.e.ElasticServer - could not find java; set JAVA_HOME or ensure java is in
 		// PATH
-		runner = TestHelpers.startElasticsearch(installLocation);
+		TestHelpers.openClient();
 
 		elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex",
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex",
 						ExtensibleStore.Cache.NONE));
 
 		System.gc();
@@ -74,9 +69,9 @@ public class DeleteBenchmark {
 	}
 
 	@TearDown(Level.Trial)
-	public void afterClass() {
+	public void afterClass() throws IOException {
 		elasticsearchStore.shutDown();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Setup(Level.Invocation)

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/InitBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/InitBenchmark.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -50,7 +49,6 @@ import org.openjdk.jmh.annotations.Warmup;
 public class InitBenchmark {
 
 	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
 	SingletonClientProvider clientPool;
 
 	@Setup(Level.Trial)
@@ -58,23 +56,23 @@ public class InitBenchmark {
 		// JMH does not correctly set JAVA_HOME. Change the JAVA_HOME below if you the following error:
 		// [EmbeddedElsHandler] INFO p.a.t.e.ElasticServer - could not find java; set JAVA_HOME or ensure java is in
 		// PATH
-		runner = TestHelpers.startElasticsearch(installLocation);
+		TestHelpers.openClient();
 
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 		System.gc();
 	}
 
 	@TearDown(Level.Trial)
 	public void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Benchmark
 	public void initWithElasticsearchClientCreation() {
 
 		SailRepository elasticsearchStore = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex",
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex",
 						ExtensibleStore.Cache.NONE));
 
 		try (SailRepositoryConnection connection = elasticsearchStore.getConnection()) {

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/QueryBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/QueryBenchmark.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.rdf4j.sail.elasticsearchstore.benchmark;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -19,8 +18,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
-import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.Resource;
@@ -58,9 +55,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class QueryBenchmark {
 
-	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
-
 	private SailRepository repository;
 
 	private static final String query1;
@@ -92,10 +86,10 @@ public class QueryBenchmark {
 		// JMH does not correctly set JAVA_HOME. Change the JAVA_HOME below if you the following error:
 		// [EmbeddedElsHandler] INFO p.a.t.e.ElasticServer - could not find java; set JAVA_HOME or ensure java is in
 		// PATH
-		runner = TestHelpers.startElasticsearch(installLocation);
+		TestHelpers.openClient();
 
 		repository = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex",
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex",
 						ExtensibleStore.Cache.NONE));
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
@@ -117,9 +111,9 @@ public class QueryBenchmark {
 	}
 
 	@TearDown(Level.Trial)
-	public void afterClass() {
+	public void afterClass() throws IOException {
 		repository.shutDown();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Benchmark

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/ReadCacheBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/ReadCacheBenchmark.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.rdf4j.sail.elasticsearchstore.benchmark;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -19,8 +18,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
-import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.Literal;
@@ -57,10 +54,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ReadCacheBenchmark {
-
-	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
-
 	private SailRepository repoWithoutCache;
 	private SailRepository repoWithCache;
 
@@ -83,14 +76,13 @@ public class ReadCacheBenchmark {
 		// JMH does not correctly set JAVA_HOME. Change the JAVA_HOME below if you the following error:
 		// [EmbeddedElsHandler] INFO p.a.t.e.ElasticServer - could not find java; set JAVA_HOME or ensure java is in
 		// PATH
-		runner = TestHelpers.startElasticsearch(installLocation);
+		TestHelpers.openClient();
 
-		repoWithoutCache = new SailRepository(new ElasticsearchStore("localhost", TestHelpers.getPort(runner),
+		repoWithoutCache = new SailRepository(new ElasticsearchStore("localhost", TestHelpers.PORT,
 				TestHelpers.CLUSTER, "testindex1", ExtensibleStore.Cache.NONE));
 
 		repoWithCache = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex2"));
-
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex2"));
 		try (SailRepositoryConnection connection = repoWithCache.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
 			connection.clear();
@@ -115,9 +107,9 @@ public class ReadCacheBenchmark {
 	}
 
 	@TearDown(Level.Trial)
-	public void afterClass() {
+	public void afterClass() throws IOException {
 		repoWithoutCache.shutDown();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Benchmark

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/TransactionBenchmark.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/benchmark/TransactionBenchmark.java
@@ -11,16 +11,11 @@
 
 package org.eclipse.rdf4j.sail.elasticsearchstore.benchmark;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
 import java.util.stream.IntStream;
 
-import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -52,22 +47,17 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10)
 public class TransactionBenchmark {
 
-	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
-
 	private SailRepository repository;
-
-	private List<Statement> statementList;
 
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException, InterruptedException {
 		// JMH does not correctly set JAVA_HOME. Change the JAVA_HOME below if you the following error:
 		// [EmbeddedElsHandler] INFO p.a.t.e.ElasticServer - could not find java; set JAVA_HOME or ensure java is in
 		// PATH
-		runner = TestHelpers.startElasticsearch(installLocation);
+		TestHelpers.openClient();
 
 		repository = new SailRepository(
-				new ElasticsearchStore("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER, "testindex",
+				new ElasticsearchStore("localhost", TestHelpers.PORT, TestHelpers.CLUSTER, "testindex",
 						ExtensibleStore.Cache.NONE));
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
@@ -83,9 +73,9 @@ public class TransactionBenchmark {
 	}
 
 	@TearDown(Level.Trial)
-	public void afterClass() {
+	public void afterClass() throws IOException {
 		repository.shutDown();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Benchmark

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchGraphQueryResultIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchGraphQueryResultIT.java
@@ -10,10 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
@@ -22,25 +20,21 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.GraphQueryResultTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchGraphQueryResultIT extends GraphQueryResultTest {
 
-	@TempDir
-	static File installLocation;
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreConcurrencyIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreConcurrencyIT.java
@@ -10,10 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailException;
@@ -23,7 +21,6 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.sail.SailConcurrencyTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailConcurrencyTest} for testing the class
@@ -31,21 +28,18 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public class ElasticsearchStoreConcurrencyIT extends SailConcurrencyTest {
 
-	@TempDir
-	static File installLocation;
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	/*---------*

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreConnectionIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreConnectionIT.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 import java.io.File;
 import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.transaction.IsolationLevel;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.repository.Repository;
@@ -24,22 +23,21 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.RepositoryConnectionTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchStoreConnectionIT extends RepositoryConnectionTest {
-	private static ElasticsearchClusterRunner runner;
+
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
-	public static void beforeClass(@TempDir File installLocation) throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+	public static void beforeClass() throws IOException, InterruptedException {
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	public static IsolationLevel[] parameters() {
@@ -51,8 +49,9 @@ public class ElasticsearchStoreConnectionIT extends RepositoryConnectionTest {
 	}
 
 	@Override
-	protected Repository createRepository(File dataDir) {
+	protected Repository createRepository(File f) {
 		return new SailRepository(
 				new ElasticsearchStore(clientPool, "index1"));
 	}
+
 }

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreContextIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreContextIT.java
@@ -10,11 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
@@ -30,20 +27,18 @@ import org.junit.jupiter.api.BeforeAll;
  */
 public class ElasticsearchStoreContextIT extends RDFNotifyingStoreTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreIT.java
@@ -10,11 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailException;
@@ -31,24 +28,18 @@ import org.junit.jupiter.api.BeforeAll;
  */
 public class ElasticsearchStoreIT extends RDFNotifyingStoreTest {
 
-	/*---------*
-	 * Methods *
-	 *---------*/
-
-	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
 	static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreInterruptIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreInterruptIT.java
@@ -10,10 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
@@ -23,7 +21,6 @@ import org.eclipse.rdf4j.testsuite.sail.SailConcurrencyTest;
 import org.eclipse.rdf4j.testsuite.sail.SailInterruptTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailConcurrencyTest} for testing the class
@@ -31,21 +28,18 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public class ElasticsearchStoreInterruptIT extends SailInterruptTest {
 
-	@TempDir
-	static File installLocation;
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreIsolationLevelIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreIsolationLevelIT.java
@@ -10,9 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
+import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.Sail;
@@ -23,7 +22,6 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.sail.SailIsolationLevelTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailIsolationLevelTest} for testing the class
@@ -31,23 +29,20 @@ import org.junit.jupiter.api.io.TempDir;
  */
 public class ElasticsearchStoreIsolationLevelIT extends SailIsolationLevelTest {
 
-	@TempDir
-	static File installLocation;
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
-	public static void beforeClass() throws Exception {
+	public static void beforeClass() throws IOException, InterruptedException {
 		SailIsolationLevelTest.setUpClass();
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass2() throws Exception {
 		SailIsolationLevelTest.afterClass();
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreRepositoryIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreRepositoryIT.java
@@ -10,11 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
@@ -27,20 +24,18 @@ import org.junit.jupiter.api.Disabled;
 
 public class ElasticsearchStoreRepositoryIT extends RepositoryTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreSparqlOrderByIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreSparqlOrderByIT.java
@@ -10,10 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
@@ -22,25 +20,21 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.SparqlOrderByTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchStoreSparqlOrderByIT extends SparqlOrderByTest {
 
-	@TempDir
-	static File installLocation;
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreSparqlRegexIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreSparqlRegexIT.java
@@ -10,10 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
@@ -22,25 +20,21 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.SparqlRegexTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchStoreSparqlRegexIT extends SparqlRegexTest {
 
-	@TempDir
-	static File installLocation;
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreTupleQueryResultIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreTupleQueryResultIT.java
@@ -10,10 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
@@ -22,25 +20,21 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.TupleQueryResultTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchStoreTupleQueryResultIT extends TupleQueryResultTest {
 
-	@TempDir
-	static File installLocation;
-	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
 	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
-		runner = TestHelpers.startElasticsearch(installLocation);
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
+		TestHelpers.openClient();
+		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
 	}
 
 	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
-		TestHelpers.stopElasticsearch(runner);
+		TestHelpers.closeClient();
 	}
 
 	@Override

--- a/core/sail/elasticsearch/pom.xml
+++ b/core/sail/elasticsearch/pom.xml
@@ -25,6 +25,10 @@
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpcore</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<!-- org.elasticsearch.client:transport pulls in JCL -->

--- a/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -88,6 +88,13 @@ import com.google.common.collect.Iterables;
 /**
  * Requires an Elasticsearch cluster with the DeleteByQuery plugin.
  *
+ * Note that, while RDF4J is licensed under the EDL, several ElasticSearch dependencies are licensed under the Elastic
+ * license or the SSPL, which may have implications for some projects.
+ *
+ * Please consult the ElasticSearch website and license FAQ for more information.
+ *
+ * @see <a href="https://www.elastic.co/licensing/elastic-license/faq">Elastic License FAQ</a>
+ *
  * @see LuceneSail
  */
 public class ElasticsearchIndex extends AbstractSearchIndex {

--- a/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/package-info.java
+++ b/core/sail/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/package-info.java
@@ -10,5 +10,12 @@
  *******************************************************************************/
 /**
  * ElasticSearch index for the {@link org.eclipse.rdf4j.sail.lucene.LuceneSail}.
+ *
+ * Note that, while RDF4J is licensed under the EDL, several ElasticSearch dependencies are licensed under the Elastic
+ * License or the SSPL, which may have implications for some projects.
+ *
+ * Please consult the ElasticSearch website and license FAQ for more information.
+ *
+ * @see <a href="https://www.elastic.co/licensing/elastic-license/faq">Elastic License FAQ</a>
  */
 package org.eclipse.rdf4j.sail.elasticsearch;

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
@@ -301,6 +301,7 @@ public class SolrIndex extends AbstractSearchIndex {
 		String query = param.getQuery();
 		SolrQuery q = prepareQuery(propertyURI, new SolrQuery(query));
 		if (highlight) {
+			q.set("hl.method", "unified");
 			q.setHighlight(true);
 			String field = (propertyURI != null) ? SearchFields.getPropertyField(propertyURI) : "*";
 			q.addHighlightField(field);

--- a/pom.xml
+++ b/pom.xml
@@ -371,11 +371,12 @@
 		<httpcore.version>4.4.16</httpcore.version>
 		<jsonldjava.version>0.13.4</jsonldjava.version>
 		<last.japicmp.compare.version>4.0.0</last.japicmp.compare.version>
-		<lucene.version>8.5.1</lucene.version>
+		<jaxb.version>2.3.3</jaxb.version>
 		<lwjgl.version>3.3.1</lwjgl.version>
-		<solr.version>8.4.1</solr.version>
-		<elasticsearch.version>7.8.1</elasticsearch.version>
-		<spring.version>5.3.24</spring.version>
+		<lucene.version>8.9.0</lucene.version>
+		<solr.version>8.9.0</solr.version>
+		<elasticsearch.version>7.15.2</elasticsearch.version>
+		<spring.version>5.3.23</spring.version>
 		<guava.version>30.1.1-jre</guava.version>
 		<jmhVersion>1.35</jmhVersion>
 		<servlet.version>3.1.0</servlet.version>

--- a/site/content/documentation/programming/repository.md
+++ b/site/content/documentation/programming/repository.md
@@ -109,6 +109,10 @@ The ElasticsearchStore stores RDF data in Elasticsearch. Not to be confused with
 The ElasticsearchStore is experimental and future releases may be incompatible with the current version. Write-ahead-logging is not supported.
 This means that a write operation can appear to have partially succeeded if the ElasticsearchStore looses its connection to Elasticsearch during a commit.
 
+Note that, while RDF4J is licensed under the EDL, several ElasticSearch dependencies are licensed under the Elastic License or the SSPL,
+which may have implications for some projects.
+Please consult the ElasticSearch website and [license FAQ](https://www.elastic.co/licensing/elastic-license/faq) for more information.
+ 
 Transaction isolation is not as strong as for the other stores. The highest supported level is READ_COMMITTED, and even this
 level is only guaranteed when all other transactions also use READ_COMMITTED.
 


### PR DESCRIPTION
GitHub issue resolved: #3396 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- upgrade solr and lucene dependencies
- use the "unified" solr highlighter (which will be default in solr 9), since the test fails when using default/original highlighter
- use elasticsearch-maven-plugin instead of elasticsearch-runner
- minor refactoring of tests

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

