### PR TITLE
GH-4376 fix usage of deprecated spring/spring-boot APIs

### DIFF
--- a/spring-components/spring-boot-sparql-web/src/test/java/org/eclipse/rdf4j/http/server/readonly/MemoryBackedOnlySparqlApplicationTest.java
+++ b/spring-components/spring-boot-sparql-web/src/test/java/org/eclipse/rdf4j/http/server/readonly/MemoryBackedOnlySparqlApplicationTest.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/ServerInterceptor.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/ServerInterceptor.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.http.server;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
  * Base class for single-use request interceptors. This implementation sets the thread name to something sensible at the
@@ -22,7 +22,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
  *
  * @author Herko ter Horst
  */
-public abstract class ServerInterceptor extends HandlerInterceptorAdapter {
+public abstract class ServerInterceptor implements HandlerInterceptor {
 
 	private volatile String origThreadName;
 
@@ -34,7 +34,7 @@ public abstract class ServerInterceptor extends HandlerInterceptorAdapter {
 
 		setRequestAttributes(request);
 
-		return super.preHandle(request, response, handler);
+		return HandlerInterceptor.super.preHandle(request, response, handler);
 	}
 
 	@Override


### PR DESCRIPTION
GitHub issue resolved: #4376 

Briefly describe the changes proposed in this PR:

Before attempting to upgrade to new major versions of spring/spring-boot we should fix all use of deprecated APIs. This will ease the migration as deprecated APIs have a tendency of being removed in new major versions.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

