### PR TITLE
GH-4382 Fix usage of deprecated Jackson APIs

### DIFF
--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONParser.java
@@ -42,10 +42,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.StreamWriteFeature;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 
 /**
  * Abstract base class for SPARQL Results JSON Parsers. Provides a common implementation of both boolean and tuple
@@ -516,59 +519,59 @@ public abstract class AbstractSPARQLJSONParser extends AbstractQueryResultParser
 	 * @return A newly configured JsonFactory based on the currently enabled settings
 	 */
 	private JsonFactory configureNewJsonFactory() {
-		final JsonFactory nextJsonFactory = new JsonFactory();
+		final JsonFactoryBuilder builder = new JsonFactoryBuilder();
 		// Disable features that may work for most JSON where the field names are
 		// in limited supply,
 		// but does not work for SPARQL/JSON where a wide range of URIs are used for
 		// subjects and predicates
-		nextJsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
-		nextJsonFactory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
-		nextJsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+		builder.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+		builder.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
+		builder.disable(StreamWriteFeature.AUTO_CLOSE_TARGET);
 
 		if (getParserConfig().isSet(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
+			builder.configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
 					getParserConfig().get(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_COMMENTS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS,
+			builder.configure(JsonReadFeature.ALLOW_JAVA_COMMENTS,
 					getParserConfig().get(JSONSettings.ALLOW_COMMENTS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS,
+			builder.configure(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS,
 					getParserConfig().get(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS,
+			builder.configure(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS,
 					getParserConfig().get(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_SINGLE_QUOTES)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES,
+			builder.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES,
 					getParserConfig().get(JSONSettings.ALLOW_SINGLE_QUOTES));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
+			builder.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS,
 					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES,
+			builder.configure(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES,
 					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_YAML_COMMENTS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS,
+			builder.configure(JsonReadFeature.ALLOW_YAML_COMMENTS,
 					getParserConfig().get(JSONSettings.ALLOW_YAML_COMMENTS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_TRAILING_COMMA)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA,
+			builder.configure(JsonReadFeature.ALLOW_TRAILING_COMMA,
 					getParserConfig().get(JSONSettings.ALLOW_TRAILING_COMMA));
 		}
 		if (getParserConfig().isSet(JSONSettings.INCLUDE_SOURCE_IN_LOCATION)) {
-			nextJsonFactory.configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION,
+			builder.configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION,
 					getParserConfig().get(JSONSettings.INCLUDE_SOURCE_IN_LOCATION));
 		}
 		if (getParserConfig().isSet(JSONSettings.STRICT_DUPLICATE_DETECTION)) {
-			nextJsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION,
+			builder.configure(StreamReadFeature.STRICT_DUPLICATE_DETECTION,
 					getParserConfig().get(JSONSettings.STRICT_DUPLICATE_DETECTION));
 		}
-		return nextJsonFactory;
+		return builder.build();
 	}
 }

--- a/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
+++ b/core/queryresultio/sparqljson/src/main/java/org/eclipse/rdf4j/query/resultio/sparqljson/AbstractSPARQLJSONWriter.java
@@ -38,7 +38,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter;
@@ -50,18 +52,16 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter;
  */
 abstract class AbstractSPARQLJSONWriter extends AbstractQueryResultWriter implements CharSink {
 
-	private static final JsonFactory JSON_FACTORY = new JsonFactory();
-
-	static {
-		// Disable features that may work for most JSON where the field names are
-		// in limited supply,
-		// but does not work for RDF/JSON where a wide range of URIs are used for
-		// subjects and
-		// predicates
-		JSON_FACTORY.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
-		JSON_FACTORY.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
-		JSON_FACTORY.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
-	}
+	private static final JsonFactory JSON_FACTORY = new JsonFactoryBuilder()
+			// Disable features that may work for most JSON where the field names are
+			// in limited supply,
+			// but does not work for RDF/JSON where a wide range of URIs are used for
+			// subjects and
+			// predicates
+			.disable(JsonFactory.Feature.INTERN_FIELD_NAMES)
+			.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES)
+			.disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+			.build();
 
 	protected boolean firstTupleWritten = false;
 

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONParserCustomTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONParserCustomTest.java
@@ -12,8 +12,8 @@ package org.eclipse.rdf4j.query.resultio.sparqljson;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.ContentReference;
 
 /**
  * Custom (non-manifest) tests for SPARQL/JSON parser.
@@ -356,8 +357,8 @@ public class SPARQLJSONParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(2, cause.getLocation().getColumnNr());
-			assertNotNull(cause.getLocation().getSourceRef());
-			assertEquals(source, cause.getLocation().getSourceRef());
+			assertNotEquals(ContentReference.unknown(), cause.getLocation().contentReference());
+			assertEquals(source, cause.getLocation().contentReference().getRawContent());
 		}
 	}
 
@@ -374,8 +375,8 @@ public class SPARQLJSONParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(2, cause.getLocation().getColumnNr());
-			assertNotNull(cause.getLocation().getSourceRef());
-			assertEquals(source, cause.getLocation().getSourceRef());
+			assertNotEquals(ContentReference.unknown(), cause.getLocation().contentReference());
+			assertEquals(source, cause.getLocation().contentReference().getRawContent());
 		}
 	}
 
@@ -391,7 +392,7 @@ public class SPARQLJSONParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(2, cause.getLocation().getColumnNr());
-			assertNull(cause.getLocation().getSourceRef());
+			assertEquals(ContentReference.unknown(), cause.getLocation().contentReference());
 		}
 	}
 

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParser.java
@@ -28,8 +28,11 @@ import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONSettings;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jsonldjava.core.DocumentLoader;
 import com.github.jsonldjava.core.JsonLdError;
@@ -155,53 +158,53 @@ public class JSONLDParser extends AbstractRDFParser {
 	 * @return A newly configured JsonFactory based on the currently enabled settings
 	 */
 	private JsonFactory configureNewJsonFactory() {
-		final JsonFactory nextJsonFactory = new JsonFactory(JSON_MAPPER);
+		JsonFactoryBuilder builder = new JsonFactoryBuilder();
 		ParserConfig parserConfig = getParserConfig();
 
 		if (parserConfig.isSet(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
+			builder.configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
 					parserConfig.get(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER));
 		}
 		if (parserConfig.isSet(JSONSettings.ALLOW_COMMENTS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS,
+			builder.configure(JsonReadFeature.ALLOW_JAVA_COMMENTS,
 					parserConfig.get(JSONSettings.ALLOW_COMMENTS));
 		}
 		if (parserConfig.isSet(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS,
+			builder.configure(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS,
 					parserConfig.get(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS));
 		}
 		if (parserConfig.isSet(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS,
+			builder.configure(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS,
 					parserConfig.get(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS));
 		}
 		if (parserConfig.isSet(JSONSettings.ALLOW_SINGLE_QUOTES)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES,
+			builder.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES,
 					parserConfig.get(JSONSettings.ALLOW_SINGLE_QUOTES));
 		}
 		if (parserConfig.isSet(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
+			builder.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS,
 					parserConfig.get(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS));
 		}
 		if (parserConfig.isSet(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES,
+			builder.configure(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES,
 					parserConfig.get(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES));
 		}
 		if (parserConfig.isSet(JSONSettings.ALLOW_YAML_COMMENTS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS,
+			builder.configure(JsonReadFeature.ALLOW_YAML_COMMENTS,
 					parserConfig.get(JSONSettings.ALLOW_YAML_COMMENTS));
 		}
 		if (parserConfig.isSet(JSONSettings.ALLOW_TRAILING_COMMA)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA,
+			builder.configure(JsonReadFeature.ALLOW_TRAILING_COMMA,
 					parserConfig.get(JSONSettings.ALLOW_TRAILING_COMMA));
 		}
 		if (parserConfig.isSet(JSONSettings.INCLUDE_SOURCE_IN_LOCATION)) {
-			nextJsonFactory.configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION,
+			builder.configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION,
 					parserConfig.get(JSONSettings.INCLUDE_SOURCE_IN_LOCATION));
 		}
 		if (parserConfig.isSet(JSONSettings.STRICT_DUPLICATE_DETECTION)) {
-			nextJsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION,
+			builder.configure(StreamReadFeature.STRICT_DUPLICATE_DETECTION,
 					parserConfig.get(JSONSettings.STRICT_DUPLICATE_DETECTION));
 		}
-		return nextJsonFactory;
+		return builder.build().setCodec(JSON_MAPPER);
 	}
 }

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -12,8 +12,8 @@ package org.eclipse.rdf4j.rio.jsonld;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.ContentReference;
 import com.github.jsonldjava.core.DocumentLoader;
 
 /**
@@ -361,8 +362,8 @@ public class JSONLDParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(3, cause.getLocation().getColumnNr());
-			assertNotNull(cause.getLocation().getSourceRef());
-			assertEquals(source, cause.getLocation().getSourceRef());
+			assertNotEquals(ContentReference.unknown(), cause.getLocation().contentReference());
+			assertEquals(source, cause.getLocation().contentReference().getRawContent());
 		}
 	}
 
@@ -379,8 +380,8 @@ public class JSONLDParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(3, cause.getLocation().getColumnNr());
-			assertNotNull(cause.getLocation().getSourceRef());
-			assertEquals(source, cause.getLocation().getSourceRef());
+			assertNotEquals(ContentReference.unknown(), cause.getLocation().contentReference());
+			assertEquals(source, cause.getLocation().contentReference().getRawContent());
 		}
 	}
 
@@ -396,7 +397,7 @@ public class JSONLDParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(3, cause.getLocation().getColumnNr());
-			assertNull(cause.getLocation().getSourceRef());
+			assertEquals(ContentReference.unknown(), cause.getLocation().contentReference());
 		}
 	}
 

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParser.java
@@ -34,11 +34,14 @@ import org.eclipse.rdf4j.rio.helpers.JSONSettings;
 import org.eclipse.rdf4j.rio.helpers.RDFJSONParserSettings;
 
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.StreamWriteFeature;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 
 /**
  * {@link RDFParser} implementation for the RDF/JSON format
@@ -393,59 +396,59 @@ public class RDFJSONParser extends AbstractRDFParser {
 	 * @return A newly configured JsonFactory based on the currently enabled settings
 	 */
 	private JsonFactory configureNewJsonFactory() {
-		final JsonFactory nextJsonFactory = new JsonFactory();
+		JsonFactoryBuilder builder = new JsonFactoryBuilder();
 		// Disable features that may work for most JSON where the field names are
 		// in limited supply,
 		// but does not work for RDF/JSON where a wide range of URIs are used for
 		// subjects and predicates
-		nextJsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
-		nextJsonFactory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
-		nextJsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+		builder.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+		builder.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
+		builder.disable(StreamWriteFeature.AUTO_CLOSE_TARGET);
 
 		if (getParserConfig().isSet(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
+			builder.configure(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER,
 					getParserConfig().get(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_COMMENTS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS,
+			builder.configure(JsonReadFeature.ALLOW_JAVA_COMMENTS,
 					getParserConfig().get(JSONSettings.ALLOW_COMMENTS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS,
+			builder.configure(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS,
 					getParserConfig().get(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_NUMERIC_LEADING_ZEROS,
+			builder.configure(JsonReadFeature.ALLOW_LEADING_ZEROS_FOR_NUMBERS,
 					getParserConfig().get(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_SINGLE_QUOTES)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES,
+			builder.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES,
 					getParserConfig().get(JSONSettings.ALLOW_SINGLE_QUOTES));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS,
+			builder.configure(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS,
 					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES,
+			builder.configure(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES,
 					getParserConfig().get(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_YAML_COMMENTS)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_YAML_COMMENTS,
+			builder.configure(JsonReadFeature.ALLOW_YAML_COMMENTS,
 					getParserConfig().get(JSONSettings.ALLOW_YAML_COMMENTS));
 		}
 		if (getParserConfig().isSet(JSONSettings.ALLOW_TRAILING_COMMA)) {
-			nextJsonFactory.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA,
+			builder.configure(JsonReadFeature.ALLOW_TRAILING_COMMA,
 					getParserConfig().get(JSONSettings.ALLOW_TRAILING_COMMA));
 		}
 		if (getParserConfig().isSet(JSONSettings.INCLUDE_SOURCE_IN_LOCATION)) {
-			nextJsonFactory.configure(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION,
+			builder.configure(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION,
 					getParserConfig().get(JSONSettings.INCLUDE_SOURCE_IN_LOCATION));
 		}
 		if (getParserConfig().isSet(JSONSettings.STRICT_DUPLICATE_DETECTION)) {
-			nextJsonFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION,
+			builder.configure(StreamReadFeature.STRICT_DUPLICATE_DETECTION,
 					getParserConfig().get(JSONSettings.STRICT_DUPLICATE_DETECTION));
 		}
-		return nextJsonFactory;
+		return builder.build();
 	}
 }

--- a/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
+++ b/core/rio/rdfjson/src/main/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONWriter.java
@@ -40,8 +40,10 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.RDFJSONWriterSettings;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter;
@@ -269,16 +271,16 @@ public class RDFJSONWriter extends AbstractRDFWriter implements CharSink {
 	 * @return A newly configured JsonFactory based on the currently enabled settings
 	 */
 	private JsonFactory configureNewJsonFactory() {
-		final JsonFactory nextJsonFactory = new JsonFactory();
+		JsonFactoryBuilder builder = new JsonFactoryBuilder();
 		// Disable features that may work for most JSON where the field names are
 		// in limited supply,
 		// but does not work for RDF/JSON where a wide range of URIs are used for
 		// subjects and predicates
-		nextJsonFactory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
-		nextJsonFactory.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
-		nextJsonFactory.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+		builder.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+		builder.disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES);
+		builder.disable(StreamWriteFeature.AUTO_CLOSE_TARGET);
 
-		return nextJsonFactory;
+		return builder.build();
 	}
 
 	/**

--- a/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserCustomTest.java
+++ b/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserCustomTest.java
@@ -12,8 +12,8 @@ package org.eclipse.rdf4j.rio.rdfjson;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.io.ContentReference;
 
 /**
  * Custom (non-manifest) tests for RDF/JSON parser.
@@ -353,8 +354,8 @@ public class RDFJSONParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(2, cause.getLocation().getColumnNr());
-			assertNotNull(cause.getLocation().getSourceRef());
-			assertEquals(source, cause.getLocation().getSourceRef());
+			assertNotEquals(ContentReference.unknown(), cause.getLocation().contentReference());
+			assertEquals(source, cause.getLocation().contentReference().getRawContent());
 		}
 	}
 
@@ -371,8 +372,8 @@ public class RDFJSONParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(2, cause.getLocation().getColumnNr());
-			assertNotNull(cause.getLocation().getSourceRef());
-			assertEquals(source, cause.getLocation().getSourceRef());
+			assertNotEquals(ContentReference.unknown(), cause.getLocation().contentReference());
+			assertEquals(source, cause.getLocation().contentReference().getRawContent());
 		}
 	}
 
@@ -388,7 +389,7 @@ public class RDFJSONParserCustomTest {
 			JsonProcessingException cause = (JsonProcessingException) e.getCause();
 			assertEquals(2, cause.getLocation().getLineNr());
 			assertEquals(2, cause.getLocation().getColumnNr());
-			assertNull(cause.getLocation().getSourceRef());
+			assertEquals(ContentReference.unknown(), cause.getLocation().contentReference());
 		}
 	}
 


### PR DESCRIPTION
GitHub issue resolved: #4382

Briefly describe the changes proposed in this PR:

This PR fixes all use of currently deprecated Jackson APIs.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

