### PR TITLE
refactor: eliminate commons-fileupload dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,11 +391,6 @@
 				<version>1.4</version>
 			</dependency>
 			<dependency>
-				<groupId>commons-fileupload</groupId>
-				<artifactId>commons-fileupload</artifactId>
-				<version>1.3.3</version>
-			</dependency>
-			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
 				<version>2.11.0</version>

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -39,11 +39,6 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
-		<!-- Required for CommonsMultipartResolver from the Spring Framework -->
-		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/base/TransformationServlet.java
+++ b/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/base/TransformationServlet.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -31,6 +32,7 @@ import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@MultipartConfig
 public abstract class TransformationServlet extends AbstractRepositoryServlet {
 
 	protected static final ParserConfig NON_VERIFYING_PARSER_CONFIG;

--- a/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/AddServlet.java
+++ b/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/AddServlet.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.fileupload.FileUploadException;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -41,7 +40,7 @@ public class AddServlet extends TransformationServlet {
 
 	@Override
 	protected void doPost(WorkbenchRequest req, HttpServletResponse resp, String xslPath)
-			throws IOException, RepositoryException, FileUploadException, QueryResultHandlerException {
+			throws IOException, RepositoryException, QueryResultHandlerException {
 		try {
 			String baseURI = req.getParameter("baseURI");
 			String contentType = req.getParameter("Content-Type");


### PR DESCRIPTION
and replace it with multipart support added in Servlet 3.0.

GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

commons-fileupload hasn't had any release since 2018, and is not really required - as Java EE added support for multipart handling in Servlet 3.0, ref. https://docs.oracle.com/javaee/7/tutorial/servlets011.htm

Removing the dependency to commons-fileupload is a pre-requirement to the javax -> jakarta migration proposed in https://github.com/eclipse/rdf4j/issues/3559.

I did the simplest thing to remove the dependency, and IMO the affected code should be refactored more, but I am leaving this to a follow-up PR.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

