### PR TITLE
GH-4384 Migration to JUnit 5

### DIFF
--- a/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/IsomorphicTest.java
+++ b/compliance/model/src/test/java/org/eclipse/rdf4j/model/util/IsomorphicTest.java
@@ -24,8 +24,9 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class IsomorphicTest {
 
@@ -58,7 +59,7 @@ public class IsomorphicTest {
 	static private Model manyProperties_2;
 	static private Model manyProperties2_2;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() {
 		empty = getModel("empty.ttl");
 		blankNodes = getModel("blankNodes.ttl");
@@ -188,7 +189,8 @@ public class IsomorphicTest {
 		assertThat(Models.isomorphic(m1, m2));
 	}
 
-	@Test(timeout = 2000)
+	@Test
+	@Timeout(2)
 	public void testValidationReport_LexicalOrdering() throws IOException {
 		Model m1 = getModel("shaclValidationReport.ttl");
 		Model m2 = getModel("shaclValidationReport.ttl");

--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -142,11 +142,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryOptimisticIsolationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryOptimisticIsolationTest.java
@@ -14,8 +14,8 @@ import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
 import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryConfig;
 import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * @author jeen
@@ -24,7 +24,7 @@ public class HTTPRepositoryOptimisticIsolationTest extends OptimisticIsolationTe
 
 	private static HTTPMemServer server;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 
@@ -46,7 +46,7 @@ public class HTTPRepositoryOptimisticIsolationTest extends OptimisticIsolationTe
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 		server.stop();

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTransactionTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTransactionTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.repository.http;
 
 import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HTTPRepositoryTransactionTest {
 

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPSparqlDatasetTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPSparqlDatasetTest.java
@@ -12,14 +12,14 @@ package org.eclipse.rdf4j.repository.http;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.testsuite.repository.SparqlDatasetTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class HTTPSparqlDatasetTest extends SparqlDatasetTest {
 
 	private static HTTPMemServer server;
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new HTTPMemServer();
 		try {
@@ -30,7 +30,7 @@ public class HTTPSparqlDatasetTest extends SparqlDatasetTest {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 	}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPSparqlSetBindingTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPSparqlSetBindingTest.java
@@ -12,14 +12,14 @@ package org.eclipse.rdf4j.repository.http;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.testsuite.repository.SparqlSetBindingTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class HTTPSparqlSetBindingTest extends SparqlSetBindingTest {
 
 	private static HTTPMemServer server;
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new HTTPMemServer();
 		try {
@@ -30,7 +30,7 @@ public class HTTPSparqlSetBindingTest extends SparqlSetBindingTest {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 	}

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManagerIntegrationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManagerIntegrationTest.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.repository.manager;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -35,11 +36,10 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Integration tests for {@link LocalRepositoryManager}
@@ -48,10 +48,8 @@ import org.junit.rules.TemporaryFolder;
  */
 public class LocalRepositoryManagerIntegrationTest extends RepositoryManagerIntegrationTest {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-
-	private File datadir;
+	@TempDir
+	File datadir;
 
 	private static final String TEST_REPO = "test";
 
@@ -60,10 +58,9 @@ public class LocalRepositoryManagerIntegrationTest extends RepositoryManagerInte
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
-		datadir = tempDir.newFolder("local-repositorysubject-test");
 		subject = new LocalRepositoryManager(datadir);
 		subject.init();
 
@@ -79,14 +76,13 @@ public class LocalRepositoryManagerIntegrationTest extends RepositoryManagerInte
 	/**
 	 * @throws IOException if a problem occurs deleting temporary resources
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws IOException {
 		subject.shutDown();
 	}
 
 	/**
-	 * Test method for
-	 * {@link org.eclipse.rdf4j.repository.subject.LocalRepositoryManager#getRepository(java.lang.String)} .
+	 * Test method for {@link LocalRepositoryManager#getRepository(java.lang.String)} .
 	 *
 	 * @throws RepositoryException       if a problem occurs accessing the repository
 	 * @throws RepositoryConfigException if a problem occurs accessing the repository
@@ -159,7 +155,7 @@ public class LocalRepositoryManagerIntegrationTest extends RepositoryManagerInte
 	}
 
 	/**
-	 * Test method for {@link RepositoryManager.isSafeToRemove(String)}.
+	 * Test method for {@link RepositoryManager#isSafeToRemove(String)}.
 	 *
 	 * @throws RepositoryException       if a problem occurs during execution
 	 * @throws RepositoryConfigException if a problem occurs during execution
@@ -189,13 +185,12 @@ public class LocalRepositoryManagerIntegrationTest extends RepositoryManagerInte
 		}
 	}
 
-	@Test(expected = RepositoryConfigException.class)
+	@Test
 	public void testAddConfig_validation() throws Exception {
 		InputStream in = getClass().getResourceAsStream("/fixtures/memory-invalid.ttl");
 		Model model = Rio.parse(in, RDFFormat.TURTLE);
-		RepositoryConfig config = RepositoryConfigUtil.getRepositoryConfig(model, "Test");
 
-		subject.addRepositoryConfig(config);
+		assertThrows(RepositoryConfigException.class, () -> RepositoryConfigUtil.getRepositoryConfig(model, "Test"));
 	}
 
 }

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/manager/RepositoryManagerIntegrationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/manager/RepositoryManagerIntegrationTest.java
@@ -19,13 +19,13 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class RepositoryManagerIntegrationTest {
 
 	protected RepositoryManager subject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		subject = new RepositoryManager() {
 

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLGraphQueryResultTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLGraphQueryResultTest.java
@@ -14,8 +14,8 @@ import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.http.HTTPMemServer;
 import org.eclipse.rdf4j.testsuite.repository.GraphQueryResultTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * @author Jeen Broekstra
@@ -24,7 +24,7 @@ public class SPARQLGraphQueryResultTest extends GraphQueryResultTest {
 
 	private static HTTPMemServer server;
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new HTTPMemServer();
 		try {
@@ -35,7 +35,7 @@ public class SPARQLGraphQueryResultTest extends GraphQueryResultTest {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 		server = null;

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceIntegrationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceIntegrationTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql.federation;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -34,10 +36,9 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
 
@@ -54,7 +55,7 @@ public class RepositoryFederatedServiceIntegrationTest {
 	private SailRepository localRepo;
 	private RepositoryFederatedService federatedService;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		serviceRepo = new SailRepository(new MemoryStore());
 		serviceRepo.init();
@@ -72,7 +73,7 @@ public class RepositoryFederatedServiceIntegrationTest {
 		localRepo.init();
 	}
 
-	@After
+	@AfterEach
 	public void after() {
 		federatedService.shutdown();
 		localRepo.shutDown();
@@ -220,10 +221,10 @@ public class RepositoryFederatedServiceIntegrationTest {
 		String query = "SELECT ?var ?cnt WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 2 }  . SERVICE <urn:dummy> { SELECT ?var ?cnt ?__rowIdx WHERE { SELECT (COUNT(?s2) AS ?cnt) WHERE { ?s2 ?p2 ?var  } } } }";
 
 		List<BindingSet> res = evaluateQuery(query);
-		Assert.assertEquals(2, res.size());
+		assertEquals(2, res.size());
 		BindingSet b1 = res.get(0);
-		Assert.assertEquals(l("val1"), b1.getValue("var"));
-		Assert.assertEquals(1, ((Literal) b1.getValue("cnt")).intValue());
+		assertEquals(l("val1"), b1.getValue("var"));
+		assertEquals(1, ((Literal) b1.getValue("cnt")).intValue());
 	}
 
 	@Test
@@ -236,10 +237,10 @@ public class RepositoryFederatedServiceIntegrationTest {
 		String query = "SELECT ?var ?cnt WHERE { SERVICE <urn:dummy> { SELECT ?var { ?s ?p ?var } LIMIT 1 }  . SERVICE <urn:dummy> { SELECT ?var ?cnt ?__rowIdx WHERE { SELECT (COUNT(?s2) AS ?cnt) WHERE { ?s2 ?p2 ?var  } } } }";
 
 		List<BindingSet> res = evaluateQuery(query);
-		Assert.assertEquals(1, res.size());
+		assertEquals(1, res.size());
 		BindingSet b1 = res.get(0);
-		Assert.assertEquals(l("val1"), b1.getValue("var"));
-		Assert.assertEquals(1, ((Literal) b1.getValue("cnt")).intValue());
+		assertEquals(l("val1"), b1.getValue("var"));
+		assertEquals(1, ((Literal) b1.getValue("cnt")).intValue());
 	}
 
 	@Test
@@ -362,6 +363,6 @@ public class RepositoryFederatedServiceIntegrationTest {
 	}
 
 	private void assertResultEquals(List<BindingSet> res, String bindingName, List<Value> expected) {
-		Assert.assertEquals(expected, res.stream().map(b -> b.getValue(bindingName)).collect(Collectors.toList()));
+		assertEquals(expected, res.stream().map(b -> b.getValue(bindingName)).collect(Collectors.toList()));
 	}
 }

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.rio.n3;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.turtle.TurtleParser;
 import org.eclipse.rdf4j.testsuite.rio.n3.N3ParserTestCase;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 import junit.framework.Test;
 
@@ -21,7 +21,7 @@ import junit.framework.Test;
  * JUnit test for the N3 parser that uses the tests that are available
  * <a href="http://www.w3.org/2000/10/swap/test/n3parser.tests">online</a>.
  */
-@Ignore("FIXME: This test is badly broken")
+@Disabled("FIXME: This test is badly broken")
 public class N3ParserTest extends N3ParserTestCase {
 
 	public static Test suite() throws Exception {

--- a/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterInliningTest.java
+++ b/compliance/rio/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterInliningTest.java
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Integration tests on blank node inlining behavior of the TurtleWriter.

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/ArbitraryLengthPathTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/ArbitraryLengthPathTest.java
@@ -19,9 +19,9 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import junit.framework.TestCase;
 
@@ -34,14 +34,14 @@ public class ArbitraryLengthPathTest extends TestCase {
 
 	private RepositoryConnection con;
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
 		repo = new SailRepository(new MemoryStore());
 		con = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	@Override
 	public void tearDown() throws Exception {
 		con.close();

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/HTTPSparqlUpdateTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/HTTPSparqlUpdateTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.query.parser.sparql;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -22,10 +23,10 @@ import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.testsuite.query.parser.sparql.SPARQLUpdateTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -36,7 +37,7 @@ public class HTTPSparqlUpdateTest extends SPARQLUpdateTest {
 
 	private static final String repositoryId = "test-sparql";
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new SPARQLEmbeddedServer(List.of(repositoryId));
 		try {
@@ -47,7 +48,7 @@ public class HTTPSparqlUpdateTest extends SPARQLUpdateTest {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 	}
@@ -57,7 +58,7 @@ public class HTTPSparqlUpdateTest extends SPARQLUpdateTest {
 		return new HTTPRepository(server.getRepositoryUrl(repositoryId));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	@Override
 	public void testAutoCommitHandling() {
@@ -98,7 +99,7 @@ public class HTTPSparqlUpdateTest extends SPARQLUpdateTest {
 		}
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	@Override
 	public void testConsecutiveUpdatesInSameTransaction() {
@@ -108,18 +109,24 @@ public class HTTPSparqlUpdateTest extends SPARQLUpdateTest {
 				"temporarily disabled testConsecutiveUpdatesInSameTransaction() for HTTPRepository. See SES-1652");
 	}
 
-	@Ignore
-	@Test(expected = MalformedQueryException.class)
+	@Disabled
+	@Test
 	@Override
 	public void testInvalidInsertUpdate() {
+		// FIXME: Where is the test?
+		assertThrows(MalformedQueryException.class, () -> {
+		});
 		// disabling test
 		System.err.println("temporarily disabled testInvalidInsertUpdate for HTTPRepository. See Issue #420");
 	}
 
-	@Ignore
-	@Test(expected = MalformedQueryException.class)
+	@Disabled
+	@Test
 	@Override
 	public void testInvalidDeleteUpdate() {
+		// FIXME: Where is the test?
+		assertThrows(MalformedQueryException.class, () -> {
+		});
 		// disabling test
 		System.err.println("temporarily disabled testInvalidDeleteUpdate for HTTPRepository. See Issue #420");
 	}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/CustomFunctionEvaluationTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/function/CustomFunctionEvaluationTest.java
@@ -20,8 +20,8 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Integration tests for evaluation of custom functions in SPARQL
@@ -32,7 +32,7 @@ public class CustomFunctionEvaluationTest {
 
 	private SailRepository rep;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		rep = new SailRepository(new MemoryStore());
 	}

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/W3CApprovedSPARQL11QueryTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/W3CApprovedSPARQL11QueryTest.java
@@ -19,11 +19,11 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest.SPARQL11ManifestTest;
 import org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest.SPARQLQueryTest;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 import junit.framework.Test;
 
-@Ignore("replaced by org.eclipse.rdf4j.sail.memory.MemorySPARQL11QueryComplianceTest")
+@Disabled("replaced by org.eclipse.rdf4j.sail.memory.MemorySPARQL11QueryComplianceTest")
 @Deprecated
 public class W3CApprovedSPARQL11QueryTest extends SPARQLQueryTest {
 

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/W3CApprovedSPARQL11UpdateTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/manifest/W3CApprovedSPARQL11UpdateTest.java
@@ -17,12 +17,12 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest.SPARQL11UpdateComplianceTest;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 /**
  * @author Jeen Broekstra
  */
-@Ignore("replaced by org.eclipse.rdf4j.sail.memory.MemorySPARQL11updateComplianceTest")
+@Disabled("replaced by org.eclipse.rdf4j.sail.memory.MemorySPARQL11updateComplianceTest")
 @Deprecated
 public class W3CApprovedSPARQL11UpdateTest extends SPARQL11UpdateComplianceTest {
 

--- a/core/common/io/src/test/java/org/eclipse/rdf4j/common/io/ByteArrayUtilTest.java
+++ b/core/common/io/src/test/java/org/eclipse/rdf4j/common/io/ByteArrayUtilTest.java
@@ -10,21 +10,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.io;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.BitSet;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class ByteArrayUtilTest {
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void testMatchesPattern() {
@@ -78,8 +74,7 @@ public class ByteArrayUtilTest {
 		assertEquals((1 << 24) + (2 << 16) + (3 << 8) + 4, ByteArrayUtil.getInt(new byte[] { 1, 2, 3, 4 }, 0));
 		assertEquals((1 << 24) + (2 << 16) + (3 << 8) + 4, ByteArrayUtil.getInt(new byte[] { 10, 1, 2, 3, 4, 10 }, 1));
 
-		thrown.expect(ArrayIndexOutOfBoundsException.class);
-		ByteArrayUtil.getInt(new byte[] { 1 }, 0);
+		assertThrows(ArrayIndexOutOfBoundsException.class, () -> ByteArrayUtil.getInt(new byte[] { 1 }, 0));
 	}
 
 	@Test
@@ -89,8 +84,7 @@ public class ByteArrayUtilTest {
 		assertEquals(1L << 56, ByteArrayUtil.getLong(new byte[] { 1, 0, 0, 0, 0, 0, 0, 0 }, 0));
 		assertEquals(0L, ByteArrayUtil.getLong(new byte[] { 127, 0, 0, 0, 0, 0, 0, 0, 0, 127 }, 1));
 
-		thrown.expect(ArrayIndexOutOfBoundsException.class);
-		ByteArrayUtil.getLong(new byte[] { 1 }, 0);
+		assertThrows(ArrayIndexOutOfBoundsException.class, () -> ByteArrayUtil.getLong(new byte[] { 1 }, 0));
 	}
 
 	@Test

--- a/core/common/io/src/test/java/org/eclipse/rdf4j/common/io/ZipUtilTest.java
+++ b/core/common/io/src/test/java/org/eclipse/rdf4j/common/io/ZipUtilTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.io;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -20,17 +20,18 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ZipUtilTest {
-	@Rule
-	public TemporaryFolder dir = new TemporaryFolder();
+
+	@TempDir
+	public File dir;
 
 	@Test
 	public void testWriteEntryNormal() throws IOException {
-		File f = dir.newFile("testok.zip");
+		File f = new File(dir, "testok.zip");
+		f.createNewFile();
 
 		try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f))) {
 			ZipEntry e = new ZipEntry("helloworld.txt");
@@ -40,15 +41,17 @@ public class ZipUtilTest {
 		}
 
 		ZipFile zf = new ZipFile(f);
-		File subdir = dir.newFolder("extract");
+		File subdir = new File(dir, "extract");
+		subdir.mkdir();
 		ZipUtil.extract(zf, subdir);
 
-		assertTrue("File not extracted", new File(subdir, "helloworld.txt").exists());
+		assertTrue(new File(subdir, "helloworld.txt").exists(), () -> "File not extracted");
 	}
 
 	@Test
 	public void testWriteEntryPathTraversing() throws IOException {
-		File f = dir.newFile("testnotok.zip");
+		File f = new File(dir, "testnotok.zip");
+		f.createNewFile();
 
 		try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f))) {
 			ZipEntry e = new ZipEntry("hello/../../world.txt");
@@ -58,7 +61,8 @@ public class ZipUtilTest {
 		}
 
 		ZipFile zf = new ZipFile(f);
-		File subdir = dir.newFolder("extract");
+		File subdir = new File(dir, "extract");
+		subdir.mkdir();
 		try {
 			ZipUtil.extract(zf, subdir);
 			fail("No exception thrown");

--- a/core/common/io/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java
+++ b/core/common/io/src/test/java/org/eclipse/rdf4j/common/net/ParsedIRITest.java
@@ -11,18 +11,19 @@
 package org.eclipse.rdf4j.common.net;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joseph Walton
@@ -58,9 +59,9 @@ public class ParsedIRITest {
 		}
 	}
 
-	@Test(expected = URISyntaxException.class)
+	@Test
 	public void testIncorrectIPv4() throws URISyntaxException {
-		ParsedIRI iri = new ParsedIRI("http://127.0.0.256/");
+		assertThrows(URISyntaxException.class, () -> new ParsedIRI("http://127.0.0.256/"));
 	}
 
 	@Test
@@ -72,9 +73,9 @@ public class ParsedIRITest {
 		assertThat(uri.getHost()).isEqualTo("385.fwk19480900");
 	}
 
-	@Test(expected = URISyntaxException.class)
+	@Test
 	public void testHttpSchemeHostProcessing() throws URISyntaxException {
-		ParsedIRI uri = new ParsedIRI("http://385.fwk19480900/test.ttl");
+		assertThrows(URISyntaxException.class, () -> new ParsedIRI("http://385.fwk19480900/test.ttl"));
 	}
 
 	@Test

--- a/core/common/io/src/test/java/org/eclipse/rdf4j/common/net/ParsedURITest.java
+++ b/core/common/io/src/test/java/org/eclipse/rdf4j/common/net/ParsedURITest.java
@@ -10,14 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.net;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URISyntaxException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Joseph Walton

--- a/core/common/iterator/src/test/java/org/eclipse/rdf4j/common/iteration/AutoClosingIterationTest.java
+++ b/core/common/iterator/src/test/java/org/eclipse/rdf4j/common/iteration/AutoClosingIterationTest.java
@@ -10,15 +10,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.iteration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AutoClosingIterationTest {
 

--- a/core/common/iterator/src/test/java/org/eclipse/rdf4j/common/iteration/SilentIterationTest.java
+++ b/core/common/iterator/src/test/java/org/eclipse/rdf4j/common/iteration/SilentIterationTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SilentIterationTest {
 

--- a/core/common/text/src/test/java/org/eclipse/rdf4j/common/text/StringUtilTest.java
+++ b/core/common/text/src/test/java/org/eclipse/rdf4j/common/text/StringUtilTest.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.text;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
 import org.eclipse.rdf4j.common.net.ParsedIRI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -32,7 +32,7 @@ public class StringUtilTest {
 		StringBuffer out = new StringBuffer();
 		StringUtil.simpleEscapeIRI(str, out, true);
 		String encoded = out.toString();
-		assertEquals("Encoded does not match parsed", encoded, parsed);
+		assertEquals(encoded, parsed, "Encoded does not match parsed");
 	}
 
 	@Test
@@ -43,6 +43,6 @@ public class StringUtilTest {
 		StringUtil.simpleEscapeIRI(str, out, false);
 		String encoded = out.toString();
 
-		assertEquals("Encoded does not match parsed", encoded, parsed);
+		assertEquals(encoded, parsed, "Encoded does not match parsed");
 	}
 }

--- a/core/common/transaction/src/test/java/org/eclipse/rdf4j/common/transaction/IsolationLevelsTest.java
+++ b/core/common/transaction/src/test/java/org/eclipse/rdf4j/common/transaction/IsolationLevelsTest.java
@@ -10,17 +10,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SesameHTTPClientTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/SesameHTTPClientTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.client;
 
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/IRITest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/IRITest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract {@link IRI} test suite.

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/LiteralTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -48,7 +49,7 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.eclipse.rdf4j.model.base.CoreDatatype;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract {@link Literal} test suite.
@@ -894,9 +895,9 @@ public abstract class LiteralTest {
 
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public final void testCoreDatatypeTypedConstructorNullDatatype() {
-		literal("label", ((CoreDatatype) null));
+		assertThrows(NullPointerException.class, () -> literal("label", ((CoreDatatype) null)));
 	}
 
 	//// String Value //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/NamespaceTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/NamespaceTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Objects;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract {@link Namespace} test suite.

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/StatementTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/StatementTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.util.Objects;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract {@link Statement} test suite.

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/TripleTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/TripleTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.util.Objects;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract {@link Triple} test suite.

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/ValueFactoryTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/ValueFactoryTest.java
@@ -71,7 +71,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract {@link ValueFactory} test suite.

--- a/core/model-api/src/test/java/org/eclipse/rdf4j/model/base/CoreDatatypeTest.java
+++ b/core/model-api/src/test/java/org/eclipse/rdf4j/model/base/CoreDatatypeTest.java
@@ -20,8 +20,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CoreDatatypeTest {
 
@@ -41,7 +40,7 @@ public class CoreDatatypeTest {
 				.map(CoreDatatype::getIri)
 				.map(Object::toString)
 				.collect(Collectors.toList());
-		Assert.assertEquals(datatypeIRIs, datatypeIRIsSortedByEnum);
+		assertEquals(datatypeIRIs, datatypeIRIsSortedByEnum);
 
 	}
 
@@ -61,7 +60,7 @@ public class CoreDatatypeTest {
 				.map(CoreDatatype::getIri)
 				.map(Object::toString)
 				.collect(Collectors.toList());
-		Assert.assertEquals(datatypeIRIs, datatypeIRIsSortedByEnum);
+		assertEquals(datatypeIRIs, datatypeIRIsSortedByEnum);
 
 	}
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/datatypes/XMLDatatypeUtilTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.fail;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests on {@link org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/ContextStatementTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/ContextStatementTest.java
@@ -19,9 +19,9 @@ import java.util.Set;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ContextStatementTest {
 
@@ -39,11 +39,11 @@ public class ContextStatementTest {
 
 	private static final IRI g2 = vf.createIRI("urn:g2");
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/DynamicModelConcurrentModificationAndUpgradeTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/DynamicModelConcurrentModificationAndUpgradeTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CountDownLatch;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DynamicModelConcurrentModificationAndUpgradeTest {
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/SimpleValueFactoryTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/SimpleValueFactoryTest.java
@@ -12,7 +12,7 @@ package org.eclipse.rdf4j.model.impl;
 
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.ValueFactoryTest;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author jeen
@@ -29,7 +29,7 @@ public class SimpleValueFactoryTest extends ValueFactoryTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		f = SimpleValueFactory.getInstance();
 	}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/GraphComparisonsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/GraphComparisonsTest.java
@@ -24,7 +24,7 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.TreeModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Charsets;
 import com.google.common.hash.HashCode;

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelBuilderTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelBuilderTest.java
@@ -21,8 +21,8 @@ import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ModelBuilderTest {
 
@@ -30,7 +30,7 @@ public class ModelBuilderTest {
 
 	private Model model;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		model = new LinkedHashModel();
 		testBuilder = new ModelBuilder(model);

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelCollectorTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelCollectorTest.java
@@ -20,8 +20,8 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart.Hanssens
@@ -31,7 +31,7 @@ public class ModelCollectorTest {
 	private final Set<Statement> stmts = new HashSet<>();
 	private final ValueFactory F = SimpleValueFactory.getInstance();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		for (int i = 0; i < nrStmts; i++) {
 			stmts.add(F.createStatement(F.createIRI("http://www.example.com/" + i), RDFS.LABEL, F.createLiteral(i)));

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ModelsTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Optional;
 import java.util.Set;
@@ -33,9 +34,8 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests on {@link Models} utility methods.
@@ -56,7 +56,7 @@ public class ModelsTest {
 
 	private BNode baz;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		model1 = new LinkedHashModel();
 		model2 = new LinkedHashModel();
@@ -357,14 +357,14 @@ public class ModelsTest {
 
 		try {
 			Models.getProperty(model1, foo, null).orElse(null);
-			Assert.fail("should have resulted in exception");
+			fail("should have resulted in exception");
 		} catch (NullPointerException e) {
 			// expected
 		}
 
 		try {
 			Models.getProperty(model1, null, bar).orElse(null);
-			Assert.fail("should have resulted in exception");
+			fail("should have resulted in exception");
 		} catch (NullPointerException e) {
 			// expected
 		}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/NamespacesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/NamespacesTest.java
@@ -32,8 +32,8 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SESAME;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -48,7 +48,7 @@ public class NamespacesTest {
 
 	private String testName2;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		testPrefix1 = "ns1";
 		testPrefix2 = "ns2";

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/RDFCollectionsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/RDFCollectionsTest.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.model.util;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -31,8 +32,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RDFCollectionsTest {
 
@@ -46,7 +47,7 @@ public class RDFCollectionsTest {
 
 	private Literal c;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		a = Literals.createLiteral(vf, "A");
 		b = Literals.createLiteral(vf, "B");
@@ -73,15 +74,15 @@ public class RDFCollectionsTest {
 
 	}
 
-	@Test(expected = ModelException.class)
+	@Test
 	public void testNonWellformedCollection_MissingTerminator() {
 		Resource head = vf.createBNode();
 		Model m = RDFCollections.asRDF(values, head, new TreeModel());
 		m.remove(null, RDF.REST, RDF.NIL);
-		RDFCollections.asValues(m, head, new ArrayList<>());
+		assertThrows(ModelException.class, () -> RDFCollections.asValues(m, head, new ArrayList<>()));
 	}
 
-	@Test(expected = ModelException.class)
+	@Test
 	public void testNonWellformedCollection_Cycle() {
 		Resource head = vf.createBNode("z");
 		Model m = RDFCollections.asRDF(values, head, new TreeModel());
@@ -91,16 +92,16 @@ public class RDFCollectionsTest {
 		m.remove(head, RDF.REST, null);
 		m.add(head, RDF.REST, head);
 
-		RDFCollections.asValues(m, head, new ArrayList<>());
+		assertThrows(ModelException.class, () -> RDFCollections.asValues(m, head, new ArrayList<>()));
 	}
 
-	@Test(expected = ModelException.class)
+	@Test
 	public void testNonWellformedCollection_IncorrectHeadNode() {
 		Resource head = vf.createBNode();
 		Model m = RDFCollections.asRDF(values, head, new TreeModel());
 
 		// Use resource that is unrelated to the actual collection as the head node
-		RDFCollections.asValues(m, vf.createBNode(), new ArrayList<>());
+		assertThrows(ModelException.class, () -> RDFCollections.asValues(m, vf.createBNode(), new ArrayList<>()));
 	}
 
 	@Test

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/RDFContainersTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/RDFContainersTest.java
@@ -32,8 +32,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RDFContainersTest {
 
@@ -53,7 +53,7 @@ public class RDFContainersTest {
 
 	private IRI RDF_3;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		a = Literals.createLiteral(vf, "A");
 		b = Literals.createLiteral(vf, "B");

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/StatementsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/StatementsTest.java
@@ -27,7 +27,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StatementsTest {
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/URIUtilTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/URIUtilTest.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.model.util;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Arjohn Kampman

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/ValuesTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.model.util.Values.namespace;
 import static org.eclipse.rdf4j.model.util.Values.triple;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -44,8 +45,8 @@ import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests on {@link Values} convenience functions.
@@ -60,7 +61,7 @@ public class ValuesTest {
 
 	private ValueFactory vf;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		vf = mock(ValueFactory.class);
 	}
@@ -89,14 +90,14 @@ public class ValuesTest {
 		verify(vf).createIRI(RDF.NAMESPACE, "type");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidIri1() {
-		iri("http://an invalid iri/");
+		assertThrows(IllegalArgumentException.class, () -> iri("http://an invalid iri/"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidIri2() {
-		iri("http://valid-namespace.org/", "invalid localname");
+		assertThrows(IllegalArgumentException.class, () -> iri("http://valid-namespace.org/", "invalid localname"));
 	}
 
 	@Test
@@ -269,16 +270,16 @@ public class ValuesTest {
 		verify(vf).createLiteral(lexValue, XSD.INT);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidTypedLiteral() {
 		String lexValue = "fourty two";
-		literal(lexValue, XSD.INT);
+		assertThrows(IllegalArgumentException.class, () -> literal(lexValue, XSD.INT));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testInvalidTypedLiteralCoreDatatype() {
 		String lexValue = "fourty two";
-		literal(lexValue, CoreDatatype.XSD.INT);
+		assertThrows(IllegalArgumentException.class, () -> literal(lexValue, CoreDatatype.XSD.INT));
 	}
 
 	@Test

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/VocabulariesTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/VocabulariesTest.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.HYDRA;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -126,11 +126,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>

--- a/core/query/pom.xml
+++ b/core/query/pom.xml
@@ -36,6 +36,11 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-suite-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/AllTests.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/AllTests.java
@@ -10,15 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.iteration;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
 /**
  * @author akam
  */
-@RunWith(Suite.class)
-@SuiteClasses({ LimitIterationTest.class, EmptyIterationTest.class, OffsetIterationTest.class,
+@Suite
+@SelectClasses({ LimitIterationTest.class, EmptyIterationTest.class, OffsetIterationTest.class,
 		ConvertingIterationTest.class, CloseableIteratorIterationTest.class, DelayedIterationTest.class,
 		DistinctIterationTest.class, ExceptionConvertingIterationTest.class, FilterIterationTest.class,
 		IntersectionIterationTest.class, DistinctIntersectionIterationTest.class, IteratorIterationTest.class,

--- a/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/CloseableIterationTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/CloseableIterationTest.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.iteration;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -37,7 +37,7 @@ public abstract class CloseableIterationTest extends IterationTest {
 
 			iter.close();
 
-			assertFalse("closed iteration should not contain any more elements", iter.hasNext());
+			assertFalse(iter.hasNext(), "closed iteration should not contain any more elements");
 
 			try {
 				iter.next();

--- a/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/IterationTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/IterationTest.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.iteration;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class IterationTest {
 
@@ -45,6 +45,6 @@ public abstract class IterationTest {
 			count++;
 		}
 
-		assertEquals("test iteration contains incorrect number of elements", getTestIterationSize(), count);
+		assertEquals(getTestIterationSize(), count, "test iteration contains incorrect number of elements");
 	}
 }

--- a/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/LimitIterationTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/LimitIterationTest.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.iteration;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LimitIterationTest extends CloseableIterationTest {
 
@@ -38,7 +38,7 @@ public class LimitIterationTest extends CloseableIterationTest {
 			Iteration<String, Exception> iter = createLimitIteration(limit);
 			List<String> resultList = Iterations.asList(iter);
 			List<String> expectedList = stringList1.subList(0, limit);
-			assertEquals("testInRangeOffset failed for limit: " + limit, expectedList, resultList);
+			assertEquals(expectedList, resultList, "testInRangeOffset failed for limit: " + limit);
 		}
 	}
 

--- a/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/OffsetIterationTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/OffsetIterationTest.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.iteration;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OffsetIterationTest extends CloseableIterationTest {
 
@@ -39,7 +39,7 @@ public class OffsetIterationTest extends CloseableIterationTest {
 			Iteration<String, Exception> iter = createOffsetIteration(offset);
 			List<String> resultList = Iterations.asList(iter);
 			List<String> expectedList = stringList1.subList(offset, stringList1.size());
-			assertEquals("test failed for offset: " + offset, expectedList, resultList);
+			assertEquals(expectedList, resultList, "test failed for offset: " + offset);
 		}
 	}
 

--- a/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/UnionIterationTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/common/iteration/UnionIterationTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.iteration;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UnionIterationTest extends CloseableIterationTest {
 
@@ -35,8 +35,8 @@ public class UnionIterationTest extends CloseableIterationTest {
 			unionIter.next();
 		}
 
-		assertTrue("iter1 should have been closed", iter1.isClosed());
-		assertTrue("iter2 should have been closed", iter2.isClosed());
-		assertTrue("iter3 should have been closed", iter3.isClosed());
+		assertTrue(iter1.isClosed(), "iter1 should have been closed");
+		assertTrue(iter2.isClosed(), "iter2 should have been closed");
+		assertTrue(iter3.isClosed(), "iter3 should have been closed");
 	}
 }

--- a/core/query/src/test/java/org/eclipse/rdf4j/query/BindingSetTest.java
+++ b/core/query/src/test/java/org/eclipse/rdf4j/query/BindingSetTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for BindingSet implementations.

--- a/core/queryalgebra/evaluation/pom.xml
+++ b/core/queryalgebra/evaluation/pom.xml
@@ -71,6 +71,12 @@
 			<version>${jmhVersion}</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- This module uses parameterized tests and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSetTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/ArrayBindingSetTest.java
@@ -10,17 +10,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ArrayBindingSetTest {
 
@@ -29,7 +29,7 @@ public class ArrayBindingSetTest {
 
 	private final ValueFactory vf = SimpleValueFactory.getInstance();
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		qbs.getDirectSetBinding("foo").accept(vf.createIRI("urn:foo"), qbs);
 		mbs.addBinding("foo", vf.createIRI("urn:foo"));
@@ -53,8 +53,8 @@ public class ArrayBindingSetTest {
 	public void testHashcodeMapBindingSet() {
 		assertTrue(qbs.equals(mbs));
 		assertTrue(mbs.equals(qbs));
-		assertEquals("objects that return true on their equals() method must have identical hash codes", qbs.hashCode(),
-				mbs.hashCode());
+		assertEquals(qbs.hashCode(), mbs.hashCode(),
+				"objects that return true on their equals() method must have identical hash codes");
 	}
 
 	/**

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSetTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSetTest.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,8 +27,8 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class QueryBindingSetTest {
 
@@ -37,7 +37,7 @@ public class QueryBindingSetTest {
 
 	private final ValueFactory vf = SimpleValueFactory.getInstance();
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		qbs.addBinding("foo", vf.createIRI("urn:foo"));
 		mbs.addBinding("foo", vf.createIRI("urn:foo"));
@@ -194,8 +194,8 @@ public class QueryBindingSetTest {
 	public void testHashcodeMapBindingSet() {
 		assertTrue(qbs.equals(mbs));
 		assertTrue(mbs.equals(qbs));
-		assertEquals("objects that return true on their equals() method must have identical hash codes", qbs.hashCode(),
-				mbs.hashCode());
+		assertEquals(qbs.hashCode(), mbs.hashCode(),
+				"objects that return true on their equals() method must have identical hash codes");
 	}
 
 	/**

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/NowTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/NowTest.java
@@ -10,18 +10,19 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.datetime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -35,7 +36,7 @@ public class NowTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		now = new Now();
 	}
@@ -43,7 +44,7 @@ public class NowTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/TimezoneTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/TimezoneTest.java
@@ -10,18 +10,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.datetime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -35,7 +35,7 @@ public class TimezoneTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		timezone = new Timezone();
 	}
@@ -43,7 +43,7 @@ public class TimezoneTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/TzTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/TzTest.java
@@ -10,18 +10,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.datetime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -35,7 +35,7 @@ public class TzTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		tz = new Tz();
 	}
@@ -43,7 +43,7 @@ public class TzTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/HashFunctionTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/HashFunctionTest.java
@@ -10,16 +10,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.hash;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/HashLeadingZeroTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/HashLeadingZeroTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.hash;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Bart Hanssens
@@ -22,7 +22,7 @@ public class HashLeadingZeroTest extends HashFunctionTest {
 	 *
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setHashFunction(new MD5());
 		setToHash("363");

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/MD5Test.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/MD5Test.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.hash;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author jeen
@@ -20,7 +20,7 @@ public class MD5Test extends HashFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setHashFunction(new MD5());
 		setToHash("abc");

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/SHA1Test.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/SHA1Test.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.hash;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author jeen
@@ -20,7 +20,7 @@ public class SHA1Test extends HashFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setHashFunction(new SHA1());
 		setToHash("abc");

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/SHA256Test.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/SHA256Test.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.hash;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author jeen
@@ -20,7 +20,7 @@ public class SHA256Test extends HashFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setHashFunction(new SHA256());
 		setToHash("abc");

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/SHA384Test.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/SHA384Test.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.hash;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author jeen
@@ -20,7 +20,7 @@ public class SHA384Test extends HashFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setHashFunction(new SHA384());
 		setToHash("abc");

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/SHA512Test.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/SHA512Test.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.hash;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author jeen
@@ -20,7 +20,7 @@ public class SHA512Test extends HashFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setHashFunction(new SHA512());
 		setToHash("abc");

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/numeric/RandTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/numeric/RandTest.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.numeric;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -36,9 +36,9 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -52,7 +52,7 @@ public class RandTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		rand = new Rand();
 	}
@@ -60,7 +60,7 @@ public class RandTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/numeric/RoundTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/numeric/RoundTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.numeric;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigDecimal;
 
@@ -20,9 +20,9 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -36,7 +36,7 @@ public class RoundTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		round = new Round();
 	}
@@ -44,7 +44,7 @@ public class RoundTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/ConcatTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/ConcatTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -20,8 +20,8 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ConcatTest {
 
@@ -39,7 +39,7 @@ public class ConcatTest {
 
 	private static final Literal foo_nl = vf.createLiteral("foo", "nl");
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		concatFunc = new Concat();
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/LowerCaseTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/LowerCaseTest.java
@@ -10,16 +10,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -33,7 +33,7 @@ public class LowerCaseTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		lcaseFunc = new LowerCase();
 	}
@@ -41,7 +41,7 @@ public class LowerCaseTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/RegexTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/RegexTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
@@ -27,9 +27,9 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.EmptyTripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.repository.sparql.federation.SPARQLServiceResolver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author james
@@ -40,12 +40,12 @@ public class RegexTest {
 
 	private SPARQLServiceResolver serviceResolver;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		serviceResolver = new SPARQLServiceResolver();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		serviceResolver.shutDown();
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/ReplaceTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/ReplaceTest.java
@@ -10,16 +10,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -33,7 +33,7 @@ public class ReplaceTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		replaceFunc = new Replace();
 	}
@@ -41,7 +41,7 @@ public class ReplaceTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/StrAfterTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/StrAfterTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -20,9 +20,9 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -36,7 +36,7 @@ public class StrAfterTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		strAfterFunc = new StrAfter();
 	}
@@ -44,7 +44,7 @@ public class StrAfterTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/StrBeforeTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/StrBeforeTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -20,9 +20,9 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -36,7 +36,7 @@ public class StrBeforeTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		strBeforeFunc = new StrBefore();
 	}
@@ -44,7 +44,7 @@ public class StrBeforeTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/SubstringTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/SubstringTest.java
@@ -10,17 +10,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -34,7 +34,7 @@ public class SubstringTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		substrFunc = new Substring();
 	}
@@ -42,7 +42,7 @@ public class SubstringTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/UpperCaseTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/UpperCaseTest.java
@@ -10,16 +10,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -33,7 +33,7 @@ public class UpperCaseTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		ucaseFunc = new UpperCase();
 	}
@@ -41,7 +41,7 @@ public class UpperCaseTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/IsTripleFunctionTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/IsTripleFunctionTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.triple;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -21,9 +21,9 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test rdf:isTriple(a) function
@@ -39,7 +39,7 @@ public class IsTripleFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		function = new IsTripleFunction();
 	}
@@ -47,7 +47,7 @@ public class IsTripleFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 
@@ -60,28 +60,26 @@ public class IsTripleFunctionTest {
 
 		Value value = function.evaluate(f, testValue);
 		assertNotNull(value);
-		assertTrue("expect Literal", value instanceof Literal);
-		assertTrue("expect positive result", ((Literal) value).booleanValue());
+		assertTrue(value instanceof Literal, "expect Literal");
+		assertTrue(((Literal) value).booleanValue(), "expect positive result");
 		value = function.evaluate(f, subj);
 		assertNotNull(value);
-		assertTrue("expect Literal", value instanceof Literal);
-		assertTrue("expect negative result", !((Literal) value).booleanValue());
+		assertTrue(value instanceof Literal, "expect Literal");
+		assertTrue(!((Literal) value).booleanValue(), "expect negative result");
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testNegativeWrongArguments() {
 		IRI subj = f.createIRI("urn:a");
 		IRI pred = f.createIRI("urn:b");
 		IRI obj = f.createIRI("urn:c");
 		Triple testValue = f.createTriple(subj, pred, obj);
 
-		function.evaluate(f, testValue, subj);
-		fail("expect ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, testValue, subj));
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testNegativeNoArguments() {
-		function.evaluate(f);
-		fail("expect ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f));
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/StatementFunctionTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/StatementFunctionTest.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.triple;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -23,9 +23,9 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test rdf:Statement(a, b, c) function cases covered: subject one of (IRI | BNode | Triple | Literal) predicate one of
@@ -42,7 +42,7 @@ public class StatementFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		function = new StatementFunction();
 	}
@@ -50,7 +50,7 @@ public class StatementFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 
@@ -62,9 +62,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -75,9 +75,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -88,9 +88,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -101,9 +101,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -114,9 +114,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -127,9 +127,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -140,9 +140,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -153,9 +153,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -166,9 +166,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -179,9 +179,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -192,9 +192,9 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
 	@Test
@@ -205,38 +205,35 @@ public class StatementFunctionTest {
 
 		Value value = function.evaluate(f, subj, pred, obj);
 		assertNotNull(value);
-		assertTrue("expect Triple", value instanceof Triple);
+		assertTrue(value instanceof Triple, "expect Triple");
 		Triple other = f.createTriple(subj, pred, obj);
-		assertEquals("expect to be the same", value, other);
+		assertEquals(value, other, "expect to be the same");
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testNegariveWrongNumberOfArguments() {
 		IRI subj = f.createIRI("urn:a");
 		IRI pred = f.createIRI("urn:b");
 		IRI obj = f.createIRI("urn:c");
 
-		function.evaluate(f, subj, pred, obj, null);
-		fail("should throw ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, subj, pred, obj, null));
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testNegativeLiteralAsSubject() {
 		Literal subj = f.createLiteral(1);
 		IRI pred = f.createIRI("urn:b");
 		IRI obj = f.createIRI("urn:c");
 
-		function.evaluate(f, subj, pred, obj);
-		fail("should not accept Literal as subject");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, subj, pred, obj));
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testNegativeLiteralAsPredicate() {
 		Literal subj = f.createLiteral(1);
 		IRI pred = f.createIRI("urn:b");
 		IRI obj = f.createIRI("urn:c");
 
-		function.evaluate(f, subj, pred, obj);
-		fail("should not accept Literal as predicate");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, subj, pred, obj));
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TripleObjectFunctionTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TripleObjectFunctionTest.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.triple;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Triple;
@@ -21,9 +21,9 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test rdf:subject(a) function
@@ -39,7 +39,7 @@ public class TripleObjectFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		function = new TripleObjectFunction();
 	}
@@ -47,7 +47,7 @@ public class TripleObjectFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 
@@ -60,26 +60,24 @@ public class TripleObjectFunctionTest {
 
 		Value value = function.evaluate(f, testValue);
 		assertNotNull(value);
-		assertTrue("expect IRI", value instanceof IRI);
-		assertEquals("expect same value", obj, value);
+		assertTrue(value instanceof IRI, "expect IRI");
+		assertEquals(obj, value, "expect same value");
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testNegativeWrongArguments() {
 		IRI subj = f.createIRI("urn:a");
 		IRI pred = f.createIRI("urn:b");
 		IRI obj = f.createIRI("urn:c");
 		Triple testValue = f.createTriple(subj, pred, obj);
 
-		function.evaluate(f, testValue, subj);
-		fail("expect ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, testValue, subj));
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testWrongArguments() {
 		IRI subj = f.createIRI("urn:a");
 
-		function.evaluate(f, subj);
-		fail("expect ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, subj));
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TriplePredicateFunctionTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TriplePredicateFunctionTest.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.triple;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Triple;
@@ -21,9 +21,9 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test rdf:predicate(a) function
@@ -39,7 +39,7 @@ public class TriplePredicateFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		function = new TriplePredicateFunction();
 	}
@@ -47,7 +47,7 @@ public class TriplePredicateFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 
@@ -60,26 +60,24 @@ public class TriplePredicateFunctionTest {
 
 		Value value = function.evaluate(f, testValue);
 		assertNotNull(value);
-		assertTrue("expect IRI", value instanceof IRI);
-		assertEquals("expect same value", pred, value);
+		assertTrue(value instanceof IRI, "expect IRI");
+		assertEquals(pred, value, "expect same value");
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testNegativeWrongArguments() {
 		IRI subj = f.createIRI("urn:a");
 		IRI pred = f.createIRI("urn:b");
 		IRI obj = f.createIRI("urn:c");
 		Triple testValue = f.createTriple(subj, pred, obj);
 
-		function.evaluate(f, testValue, subj);
-		fail("expect ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, testValue, subj));
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testWrongArguments() {
 		IRI subj = f.createIRI("urn:a");
 
-		function.evaluate(f, subj);
-		fail("expect ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, subj));
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TripleSubjectFunctionTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/triple/TripleSubjectFunctionTest.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.triple;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Triple;
@@ -21,9 +21,9 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test rdf:subject(a) function
@@ -39,7 +39,7 @@ public class TripleSubjectFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		function = new TripleSubjectFunction();
 	}
@@ -47,7 +47,7 @@ public class TripleSubjectFunctionTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 
@@ -60,26 +60,24 @@ public class TripleSubjectFunctionTest {
 
 		Value value = function.evaluate(f, testValue);
 		assertNotNull(value);
-		assertTrue("expect IRI", value instanceof IRI);
-		assertEquals("expect same value", subj, value);
+		assertTrue(value instanceof IRI, "expect IRI");
+		assertEquals(subj, value, "expect same value");
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testNegativeWrongArguments() {
 		IRI subj = f.createIRI("urn:a");
 		IRI pred = f.createIRI("urn:b");
 		IRI obj = f.createIRI("urn:c");
 		Triple testValue = f.createTriple(subj, pred, obj);
 
-		function.evaluate(f, testValue, subj);
-		fail("expect ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, testValue, subj));
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testWrongArguments() {
 		IRI subj = f.createIRI("urn:a");
 
-		function.evaluate(f, subj);
-		fail("expect ValueExprEvaluationException");
+		assertThrows(ValueExprEvaluationException.class, () -> function.evaluate(f, subj));
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/xsd/TestDateTimeCast.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/xsd/TestDateTimeCast.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.xsd;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -21,9 +21,9 @@ import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -37,7 +37,7 @@ public class TestDateTimeCast {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		dtCast = new DateTimeCast();
 	}
@@ -45,7 +45,7 @@ public class TestDateTimeCast {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/xsd/TestIntegerDatatypeCast.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/xsd/TestIntegerDatatypeCast.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.xsd;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigInteger;
 import java.util.Optional;
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class TestIntegerDatatypeCast<T extends IntegerCastFunction> {
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/xsd/TestStringCast.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/xsd/TestStringCast.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.xsd;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -21,9 +21,9 @@ import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -37,7 +37,7 @@ public class TestStringCast {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		stringCast = new StringCast();
 	}
@@ -45,7 +45,7 @@ public class TestStringCast {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/FilterOptimizerTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -33,7 +33,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerTest;
 import org.eclipse.rdf4j.query.algebra.evaluation.optimizer.FilterOptimizer;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FilterOptimizerTest extends QueryOptimizerTest {
 

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ProjectionRemovalOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ProjectionRemovalOptimizerTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.query.QueryLanguage;

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryCostEstimatesTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryCostEstimatesTest.java
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.query.algebra.evaluation.optimizer.QueryJoinOptimizer;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests that cost estimates are printed as part of the plan

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizerTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizerTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,8 +37,7 @@ import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests to monitor QueryJoinOptimizer behaviour.
@@ -59,7 +60,7 @@ public class QueryJoinOptimizerTest extends QueryOptimizerTest {
 		testOptimizer(expectedQuery, query);
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testContextOptimization() throws RDF4JException {
 		String query = "prefix ex: <ex:>" + "select ?x ?y ?z ?g ?p ?o where {" + " graph ?g {" + "  ex:s ?sp ?so. "
 				+ "  ?ps ex:p ?po. " + "  ?os ?op 'ex:o'. " + " }" + " ?x ?y ?z. " + "}";
@@ -71,7 +72,7 @@ public class QueryJoinOptimizerTest extends QueryOptimizerTest {
 		String expectedQuery = "prefix ex: <ex:>" + "select ?x ?y ?z ?g ?p ?o where {" + " graph ?g {"
 				+ "  ex:s ?sp ?so. " + "  ?ps ex:p ?po. " + "  ?os ?op 'ex:o'. " + " }" + " ?x ?y ?z. " + "}";
 
-		testOptimizer(expectedQuery, query);
+		assertThrows(AssertionError.class, () -> testOptimizer(expectedQuery, query));
 	}
 
 	@Test
@@ -107,8 +108,7 @@ public class QueryJoinOptimizerTest extends QueryOptimizerTest {
 		QueryRoot optRoot = new QueryRoot(q.getTupleExpr());
 		opt.optimize(optRoot, null, null);
 		TupleExpr leaf = findLeaf(optRoot);
-		Assert.assertTrue("Extension must be evaluated before StatementPattern",
-				leaf.getParentNode() instanceof Extension);
+		assertTrue(leaf.getParentNode() instanceof Extension, "Extension must be evaluated before StatementPattern");
 	}
 
 	@Test

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizierTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizierTest.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -23,7 +23,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
 import org.eclipse.rdf4j.query.algebra.evaluation.optimizer.RegexAsStringFunctionOptimizer;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests to make sure the RegexAsStringFunctionOptomizer behaves.

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -42,14 +42,14 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class StrictEvaluationStrategyTest {
 
 	private EvaluationStrategy strategy;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		strategy = new StrictEvaluationStrategy(new EmptyTripleSource(), null);
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIteratorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/GroupIteratorTest.java
@@ -53,9 +53,9 @@ import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateCollector;
 import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunction;
 import org.eclipse.rdf4j.query.parser.sparql.aggregate.AggregateFunctionFactory;
 import org.eclipse.rdf4j.query.parser.sparql.aggregate.CustomAggregateFunctionRegistry;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -69,7 +69,7 @@ public class GroupIteratorTest {
 	private static BindingSetAssignment NONEMPTY_ASSIGNMENT;
 	private static AggregateFunctionFactory aggregateFunctionFactory;
 
-	@BeforeClass
+	@BeforeAll
 	public static void init() {
 		EMPTY_ASSIGNMENT = new BindingSetAssignment();
 		EMPTY_ASSIGNMENT.setBindingSets(Collections.emptyList());
@@ -126,7 +126,7 @@ public class GroupIteratorTest {
 		CustomAggregateFunctionRegistry.getInstance().add(aggregateFunctionFactory);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void cleanUp() {
 		CustomAggregateFunctionRegistry.getInstance().remove(aggregateFunctionFactory);
 	}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIterationTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIterationTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author MJAHale

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/JoinIteratorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/JoinIteratorTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -36,7 +36,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author MJAHale

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/OrderIteratorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/OrderIteratorTest.java
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,13 +27,13 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author james
  */
-public class OrderIteratorTest extends TestCase {
+public class OrderIteratorTest {
 
 	class IterationStub extends CloseableIteratorIteration<BindingSet, QueryEvaluationException> {
 
@@ -134,6 +138,7 @@ public class OrderIteratorTest extends TestCase {
 
 	private SizeComparator cmp;
 
+	@Test
 	public void testFirstHasNext() throws Exception {
 		order.hasNext();
 		assertEquals(list.size() + 1, iteration.hasNextCount);
@@ -141,6 +146,7 @@ public class OrderIteratorTest extends TestCase {
 		assertEquals(0, iteration.removeCount);
 	}
 
+	@Test
 	public void testHasNext() throws Exception {
 		order.hasNext();
 		order.next();
@@ -150,6 +156,7 @@ public class OrderIteratorTest extends TestCase {
 		assertEquals(0, iteration.removeCount);
 	}
 
+	@Test
 	public void testFirstNext() throws Exception {
 		order.next();
 		assertEquals(list.size() + 1, iteration.hasNextCount);
@@ -157,6 +164,7 @@ public class OrderIteratorTest extends TestCase {
 		assertEquals(0, iteration.removeCount);
 	}
 
+	@Test
 	public void testNext() throws Exception {
 		order.next();
 		order.next();
@@ -165,6 +173,7 @@ public class OrderIteratorTest extends TestCase {
 		assertEquals(0, iteration.removeCount);
 	}
 
+	@Test
 	public void testRemove() throws Exception {
 		try {
 			order.remove();
@@ -174,6 +183,7 @@ public class OrderIteratorTest extends TestCase {
 
 	}
 
+	@Test
 	public void testSorting() throws Exception {
 		List<BindingSet> sorted = new ArrayList<>(list);
 		Collections.sort(sorted, cmp);
@@ -183,7 +193,7 @@ public class OrderIteratorTest extends TestCase {
 		assertFalse(order.hasNext());
 	}
 
-	@Override
+	@BeforeEach
 	protected void setUp() throws Exception {
 		list = Arrays.asList(b3, b5, b2, b1, b4, b2);
 		cmp = new SizeComparator();

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIterationTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/ZeroLengthPathIterationTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.iterator;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
@@ -32,8 +32,8 @@ import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -44,7 +44,7 @@ public class ZeroLengthPathIterationTest {
 
 	private EvaluationStrategy evaluator;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		Model m = new LinkedHashModel();
 		m.add(RDF.ALT, RDF.TYPE, RDFS.CLASS);
@@ -83,9 +83,9 @@ public class ZeroLengthPathIterationTest {
 				bindings, new QueryEvaluationContext.Minimal(null))) {
 			BindingSet result = zlp.getNextElement();
 
-			assertTrue("zlp evaluation should have retained unrelated input binding", result.hasBinding("a"));
-			assertTrue("zlp evaluation should binding for subject var", result.hasBinding("x"));
-			assertTrue("zlp evaluation should binding for object var", result.hasBinding("y"));
+			assertTrue(result.hasBinding("a"), "zlp evaluation should have retained unrelated input binding");
+			assertTrue(result.hasBinding("x"), "zlp evaluation should binding for subject var");
+			assertTrue(result.hasBinding("y"), "zlp evaluation should binding for object var");
 		}
 	}
 }

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/LiteralComparatorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/LiteralComparatorTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,8 +23,8 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author james
@@ -138,7 +138,7 @@ public class LiteralComparatorTest {
 		assertTrue(list.indexOf(nine) < list.indexOf(ten));
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		DatatypeFactory factory = DatatypeFactory.newInstance();
 		XMLGregorianCalendar mar = factory.newXMLGregorianCalendar("2000-03-04T20:00:00Z");

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/OrderComparatorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/OrderComparatorTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -37,8 +37,8 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedService;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author james
@@ -210,7 +210,7 @@ public class OrderComparatorTest {
 		assertTrue(sud.compare(a, b) != sud.compare(b, a));
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		asc.setAscending(true);
 		desc.setAscending(false);

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilTest.java
@@ -13,10 +13,10 @@ package org.eclipse.rdf4j.query.algebra.evaluation.util;
 import static org.eclipse.rdf4j.query.algebra.Compare.CompareOp.EQ;
 import static org.eclipse.rdf4j.query.algebra.Compare.CompareOp.LT;
 import static org.eclipse.rdf4j.query.algebra.Compare.CompareOp.NE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -33,8 +33,8 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.Compare;
 import org.eclipse.rdf4j.query.algebra.Compare.CompareOp;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jeen Broekstra
@@ -83,7 +83,7 @@ public class QueryEvaluationUtilTest {
 
 	private Literal arg2unknown;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		arg1simple = f.createLiteral("abc");
 		arg2simple = f.createLiteral("b");
@@ -442,8 +442,8 @@ public class QueryEvaluationUtilTest {
 	 * @param op   The operator for the comparison
 	 */
 	private void assertCompareFalse(Literal lit1, Literal lit2, CompareOp op, boolean strict) {
-		assertFalse("Compare did not return false for " + lit1.toString() + op.getSymbol() + lit2.toString(),
-				QueryEvaluationUtil.compareLiterals(lit1, lit2, op, strict));
+		assertFalse(QueryEvaluationUtil.compareLiterals(lit1, lit2, op, strict),
+				"Compare did not return false for " + lit1.toString() + op.getSymbol() + lit2.toString());
 	}
 
 	private void assertCompareTrue(Literal lit1, Literal lit2, CompareOp op) {
@@ -460,8 +460,8 @@ public class QueryEvaluationUtilTest {
 	 * @param strict boolean switch between strict and extended comparison
 	 */
 	private void assertCompareTrue(Literal lit1, Literal lit2, CompareOp op, boolean strict) {
-		assertTrue("Compare did not return true for " + lit1.toString() + op.getSymbol() + lit2.toString(),
-				QueryEvaluationUtil.compareLiterals(lit1, lit2, op, strict));
+		assertTrue(QueryEvaluationUtil.compareLiterals(lit1, lit2, op, strict),
+				"Compare did not return true for " + lit1.toString() + op.getSymbol() + lit2.toString());
 	}
 
 	/**

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilityTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/QueryEvaluationUtilityTest.java
@@ -13,10 +13,10 @@ package org.eclipse.rdf4j.query.algebra.evaluation.util;
 import static org.eclipse.rdf4j.query.algebra.Compare.CompareOp.EQ;
 import static org.eclipse.rdf4j.query.algebra.Compare.CompareOp.LT;
 import static org.eclipse.rdf4j.query.algebra.Compare.CompareOp.NE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -32,8 +32,8 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.Compare.CompareOp;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jeen Broekstra
@@ -83,7 +83,7 @@ public class QueryEvaluationUtilityTest {
 
 	private Literal arg2unknown;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		arg1simple = f.createLiteral("abc");
 		arg2simple = f.createLiteral("b");
@@ -440,8 +440,8 @@ public class QueryEvaluationUtilityTest {
 	 * @param op   The operator for the comparison
 	 */
 	private void assertCompareFalse(Literal lit1, Literal lit2, CompareOp op, boolean strict) {
-		assertFalse("Compare did not return false for " + lit1.toString() + op.getSymbol() + lit2.toString(),
-				QueryEvaluationUtility.compareLiterals(lit1, lit2, op, strict).orElse(false));
+		assertFalse(QueryEvaluationUtility.compareLiterals(lit1, lit2, op, strict).orElse(false),
+				"Compare did not return false for " + lit1.toString() + op.getSymbol() + lit2.toString());
 	}
 
 	private void assertCompareTrue(Literal lit1, Literal lit2, CompareOp op) {
@@ -458,8 +458,8 @@ public class QueryEvaluationUtilityTest {
 	 * @param strict boolean switch between strict and extended comparison
 	 */
 	private void assertCompareTrue(Literal lit1, Literal lit2, CompareOp op, boolean strict) {
-		assertTrue("Compare did not return true for " + lit1.toString() + op.getSymbol() + lit2.toString(),
-				QueryEvaluationUtility.compareLiterals(lit1, lit2, op, strict).orElse(false));
+		assertTrue(QueryEvaluationUtility.compareLiterals(lit1, lit2, op, strict).orElse(false),
+				"Compare did not return true for " + lit1.toString() + op.getSymbol() + lit2.toString());
 	}
 
 	/**

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/ValueComparatorTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/ValueComparatorTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.util;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author james

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/XMLDatatypeMathUtilTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/XMLDatatypeMathUtilTest.java
@@ -11,14 +11,14 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.util;
 
 import static org.eclipse.rdf4j.query.algebra.MathExpr.MathOp;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.base.CoreDatatype;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thomas Pellissier Tanon

--- a/core/queryalgebra/geosparql/pom.xml
+++ b/core/queryalgebra/geosparql/pom.xml
@@ -35,5 +35,10 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/BufferTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/BufferTest.java
@@ -11,7 +11,8 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -22,7 +23,7 @@ import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -63,13 +64,15 @@ public class BufferTest {
 		assertThat(result.getLabel()).startsWith("POLYGON ((23.708505");
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testEvaluateWithInvalidRadius() {
-		buffer.evaluate(f, point, f.createLiteral("foobar", XSD.DECIMAL), unit);
+		assertThrows(ValueExprEvaluationException.class,
+				() -> buffer.evaluate(f, point, f.createLiteral("foobar", XSD.DECIMAL), unit));
 	}
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testEvaluateWithInvalidUnit() {
-		buffer.evaluate(f, point, f.createLiteral(1.0), FOAF.PERSON);
+		assertThrows(ValueExprEvaluationException.class,
+				() -> buffer.evaluate(f, point, f.createLiteral(1.0), FOAF.PERSON));
 	}
 }

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DistanceTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DistanceTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.BindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -36,16 +36,16 @@ public class DistanceTest {
 	public void testDistanceAmBxl() throws IOException {
 		BindingSet bs = GeoSPARQLTests.getBindingSet("distance.rq");
 
-		assertNotNull("Bindingset is null", bs);
+		assertNotNull(bs, "Bindingset is null");
 
 		Value value = bs.getBinding("dist").getValue();
-		assertNotNull("Binded value is null", value);
+		assertNotNull(value, "Binded value is null");
 
-		assertTrue("Value is not a literal", value instanceof Literal);
+		assertTrue(value instanceof Literal, "Value is not a literal");
 		Literal l = (Literal) value;
-		assertTrue("Literal not of type double", l.getDatatype().equals(XSD.DOUBLE));
+		assertTrue(l.getDatatype().equals(XSD.DOUBLE), "Literal not of type double");
 
-		assertEquals("Distance Amsterdam-Brussels not correct", 173, l.doubleValue() / 1000, 0.5);
+		assertEquals(173, l.doubleValue() / 1000, 0.5, "Distance Amsterdam-Brussels not correct");
 	}
 
 	/**
@@ -57,7 +57,7 @@ public class DistanceTest {
 	public void testDistanceSame() throws IOException {
 		BindingSet bs = GeoSPARQLTests.getBindingSet("distance_same.rq");
 
-		assertNotNull("Bindingset is null", bs);
+		assertNotNull(bs, "Bindingset is null");
 
 		Value v1 = bs.getBinding("dist1").getValue();
 		double ambxl = ((Literal) v1).doubleValue();
@@ -65,7 +65,6 @@ public class DistanceTest {
 		Value v2 = bs.getBinding("dist2").getValue();
 		double bxlam = ((Literal) v2).doubleValue();
 
-		assertEquals("Distance Amsterdam-Brussels not correct", ambxl, bxlam, 0.1);
+		assertEquals(ambxl, bxlam, 0.1, "Distance Amsterdam-Brussels not correct");
 	}
-
 }

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhContainsTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhContainsTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -20,7 +20,7 @@ import java.util.List;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -36,16 +36,16 @@ public class EhContainsTest extends GeometricRelationFunctionTest {
 	public void testEhContainsDenver() throws IOException {
 		List<BindingSet> list = GeoSPARQLTests.getResults("ehcontains.rq");
 
-		assertNotNull("Resultset is null", list);
-		assertEquals("Number of results must be one", 1, list.size());
+		assertNotNull(list, "Resultset is null");
+		assertEquals(1, list.size(), "Number of results must be one");
 
 		Value value = list.get(0).getBinding("city").getValue();
-		assertNotNull("Binded value is null", value);
+		assertNotNull(value, "Binded value is null");
 
-		assertTrue("Value is not an IRI", value instanceof IRI);
+		assertTrue(value instanceof IRI, "Value is not an IRI");
 		IRI iri = (IRI) value;
 
-		assertEquals("City is not Denver", "http://example.org/denver", iri.stringValue());
+		assertEquals("http://example.org/denver", iri.stringValue(), "City is not Denver");
 	}
 
 	@Override

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunctionTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunctionTest.java
@@ -10,16 +10,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class GeometricBinaryFunctionTest {
 
 	Literal amsterdam = SimpleValueFactory.getInstance().createLiteral("POINT(4.9 52.37)", GEO.WKT_LITERAL);
@@ -28,11 +30,12 @@ public abstract class GeometricBinaryFunctionTest {
 
 	protected abstract GeometricBinaryFunction testedFunction();
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testRelationExceptionHandling() {
 		GeometricBinaryFunction testedFunction = Mockito.spy(testedFunction());
 		Mockito.doThrow(new RuntimeException("forsooth!")).when(testedFunction).operation(Mockito.any(), Mockito.any());
-		testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam, brussels);
+		assertThrows(ValueExprEvaluationException.class,
+				() -> testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam, brussels));
 	}
 
 }

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunctionTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunctionTest.java
@@ -10,16 +10,18 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class GeometricRelationFunctionTest {
 
 	Literal amsterdam = SimpleValueFactory.getInstance().createLiteral("POINT(4.9 52.37)", GEO.WKT_LITERAL);
@@ -28,11 +30,11 @@ public abstract class GeometricRelationFunctionTest {
 
 	protected abstract GeometricRelationFunction testedFunction();
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testRelationExceptionHandling() {
 		GeometricRelationFunction testedFunction = Mockito.spy(testedFunction());
 		Mockito.doThrow(new RuntimeException("forsooth!")).when(testedFunction).relation(Mockito.any(), Mockito.any());
-		testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam, brussels);
+		assertThrows(ValueExprEvaluationException.class,
+				() -> testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam, brussels));
 	}
-
 }

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunctionTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunctionTest.java
@@ -10,27 +10,30 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class GeometricUnaryFunctionTest {
 
 	Literal amsterdam = SimpleValueFactory.getInstance().createLiteral("POINT(4.9 52.37)", GEO.WKT_LITERAL);
 
 	protected abstract GeometricUnaryFunction testedFunction();
 
-	@Test(expected = ValueExprEvaluationException.class)
+	@Test
 	public void testRelationExceptionHandling() {
 		GeometricUnaryFunction testedFunction = Mockito.spy(testedFunction());
 		Mockito.doThrow(new RuntimeException("forsooth!")).when(testedFunction).operation(Mockito.any());
-		testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam);
+		assertThrows(ValueExprEvaluationException.class,
+				() -> testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam));
 	}
 
 }

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfContainsTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfContainsTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -20,7 +20,7 @@ import java.util.List;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.query.BindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -36,16 +36,16 @@ public class SfContainsTest extends GeometricRelationFunctionTest {
 	public void testSfContainsDenver() throws IOException {
 		List<BindingSet> list = GeoSPARQLTests.getResults("sfcontains.rq");
 
-		assertNotNull("Resultset is null", list);
-		assertEquals("Number of results must be one", 1, list.size());
+		assertNotNull(list, "Resultset is null");
+		assertEquals(1, list.size(), "Number of results must be one");
 
 		Value value = list.get(0).getBinding("city").getValue();
-		assertNotNull("Binded value is null", value);
+		assertNotNull(value, "Binded value is null");
 
-		assertTrue("Value is not an IRI", value instanceof IRI);
+		assertTrue(value instanceof IRI, "Value is not an IRI");
 		IRI iri = (IRI) value;
 
-		assertEquals("City is not Denver", "http://example.org/denver", iri.stringValue());
+		assertEquals("http://example.org/denver", iri.stringValue(), "City is not Denver");
 	}
 
 	@Override

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfEqualsTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfEqualsTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SfEqualsTest extends GeometricRelationFunctionTest {
 

--- a/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfWithinTest.java
+++ b/core/queryalgebra/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfWithinTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.BindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -36,16 +36,16 @@ public class SfWithinTest extends GeometricRelationFunctionTest {
 	public void testDenverSfWithinColorado() throws IOException {
 		BindingSet bs = GeoSPARQLTests.getBindingSet("sfwithin_denver.rq");
 
-		assertNotNull("Bindingset is null", bs);
+		assertNotNull(bs, "Bindingset is null");
 
 		Value value = bs.getBinding("within").getValue();
-		assertNotNull("Binded value is null", value);
+		assertNotNull(value, "Binded value is null");
 
-		assertTrue("Value is not a literal", value instanceof Literal);
+		assertTrue(value instanceof Literal, "Value is not a literal");
 		Literal l = (Literal) value;
-		assertTrue("Literal not of type double", l.getDatatype().equals(XSD.BOOLEAN));
+		assertTrue(l.getDatatype().equals(XSD.BOOLEAN), "Literal not of type double");
 
-		assertTrue("Denver not within Colorado", l.booleanValue());
+		assertTrue(l.booleanValue(), "Denver not within Colorado");
 	}
 
 	/**
@@ -57,16 +57,16 @@ public class SfWithinTest extends GeometricRelationFunctionTest {
 	public void testBrusselsSfWithinColorado() throws IOException {
 		BindingSet bs = GeoSPARQLTests.getBindingSet("sfwithin_brussels.rq");
 
-		assertNotNull("Bindingset is null", bs);
+		assertNotNull(bs, "Bindingset is null");
 
 		Value value = bs.getBinding("within").getValue();
-		assertNotNull("Binded value is null", value);
+		assertNotNull(value, "Binded value is null");
 
-		assertTrue("Value is not a literal", value instanceof Literal);
+		assertTrue(value instanceof Literal, "Value is not a literal");
 		Literal l = (Literal) value;
-		assertTrue("Literal not of type double", l.getDatatype().equals(XSD.BOOLEAN));
+		assertTrue(l.getDatatype().equals(XSD.BOOLEAN), "Literal not of type double");
 
-		assertFalse("Brussels within Colorado", l.booleanValue());
+		assertFalse(l.booleanValue(), "Brussels within Colorado");
 	}
 
 	@Override

--- a/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNodeTest.java
+++ b/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/AbstractQueryModelNodeTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AbstractQueryModelNodeTest {
 

--- a/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprsTest.java
+++ b/core/queryalgebra/model/src/test/java/org/eclipse/rdf4j/query/algebra/helpers/TupleExprsTest.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.query.algebra.Not;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TupleExprsTest {
 

--- a/core/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryParserUtilTest.java
+++ b/core/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryParserUtilTest.java
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Andreas Schwarte
@@ -25,6 +26,6 @@ public class QueryParserUtilTest {
 				+ "# one more comment\r\n" + "SELECT * WHERE { ?s ?p ?o }";
 
 		String restQuery = QueryParserUtil.removeSPARQLQueryProlog(queryString);
-		Assert.assertEquals("SELECT * WHERE { ?s ?p ?o }", restQuery);
+		assertEquals("SELECT * WHERE { ?s ?p ?o }", restQuery);
 	}
 }

--- a/core/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryPrologLexerTest.java
+++ b/core/queryparser/api/src/test/java/org/eclipse/rdf4j/query/parser/QueryPrologLexerTest.java
@@ -10,16 +10,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
 import org.eclipse.rdf4j.query.parser.QueryPrologLexer.Token;
 import org.eclipse.rdf4j.query.parser.QueryPrologLexer.TokenType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLQueriesTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLQueriesTest.java
@@ -17,7 +17,7 @@ import static org.eclipse.rdf4j.model.util.Values.namespace;
 import java.util.Arrays;
 
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SPARQLQueriesTest {
 

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateDataBlockParserTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLUpdateDataBlockParserTest.java
@@ -15,7 +15,7 @@ import java.io.StringReader;
 
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Damyan Ognyanov

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestPropPathMisbehaviour.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestPropPathMisbehaviour.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser.sparql;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.query.algebra.ArbitraryLengthPath;
 import org.eclipse.rdf4j.query.algebra.Distinct;
@@ -23,9 +23,9 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.Union;
 import org.eclipse.rdf4j.query.algebra.ZeroLengthPath;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestPropPathMisbehaviour {
 	private SPARQLParser parser;
@@ -33,7 +33,7 @@ public class TestPropPathMisbehaviour {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = new SPARQLParser();
 	}
@@ -41,7 +41,7 @@ public class TestPropPathMisbehaviour {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		parser = null;
 	}
@@ -59,23 +59,23 @@ public class TestPropPathMisbehaviour {
 
 		assertNotNull(q);
 		TupleExpr tupleExpr = q.getTupleExpr();
-		assertTrue("expect queryroot", tupleExpr instanceof QueryRoot);
+		assertTrue(tupleExpr instanceof QueryRoot, "expect queryroot");
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 
-		assertTrue("expect join", proj.getArg() instanceof Join);
-		assertTrue("expect left arg to be ALP", ((Join) proj.getArg()).getLeftArg() instanceof ArbitraryLengthPath);
+		assertTrue(proj.getArg() instanceof Join, "expect join");
+		assertTrue(((Join) proj.getArg()).getLeftArg() instanceof ArbitraryLengthPath, "expect left arg to be ALP");
 		ArbitraryLengthPath alp = (ArbitraryLengthPath) ((Join) proj.getArg()).getLeftArg();
 
-		assertTrue("expect single statement pattern in alp PE", alp.getPathExpression() instanceof StatementPattern);
+		assertTrue(alp.getPathExpression() instanceof StatementPattern, "expect single statement pattern in alp PE");
 		StatementPattern sp = (StatementPattern) alp.getPathExpression();
 		assertNotNull(sp.getSubjectVar());
 
-		assertTrue("expect subj var to be iri", "iri".equals(sp.getSubjectVar().getName()));
+		assertTrue("iri".equals(sp.getSubjectVar().getName()), "expect subj var to be iri");
 
-		assertTrue("expect obj var of the pattern to be same as the objVar of ALP",
-				alp.getObjectVar().equals(sp.getObjectVar()));
+		assertTrue(alp.getObjectVar().equals(sp.getObjectVar()),
+				"expect obj var of the pattern to be same as the objVar of ALP");
 	}
 
 	@Test
@@ -87,28 +87,28 @@ public class TestPropPathMisbehaviour {
 
 		assertNotNull(q);
 		TupleExpr tupleExpr = q.getTupleExpr();
-		assertTrue("expect queryroot", tupleExpr instanceof QueryRoot);
+		assertTrue(tupleExpr instanceof QueryRoot, "expect queryroot");
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 
-		assertTrue("expect join", proj.getArg() instanceof Join);
-		assertTrue("expect left arg to be ALP", ((Join) proj.getArg()).getLeftArg() instanceof ArbitraryLengthPath);
+		assertTrue(proj.getArg() instanceof Join, "expect join");
+		assertTrue(((Join) proj.getArg()).getLeftArg() instanceof ArbitraryLengthPath, "expect left arg to be ALP");
 		ArbitraryLengthPath alp = (ArbitraryLengthPath) ((Join) proj.getArg()).getLeftArg();
 
-		assertTrue("expect single statement pattern in alp PE", alp.getPathExpression() instanceof StatementPattern);
+		assertTrue(alp.getPathExpression() instanceof StatementPattern, "expect single statement pattern in alp PE");
 		StatementPattern sp = (StatementPattern) alp.getPathExpression();
 		assertNotNull(sp.getSubjectVar());
 
-		assertTrue("expect right arg to be Distinct", ((Join) proj.getArg()).getRightArg() instanceof Distinct);
+		assertTrue(((Join) proj.getArg()).getRightArg() instanceof Distinct, "expect right arg to be Distinct");
 		Distinct dist = (Distinct) ((Join) proj.getArg()).getRightArg();
-		assertTrue("expect projection", dist.getArg() instanceof Projection);
+		assertTrue(dist.getArg() instanceof Projection, "expect projection");
 		Projection proj2 = (Projection) dist.getArg();
-		assertTrue("expect Union as projection arg", proj2.getArg() instanceof Union);
-		assertTrue("expect Union Left arg to be ZeroPath",
-				((Union) proj2.getArg()).getLeftArg() instanceof ZeroLengthPath);
-		assertTrue("expect Union Right arg to be StatementPattern",
-				((Union) proj2.getArg()).getRightArg() instanceof StatementPattern);
-		assertTrue("expect projection to do NOT be a subQuery", !proj2.isSubquery());
+		assertTrue(proj2.getArg() instanceof Union, "expect Union as projection arg");
+		assertTrue(((Union) proj2.getArg()).getLeftArg() instanceof ZeroLengthPath,
+				"expect Union Left arg to be ZeroPath");
+		assertTrue(((Union) proj2.getArg()).getRightArg() instanceof StatementPattern,
+				"expect Union Right arg to be StatementPattern");
+		assertTrue(!proj2.isSubquery(), "expect projection to do NOT be a subQuery");
 	}
 }

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestServiceUpdateExprBuilder.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestServiceUpdateExprBuilder.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.query.parser.sparql;
 
 import org.eclipse.rdf4j.query.algebra.Service;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestServiceUpdateExprBuilder {
 

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestSparqlStarParser.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/TestSparqlStarParser.java
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.parser.sparql;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,20 +46,21 @@ import org.eclipse.rdf4j.query.algebra.ValueExprTripleRef;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.ParsedUpdate;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author damyan.ognyanov
  */
 public class TestSparqlStarParser {
+
 	private SPARQLParser parser;
 
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = new SPARQLParser();
 	}
@@ -66,7 +68,7 @@ public class TestSparqlStarParser {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		parser = null;
 	}
@@ -97,30 +99,30 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 
-		assertTrue("expect extension", proj.getArg() instanceof Extension);
+		assertTrue(proj.getArg() instanceof Extension, "expect extension");
 		Extension ext = (Extension) proj.getArg();
 
-		assertTrue("single extention elemrnt", ext.getElements().size() == 1);
+		assertTrue(ext.getElements().size() == 1, "single extention elemrnt");
 		ExtensionElem elem = ext.getElements().get(0);
 
-		assertEquals("name should match", elem.getName(), "ref");
-		assertTrue("expect ValueExprTripleRef", elem.getExpr() instanceof ValueExprTripleRef);
+		assertEquals("ref", elem.getName(), "name should match");
+		assertTrue(elem.getExpr() instanceof ValueExprTripleRef, "expect ValueExprTripleRef");
 		ValueExprTripleRef ref = (ValueExprTripleRef) elem.getExpr();
 
-		assertTrue("expect not null subject", ref.getSubjectVar().getValue() != null);
-		assertTrue("expect IRI subject", ref.getSubjectVar().getValue() instanceof IRI);
-		assertEquals("subject should match", ref.getSubjectVar().getValue().toString(), "urn:A");
+		assertTrue(ref.getSubjectVar().getValue() != null, "expect not null subject");
+		assertTrue(ref.getSubjectVar().getValue() instanceof IRI, "expect IRI subject");
+		assertEquals("urn:A", ref.getSubjectVar().getValue().toString(), "subject should match");
 
-		assertTrue("expect not null predicate", ref.getPredicateVar().getValue() != null);
-		assertTrue("expect IRI predicate", ref.getPredicateVar().getValue() instanceof IRI);
-		assertEquals("predicate should match", ref.getPredicateVar().getValue().toString(), "urn:B");
+		assertTrue(ref.getPredicateVar().getValue() != null, "expect not null predicate");
+		assertTrue(ref.getPredicateVar().getValue() instanceof IRI, "expect IRI predicate");
+		assertEquals("urn:B", ref.getPredicateVar().getValue().toString(), "predicate should match");
 
-		assertTrue("expect not null object", ref.getObjectVar().getValue() != null);
-		assertTrue("expect Literal object", ref.getObjectVar().getValue() instanceof Literal);
-		assertEquals("object should match", ((Literal) ref.getObjectVar().getValue()).intValue(), 1);
+		assertTrue(ref.getObjectVar().getValue() != null, "expect not null object");
+		assertTrue(ref.getObjectVar().getValue() instanceof Literal, "expect Literal object");
+		assertEquals(1, ((Literal) ref.getObjectVar().getValue()).intValue(), "object should match");
 	}
 
 	/*-
@@ -141,30 +143,30 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 
-		assertTrue("expect BindingSetAssignment as arg", proj.getArg() instanceof BindingSetAssignment);
+		assertTrue(proj.getArg() instanceof BindingSetAssignment, "expect BindingSetAssignment as arg");
 		BindingSetAssignment values = (BindingSetAssignment) proj.getArg();
 		boolean[] oneValue = new boolean[] { false };
 		values.getBindingSets().forEach(bs -> {
 			Value v = bs.getValue("ref");
-			assertTrue("expect binding for ref", v != null);
-			assertTrue("expect Triple ", v instanceof Triple);
+			assertTrue(v != null, "expect binding for ref");
+			assertTrue(v instanceof Triple, "expect Triple ");
 			Triple triple = (Triple) v;
-			assertTrue("subject should be IRI", triple.getSubject() instanceof IRI);
-			assertEquals("subject should match", "urn:A", triple.getSubject().toString());
+			assertTrue(triple.getSubject() instanceof IRI, "subject should be IRI");
+			assertEquals("urn:A", triple.getSubject().toString(), "subject should match");
 
-			assertTrue("predicate should be IRI", triple.getPredicate() instanceof IRI);
-			assertEquals("predicate should match", "urn:B", triple.getPredicate().toString());
+			assertTrue(triple.getPredicate() instanceof IRI, "predicate should be IRI");
+			assertEquals("urn:B", triple.getPredicate().toString(), "predicate should match");
 
-			assertTrue("object should be Literal", triple.getObject() instanceof Literal);
-			assertEquals("object should match", 1, ((Literal) triple.getObject()).intValue());
+			assertTrue(triple.getObject() instanceof Literal, "object should be Literal");
+			assertEquals(1, ((Literal) triple.getObject()).intValue(), "object should match");
 
-			assertTrue("expect one value", oneValue[0] == false);
+			assertTrue(oneValue[0] == false, "expect one value");
 			oneValue[0] = true;
 		});
-		assertTrue("expect one value", oneValue[0]);
+		assertTrue(oneValue[0], "expect one value");
 	}
 
 	/*-
@@ -192,26 +194,26 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 
-		assertTrue("expect extension", proj.getArg() instanceof Extension);
+		assertTrue(proj.getArg() instanceof Extension, "expect extension");
 		Extension ext = (Extension) proj.getArg();
-		assertTrue("single extension element", ext.getElements().size() == 1);
+		assertTrue(ext.getElements().size() == 1, "single extension element");
 		ExtensionElem elem = ext.getElements().get(0);
 
-		assertEquals("name should match", elem.getName(), "ref");
-		assertTrue("expect Var in extension element", elem.getExpr() instanceof Var);
+		assertEquals("ref", elem.getName(), "name should match");
+		assertTrue(elem.getExpr() instanceof Var, "expect Var in extension element");
 		String anonVar = ((Var) elem.getExpr()).getName();
 
-		assertTrue("expect TripleRef", ext.getArg() instanceof TripleRef);
+		assertTrue(ext.getArg() instanceof TripleRef, "expect TripleRef");
 		TripleRef triple = (TripleRef) ext.getArg();
 
-		assertEquals("ext var should match", anonVar, triple.getExprVar().getName());
-		assertEquals("subj var should match", "urn:A", triple.getSubjectVar().getValue().toString());
-		assertEquals("pred var should match", "urn:B", triple.getPredicateVar().getValue().toString());
-		assertTrue("obj var value should be Literal", triple.getObjectVar().getValue() instanceof Literal);
-		assertEquals("obj var should match", 1, ((Literal) triple.getObjectVar().getValue()).intValue());
+		assertEquals(anonVar, triple.getExprVar().getName(), "ext var should match");
+		assertEquals("urn:A", triple.getSubjectVar().getValue().toString(), "subj var should match");
+		assertEquals("urn:B", triple.getPredicateVar().getValue().toString(), "pred var should match");
+		assertTrue(triple.getObjectVar().getValue() instanceof Literal, "obj var value should be Literal");
+		assertEquals(1, ((Literal) triple.getObjectVar().getValue()).intValue(), "obj var should match");
 	}
 
 	/*-
@@ -243,37 +245,36 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
 			listNames.add(el.getName());
 		});
-		assertEquals("expect all bindings", 4, list.size());
-		assertTrue("expect s", listNames.contains("s"));
-		assertTrue("expect p", listNames.contains("p"));
-		assertTrue("expect o", listNames.contains("o"));
-		assertTrue("expect ref", listNames.contains("ref"));
+		assertThat(list)
+				.hasSize(4);
+		assertThat(listNames)
+				.containsExactlyInAnyOrder("s", "p", "o", "ref");
 
-		assertTrue("expect extension", proj.getArg() instanceof Extension);
+		assertTrue(proj.getArg() instanceof Extension, "expect extension");
 		Extension ext = (Extension) proj.getArg();
-		assertTrue("single extention elemrnt", ext.getElements().size() == 1);
+		assertTrue(ext.getElements().size() == 1, "single extention elemrnt");
 		ExtensionElem elem = ext.getElements().get(0);
 
-		assertEquals("name should match", elem.getName(), "ref");
-		assertTrue("expect Var in extention element", elem.getExpr() instanceof Var);
+		assertEquals("ref", elem.getName(), "name should match");
+		assertTrue(elem.getExpr() instanceof Var, "expect Var in extention element");
 
 		String anonVar = ((Var) elem.getExpr()).getName();
 
-		assertTrue("expect TripleRef", ext.getArg() instanceof TripleRef);
+		assertTrue(ext.getArg() instanceof TripleRef, "expect TripleRef");
 		TripleRef triple = (TripleRef) ext.getArg();
 
-		assertEquals("ext var should match", anonVar, triple.getExprVar().getName());
+		assertEquals(anonVar, triple.getExprVar().getName(), "ext var should match");
 
-		assertEquals("subj var name should match", "s", triple.getSubjectVar().getName());
-		assertEquals("pred var name should match", "p", triple.getPredicateVar().getName());
-		assertEquals("obj var name should match", "o", triple.getObjectVar().getName());
+		assertEquals("s", triple.getSubjectVar().getName(), "subj var name should match");
+		assertEquals("p", triple.getPredicateVar().getName(), "pred var name should match");
+		assertEquals("o", triple.getObjectVar().getName(), "obj var name should match");
 	}
 
 	/*-
@@ -306,36 +307,35 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
 			listNames.add(el.getName());
 		});
-		assertEquals("expect all bindings", 4, list.size());
-		assertTrue("expect s", listNames.contains("s"));
-		assertTrue("expect p", listNames.contains("p"));
-		assertTrue("expect o", listNames.contains("o"));
-		assertTrue("expect val", listNames.contains("val"));
+		assertThat(list)
+				.hasSize(4);
+		assertThat(listNames)
+				.containsExactlyInAnyOrder("s", "p", "o", "val");
 
-		assertTrue("expect Join", proj.getArg() instanceof Join);
+		assertTrue(proj.getArg() instanceof Join, "expect Join");
 		Join join = (Join) proj.getArg();
 
-		assertTrue("expect right arg of Join be StatementPattern", join.getRightArg() instanceof StatementPattern);
+		assertTrue(join.getRightArg() instanceof StatementPattern, "expect right arg of Join be StatementPattern");
 		StatementPattern pattern = (StatementPattern) join.getRightArg();
 		String anonVar = pattern.getSubjectVar().getName();
-		assertEquals("statement pattern predVar value", "urn:pred", pattern.getPredicateVar().getValue().toString());
-		assertEquals("statement pattern obj var name", "val", pattern.getObjectVar().getName());
+		assertEquals("urn:pred", pattern.getPredicateVar().getValue().toString(), "statement pattern predVar value");
+		assertEquals("val", pattern.getObjectVar().getName(), "statement pattern obj var name");
 
-		assertTrue("expect left arg of Join be TripleRef", join.getLeftArg() instanceof TripleRef);
+		assertTrue(join.getLeftArg() instanceof TripleRef, "expect left arg of Join be TripleRef");
 		TripleRef triple = (TripleRef) join.getLeftArg();
 
-		assertEquals("ext var should match", anonVar, triple.getExprVar().getName());
+		assertEquals(anonVar, triple.getExprVar().getName(), "ext var should match");
 
-		assertEquals("subj var name should match", "s", triple.getSubjectVar().getName());
-		assertEquals("pred var name should match", "p", triple.getPredicateVar().getName());
-		assertEquals("obj var name should match", "o", triple.getObjectVar().getName());
+		assertEquals("s", triple.getSubjectVar().getName(), "subj var name should match");
+		assertEquals("p", triple.getPredicateVar().getName(), "pred var name should match");
+		assertEquals("o", triple.getObjectVar().getName(), "obj var name should match");
 	}
 
 	/*-
@@ -376,48 +376,46 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
 			listNames.add(el.getName());
 		});
-		assertEquals("expect all bindings", 6, list.size());
-		assertTrue("expect s", listNames.contains("s"));
-		assertTrue("expect p", listNames.contains("p"));
-		assertTrue("expect o", listNames.contains("o"));
-		assertTrue("expect q", listNames.contains("q"));
-		assertTrue("expect r", listNames.contains("r"));
-		assertTrue("expect val", listNames.contains("val"));
+		assertThat(list)
+				.hasSize(6)
+				.withFailMessage("expect all bindings");
+		assertThat(listNames)
+				.containsExactlyInAnyOrder("s", "p", "o", "q", "r", "val");
 
-		assertTrue("expect Join", proj.getArg() instanceof Join);
+		assertTrue(proj.getArg() instanceof Join, "expect Join");
 		Join join = (Join) proj.getArg();
 
-		assertTrue("expect right arg of Join be StatementPattern", join.getRightArg() instanceof StatementPattern);
+		assertTrue(join.getRightArg() instanceof StatementPattern, "expect right arg of Join be StatementPattern");
 		StatementPattern pattern = (StatementPattern) join.getRightArg();
 		String anonVar = pattern.getSubjectVar().getName();
-		assertEquals("statement pattern predVar value", "urn:pred", pattern.getPredicateVar().getValue().toString());
-		assertEquals("statement pattern obj var name", "val", pattern.getObjectVar().getName());
+		assertEquals("urn:pred", pattern.getPredicateVar().getValue().toString(), "statement pattern predVar value");
+		assertEquals("val", pattern.getObjectVar().getName(), "statement pattern obj var name");
 
-		assertTrue("expect left arg of first Join be Join", join.getLeftArg() instanceof Join);
+		assertTrue(join.getLeftArg() instanceof Join, "expect left arg of first Join be Join");
 		Join join2 = (Join) join.getLeftArg();
 
-		assertTrue("expect left arg of second Join be TripleRef", join2.getLeftArg() instanceof TripleRef);
+		assertTrue(join2.getLeftArg() instanceof TripleRef, "expect left arg of second Join be TripleRef");
 		TripleRef tripleLeft = (TripleRef) join2.getLeftArg();
-		assertEquals("subj var name should match", "s", tripleLeft.getSubjectVar().getName());
-		assertEquals("pred var name should match", "p", tripleLeft.getPredicateVar().getName());
-		assertEquals("obj var name should match", "o", tripleLeft.getObjectVar().getName());
+		assertEquals("s", tripleLeft.getSubjectVar().getName(), "subj var name should match");
+		assertEquals("p", tripleLeft.getPredicateVar().getName(), "pred var name should match");
+		assertEquals("o", tripleLeft.getObjectVar().getName(), "obj var name should match");
 		String anonVarLeftTripleRef = tripleLeft.getExprVar().getName();
 
-		assertTrue("expect right arg of second Join be TripleRef", join2.getRightArg() instanceof TripleRef);
+		assertTrue(join2.getRightArg() instanceof TripleRef, "expect right arg of second Join be TripleRef");
 		TripleRef triple = (TripleRef) join2.getRightArg();
 
-		assertEquals("subj var name should match anon", anonVarLeftTripleRef, triple.getSubjectVar().getName());
-		assertEquals("pred var name should match", "q", triple.getPredicateVar().getName());
-		assertEquals("obj var name should match", "r", triple.getObjectVar().getName());
+		assertEquals(anonVarLeftTripleRef, triple.getSubjectVar().getName(), "subj var name should match anon");
+		assertEquals("q", triple.getPredicateVar().getName(), "pred var name should match");
+		assertEquals("r", triple.getObjectVar().getName(), "obj var name should match");
 
-		assertEquals("ext var should match", anonVar, triple.getExprVar().getName());
+		assertEquals(anonVar, triple.getExprVar().getName(), "ext var should match");
 	}
 
 	/*-
@@ -454,8 +452,8 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect Reduced", tupleExpr instanceof Reduced);
-		assertTrue("expect projection", ((Reduced) tupleExpr).getArg() instanceof Projection);
+		assertTrue(tupleExpr instanceof Reduced, "expect Reduced");
+		assertTrue(((Reduced) tupleExpr).getArg() instanceof Projection, "expect projection");
 		Projection proj = (Projection) ((Reduced) tupleExpr).getArg();
 
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
@@ -463,43 +461,43 @@ public class TestSparqlStarParser {
 		list.forEach(el -> {
 			listTargetNames.add(el.getProjectionAlias().orElse(null));
 		});
-		assertEquals("expect all bindings", 3, list.size());
-		assertTrue("expect target subject", listTargetNames.contains("subject"));
-		assertTrue("expect target predicate", listTargetNames.contains("predicate"));
-		assertTrue("expect target oobject", listTargetNames.contains("object"));
+		assertThat(list)
+				.hasSize(3);
+		assertThat(listTargetNames)
+				.containsExactlyInAnyOrder("subject", "predicate", "object");
 
 		final ArrayList<String> listSourceNames = new ArrayList<>();
 		list.forEach(el -> {
 			listSourceNames.add(el.getName());
 		});
 
-		assertTrue("expect extension", proj.getArg() instanceof Extension);
+		assertTrue(proj.getArg() instanceof Extension, "expect extension");
 		Extension ext = (Extension) proj.getArg();
-		assertTrue("three extention elements", ext.getElements().size() == 3);
+		assertTrue(ext.getElements().size() == 3, "three extention elements");
 		ExtensionElem elem = ext.getElements().get(0);
 
-		assertEquals("anon name should match first", elem.getName(), listSourceNames.get(0));
+		assertEquals(elem.getName(), listSourceNames.get(0), "anon name should match first");
 
-		assertTrue("expect ValueExprTripleRef in extention element", elem.getExpr() instanceof ValueExprTripleRef);
+		assertTrue(elem.getExpr() instanceof ValueExprTripleRef, "expect ValueExprTripleRef in extention element");
 		ValueExprTripleRef ref = (ValueExprTripleRef) elem.getExpr();
-		assertEquals("subject var name", "s", ref.getSubjectVar().getName());
-		assertEquals("predicate var name", "p", ref.getPredicateVar().getName());
-		assertEquals("object var name", "o", ref.getObjectVar().getName());
+		assertEquals("s", ref.getSubjectVar().getName(), "subject var name");
+		assertEquals("p", ref.getPredicateVar().getName(), "predicate var name");
+		assertEquals("o", ref.getObjectVar().getName(), "object var name");
 
 		elem = ext.getElements().get(1);
-		assertEquals("names should match", elem.getName(), listSourceNames.get(1));
-		assertEquals("value should match", "urn:pred", ((ValueConstant) elem.getExpr()).getValue().toString());
+		assertEquals(elem.getName(), listSourceNames.get(1), "names should match");
+		assertEquals("urn:pred", ((ValueConstant) elem.getExpr()).getValue().toString(), "value should match");
 
 		elem = ext.getElements().get(2);
-		assertEquals("names should match", elem.getName(), listSourceNames.get(2));
-		assertEquals("value should match", "urn:value", ((ValueConstant) elem.getExpr()).getValue().toString());
+		assertEquals(elem.getName(), listSourceNames.get(2), "names should match");
+		assertEquals("urn:value", ((ValueConstant) elem.getExpr()).getValue().toString(), "value should match");
 
-		assertTrue("expect StatementPattern", ext.getArg() instanceof StatementPattern);
+		assertTrue(ext.getArg() instanceof StatementPattern, "expect StatementPattern");
 		StatementPattern pattern = (StatementPattern) ext.getArg();
 
-		assertEquals("subj var name should match", "s", pattern.getSubjectVar().getName());
-		assertEquals("pred var name should match", "p", pattern.getPredicateVar().getName());
-		assertEquals("obj var name should match", "o", pattern.getObjectVar().getName());
+		assertEquals("s", pattern.getSubjectVar().getName(), "subj var name should match");
+		assertEquals("p", pattern.getPredicateVar().getName(), "pred var name should match");
+		assertEquals("o", pattern.getObjectVar().getName(), "obj var name should match");
 	}
 
 	/*-
@@ -534,43 +532,42 @@ public class TestSparqlStarParser {
 		ParsedUpdate q = parser.parseUpdate(simpleSparqlQuery, null);
 
 		assertNotNull(q);
-		assertTrue("expect single UpdateExpr", q.getUpdateExprs().size() == 1);
+		assertTrue(q.getUpdateExprs().size() == 1, "expect single UpdateExpr");
 		UpdateExpr updateExpr = q.getUpdateExprs().get(0);
-		assertTrue("expect Modify UpdateExpr", updateExpr instanceof Modify);
+		assertTrue(updateExpr instanceof Modify, "expect Modify UpdateExpr");
 		Modify modify = (Modify) updateExpr;
-		assertTrue("expect no DELETE", modify.getDeleteExpr() == null);
+		assertTrue(modify.getDeleteExpr() == null, "expect no DELETE");
 
-		assertTrue("expect INSERT", modify.getInsertExpr() != null);
-		assertTrue("expect INSERT as statamentPattern", modify.getInsertExpr() instanceof StatementPattern);
+		assertTrue(modify.getInsertExpr() != null, "expect INSERT");
+		assertTrue(modify.getInsertExpr() instanceof StatementPattern, "expect INSERT as statamentPattern");
 		StatementPattern insert = (StatementPattern) modify.getInsertExpr();
 		String anonVar = insert.getSubjectVar().getName();
-		assertEquals("expect predicate", "urn:pred", insert.getPredicateVar().getValue().toString());
-		assertEquals("expect object", "urn:value", insert.getObjectVar().getValue().toString());
+		assertEquals("urn:pred", insert.getPredicateVar().getValue().toString(), "expect predicate");
+		assertEquals("urn:value", insert.getObjectVar().getValue().toString(), "expect object");
 
-		assertTrue("expect WHERE", modify.getWhereExpr() != null);
-		assertTrue("expect WHERE as extension", modify.getWhereExpr() instanceof Extension);
+		assertTrue(modify.getWhereExpr() != null, "expect WHERE");
+		assertTrue(modify.getWhereExpr() instanceof Extension, "expect WHERE as extension");
 
 		Extension where = (Extension) modify.getWhereExpr();
 
 		Extension ext = (Extension) where;
-		assertTrue("one extention element", ext.getElements().size() == 1);
+		assertTrue(ext.getElements().size() == 1, "one extention element");
 		ExtensionElem elem = ext.getElements().get(0);
 
-		assertEquals("anon name should match first", elem.getName(), anonVar);
+		assertEquals(elem.getName(), anonVar, "anon name should match first");
 
-		assertTrue("expect ValueExprTripleRef in extention element", elem.getExpr() instanceof ValueExprTripleRef);
+		assertTrue(elem.getExpr() instanceof ValueExprTripleRef, "expect ValueExprTripleRef in extention element");
 		ValueExprTripleRef ref = (ValueExprTripleRef) elem.getExpr();
-		assertEquals("subject var name", "s", ref.getSubjectVar().getName());
-		assertEquals("predicate var name", "p", ref.getPredicateVar().getName());
-		assertEquals("object var name", "o", ref.getObjectVar().getName());
+		assertEquals("s", ref.getSubjectVar().getName(), "subject var name");
+		assertEquals("p", ref.getPredicateVar().getName(), "predicate var name");
+		assertEquals("o", ref.getObjectVar().getName(), "object var name");
 
-		assertTrue("expect StatementPattern as extension argument", ext.getArg() instanceof StatementPattern);
+		assertTrue(ext.getArg() instanceof StatementPattern, "expect StatementPattern as extension argument");
 		StatementPattern pattern = (StatementPattern) ext.getArg();
-		assertEquals("subject var name should match", pattern.getSubjectVar().getName(), ref.getSubjectVar().getName());
-		assertEquals("predicate var name should match", pattern.getPredicateVar().getName(),
-				ref.getPredicateVar().getName());
-		assertEquals("object var name should match", pattern.getObjectVar().getName(), ref.getObjectVar().getName());
-
+		assertEquals(pattern.getSubjectVar().getName(), ref.getSubjectVar().getName(), "subject var name should match");
+		assertEquals(pattern.getPredicateVar().getName(), ref.getPredicateVar().getName(),
+				"predicate var name should match");
+		assertEquals(pattern.getObjectVar().getName(), ref.getObjectVar().getName(), "object var name should match");
 	}
 
 	/*-
@@ -605,43 +602,42 @@ public class TestSparqlStarParser {
 		ParsedUpdate q = parser.parseUpdate(simpleSparqlQuery, null);
 
 		assertNotNull(q);
-		assertTrue("expect single UpdateExpr", q.getUpdateExprs().size() == 1);
+		assertTrue(q.getUpdateExprs().size() == 1, "expect single UpdateExpr");
 		UpdateExpr updateExpr = q.getUpdateExprs().get(0);
-		assertTrue("expect Modify UpdateExpr", updateExpr instanceof Modify);
+		assertTrue(updateExpr instanceof Modify, "expect Modify UpdateExpr");
 		Modify modify = (Modify) updateExpr;
-		assertTrue("expect no INSERT", modify.getInsertExpr() == null);
+		assertTrue(modify.getInsertExpr() == null, "expect no INSERT");
 
-		assertTrue("expect DELETE", modify.getDeleteExpr() != null);
-		assertTrue("expect DETELE as statamentPattern", modify.getDeleteExpr() instanceof StatementPattern);
+		assertTrue(modify.getDeleteExpr() != null, "expect DELETE");
+		assertTrue(modify.getDeleteExpr() instanceof StatementPattern, "expect DETELE as statamentPattern");
 		StatementPattern insert = (StatementPattern) modify.getDeleteExpr();
 		String anonVar = insert.getSubjectVar().getName();
-		assertEquals("expect predicate", "urn:pred", insert.getPredicateVar().getValue().toString());
-		assertEquals("expect object", "urn:value", insert.getObjectVar().getValue().toString());
+		assertEquals("urn:pred", insert.getPredicateVar().getValue().toString(), "expect predicate");
+		assertEquals("urn:value", insert.getObjectVar().getValue().toString(), "expect object");
 
-		assertTrue("expect WHERE", modify.getWhereExpr() != null);
-		assertTrue("expect WHERE as extension", modify.getWhereExpr() instanceof Extension);
+		assertTrue(modify.getWhereExpr() != null, "expect WHERE");
+		assertTrue(modify.getWhereExpr() instanceof Extension, "expect WHERE as extension");
 
 		Extension where = (Extension) modify.getWhereExpr();
 
 		Extension ext = (Extension) where;
-		assertTrue("one extention element", ext.getElements().size() == 1);
+		assertTrue(ext.getElements().size() == 1, "one extention element");
 		ExtensionElem elem = ext.getElements().get(0);
 
-		assertEquals("anon name should match first", elem.getName(), anonVar);
+		assertEquals(elem.getName(), anonVar, "anon name should match first");
 
-		assertTrue("expect ValueExprTripleRef in extention element", elem.getExpr() instanceof ValueExprTripleRef);
+		assertTrue(elem.getExpr() instanceof ValueExprTripleRef, "expect ValueExprTripleRef in extention element");
 		ValueExprTripleRef ref = (ValueExprTripleRef) elem.getExpr();
-		assertEquals("subject var name", "s", ref.getSubjectVar().getName());
-		assertEquals("predicate var name", "p", ref.getPredicateVar().getName());
-		assertEquals("object var name", "o", ref.getObjectVar().getName());
+		assertEquals("s", ref.getSubjectVar().getName(), "subject var name");
+		assertEquals("p", ref.getPredicateVar().getName(), "predicate var name");
+		assertEquals("o", ref.getObjectVar().getName(), "object var name");
 
-		assertTrue("expect StatementPattern as extension argument", ext.getArg() instanceof StatementPattern);
+		assertTrue(ext.getArg() instanceof StatementPattern, "expect StatementPattern as extension argument");
 		StatementPattern pattern = (StatementPattern) ext.getArg();
-		assertEquals("subject var name should match", pattern.getSubjectVar().getName(), ref.getSubjectVar().getName());
-		assertEquals("predicate var name should match", pattern.getPredicateVar().getName(),
-				ref.getPredicateVar().getName());
-		assertEquals("object var name should match", pattern.getObjectVar().getName(), ref.getObjectVar().getName());
-
+		assertEquals(pattern.getSubjectVar().getName(), ref.getSubjectVar().getName(), "subject var name should match");
+		assertEquals(pattern.getPredicateVar().getName(), ref.getPredicateVar().getName(),
+				"predicate var name should match");
+		assertEquals(pattern.getObjectVar().getName(), ref.getObjectVar().getName(), "object var name should match");
 	}
 
 	/*-
@@ -679,52 +675,53 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
 			listNames.add(el.getName());
 		});
-		assertEquals("expect all bindings", 2, list.size());
-		assertTrue("expect ref", listNames.contains("ref"));
-		assertTrue("expect count", listNames.contains("count"));
+		assertThat(list)
+				.hasSize(2);
+		assertThat(listNames)
+				.containsExactlyInAnyOrder("ref", "count");
 
-		assertTrue("expect extension", proj.getArg() instanceof Extension);
+		assertTrue(proj.getArg() instanceof Extension, "expect extension");
 		Extension ext = (Extension) proj.getArg();
-		assertTrue("one extension element", ext.getElements().size() == 1);
+		assertTrue(ext.getElements().size() == 1, "one extension element");
 		ExtensionElem elem = ext.getElements().get(0);
 
-		assertEquals("name should match", elem.getName(), "count");
-		assertTrue("expect Count in extention element", elem.getExpr() instanceof Count);
+		assertEquals("count", elem.getName(), "name should match");
+		assertTrue(elem.getExpr() instanceof Count, "expect Count in extention element");
 		Count count = (Count) elem.getExpr();
-		assertTrue("expect count distinct", count.isDistinct());
-		assertTrue("expect count over var", count.getArg() instanceof Var);
-		assertEquals("expect count var p", "p", ((Var) count.getArg()).getName());
+		assertTrue(count.isDistinct(), "expect count distinct");
+		assertTrue(count.getArg() instanceof Var, "expect count over var");
+		assertEquals("p", ((Var) count.getArg()).getName(), "expect count var p");
 
-		assertTrue("expect Group", ext.getArg() instanceof Group);
+		assertTrue(ext.getArg() instanceof Group, "expect Group");
 		Group group = (Group) ext.getArg();
-		assertTrue("expect group bindings", group.getGroupBindingNames().size() == 1);
-		assertTrue("expect group over ref", group.getGroupBindingNames().contains("ref"));
+		assertThat(group.getGroupBindingNames())
+				.containsExactly("ref");
 
-		assertTrue("expect Extension", group.getArg() instanceof Extension);
+		assertTrue(group.getArg() instanceof Extension, "expect Extension");
 		ext = (Extension) group.getArg();
 
-		assertTrue("single extention elemrnt", ext.getElements().size() == 1);
+		assertTrue(ext.getElements().size() == 1, "single extention elemrnt");
 		elem = ext.getElements().get(0);
 
-		assertEquals("name should match", elem.getName(), "ref");
-		assertTrue("expect Var in extention element", elem.getExpr() instanceof Var);
+		assertEquals("ref", elem.getName(), "name should match");
+		assertTrue(elem.getExpr() instanceof Var, "expect Var in extention element");
 		String anonVar = ((Var) elem.getExpr()).getName();
 
-		assertTrue("expect TripleRef", ext.getArg() instanceof TripleRef);
+		assertTrue(ext.getArg() instanceof TripleRef, "expect TripleRef");
 		TripleRef triple = (TripleRef) ext.getArg();
 
-		assertEquals("ext var should match", anonVar, triple.getExprVar().getName());
+		assertEquals(anonVar, triple.getExprVar().getName(), "ext var should match");
 
-		assertEquals("subj var name should match", "s", triple.getSubjectVar().getName());
-		assertEquals("pred var name should match", "p", triple.getPredicateVar().getName());
-		assertEquals("obj var name should match", "o", triple.getObjectVar().getName());
+		assertEquals("s", triple.getSubjectVar().getName(), "subj var name should match");
+		assertEquals("p", triple.getPredicateVar().getName(), "pred var name should match");
+		assertEquals("o", triple.getObjectVar().getName(), "obj var name should match");
 	}
 
 	/*-
@@ -762,45 +759,45 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
 			listNames.add(el.getName());
 		});
-		assertEquals("expect all bindings", 3, list.size());
-		assertTrue("expect s", listNames.contains("s"));
-		assertTrue("expect p", listNames.contains("p"));
-		assertTrue("expect o", listNames.contains("o"));
+		assertThat(list)
+				.hasSize(3);
+		assertThat(listNames)
+				.containsExactlyInAnyOrder("s", "p", "o");
 
-		assertTrue("expect Filter", proj.getArg() instanceof Filter);
+		assertTrue(proj.getArg() instanceof Filter, "expect Filter");
 		Filter filter = (Filter) proj.getArg();
 
-		assertTrue("expect Exists", filter.getCondition() instanceof Exists);
+		assertTrue(filter.getCondition() instanceof Exists, "expect Exists");
 		Exists exists = (Exists) filter.getCondition();
 
-		assertTrue("expect join", exists.getSubQuery() instanceof Join);
+		assertTrue(exists.getSubQuery() instanceof Join, "expect join");
 		Join join = (Join) exists.getSubQuery();
 
-		assertTrue("expect join left arg as TripleRef", join.getLeftArg() instanceof TripleRef);
+		assertTrue(join.getLeftArg() instanceof TripleRef, "expect join left arg as TripleRef");
 		TripleRef ref = (TripleRef) join.getLeftArg();
-		assertEquals("expect subj var", "s", ref.getSubjectVar().getName());
-		assertEquals("expect pred var", "p", ref.getPredicateVar().getName());
-		assertEquals("expect obj value", "urn:value", ref.getObjectVar().getValue().toString());
+		assertEquals("s", ref.getSubjectVar().getName(), "expect subj var");
+		assertEquals("p", ref.getPredicateVar().getName(), "expect pred var");
+		assertEquals("urn:value", ref.getObjectVar().getValue().toString(), "expect obj value");
 
-		assertTrue("expect join right arg as StatementPattern", join.getRightArg() instanceof StatementPattern);
+		assertTrue(join.getRightArg() instanceof StatementPattern, "expect join right arg as StatementPattern");
 		StatementPattern pattern = (StatementPattern) join.getRightArg();
-		assertEquals("expect same var names", ref.getExprVar().getName(), pattern.getSubjectVar().getName());
-		assertEquals("expect pred var value", "urn:pred", pattern.getPredicateVar().getValue().toString());
-		assertEquals("expect obj var name", "q", pattern.getObjectVar().getName());
+		assertEquals(ref.getExprVar().getName(), pattern.getSubjectVar().getName(), "expect same var names");
+		assertEquals("urn:pred", pattern.getPredicateVar().getValue().toString(), "expect pred var value");
+		assertEquals("q", pattern.getObjectVar().getName(), "expect obj var name");
 
-		assertTrue("expect fiter argument as statement pattern", filter.getArg() instanceof StatementPattern);
+		assertTrue(filter.getArg() instanceof StatementPattern, "expect fiter argument as statement pattern");
 		pattern = (StatementPattern) filter.getArg();
 
-		assertEquals("subj var name should match", "s", pattern.getSubjectVar().getName());
-		assertEquals("pred var name should match", "p", pattern.getPredicateVar().getName());
-		assertEquals("obj var name should match", "o", pattern.getObjectVar().getName());
+		assertEquals("s", pattern.getSubjectVar().getName(), "subj var name should match");
+		assertEquals("p", pattern.getPredicateVar().getName(), "pred var name should match");
+		assertEquals("o", pattern.getObjectVar().getName(), "obj var name should match");
 	}
 
 	/*-
@@ -828,31 +825,33 @@ public class TestSparqlStarParser {
 		TupleExpr tupleExpr = q.getTupleExpr();
 		assertTrue(tupleExpr instanceof QueryRoot);
 		tupleExpr = ((QueryRoot) tupleExpr).getArg();
-		assertTrue("expect projection", tupleExpr instanceof Projection);
+		assertTrue(tupleExpr instanceof Projection, "expect projection");
 		Projection proj = (Projection) tupleExpr;
 		List<ProjectionElem> list = proj.getProjectionElemList().getElements();
 		final ArrayList<String> listNames = new ArrayList<>();
 		list.forEach(el -> {
 			listNames.add(el.getName());
 		});
-		assertEquals("expect one binding", 1, list.size());
-		assertTrue("expect str", listNames.contains("str"));
+		assertThat(list)
+				.hasSize(1);
+		assertThat(listNames)
+				.containsExactly("str");
 
-		assertTrue("expect Extension", proj.getArg() instanceof Extension);
+		assertTrue(proj.getArg() instanceof Extension, "expect Extension");
 		Extension ext = (Extension) proj.getArg();
 
-		assertTrue("one extention element", ext.getElements().size() == 1);
+		assertTrue(ext.getElements().size() == 1, "one extention element");
 		ExtensionElem elem = ext.getElements().get(0);
 
-		assertEquals("name should match", "str", elem.getName());
-		assertTrue("expect Str in extention element", elem.getExpr() instanceof Str);
+		assertEquals("str", elem.getName(), "name should match");
+		assertTrue(elem.getExpr() instanceof Str, "expect Str in extention element");
 
-		assertTrue("expect ValueExprTripleRef in extention element",
-				((Str) elem.getExpr()).getArg() instanceof ValueExprTripleRef);
+		assertTrue(((Str) elem.getExpr()).getArg() instanceof ValueExprTripleRef,
+				"expect ValueExprTripleRef in extention element");
 		ValueExprTripleRef ref = (ValueExprTripleRef) ((Str) elem.getExpr()).getArg();
-		assertEquals("subject var value", "urn:a", ref.getSubjectVar().getValue().toString());
-		assertEquals("predicate var name", "urn:b", ref.getPredicateVar().getValue().toString());
-		assertEquals("object var name", "urn:c", ref.getObjectVar().getValue().toString());
+		assertEquals("urn:a", ref.getSubjectVar().getValue().toString(), "subject var value");
+		assertEquals("urn:b", ref.getPredicateVar().getValue().toString(), "predicate var name");
+		assertEquals("urn:c", ref.getObjectVar().getValue().toString(), "object var name");
 	}
 
 	/*-
@@ -880,47 +879,47 @@ public class TestSparqlStarParser {
 		assertNotNull(q);
 		List<UpdateExpr> list = q.getUpdateExprs();
 		assertNotNull(list);
-		assertEquals("expect single update expr", 1, list.size());
-		assertTrue("expect modify op", list.get(0) instanceof Modify);
+		assertEquals(list.size(), 1, "expect single update expr");
+		assertTrue(list.get(0) instanceof Modify, "expect modify op");
 		Modify op = (Modify) list.get(0);
-		assertTrue("do not expect delete", null == op.getDeleteExpr());
+		assertTrue(null == op.getDeleteExpr(), "do not expect delete");
 		assertNotNull(op.getInsertExpr());
-		assertTrue("expect singleton", op.getInsertExpr() instanceof SingletonSet);
+		assertTrue(op.getInsertExpr() instanceof SingletonSet, "expect singleton");
 
 		assertNotNull(op.getWhereExpr());
-		assertTrue("expect join in where", op.getWhereExpr() instanceof Join);
+		assertTrue(op.getWhereExpr() instanceof Join, "expect join in where");
 		Join join = (Join) op.getWhereExpr();
-		assertTrue("expect left is TripleRef", join.getLeftArg() instanceof TripleRef);
+		assertTrue(join.getLeftArg() instanceof TripleRef, "expect left is TripleRef");
 		TripleRef ref = (TripleRef) join.getLeftArg();
-		assertTrue("expect right is StatementPattern", join.getRightArg() instanceof StatementPattern);
+		assertTrue(join.getRightArg() instanceof StatementPattern, "expect right is StatementPattern");
 		StatementPattern st = (StatementPattern) join.getRightArg();
-		assertEquals("expect same Var", ref.getExprVar().getName(), st.getSubjectVar().getName());
+		assertEquals(ref.getExprVar().getName(), st.getSubjectVar().getName(), "expect same Var");
 	}
 
 	/*-
 	 * Expected UpdateExpr:
-		Modify
-		   StatementPattern
-		      Var (name=_anon_24e6f014_3e16_49f9_ad0f_ef6d8045bbe9, anonymous)
-		      Var (name=_const_6a634a7_uri, value=urn:p, anonymous)
-		      Var (name=_const_31_lit_5fc8fb17_0, value="1"^^<http://www.w3.org/2001/XMLSchema#integer>, anonymous)
+	    Modify
+	       StatementPattern
+	          Var (name=_anon_24e6f014_3e16_49f9_ad0f_ef6d8045bbe9, anonymous)
+	          Var (name=_const_6a634a7_uri, value=urn:p, anonymous)
+	          Var (name=_const_31_lit_5fc8fb17_0, value="1"^^<http://www.w3.org/2001/XMLSchema#integer>, anonymous)
 
-		   Extension
-		      ExtensionElem (_anon_24e6f014_3e16_49f9_ad0f_ef6d8045bbe9)
-		         ValueExprTripleRef
-		            Var (name=_const_6a63498_uri, value=urn:a, anonymous)
-		            Var (name=_const_6a63499_uri, value=urn:b, anonymous)
-		            Var (name=_const_6a6349a_uri, value=urn:c, anonymous)
-		      Join
-		         TripleRef
-		            Var (name=_const_6a63498_uri, value=urn:a, anonymous)
-		            Var (name=_const_6a63499_uri, value=urn:b, anonymous)
-		            Var (name=_const_6a6349a_uri, value=urn:c, anonymous)
-		            Var (name=_anon_9e07cd00_0c02_4754_89ad_0ce4a5264d6e, anonymous)
-		         StatementPattern
-		            Var (name=_anon_9e07cd00_0c02_4754_89ad_0ce4a5264d6e, anonymous)
-		            Var (name=_const_6a634a7_uri, value=urn:p, anonymous)
-		            Var (name=_const_31_lit_5fc8fb17_0, value="1"^^<http://www.w3.org/2001/XMLSchema#integer>, anonymous)
+	       Extension
+	          ExtensionElem (_anon_24e6f014_3e16_49f9_ad0f_ef6d8045bbe9)
+	             ValueExprTripleRef
+	                Var (name=_const_6a63498_uri, value=urn:a, anonymous)
+	                Var (name=_const_6a63499_uri, value=urn:b, anonymous)
+	                Var (name=_const_6a6349a_uri, value=urn:c, anonymous)
+	          Join
+	             TripleRef
+	                Var (name=_const_6a63498_uri, value=urn:a, anonymous)
+	                Var (name=_const_6a63499_uri, value=urn:b, anonymous)
+	                Var (name=_const_6a6349a_uri, value=urn:c, anonymous)
+	                Var (name=_anon_9e07cd00_0c02_4754_89ad_0ce4a5264d6e, anonymous)
+	             StatementPattern
+	                Var (name=_anon_9e07cd00_0c02_4754_89ad_0ce4a5264d6e, anonymous)
+	                Var (name=_const_6a634a7_uri, value=urn:p, anonymous)
+	                Var (name=_const_31_lit_5fc8fb17_0, value="1"^^<http://www.w3.org/2001/XMLSchema#integer>, anonymous)
 	 * @throws Exception
 	 */
 	@Test
@@ -931,33 +930,32 @@ public class TestSparqlStarParser {
 		assertNotNull(q);
 		List<UpdateExpr> list = q.getUpdateExprs();
 		assertNotNull(list);
-		assertEquals("expect single update expr", 1, list.size());
-		assertTrue("expect modify op", list.get(0) instanceof Modify);
+		assertEquals(list.size(), 1, "expect single update expr");
+		assertTrue(list.get(0) instanceof Modify, "expect modify op");
 		Modify op = (Modify) list.get(0);
-		assertTrue("do not expect delete", null == op.getDeleteExpr());
+		assertTrue(null == op.getDeleteExpr(), "do not expect delete");
 		assertNotNull(op.getInsertExpr());
-		assertTrue("expect statement pattern", op.getInsertExpr() instanceof StatementPattern);
+		assertTrue(op.getInsertExpr() instanceof StatementPattern, "expect statement pattern");
 		StatementPattern insetPattern = (StatementPattern) op.getInsertExpr();
 
 		assertNotNull(op.getWhereExpr());
-		assertTrue("expect extension in where", op.getWhereExpr() instanceof Extension);
+		assertTrue(op.getWhereExpr() instanceof Extension, "expect extension in where");
 		Extension ext = (Extension) op.getWhereExpr();
 		ExtensionElem el = ext.getElements().get(0);
-		assertTrue("expect valueExprTripleRef", el.getExpr() instanceof ValueExprTripleRef);
-		assertEquals("expect same var", el.getName(), insetPattern.getSubjectVar().getName());
-		assertTrue("expect Join", ext.getArg() instanceof Join);
+		assertTrue(el.getExpr() instanceof ValueExprTripleRef, "expect valueExprTripleRef");
+		assertEquals(el.getName(), insetPattern.getSubjectVar().getName(), "expect same var");
+		assertTrue(ext.getArg() instanceof Join, "expect Join");
 		Join join = (Join) ext.getArg();
-		assertTrue("expect left is TripleRef", join.getLeftArg() instanceof TripleRef);
+		assertTrue(join.getLeftArg() instanceof TripleRef, "expect left is TripleRef");
 		TripleRef ref = (TripleRef) join.getLeftArg();
-		assertTrue("expect right is StatementPattern", join.getRightArg() instanceof StatementPattern);
+		assertTrue(join.getRightArg() instanceof StatementPattern, "expect right is StatementPattern");
 		StatementPattern st = (StatementPattern) join.getRightArg();
-		assertEquals("expect same Var", ref.getExprVar().getName(), st.getSubjectVar().getName());
-
+		assertEquals(ref.getExprVar().getName(), st.getSubjectVar().getName(), "expect same Var");
 	}
 
 	/*-
 	 * Expected UpdateExpr:
-		Modify
+	    Modify
 	 * @throws Exception
 	 */
 	@Test
@@ -968,21 +966,21 @@ public class TestSparqlStarParser {
 		assertNotNull(q);
 		List<UpdateExpr> list = q.getUpdateExprs();
 		assertNotNull(list);
-		assertEquals("expect single update expr", 1, list.size());
-		assertTrue("expect modify op", list.get(0) instanceof Modify);
+		assertEquals(list.size(), 1, "expect single update expr");
+		assertTrue(list.get(0) instanceof Modify, "expect modify op");
 		Modify op = (Modify) list.get(0);
-		assertTrue("do not expect delete", null == op.getDeleteExpr());
+		assertTrue(null == op.getDeleteExpr(), "do not expect delete");
 		assertNotNull(op.getInsertExpr());
-		assertTrue("expect statement pattern", op.getInsertExpr() instanceof StatementPattern);
+		assertTrue(op.getInsertExpr() instanceof StatementPattern, "expect statement pattern");
 		assertNotNull(op.getWhereExpr());
 
-		assertTrue("expect join in where", op.getWhereExpr() instanceof Join);
+		assertTrue(op.getWhereExpr() instanceof Join, "expect join in where");
 		Join join = (Join) op.getWhereExpr();
-		assertTrue("expect left is TripleRef", join.getLeftArg() instanceof TripleRef);
+		assertTrue(join.getLeftArg() instanceof TripleRef, "expect left is TripleRef");
 		TripleRef ref = (TripleRef) join.getLeftArg();
-		assertTrue("expect right is StatementPattern", join.getRightArg() instanceof StatementPattern);
+		assertTrue(join.getRightArg() instanceof StatementPattern, "expect right is StatementPattern");
 		StatementPattern st = (StatementPattern) join.getRightArg();
-		assertEquals("expect same Var", ref.getExprVar().getName(), st.getSubjectVar().getName());
+		assertEquals(ref.getExprVar().getName(), st.getSubjectVar().getName(), "expect same Var");
 	}
 
 	/*-

--- a/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/WildcardProjectionProcessorTest.java
+++ b/core/queryparser/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/WildcardProjectionProcessorTest.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.query.parser.sparql.ast.ASTQueryContainer;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTSelectQuery;
 import org.eclipse.rdf4j.query.parser.sparql.ast.ASTVar;
 import org.eclipse.rdf4j.query.parser.sparql.ast.SyntaxTreeBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WildcardProjectionProcessorTest {
 

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONBooleanTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONBooleanTest.java
@@ -10,15 +10,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractQueryResultIOBooleanTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONParserCustomTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONParserCustomTest.java
@@ -10,11 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -34,10 +35,8 @@ import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.helpers.JSONSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -100,9 +99,6 @@ public class SPARQLJSONParserCustomTest {
 
 	private QueryResultParser parser;
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
 	private QueryResultCollector results;
 
 	private ParseErrorCollector errors;
@@ -120,7 +116,7 @@ public class SPARQLJSONParserCustomTest {
 	private final Literal testBindingValueLiteralUnquotedControlChar = SimpleValueFactory.getInstance()
 			.createLiteral("42\u0009", XSD.STRING);
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = QueryResultIO.createTupleParser(TupleQueryResultFormat.JSON);
 		errors = new ParseErrorCollector();
@@ -152,9 +148,9 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowBackslashEscapingAnyCharacterDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(BACKSLASH_ESCAPED_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(BACKSLASH_ESCAPED_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -166,17 +162,17 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowBackslashEscapingAnyCharacterDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, false);
-		parser.parseQueryResult(stringToInputStream(BACKSLASH_ESCAPED_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(BACKSLASH_ESCAPED_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testAllowCommentsDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(COMMENTS_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(COMMENTS_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -188,17 +184,17 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowCommentsDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_COMMENTS, false);
-		parser.parseQueryResult(stringToInputStream(COMMENTS_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(COMMENTS_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testAllowNonNumericNumbersDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(NON_NUMERIC_NUMBERS_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(NON_NUMERIC_NUMBERS_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -210,17 +206,17 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowNonNumericNumbersDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, false);
-		parser.parseQueryResult(stringToInputStream(NON_NUMERIC_NUMBERS_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(NON_NUMERIC_NUMBERS_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testAllowNumericLeadingZeroesDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(NUMERIC_LEADING_ZEROES_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(NUMERIC_LEADING_ZEROES_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -232,17 +228,17 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowNumericLeadingZeroesDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, false);
-		parser.parseQueryResult(stringToInputStream(NUMERIC_LEADING_ZEROES_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(NUMERIC_LEADING_ZEROES_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testAllowSingleQuotesDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(SINGLE_QUOTES_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(SINGLE_QUOTES_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -254,17 +250,17 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowSingleQuotesDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, false);
-		parser.parseQueryResult(stringToInputStream(SINGLE_QUOTES_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(SINGLE_QUOTES_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testAllowUnquotedControlCharactersDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(UNQUOTED_CONTROL_CHARS_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(UNQUOTED_CONTROL_CHARS_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -276,17 +272,17 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowUnquotedControlCharactersDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, false);
-		parser.parseQueryResult(stringToInputStream(UNQUOTED_CONTROL_CHARS_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(UNQUOTED_CONTROL_CHARS_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testAllowUnquotedFieldNamesDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(UNQUOTED_FIELD_NAMES_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(UNQUOTED_FIELD_NAMES_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -298,17 +294,17 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowUnquotedFieldNamesDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, false);
-		parser.parseQueryResult(stringToInputStream(UNQUOTED_FIELD_NAMES_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(UNQUOTED_FIELD_NAMES_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testAllowYamlCommentsDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(YAML_COMMENTS_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(YAML_COMMENTS_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -320,17 +316,17 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowYamlCommentsDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, false);
-		parser.parseQueryResult(stringToInputStream(YAML_COMMENTS_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(YAML_COMMENTS_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testAllowTrailingCommaDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
-		parser.parseQueryResult(stringToInputStream(TRAILING_COMMA_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(TRAILING_COMMA_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -342,10 +338,10 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testAllowTrailingCommaDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, false);
-		parser.parseQueryResult(stringToInputStream(TRAILING_COMMA_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(TRAILING_COMMA_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
@@ -401,26 +397,26 @@ public class SPARQLJSONParserCustomTest {
 
 	@Test
 	public void testStrictDuplicateDetectionDefault() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
-		parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testStrictDuplicateDetectionEnabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, true);
-		parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test
 	public void testStrictDuplicateDetectionDisabled() throws Exception {
-		thrown.expect(QueryResultParseException.class);
-		thrown.expectMessage("Could not parse SPARQL/JSON");
 		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
-		parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING));
+		assertThatThrownBy(() -> parser.parseQueryResult(stringToInputStream(STRICT_DUPLICATE_DETECTION_TEST_STRING)))
+				.isInstanceOf(QueryResultParseException.class)
+				.hasMessage("Could not parse SPARQL/JSON");
 	}
 
 	@Test

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleBackgroundTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleBackgroundTest.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,7 +36,7 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.UnsupportedQueryResultFormatException;
 import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractQueryResultIOTupleTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -72,7 +72,7 @@ public class SPARQLJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTes
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/bindings1.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be two variables
@@ -123,7 +123,7 @@ public class SPARQLJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTes
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/bindings2.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be 7 variables
@@ -213,7 +213,7 @@ public class SPARQLJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTes
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/non-standard-distinct.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be 1 variable
@@ -233,7 +233,7 @@ public class SPARQLJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTes
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/non-standard-ordered.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be 1 variable
@@ -253,7 +253,7 @@ public class SPARQLJSONTupleBackgroundTest extends AbstractQueryResultIOTupleTes
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/non-standard-distinct-ordered.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be 1 variable

--- a/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
+++ b/core/queryresultio/sparqljson/src/test/java/org/eclipse/rdf4j/query/resultio/sparqljson/SPARQLJSONTupleTest.java
@@ -10,14 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqljson;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 
@@ -34,7 +34,7 @@ import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractQueryResultIOTupleTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -64,7 +64,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/bindings1.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be two variables
@@ -115,7 +115,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/bindings2.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be 7 variables
@@ -205,7 +205,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/non-standard-distinct.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be 1 variable
@@ -225,7 +225,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/non-standard-ordered.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be 1 variable
@@ -245,7 +245,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/non-standard-distinct-ordered.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be 1 variable
@@ -265,7 +265,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/other-keys.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		// there must be two variables
@@ -297,7 +297,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/rdfstar-extendedformat-rdf4j.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		assertThat(handler.getBindingNames().size()).isEqualTo(3);
@@ -316,7 +316,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 
 		InputStream stream = this.getClass()
 				.getResourceAsStream("/sparqljson/rdfstar-extendedformat-rdf4j-incompletetriple.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		assertThatThrownBy(() -> parser.parseQueryResult(stream)).isInstanceOf(QueryResultParseException.class)
 				.hasMessageContaining("Incomplete or invalid triple value");
 	}
@@ -329,7 +329,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 
 		InputStream stream = this.getClass()
 				.getResourceAsStream("/sparqljson/rdfstar-extendedformat-rdf4j-doublesubject.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		assertThatThrownBy(() -> parser.parseQueryResult(stream)).isInstanceOf(QueryResultParseException.class)
 				.hasMessageContaining("s field encountered twice in triple value:");
 	}
@@ -341,7 +341,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/rdfstar-extendedformat-stardog.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		assertThat(handler.getBindingNames().size()).isEqualTo(3);
@@ -360,7 +360,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 
 		InputStream stream = this.getClass()
 				.getResourceAsStream("/sparqljson/rdfstar-extendedformat-stardog-namedgraph.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		assertThat(handler.getBindingNames().size()).isEqualTo(3);
@@ -378,7 +378,7 @@ public class SPARQLJSONTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqljson/rdfstar-extendedformat-jena.srj");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		assertThat(handler.getBindingNames().size()).isEqualTo(3);

--- a/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLParserCustomTest.java
+++ b/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLParserCustomTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.sparqlxml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.query.resultio.QueryResultIO;
 import org.eclipse.rdf4j.query.resultio.QueryResultParseException;
@@ -22,8 +22,9 @@ import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.XMLParserSettings;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Custom tests for SPARQL/XML Parser.
@@ -154,8 +155,9 @@ public class SPARQLXMLParserCustomTest {
 	 *
 	 * @throws Exception
 	 */
-	@Ignore
-	@Test(timeout = 10000)
+	@Disabled
+	@Test
+	@Timeout(10)
 	public void testEntityExpansionNoSecureProcessing() throws Exception {
 		QueryResultCollector handler = new QueryResultCollector();
 		ParseErrorCollector errorCollector = new ParseErrorCollector();

--- a/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleTest.java
+++ b/core/queryresultio/sparqlxml/src/test/java/org/eclipse/rdf4j/query/resultio/sparqlxml/SPARQLXMLTupleTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.query.resultio.sparqlxml;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.InputStream;
 
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractQueryResultIOTupleTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -50,7 +50,7 @@ public class SPARQLXMLTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqlxml/rdfstar-extendedformat-rdf4j.srx");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		assertThat(handler.getBindingNames().size()).isEqualTo(3);
@@ -68,7 +68,7 @@ public class SPARQLXMLTupleTest extends AbstractQueryResultIOTupleTest {
 		parser.setQueryResultHandler(handler);
 
 		InputStream stream = this.getClass().getResourceAsStream("/sparqlxml/rdfstar-extendedformat-stardog.srx");
-		assertNotNull("Could not find test resource", stream);
+		assertNotNull(stream, "Could not find test resource");
 		parser.parseQueryResult(stream);
 
 		assertThat(handler.getBindingNames().size()).isEqualTo(3);

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleBackgroundTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleBackgroundTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.text.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.query.resultio.QueryResultIO;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractQueryResultIOTupleTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleQueryResultWriterTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleQueryResultWriterTest.java
@@ -15,8 +15,8 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory;
 import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractTupleQueryResultWriterTest;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Jeen Broekstra
@@ -34,13 +34,13 @@ public class SPARQLCSVTupleQueryResultWriterTest extends AbstractTupleQueryResul
 	}
 
 	@Override
-	@Ignore("pending implementation of RDF-star extensions for the csv format")
+	@Disabled("pending implementation of RDF-star extensions for the csv format")
 	@Test
 	public void testRDFStarHandling_NoEncoding() throws Exception {
 	}
 
 	@Override
-	@Ignore("pending implementation of RDF-star extensions for the csv format")
+	@Disabled("pending implementation of RDF-star extensions for the csv format")
 	@Test
 	public void testRDFStarHandling_DeepNesting() throws Exception {
 	}

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/csv/SPARQLCSVTupleTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.text.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.query.resultio.QueryResultIO;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractQueryResultIOTupleTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVCustomTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVCustomTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.text.tsv;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -26,8 +26,8 @@ import org.eclipse.rdf4j.query.impl.IteratingTupleQueryResult;
 import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.resultio.QueryResultIO;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Custom tests for the SPARQL TSV writer.
@@ -44,7 +44,7 @@ public class SPARQLTSVCustomTest {
 	 *
 	 * @throws Exception
 	 */
-	@Ignore("This test does not work with RDF-1.1")
+	@Disabled("This test does not work with RDF-1.1")
 	@Test
 	public void testSES2126QuotedLiteralIntegerAsStringExplicitType() throws Exception {
 		List<String> bindingNames = List.of("test");

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleBackgroundTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleBackgroundTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.text.tsv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -34,7 +34,7 @@ import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 import org.eclipse.rdf4j.query.resultio.UnsupportedQueryResultFormatException;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractQueryResultIOTupleTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVTupleTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.resultio.text.tsv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
@@ -30,7 +30,7 @@ import org.eclipse.rdf4j.query.resultio.QueryResultIO;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter;
 import org.eclipse.rdf4j.testsuite.query.resultio.AbstractQueryResultIOTupleTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell

--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -68,6 +68,12 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- This module uses WireMock in tests and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/TestConfigTemplate.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/TestConfigTemplate.java
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dale Visser
@@ -48,9 +49,9 @@ public class TestConfigTemplate {
 		assertEquals(ConfigTemplate.escapeMultilineQuotes("\"\"\"", value), "\" \"\" \\\"\\\"\\\" \\\"\\\"\\\"\"");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public final void testInvalidDelimiterThrowsException() {
-		ConfigTemplate.escapeMultilineQuotes("'", "any value");
+		assertThrows(IllegalArgumentException.class, () -> ConfigTemplate.escapeMultilineQuotes("'", "any value"));
 	}
 
 	@Test

--- a/core/repository/contextaware/src/test/java/org/eclipse/rdf4j/repository/contextaware/ContextAwareConnectionTest.java
+++ b/core/repository/contextaware/src/test/java/org/eclipse/rdf4j/repository/contextaware/ContextAwareConnectionTest.java
@@ -11,8 +11,8 @@
 package org.eclipse.rdf4j.repository.contextaware;
 
 import static org.eclipse.rdf4j.query.QueryLanguage.SPARQL;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -39,7 +39,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.base.RepositoryConnectionWrapper;
 import org.eclipse.rdf4j.repository.base.RepositoryWrapper;
 import org.eclipse.rdf4j.rio.RDFHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ContextAwareConnectionTest {
 

--- a/core/repository/event/src/test/java/org/eclipse/rdf4j/repository/event/InterceptorTest.java
+++ b/core/repository/event/src/test/java/org/eclipse/rdf4j/repository/event/InterceptorTest.java
@@ -11,8 +11,8 @@
 package org.eclipse.rdf4j.repository.event;
 
 import static org.eclipse.rdf4j.query.QueryLanguage.SPARQL;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.repository.base.RepositoryConnectionWrapper;
 import org.eclipse.rdf4j.repository.base.RepositoryWrapper;
 import org.eclipse.rdf4j.repository.event.base.InterceptingRepositoryConnectionWrapper;
 import org.eclipse.rdf4j.repository.event.base.RepositoryConnectionInterceptorAdapter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Leigh

--- a/core/repository/event/src/test/java/org/eclipse/rdf4j/repository/event/NotifyingTest.java
+++ b/core/repository/event/src/test/java/org/eclipse/rdf4j/repository/event/NotifyingTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.repository.event;
 
 import static org.eclipse.rdf4j.query.QueryLanguage.SPARQL;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -34,7 +34,7 @@ import org.eclipse.rdf4j.repository.base.RepositoryConnectionWrapper;
 import org.eclipse.rdf4j.repository.base.RepositoryWrapper;
 import org.eclipse.rdf4j.repository.event.base.NotifyingRepositoryConnectionWrapper;
 import org.eclipse.rdf4j.repository.event.base.RepositoryConnectionListenerAdapter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Leigh

--- a/core/repository/manager/pom.xml
+++ b/core/repository/manager/pom.xml
@@ -71,6 +71,12 @@
 			<artifactId>jcl-over-slf4j</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- This module uses WireMock in tests and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManagerTest.java
+++ b/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManagerTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.manager;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
@@ -59,11 +60,11 @@ public class LocalRepositoryManagerTest extends RepositoryManagerTest {
 		subject.shutDown();
 	}
 
-	@Test(expected = RepositoryConfigException.class)
+	@Test
 	public void testAddRepositoryConfig_validation() {
 		RepositoryConfig config = mock(RepositoryConfig.class);
 		doThrow(RepositoryConfigException.class).when(config).validate();
 
-		subject.addRepositoryConfig(config);
+		assertThrows(RepositoryConfigException.class, () -> subject.addRepositoryConfig(config));
 	}
 }

--- a/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
+++ b/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RemoteRepositoryManagerTest.java
@@ -22,6 +22,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
@@ -109,7 +110,7 @@ public class RemoteRepositoryManagerTest extends RepositoryManagerTest {
 		wireMockRule.verify(getRequestedFor(urlEqualTo("/rdf4j-server/repositories/test/config")));
 	}
 
-	@Test(expected = RepositoryException.class)
+	@Test
 	public void testAddRepositoryConfigLegacy() {
 		wireMockRule.stubFor(
 				get(urlEqualTo("/rdf4j-server/protocol")).willReturn(aResponse().withStatus(200).withBody("8")));
@@ -122,6 +123,6 @@ public class RemoteRepositoryManagerTest extends RepositoryManagerTest {
 
 		RepositoryConfig config = new RepositoryConfig("test");
 
-		subject.addRepositoryConfig(config);
+		assertThrows(RepositoryException.class, () -> subject.addRepositoryConfig(config));
 	}
 }

--- a/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RepositoryManagerTest.java
+++ b/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RepositoryManagerTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.repository.manager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -85,8 +86,8 @@ public class RepositoryManagerTest {
 		assertThat(subject.getModelFactory()).isEqualTo(f);
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test
 	public void testSetModelFactoryWithNull() {
-		subject.setModelFactory(null);
+		assertThrows(NullPointerException.class, () -> subject.setModelFactory(null));
 	}
 }

--- a/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
+++ b/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
@@ -26,8 +26,8 @@ import org.eclipse.rdf4j.query.Query;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.sail.SailConnection;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link SailRepositoryConnection}
@@ -40,7 +40,7 @@ public class SailRepositoryConnectionTest {
 	private SailConnection sailConnection;
 	private SailRepository sailRepository;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		sailConnection = mock(SailConnection.class);
 		sailRepository = mock(SailRepository.class);

--- a/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/config/TestProxyRepositoryFactory.java
+++ b/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/config/TestProxyRepositoryFactory.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.repository.sail.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -26,7 +27,7 @@ import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
 import org.eclipse.rdf4j.repository.sail.ProxyRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestProxyRepositoryFactory {
 
@@ -37,11 +38,11 @@ public class TestProxyRepositoryFactory {
 		assertThat(factory.getRepositoryType()).isEqualTo("openrdf:ProxyRepository");
 	}
 
-	@Test(expected = RepositoryConfigException.class)
+	@Test
 	public final void testGetConfig() throws RepositoryConfigException {
 		RepositoryImplConfig factoryConfig = factory.getConfig();
 		assertThat(factoryConfig).isInstanceOf(ProxyRepositoryConfig.class);
-		factoryConfig.validate();
+		assertThrows(RepositoryConfigException.class, () -> factoryConfig.validate());
 	}
 
 	@Test

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLConnectionTest.java
@@ -28,8 +28,8 @@ import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.rio.ParserConfig;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class SPARQLConnectionTest {
@@ -38,7 +38,7 @@ public class SPARQLConnectionTest {
 	private SPARQLProtocolSession client;
 	private final ValueFactory vf = SimpleValueFactory.getInstance();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		client = mock(SPARQLProtocolSession.class);
 		subject = new SPARQLConnection(null, client);

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedServiceTest.java
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql.federation;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 public class RepositoryFederatedServiceTest {
 
@@ -21,28 +22,28 @@ public class RepositoryFederatedServiceTest {
 		// dummy instance for test
 		RepositoryFederatedService inst = new RepositoryFederatedService(null);
 
-		Assert.assertEquals(
+		assertEquals(
 				"SELECT ?s ?var ?__rowIdx WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?var }",
 				inst.insertValuesClause("SELECT ?s ?var ?__rowIdx WHERE { ?s ?p ?var }",
 						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
 
-		Assert.assertEquals(
+		assertEquals(
 				"SELECT ?s ?var ?__rowIdx WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }?s ?p ?var}",
 				inst.insertValuesClause("SELECT ?s ?var ?__rowIdx WHERE {?s ?p ?var}",
 						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
 
-		Assert.assertEquals(
+		assertEquals(
 				"SELECT ?s ?var ?__rowIdx { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?varv}",
 				inst.insertValuesClause("SELECT ?s ?var ?__rowIdx { ?s ?p ?varv}",
 						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
 
 		// test insertion of ?__rowIdx projection
-		Assert.assertEquals(
+		assertEquals(
 				"SELECT ?__rowIdx ?s ?var WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?var }",
 				inst.insertValuesClause("SELECT ?s ?var WHERE { ?s ?p ?var }",
 						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
 
-		Assert.assertEquals(
+		assertEquals(
 				"SELECT * WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?var }",
 				inst.insertValuesClause("SELECT * WHERE { ?s ?p ?var }",
 						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));
@@ -50,7 +51,7 @@ public class RepositoryFederatedServiceTest {
 		// Query pattern contains "SELECT *" with whitespace, which we do not match
 		// => we currently generate an invalid query which is then evaluated using
 		// the fallback to simple evaluation
-		Assert.assertEquals(
+		assertEquals(
 				"SELECT ?__rowIdx   * WHERE { VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) } ?s ?p ?var }",
 				inst.insertValuesClause("SELECT   * WHERE { ?s ?p ?var }",
 						"VALUES (?var ?__rowIdx) { (:val1 1) (:val2 2) }"));

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtilTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/query/QueryStringUtilTest.java
@@ -8,15 +8,15 @@
  */
 package org.eclipse.rdf4j.repository.sparql.query;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that QueryStringUtil converts values to their SPARQL string representations.

--- a/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLQueryBindingSetTest.java
+++ b/core/repository/sparql/src/test/java/org/eclipse/rdf4j/repository/sparql/query/SPARQLQueryBindingSetTest.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sparql.query;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.BindingSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/AbstractParserHandlingTest.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -41,9 +41,9 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.RDFStarUtil;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -213,7 +213,7 @@ public abstract class AbstractParserHandlingTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		testParser = getParser();
 
@@ -228,7 +228,7 @@ public abstract class AbstractParserHandlingTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		testListener.reset();
 		testListener = null;
@@ -969,13 +969,13 @@ public abstract class AbstractParserHandlingTest {
 			logger.trace("Expected: {}", expectedModel);
 			logger.trace("Actual: {}", testStatements);
 		}
-		assertTrue("Did not find expected statements", Models.isomorphic(expectedModel, testStatements));
+		assertTrue(Models.isomorphic(expectedModel, testStatements), "Did not find expected statements");
 	}
 
 	private void assertErrorListener(int expectedWarnings, int expectedErrors, int expectedFatalErrors) {
-		assertEquals("Unexpected number of fatal errors", expectedFatalErrors, testListener.getFatalErrors().size());
-		assertEquals("Unexpected number of errors", expectedErrors, testListener.getErrors().size());
-		assertEquals("Unexpected number of warnings", expectedWarnings, testListener.getWarnings().size());
+		assertEquals(expectedFatalErrors, testListener.getFatalErrors().size(), "Unexpected number of fatal errors");
+		assertEquals(expectedErrors, testListener.getErrors().size(), "Unexpected number of errors");
+		assertEquals(expectedWarnings, testListener.getWarnings().size(), "Unexpected number of warnings");
 	}
 
 	private Model getTestModel(String datatypeValue, IRI datatypeURI) {

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/BaseURIHandlingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/BaseURIHandlingTest.java
@@ -11,11 +11,12 @@
 package org.eclipse.rdf4j.rio;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InputStream;
 
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for handling of base URIs by {@link RDFParser} implementations.
@@ -33,12 +34,12 @@ public abstract class BaseURIHandlingTest {
 		assertThat(collector.getStatements()).isNotEmpty();
 	}
 
-	@Test(expected = RDFParseException.class)
+	@Test
 	public void testParseWithoutBaseUri_Relative() throws Exception {
 		StatementCollector collector = new StatementCollector();
 		RDFParser parser = getParserFactory().getParser();
 		parser.setRDFHandler(collector);
-		parser.parse(getDataWithRelativeIris());
+		assertThrows(RDFParseException.class, () -> parser.parse(getDataWithRelativeIris()));
 	}
 
 	@Test

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/ParserConfigTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/ParserConfigTest.java
@@ -10,17 +10,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.HashSet;
 
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for ParserConfig to verify that the core operations succeed and are consistent.
@@ -67,7 +67,7 @@ public class ParserConfigTest {
 	 * {@link org.eclipse.rdf4j.rio.ParserConfig#ParserConfig(boolean, boolean, boolean, org.eclipse.rdf4j.rio.RDFParser.DatatypeHandling)}
 	 * .
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testParserConfigBooleanBooleanBooleanDatatypeHandling() {
 		fail("Not yet implemented");

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RDFWriterTest.java
@@ -11,11 +11,11 @@
 package org.eclipse.rdf4j.rio;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -68,11 +68,8 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONLDMode;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,8 +81,8 @@ public abstract class RDFWriterTest {
 
 	private static final Logger logger = LoggerFactory.getLogger(RDFWriterTest.class);
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File tempDir;
 
 	protected RDFWriterFactory rdfWriterFactory;
 
@@ -334,8 +331,8 @@ public abstract class RDFWriterTest {
 	@Test
 	public void testRoundTrip_NonDefaultCharEncoding() throws Exception {
 		assumeTrue(
-				"Writer for format " + rdfWriterFactory.getRDFFormat().getName() + " does not use character encoding",
-				rdfWriterFactory.getRDFFormat().hasCharset());
+				rdfWriterFactory.getRDFFormat().hasCharset(),
+				"Writer for format " + rdfWriterFactory.getRDFFormat().getName() + " does not use character encoding");
 
 		// use Windows-1250 character encoding instead of format default
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -462,97 +459,97 @@ public abstract class RDFWriterTest {
 		rdfParser.parse(in, "foo:bar");
 
 		if (rdfParser.getRDFFormat().supportsContexts()) {
-			assertEquals("Unexpected number of statements, found " + model.size(), 30, model.size());
+			assertEquals(30, model.size(), "Unexpected number of statements, found " + model.size());
 		} else {
 			// Two sets of two statements, st23/st24 and st27/st28 in the input set differ only on context
 			// which isn't preserved by this format
-			assertEquals("Unexpected number of statements, found " + model.size(), 28, model.size());
+			assertEquals(28, model.size(), "Unexpected number of statements, found " + model.size());
 		}
 
 		if (rdfParser.getRDFFormat().supportsNamespaces()) {
-			assertTrue("Expected at least one namespace, found" + model.getNamespaces().size(),
-					model.getNamespaces().size() >= 1);
+			assertTrue(model.getNamespaces().size() >= 1,
+					"Expected at least one namespace, found" + model.getNamespaces().size());
 			assertEquals(exNs, model.getNamespace("ex").get().getName());
 		}
 
 		// Test for four unique statements for blank nodes in subject position
-		assertEquals("Unexpected number of statements with blank node subjects", 5,
-				model.filter(null, uri1, plainLit).size());
+		assertEquals(5, model.filter(null, uri1, plainLit).size(),
+				"Unexpected number of statements with blank node subjects");
 		// Test for four unique statements for blank nodes in object position
-		assertEquals("Unexpected number of statements with blank node objects", 5,
-				model.filter(uri2, uri1, null).size());
+		assertEquals(5, model.filter(uri2, uri1, null).size(),
+				"Unexpected number of statements with blank node objects");
 		if (rdfParser.getRDFFormat().supportsContexts()) {
-			assertTrue("missing statement with language literal and context: st11", model.contains(st11));
+			assertTrue(model.contains(st11), "missing statement with language literal and context: st11");
 		} else {
-			assertTrue("missing statement with language literal: st11",
-					model.contains(vf.createStatement(uri1, uri2, langLit)));
+			assertTrue(model.contains(vf.createStatement(uri1, uri2, langLit)),
+					"missing statement with language literal: st11");
 		}
-		assertTrue("missing statement with datatype: st12", model.contains(st12));
+		assertTrue(model.contains(st12), "missing statement with datatype: st12");
 		if (rdfParser.getRDFFormat().equals(RDFFormat.RDFXML)) {
 			logger.warn(
 					"FIXME: SES-879: RDFXML Parser does not preserve literals starting or ending in newline character");
 		} else {
-			assertTrue("missing statement with literal ending with newline: st13", model.contains(st13));
-			assertTrue("missing statement with literal starting with newline: st14", model.contains(st14));
-			assertTrue("missing statement with literal containing multiple newlines: st15", model.contains(st15));
+			assertTrue(model.contains(st13), "missing statement with literal ending with newline: st13");
+			assertTrue(model.contains(st14), "missing statement with literal starting with newline: st14");
+			assertTrue(model.contains(st15), "missing statement with literal containing multiple newlines: st15");
 		}
-		assertTrue("missing statement with single quotes: st16", model.contains(st16));
-		assertTrue("missing statement with double quotes: st17", model.contains(st17));
-		assertTrue("missing statement with object URI ending in period: st18", model.contains(st18));
-		assertTrue("missing statement with predicate URI ending in period: st19", model.contains(st19));
-		assertTrue("missing statement with subject URI ending in period: st20", model.contains(st20));
+		assertTrue(model.contains(st16), "missing statement with single quotes: st16");
+		assertTrue(model.contains(st17), "missing statement with double quotes: st17");
+		assertTrue(model.contains(st18), "missing statement with object URI ending in period: st18");
+		assertTrue(model.contains(st19), "missing statement with predicate URI ending in period: st19");
+		assertTrue(model.contains(st20), "missing statement with subject URI ending in period: st20");
 
-		assertEquals("missing statement with blank node single use subject: st21", 1,
-				model.filter(null, uri4, uri5).size());
+		assertEquals(1, model.filter(null, uri4, uri5).size(),
+				"missing statement with blank node single use subject: st21");
 
-		assertEquals("missing statement with blank node single use object: st22", 1,
-				model.filter(uri4, uri5, null).size());
+		assertEquals(1, model.filter(uri4, uri5, null).size(),
+				"missing statement with blank node single use object: st22");
 
 		Model st23Statements = model.filter(null, uri4, uri3);
 		if (rdfParser.getRDFFormat().supportsContexts()) {
-			assertEquals("missing statement with blank node use: st23/st24", 2, st23Statements.size());
+			assertEquals(2, st23Statements.size(), "missing statement with blank node use: st23/st24");
 			Set<Resource> st23Contexts = st23Statements.contexts();
 			assertTrue(st23Contexts.contains(uri1));
 			assertTrue(st23Contexts.contains(uri2));
 		} else {
-			assertEquals("missing statement with blank node use: st23/st24", 1, st23Statements.size());
+			assertEquals(1, st23Statements.size(), "missing statement with blank node use: st23/st24");
 		}
-		assertEquals("missing statement with blank node use subject and object: st25", 1,
-				model.filter(null, uri5, uri4).size());
-		assertEquals("missing statement with blank node use subject and object: st26", 1,
-				model.filter(uri4, uri3, null).size());
+		assertEquals(1, model.filter(null, uri5, uri4).size(),
+				"missing statement with blank node use subject and object: st25");
+		assertEquals(1, model.filter(uri4, uri3, null).size(),
+				"missing statement with blank node use subject and object: st26");
 		Model st27Statements = model.filter(uri3, uri4, null);
 		if (rdfParser.getRDFFormat().supportsContexts()) {
-			assertEquals("missing statement with blank node use: object: st27/st28", 2, st27Statements.size());
+			assertEquals(2, st27Statements.size(), "missing statement with blank node use: object: st27/st28");
 			Set<Resource> st27Contexts = st27Statements.contexts();
 			assertTrue(st27Contexts.contains(uri1));
 			assertTrue(st27Contexts.contains(uri2));
 		} else {
-			assertEquals("missing statement with blank node use: object: st27/st28", 1, st27Statements.size());
+			assertEquals(1, st27Statements.size(), "missing statement with blank node use: object: st27/st28");
 		}
 		if (rdfParser.getRDFFormat().supportsContexts()) {
 			Set<Resource> st29Contexts = model.filter(uri5, uri4, uri1).contexts();
-			assertEquals("Unexpected number of contexts containing blank node context statement", 1,
-					st29Contexts.size());
-			assertNotNull("missing statements with blank node context: st29", st29Contexts.iterator().next());
+			assertEquals(1, st29Contexts.size(),
+					"Unexpected number of contexts containing blank node context statement");
+			assertNotNull(st29Contexts.iterator().next(), "missing statements with blank node context: st29");
 
 			Set<Resource> st30Contexts = model.filter(uri5, uri4, uri2).contexts();
-			assertEquals("Unexpected number of contexts containing blank node context statement", 1,
-					st30Contexts.size());
-			assertNotNull("missing statements with blank node context: st30", st30Contexts.iterator().next());
+			assertEquals(1, st30Contexts.size(),
+					"Unexpected number of contexts containing blank node context statement");
+			assertNotNull(st30Contexts.iterator().next(), "missing statements with blank node context: st30");
 
-			assertEquals("Context for two blank node statements was not the same", st29Contexts.iterator().next(),
-					st30Contexts.iterator().next());
+			assertEquals(st29Contexts.iterator().next(), st30Contexts.iterator().next(),
+					"Context for two blank node statements was not the same");
 
-			assertEquals("Unexpected number of statements in the blank node context", 2,
-					model.filter(null, null, null, st29Contexts.iterator().next()).size());
-			assertEquals("Unexpected number of statements in the blank node context", 2,
-					model.filter(null, null, null, st30Contexts.iterator().next()).size());
+			assertEquals(2, model.filter(null, null, null, st29Contexts.iterator().next()).size(),
+					"Unexpected number of statements in the blank node context");
+			assertEquals(2, model.filter(null, null, null, st30Contexts.iterator().next()).size(),
+					"Unexpected number of statements in the blank node context");
 		} else {
-			assertEquals("missing statement with blank node context in non-quads format: st29", 1,
-					model.filter(uri5, uri4, uri1).size());
-			assertEquals("missing statement with blank node context in non-quads format: st30", 1,
-					model.filter(uri5, uri4, uri2).size());
+			assertEquals(1, model.filter(uri5, uri4, uri1).size(),
+					"missing statement with blank node context in non-quads format: st29");
+			assertEquals(1, model.filter(uri5, uri4, uri2).size(),
+					"missing statement with blank node context in non-quads format: st30");
 		}
 	}
 
@@ -581,11 +578,11 @@ public abstract class RDFWriterTest {
 
 		rdfParser.parse(in, "foo:bar");
 
-		assertEquals("Unexpected number of statements, found " + model.size(), 3, model.size());
+		assertEquals(3, model.size(), "Unexpected number of statements, found " + model.size());
 
-		assertTrue("missing statement with double " + st1.getObject(), model.contains(st1));
-		assertTrue("missing statement with double " + st2.getObject(), model.contains(st2));
-		assertTrue("missing statement with double " + st3.getObject(), model.contains(st3));
+		assertTrue(model.contains(st1), "missing statement with double " + st1.getObject());
+		assertTrue(model.contains(st2), "missing statement with double " + st2.getObject());
+		assertTrue(model.contains(st3), "missing statement with double " + st3.getObject());
 	}
 
 	@Test
@@ -619,10 +616,10 @@ public abstract class RDFWriterTest {
 		rdfParser.parse(in, "foo:bar");
 
 		Collection<Statement> statements = stCollector.getStatements();
-		assertEquals("Unexpected number of statements", 1, statements.size());
+		assertEquals(1, statements.size(), "Unexpected number of statements");
 
 		Statement parsedSt = statements.iterator().next();
-		assertEquals("Written and parsed statements are not equal", st, parsedSt);
+		assertEquals(st, parsedSt, "Written and parsed statements are not equal");
 	}
 
 	@Test
@@ -656,10 +653,10 @@ public abstract class RDFWriterTest {
 		rdfParser.parse(in, "foo:bar");
 
 		Collection<Statement> statements = stCollector.getStatements();
-		assertEquals("Unexpected number of statements", 1, statements.size());
+		assertEquals(1, statements.size(), "Unexpected number of statements");
 
 		Statement parsedSt = statements.iterator().next();
-		assertEquals("Written and parsed statements are not equal", st, parsedSt);
+		assertEquals(st, parsedSt, "Written and parsed statements are not equal");
 	}
 
 	@Test
@@ -771,9 +768,11 @@ public abstract class RDFWriterTest {
 		}
 		logger.debug("Test class: " + this.getClass().getName());
 		logger.debug("Test statements size: " + model.size() + " (" + rdfWriterFactory.getRDFFormat() + ")");
-		assertFalse("Did not generate any test statements", model.isEmpty());
+		assertFalse(model.isEmpty(), "Did not generate any test statements");
 
-		File testFile = tempDir.newFile("performancetest." + rdfWriterFactory.getRDFFormat().getDefaultFileExtension());
+		File testFile = new File(tempDir,
+				"performancetest." + rdfWriterFactory.getRDFFormat().getDefaultFileExtension());
+		testFile.createNewFile();
 
 		try (OutputStream out = new BufferedOutputStream(new FileOutputStream(testFile))) {
 
@@ -829,13 +828,12 @@ public abstract class RDFWriterTest {
 //						Rio.write(parsedModel, System.out, RDFFormat.NQUADS);
 					}
 				}
-				assertEquals(
-						"Unexpected number of statements, expected " + model.size() + " found " + parsedModel.size(),
-						model.size(), parsedModel.size());
+				assertEquals(model.size(), parsedModel.size(),
+						"Unexpected number of statements, expected " + model.size() + " found " + parsedModel.size());
 
 				if (rdfParser.getRDFFormat().supportsNamespaces()) {
-					assertTrue("Expected at least 5 namespaces, found " + parsedModel.getNamespaces().size(),
-							parsedModel.getNamespaces().size() >= 5);
+					assertTrue(parsedModel.getNamespaces().size() >= 5,
+							"Expected at least 5 namespaces, found " + parsedModel.getNamespaces().size());
 					assertEquals(exNs, parsedModel.getNamespace("ex").get().getName());
 				}
 			}
@@ -1824,10 +1822,10 @@ public abstract class RDFWriterTest {
 		Model parsedOutput = new LinkedHashModel();
 		rdfParser.setRDFHandler(new StatementCollector(parsedOutput));
 		rdfParser.parse(inputReader, "");
-		Assert.assertEquals(model.size(), parsedOutput.size());
+		assertEquals(model.size(), parsedOutput.size());
 		ByteArrayInputStream inputReader2 = new ByteArrayInputStream(outputWriter.toByteArray());
 		rdfParser.parse(inputReader2, "");
-		Assert.assertEquals(model.size(), parsedOutput.size());
+		assertEquals(model.size(), parsedOutput.size());
 	}
 
 	@Test
@@ -1896,8 +1894,9 @@ public abstract class RDFWriterTest {
 			try (ByteArrayOutputStream outs = new ByteArrayOutputStream()) {
 				RDFWriter rdfWriter = rdfWriterFactory.getWriter(outs);
 
-				Assume.assumeTrue("Test makes sense only if RDFWriter is a Closeable",
-						rdfWriter instanceof Closeable);
+				assumeTrue(
+						rdfWriter instanceof Closeable,
+						"Test makes sense only if RDFWriter is a Closeable");
 
 				rdfWriter.startRDF();
 				rdfWriter.handleNamespace("ex", "http://example.com/");
@@ -1936,7 +1935,7 @@ public abstract class RDFWriterTest {
 			Resource subj = st.getSubject() instanceof IRI ? st.getSubject() : null;
 			IRI pred = st.getPredicate();
 			Value obj = st.getObject() instanceof BNode ? null : st.getObject();
-			assertTrue("Missing " + st, actual.contains(subj, pred, obj));
+			assertTrue(actual.contains(subj, pred, obj), "Missing " + st);
 			assertEquals(actual.filter(subj, pred, obj).size(), actual.filter(subj, pred, obj).size());
 		}
 	}

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioConfigTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/RioConfigTest.java
@@ -14,9 +14,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.rdf4j.rio.helpers.AbstractRioSetting;
 import org.eclipse.rdf4j.rio.helpers.BooleanRioSetting;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RioConfigTest {
 
@@ -26,12 +26,12 @@ public class RioConfigTest {
 
 	private final BooleanRioSetting testSetting = new BooleanRioSetting(key, "test setting", true);
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		config = new RioConfig();
 	}
 
-	@After
+	@AfterEach
 	public void cleanup() {
 		System.clearProperty(key);
 	}

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParserTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParserTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,8 +21,8 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -55,7 +55,7 @@ public class AbstractRDFParserTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = new MyRDFParser();
 	}

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettingsTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BasicParserSettingsTest.java
@@ -10,26 +10,24 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.util.Namespaces;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BasicParserSettingsTest {
+
 	@Test
 	public void testAdditionalPrefixes() {
-		assertTrue("No additional prefixes", Namespaces.DEFAULT_RDF4J.size() > Namespaces.DEFAULT_RDFA11.size());
+		assertTrue(Namespaces.DEFAULT_RDF4J.size() > Namespaces.DEFAULT_RDFA11.size(), "No additional prefixes");
 	}
 
 	@Test
 	public void testImmutable() {
-		try {
-			Namespaces.DEFAULT_RDF4J.add(new SimpleNamespace("ex", "http://www.example.com"));
-			fail("Not immutable");
-		} catch (UnsupportedOperationException use) {
-			// ok
-		}
+		assertThatThrownBy(() -> Namespaces.DEFAULT_RDF4J.add(new SimpleNamespace("ex", "http://www.example.com")))
+				.isInstanceOf(UnsupportedOperationException.class)
+				.withFailMessage("Not immutable");
 	}
 }

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSettingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/BooleanRioSettingTest.java
@@ -13,14 +13,14 @@ package org.eclipse.rdf4j.rio.helpers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.rdf4j.rio.RioSetting;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class BooleanRioSettingTest extends RioSettingTest<Boolean> {
 
 	@Test
 	@Override
-	@Ignore
+	@Disabled
 	public void testConvertIllegal() throws Exception {
 	}
 

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/NTriplesUtilTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/NTriplesUtilTest.java
@@ -11,8 +11,9 @@
 package org.eclipse.rdf4j.rio.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -24,8 +25,8 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DC;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link NTriplesUtil}
@@ -37,7 +38,7 @@ public class NTriplesUtilTest {
 	private StringBuilder appendable;
 	private final ValueFactory f = SimpleValueFactory.getInstance();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		appendable = new StringBuilder();
 	}
@@ -146,9 +147,9 @@ public class NTriplesUtilTest {
 		}
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testParseIRIvsTriple() {
-		NTriplesUtil.parseURI("<<<urn:a><urn:b><urn:c>>>", f);
+		assertThrows(IllegalArgumentException.class, () -> NTriplesUtil.parseURI("<<<urn:a><urn:b><urn:c>>>", f));
 	}
 
 	@Test

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RDFParserHelperTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RDFParserHelperTest.java
@@ -10,10 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -28,12 +29,10 @@ import org.eclipse.rdf4j.rio.LanguageHandler;
 import org.eclipse.rdf4j.rio.ParseErrorListener;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link RDFParserHelper} methods.
@@ -43,9 +42,6 @@ import org.junit.rules.ExpectedException;
 public class RDFParserHelperTest {
 
 	private static final String TEST_MESSAGE_FOR_FAILURE = "Test message for failure.";
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	private static final String LABEL_TESTA = "test-a";
 
@@ -60,7 +56,7 @@ public class RDFParserHelperTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parserConfig = new ParserConfig();
 		// By default we wipe out the SPI loaded datatype and language handlers
@@ -75,7 +71,7 @@ public class RDFParserHelperTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 
@@ -86,9 +82,10 @@ public class RDFParserHelperTest {
 	 */
 	@Test
 	public final void testCreateLiteralLabelNull() throws Exception {
-		thrown.expect(NullPointerException.class);
-		thrown.expectMessage("Cannot create a literal using a null label");
-		RDFParserHelper.createLiteral(null, null, null, parserConfig, errListener, valueFactory);
+		assertThatThrownBy(
+				() -> RDFParserHelper.createLiteral(null, null, null, parserConfig, errListener, valueFactory))
+				.isInstanceOf(NullPointerException.class)
+				.hasMessage("Cannot create a literal using a null label");
 	}
 
 	/**
@@ -171,8 +168,9 @@ public class RDFParserHelperTest {
 	public final void testCreateLiteralLabelNoLanguageWithRDFLangStringWithVerify() throws Exception {
 		parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 		assertTrue(parserConfig.get(BasicParserSettings.VERIFY_DATATYPE_VALUES));
-		thrown.expect(RDFParseException.class);
-		RDFParserHelper.createLiteral(LABEL_TESTA, null, RDF.LANGSTRING, parserConfig, errListener, valueFactory);
+		assertThatThrownBy(() -> RDFParserHelper.createLiteral(LABEL_TESTA, null, RDF.LANGSTRING, parserConfig,
+				errListener, valueFactory))
+				.isInstanceOf(RDFParseException.class);
 	}
 
 	@Test
@@ -188,14 +186,12 @@ public class RDFParserHelperTest {
 	public final void testReportErrorStringFatalActive() throws Exception {
 		parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 		assertTrue(parserConfig.get(BasicParserSettings.VERIFY_DATATYPE_VALUES));
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage(TEST_MESSAGE_FOR_FAILURE);
-		try {
-			RDFParserHelper.reportError(TEST_MESSAGE_FOR_FAILURE, BasicParserSettings.VERIFY_DATATYPE_VALUES,
-					parserConfig, errListener);
-		} finally {
-			assertErrorListener(0, 1, 0);
-		}
+		assertThatThrownBy(
+				() -> RDFParserHelper.reportError(TEST_MESSAGE_FOR_FAILURE, BasicParserSettings.VERIFY_DATATYPE_VALUES,
+						parserConfig, errListener))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage(TEST_MESSAGE_FOR_FAILURE);
+		assertErrorListener(0, 1, 0);
 	}
 
 	@Test
@@ -229,14 +225,14 @@ public class RDFParserHelperTest {
 	public final void testReportErrorStringIntIntFatalActive() throws Exception {
 		parserConfig.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
 		assertTrue(parserConfig.get(BasicParserSettings.VERIFY_DATATYPE_VALUES));
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage(TEST_MESSAGE_FOR_FAILURE);
-		try {
-			RDFParserHelper.reportError(TEST_MESSAGE_FOR_FAILURE, 1, 1, BasicParserSettings.VERIFY_DATATYPE_VALUES,
-					parserConfig, errListener);
-		} finally {
-			assertErrorListener(0, 1, 0);
-		}
+		assertThatThrownBy(
+				() -> RDFParserHelper.reportError(TEST_MESSAGE_FOR_FAILURE, 1, 1,
+						BasicParserSettings.VERIFY_DATATYPE_VALUES,
+						parserConfig, errListener))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining(TEST_MESSAGE_FOR_FAILURE);
+
+		assertErrorListener(0, 1, 0);
 	}
 
 	@Test
@@ -271,7 +267,7 @@ public class RDFParserHelperTest {
 	 * {@link org.eclipse.rdf4j.rio.helpers.RDFParserHelper#reportError(java.lang.Exception, int, int, org.eclipse.rdf4j.rio.RioSetting, org.eclipse.rdf4j.rio.ParserConfig, org.eclipse.rdf4j.rio.ParseErrorListener)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testReportErrorExceptionIntInt() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -282,7 +278,7 @@ public class RDFParserHelperTest {
 	 * {@link org.eclipse.rdf4j.rio.helpers.RDFParserHelper#reportFatalError(java.lang.String, org.eclipse.rdf4j.rio.ParseErrorListener)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testReportFatalErrorString() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -293,7 +289,7 @@ public class RDFParserHelperTest {
 	 * {@link org.eclipse.rdf4j.rio.helpers.RDFParserHelper#reportFatalError(java.lang.String, int, int, org.eclipse.rdf4j.rio.ParseErrorListener)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testReportFatalErrorStringIntInt() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -304,7 +300,7 @@ public class RDFParserHelperTest {
 	 * {@link org.eclipse.rdf4j.rio.helpers.RDFParserHelper#reportFatalError(java.lang.Exception, org.eclipse.rdf4j.rio.ParseErrorListener)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testReportFatalErrorException() throws Exception {
 		fail("Not yet implemented"); // TODO
@@ -315,7 +311,7 @@ public class RDFParserHelperTest {
 	 * {@link org.eclipse.rdf4j.rio.helpers.RDFParserHelper#reportFatalError(java.lang.Exception, int, int, org.eclipse.rdf4j.rio.ParseErrorListener)}
 	 * .
 	 */
-	@Ignore
+	@Disabled
 	@Test
 	public final void testReportFatalErrorExceptionIntInt() throws Exception {
 		fail("Not yet implemented"); // TODO

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RDFStarUtilTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RDFStarUtilTest.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -24,7 +24,7 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Pavel Mihaylov

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioFileTypeDetectorTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioFileTypeDetectorTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.file.spi.FileTypeDetector;
 import java.util.ServiceLoader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RioFileTypeDetectorTest {
 	@Test

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioSettingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/RioSettingTest.java
@@ -14,8 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.eclipse.rdf4j.rio.RioSetting;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class RioSettingTest<T> {
 
@@ -28,7 +28,7 @@ public abstract class RioSettingTest<T> {
 	 */
 	protected RioSetting<T> subject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		subject = createRioSetting(TEST_KEY, TEST_DESCRIPTION, getDefaultValue());
 	}

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/StatementCollectorTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/StatementCollectorTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,9 +25,9 @@ import java.util.Set;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -37,14 +37,14 @@ public class StatementCollectorTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 	}
 
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/StringRioSettingTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/StringRioSettingTest.java
@@ -11,14 +11,14 @@
 package org.eclipse.rdf4j.rio.helpers;
 
 import org.eclipse.rdf4j.rio.RioSetting;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class StringRioSettingTest extends RioSettingTest<String> {
 
 	@Test
 	@Override
-	@Ignore
+	@Disabled
 	public void testConvertIllegal() throws Exception {
 	}
 

--- a/core/rio/datatypes/src/test/java/org/eclipse/rdf4j/rio/datatypes/AbstractDatatypeHandlerTest.java
+++ b/core/rio/datatypes/src/test/java/org/eclipse/rdf4j/rio/datatypes/AbstractDatatypeHandlerTest.java
@@ -10,21 +10,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.datatypes;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.util.LiteralUtilException;
 import org.eclipse.rdf4j.rio.DatatypeHandler;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test for DatatypeHandler interface.
@@ -32,9 +31,6 @@ import org.junit.rules.ExpectedException;
  * @author Peter Ansell
  */
 public abstract class AbstractDatatypeHandlerTest {
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	/**
 	 * Generates a new instance of the {@link DatatypeHandler} implementation in question and returns it.
@@ -91,13 +87,13 @@ public abstract class AbstractDatatypeHandlerTest {
 
 	private ValueFactory vf;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		testHandler = getNewDatatypeHandler();
 		vf = getValueFactory();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		testHandler = null;
 		vf = null;
@@ -108,8 +104,8 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testIsRecognizedDatatypeNull() throws Exception {
-		thrown.expect(NullPointerException.class);
-		testHandler.isRecognizedDatatype(null);
+		assertThatThrownBy(() -> testHandler.isRecognizedDatatype(null))
+				.isInstanceOf(NullPointerException.class);
 	}
 
 	/**
@@ -134,8 +130,8 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testVerifyDatatypeNullDatatypeUri() throws Exception {
-		thrown.expect(NullPointerException.class);
-		testHandler.verifyDatatype(getValueMatchingRecognisedDatatypeUri(), null);
+		assertThatThrownBy(() -> testHandler.verifyDatatype(getValueMatchingRecognisedDatatypeUri(), null))
+				.isInstanceOf(NullPointerException.class);
 	}
 
 	/**
@@ -144,8 +140,8 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testVerifyDatatypeNullValueRecognised() throws Exception {
-		thrown.expect(NullPointerException.class);
-		testHandler.verifyDatatype(null, getRecognisedDatatypeUri());
+		assertThatThrownBy(() -> testHandler.verifyDatatype(null, getRecognisedDatatypeUri()))
+				.isInstanceOf(NullPointerException.class);
 	}
 
 	/**
@@ -154,8 +150,8 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testVerifyDatatypeNullValueUnrecognised() throws Exception {
-		thrown.expect(LiteralUtilException.class);
-		testHandler.verifyDatatype(null, getUnrecognisedDatatypeUri());
+		assertThatThrownBy(() -> testHandler.verifyDatatype(null, getUnrecognisedDatatypeUri()))
+				.isInstanceOf(LiteralUtilException.class);
 	}
 
 	/**
@@ -164,8 +160,9 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testVerifyDatatypeUnrecognisedDatatypeUri() throws Exception {
-		thrown.expect(LiteralUtilException.class);
-		testHandler.verifyDatatype(getValueMatchingRecognisedDatatypeUri(), getUnrecognisedDatatypeUri());
+		assertThatThrownBy(
+				() -> testHandler.verifyDatatype(getValueMatchingRecognisedDatatypeUri(), getUnrecognisedDatatypeUri()))
+				.isInstanceOf(LiteralUtilException.class);
 	}
 
 	/**
@@ -193,8 +190,8 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testNormalizeDatatypeNullDatatypeUri() throws Exception {
-		thrown.expect(NullPointerException.class);
-		testHandler.normalizeDatatype(getValueMatchingRecognisedDatatypeUri(), null, vf);
+		assertThatThrownBy(() -> testHandler.normalizeDatatype(getValueMatchingRecognisedDatatypeUri(), null, vf))
+				.isInstanceOf(NullPointerException.class);
 	}
 
 	/**
@@ -204,8 +201,8 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testNormalizeDatatypeNullValue() throws Exception {
-		thrown.expect(NullPointerException.class);
-		testHandler.normalizeDatatype(null, getRecognisedDatatypeUri(), vf);
+		assertThatThrownBy(() -> testHandler.normalizeDatatype(null, getRecognisedDatatypeUri(), vf))
+				.isInstanceOf(NullPointerException.class);
 	}
 
 	/**
@@ -215,8 +212,9 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testNormalizeDatatypeUnrecognisedDatatypeUri() throws Exception {
-		thrown.expect(LiteralUtilException.class);
-		testHandler.normalizeDatatype(getValueMatchingRecognisedDatatypeUri(), getUnrecognisedDatatypeUri(), vf);
+		assertThatThrownBy(() -> testHandler.normalizeDatatype(getValueMatchingRecognisedDatatypeUri(),
+				getUnrecognisedDatatypeUri(), vf))
+				.isInstanceOf(LiteralUtilException.class);
 	}
 
 	/**
@@ -226,8 +224,9 @@ public abstract class AbstractDatatypeHandlerTest {
 	 */
 	@Test
 	public void testNormalizeDatatypeInvalidValue() throws Exception {
-		thrown.expect(LiteralUtilException.class);
-		testHandler.normalizeDatatype(getValueNotMatchingRecognisedDatatypeUri(), getRecognisedDatatypeUri(), vf);
+		assertThatThrownBy(() -> testHandler.normalizeDatatype(getValueNotMatchingRecognisedDatatypeUri(),
+				getRecognisedDatatypeUri(), vf))
+				.isInstanceOf(LiteralUtilException.class);
 	}
 
 	/**
@@ -260,5 +259,4 @@ public abstract class AbstractDatatypeHandlerTest {
 
 		assertEquals(expectedResult, result);
 	}
-
 }

--- a/core/rio/datatypes/src/test/java/org/eclipse/rdf4j/rio/datatypes/DBPediaCelsiusDatatypeHandlerTest.java
+++ b/core/rio/datatypes/src/test/java/org/eclipse/rdf4j/rio/datatypes/DBPediaCelsiusDatatypeHandlerTest.java
@@ -16,8 +16,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.DatatypeHandler;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link DBPediaDatatypeHandler} with http://dbpedia.org/datatype/degreeCelsius .
@@ -26,13 +26,13 @@ import org.junit.Test;
  */
 public class DBPediaCelsiusDatatypeHandlerTest extends AbstractDatatypeHandlerTest {
 
-	@Ignore("DBPedia datatypes are not currently verified")
+	@Disabled("DBPedia datatypes are not currently verified")
 	@Test
 	@Override
 	public void testVerifyDatatypeInvalidValue() throws Exception {
 	}
 
-	@Ignore("DBPedia datatypes are not currently normalised")
+	@Disabled("DBPedia datatypes are not currently normalised")
 	@Test
 	@Override
 	public void testNormalizeDatatypeInvalidValue() throws Exception {

--- a/core/rio/datatypes/src/test/java/org/eclipse/rdf4j/rio/datatypes/RDFLangStringDatatypeHandlerTest.java
+++ b/core/rio/datatypes/src/test/java/org/eclipse/rdf4j/rio/datatypes/RDFLangStringDatatypeHandlerTest.java
@@ -17,8 +17,8 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.DatatypeHandler;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link RDFDatatypeHandler} with {@link RDF#LANGSTRING}.
@@ -27,19 +27,19 @@ import org.junit.Test;
  */
 public class RDFLangStringDatatypeHandlerTest extends AbstractDatatypeHandlerTest {
 
-	@Ignore("There are no invalid values for RDF LangString other than null, which is tested seperately")
+	@Disabled("There are no invalid values for RDF LangString other than null, which is tested seperately")
 	@Test
 	@Override
 	public void testVerifyDatatypeInvalidValue() throws Exception {
 	}
 
-	@Ignore("There are no invalid values for RDF LangString other than null, which is tested seperately")
+	@Disabled("There are no invalid values for RDF LangString other than null, which is tested seperately")
 	@Test
 	@Override
 	public void testNormalizeDatatypeInvalidValue() throws Exception {
 	}
 
-	@Ignore("This test relies on a null language, which is not allowed for RDF.LANGSTRING")
+	@Disabled("This test relies on a null language, which is not allowed for RDF.LANGSTRING")
 	@Test
 	@Override
 	public void testNormalizeDatatypeValidValue() throws Exception {

--- a/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/CRC16Test.java
+++ b/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/CRC16Test.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.hdt;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -24,7 +24,7 @@ public class CRC16Test {
 	public void testHello() {
 		CRC16 crc = new CRC16();
 		crc.update("Hello world".getBytes(StandardCharsets.US_ASCII), 0, "Hello world".length());
-		assertEquals("CRC hello world not correct", 0xF96A, crc.getValue());
+		assertEquals(0xF96A, crc.getValue(), "CRC hello world not correct");
 	}
 
 	@Test
@@ -33,6 +33,6 @@ public class CRC16Test {
 		for (byte b : "Hello world".getBytes(StandardCharsets.US_ASCII)) {
 			crc.update(b);
 		}
-		assertEquals("CRC hello world not correct", 0xF96A, crc.getValue());
+		assertEquals(0xF96A, crc.getValue(), "CRC hello world not correct");
 	}
 }

--- a/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/CRC32Test.java
+++ b/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/CRC32Test.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.hdt;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -24,7 +24,7 @@ public class CRC32Test {
 	public void testHello() {
 		CRC32 crc = new CRC32();
 		crc.update("Hello world".getBytes(StandardCharsets.US_ASCII), 0, "Hello world".length());
-		assertEquals("CRC hello world not correct", 0x72B51F78, crc.getValue());
+		assertEquals(0x72B51F78, crc.getValue(), "CRC hello world not correct");
 	}
 
 	@Test
@@ -33,6 +33,6 @@ public class CRC32Test {
 		for (byte b : "Hello world".getBytes(StandardCharsets.US_ASCII)) {
 			crc.update(b);
 		}
-		assertEquals("CRC hello world not correct", 0x72B51F78, crc.getValue());
+		assertEquals(0x72B51F78, crc.getValue(), "CRC hello world not correct");
 	}
 }

--- a/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/CRC8Test.java
+++ b/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/CRC8Test.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.hdt;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart.Hanssens
@@ -24,7 +24,7 @@ public class CRC8Test {
 	public void testHello() {
 		CRC8 crc = new CRC8();
 		crc.update("Hello world".getBytes(StandardCharsets.US_ASCII), 0, "Hello world".length());
-		assertEquals("CRC hello world not correct", 0x41, crc.getValue());
+		assertEquals(0x41, crc.getValue(), "CRC hello world not correct");
 	}
 
 	@Test
@@ -33,6 +33,6 @@ public class CRC8Test {
 		for (byte b : "Hello world".getBytes(StandardCharsets.US_ASCII)) {
 			crc.update(b);
 		}
-		assertEquals("CRC hello world not correct", 0x41, crc.getValue());
+		assertEquals(0x41, crc.getValue(), "CRC hello world not correct");
 	}
 }

--- a/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/HDTParserTest.java
+++ b/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/HDTParserTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.hdt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.InputStream;
 
@@ -21,8 +21,8 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart Hanssens
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class HDTParserTest {
 	private RDFParser parser;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = Rio.createParser(RDFFormat.HDT);
 		parser.setParseLocationListener((line, col) -> System.err.println("byte " + line));
@@ -52,13 +52,13 @@ public class HDTParserTest {
 		try (InputStream is = HDTParserTest.class.getResourceAsStream("/test.hdt")) {
 			parser.setRDFHandler(new StatementCollector(m));
 			parser.parse(is, "");
-			assertEquals("Number of statements does not match", 43, m.size());
+			assertEquals(43, m.size(), "Number of statements does not match");
 		} catch (Exception e) {
 			fail(e.getMessage());
 		}
 
 		orig.removeAll(m);
-		assertEquals("HDT model does not match original NT file", 0, orig.size());
+		assertEquals(0, orig.size(), "HDT model does not match original NT file");
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class HDTParserTest {
 		try (InputStream is = HDTParserTest.class.getResourceAsStream("/test-pos.hdt")) {
 			parser.setRDFHandler(new StatementCollector(m));
 			parser.parse(is, "");
-			assertEquals("Number of statements does not match", 43, m.size());
+			assertEquals(43, m.size(), "Number of statements does not match");
 			fail("Unsupported not caught");
 		} catch (Exception e) {
 			assertEquals(e.getMessage(), "Triples section: order 4, but only SPO order is supported");

--- a/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/VByteTest.java
+++ b/core/rio/hdt/src/test/java/org/eclipse/rdf4j/rio/hdt/VByteTest.java
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.hdt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Bart.Hanssens
@@ -24,12 +24,12 @@ import org.junit.Test;
 public class VByteTest {
 	@Test
 	public void test127() {
-		assertEquals("127 not correctly decoded", 127, VByte.decode(new byte[] { (byte) 0xff }, 1));
+		assertEquals(127, VByte.decode(new byte[] { (byte) 0xff }, 1), "127 not correctly decoded");
 	}
 
 	@Test
 	public void test128() {
-		assertEquals("128 not correctly decoded", 128, VByte.decode(new byte[] { (byte) 0x00, (byte) 0x81 }, 2));
+		assertEquals(128, VByte.decode(new byte[] { (byte) 0x00, (byte) 0x81 }, 2), "128 not correctly decoded");
 	}
 
 	@Test
@@ -37,7 +37,7 @@ public class VByteTest {
 		byte b[] = new byte[] { (byte) 0x00, (byte) 0x81 };
 
 		try (ByteArrayInputStream bis = new ByteArrayInputStream(b)) {
-			assertEquals("128 not correctly decoded", 128, VByte.decode(bis));
+			assertEquals(128, VByte.decode(bis), "128 not correctly decoded");
 		} catch (IOException ioe) {
 			fail(ioe.getMessage());
 		}

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDHierarchicalWriterTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.jsonld;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,8 +35,8 @@ import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yasen Marinov
@@ -47,7 +47,7 @@ public class JSONLDHierarchicalWriterTest {
 	private Model model;
 	private WriterConfig writerConfig;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		model = new LinkedHashModel();
 		writerConfig = new WriterConfig();
@@ -357,13 +357,13 @@ public class JSONLDHierarchicalWriterTest {
 			if (Arrays.binarySearch(toIgnore, b) < 0) {
 				while (Arrays.binarySearch(toIgnore, charInFile = is.read()) >= 0) {
 				}
-				assertEquals("Files are equal", charInFile, b);
+				assertEquals(charInFile, b, "Files are equal");
 			}
 		}
 
 		@Override
 		public void close() throws IOException {
-			assertTrue("Streams match", is.read() == -1);
+			assertTrue(is.read() == -1, "Streams match");
 			super.close();
 		}
 	}

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDInternalTripleCallbackTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDInternalTripleCallbackTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.jsonld;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.JsonLdProcessor;
@@ -59,7 +59,7 @@ public class JSONLDInternalTripleCallbackTest {
 			final Statement stmt = statements.next();
 
 			System.out.println(stmt.toString());
-			assertEquals("Output was not as expected", expectedString, stmt.toString());
+			assertEquals(expectedString, stmt.toString(), "Output was not as expected");
 		}
 
 		assertEquals(0, parseErrorListener.getFatalErrors().size());

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDParserCustomTest.java
@@ -10,11 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.jsonld;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -35,11 +36,9 @@ import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.jsonldjava.core.DocumentLoader;
@@ -50,6 +49,7 @@ import com.github.jsonldjava.core.DocumentLoader;
  * @author Peter Ansell
  */
 public class JSONLDParserCustomTest {
+
 	/**
 	 * Backslash escaped "h" in "http"
 	 */
@@ -108,9 +108,6 @@ public class JSONLDParserCustomTest {
 
 	private RDFParser parser;
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
 	private ParseErrorCollector errors;
 
 	private Model model;
@@ -125,7 +122,7 @@ public class JSONLDParserCustomTest {
 	private final Literal testObjectLiteralNumber = F.createLiteral("42", XSD.INTEGER);
 	private final Literal testObjectLiteralUnquotedControlChar = F.createLiteral("42\u0009", XSD.STRING);
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = Rio.createParser(RDFFormat.JSONLD);
 		errors = new ParseErrorCollector();
@@ -140,8 +137,8 @@ public class JSONLDParserCustomTest {
 		assertEquals(0, errors.getFatalErrors().size());
 
 		assertEquals(1, model.size());
-		assertTrue("model was not as expected: " + model.toString(),
-				model.contains(nextSubject, nextPredicate, nextObject));
+		assertTrue(model.contains(nextSubject, nextPredicate, nextObject),
+				"model was not as expected: " + model.toString());
 	}
 
 	@Test
@@ -152,9 +149,9 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowBackslashEscapingAnyCharacterDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -166,17 +163,18 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowBackslashEscapingAnyCharacterDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, false);
-		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
+
 	}
 
 	@Test
 	public void testAllowCommentsDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(COMMENTS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -188,21 +186,21 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowCommentsDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_COMMENTS, false);
-		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(COMMENTS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
 	public void testAllowNonNumericNumbersDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
-	@Ignore("temporarily disabled due to breaking on command line but not in Eclipse")
+	@Disabled("temporarily disabled due to breaking on command line but not in Eclipse")
 	public void testAllowNonNumericNumbersEnabled() throws Exception {
 		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, true);
 		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
@@ -213,17 +211,17 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowNonNumericNumbersDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, false);
-		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
 	public void testAllowNumericLeadingZeroesDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -235,17 +233,17 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowNumericLeadingZeroesDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, false);
-		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
 	public void testAllowSingleQuotesDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -257,17 +255,17 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowSingleQuotesDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, false);
-		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
 	public void testAllowUnquotedControlCharactersDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -279,17 +277,17 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowUnquotedControlCharactersDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, false);
-		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
 	public void testAllowUnquotedFieldNamesDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -301,17 +299,17 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowUnquotedFieldNamesDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, false);
-		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
 	public void testAllowYamlCommentsDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -323,17 +321,17 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowYamlCommentsDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, false);
-		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
 	public void testAllowTrailingCommaDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
-		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -345,10 +343,10 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testAllowTrailingCommaDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, false);
-		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test
@@ -411,10 +409,10 @@ public class JSONLDParserCustomTest {
 
 	@Test
 	public void testStrictDuplicateDetectionEnabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Could not parse JSONLD");
 		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, true);
-		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessageContaining("Could not parse JSONLD");
 	}
 
 	@Test

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterBackgroundTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.jsonld;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,8 +38,8 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONLDMode;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -73,7 +73,7 @@ public class JSONLDWriterBackgroundTest extends RDFWriterTest {
 
 	@Test
 	@Override
-	@Ignore("TODO: Determine why this test is breaking")
+	@Disabled("TODO: Determine why this test is breaking")
 	public void testIllegalPrefix() throws RDFHandlerException, RDFParseException, IOException {
 	}
 
@@ -106,13 +106,13 @@ public class JSONLDWriterBackgroundTest extends RDFWriterTest {
 
 		rdfParser.parse(in, "foo:bar");
 
-		assertEquals("Unexpected number of statements, found " + model.size(), 1, model.size());
+		assertEquals(1, model.size(), "Unexpected number of statements, found " + model.size());
 
-		assertTrue("missing namespaced statement", model.contains(st1));
+		assertTrue(model.contains(st1), "missing namespaced statement");
 
 		if (rdfParser.getRDFFormat().supportsNamespaces()) {
-			assertTrue("Expected at least one namespace, found " + model.getNamespaces().size(),
-					model.getNamespaces().size() >= 1);
+			assertTrue(model.getNamespaces().size() >= 1,
+					"Expected at least one namespace, found " + model.getNamespaces().size());
 			assertEquals(exNs, model.getNamespace("ex").get().getName());
 		}
 	}

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.jsonld;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,8 +38,8 @@ import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONLDMode;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell
@@ -66,7 +66,7 @@ public class JSONLDWriterTest extends RDFWriterTest {
 
 	@Test
 	@Override
-	@Ignore("TODO: Determine why this test is breaking")
+	@Disabled("TODO: Determine why this test is breaking")
 	public void testIllegalPrefix() throws RDFHandlerException, RDFParseException, IOException {
 	}
 
@@ -86,7 +86,7 @@ public class JSONLDWriterTest extends RDFWriterTest {
 		rdfWriter.handleStatement(vf.createStatement(uri1, uri2, vf.createBNode()));
 		rdfWriter.endRDF();
 
-		assertTrue("Does not contain @vocab", w.toString().contains("@vocab"));
+		assertTrue(w.toString().contains("@vocab"), "Does not contain @vocab");
 	}
 
 	@Test
@@ -117,13 +117,13 @@ public class JSONLDWriterTest extends RDFWriterTest {
 
 		rdfParser.parse(in, "foo:bar");
 
-		assertEquals("Unexpected number of statements, found " + model.size(), 1, model.size());
+		assertEquals(1, model.size(), "Unexpected number of statements, found " + model.size());
 
-		assertTrue("missing namespaced statement", model.contains(st1));
+		assertTrue(model.contains(st1), "missing namespaced statement");
 
 		if (rdfParser.getRDFFormat().supportsNamespaces()) {
-			assertTrue("Expected at least one namespace, found " + model.getNamespaces().size(),
-					model.getNamespaces().size() >= 1);
+			assertTrue(model.getNamespaces().size() >= 1,
+					"Expected at least one namespace, found " + model.getNamespaces().size());
 			assertEquals(exNs, model.getNamespace("ex").get().getName());
 		}
 	}
@@ -148,7 +148,7 @@ public class JSONLDWriterTest extends RDFWriterTest {
 		rdfWriter.handleStatement(stmt);
 		rdfWriter.endRDF();
 
-		assertTrue("Does contain @type", !w.toString().contains("@type"));
+		assertTrue(!w.toString().contains("@type"), "Does contain @type");
 	}
 
 	@Override

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParserTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDParserTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.ndjsonld;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NDJSONLDParserTest {
 

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriterTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/ndjsonld/NDJSONLDWriterTest.java
@@ -22,8 +22,8 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.JSONLDMode;
 import org.eclipse.rdf4j.rio.helpers.JSONLDSettings;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class NDJSONLDWriterTest extends RDFWriterTest {
 
@@ -33,7 +33,7 @@ public class NDJSONLDWriterTest extends RDFWriterTest {
 
 	@Test
 	@Override
-	@Ignore("TODO: See case for JSONLDWriterTest")
+	@Disabled("TODO: See case for JSONLDWriterTest")
 	public void testIllegalPrefix() throws RDFHandlerException, RDFParseException, IOException {
 	}
 

--- a/core/rio/n3/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
+++ b/core/rio/n3/src/test/java/org/eclipse/rdf4j/rio/n3/N3ParserTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.rio.n3;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -22,8 +22,8 @@ import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author tanisha
@@ -44,7 +44,7 @@ public class N3ParserTest {
 
 	private final SimpleParseLocationListener locationListener = new SimpleParseLocationListener();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		parser = new N3Parser();
 		parser.setParseErrorListener(errorCollector);

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsParserUnitTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.rio.nquads;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -609,8 +609,8 @@ public abstract class AbstractNQuadsParserUnitTest {
 	private class TestParseLocationListener extends SimpleParseLocationListener {
 
 		private void assertListener(int row, int col) {
-			assertEquals("Unexpected last row", row, this.getLineNo());
-			assertEquals("Unexpected last col", col, this.getColumnNo());
+			assertEquals(row, this.getLineNo(), "Unexpected last row");
+			assertEquals(col, this.getColumnNo(), "Unexpected last col");
 		}
 
 	}
@@ -636,7 +636,7 @@ public abstract class AbstractNQuadsParserUnitTest {
 		public void assertHandler(int expected) {
 			assertTrue(started, "Never started.");
 			assertTrue(ended, "Never ended.");
-			assertEquals("Unexpected number of statements.", expected, getStatements().size());
+			assertEquals(expected, getStatements().size(), "Unexpected number of statements.");
 		}
 	}
 

--- a/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsWriterTest.java
+++ b/core/rio/nquads/src/test/java/org/eclipse/rdf4j/rio/nquads/AbstractNQuadsWriterTest.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.nquads;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -27,10 +30,9 @@ import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.NTriplesWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 
@@ -44,13 +46,13 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 		super(writerF, parserF);
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = rdfParserFactory.getParser();
 		vf = SimpleValueFactory.getInstance();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		parser = null;
 		writer = null;
@@ -62,7 +64,7 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 		parser.setRDFHandler(statementCollector);
 		parser.parse(this.getClass().getResourceAsStream("/testcases/nquads/test2.nq"), "http://test.base.uri");
 
-		Assert.assertEquals(400, statementCollector.getStatements().size());
+		assertEquals(400, statementCollector.getStatements().size());
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		writer = rdfWriterFactory.getWriter(baos);
@@ -72,7 +74,7 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 		}
 		writer.endRDF();
 
-		Assert.assertEquals("Unexpected number of lines.", 400, baos.toString().split("\n").length);
+		assertEquals(400, baos.toString().split("\n").length, "Unexpected number of lines.");
 	}
 
 	@Test
@@ -88,8 +90,8 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 
 		String content = baos.toString();
 		String[] lines = content.split("\n");
-		Assert.assertEquals("Unexpected number of lines.", 1, lines.length);
-		Assert.assertEquals(
+		assertEquals(1, lines.length, "Unexpected number of lines.");
+		assertEquals(
 				"<http://test.example.org/test/subject/1> <http://other.example.com/test/predicate/1> \"test literal\" .",
 				lines[0]);
 	}
@@ -108,8 +110,8 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 
 		String content = baos.toString();
 		String[] lines = content.split("\n");
-		Assert.assertEquals("Unexpected number of lines.", 1, lines.length);
-		Assert.assertEquals(
+		assertEquals(1, lines.length, "Unexpected number of lines.");
+		assertEquals(
 				"<http://test.example.org/test/subject/1> <http://other.example.com/test/predicate/1> \"test literal\"^^<http://www.w3.org/2001/XMLSchema#string> .",
 				lines[0]);
 	}
@@ -128,8 +130,8 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 
 		String content = baos.toString();
 		String[] lines = content.split("\n");
-		Assert.assertEquals("Unexpected number of lines.", 1, lines.length);
-		Assert.assertTrue(lines[0].startsWith(
+		assertEquals(1, lines.length, "Unexpected number of lines.");
+		assertTrue(lines[0].startsWith(
 				"<http://test.example.org/test/subject/1> <http://other.example.com/test/predicate/1> \"test literal\" _:"));
 	}
 
@@ -148,8 +150,8 @@ public abstract class AbstractNQuadsWriterTest extends RDFWriterTest {
 
 		String content = baos.toString();
 		String[] lines = content.split("\n");
-		Assert.assertEquals("Unexpected number of lines.", 1, lines.length);
-		Assert.assertTrue(lines[0].startsWith(
+		assertEquals(1, lines.length, "Unexpected number of lines.");
+		assertTrue(lines[0].startsWith(
 				"<http://test.example.org/test/subject/1> <http://other.example.com/test/predicate/1> \"test literal\"^^<http://www.w3.org/2001/XMLSchema#string> _:"));
 	}
 

--- a/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
+++ b/core/rio/ntriples/src/test/java/org/eclipse/rdf4j/rio/ntriples/AbstractNTriplesParserUnitTest.java
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.ntriples;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.InputStream;
 import java.io.StringReader;
@@ -34,7 +35,7 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.NTriplesParserSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for N-Triples Parser.
@@ -383,22 +384,18 @@ public abstract class AbstractNTriplesParserUnitTest {
 		assertEquals(0, model.objects().size());
 	}
 
-	@Test(expected = RDFParseException.class)
+	@Test
 	public void testBlankNodeIdentifiersWithDotAsLastCahracter() throws Exception {
 		// The character . may appear anywhere except the first or last character.
 		RDFParser ntriplesParser = new NTriplesParser();
 		Model model = new LinkedHashModel();
 		ntriplesParser.setRDFHandler(new StatementCollector(model));
-		try {
-			ntriplesParser.parse(new StringReader("_:123 <urn:test:predicate> _:456. ."), NTRIPLES_TEST_URL);
-		} catch (RDFParseException e) {
-			assertEquals(0, model.size());
-			assertEquals(0, model.subjects().size());
-			assertEquals(0, model.predicates().size());
-			assertEquals(0, model.objects().size());
-			throw e;
-		}
-		fail("Should have failed to parse invalid N-Triples bnode with '.' at the end of the bnode label");
+		assertThrows(RDFParseException.class,
+				() -> ntriplesParser.parse(new StringReader("_:123 <urn:test:predicate> _:456. ."), NTRIPLES_TEST_URL));
+		assertEquals(0, model.size());
+		assertEquals(0, model.subjects().size());
+		assertEquals(0, model.predicates().size());
+		assertEquals(0, model.objects().size());
 	}
 
 	@Test
@@ -427,18 +424,18 @@ public abstract class AbstractNTriplesParserUnitTest {
 						+ " in charactersList");
 			}
 
-			assertEquals("Should parse '" + character + "'", 1, model.size());
-			assertEquals("Should have subject when triple has character : '" + character + "'", 1,
-					model.subjects().size());
-			assertEquals("Should have predicate when triple has character : '" + character + "'", 1,
-					model.predicates().size());
-			assertEquals("Should have object when triple has character : '" + character + "'", 1,
-					model.objects().size());
+			assertEquals(1, model.size(), "Should parse '" + character + "'");
+			assertEquals(1, model.subjects().size(),
+					"Should have subject when triple has character : '" + character + "'");
+			assertEquals(1, model.predicates().size(),
+					"Should have predicate when triple has character : '" + character + "'");
+			assertEquals(1, model.objects().size(),
+					"Should have object when triple has character : '" + character + "'");
 		}
 
 	}
 
-	@Test(expected = RDFParseException.class)
+	@Test
 	public void testBlankNodeIdentifiersWithOtherCharactersAsFirstCharacter() throws Exception {
 		// The characters -, U+00B7, U+0300 to U+036F and U+203F to U+2040 are permitted anywhere except the first
 		// character.
@@ -455,19 +452,15 @@ public abstract class AbstractNTriplesParserUnitTest {
 			Model model = new LinkedHashModel();
 			ntriplesParser.setRDFHandler(new StatementCollector(model));
 
-			try {
+			assertThrows(RDFParseException.class, () -> {
 				ntriplesParser.parse(
 						new StringReader("<urn:test:subject> <urn:test:predicate> _:" + character + "1 . "),
 						NTRIPLES_TEST_URL);
-			} catch (RDFParseException e) {
-				assertEquals(0, model.size());
-				assertEquals(0, model.subjects().size());
-				assertEquals(0, model.predicates().size());
-				assertEquals(0, model.objects().size());
-				throw e;
-			}
-			fail("Should have failed to parse invalid N-Triples bnode with '" + character
-					+ "' at the begining of the bnode label");
+			});
+			assertEquals(0, model.size());
+			assertEquals(0, model.subjects().size());
+			assertEquals(0, model.predicates().size());
+			assertEquals(0, model.objects().size());
 		}
 	}
 
@@ -513,7 +506,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 		List<String> errors = collector.getErrors();
 
 		assertEquals(1, errors.size());
-		assertTrue("Unknown line number", errors.get(0).contains("(1, 32)"));
+		assertTrue(errors.get(0).contains("(1, 32)"), "Unknown line number");
 	}
 
 	@Test
@@ -531,7 +524,7 @@ public abstract class AbstractNTriplesParserUnitTest {
 		List<String> errors = collector.getErrors();
 
 		assertEquals(1, errors.size());
-		assertTrue("Unknown line number", errors.get(0).contains("(1, 32)"));
+		assertTrue(errors.get(0).contains("(1, 32)"), "Unknown line number");
 	}
 
 	protected abstract RDFParser createRDFParser();

--- a/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONMimeTypeTest.java
+++ b/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONMimeTypeTest.java
@@ -10,11 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfjson;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Peter Ansell

--- a/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserCustomTest.java
+++ b/core/rio/rdfjson/src/test/java/org/eclipse/rdf4j/rio/rdfjson/RDFJSONParserCustomTest.java
@@ -10,11 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfjson;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -34,10 +35,8 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector;
 import org.eclipse.rdf4j.rio.helpers.JSONSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -100,9 +99,6 @@ public class RDFJSONParserCustomTest {
 
 	private RDFParser parser;
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
 	private ParseErrorCollector errors;
 
 	private Model model;
@@ -122,7 +118,7 @@ public class RDFJSONParserCustomTest {
 	private final Literal testObjectLiteralUnquotedControlChar = SimpleValueFactory.getInstance()
 			.createLiteral("42\u0009", XSD.STRING);
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		parser = Rio.createParser(RDFFormat.RDFJSON);
 		errors = new ParseErrorCollector();
@@ -137,8 +133,8 @@ public class RDFJSONParserCustomTest {
 		assertEquals(0, errors.getFatalErrors().size());
 
 		assertEquals(1, model.size());
-		assertTrue("model was not as expected: " + model.toString(),
-				model.contains(nextSubject, nextPredicate, nextObject));
+		assertTrue(model.contains(nextSubject, nextPredicate, nextObject),
+				"model was not as expected: " + model.toString());
 	}
 
 	@Test
@@ -149,9 +145,9 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowBackslashEscapingAnyCharacterDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 5]");
-		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 5]");
 	}
 
 	@Test
@@ -163,17 +159,17 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowBackslashEscapingAnyCharacterDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 5]");
 		parser.set(JSONSettings.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, false);
-		parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(BACKSLASH_ESCAPED_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 5]");
 	}
 
 	@Test
 	public void testAllowCommentsDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 3]");
-		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(COMMENTS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 3]");
 	}
 
 	@Test
@@ -185,17 +181,17 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowCommentsDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 3]");
 		parser.set(JSONSettings.ALLOW_COMMENTS, false);
-		parser.parse(new StringReader(COMMENTS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(COMMENTS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 3]");
 	}
 
 	@Test
 	public void testAllowNonNumericNumbersDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 74]");
-		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 74]");
 	}
 
 	@Test
@@ -207,17 +203,17 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowNonNumericNumbersDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 74]");
 		parser.set(JSONSettings.ALLOW_NON_NUMERIC_NUMBERS, false);
-		parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(NON_NUMERIC_NUMBERS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 74]");
 	}
 
 	@Test
 	public void testAllowNumericLeadingZeroesDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 72]");
-		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 72]");
 	}
 
 	@Test
@@ -229,17 +225,17 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowNumericLeadingZeroesDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 72]");
 		parser.set(JSONSettings.ALLOW_NUMERIC_LEADING_ZEROS, false);
-		parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(NUMERIC_LEADING_ZEROES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 72]");
 	}
 
 	@Test
 	public void testAllowSingleQuotesDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 3]");
-		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 3]");
 	}
 
 	@Test
@@ -251,17 +247,17 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowSingleQuotesDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 3]");
 		parser.set(JSONSettings.ALLOW_SINGLE_QUOTES, false);
-		parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(SINGLE_QUOTES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 3]");
 	}
 
 	@Test
 	public void testAllowUnquotedControlCharactersDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 75]");
-		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 75]");
 	}
 
 	@Test
@@ -273,17 +269,17 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowUnquotedControlCharactersDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 75]");
 		parser.set(JSONSettings.ALLOW_UNQUOTED_CONTROL_CHARS, false);
-		parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(UNQUOTED_CONTROL_CHARS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 75]");
 	}
 
 	@Test
 	public void testAllowUnquotedFieldNamesDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 63]");
-		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 63]");
 	}
 
 	@Test
@@ -295,17 +291,17 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowUnquotedFieldNamesDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 63]");
 		parser.set(JSONSettings.ALLOW_UNQUOTED_FIELD_NAMES, false);
-		parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(UNQUOTED_FIELD_NAMES_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 63]");
 	}
 
 	@Test
 	public void testAllowYamlCommentsDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 2, column 2]");
-		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 2, column 2]");
 	}
 
 	@Test
@@ -317,17 +313,17 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowYamlCommentsDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 2, column 2]");
 		parser.set(JSONSettings.ALLOW_YAML_COMMENTS, false);
-		parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(YAML_COMMENTS_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 2, column 2]");
 	}
 
 	@Test
 	public void testAllowTrailingCommaDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 113]");
-		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 113]");
 	}
 
 	@Test
@@ -339,10 +335,10 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testAllowTrailingCommaDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 113]");
 		parser.set(JSONSettings.ALLOW_TRAILING_COMMA, false);
-		parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(TRAILING_COMMA_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 113]");
 	}
 
 	@Test
@@ -398,29 +394,29 @@ public class RDFJSONParserCustomTest {
 
 	@Test
 	public void testStrictDuplicateDetectionDefault() throws Exception {
-		thrown.expect(RDFParseException.class);
-		// Extra checking inbuilt in this case. This verifies it moves past Jackson into RDFJSONParser
-		thrown.expectMessage(
-				"Multiple types found for a single object: subject=http://example.com/Subj1 predicate=http://example.com/prop1 [line 1, column 122]");
 		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
-		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				// Extra checking inbuilt in this case. This verifies it moves past Jackson into RDFJSONParser
+				.hasMessage(
+						"Multiple types found for a single object: subject=http://example.com/Subj1 predicate=http://example.com/prop1 [line 1, column 122]");
 	}
 
 	@Test
 	public void testStrictDuplicateDetectionEnabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		thrown.expectMessage("Found IOException during parsing [line 1, column 119]");
 		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, true);
-		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				.hasMessage("Found IOException during parsing [line 1, column 119]");
 	}
 
 	@Test
 	public void testStrictDuplicateDetectionDisabled() throws Exception {
-		thrown.expect(RDFParseException.class);
-		// Extra checking inbuilt in this case. This verifies it moves past Jackson into RDFJSONParser
-		thrown.expectMessage(
-				"Multiple types found for a single object: subject=http://example.com/Subj1 predicate=http://example.com/prop1 [line 1, column 122]");
 		parser.set(JSONSettings.STRICT_DUPLICATE_DETECTION, false);
-		parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), "");
+		assertThatThrownBy(() -> parser.parse(new StringReader(STRICT_DUPLICATE_DETECTION_TEST_STRING), ""))
+				.isInstanceOf(RDFParseException.class)
+				// Extra checking inbuilt in this case. This verifies it moves past Jackson into RDFJSONParser
+				.hasMessage(
+						"Multiple types found for a single object: subject=http://example.com/Subj1 predicate=http://example.com/prop1 [line 1, column 122]");
 	}
 }

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserCustomTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserCustomTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfxml;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,8 +32,9 @@ import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.rio.helpers.XMLParserSettings;
 import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriter;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Custom tests for RDFXML Parser.
@@ -144,8 +145,9 @@ public class RDFXMLParserCustomTest {
 	 *
 	 * @throws Exception
 	 */
-	@Ignore
-	@Test(timeout = 10000)
+	@Disabled
+	@Test
+	@Timeout(10)
 	public void testEntityExpansionNoSecureProcessing() throws Exception {
 		final Model aGraph = new LinkedHashModel();
 		ParseErrorCollector errorCollector = new ParseErrorCollector();

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.rio.rdfxml;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -37,9 +37,9 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.rio.helpers.XMLParserSettings;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RDFXMLParserTest {
 
@@ -53,7 +53,7 @@ public class RDFXMLParserTest {
 
 	private Locale platformLocale;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		platformLocale = Locale.getDefault();
 
@@ -67,7 +67,7 @@ public class RDFXMLParserTest {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Locale.setDefault(platformLocale);
 	}
@@ -76,7 +76,7 @@ public class RDFXMLParserTest {
 	public void rdfXmlLoadedFromInsideAJarResolvesRelativeUris() throws Exception {
 		URL zipfileUrl = this.getClass().getResource("/org/eclipse/rdf4j/rio/rdfxml/sample-with-rdfxml-data.zip");
 
-		assertNotNull("The sample-data.zip file must be present for this test", zipfileUrl);
+		assertNotNull(zipfileUrl, "The sample-data.zip file must be present for this test");
 
 		String url = "jar:" + zipfileUrl + "!/index.rdf";
 
@@ -107,7 +107,7 @@ public class RDFXMLParserTest {
 		assertEquals("jar", javaUrl.getProtocol());
 
 		try (InputStream uc = javaUrl.openStream()) {
-			assertEquals("The resource stream should be empty", -1, uc.read());
+			assertEquals(-1, uc.read(), "The resource stream should be empty");
 		}
 
 		assertEquals(res, stmt2.getSubject());

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterBackgroundTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterBackgroundTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfxml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.rio.RioSetting;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriterFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RDFXMLPrettyWriterBackgroundTest extends AbstractRDFXMLWriterTest {
 

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLPrettyWriterTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfxml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,7 +41,7 @@ import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriter;
 import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriterFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RDFXMLPrettyWriterTest extends AbstractRDFXMLWriterTest {
 

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLWriterTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.rdfxml;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.StringWriter;
 
 import org.eclipse.rdf4j.model.Statement;
@@ -18,8 +20,7 @@ import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.XMLWriterSettings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RDFXMLWriterTest extends AbstractRDFXMLWriterTest {
 
@@ -35,21 +36,21 @@ public class RDFXMLWriterTest extends AbstractRDFXMLWriterTest {
 	@Test
 	public void singleQuotesAttributes() {
 		String str = writeQuotable(true, false);
-		Assert.assertTrue("No single quotes around attributes",
-				str.startsWith("<?xml version='1.0' encoding='UTF-8'?>"));
+		assertTrue(str.startsWith("<?xml version='1.0' encoding='UTF-8'?>"),
+				"No single quotes around attributes");
 	}
 
 	@Test
 	public void singleQuotesAttributesText() {
 		String str = writeQuotable(true, true);
-		Assert.assertTrue("Quotes not replaced by entities", str.contains("&apos;"));
+		assertTrue(str.contains("&apos;"), "Quotes not replaced by entities");
 	}
 
 	@Test
 	public void doubleQuotesAttributes() {
 		String str = writeQuotable(false, false);
-		Assert.assertTrue("Not double quotes around attributes",
-				str.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		assertTrue(str.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"),
+				"Not double quotes around attributes");
 	}
 
 	@Test
@@ -57,7 +58,7 @@ public class RDFXMLWriterTest extends AbstractRDFXMLWriterTest {
 		String str = writeQuotable(false, true);
 		System.err.println(str);
 
-		Assert.assertTrue("Quotes not replaced by entities", str.contains("&quot;"));
+		assertTrue(str.contains("&quot;"), "Quotes not replaced by entities");
 	}
 
 	/**

--- a/core/rio/trig/pom.xml
+++ b/core/rio/trig/pom.xml
@@ -56,5 +56,11 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- This module uses timeout rule, and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarMimeTypeRDFFormatTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarMimeTypeRDFFormatTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trigstar;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -18,7 +18,7 @@ import java.io.Writer;
 
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Pavel Mihaylov

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.trigstar;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,8 +33,9 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Pavel Mihaylov
@@ -52,7 +53,7 @@ public class TriGStarParserTest {
 
 	private final SimpleParseLocationListener locationListener = new SimpleParseLocationListener();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		parser = new TriGStarParser();
 		parser.setParseErrorListener(errorCollector);

--- a/core/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
+++ b/core/rio/trix/src/test/java/org/eclipse/rdf4j/rio/trix/TriXParserTest.java
@@ -12,8 +12,8 @@ package org.eclipse.rdf4j.rio.trix;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -27,9 +27,9 @@ import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.rio.helpers.XMLParserSettings;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TriXParserTest {
 
@@ -43,7 +43,7 @@ public class TriXParserTest {
 
 	private Locale platformLocale;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		platformLocale = Locale.getDefault();
 
@@ -56,7 +56,7 @@ public class TriXParserTest {
 		parser.setParseErrorListener(el);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		Locale.setDefault(platformLocale);
 	}

--- a/core/rio/turtle/pom.xml
+++ b/core/rio/turtle/pom.xml
@@ -61,5 +61,11 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- This module uses timeout rule, and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleMimeTypeTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleMimeTypeTest.java
@@ -10,26 +10,30 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Leigh
  */
-public class TurtleMimeTypeTest extends TestCase {
+public class TurtleMimeTypeTest {
 
+	@Test
 	public void testTextTurtle() {
 		assertEquals(RDFFormat.TURTLE,
 				Rio.getParserFormatForMIMEType("text/turtle").orElseThrow(Rio.unsupportedFormat(RDFFormat.TURTLE)));
 	}
 
+	@Test
 	public void testTextTurtleUtf8() {
 		assertEquals(RDFFormat.TURTLE, Rio.getParserFormatForMIMEType("text/turtle;charset=UTF-8")
 				.orElseThrow(Rio.unsupportedFormat(RDFFormat.TURTLE)));
 	}
 
+	@Test
 	public void testApplicationXTurtle() {
 		assertEquals(RDFFormat.TURTLE, Rio.getParserFormatForMIMEType("application/x-turtle")
 				.orElseThrow(Rio.unsupportedFormat(RDFFormat.TURTLE)));

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleParserTest.java
@@ -11,11 +11,12 @@
 package org.eclipse.rdf4j.rio.turtle;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,8 +44,8 @@ import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.rio.helpers.TurtleParserSettings;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -65,7 +66,7 @@ public class TurtleParserTest {
 
 	private final SimpleParseLocationListener locationListener = new SimpleParseLocationListener();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		parser = new TurtleParser();
 		parser.setParseErrorListener(errorCollector);
@@ -425,7 +426,7 @@ public class TurtleParserTest {
 	public void rdfXmlLoadedFromInsideAJarResolvesRelativeUris() throws IOException {
 		URL zipfileUrl = TurtleParserTest.class.getResource("sample-with-turtle-data.zip");
 
-		assertNotNull("The sample-with-turtle-data.zip file must be present for this test", zipfileUrl);
+		assertNotNull(zipfileUrl, "The sample-with-turtle-data.zip file must be present for this test");
 
 		String url = "jar:" + zipfileUrl + "!/index.ttl";
 
@@ -459,7 +460,7 @@ public class TurtleParserTest {
 		assertEquals("jar", javaUrl.getProtocol());
 
 		try (InputStream uc = javaUrl.openStream()) {
-			assertEquals("The resource stream should be empty", -1, uc.read());
+			assertEquals(-1, uc.read(), "The resource stream should be empty");
 		}
 
 		assertEquals(res, stmt2.getSubject());
@@ -570,12 +571,12 @@ public class TurtleParserTest {
 		}
 	}
 
-	@Test(expected = RDFParseException.class)
+	@Test
 	public void testParseRDFStar_TurtleStarDisabled() throws IOException {
 		parser.getParserConfig().set(TurtleParserSettings.ACCEPT_TURTLESTAR, false);
 
 		try (InputStream in = this.getClass().getResourceAsStream("/test-rdfstar.ttls")) {
-			parser.parse(in, baseURI);
+			assertThrows(RDFParseException.class, () -> parser.parse(in, baseURI));
 		}
 	}
 

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtlePrettyWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtlePrettyWriterTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.TurtleWriterSettings;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Arjohn Kampman

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleUtilTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleUtilTest.java
@@ -10,13 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for the utility methods in {@link TurtleUtil}.
@@ -28,21 +28,21 @@ public class TurtleUtilTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 	}
 
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 	}
 
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#findURISplitIndex(java.lang.String)} .
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testFindURISplitIndex() {
 
@@ -59,7 +59,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPN_CHARS_BASE(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPN_CHARS_BASE() {
 
@@ -68,7 +68,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPN_CHARS_U(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPN_CHARS_U() {
 
@@ -77,7 +77,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPN_CHARS(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPN_CHARS() {
 
@@ -86,7 +86,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPrefixStartChar(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPrefixStartChar() {
 
@@ -95,7 +95,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isNameStartChar(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsNameStartChar() {
 
@@ -112,7 +112,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isNameEndChar(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsNameEndChar() {
 
@@ -121,7 +121,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isLocalEscapedChar(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsLocalEscapedChar() {
 
@@ -130,7 +130,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPrefixChar(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPrefixChar() {
 
@@ -139,7 +139,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isLanguageStartChar(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsLanguageStartChar() {
 
@@ -148,7 +148,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isLanguageChar(int)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsLanguageChar() {
 
@@ -157,7 +157,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPN_PREFIX(java.lang.String)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPN_PREFIX() {
 
@@ -166,7 +166,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPLX_START(java.lang.String)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPLX_START() {
 
@@ -175,7 +175,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPERCENT(java.lang.String)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPERCENT() {
 
@@ -184,7 +184,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPLX_INTERNAL(java.lang.String)} .
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPLX_INTERNAL() {
 
@@ -193,7 +193,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#isPN_LOCAL_ESC(java.lang.String)} .
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testIsPN_LOCAL_ESC() {
 
@@ -236,7 +236,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#encodeString(java.lang.String)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testEncodeString() {
 
@@ -245,7 +245,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#encodeLongString(java.lang.String)} .
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testEncodeLongString() {
 
@@ -254,7 +254,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#encodeURIString(java.lang.String)} .
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testEncodeURIString() {
 
@@ -263,7 +263,7 @@ public class TurtleUtilTest {
 	/**
 	 * Test method for {@link org.eclipse.rdf4j.rio.turtle.TurtleUtil#decodeString(java.lang.String)}.
 	 */
-	@Ignore("TODO: Implement me")
+	@Disabled("TODO: Implement me")
 	@Test
 	public final void testDecodeString() {
 

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/TurtleWriterTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtle;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -23,8 +23,8 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.rio.helpers.TurtleWriterSettings;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Arjohn Kampman
@@ -193,7 +193,7 @@ public class TurtleWriterTest extends AbstractTurtleWriterTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void anotherBnodeTest() throws Exception {
 		String data = "@prefix ex:    <http://example.com/ns#> .\n" +
 				"@prefix sh:    <http://www.w3.org/ns/shacl#> .\n" +

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TestGH3323StackoverflowRDFStar.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TestGH3323StackoverflowRDFStar.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestGH3323StackoverflowRDFStar {
 

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarMimeTypeRDFFormatTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarMimeTypeRDFFormatTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.turtlestar;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -18,7 +18,7 @@ import java.io.Writer;
 
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Pavel Mihaylov

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtlestar/TurtleStarParserTest.java
@@ -15,9 +15,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.rdf4j.model.util.Statements.statement;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,8 +40,8 @@ import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 import org.eclipse.rdf4j.rio.helpers.TurtleParserSettings;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Pavel Mihaylov
@@ -59,7 +59,7 @@ public class TurtleStarParserTest {
 
 	private final SimpleParseLocationListener locationListener = new SimpleParseLocationListener();
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		parser = new TurtleStarParser();
 		parser.setParseErrorListener(errorCollector);

--- a/core/sail/api/src/test/java/org/eclipse/rdf4j/sail/helpers/AbstractSailTest.java
+++ b/core/sail/api/src/test/java/org/eclipse/rdf4j/sail/helpers/AbstractSailTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.sail.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 

--- a/core/sail/base/src/test/java/org/eclipse/rdf4j/sail/base/ChangesetTest.java
+++ b/core/sail/base/src/test/java/org/eclipse/rdf4j/sail/base/ChangesetTest.java
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChangesetTest {
 

--- a/core/sail/base/src/test/java/org/eclipse/rdf4j/sail/base/SnapshotSailStoreTest.java
+++ b/core/sail/base/src/test/java/org/eclipse/rdf4j/sail/base/SnapshotSailStoreTest.java
@@ -33,7 +33,7 @@ import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.helpers.AbstractNotifyingSail;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Minimal tests for the functionality of {@link SnapshotSailStore}

--- a/core/sail/elasticsearch-store/pom.xml
+++ b/core/sail/elasticsearch-store/pom.xml
@@ -27,8 +27,8 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreWalIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchStoreWalIT.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -31,12 +30,13 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,26 +47,27 @@ public class ElasticsearchStoreWalIT {
 	private static ElasticsearchClusterRunner runner;
 	private static final SimpleValueFactory vf = SimpleValueFactory.getInstance();
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws IOException {
 		TestHelpers.stopElasticsearch(runner);
 	}
 
-	@After
+	@AfterEach
 	public void after() throws UnknownHostException {
 		runner.admin().indices().refresh(Requests.refreshRequest("*")).actionGet();
 		deleteAllIndexes();
 
 	}
 
-	@Before
+	@BeforeEach
 	public void before() throws UnknownHostException {
 //		embeddedElastic.refreshIndices();
 //
@@ -100,7 +101,7 @@ public class ElasticsearchStoreWalIT {
 
 	}
 
-	@Ignore // No WAL implemented yet
+	@Disabled // No WAL implemented yet
 	@Test
 	public void testAddLargeDataset() {
 
@@ -162,7 +163,7 @@ public class ElasticsearchStoreWalIT {
 
 	}
 
-	@Ignore // No WAL implemented yet
+	@Disabled // No WAL implemented yet
 	@Test
 	public void testRemoveLargeDataset() {
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/InferenceIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/InferenceIT.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -37,10 +36,11 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,22 +52,23 @@ public class InferenceIT {
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider singletonClientProvider;
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		singletonClientProvider = new SingletonClientProvider("localhost",
 				TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		singletonClientProvider.close();
 		TestHelpers.stopElasticsearch(runner);
 	}
 
-	@After
+	@AfterEach
 	public void after() {
 		runner.admin().indices().refresh(Requests.refreshRequest("*")).actionGet();
 		deleteAllIndexes();

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchGraphQueryResultIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchGraphQueryResultIT.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -21,22 +20,24 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.GraphQueryResultTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchGraphQueryResultIT extends GraphQueryResultTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreConcurrencyIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreConcurrencyIT.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
@@ -22,8 +21,9 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.sail.SailConcurrencyTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailConcurrencyTest} for testing the class
@@ -31,17 +31,18 @@ import org.junit.BeforeClass;
  */
 public class ElasticsearchStoreConcurrencyIT extends SailConcurrencyTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreInterruptIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreInterruptIT.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
@@ -22,8 +21,9 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.sail.SailConcurrencyTest;
 import org.eclipse.rdf4j.testsuite.sail.SailInterruptTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailConcurrencyTest} for testing the class
@@ -31,17 +31,18 @@ import org.junit.BeforeClass;
  */
 public class ElasticsearchStoreInterruptIT extends SailInterruptTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreIsolationLevelIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreIsolationLevelIT.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 
 import java.io.File;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
@@ -22,8 +21,9 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.sail.SailIsolationLevelTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailIsolationLevelTest} for testing the class
@@ -31,18 +31,19 @@ import org.junit.BeforeClass;
  */
 public class ElasticsearchStoreIsolationLevelIT extends SailIsolationLevelTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws Exception {
 		SailIsolationLevelTest.setUpClass();
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass2() throws Exception {
 		SailIsolationLevelTest.afterClass();
 		clientPool.close();

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreSparqlOrderByIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreSparqlOrderByIT.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -21,22 +20,24 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.SparqlOrderByTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchStoreSparqlOrderByIT extends SparqlOrderByTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreSparqlRegexIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreSparqlRegexIT.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -21,22 +20,24 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.SparqlRegexTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchStoreSparqlRegexIT extends SparqlRegexTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreTupleQueryResultIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreTupleQueryResultIT.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 import java.io.File;
 import java.io.IOException;
 
-import org.assertj.core.util.Files;
 import org.codelibs.elasticsearch.runner.ElasticsearchClusterRunner;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -23,10 +22,12 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.TupleQueryResultTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ElasticsearchStoreTupleQueryResultIT extends TupleQueryResultTest {
 
-	private static final File installLocation = Files.newTemporaryFolder();
+	@TempDir
+	static File installLocation;
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfigTest.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfigTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.sail.elasticsearchstore.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Model;
@@ -19,8 +20,8 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ElasticsearchStoreConfigTest {
 
@@ -30,7 +31,7 @@ public class ElasticsearchStoreConfigTest {
 
 	private ModelBuilder mb;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		subject = new ElasticsearchStoreConfig();
 		implNode = SimpleValueFactory.getInstance().createBNode();
@@ -79,13 +80,13 @@ public class ElasticsearchStoreConfigTest {
 		assertThat(subject.getPort()).isEqualTo(9300);
 	}
 
-	@Test(expected = SailConfigException.class)
+	@Test
 	public void parseInvalidModelGivesCorrectException() {
 
 		mb
 				.add(ElasticsearchStoreSchema.port, "port1");
 
-		subject.parse(mb.build(), implNode);
+		assertThrows(SailConfigException.class, () -> subject.parse(mb.build(), implNode));
 
 	}
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreFactoryTest.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreFactoryTest.java
@@ -11,17 +11,18 @@
 package org.eclipse.rdf4j.sail.elasticsearchstore.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ElasticsearchStoreFactoryTest {
 
 	private ElasticsearchStoreFactory subject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		subject = new ElasticsearchStoreFactory();
 	}
@@ -34,10 +35,10 @@ public class ElasticsearchStoreFactoryTest {
 	/**
 	 * Verify that the created sail is configured according to the supplied default configuration.
 	 */
-	@Test(expected = SailConfigException.class)
+	@Test
 	public void getSailWithDefaultConfigFails() {
 		ElasticsearchStoreConfig config = new ElasticsearchStoreConfig();
-		ElasticsearchStore sail = (ElasticsearchStore) subject.getSail(config);
+		assertThrows(SailConfigException.class, () -> subject.getSail(config));
 	}
 
 	/**

--- a/core/sail/extensible-store/pom.xml
+++ b/core/sail/extensible-store/pom.xml
@@ -49,8 +49,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestore/TransactionIsolationAndWalTests.java
+++ b/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestore/TransactionIsolationAndWalTests.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.extensiblestore;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestore/evaluationstatistics/EvaluationStatisticsTest.java
+++ b/core/sail/extensible-store/src/test/java/org/eclipse/rdf4j/sail/extensiblestore/evaluationstatistics/EvaluationStatisticsTest.java
@@ -27,7 +27,7 @@ import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.extensiblestore.valuefactory.ExtensibleStatementHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/InferredContextTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/InferredContextTest.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class InferredContextTest {
 

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/MemInferencingTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/MemInferencingTest.java
@@ -28,7 +28,7 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.testsuite.sail.InferencingTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MemInferencingTest extends InferencingTest {
 

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/NativeStoreInferencingTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/NativeStoreInferencingTest.java
@@ -10,28 +10,23 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.inferencer.fc;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.eclipse.rdf4j.testsuite.sail.InferencingTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeStoreInferencingTest extends InferencingTest {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Override
 	protected Sail createSail() {
-		try {
-			NotifyingSail sailStack = new NativeStore(tempDir.newFolder(), "spoc,posc");
-			sailStack = new SchemaCachingRDFSInferencer(sailStack);
-			return sailStack;
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		NotifyingSail sailStack = new NativeStore(dataDir, "spoc,posc");
+		sailStack = new SchemaCachingRDFSInferencer(sailStack);
+		return sailStack;
 	}
 }

--- a/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerNativeIsolationLevelTest.java
+++ b/core/sail/inferencer/src/test/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerNativeIsolationLevelTest.java
@@ -10,14 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.inferencer.fc;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.eclipse.rdf4j.testsuite.sail.SailIsolationLevelTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailIsolationLevelTest} for testing the {@link SchemaCachingRDFSInferencer}.
@@ -28,8 +27,8 @@ public class SchemaCachingRDFSInferencerNativeIsolationLevelTest extends SailIso
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File tempDir;
 
 	/*---------*
 	 * Methods *
@@ -37,11 +36,7 @@ public class SchemaCachingRDFSInferencerNativeIsolationLevelTest extends SailIso
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			return new SchemaCachingRDFSInferencer(new NativeStore(tempDir.newFolder(), "spoc,posc"));
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		return new SchemaCachingRDFSInferencer(new NativeStore(tempDir, "spoc,posc"));
 	}
 
 	@Override

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/CardinalityTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/CardinalityTest.java
@@ -17,11 +17,10 @@ import java.util.Random;
 import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.sail.lmdb.model.LmdbValue;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,14 +30,15 @@ import org.slf4j.LoggerFactory;
 public class CardinalityTest {
 	final static Logger logger = LoggerFactory.getLogger(CardinalityTest.class);
 
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+	@TempDir
+	File tempFolder;
 
 	protected TripleStore tripleStore;
 
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
-		File dataDir = tempFolder.newFolder("triplestore");
+		File dataDir = new File(tempFolder, "triplestore");
+		dataDir.mkdir();
 		tripleStore = new TripleStore(dataDir, new LmdbStoreConfig("spoc,posc"));
 	}
 
@@ -82,7 +82,7 @@ public class CardinalityTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void after() throws Exception {
 		tripleStore.close();
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/ContextStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/ContextStoreTest.java
@@ -20,10 +20,9 @@ import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Unit tests for {@link ContextStore}
@@ -37,16 +36,14 @@ public class ContextStoreTest {
 	private final Resource g1 = vf.createIRI("http://example.org/g1");
 	private final Resource g2 = vf.createBNode();
 
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
 	private File dataDir;
 
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
-	public void setUp() throws Exception {
-		dataDir = tmpDir.newFolder();
+	@BeforeEach
+	public void setUp(@TempDir File tmpDir) throws Exception {
+		dataDir = tmpDir;
 		LmdbSailStore sailStore = mock(LmdbSailStore.class);
 
 		when(sailStore.getValueFactory()).thenReturn(SimpleValueFactory.getInstance());

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/DefaultIndexTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/DefaultIndexTest.java
@@ -19,17 +19,13 @@ import java.util.Properties;
 
 import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DefaultIndexTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
 
 	@Test
-	public void testDefaultIndex() throws Exception {
-		File dir = tmpDir.newFolder();
+	public void testDefaultIndex(@TempDir File dir) throws Exception {
 		TripleStore store = new TripleStore(dir, new LmdbStoreConfig());
 		store.close();
 		// check that the triple store used the default index
@@ -38,8 +34,7 @@ public class DefaultIndexTest {
 	}
 
 	@Test
-	public void testExistingIndex() throws Exception {
-		File dir = tmpDir.newFolder();
+	public void testExistingIndex(@TempDir File dir) throws Exception {
 		// set a non-default index
 		TripleStore store = new TripleStore(dir, new LmdbStoreConfig("spoc,opsc"));
 		store.close();

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbCascadeValueExceptionTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbCascadeValueExceptionTest.java
@@ -10,21 +10,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.repository.CascadeValueExceptionTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LmdbCascadeValueExceptionTest extends CascadeValueExceptionTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new LmdbStore(tmpDir.getRoot(), new LmdbStoreConfig("spoc")));
+		return new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig("spoc")));
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbGraphQueryResultTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbGraphQueryResultTest.java
@@ -10,21 +10,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.repository.GraphQueryResultTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LmdbGraphQueryResultTest extends GraphQueryResultTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new LmdbStore(tmpDir.getRoot(), new LmdbStoreConfig("spoc")));
+		return new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig("spoc")));
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbOptimisticIsolationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbOptimisticIsolationTest.java
@@ -15,12 +15,12 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class LmdbOptimisticIsolationTest extends OptimisticIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -30,7 +30,7 @@ public class LmdbOptimisticIsolationTest extends OptimisticIsolationTest {
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSailStoreTest.java
@@ -29,19 +29,15 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Extended test for {@link LmdbStore}.
  */
 public class LmdbSailStoreTest {
-
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	protected Repository repo;
 
@@ -58,9 +54,8 @@ public class LmdbSailStoreTest {
 	protected final Statement S2 = F.createStatement(F.createIRI("http://example.org/2"), RDFS.LABEL,
 			F.createLiteral("two"));
 
-	@Before
-	public void before() throws Exception {
-		File dataDir = tempFolder.newFolder("dbmodel");
+	@BeforeEach
+	public void before(@TempDir File dataDir) throws Exception {
 		repo = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig("spoc,posc")));
 		repo.init();
 
@@ -198,7 +193,7 @@ public class LmdbSailStoreTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void after() throws Exception {
 		repo.shutDown();
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSparqlOrderByTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSparqlOrderByTest.java
@@ -10,21 +10,22 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.repository.SparqlOrderByTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LmdbSparqlOrderByTest extends SparqlOrderByTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+
+	@TempDir
+	File dataDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new LmdbStore(tmpDir.getRoot(), new LmdbStoreConfig("spoc")));
+		return new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig("spoc")));
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSparqlRegexTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbSparqlRegexTest.java
@@ -10,21 +10,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.repository.SparqlRegexTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LmdbSparqlRegexTest extends SparqlRegexTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new LmdbStore(tmpDir.getRoot(), new LmdbStoreConfig("spoc")));
+		return new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig("spoc")));
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreConcurrencyTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreConcurrencyTest.java
@@ -10,14 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.sail.SailConcurrencyTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailConcurrencyTest} for testing the class {@link LmdbStore}.
@@ -28,8 +27,8 @@ public class LmdbStoreConcurrencyTest extends SailConcurrencyTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -37,13 +36,9 @@ public class LmdbStoreConcurrencyTest extends SailConcurrencyTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			LmdbStoreConfig config = new LmdbStoreConfig("spoc,posc");
-			config.setValueDBSize(52428800); // 50 MiB
-			config.setTripleDBSize(config.getValueDBSize());
-			return new LmdbStore(tempDir.newFolder(), config);
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		LmdbStoreConfig config = new LmdbStoreConfig("spoc,posc");
+		config.setValueDBSize(52428800); // 50 MiB
+		config.setTripleDBSize(config.getValueDBSize());
+		return new LmdbStore(dataDir, config);
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreConsistencyIT.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreConsistencyIT.java
@@ -31,9 +31,8 @@ import org.eclipse.rdf4j.repository.util.RDFInserter;
 import org.eclipse.rdf4j.repository.util.RDFLoader;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,26 +40,22 @@ import org.slf4j.LoggerFactory;
  * Integration tests for checking Lmdb Store index consistency.
  */
 public class LmdbStoreConsistencyIT {
+
 	private static final Logger logger = LoggerFactory.getLogger(LmdbStoreConsistencyIT.class);
 
 	/*-----------*
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-
 	/*---------*
 	 * Methods *
 	 *---------*/
 
 	@Test
-	public void testSES1867IndexCorruption() throws Exception {
+	public void testSES1867IndexCorruption(@TempDir File dataDir) throws Exception {
 		ValueFactory vf = SimpleValueFactory.getInstance();
 		IRI oldContext = vf.createIRI("http://example.org/oldContext");
 		IRI newContext = vf.createIRI("http://example.org/newContext");
-
-		File dataDir = tempDir.newFolder();
 
 		Repository repo = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig("spoc,psoc")));
 
@@ -102,7 +97,6 @@ public class LmdbStoreConsistencyIT {
 			// Step 3: check whether oldContext is actually empty
 			List<Statement> stmts = Iterations.asList(conn.getStatements(null, null, null, false, oldContext));
 			logger.info("Not deleted statements: " + stmts.size());
-
 		}
 		repo.shutDown();
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreDirLockTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreDirLockTest.java
@@ -17,18 +17,13 @@ import java.io.File;
 
 import org.eclipse.rdf4j.sail.SailLockedException;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LmdbStoreDirLockTest {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-
 	@Test
-	public void testLocking() throws Exception {
-		File dataDir = tempDir.newFolder();
+	public void testLocking(@TempDir File dataDir) throws Exception {
 		LmdbStore sail = new LmdbStore(dataDir, new LmdbStoreConfig("spoc,posc"));
 		sail.init();
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreErrorHandlingTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreErrorHandlingTest.java
@@ -20,22 +20,16 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for the correct handling of internal LMDB store errors.
  */
 public class LmdbStoreErrorHandlingTest {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-
 	@Test
-	public void testMapFullError() throws Exception {
-		File dataDir = tempDir.newFolder();
-
+	public void testMapFullError(@TempDir File dataDir) throws Exception {
 		LmdbStoreConfig config = new LmdbStoreConfig("spoc,psoc");
 		// set small db size
 		config.setValueDBSize(50000);

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreInterruptTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreInterruptTest.java
@@ -10,15 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.sail.SailConcurrencyTest;
 import org.eclipse.rdf4j.testsuite.sail.SailInterruptTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailConcurrencyTest} for testing the class {@link LmdbStore}.
@@ -29,8 +28,8 @@ public class LmdbStoreInterruptTest extends SailInterruptTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -38,11 +37,6 @@ public class LmdbStoreInterruptTest extends SailInterruptTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			return new LmdbStore(tempDir.newFolder(), new LmdbStoreConfig("spoc,posc"));
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		return new LmdbStore(dataDir, new LmdbStoreConfig("spoc,posc"));
 	}
-
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreIsolationLevelTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreIsolationLevelTest.java
@@ -10,14 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.sail.SailIsolationLevelTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailIsolationLevelTest} for testing the class {@link LmdbStore}.
@@ -28,8 +27,8 @@ public class LmdbStoreIsolationLevelTest extends SailIsolationLevelTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	File tempDir;
 
 	/*---------*
 	 * Methods *
@@ -37,10 +36,6 @@ public class LmdbStoreIsolationLevelTest extends SailIsolationLevelTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			return new LmdbStore(tempDir.newFolder(), new LmdbStoreConfig("spoc,posc"));
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		return new LmdbStore(tempDir, new LmdbStoreConfig("spoc,posc"));
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreTmpDatadirTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreTmpDatadirTest.java
@@ -16,18 +16,13 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LmdbStoreTmpDatadirTest {
 
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
-
 	@Test
-	public void testNoTmpDatadir() throws IOException {
-		File dataDir = tempFolder.newFolder();
+	public void testNoTmpDatadir(@TempDir File dataDir) throws IOException {
 		LmdbStore store = new LmdbStore(dataDir);
 
 		store.init();
@@ -62,8 +57,7 @@ public class LmdbStoreTmpDatadirTest {
 	}
 
 	@Test
-	public void testDatadirMix() throws IOException {
-		File dataDir = tempFolder.newFolder();
+	public void testDatadirMix(@TempDir File dataDir) throws IOException {
 		LmdbStore store = new LmdbStore(dataDir);
 
 		store.init();

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LongMultithreadedTransactions.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LongMultithreadedTransactions.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import java.io.File;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -22,21 +23,20 @@ import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.sail.SailConnection;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LongMultithreadedTransactions {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File tmpDir;
 
 	NotifyingSail getBaseSail() {
-		return new LmdbStore(tmpDir.getRoot());
+		return new LmdbStore(tmpDir);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void test() {
 
 		ValueFactory vf = SimpleValueFactory.getInstance();
@@ -67,7 +67,7 @@ public class LongMultithreadedTransactions {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void test1() {
 
 		ValueFactory vf = SimpleValueFactory.getInstance();

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/QueryBenchmarkTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/QueryBenchmarkTest.java
@@ -27,9 +27,9 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -61,7 +61,7 @@ public class QueryBenchmarkTest {
 		}
 	}
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException {
 		tempDir.create();
 		File file = tempDir.newFolder();
@@ -84,7 +84,7 @@ public class QueryBenchmarkTest {
 		return QueryBenchmarkTest.class.getClassLoader().getResourceAsStream(name);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws IOException {
 		tempDir.delete();
 		repository.shutDown();

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TestLmdbStoreUpgrade.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TestLmdbStoreUpgrade.java
@@ -22,21 +22,16 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  *
  */
 public class TestLmdbStoreUpgrade {
 
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
-
 	@Test
-	public void testDevel() throws IOException, SailException {
-		File dataDir = tmpDir.getRoot();
+	public void testDevel(@TempDir File dataDir) throws IOException, SailException {
 		LmdbStore store = new LmdbStore(dataDir);
 		try {
 			store.init();

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreTest.java
@@ -17,25 +17,19 @@ import java.io.IOException;
 
 import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Low-level tests for {@link TripleStore}.
  */
 public class TripleStoreTest {
-
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
-
 	protected TripleStore tripleStore;
 
-	@Before
-	public void before() throws Exception {
-		File dataDir = tempFolder.newFolder("triplestore");
+	@BeforeEach
+	public void before(@TempDir File dataDir) throws Exception {
 		tripleStore = new TripleStore(dataDir, new LmdbStoreConfig("spoc,posc"));
 	}
 
@@ -72,7 +66,7 @@ public class TripleStoreTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void after() throws Exception {
 		tripleStore.close();
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/VarintTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/VarintTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.nio.ByteBuffer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VarintTest {
 

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,7 +24,7 @@ import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DistanceQuerySpecTest extends SearchQueryEvaluatorTest {
 

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/GeoRelationQuerySpecTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/GeoRelationQuerySpecTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,7 +24,7 @@ import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeoRelationQuerySpecTest extends SearchQueryEvaluatorTest {
 

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/LangSpecTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/LangSpecTest.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Properties;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -17,9 +20,8 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.Var;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.shape.Point;
 
@@ -124,7 +126,7 @@ public class LangSpecTest {
 	SearchIndex index;
 	Properties prop;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		index = new SearchIndexImpl();
 		prop = new Properties();
@@ -136,9 +138,9 @@ public class LangSpecTest {
 
 		// test that without setting the LuceneSail.INDEXEDLANG property, the accept method is still
 		// working as intended
-		Assert.assertTrue(index.accept(VF.createLiteral("my literal")));
-		Assert.assertTrue(index.accept(VF.createLiteral("my literal", "en")));
-		Assert.assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
+		assertTrue(index.accept(VF.createLiteral("my literal")));
+		assertTrue(index.accept(VF.createLiteral("my literal", "en")));
+		assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
 	}
 
 	@Test
@@ -147,9 +149,9 @@ public class LangSpecTest {
 		index.initialize(prop);
 
 		// test that with the LuceneSail.INDEXEDLANG property, we are only accepting literals of the right language
-		Assert.assertFalse(index.accept(VF.createLiteral("my literal")));
-		Assert.assertFalse(index.accept(VF.createLiteral("my literal", "en")));
-		Assert.assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
+		assertFalse(index.accept(VF.createLiteral("my literal")));
+		assertFalse(index.accept(VF.createLiteral("my literal", "en")));
+		assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
 	}
 
 	@Test
@@ -158,9 +160,9 @@ public class LangSpecTest {
 		index.initialize(prop);
 
 		// test that with the LuceneSail.INDEXEDLANG property, we are only accepting literals of the right languages
-		Assert.assertFalse(index.accept(VF.createLiteral("my literal")));
-		Assert.assertTrue(index.accept(VF.createLiteral("my literal", "en")));
-		Assert.assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
-		Assert.assertFalse(index.accept(VF.createLiteral("mi literal", "es")));
+		assertFalse(index.accept(VF.createLiteral("my literal")));
+		assertTrue(index.accept(VF.createLiteral("my literal", "en")));
+		assertTrue(index.accept(VF.createLiteral("mon litteral", "fr")));
+		assertFalse(index.accept(VF.createLiteral("mi literal", "es")));
 	}
 }

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilderTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilderTest.java
@@ -16,9 +16,9 @@ import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.MATCHES;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.QUERY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SCORE;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SNIPPET;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,8 +30,8 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class QuerySpecBuilderTest {
 
@@ -39,7 +39,7 @@ public class QuerySpecBuilderTest {
 
 	private SPARQLParser parser;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		interpreter = new QuerySpecBuilder(true);
 		parser = new SPARQLParser();
@@ -193,7 +193,7 @@ public class QuerySpecBuilderTest {
 		ParsedQuery query = parser.parseQuery(queryString, null);
 		TupleExpr tupleExpr = query.getTupleExpr();
 		Collection<SearchQueryEvaluator> queries = process(interpreter, tupleExpr);
-		assertEquals("expect one query", 1, queries.size());
+		assertEquals(1, queries.size(), "expect one query");
 	}
 
 	private Collection<SearchQueryEvaluator> process(SearchQueryInterpreter interpreter, TupleExpr tupleExpr) {

--- a/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/QuerySpecTest.java
+++ b/core/sail/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/QuerySpecTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +18,7 @@ import java.util.List;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class QuerySpecTest extends SearchQueryEvaluatorTest {
 	private static final String QUERY = "PREFIX search: <http://www.openrdf.org/contrib/lucenesail#>\n" +

--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -73,5 +73,11 @@
 			<groupId>org.locationtech.jts</groupId>
 			<artifactId>jts-core</artifactId>
 		</dependency>
+		<!-- This module uses timeout rule, and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneFuzzinessPrefixTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneFuzzinessPrefixTest.java
@@ -29,10 +29,9 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LuceneFuzzinessPrefixTest {
 	private static final ValueFactory VF = SimpleValueFactory.getInstance();
@@ -50,17 +49,14 @@ public class LuceneFuzzinessPrefixTest {
 		return String.join(" \n", lines);
 	}
 
-	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
-
 	private LuceneSail sail;
 	private MemoryStore memoryStore;
 	private SailRepository repository;
+	@TempDir
 	private File dataDir;
 
-	@Before
+	@BeforeEach
 	public void setup() throws IOException {
-		dataDir = tmpFolder.newFolder();
 		memoryStore = new MemoryStore();
 		sail = new LuceneSail();
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, "lucene-index");

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexIdFilteringTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexIdFilteringTest.java
@@ -10,6 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,17 +32,16 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.evaluation.TupleFunctionEvaluationMode;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
 public class LuceneIndexIdFilteringTest {
+
 	private static final Logger LOG = LoggerFactory.getLogger(LuceneIndexIdFilteringTest.class);
 	private static final ValueFactory VF = SimpleValueFactory.getInstance();
 	private static final String NAMESPACE = "http://example.org/";
@@ -54,14 +58,11 @@ public class LuceneIndexIdFilteringTest {
 		return String.join(" \n", lines);
 	}
 
-	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
-
 	LuceneSail sailType1, sailType2, sailType3;
 	SailRepository repository;
 
-	@Before
-	public void setup() throws IOException {
+	@BeforeEach
+	public void setup(@TempDir File dataDir) throws IOException {
 		// sails schema
 		// sailType1(LuceneSail) -> sailType2(LuceneSail) -> sailType3(LuceneSail) -> memoryStore(MemoryStore)
 
@@ -90,7 +91,7 @@ public class LuceneIndexIdFilteringTest {
 		sailType1.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
 		sailType1.setEvaluationMode(TupleFunctionEvaluationMode.NATIVE);
 		sailType1.setBaseSail(sailType2);
-		sailType1.setDataDir(tmpFolder.newFolder());
+		sailType1.setDataDir(dataDir);
 	}
 
 	private void initSails() {
@@ -132,13 +133,13 @@ public class LuceneIndexIdFilteringTest {
 							set = result.next();
 							LOG.error("- {}", set.getValue("result").stringValue().substring(NAMESPACE.length()));
 						}
-						Assert.fail("The element '" + element + "' was in the index, but wasn't excepted");
+						fail("The element '" + element + "' was in the index, but wasn't excepted");
 					}
 				}
 			}
 
 			if (!exceptedDocSet.isEmpty()) {
-				Assert.fail("Unexpected docs: " + exceptedDocSet);
+				fail("Unexpected docs: " + exceptedDocSet);
 			}
 		}
 	}
@@ -252,7 +253,7 @@ public class LuceneIndexIdFilteringTest {
 					for (QueryElement el : exceptedElements) {
 						// union lines shouldn't be containing multiple results
 						if (union && elementValue != null) {
-							Assert.assertNull("union test returns multiple results", set.getValue(el.resultName));
+							assertNull(set.getValue(el.resultName), "union test returns multiple results");
 							continue;
 						}
 						elementValue = set.getValue(el.resultName);
@@ -268,11 +269,11 @@ public class LuceneIndexIdFilteringTest {
 								set = result.next();
 								LOG.error("- {}", set);
 							}
-							Assert.fail("The element '" + element + "' was in the index "
+							fail("The element '" + element + "' was in the index "
 									+ el.resultName + ", but wasn't excepted");
 						}
 					}
-					Assert.assertNotNull("No element for the set: " + set, elementValue);
+					assertNotNull(elementValue, "No element for the set: " + set);
 				}
 			}
 
@@ -286,7 +287,7 @@ public class LuceneIndexIdFilteringTest {
 			}
 
 			if (!missing.isEmpty()) {
-				Assert.fail("Unexpected docs: " + missing);
+				fail("Unexpected docs: " + missing);
 			}
 		}
 	}
@@ -414,6 +415,7 @@ public class LuceneIndexIdFilteringTest {
 	}
 
 	static class QueryElement {
+
 		List<String> elements;
 		String resultName;
 

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/TypeSpecTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/TypeSpecTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
@@ -25,17 +27,16 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Sets;
 
 public class TypeSpecTest {
+
 	private static final Logger LOG = LoggerFactory.getLogger(TypeSpecTest.class);
 	private static final ValueFactory VF = SimpleValueFactory.getInstance();
 	private static final String EX_NS = "http://example.org/";
@@ -66,23 +67,19 @@ public class TypeSpecTest {
 		);
 	}
 
-	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
-
 	LuceneSail sail;
 	MemoryStore memoryStore;
 	SailRepository repository;
+	@TempDir
 	File dataDir;
 
-	@Before
+	@BeforeEach
 	public void setup() throws IOException {
-		dataDir = tmpFolder.newFolder();
 		memoryStore = new MemoryStore();
 		// enable lock tracking
 		sail = new LuceneSail();
 		sail.setParameter(LuceneSail.LUCENE_DIR_KEY, "lucene-index");
 		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneSail.DEFAULT_INDEX_CLASS);
-
 	}
 
 	private void initSail() {
@@ -154,13 +151,13 @@ public class TypeSpecTest {
 							set = result.next();
 							LOG.error("- {}", set.getValue("result").stringValue().substring(EX_NS.length()));
 						}
-						Assert.fail("The element '" + element + "' was in the index, but wasn't excepted");
+						fail("The element '" + element + "' was in the index, but wasn't excepted");
 					}
 				}
 			}
 
 			if (!exceptedDocSet.isEmpty()) {
-				Assert.fail("Unexpected docs: " + exceptedDocSet);
+				fail("Unexpected docs: " + exceptedDocSet);
 			}
 		}
 	}
@@ -244,7 +241,6 @@ public class TypeSpecTest {
 		assertQuery(
 				"bbb", "ccc", "ddd", "eee", "fff"
 		);
-
 	}
 
 	@Test
@@ -493,5 +489,4 @@ public class TypeSpecTest {
 				"ddd", "eee"
 		);
 	}
-
 }

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndexLocationTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndexLocationTest.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -24,12 +27,10 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,9 +45,6 @@ public class LuceneIndexLocationTest {
 
 	private final String luceneIndexPath = "sail-index";
 
-	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
-
 	Sail sail;
 
 	SailRepository repository;
@@ -60,10 +58,8 @@ public class LuceneIndexLocationTest {
 	 *
 	 * @throws Exception
 	 */
-	@Before
-	public void setUp() throws Exception {
-		File dataDir = tmpFolder.newFolder();
-
+	@BeforeEach
+	public void setUp(@TempDir File dataDir) throws Exception {
 		sail = new MemoryStore();
 
 		LuceneSail lucene = new LuceneSail();
@@ -86,7 +82,7 @@ public class LuceneIndexLocationTest {
 		connection = repository.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws IOException, RepositoryException {
 		try {
 			if (connection != null) {
@@ -110,11 +106,10 @@ public class LuceneIndexLocationTest {
 		Path lucenePath = repository.getDataDir().toPath().resolve(luceneIndexPath);
 
 		log.info("Lucene index location: {}", lucenePath);
-		Assert.assertEquals(dataDir.getAbsolutePath() + File.separator + luceneIndexPath,
+		assertEquals(dataDir.getAbsolutePath() + File.separator + luceneIndexPath,
 				lucenePath.toAbsolutePath().toString());
 
-		Assert.assertTrue(lucenePath.toFile().exists());
-		Assert.assertTrue(lucenePath.toFile().isDirectory());
+		assertTrue(lucenePath.toFile().exists());
+		assertTrue(lucenePath.toFile().isDirectory());
 	}
-
 }

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndexTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndexTest.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -47,9 +47,9 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.lucene.SearchFields;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LuceneIndexTest {
 
@@ -107,14 +107,14 @@ public class LuceneIndexTest {
 
 	LuceneIndex index;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		directory = new RAMDirectory();
 		analyzer = new StandardAnalyzer();
 		index = new LuceneIndex(directory, analyzer);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		index.shutDown();
 		Properties.setLockTrackingEnabled(false);
@@ -401,10 +401,10 @@ public class LuceneIndexTest {
 		Literal literal2 = vf.createLiteral("hi there, too", STRING);
 		Literal literal3 = vf.createLiteral("1.0");
 		Literal literal4 = vf.createLiteral("1.0", FLOAT);
-		assertEquals("Is the first literal accepted?", true, index.accept(literal1));
-		assertEquals("Is the second literal accepted?", true, index.accept(literal2));
-		assertEquals("Is the third literal accepted?", true, index.accept(literal3));
-		assertEquals("Is the fourth literal accepted?", false, index.accept(literal4));
+		assertEquals(true, index.accept(literal1), "Is the first literal accepted?");
+		assertEquals(true, index.accept(literal2), "Is the second literal accepted?");
+		assertEquals(true, index.accept(literal3), "Is the third literal accepted?");
+		assertEquals(false, index.accept(literal4), "Is the fourth literal accepted?");
 	}
 
 	private void assertStatement(Statement statement) throws Exception {
@@ -429,7 +429,7 @@ public class LuceneIndexTest {
 	 */
 	private void assertStatement(Statement statement, Document document) {
 		IndexableField[] fields = document.getFields(SearchFields.getPropertyField(statement.getPredicate()));
-		assertNotNull("field " + statement.getPredicate() + " not found in document " + document, fields);
+		assertNotNull(fields, "field " + statement.getPredicate() + " not found in document " + document);
 		for (IndexableField f : fields) {
 			if (((Literal) statement.getObject()).getLabel().equals(f.stringValue())) {
 				return;

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/PersistentMemoryStoreIsolationLevelTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/PersistentMemoryStoreIsolationLevelTest.java
@@ -10,12 +10,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link MemoryStoreIsolationLevelTest} for testing the class {@link MemoryStore} using on-disk
@@ -23,8 +22,8 @@ import org.junit.rules.TemporaryFolder;
  */
 public class PersistentMemoryStoreIsolationLevelTest extends MemoryStoreIsolationLevelTest {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File tempDir;
 
 	/*---------*
 	 * Methods *
@@ -32,12 +31,9 @@ public class PersistentMemoryStoreIsolationLevelTest extends MemoryStoreIsolatio
 
 	@Override
 	protected Sail createSail() throws SailException {
-		MemoryStore sail;
-		try {
-			sail = new MemoryStore(tempDir.newFolder("memory-store"));
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		File dataDir = new File(tempDir, "memory-store");
+		dataDir.mkdir();
+		MemoryStore sail = new MemoryStore(dataDir);
 		sail.setSyncDelay(100);
 		return sail;
 	}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
@@ -20,10 +20,9 @@ import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Unit tests for {@link ContextStore}
@@ -39,16 +38,14 @@ public class ContextStoreTest {
 	private final Resource g1 = vf.createIRI("http://example.org/g1");
 	private final Resource g2 = vf.createBNode();
 
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
-	private File dataDir;
+	@TempDir
+	File dataDir;
 
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		dataDir = tmpDir.newFolder();
 		NativeSailStore sailStore = mock(NativeSailStore.class);
 
 		when(sailStore.getValueFactory()).thenReturn(SimpleValueFactory.getInstance());
@@ -136,5 +133,4 @@ public class ContextStoreTest {
 		}
 		return count;
 	}
-
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/DefaultIndexTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/DefaultIndexTest.java
@@ -18,17 +18,15 @@ import java.io.InputStream;
 import java.util.Properties;
 
 import org.eclipse.rdf4j.common.io.FileUtil;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DefaultIndexTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File dir;
 
 	@Test
 	public void testDefaultIndex() throws Exception {
-		File dir = tmpDir.newFolder();
 		TripleStore store = new TripleStore(dir, null);
 		store.close();
 		// check that the triple store used the default index
@@ -38,7 +36,6 @@ public class DefaultIndexTest {
 
 	@Test
 	public void testExistingIndex() throws Exception {
-		File dir = tmpDir.newFolder();
 		// set a non-default index
 		TripleStore store = new TripleStore(dir, "spoc,opsc");
 		store.close();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/LongMultithreadedTransactions.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/LongMultithreadedTransactions.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import java.io.File;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -22,21 +23,20 @@ import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.sail.SailConnection;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LongMultithreadedTransactions {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File tmpDir;
 
 	NotifyingSail getBaseSail() {
-		return new NativeStore(tmpDir.getRoot());
+		return new NativeStore(tmpDir);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void test() {
 
 		ValueFactory vf = SimpleValueFactory.getInstance();
@@ -67,7 +67,7 @@ public class LongMultithreadedTransactions {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void test1() {
 
 		ValueFactory vf = SimpleValueFactory.getInstance();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeCascadeValueExceptionTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeCascadeValueExceptionTest.java
@@ -10,20 +10,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.testsuite.repository.CascadeValueExceptionTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeCascadeValueExceptionTest extends CascadeValueExceptionTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File tmpDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
+		return new SailRepository(new NativeStore(tmpDir, "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeGraphQueryResultTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeGraphQueryResultTest.java
@@ -10,20 +10,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.testsuite.repository.GraphQueryResultTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeGraphQueryResultTest extends GraphQueryResultTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
+		return new SailRepository(new NativeStore(dataDir, "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeOptimisticIsolationTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeOptimisticIsolationTest.java
@@ -15,12 +15,12 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class NativeOptimisticIsolationTest extends OptimisticIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -30,7 +30,7 @@ public class NativeOptimisticIsolationTest extends OptimisticIsolationTest {
 		});
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStoreTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStoreTest.java
@@ -24,19 +24,18 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of RDFStoreTest for testing the class {@link NativeStore}.
  */
 public class NativeSailStoreTest {
 
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+	@TempDir
+	File tempFolder;
 
 	protected Repository repo;
 
@@ -53,9 +52,10 @@ public class NativeSailStoreTest {
 	protected final Statement S2 = F.createStatement(F.createIRI("http://example.org/2"), RDFS.LABEL,
 			F.createLiteral("two"));
 
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
-		File dataDir = tempFolder.newFolder("dbmodel");
+		File dataDir = new File(tempFolder, "dbmodel");
+		dataDir.mkdir();
 		repo = new SailRepository(new NativeStore(dataDir, "spoc,posc"));
 		repo.init();
 
@@ -126,7 +126,7 @@ public class NativeSailStoreTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void after() throws Exception {
 		repo.shutDown();
 	}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSparqlOrderByTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSparqlOrderByTest.java
@@ -10,20 +10,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.testsuite.repository.SparqlOrderByTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeSparqlOrderByTest extends SparqlOrderByTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+
+	@TempDir
+	File dataDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
+		return new SailRepository(new NativeStore(dataDir, "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSparqlRegexTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSparqlRegexTest.java
@@ -10,20 +10,20 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.testsuite.repository.SparqlRegexTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeSparqlRegexTest extends SparqlRegexTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Override
 	protected Repository newRepository() throws IOException {
-		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
+		return new SailRepository(new NativeStore(dataDir, "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConcurrencyTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConcurrencyTest.java
@@ -10,13 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.testsuite.sail.SailConcurrencyTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailConcurrencyTest} for testing the class {@link NativeStore}.
@@ -27,8 +26,8 @@ public class NativeStoreConcurrencyTest extends SailConcurrencyTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -36,10 +35,6 @@ public class NativeStoreConcurrencyTest extends SailConcurrencyTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			return new NativeStore(tempDir.newFolder(), "spoc,posc");
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		return new NativeStore(dataDir, "spoc,posc");
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConsistencyIT.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConsistencyIT.java
@@ -30,9 +30,8 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.util.RDFInserter;
 import org.eclipse.rdf4j.repository.util.RDFLoader;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,20 +47,15 @@ public class NativeStoreConsistencyIT {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-
 	/*---------*
 	 * Methods *
 	 *---------*/
 
 	@Test
-	public void testSES1867IndexCorruption() throws Exception {
+	public void testSES1867IndexCorruption(@TempDir File dataDir) throws Exception {
 		ValueFactory vf = SimpleValueFactory.getInstance();
 		IRI oldContext = vf.createIRI("http://example.org/oldContext");
 		IRI newContext = vf.createIRI("http://example.org/newContext");
-
-		File dataDir = tempDir.newFolder();
 
 		Repository repo = new SailRepository(new NativeStore(dataDir, "spoc,psoc"));
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreDirLockTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreDirLockTest.java
@@ -16,18 +16,16 @@ import static org.junit.Assert.fail;
 import java.io.File;
 
 import org.eclipse.rdf4j.sail.SailLockedException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeStoreDirLockTest {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Test
 	public void testLocking() throws Exception {
-		File dataDir = tempDir.newFolder();
 		NativeStore sail = new NativeStore(dataDir, "spoc,posc");
 		sail.init();
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreInterruptTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreInterruptTest.java
@@ -10,14 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.testsuite.sail.SailConcurrencyTest;
 import org.eclipse.rdf4j.testsuite.sail.SailInterruptTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailConcurrencyTest} for testing the class {@link NativeStore}.
@@ -28,8 +27,8 @@ public class NativeStoreInterruptTest extends SailInterruptTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -37,11 +36,6 @@ public class NativeStoreInterruptTest extends SailInterruptTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			return new NativeStore(tempDir.newFolder(), "spoc,posc");
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		return new NativeStore(dataDir, "spoc,posc");
 	}
-
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreIsolationLevelTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreIsolationLevelTest.java
@@ -10,13 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.testsuite.sail.SailIsolationLevelTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of {@link SailIsolationLevelTest} for testing the class {@link NativeStore}.
@@ -27,8 +26,8 @@ public class NativeStoreIsolationLevelTest extends SailIsolationLevelTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File tempDir;
 
 	/*---------*
 	 * Methods *
@@ -36,10 +35,6 @@ public class NativeStoreIsolationLevelTest extends SailIsolationLevelTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			return new NativeStore(tempDir.newFolder(), "spoc,posc");
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		return new NativeStore(tempDir, "spoc,posc");
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTmpDatadirTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTmpDatadirTest.java
@@ -14,20 +14,17 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeStoreTmpDatadirTest {
 
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Test
-	public void testNoTmpDatadir() throws IOException {
-		File dataDir = tempFolder.newFolder();
+	public void testNoTmpDatadir() {
 		NativeStore store = new NativeStore(dataDir);
 
 		store.init();
@@ -38,7 +35,7 @@ public class NativeStoreTmpDatadirTest {
 	}
 
 	@Test
-	public void testTmpDatadir() throws IOException {
+	public void testTmpDatadir() {
 		NativeStore store = new NativeStore();
 		store.init();
 		File dataDir = store.getDataDir();
@@ -49,7 +46,7 @@ public class NativeStoreTmpDatadirTest {
 	}
 
 	@Test
-	public void testTmpDatadirReinit() throws IOException {
+	public void testTmpDatadirReinit() {
 		NativeStore store = new NativeStore();
 		store.init();
 		File dataDir1 = store.getDataDir();
@@ -62,8 +59,7 @@ public class NativeStoreTmpDatadirTest {
 	}
 
 	@Test
-	public void testDatadirMix() throws IOException {
-		File dataDir = tempFolder.newFolder();
+	public void testDatadirMix() {
 		NativeStore store = new NativeStore(dataDir);
 
 		store.init();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTxnTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTxnTest.java
@@ -12,10 +12,11 @@ package org.eclipse.rdf4j.sail.nativerdf;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -32,17 +33,15 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.nativerdf.btree.RecordIterator;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class NativeStoreTxnTest {
 
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+	@TempDir
+	File tempFolder;
 
 	protected Repository repo;
 
@@ -50,15 +49,15 @@ public class NativeStoreTxnTest {
 
 	protected IRI ctx = vf.createIRI("http://ex.org/ctx");
 
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 
-		File dataDir = tempFolder.newFolder("dbmodel");
+		File dataDir = new File(tempFolder, "dbmodel");
 		repo = new SailRepository(new NativeStore(dataDir, "spoc,posc"));
 		repo.init();
 	}
 
-	@After
+	@AfterEach
 	public void after() throws Exception {
 		repo.shutDown();
 	}
@@ -87,14 +86,14 @@ public class NativeStoreTxnTest {
 		for (File file : repoDir.listFiles()) {
 			System.out.println("# " + file.getName());
 		}
-		Assert.assertEquals(15, repoDir.listFiles().length);
+		assertEquals(15, repoDir.listFiles().length);
 
 		// make sure there is no txncacheXXX.dat file
-		Assert.assertFalse(Files.list(repoDir.getAbsoluteFile().toPath())
+		assertFalse(Files.list(repoDir.getAbsoluteFile().toPath())
 				.anyMatch(file -> file.toFile().getName().matches("txncache[0-9]+.*dat")));
 
 		try (RepositoryConnection conn = repo.getConnection()) {
-			Assert.assertEquals(1, conn.size());
+			assertEquals(1, conn.size());
 		}
 	}
 
@@ -152,7 +151,6 @@ public class NativeStoreTxnTest {
 		TxnStatusFile.TxnStatus currentStatus = new TxnStatusFile(repo.getDataDir()).getTxnStatus();
 
 		assertEquals(TxnStatusFile.TxnStatus.NONE, currentStatus);
-
 	}
 
 	@Test
@@ -166,6 +164,5 @@ public class NativeStoreTxnTest {
 				assertNotEquals(firstByteInOldValue, firstByteInNewValue);
 			}
 		}
-
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/QueryBenchmarkTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/QueryBenchmarkTest.java
@@ -26,9 +26,9 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -60,7 +60,7 @@ public class QueryBenchmarkTest {
 
 	static List<Statement> statementList;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException {
 		tempDir.create();
 		File file = tempDir.newFolder();
@@ -86,7 +86,7 @@ public class QueryBenchmarkTest {
 		return QueryBenchmarkTest.class.getClassLoader().getResourceAsStream(name);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws IOException {
 		tempDir.delete();
 		repository.shutDown();

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreUpgrade.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreUpgrade.java
@@ -30,9 +30,8 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author James Leigh
@@ -43,12 +42,11 @@ public class TestNativeStoreUpgrade {
 
 	private static final String ZIP_2_7_15_INCONSISTENT = "/nativerdf-inconsistent-2.7.15.zip";
 
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File dataDir;
 
 	@Test
-	public void testDevel() throws IOException, SailException {
-		File dataDir = tmpDir.getRoot();
+	public void testDevel() throws SailException {
 		NativeStore store = new NativeStore(dataDir);
 		try {
 			store.init();
@@ -68,7 +66,6 @@ public class TestNativeStoreUpgrade {
 
 	@Test
 	public void test2715() throws IOException, SailException {
-		File dataDir = tmpDir.getRoot();
 		extractZipResource(ZIP_2_7_15, dataDir);
 		assertFalse(new File(dataDir, "nativerdf.ver").exists());
 		assertValue(dataDir);
@@ -77,7 +74,6 @@ public class TestNativeStoreUpgrade {
 
 	@Test
 	public void test2715Inconsistent() throws IOException, SailException {
-		File dataDir = tmpDir.getRoot();
 		extractZipResource(ZIP_2_7_15_INCONSISTENT, dataDir);
 		assertFalse(new File(dataDir, "nativerdf.ver").exists());
 		NativeStore store = new NativeStore(dataDir);
@@ -88,7 +84,6 @@ public class TestNativeStoreUpgrade {
 		} finally {
 			store.shutDown();
 		}
-
 	}
 
 	public void assertValue(File dataDir) throws SailException {
@@ -123,5 +118,4 @@ public class TestNativeStoreUpgrade {
 			}
 		}
 	}
-
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
@@ -17,20 +17,19 @@ import java.io.File;
 
 import org.eclipse.rdf4j.sail.nativerdf.TxnStatusFile.TxnStatus;
 import org.eclipse.rdf4j.sail.nativerdf.btree.RecordIterator;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of RDFStoreTest for testing the class {@link NativeStore}.
  */
 public class TripleStoreRecoveryTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+
+	@TempDir
+	File dataDir;
 
 	@Test
 	public void testRollbackRecovery() throws Exception {
-		File dataDir = tmpDir.getRoot();
 		TripleStore tripleStore = new TripleStore(dataDir, "spoc");
 		try {
 			tripleStore.startTransaction();
@@ -53,7 +52,6 @@ public class TripleStoreRecoveryTest {
 
 	@Test
 	public void testCommitRecovery() throws Exception {
-		File dataDir = tmpDir.getRoot();
 		TripleStore tripleStore = new TripleStore(dataDir, "spoc");
 		try {
 			tripleStore.startTransaction();
@@ -83,5 +81,4 @@ public class TripleStoreRecoveryTest {
 			tripleStore.close();
 		}
 	}
-
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTreeBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTreeBenchmark.java
@@ -10,15 +10,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf.btree;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Random;
 
 import org.eclipse.rdf4j.common.io.ByteArrayUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author Arjohn Kampman
@@ -31,8 +31,8 @@ public class BTreeBenchmark {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File tmpDir;
 
 	private BTree btree;
 
@@ -40,12 +40,12 @@ public class BTreeBenchmark {
 	 * Methods *
 	 *---------*/
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		btree = new BTree(tmpDir.newFolder(), "test", 4096, 8);
+		btree = new BTree(tmpDir, "test", 4096, 8);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		btree.delete();
 	}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTreeTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTreeTest.java
@@ -10,15 +10,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf.btree;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author Arjohn Kampman
@@ -48,8 +48,8 @@ public class BTreeTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	File tmpDir;
 
 	private BTree btree;
 
@@ -57,12 +57,12 @@ public class BTreeTest {
 	 * Methods *
 	 *---------*/
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		btree = new BTree(tmpDir.newFolder(), "test", 85, 1);
+		btree = new BTree(tmpDir, "test", 85, 1);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		btree.delete();
 	}

--- a/core/sparqlbuilder/pom.xml
+++ b/core/sparqlbuilder/pom.xml
@@ -15,5 +15,11 @@
 			<artifactId>rdf4j-model</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ExpressionsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ExpressionsTest.java
@@ -11,15 +11,15 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.constraint;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ExpressionsTest {
 
@@ -68,14 +68,14 @@ public class ExpressionsTest {
 	public void test_BIND_fromOtherVariable() {
 		Variable from = SparqlBuilder.var("from");
 		Variable to = SparqlBuilder.var("to");
-		Assertions.assertEquals(
+		assertEquals(
 				"BIND( ?from AS ?to )", Expressions.bind(from, to).getQueryString());
 	}
 
 	@Test
 	public void test_NOT_IN_twoIris() {
 		Variable test = SparqlBuilder.var("test");
-		Assertions.assertEquals(
+		assertEquals(
 				"?test NOT IN ( <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>, <http://www.w3.org/2000/01/rdf-schema#subClassOf> )",
 				Expressions.notIn(test, Rdf.iri(RDF.TYPE), Rdf.iri(RDFS.SUBCLASSOF))
 						.getQueryString());
@@ -84,7 +84,7 @@ public class ExpressionsTest {
 	@Test
 	public void test_IS_BLANK() {
 		Variable test = SparqlBuilder.var("test");
-		Assertions.assertEquals(
+		assertEquals(
 				"isBLANK( ?test )", Expressions.isBlank(test).getQueryString());
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/PropertyPathTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/propertypath/builder/PropertyPathTest.java
@@ -14,27 +14,26 @@ package org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.toRdfLiteralArray;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.PropertyPath;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
-import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PropertyPathTest {
 	@Test
 	public void testEmptyPropertyPathBuilderFromExpressions() {
 		PropertyPath p = PropertyPaths.path().pred(iri(RDFS.LABEL)).build();
-		Assertions.assertEquals("<" + RDFS.LABEL + ">", p.getQueryString());
+		assertEquals("<" + RDFS.LABEL + ">", p.getQueryString());
 	}
 
 	@Test
 	public void testPredPropertyPathBuilderFromExpressions() {
 		PropertyPath p = PropertyPaths.path(iri(RDFS.LABEL)).build();
-		Assertions.assertEquals("<" + RDFS.LABEL + ">", p.getQueryString());
+		assertEquals("<" + RDFS.LABEL + ">", p.getQueryString());
 	}
 
 	@Test
@@ -44,7 +43,7 @@ public class PropertyPathTest {
 				.pred(iri(RDFS.LABEL))
 				.or(iri(RDFS.COMMENT))
 				.build();
-		Assertions.assertEquals("( <" + RDFS.LABEL + "> | <" + RDFS.COMMENT + "> )", p.getQueryString());
+		assertEquals("( <" + RDFS.LABEL + "> | <" + RDFS.COMMENT + "> )", p.getQueryString());
 	}
 
 	@Test
@@ -54,7 +53,7 @@ public class PropertyPathTest {
 				.pred(iri(RDFS.LABEL))
 				.or(builder -> builder.pred(iri(RDFS.COMMENT)))
 				.build();
-		Assertions.assertEquals("( <" + RDFS.LABEL + "> | <" + RDFS.COMMENT + "> )", p.getQueryString());
+		assertEquals("( <" + RDFS.LABEL + "> | <" + RDFS.COMMENT + "> )", p.getQueryString());
 	}
 
 	@Test
@@ -64,7 +63,7 @@ public class PropertyPathTest {
 				.pred(iri(RDFS.LABEL))
 				.or(PropertyPaths.path(iri(RDFS.COMMENT)).build())
 				.build();
-		Assertions.assertEquals("( <" + RDFS.LABEL + "> | <" + RDFS.COMMENT + "> )", p.getQueryString());
+		assertEquals("( <" + RDFS.LABEL + "> | <" + RDFS.COMMENT + "> )", p.getQueryString());
 	}
 
 	@Test
@@ -74,7 +73,7 @@ public class PropertyPathTest {
 				.pred(iri(RDFS.SUBCLASSOF))
 				.then(iri(RDFS.COMMENT))
 				.build();
-		Assertions.assertEquals("<" + RDFS.SUBCLASSOF + "> / <" + RDFS.COMMENT + ">", p.getQueryString());
+		assertEquals("<" + RDFS.SUBCLASSOF + "> / <" + RDFS.COMMENT + ">", p.getQueryString());
 	}
 
 	@Test
@@ -84,7 +83,7 @@ public class PropertyPathTest {
 				.pred(iri(RDFS.SUBCLASSOF))
 				.then(builder -> builder.pred(iri(RDFS.COMMENT)))
 				.build();
-		Assertions.assertEquals("<" + RDFS.SUBCLASSOF + "> / <" + RDFS.COMMENT + ">", p.getQueryString());
+		assertEquals("<" + RDFS.SUBCLASSOF + "> / <" + RDFS.COMMENT + ">", p.getQueryString());
 	}
 
 	@Test
@@ -94,7 +93,7 @@ public class PropertyPathTest {
 				.pred(iri(RDFS.SUBCLASSOF))
 				.then(PropertyPaths.path(iri(RDFS.COMMENT)).build())
 				.build();
-		Assertions.assertEquals("<" + RDFS.SUBCLASSOF + "> / <" + RDFS.COMMENT + ">", p.getQueryString());
+		assertEquals("<" + RDFS.SUBCLASSOF + "> / <" + RDFS.COMMENT + ">", p.getQueryString());
 	}
 
 	@Test
@@ -104,7 +103,7 @@ public class PropertyPathTest {
 				.pred(iri(RDFS.SUBCLASSOF))
 				.then(b -> b.pred(iri(RDFS.COMMENT)).or(iri(RDFS.LABEL)))
 				.build();
-		Assertions.assertEquals("<" + RDFS.SUBCLASSOF + "> / ( <" + RDFS.COMMENT + "> | <" + RDFS.LABEL + "> )",
+		assertEquals("<" + RDFS.SUBCLASSOF + "> / ( <" + RDFS.COMMENT + "> | <" + RDFS.LABEL + "> )",
 				p.getQueryString());
 	}
 
@@ -114,7 +113,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.group()
 				.build();
-		Assertions.assertEquals("( <" + RDFS.COMMENT + "> )", p.getQueryString());
+		assertEquals("( <" + RDFS.COMMENT + "> )", p.getQueryString());
 	}
 
 	@Test
@@ -123,7 +122,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.inv()
 				.build();
-		Assertions.assertEquals("^ ( <" + RDFS.COMMENT + "> )", p.getQueryString());
+		assertEquals("^ ( <" + RDFS.COMMENT + "> )", p.getQueryString());
 	}
 
 	@Test
@@ -132,7 +131,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.oneOrMore()
 				.build();
-		Assertions.assertEquals("<" + RDFS.COMMENT + "> +", p.getQueryString());
+		assertEquals("<" + RDFS.COMMENT + "> +", p.getQueryString());
 	}
 
 	@Test
@@ -141,7 +140,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.zeroOrMore()
 				.build();
-		Assertions.assertEquals("<" + RDFS.COMMENT + "> *", p.getQueryString());
+		assertEquals("<" + RDFS.COMMENT + "> *", p.getQueryString());
 	}
 
 	@Test
@@ -150,7 +149,7 @@ public class PropertyPathTest {
 				.path(iri(RDFS.COMMENT))
 				.zeroOrOne()
 				.build();
-		Assertions.assertEquals("<" + RDFS.COMMENT + "> ?", p.getQueryString());
+		assertEquals("<" + RDFS.COMMENT + "> ?", p.getQueryString());
 	}
 
 	@Test
@@ -160,7 +159,7 @@ public class PropertyPathTest {
 				.negProp()
 				.pred(iri(RDFS.COMMENT))
 				.build();
-		Assertions.assertEquals("! <" + RDFS.COMMENT + ">", p.getQueryString());
+		assertEquals("! <" + RDFS.COMMENT + ">", p.getQueryString());
 	}
 
 	@Test
@@ -170,7 +169,7 @@ public class PropertyPathTest {
 				.negProp()
 				.invPred(iri(RDFS.COMMENT))
 				.build();
-		Assertions.assertEquals("! ^ <" + RDFS.COMMENT + ">", p.getQueryString());
+		assertEquals("! ^ <" + RDFS.COMMENT + ">", p.getQueryString());
 	}
 
 	@Test
@@ -181,7 +180,7 @@ public class PropertyPathTest {
 				.invPred(iri(RDFS.COMMENT))
 				.invPred(iri(RDFS.LABEL))
 				.build();
-		Assertions.assertEquals("! ( ^ <" + RDFS.COMMENT + "> | ^ <" + RDFS.LABEL + "> )", p.getQueryString());
+		assertEquals("! ( ^ <" + RDFS.COMMENT + "> | ^ <" + RDFS.LABEL + "> )", p.getQueryString());
 	}
 
 	@Test
@@ -194,7 +193,7 @@ public class PropertyPathTest {
 				.invPred(iri(RDFS.SUBPROPERTYOF))
 				.pred(iri(RDFS.COMMENT))
 				.build();
-		Assertions.assertEquals("! ( ^ <" + RDFS.SUBCLASSOF + "> | <" + RDFS.LABEL + "> | ^ <" + RDFS.SUBPROPERTYOF
+		assertEquals("! ( ^ <" + RDFS.SUBCLASSOF + "> | <" + RDFS.LABEL + "> | ^ <" + RDFS.SUBPROPERTYOF
 				+ "> | <" + RDFS.COMMENT + "> )", p.getQueryString());
 	}
 
@@ -203,7 +202,7 @@ public class PropertyPathTest {
 		Variable x = var("x");
 		TriplePattern tp = x.has(p -> p.pred(iri(FOAF.ACCOUNT)).then(iri(FOAF.MBOX)),
 				toRdfLiteralArray("bob@example.com"));
-		Assert.assertEquals("?x " + iri(FOAF.ACCOUNT).getQueryString() + " / " + iri(FOAF.MBOX).getQueryString()
+		assertEquals("?x " + iri(FOAF.ACCOUNT).getQueryString() + " / " + iri(FOAF.MBOX).getQueryString()
 				+ " \"bob@example.com\" .", tp.getQueryString());
 	}
 
@@ -211,7 +210,7 @@ public class PropertyPathTest {
 	public void testRdfSubjectHasPropertyPathValue() {
 		Variable x = var("x");
 		TriplePattern tp = x.has(p -> p.pred(iri(FOAF.ACCOUNT)).then(iri(FOAF.MBOX)), iri("mailto:bob@example.com"));
-		Assert.assertEquals("?x " + iri(FOAF.ACCOUNT).getQueryString() + " / " + iri(FOAF.MBOX).getQueryString()
+		assertEquals("?x " + iri(FOAF.ACCOUNT).getQueryString() + " / " + iri(FOAF.MBOX).getQueryString()
 				+ " <mailto:bob@example.com> .", tp.getQueryString());
 	}
 
@@ -219,7 +218,7 @@ public class PropertyPathTest {
 	public void testRdfSubjectHasPropertyPathString() {
 		Variable x = var("x");
 		TriplePattern tp = x.has(p -> p.pred(iri(FOAF.ACCOUNT)).then(iri(FOAF.MBOX)), "bob@example.com");
-		Assert.assertEquals("?x " + iri(FOAF.ACCOUNT).getQueryString() + " / " + iri(FOAF.MBOX).getQueryString()
+		assertEquals("?x " + iri(FOAF.ACCOUNT).getQueryString() + " / " + iri(FOAF.MBOX).getQueryString()
 				+ " \"bob@example.com\" .", tp.getQueryString());
 	}
 
@@ -227,7 +226,7 @@ public class PropertyPathTest {
 	public void testRdfSubjectHasPropertyPathNumber() {
 		Variable x = var("x");
 		TriplePattern tp = x.has(p -> p.pred(iri(FOAF.KNOWS)).then(iri(FOAF.AGE)), 20);
-		Assert.assertEquals("?x " + iri(FOAF.KNOWS).getQueryString() + " / " + iri(FOAF.AGE).getQueryString() + " 20 .",
+		assertEquals("?x " + iri(FOAF.KNOWS).getQueryString() + " / " + iri(FOAF.AGE).getQueryString() + " 20 .",
 				tp.getQueryString());
 	}
 
@@ -235,7 +234,7 @@ public class PropertyPathTest {
 	public void testRdfSubjectHasPropertyPathBoolean() {
 		Variable x = var("x");
 		TriplePattern tp = x.has(p -> p.pred(iri(FOAF.ACCOUNT)).then(iri("http://example.com/ns#premium")), true);
-		Assert.assertEquals("?x " + iri(FOAF.ACCOUNT).getQueryString() + " / "
+		assertEquals("?x " + iri(FOAF.ACCOUNT).getQueryString() + " / "
 				+ iri("http://example.com/ns#premium").getQueryString() + " true .", tp.getQueryString());
 	}
 

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/PrefixDeclarationsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/PrefixDeclarationsTest.java
@@ -11,16 +11,17 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PrefixDeclarationsTest {
 	@Test
 	public void testReplaceInQuery_nothing() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals("nothing to replace",
+		assertEquals("nothing to replace",
 				pd.replacePrefixesInQuery("nothing to replace"));
 	}
 
@@ -28,7 +29,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_justTheNamespace() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals("label: to replace",
+		assertEquals("label: to replace",
 				pd.replacePrefixesInQuery("<http://example.org/ns#> to replace"));
 	}
 
@@ -36,7 +37,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_atStart() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals("label:local to replace",
+		assertEquals("label:local to replace",
 				pd.replacePrefixesInQuery("<http://example.org/ns#local> to replace"));
 	}
 
@@ -44,7 +45,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_atEnd() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals("replace label:local",
+		assertEquals("replace label:local",
 				pd.replacePrefixesInQuery("replace <http://example.org/ns#local>"));
 	}
 
@@ -52,7 +53,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_middle() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals("replace label:local in the middle",
+		assertEquals("replace label:local in the middle",
 				pd.replacePrefixesInQuery("replace <http://example.org/ns#local> in the middle"));
 	}
 
@@ -60,7 +61,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_middle_with_angled_brackets() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals("<replace <> <label:local> <in> the middle",
+		assertEquals("<replace <> <label:local> <in> the middle",
 				pd.replacePrefixesInQuery("<replace <> <<http://example.org/ns#local>> <in> the middle"));
 	}
 
@@ -69,7 +70,7 @@ public class PrefixDeclarationsTest {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
 		pd.addPrefix(new Prefix("label2", Rdf.iri("http://example.org/ns2#")));
-		Assert.assertEquals("<replace <> <label:local> <in> the middle followed by label2:local",
+		assertEquals("<replace <> <label:local> <in> the middle followed by label2:local",
 				pd.replacePrefixesInQuery(
 						"<replace <> <<http://example.org/ns#local>> <in> the middle followed by <http://example.org/ns2#local>"));
 	}
@@ -78,7 +79,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_do_not_replace_in_string() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals(
+		assertEquals(
 				"Do not replace \"<http://example.org/ns#local>\" because it's in a string, but replace label:local here.",
 				pd.replacePrefixesInQuery(
 						"Do not replace \"<http://example.org/ns#local>\" because it's in a string, but replace <http://example.org/ns#local> here."));
@@ -88,7 +89,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_do_not_replace_in_string_enclosed_with_multiline_quotes() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals(
+		assertEquals(
 				"Do not replace \"in String even if enclosed in quotes:'''<http://example.org/ns#local>'''\", but replace label:local here.",
 				pd.replacePrefixesInQuery(
 						"Do not replace \"in String even if enclosed in quotes:'''<http://example.org/ns#local>'''\", but replace <http://example.org/ns#local> here."));
@@ -98,7 +99,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_do_not_replace_in_string_enclosed_with_escaped_double_quotes() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals(
+		assertEquals(
 				"Do not replace \"in String even if enclosed in quotes:\\\"<http://example.org/ns#local>\\\"\", but replace label:local here.",
 				pd.replacePrefixesInQuery(
 						"Do not replace \"in String even if enclosed in quotes:\\\"<http://example.org/ns#local>\\\"\", but replace <http://example.org/ns#local> here."));
@@ -108,7 +109,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_do_not_replace_in_multiline_string() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals(
+		assertEquals(
 				"Do not replace '''<http://example.org/ns#local>\n\\n''' because it's in a string, but replace label:local here.",
 				pd.replacePrefixesInQuery(
 						"Do not replace '''<http://example.org/ns#local>\n\\n''' because it's in a string, but replace <http://example.org/ns#local> here."));
@@ -118,7 +119,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_do_not_replace_in_multiline_string_with_nested_quotes() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals(
+		assertEquals(
 				"Do not replace '''<http://example.org/ns#local>\nEven with a nested '\"'\n''' because it's in a string, but replace label:local here.",
 				pd.replacePrefixesInQuery(
 						"Do not replace '''<http://example.org/ns#local>\nEven with a nested '\"'\n''' because it's in a string, but replace <http://example.org/ns#local> here."));
@@ -128,7 +129,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_do_not_replace_in_multiline_string_enclosed_with_double_quotes() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals(
+		assertEquals(
 				"Do not replace '''in String even if enlosed in quotes: \"<http://example.org/ns#local>\"''', but replace label:local here.",
 				pd.replacePrefixesInQuery(
 						"Do not replace '''in String even if enlosed in quotes: \"<http://example.org/ns#local>\"''', but replace <http://example.org/ns#local> here."));
@@ -138,7 +139,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_do_not_replace_in_multiline_string_enclosed_with_escaped_double_quotes() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals(
+		assertEquals(
 				"Do not replace '''in String even if enlosed in quotes: \\\"<http://example.org/ns#local>\\\"''', but replace label:local here.",
 				pd.replacePrefixesInQuery(
 						"Do not replace '''in String even if enlosed in quotes: \\\"<http://example.org/ns#local>\\\"''', but replace <http://example.org/ns#local> here."));
@@ -148,7 +149,7 @@ public class PrefixDeclarationsTest {
 	public void testReplaceInQuery_do_not_replace_if_continuation_is_not_localname() {
 		PrefixDeclarations pd = new PrefixDeclarations();
 		pd.addPrefix(new Prefix("label", Rdf.iri("http://example.org/ns#")));
-		Assert.assertEquals(
+		assertEquals(
 				"Do not replace <http://example.org/ns#not/a/localname> because a prefix must be followed by a localname",
 				pd.replacePrefixesInQuery(
 						"Do not replace <http://example.org/ns#not/a/localname> because a prefix must be followed by a localname"));

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -21,9 +22,8 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatternNotTriples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for precedence order of all operators in SPARQL builder Queries.
@@ -34,7 +34,7 @@ public class SparqlBuilderTest {
 	protected static final String EXAMPLE_ORG_NS = "https://example.org/ns#";
 	protected static final String DC_NS = DC.NAMESPACE;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		query = Queries.SELECT();
 	}
@@ -50,7 +50,7 @@ public class SparqlBuilderTest {
 								Expressions.gt(price, Rdf.literalOf(30)))))
 				.optional();
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("( ?price < 50 && ?price > 30 )"));
+		assertThat(query.getQueryString(), CoreMatchers.containsString("( ?price < 50 && ?price > 30 )"));
 	}
 
 	@Test
@@ -66,7 +66,7 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("( ?price < 20 || ( ?price > 50 &&" +
+		assertThat(query.getQueryString(), CoreMatchers.containsString("( ?price < 20 || ( ?price > 50 &&" +
 				" ( ?price > 60 || ?price < 70 ) ) )"));
 	}
 
@@ -82,7 +82,7 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 - ( 2 * 5 ) )"));
+		assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 - ( 2 * 5 ) )"));
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 + ( 10 / 5 ) )"));
+		assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 + ( 10 / 5 ) )"));
 	}
 
 	@Test
@@ -111,7 +111,7 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("( ( 20 - 2 ) * 5 ) )"));
+		assertThat(query.getQueryString(), CoreMatchers.containsString("( ( 20 - 2 ) * 5 ) )"));
 	}
 
 	@Test
@@ -126,7 +126,7 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 + ( 10 / 5 ) ) || 30 < 50 )"));
+		assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 + ( 10 / 5 ) ) || 30 < 50 )"));
 	}
 
 	@Test
@@ -142,8 +142,8 @@ public class SparqlBuilderTest {
 				.select(title, price)
 				.where(x.has(dc.iri("title"), title),
 						pricePattern);
-		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("FILTER ( ?price < 50 )"));
-		Assert.assertThat(query.getQueryString(), CoreMatchers.containsString("FILTER ( ?price > 30 )"));
+		assertThat(query.getQueryString(), CoreMatchers.containsString("FILTER ( ?price < 50 )"));
+		assertThat(query.getQueryString(), CoreMatchers.containsString("FILTER ( ?price > 30 )"));
 	}
 
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQueryTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQueryTest.java
@@ -12,7 +12,7 @@ package org.eclipse.rdf4j.sparqlbuilder.core.query;
 
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ModifyQueryTest extends BaseExamples {
 

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/QueryWithPrefixesTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/QueryWithPrefixesTest.java
@@ -15,14 +15,14 @@ import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.lt;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.strlen;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class QueryWithPrefixesTest extends BaseExamples {
 	@Test
@@ -32,7 +32,7 @@ public class QueryWithPrefixesTest extends BaseExamples {
 				.SELECT(name)
 				.prefix(FOAF.NS)
 				.where(x.has(FOAF.NAME, name));
-		Assert.assertEquals(
+		assertEquals(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name\n"
 						+ "WHERE { ?x foaf:name ?name . }\n",
@@ -47,7 +47,7 @@ public class QueryWithPrefixesTest extends BaseExamples {
 				.prefix(FOAF.NS)
 				.prefix(XSD.NS)
 				.where(x.has(FOAF.NAME, name).filter(Expressions.equals(datatype(name), iri(XSD.STRING))));
-		Assert.assertEquals(
+		assertEquals(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
 						+ "SELECT ?name\n"
@@ -63,7 +63,7 @@ public class QueryWithPrefixesTest extends BaseExamples {
 				.INSERT(x.has(FOAF.NAME, name))
 				.prefix(FOAF.NS)
 				.where(x.has(FOAF.SURNAME, name));
-		Assert.assertEquals(
+		assertEquals(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "INSERT { ?x foaf:name ?name . }\n"
 						+ "WHERE { ?x foaf:surname ?name . }",
@@ -78,7 +78,7 @@ public class QueryWithPrefixesTest extends BaseExamples {
 				.prefix(FOAF.NS)
 				.prefix(XSD.NS)
 				.where(x.has(FOAF.SURNAME, name).filter(Expressions.equals(datatype(name), iri(XSD.STRING))));
-		Assert.assertEquals(
+		assertEquals(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
 						+ "INSERT { ?x foaf:name ?name . }\n"
@@ -94,7 +94,7 @@ public class QueryWithPrefixesTest extends BaseExamples {
 				.SELECT(name)
 				.prefix(FOAF.NS)
 				.where(x.has(p -> p.pred(FOAF.ACCOUNT).then(FOAF.MBOX).build(), name));
-		Assert.assertEquals(
+		assertEquals(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name\n"
 						+ "WHERE { ?x foaf:account / foaf:mbox ?name . }\n",
@@ -109,7 +109,7 @@ public class QueryWithPrefixesTest extends BaseExamples {
 				.prefix(FOAF.NS)
 				.where(x.has(FOAF.NAME, name)
 						.filter(lt(strlen(name), 10)));
-		Assert.assertEquals(
+		assertEquals(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name\n"
 						+ "WHERE { ?x foaf:name ?name .\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/BaseExamples.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/BaseExamples.java
@@ -20,9 +20,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * The classes inheriting from this pose as examples on how to use SparqlBuilder. They follow the SPARQL 1.1 Spec and
@@ -51,10 +49,7 @@ public class BaseExamples {
 
 	protected SelectQuery query;
 
-	@Rule
-	public TestName testName = new TestName();
-
-	@Before
+	@BeforeEach
 	public void before() {
 		resetQuery();
 	}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section11Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section11Test.java
@@ -12,6 +12,7 @@
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
@@ -23,8 +24,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section11Test extends BaseExamples {
 	@Test
@@ -43,7 +43,7 @@ public class Section11Test extends BaseExamples {
 						book.has(base.iri("price"), lprice))
 				.groupBy(org)
 				.having(Expressions.gt(sum, 10));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://books.example/>\n"
 						+ "SELECT (SUM(?lprice) AS ?totalPrice)\n"
 						+ "WHERE {\n"
@@ -76,7 +76,7 @@ public class Section11Test extends BaseExamples {
 				.where(org.has(affiliates, auth), auth.has(writesBook, book), book.has(price, lprice))
 				.groupBy(org)
 				.having(Expressions.gt(sum, 10));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://books.example/>\n"
 						+ "SELECT (SUM(?lprice) AS ?totalPrice)\n"
 						+ "WHERE {\n"
@@ -97,7 +97,7 @@ public class Section11Test extends BaseExamples {
 		query.select(SparqlBuilder.as(Expressions.avg(y), avg))
 				.where(a.has(base.iri("x"), x).andHas(base.iri("y"), y))
 				.groupBy(x);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT (AVG(?y) AS ?avg)\n"
 						+ "WHERE {\n"
 						+ "  ?a :x ?x ;\n"
@@ -117,7 +117,7 @@ public class Section11Test extends BaseExamples {
 				.where(x.has(base.iri("size"), size))
 				.groupBy(x)
 				.having(Expressions.gt(avgSize, 10));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://data.example/>\n"
 						+ "SELECT (AVG(?size) AS ?asize)\n"
 						+ "WHERE {\n"
@@ -138,7 +138,7 @@ public class Section11Test extends BaseExamples {
 				.select(x, twiceMin.as(min))
 				.where(x.has(base.iri("p"), y), x.has(base.iri("q"), z))
 				.groupBy(x, Expressions.str(z));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example.com/data/#>\n"
 						+ "SELECT ?x ((MIN(?y) * 2) AS ?min)\n"
 						+ "WHERE {\n"
@@ -159,7 +159,7 @@ public class Section11Test extends BaseExamples {
 				.select(g, Expressions.avg(p).as(avg), midRange.as(c))
 				.where(g.has(base.iri("p"), p))
 				.groupBy(g);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example.com/data/#>\n"
 						+ "SELECT ?g (AVG(?p) AS ?avg) (((MIN(?p) + MAX(?p)) / 2) AS ?c)\n"
 						+ "WHERE {\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section12Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section12Test.java
@@ -12,6 +12,7 @@
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -20,8 +21,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.SubSelect;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section12Test extends BaseExamples {
 	@Test
@@ -38,7 +38,7 @@ public class Section12Test extends BaseExamples {
 		query.prefix(base, base) // SparqlBuilder even fixes typos for you ;)
 				.select(y, minName)
 				.where(base.iri("alice").has(base.iri("knows"), y), sub);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://people.example/>\n"
 						+ "SELECT ?y ?minName\n"
 						+ "WHERE {\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section13Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section13Test.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.Dataset;
 import org.eclipse.rdf4j.sparqlbuilder.core.From;
@@ -22,8 +23,7 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section13Test extends BaseExamples {
 	@Test
@@ -33,7 +33,7 @@ public class Section13Test extends BaseExamples {
 		Variable x = var("x");
 		From defaultGraph = SparqlBuilder.from(iri("http://example.org/foaf/aliceFoaf"));
 		query.prefix(foaf).select(name).from(defaultGraph).where(x.has(foaf.iri("name"), name));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT  ?name\n"
 						+ "FROM    <http://example.org/foaf/aliceFoaf>\n"
@@ -44,7 +44,7 @@ public class Section13Test extends BaseExamples {
 	public void example_13_2_2() {
 		Dataset dataset = SparqlBuilder.dataset(SparqlBuilder.fromNamed(iri("http://example.org/alice")),
 				SparqlBuilder.fromNamed(iri("http://example.org/bob")));
-		Assert.assertThat(dataset.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(""
+		assertThat(dataset.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(""
 				+ "FROM NAMED <http://example.org/alice>\n"
 				+ "FROM NAMED <http://example.org/bob>"));
 	}
@@ -65,7 +65,7 @@ public class Section13Test extends BaseExamples {
 				.select(who, g, mbox)
 				.from(defaultGraph, aliceGraph, bobGraph)
 				.where(g.has(dc.iri("publisher"), who), namedGraph);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX dc: <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"
@@ -94,7 +94,7 @@ public class Section13Test extends BaseExamples {
 						.and(x.has(foaf.iri("mbox"), iri("mailto:bob@work.example")),
 								x.has(foaf.iri("nick"), bobNick))
 						.from(src));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "SELECT ?src ?bobNick\n"
@@ -122,7 +122,7 @@ public class Section13Test extends BaseExamples {
 						.and(x.has(foaf.iri("mbox"), iri("mailto:bob@work.example")),
 								x.has(foaf.iri("nick"), nick))
 						.from(data.iri("bobFoaf")));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX data: <http://example.org/foaf/>\n"
 						+ "\n"
@@ -161,7 +161,7 @@ public class Section13Test extends BaseExamples {
 				.from(SparqlBuilder.fromNamed(iri("http://example.org/foaf/aliceFoaf")),
 						SparqlBuilder.fromNamed(iri("http://example.org/foaf/bobFoaf")))
 				.where(aliceFoafGraph, ppdGraph);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  data:  <http://example.org/foaf/>\n"
 						+ "PREFIX  foaf:  <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX  rdfs:  <http://www.w3.org/2000/01/rdf-schema#>\n"
@@ -201,7 +201,7 @@ public class Section13Test extends BaseExamples {
 				.where(g.has(dc.iri("publisher"), name).andHas(dc.iri("date"), date),
 						GraphPatterns.and(person.has(foaf.iri("name"), name)
 								.andHas(foaf.iri("mbox"), mbox)).from(g));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX dc:   <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section15Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section15Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.OrderBy;
 import org.eclipse.rdf4j.sparqlbuilder.core.OrderCondition;
@@ -22,8 +23,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section15Test extends BaseExamples {
 	@Test
@@ -33,7 +33,7 @@ public class Section15Test extends BaseExamples {
 
 		TriplePattern employeePattern = x.has(foaf.iri("name"), name);
 		query.prefix(foaf).select(name).where(employeePattern).orderBy(name);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "SELECT ?name\n"
@@ -59,7 +59,7 @@ public class Section15Test extends BaseExamples {
 		// than Orderable instances) replaces (rather than augments)
 		// the query's order conditions
 		query.orderBy(SparqlBuilder.orderBy(empDesc));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX     :    <http://example.org/ns#>\n"
 						+ "PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
@@ -70,7 +70,7 @@ public class Section15Test extends BaseExamples {
 
 		OrderBy order = SparqlBuilder.orderBy(name, empDesc);
 		query.orderBy(order);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX     :    <http://example.org/ns#>\n"
 						+ "PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
@@ -86,7 +86,7 @@ public class Section15Test extends BaseExamples {
 		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).distinct().where(x.has(foaf.iri("name"), name));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT DISTINCT ?name WHERE { ?x foaf:name ?name .}"
 		));
@@ -103,7 +103,7 @@ public class Section15Test extends BaseExamples {
 		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).where(x.has(foaf.iri("name"), name)).orderBy(name).limit(5).offset(10);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "SELECT  ?name\n"
@@ -120,7 +120,7 @@ public class Section15Test extends BaseExamples {
 		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).where(x.has(foaf.iri("name"), name)).limit(20);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "SELECT ?name\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section16Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section16Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -36,8 +37,7 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section16Test extends BaseExamples {
 	@Test
@@ -57,7 +57,7 @@ public class Section16Test extends BaseExamples {
 		query.prefix(dc, ns)
 				.select(title, discountedPrice)
 				.where(x.has(ns.iri("price"), p), x.has(dc.iri("title"), title), x.has(ns.iri("discount"), discount));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX  ns:  <https://example.org/ns#>\n"
 						+ "SELECT  ?title ((?p*(1-?discount)) AS ?price) WHERE\n"
@@ -75,7 +75,7 @@ public class Section16Test extends BaseExamples {
 		// (rather than Projectable instances) replaces (rather than augments)
 		// the query's projections
 		query.select(newProjection);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX  ns:  <https://example.org/ns#>\n"
 						+ "SELECT  ?title (?p AS ?fullPrice) ((?fullPrice*(1-?discount)) AS ?customerPrice) WHERE\n"
@@ -92,7 +92,7 @@ public class Section16Test extends BaseExamples {
 				vcard = SparqlBuilder.prefix("vcard", iri("http://www.w3.org/2001/vcard-rdf/3.0#"));
 		Iri aliceIri = Rdf.iri("http://example.org/person#", "Alice");
 		Variable name = var("name"), x = var("x");
-		Assert.assertThat(Queries.CONSTRUCT(aliceIri.has(vcard.iri("FN"), name))
+		assertThat(Queries.CONSTRUCT(aliceIri.has(vcard.iri("FN"), name))
 				.where(x.has(foaf.iri("name"), name))
 				.prefix(foaf, vcard)
 				.getQueryString(),
@@ -120,7 +120,7 @@ public class Section16Test extends BaseExamples {
 				.where(x.has(foaf.iri("firstName"), gname).union(x.has(foaf.iri("givenname"), gname)),
 						x.has(foaf.iri("surname"), fname).union(x.has(foaf.iri("family_name"), fname)));
 
-		Assert.assertThat(cQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(cQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX vcard:   <http://www.w3.org/2001/vcard-rdf/3.0#>\n"
 						+ "\n"
@@ -153,7 +153,7 @@ public class Section16Test extends BaseExamples {
 
 		ConstructQuery query = Queries.CONSTRUCT(s.has(p, o)).where(where).prefix(dc, app, xsd);
 
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc: <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX app: <http://example.org/ns#>\n"
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
@@ -180,7 +180,7 @@ public class Section16Test extends BaseExamples {
 				.where(subject.has(foaf.iri("name"), name).andHas(site.iri("hits"), hits))
 				.orderBy(hits.desc())
 				.limit(2);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX site: <http://example.org/stats#>\n"
 						+ "\n"
@@ -202,7 +202,7 @@ public class Section16Test extends BaseExamples {
 		ConstructQuery query = Queries.CONSTRUCT(x.has(foaf.iri("name"), name))
 				.where(x.has(foaf.iri("name"), name))
 				.prefix(foaf);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "CONSTRUCT { ?x foaf:name ?name .} \n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section17Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section17Test.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -18,8 +20,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section17Test extends BaseExamples {
 	@Test
@@ -28,7 +29,7 @@ public class Section17Test extends BaseExamples {
 		Variable attributeIRI = SparqlBuilder.var("attribute_iri");
 		Iri type = rdf.iri("type");
 		Expression in = Expressions.in(attributeIRI, type);
-		Assert.assertThat(in.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(in.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"?attribute_iri IN ( rdf:type )"
 		));
 	}
@@ -39,7 +40,7 @@ public class Section17Test extends BaseExamples {
 		Variable attributeIRI = SparqlBuilder.var("attribute_iri");
 		Iri type = rdf.iri("type");
 		Expression notIn = Expressions.notIn(attributeIRI, type);
-		Assert.assertThat(notIn.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(notIn.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"?attribute_iri NOT IN ( rdf:type )"
 		));
 	}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section2Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section2Test.java
@@ -12,6 +12,7 @@
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -30,8 +31,7 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section2Test extends BaseExamples {
 	@Test
@@ -42,7 +42,7 @@ public class Section2Test extends BaseExamples {
 				title);
 
 		query.select(title).where(book1_has_title);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?title\n"
 						+ "WHERE\n"
 						+ "{\n"
@@ -61,7 +61,7 @@ public class Section2Test extends BaseExamples {
 
 		query.select(title).where(book1_has_title);
 
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?title\n"
 						+ "WHERE\n"
 						+ "{\n"
@@ -84,7 +84,7 @@ public class Section2Test extends BaseExamples {
 
 		query.prefix(foaf).select(name, mbox).where(x_hasFoafName_name, x_hasFoafMbox_mbox);
 
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE\n"
@@ -107,7 +107,7 @@ public class Section2Test extends BaseExamples {
 
 		query.prefix(foaf).select(name, mbox).where(x_hasFoafName_name, x_hasFoafMbox_mbox);
 
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE\n"
@@ -123,13 +123,13 @@ public class Section2Test extends BaseExamples {
 		TriplePattern v_hasP_cat = GraphPatterns.tp(v, p, Rdf.literalOf("cat"));
 
 		query.select(v).where(v_hasP_cat);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p \"cat\" .}"
 		));
 
 		TriplePattern v_hasP_cat_en = GraphPatterns.tp(v, p, Rdf.literalOfLanguage("cat", "en"));
 		SelectQuery queryWithLangTag = Queries.SELECT(v).where(v_hasP_cat_en);
-		Assert.assertThat(queryWithLangTag.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(queryWithLangTag.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p \"cat\"@en . }"
 		));
 	}
@@ -141,7 +141,7 @@ public class Section2Test extends BaseExamples {
 		TriplePattern v_hasP_42 = GraphPatterns.tp(v, p, Rdf.literalOf(42));
 
 		query.select(v).where(v_hasP_42);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p 42 . }"
 		));
 	}
@@ -154,7 +154,7 @@ public class Section2Test extends BaseExamples {
 				Rdf.literalOfType("abc", Rdf.iri(EXAMPLE_DATATYPE_NS, datatype)));
 
 		query.select(v).where(v_hasP_abc_dt);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p \"abc\"^^<http://example.org/datatype#specialDatatype> .}"
 		));
 	}
@@ -169,7 +169,7 @@ public class Section2Test extends BaseExamples {
 		TriplePattern v_hasP_abc_dt = GraphPatterns.tp(v, p, lit);
 
 		query.select(v).where(v_hasP_abc_dt);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p \"abc\"^^<http://example.org/datatype#specialDatatype> .}"
 		));
 
@@ -181,7 +181,7 @@ public class Section2Test extends BaseExamples {
 
 		Variable x = var("x"), name = var("name");
 		query.prefix(foaf).select(x, name).where(x.has(foaf.iri("name"), name));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?x ?name\n"
 						+ "WHERE  { ?x foaf:name ?name . }"
@@ -199,7 +199,7 @@ public class Section2Test extends BaseExamples {
 		query.prefix(foaf)
 				.select(concatAsName)
 				.where(GraphPatterns.tp(P, foaf.iri("givenName"), G).andHas(foaf.iri("surname"), S));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ( CONCAT(?G, \" \", ?S) AS ?name )\n"
 						+ "WHERE  { ?P foaf:givenName ?G ; foaf:surname ?S .}"
@@ -213,7 +213,7 @@ public class Section2Test extends BaseExamples {
 								.andHas(foaf.iri("surname"), S),
 						Expressions.bind(Expressions.concat(G, Rdf.literalOf(" "), S), name));
 
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name\n"
 						+ "WHERE  { \n"
@@ -237,7 +237,7 @@ public class Section2Test extends BaseExamples {
 		TriplePattern orgName = GraphPatterns.tp(x, org.iri("employeeName"), name);
 
 		graphQuery.prefix(prefixes).construct(foafName).where(orgName);
-		Assert.assertThat(graphQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(graphQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX org:    <https://example.com/ns#>\n"
 						+ "\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section3Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -25,8 +26,7 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section3Test extends BaseExamples {
 	@Test
@@ -40,7 +40,7 @@ public class Section3Test extends BaseExamples {
 		GraphPattern where = xTitle.filter(regex);
 
 		query.prefix(dc).select(title).where(where);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "SELECT  ?title\n"
 						+ "WHERE   { ?x dc:title ?title .\n"
@@ -49,7 +49,7 @@ public class Section3Test extends BaseExamples {
 		));
 		query = Queries.SELECT();
 		query.prefix(dc).select(title).where(xTitle.filter(Expressions.regex(title, "web", "i")));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "SELECT  ?title\n"
 						+ "WHERE   { ?x dc:title ?title .\n"
@@ -71,7 +71,7 @@ public class Section3Test extends BaseExamples {
 		query.prefix(dc, ns).select(title, price).where(where);
 		// NOTE: had to move FILTER to the end of the group graph pattern (in the original, it's between the two triple
 		// patterns).
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX  ns:  <https://example.com/ns#>\n"
 						+ "SELECT  ?title ?price\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section4Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section4Test.java
@@ -12,6 +12,7 @@
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
@@ -25,8 +26,7 @@ import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode.PropertiesBlankNode;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfPredicate;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section4Test extends BaseExamples {
 	Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
@@ -38,30 +38,30 @@ public class Section4Test extends BaseExamples {
 
 		// [ :p "v" ] .
 		PropertiesBlankNode bnode = Rdf.bNode(defPrefix.iri("p"), Rdf.literalOf("v"));
-		Assert.assertThat(bnode.toTp().getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\"] ."));
+		assertThat(bnode.toTp().getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\"] ."));
 
 		// [] :p "v" .
 		TriplePattern tp = Rdf.bNode().has(defPrefix.iri("p"), Rdf.literalOf("v"));
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[] :p \"v\" ."));
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[] :p \"v\" ."));
 
 		// [ :p "v" ] :q "w" .
 		tp = bnode.has(defPrefix.iri("q"), Rdf.literalOf("w"));
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\" ] :q \"w\" ."));
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\" ] :q \"w\" ."));
 
 		// :x :q [ :p "v" ] .
 		tp = defPrefix.iri("x").has(defPrefix.iri("q"), bnode);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(":x :q [ :p \"v\" ] ."));
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(":x :q [ :p \"v\" ] ."));
 
 		RdfBlankNode labelledNode = Rdf.bNode("b57");
 		tp = defPrefix.iri("x").has(defPrefix.iri("q"), labelledNode);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(":x :q _:b57 ."));
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(":x :q _:b57 ."));
 		tp = labelledNode.has(defPrefix.iri("p"), "v");
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("_:b57 :p \"v\". "));
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("_:b57 :p \"v\". "));
 
 		// [ foaf:name ?name ;
 		// foaf:mbox <mailto:alice@example.org> ]
 		bnode = Rdf.bNode(foaf.iri("name"), name).andHas(foaf.iri("mbox"), iri("mailto:alice@example.org"));
-		Assert.assertThat(bnode.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(bnode.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"[ foaf:name ?name ;"
 						+ "foaf:mbox <mailto:alice@example.org> ]"
 		));
@@ -72,7 +72,7 @@ public class Section4Test extends BaseExamples {
 		Variable mbox = SparqlBuilder.var("mbox");
 
 		TriplePattern tp = GraphPatterns.tp(x, foaf.iri("name"), name).andHas(foaf.iri("mbox"), mbox);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"    ?x  foaf:name  ?name ;\n"
 						+ "        foaf:mbox  ?mbox ."
 		));
@@ -86,12 +86,12 @@ public class Section4Test extends BaseExamples {
 		StringLiteral aliceNick = Rdf.literalOf("Alice"), alice_Nick = Rdf.literalOf("Alice_");
 
 		TriplePattern tp = GraphPatterns.tp(x, nick, aliceNick, alice_Nick);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"?x foaf:nick  \"Alice\" , \"Alice_\" ."
 		));
 
 		tp = x.has(foaf.iri("name"), name).andHas(nick, aliceNick, alice_Nick);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"?x  foaf:name ?name ; foaf:nick  \"Alice\" , \"Alice_\" ."
 		));
 	}
@@ -102,11 +102,11 @@ public class Section4Test extends BaseExamples {
 
 		// isA() is a shortcut method to create triples using the "a" keyword
 		TriplePattern tp = SparqlBuilder.var("x").isA(defPrefix.iri("Class1"));
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("?x  a  :Class1 ."));
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("?x  a  :Class1 ."));
 
 		// the isA predicate is a static member of RdfPredicate
 		tp = Rdf.bNode(RdfPredicate.a, defPrefix.iri("appClass")).has(defPrefix.iri("p"), "v");
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"  [ a :appClass ] :p \"v\" ."
 		));
 	}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section5Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section5Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -21,8 +22,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section5Test extends BaseExamples {
 	@Test
@@ -31,7 +31,7 @@ public class Section5Test extends BaseExamples {
 		Variable name = var("name"), mbox = var("mbox");
 		Variable x = var("x");
 		query.prefix(foaf).select(name, mbox).where(x.has(foaf.iri("name"), name), x.has(foaf.iri("mbox"), mbox));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE  {\n"
@@ -43,7 +43,7 @@ public class Section5Test extends BaseExamples {
 		GraphPattern mboxPattern = and(x.has(foaf.iri("mbox"), mbox));
 		QueryPattern where = SparqlBuilder.where(and(namePattern, mboxPattern));
 		query.where(where);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE  { { ?x foaf:name ?name . }\n"
@@ -56,7 +56,7 @@ public class Section5Test extends BaseExamples {
 	public void example_5_2_1() {
 		Variable x = var("x");
 		query.select(x);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?x\n"
 						+ "WHERE {}"));
 	}
@@ -65,7 +65,7 @@ public class Section5Test extends BaseExamples {
 	public void example_5_2_3() {
 		Prefix foaf = SparqlBuilder.prefix("foaf", iri(FOAF_NS));
 		Variable x = var("x"), name = var("name"), mbox = var("mbox");
-		Assert.assertThat(
+		assertThat(
 				x.has(foaf.iri("name"), name)
 						.and(x.has(foaf.iri("mbox"), mbox))
 						.and()

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section6Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section6Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -22,8 +23,7 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatternNotTriples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section6Test extends BaseExamples {
 	@Test
@@ -36,7 +36,7 @@ public class Section6Test extends BaseExamples {
 				GraphPatterns.optional(x.has(foaf.iri("mbox"), mbox)));
 
 		query.prefix(foaf).select(name, mbox).where(where);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE  { ?x foaf:name  ?name .\n"
@@ -55,7 +55,7 @@ public class Section6Test extends BaseExamples {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX  ns:  <https://example.org/ns#>\n"
 						+ "SELECT  ?title ?price\n"
@@ -77,7 +77,7 @@ public class Section6Test extends BaseExamples {
 				.select(name, mbox, hpage)
 				.where(namePattern, GraphPatterns.and(x.has(foaf.iri("mbox"), mbox)).optional(),
 						GraphPatterns.and(x.has(foaf.iri("homepage"), hpage)).optional());
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox ?hpage\n"
 						+ "WHERE  { ?x foaf:name  ?name .\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section7Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section7Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
@@ -21,8 +22,7 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section7Test extends BaseExamples {
 	@Test
@@ -37,7 +37,7 @@ public class Section7Test extends BaseExamples {
 		GraphPattern titlePattern = GraphPatterns.union(book.has(dc10TitleIri, title), book.has(dc11TitleIri, title));
 
 		query.prefix(dc10).prefix(dc11).select(title).where(titlePattern);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
 						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"
@@ -49,7 +49,7 @@ public class Section7Test extends BaseExamples {
 		Variable x = var("x"), y = var("y"), author = var("author");
 		GraphPattern dc10Title = book.has(dc10TitleIri, x), dc11Title = book.has(dc11TitleIri, y);
 		query.prefix(dc10, dc11).select(x, y).where(GraphPatterns.union(dc10Title, dc11Title));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
 						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"
@@ -65,7 +65,7 @@ public class Section7Test extends BaseExamples {
 		query.prefix(dc10, dc11)
 				.select(title, author)
 				.where(GraphPatterns.and(dc10Title, dc10Author).union(GraphPatterns.and(dc11Title, dc11Author)));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
 						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section8Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section8Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -26,8 +27,7 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatternNotTriples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section8Test extends BaseExamples {
 	@Test
@@ -40,7 +40,7 @@ public class Section8Test extends BaseExamples {
 		GraphPattern personWithName = person.has(foaf.iri("name"), var("name"));
 		GraphPatternNotTriples personOfTypePerson = GraphPatterns.and(person.has(rdf.iri("type"), foaf.iri("Person")));
 		query.prefix(rdf, foaf).select(person).where(personOfTypePerson.filterNotExists(personWithName));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n"
 						+ "PREFIX  foaf:   <http://xmlns.com/foaf/0.1/> \n"
 						+ "\n"
@@ -63,7 +63,7 @@ public class Section8Test extends BaseExamples {
 		GraphPattern personWithName = person.has(foaf.iri("name"), var("name"));
 		GraphPatternNotTriples personOfTypePerson = GraphPatterns.and(person.has(rdf.iri("type"), foaf.iri("Person")));
 		query.prefix(rdf, foaf).select(person).where(personOfTypePerson.filterExists(personWithName));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n"
 						+ "PREFIX  foaf:   <http://xmlns.com/foaf/0.1/> \n"
 						+ "\n"
@@ -87,7 +87,7 @@ public class Section8Test extends BaseExamples {
 		GraphPattern allNotNamedBob = GraphPatterns.and(s.has(p, o))
 				.minus(s.has(foaf.iri("givenName"), Rdf.literalOf("Bob")));
 		query.prefix(base, foaf).select(s).distinct().where(allNotNamedBob);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX :       <http://example/>\n"
 						+ "PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
@@ -108,7 +108,7 @@ public class Section8Test extends BaseExamples {
 		Iri a = base.iri("a"), b = base.iri("b"), c = base.iri("c");
 
 		query.prefix(base).all().where(GraphPatterns.and(s.has(p, o)).filterNotExists(GraphPatterns.tp(a, b, c)));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example/>\n"
 						+ "SELECT * WHERE \n"
 						+ "{ \n"
@@ -123,7 +123,7 @@ public class Section8Test extends BaseExamples {
 		// pattern(s)) replaces (rather than augments) the query's
 		// query pattern. This allows reuse of the other elements of the query.
 		query.where(where);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example/>\n"
 						+ "SELECT * WHERE \n"
 						+ "{ \n"
@@ -143,7 +143,7 @@ public class Section8Test extends BaseExamples {
 				.filterNotExists(GraphPatterns.and(x.has(base.iri("q"), m)).filter(filter));
 
 		query.prefix(base).select().all().where(notExistsFilter);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example.com/>\n"
 						+ "SELECT * WHERE {\n"
 						+ "        ?x :p ?n . \n"
@@ -157,7 +157,7 @@ public class Section8Test extends BaseExamples {
 		QueryPattern where = SparqlBuilder.where(GraphPatterns.and(x.has(base.iri("p"), n))
 				.minus(GraphPatterns.and(x.has(base.iri("q"), m)).filter(filter)));
 		query.where(where);
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example.com/>\n"
 						+ "SELECT * WHERE {\n"
 						+ "        ?x :p ?n . \n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section9Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section9Test.java
@@ -15,6 +15,7 @@ import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.notEquals;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
@@ -29,8 +30,7 @@ import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Section9Test extends BaseExamples {
 	private final Prefix rdfs = SparqlBuilder.prefix("rdfs", iri(RDFS.NS.getName()));
@@ -65,7 +65,7 @@ public class Section9Test extends BaseExamples {
 				.pred(dc.iri("title"))
 				.or(rdfs.iri("label")), displayString);
 		// NOTE: changed example: removed curly braces around, added brackets in path, added dot at end
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				":book1 ( dc:title | rdfs:label ) ?displayString ."
 		));
 	}
@@ -74,7 +74,7 @@ public class Section9Test extends BaseExamples {
 	public void example_9_2__2_alt_noprefix() {
 		TriplePattern tp = book1.has(path -> path.pred(DC.TITLE).or(RDFS.LABEL), displayString);
 		// NOTE: changed example: removed curly braces around, added brackets in path, added dot at end
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				":book1 ( <http://purl.org/dc/elements/1.1/title> | <http://www.w3.org/2000/01/rdf-schema#label> ) ?displayString ."
 		));
 	}
@@ -85,7 +85,7 @@ public class Section9Test extends BaseExamples {
 				.and(x.has(path -> path
 						.pred(foaf.iri("knows"))
 						.then(foaf.iri("name")), name));
-		Assert.assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"{\n"
 						+ "    ?x foaf:mbox <mailto:alice@example> .\n"
 						+ "    ?x foaf:knows / foaf:name ?name .\n"
@@ -101,7 +101,7 @@ public class Section9Test extends BaseExamples {
 						.pred(foaf.iri("knows"))
 						.then(foaf.iri("knows"))
 						.then(foaf.iri("name")), name));
-		Assert.assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"{\n"
 						+ "    ?x foaf:mbox <mailto:alice@example> .\n"
 						+ "    ?x foaf:knows / foaf:knows / foaf:name ?name .\n"
@@ -119,7 +119,7 @@ public class Section9Test extends BaseExamples {
 				.filter(notEquals(x, y))
 				.and(y.has(foaf.iri("name"), name));
 		// NOTE: changed example: moved FILTER to end of graph pattern, added dot
-		Assert.assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"  { ?x foaf:mbox <mailto:alice@example> .\n"
 						+ "    ?x foaf:knows / foaf:knows ?y .\n"
 						+ "    ?y foaf:name ?name .\n"
@@ -132,7 +132,7 @@ public class Section9Test extends BaseExamples {
 	public void example_9_2__6_inverse() {
 		TriplePattern tp = mailto.has(path -> path.pred(foaf.iri("mbox")).inv(), x);
 		// NOTE: changed example: removed curly braces, added dot, added brackets in path
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				" <mailto:alice@example> ^ ( foaf:mbox ) ?x ."
 		));
 	}
@@ -146,7 +146,7 @@ public class Section9Test extends BaseExamples {
 				y)
 				.filter(notEquals(x, y));
 		// NOTE: changed example: added brackets in path
-		Assert.assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"{\n"
 						+ "    ?x foaf:knows/^ ( foaf:knows ) ?y .  \n"
 						+ "    FILTER(?x != ?y)\n"
@@ -163,7 +163,7 @@ public class Section9Test extends BaseExamples {
 						.then(foaf.iri("name")), name
 				));
 		// NOTE: changed example: added brackets in path
-		Assert.assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"  {\n"
 						+ "    ?x foaf:mbox <mailto:alice@example> .\n"
 						+ "    ?x foaf:knows+/foaf:name ?name .\n"
@@ -178,7 +178,7 @@ public class Section9Test extends BaseExamples {
 				.or(ex.iri("fatherOf"))
 				.oneOrMore(), me);
 		// NOTE: changed example: remove curly braces, added dot
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"?ancestor (ex:motherOf|ex:fatherOf)+ <#me> ."
 		));
 	}
@@ -191,7 +191,7 @@ public class Section9Test extends BaseExamples {
 				.then(s -> s.pred(rdfs.iri("subClassOf"))
 						.zeroOrMore()),
 				type);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"<http://example/thing> rdf:type / rdfs:subClassOf * ?type ."
 		));
 	}
@@ -204,7 +204,7 @@ public class Section9Test extends BaseExamples {
 				.then(s -> s.pred(rdfs.iri("subClassOf"))
 						.zeroOrMore()),
 				type);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"?x rdf:type / rdfs:subClassOf * ?type ."
 		));
 	}
@@ -217,7 +217,7 @@ public class Section9Test extends BaseExamples {
 						.pred(rdfs.iri("subPropertyOf"))
 						.zeroOrMore(),
 						property));
-		Assert.assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"{ ?x ?p ?v . ?p rdfs:subPropertyOf* :property . }"
 		));
 	}
@@ -228,7 +228,7 @@ public class Section9Test extends BaseExamples {
 				.negProp()
 				.pred(rdf.iri("type"))
 				.invPred(rdf.iri("type")), y);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				" ?x !(rdf:type|^rdf:type) ?y ."
 		));
 	}
@@ -240,7 +240,7 @@ public class Section9Test extends BaseExamples {
 				.pred(rdf.iri("rest"))
 				.zeroOrMore()
 				.then(rdf.iri("first")), element);
-		Assert.assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				":list rdf:rest*/rdf:first ?element ."
 		));
 	}
@@ -254,7 +254,7 @@ public class Section9Test extends BaseExamples {
 				.where(s.has(p -> p
 						.pred(base.iri("item"))
 						.then(base.iri("price")), x));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX :   <http://example/>\n"
 						+ "SELECT * \n"
 						+ "WHERE {  ?s :item/:price ?x . }"
@@ -270,7 +270,7 @@ public class Section9Test extends BaseExamples {
 				.prefix(base)
 				.where(s.has(base.iri("item"), _a)
 						.and(_a.has(base.iri("price"), x)));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX :   <http://example/>\n"
 						+ "SELECT * \n"
 						+ "WHERE {"
@@ -289,7 +289,7 @@ public class Section9Test extends BaseExamples {
 				.prefix(base)
 				.where(s.has(base.iri("item"), _a)
 						.and(_a.has(base.iri("price"), x)));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX :   <http://example/>\n"
 						+ "SELECT * \n"
 						+ "WHERE {"
@@ -307,7 +307,7 @@ public class Section9Test extends BaseExamples {
 				.where(order.has(p -> p
 						.pred(base.iri("item"))
 						.then(base.iri("price")), x));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				" PREFIX :   <http://example/>\n"
 						+ "  SELECT (sum(?x) AS ?total)\n"
 						+ "  WHERE { \n"
@@ -327,7 +327,7 @@ public class Section9Test extends BaseExamples {
 						.then(RDFS.SUBCLASSOF)
 						.zeroOrMore(),
 						type));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  rdfs:   <http://www.w3.org/2000/01/rdf-schema#> \n"
 						+ "  PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
 						+ "  SELECT ?x ?type\n"
@@ -348,7 +348,7 @@ public class Section9Test extends BaseExamples {
 								.pred(FOAF.KNOWS)
 								.oneOrMore(),
 								person));
-		Assert.assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "  PREFIX :     <http://example/>\n"
 						+ "  SELECT ?person\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sparqlbuilder.examples.updatespec;
 
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -35,8 +36,7 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Follows the SPARQL 1.1 Update Spec starting <a href="https://www.w3.org/TR/sparql11-update/#graphManagement">here</a>
@@ -59,7 +59,7 @@ public class Section3Test extends BaseExamples {
 		insertDataQuery.prefix(dc)
 				.insertData(iri("http://example/book1").has(dc.iri("title"), Rdf.literalOf("A new book"))
 						.andHas(dc.iri("creator"), Rdf.literalOf("A.N.Other")));
-		Assert.assertThat(insertDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "INSERT DATA { "
 						+ "<http://example/book1> dc:title \"A new book\" ;\n"
@@ -80,7 +80,7 @@ public class Section3Test extends BaseExamples {
 				.insertData(iri("http://example/book1").has(ns.iri("price"), Rdf.literalOf(42)))
 				.into(iri("http://example/bookStore"));
 
-		Assert.assertThat(insertDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "PREFIX ns: <https://example.org/ns#> "
 						+ "INSERT DATA { GRAPH "
@@ -101,7 +101,7 @@ public class Section3Test extends BaseExamples {
 		deleteDataQuery.deleteData(iri("http://example/book2").has(dc.iri("title"), Rdf.literalOf("David Copperfield"))
 				.andHas(dc.iri("creator"), Rdf.literalOf("Edmund Wells")));
 
-		Assert.assertThat(deleteDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(deleteDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/>\n"
 						+ "DELETE DATA { "
 						+ "<http://example/book2> dc:title \"David Copperfield\" ; "
@@ -126,7 +126,7 @@ public class Section3Test extends BaseExamples {
 				.prefix(dc)
 				.deleteData(exampleBook.has(title, "Fundamentals of Compiler Desing"))
 				.from(bookStore);
-		Assert.assertThat(deleteTypoQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(deleteTypoQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "DELETE DATA { "
 						+ "GRAPH <http://example/bookStore> {\n"
@@ -137,7 +137,7 @@ public class Section3Test extends BaseExamples {
 				.prefix(dc)
 				.insertData(exampleBook.has(title, "Fundamentals of Compiler Design"))
 				.into(bookStore);
-		Assert.assertThat(insertFixedTitleQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertFixedTitleQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "INSERT DATA { "
 						+ "GRAPH <http://example/bookStore> {\n"
@@ -156,14 +156,14 @@ public class Section3Test extends BaseExamples {
 
 		// WITH <g1> DELETE { a b c } INSERT { x y z } WHERE { ... }
 		modify.with(g1).delete(abc).insert(xyz).where(examplePattern);
-		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"WITH <g1> DELETE { ?a ?b ?c . } INSERT { ?x ?y ?z . } where { ... }"
 		));
 
 		// DELETE { GRAPH <g1> { a b c } } INSERT { GRAPH <g1> { x y z } } USING <g1>
 		// WHERE { ... }
 		modify.with((Iri) null).delete(abc).from(g1).insert(xyz).into(g1).using(g1).where(examplePattern);
-		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"DELETE { GRAPH <g1> {?a ?b ?c . } } "
 						+ "INSERT { GRAPH <g1> { ?x ?y ?z .} } "
 						+ "USING <g1> WHERE { ... }"
@@ -187,7 +187,7 @@ public class Section3Test extends BaseExamples {
 				.insert(person.has(foaf.iri("givenName"), "William"))
 				.where(person.has(foaf.iri("givenName"), "Bill"));
 
-		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "WITH <http://example/addresses> "
 						+ "DELETE { ?person foaf:givenName \"Bill\" .} "
@@ -214,7 +214,7 @@ public class Section3Test extends BaseExamples {
 				.where(GraphPatterns.and(book.has(dc.iri("date"), date), book.has(p, v))
 						.filter(Expressions.gt(date,
 								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
-		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
 						+ "DELETE { ?book ?p ?v . } "
@@ -243,7 +243,7 @@ public class Section3Test extends BaseExamples {
 				.delete(person.has(property, value))
 				.where(person.has(property, value).andHas(foaf.iri("givenName"), "Fred"));
 
-		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "WITH <http://example/addresses> "
 						+ "DELETE { ?person ?property ?value .} "
@@ -272,7 +272,7 @@ public class Section3Test extends BaseExamples {
 				.where(and(book.has(dc.iri("date"), date), book.has(p, v)).from(iri("http://example/bookStore"))
 						.filter(Expressions.gt(date,
 								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
-		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
 						+ "INSERT { "
@@ -306,7 +306,7 @@ public class Section3Test extends BaseExamples {
 				.where(and(personNameTriple, GraphPatterns.optional(personEmailTriple))
 						.from(iri("http://example/people")));
 
-		Assert.assertThat(insertAddressesQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertAddressesQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/> "
 						+ "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
 						+ "INSERT { "
@@ -347,7 +347,7 @@ public class Section3Test extends BaseExamples {
 				.where(and(book.has(dc.iri("date"), date), book.has(p, v)).from(iri("http://example/bookStore"))
 						.filter(Expressions.lt(date,
 								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
-		Assert.assertThat(insertIntobookStore2Query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertIntobookStore2Query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "PREFIX dcmitype: <http://purl.org/dc/dcmitype/> "
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
@@ -372,7 +372,7 @@ public class Section3Test extends BaseExamples {
 						.filter(Expressions.lt(date,
 								Rdf.literalOfType("2000-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
 
-		Assert.assertThat(deleteFromBookStoreQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(deleteFromBookStoreQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"WITH <http://example/bookStore>\n"
 						+ "DELETE { ?book ?p ?v . }\n"
 						+ "WHERE { ?book dc:date ?date ;\n"
@@ -396,7 +396,7 @@ public class Section3Test extends BaseExamples {
 				.prefix(foaf)
 				.delete()
 				.where(person.has(foaf.iri("givenName"), "Fred").andHas(property, value));
-		Assert.assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "DELETE WHERE {"
 						+ " ?person foaf:givenName \"Fred\";"
@@ -424,7 +424,7 @@ public class Section3Test extends BaseExamples {
 				.where(and(person.has(foaf.iri("givenName"), "Fred").andHas(property1, value1)).from(namesGraph),
 						and(person.has(property2, value2)).from(addressesGraph));
 
-		Assert.assertThat(deleteFredFromNamesAndAddressesQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(deleteFredFromNamesAndAddressesQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "DELETE WHERE { "
 						+ "GRAPH <http://example.com/names> { "
@@ -441,11 +441,11 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_load() {
 		LoadQuery load = Queries.LOAD().from(iri(EXAMPLE_ORG_NS));
-		Assert.assertThat(load.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(load.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"LOAD <https://example.org/ns#>"
 		));
 		load = Queries.LOAD().silent().from(iri(EXAMPLE_ORG_NS)).to(iri(EXAMPLE_COM_NS));
-		Assert.assertThat(load.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(load.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"LOAD SILENT <https://example.org/ns#> INTO GRAPH <https://example.com/ns#>"
 		));
 	}
@@ -453,11 +453,11 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_clear() {
 		ClearQuery clear = Queries.CLEAR().def();
-		Assert.assertThat(clear.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(clear.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"CLEAR DEFAULT"
 		));
 		clear = Queries.CLEAR().silent().graph(iri(EXAMPLE_ORG_NS));
-		Assert.assertThat(clear.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(clear.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"CLEAR SILENT GRAPH <https://example.org/ns#>"
 		));
 	}
@@ -465,11 +465,11 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_create() {
 		CreateQuery create = Queries.CREATE().graph(iri(EXAMPLE_ORG_NS));
-		Assert.assertThat(create.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(create.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"CREATE GRAPH <https://example.org/ns#>"
 		));
 		create = Queries.CREATE().silent().graph(iri(EXAMPLE_ORG_NS));
-		Assert.assertThat(create.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(create.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"CREATE SILENT GRAPH <https://example.org/ns#>"
 		));
 	}
@@ -477,11 +477,11 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_drop() {
 		DropQuery drop = Queries.DROP().def();
-		Assert.assertThat(drop.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(drop.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"DROP DEFAULT"
 		));
 		drop = Queries.DROP().silent().graph(iri(EXAMPLE_ORG_NS));
-		Assert.assertThat(drop.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(drop.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"DROP SILENT GRAPH <https://example.org/ns#>"
 		));
 	}
@@ -492,7 +492,7 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_13() {
 		CopyQuery copy = Queries.COPY().fromDefault().to(iri("http://example.org/named"));
-		Assert.assertThat(copy.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(copy.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"COPY DEFAULT TO <http://example.org/named>"
 		));
 	}
@@ -503,7 +503,7 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_14() {
 		MoveQuery move = Queries.MOVE().fromDefault().to(iri("http://example.org/named"));
-		Assert.assertThat(move.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(move.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"MOVE DEFAULT TO <http://example.org/named>"
 		));
 	}
@@ -514,7 +514,7 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_15() {
 		AddQuery add = Queries.ADD().fromDefault().to(iri("http://example.org/named"));
-		Assert.assertThat(add.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(add.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
 				"ADD DEFAULT TO <http://example.org/named>"
 		));
 	}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfLiteralTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigInteger;
 
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfLiteral.StringLiteral;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RdfLiteralTest {
 

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtilsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/SparqlBuilderUtilsTest.java
@@ -12,7 +12,7 @@ package org.eclipse.rdf4j.sparqlbuilder.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SparqlBuilderUtilsTest {
 

--- a/core/spin/pom.xml
+++ b/core/spin/pom.xml
@@ -39,5 +39,11 @@
 			<artifactId>rdf4j-rio-turtle</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- This module uses parameterized tests and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testsuites/benchmark/pom.xml
+++ b/testsuites/benchmark/pom.xml
@@ -86,6 +86,11 @@
 			<artifactId>rdf4j-rio-n3</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 	<profiles>
 		<profile>

--- a/testsuites/lucene/pom.xml
+++ b/testsuites/lucene/pom.xml
@@ -30,5 +30,10 @@
 			<artifactId>rdf4j-spin</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testsuites/pom.xml
+++ b/testsuites/pom.xml
@@ -29,11 +29,6 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>compile</scope>

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTest.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.lang.ref.WeakReference;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;

--- a/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTupleTest.java
+++ b/testsuites/queryresultio/src/main/java/org/eclipse/rdf4j/testsuite/query/resultio/AbstractQueryResultIOTupleTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/testsuites/repository/pom.xml
+++ b/testsuites/repository/pom.xml
@@ -25,5 +25,16 @@
 			<artifactId>rdf4j-sail-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-suite-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<!-- This module uses parameterized tests and complex suite setup, and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/CascadeValueExceptionTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/CascadeValueExceptionTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryLanguage;
@@ -18,20 +18,20 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class CascadeValueExceptionTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -160,7 +160,7 @@ public abstract class CascadeValueExceptionTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repository = createRepository();
 		conn = repository.getConnection();
@@ -178,7 +178,7 @@ public abstract class CascadeValueExceptionTest {
 
 	protected abstract Repository newRepository() throws Exception;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		conn.close();
 		conn = null;

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/GraphQueryResultTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/GraphQueryResultTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,20 +29,20 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class GraphQueryResultTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -63,7 +63,7 @@ public abstract class GraphQueryResultTest {
 
 	private String multipleConstructQuery;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		rep = createRepository();
 		con = rep.getConnection();
@@ -73,7 +73,7 @@ public abstract class GraphQueryResultTest {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			con.close();
@@ -125,58 +125,58 @@ public abstract class GraphQueryResultTest {
 	@Test
 	public void testDescribeEmpty() throws Exception {
 		GraphQueryResult result = con.prepareGraphQuery(QueryLanguage.SPARQL, emptyDescribeQuery).evaluate();
-		assertFalse("Query result should be empty", result.hasNext());
+		assertFalse(result.hasNext(), "Query result should be empty");
 
 		Model model = QueryResults.asModel(result);
-		assertTrue("Query result should be empty", model.isEmpty());
+		assertTrue(model.isEmpty(), "Query result should be empty");
 	}
 
 	@Test
 	public void testDescribeSingle() throws Exception {
 		GraphQueryResult result = con.prepareGraphQuery(QueryLanguage.SPARQL, singleDescribeQuery).evaluate();
-		assertTrue("Query result should not be empty", result.hasNext());
+		assertTrue(result.hasNext(), "Query result should not be empty");
 
 		Model model = QueryResults.asModel(result);
-		assertFalse("Query result should not be empty", model.isEmpty());
+		assertFalse(model.isEmpty(), "Query result should not be empty");
 		assertEquals(1, model.size());
 	}
 
 	@Test
 	public void testDescribeMultiple() throws Exception {
 		GraphQueryResult result = con.prepareGraphQuery(QueryLanguage.SPARQL, multipleDescribeQuery).evaluate();
-		assertTrue("Query result should not be empty", result.hasNext());
+		assertTrue(result.hasNext(), "Query result should not be empty");
 
 		Model model = QueryResults.asModel(result);
-		assertFalse("Query result should not be empty", model.isEmpty());
+		assertFalse(model.isEmpty(), "Query result should not be empty");
 		assertEquals(4, model.size());
 	}
 
 	@Test
 	public void testConstructEmpty() throws Exception {
 		GraphQueryResult result = con.prepareGraphQuery(QueryLanguage.SPARQL, emptyConstructQuery).evaluate();
-		assertFalse("Query result should be empty", result.hasNext());
+		assertFalse(result.hasNext(), "Query result should be empty");
 
 		Model model = QueryResults.asModel(result);
-		assertTrue("Query result should be empty", model.isEmpty());
+		assertTrue(model.isEmpty(), "Query result should be empty");
 	}
 
 	@Test
 	public void testConstructSingle() throws Exception {
 		GraphQueryResult result = con.prepareGraphQuery(QueryLanguage.SPARQL, singleConstructQuery).evaluate();
-		assertTrue("Query result should not be empty", result.hasNext());
+		assertTrue(result.hasNext(), "Query result should not be empty");
 
 		Model model = QueryResults.asModel(result);
-		assertFalse("Query result should not be empty", model.isEmpty());
+		assertFalse(model.isEmpty(), "Query result should not be empty");
 		assertEquals(1, model.size());
 	}
 
 	@Test
 	public void testConstructMultiple() throws Exception {
 		GraphQueryResult result = con.prepareGraphQuery(QueryLanguage.SPARQL, multipleConstructQuery).evaluate();
-		assertTrue("Query result should not be empty", result.hasNext());
+		assertTrue(result.hasNext(), "Query result should not be empty");
 
 		Model model = QueryResults.asModel(result);
-		assertFalse("Query result should not be empty", model.isEmpty());
+		assertFalse(model.isEmpty(), "Query result should not be empty");
 		assertEquals(4, model.size());
 	}
 

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/OptimisticIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/OptimisticIsolationTest.java
@@ -28,8 +28,8 @@ import org.eclipse.rdf4j.testsuite.repository.optimistic.MonotonicTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.RemoveIsolationTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.SerializableTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.SnapshotTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -43,12 +43,12 @@ import org.junit.runners.Suite.SuiteClasses;
 		SerializableTest.class })
 public abstract class OptimisticIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlAggregatesTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlAggregatesTest.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -26,20 +26,20 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class SparqlAggregatesTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -128,7 +128,7 @@ public abstract class SparqlAggregatesTest {
 		result.close();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repository = createRepository();
 		vf = repository.getValueFactory();
@@ -149,7 +149,7 @@ public abstract class SparqlAggregatesTest {
 
 	protected abstract Repository newRepository() throws Exception;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		conn.close();
 		conn = null;

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlDatasetTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlDatasetTest.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -28,20 +28,20 @@ import org.eclipse.rdf4j.query.impl.SimpleDataset;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class SparqlDatasetTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -133,7 +133,7 @@ public abstract class SparqlDatasetTest {
 		result.close();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repository = createRepository();
 		vf = repository.getValueFactory();
@@ -159,7 +159,7 @@ public abstract class SparqlDatasetTest {
 
 	protected abstract Repository newRepository() throws Exception;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		conn.close();
 		conn = null;
@@ -188,7 +188,7 @@ public abstract class SparqlDatasetTest {
 			TupleQuery tupleQuery = con.prepareTupleQuery(QueryLanguage.SPARQL, "SELECT ?s ?p ?o WHERE {?s ?p ?o}");
 			TupleQueryResult res = tupleQuery.evaluate();
 
-			assertTrue("expect a result", res.hasNext());
+			assertTrue(res.hasNext(), "expect a result");
 			long count = 0;
 			while (res.hasNext()) {
 				BindingSet bs = res.next();
@@ -198,7 +198,7 @@ public abstract class SparqlDatasetTest {
 				assertTrue(bs.hasBinding("o"));
 				count++;
 			}
-			assertEquals("expect same number of solutions", count, con.size());
+			assertEquals(count, con.size(), "expect same number of solutions");
 		}
 	}
 }

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlOrderByTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlOrderByTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,20 +28,20 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class SparqlOrderByTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -77,7 +77,7 @@ public abstract class SparqlOrderByTest {
 		assertResult(query3, Arrays.asList("James Leigh", "James Leigh", "James Leigh Hunt", "Megan Leigh"));
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repository = createRepository();
 		createEmployee("james", "James Leigh", 123);
@@ -98,7 +98,7 @@ public abstract class SparqlOrderByTest {
 
 	protected abstract Repository newRepository() throws Exception;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		conn.close();
 		conn = null;

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlRegexTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlRegexTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -23,20 +23,20 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class SparqlRegexTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -111,7 +111,7 @@ public abstract class SparqlRegexTest {
 		result.close();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repository = createRepository();
 		vf = repository.getValueFactory();
@@ -133,7 +133,7 @@ public abstract class SparqlRegexTest {
 
 	protected abstract Repository newRepository() throws Exception;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		conn.close();
 		conn = null;

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlSetBindingTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/SparqlSetBindingTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -23,20 +23,20 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class SparqlSetBindingTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -78,7 +78,7 @@ public abstract class SparqlSetBindingTest {
 		result.close();
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repository = createRepository();
 		vf = repository.getValueFactory();
@@ -102,7 +102,7 @@ public abstract class SparqlSetBindingTest {
 
 	protected abstract Repository newRepository() throws Exception;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		conn.close();
 		conn = null;

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeadLockTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeadLockTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -22,20 +22,20 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeadLockTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -56,7 +56,7 @@ public class DeadLockTest {
 
 	private IRI REMBRANDT;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(DeadLockTest.class);
 		ValueFactory uf = repo.getValueFactory();
@@ -67,7 +67,7 @@ public class DeadLockTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeleteInsertTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeleteInsertTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.common.transaction.IsolationLevel;
@@ -19,11 +19,11 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that a complex delete-insert SPARQL query gets correctly executed.
@@ -31,12 +31,12 @@ import org.junit.Test;
  */
 public class DeleteInsertTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -51,13 +51,13 @@ public class DeleteInsertTest {
 
 	private final ClassLoader cl = getClass().getClassLoader();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(DeleteInsertTest.class);
 		con = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			con.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/IsolationLevelTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/IsolationLevelTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -31,11 +31,11 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.UnknownTransactionStateException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,12 +46,12 @@ import org.slf4j.LoggerFactory;
  */
 public class IsolationLevelTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -72,13 +72,13 @@ public class IsolationLevelTest {
 	 * Methods *
 	 *---------*/
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		store = OptimisticIsolationTest.getEmptyInitializedRepository(IsolationLevelTest.class);
 		failed = null;
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		store.shutDown();
 	}
@@ -480,7 +480,7 @@ public class IsolationLevelTest {
 			}
 			Value obj = stmts.next().getObject();
 			if (stmts.hasNext()) {
-				org.junit.Assert.fail("multiple literals: " + obj + " and " + stmts.next());
+				org.junit.jupiter.api.Assertions.fail("multiple literals: " + obj + " and " + stmts.next());
 			}
 			return (Literal) obj;
 		}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/LinearTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/LinearTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,11 +31,11 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Various tests on linear execution of updates.
@@ -43,12 +43,12 @@ import org.junit.Test;
  */
 public class LinearTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -95,7 +95,7 @@ public class LinearTest {
 
 	private IRI BELSHAZZAR;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(LinearTest.class);
 		lf = repo.getValueFactory();
@@ -119,7 +119,7 @@ public class LinearTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/ModificationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/ModificationTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.transaction.IsolationLevel;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
@@ -22,20 +22,20 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ModificationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -52,7 +52,7 @@ public class ModificationTest {
 
 	private IRI PICASSO;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(ModificationTest.class);
 		ValueFactory uf = repo.getValueFactory();
@@ -61,7 +61,7 @@ public class ModificationTest {
 		con = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			con.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/MonotonicTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/MonotonicTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,20 +28,20 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MonotonicTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -88,7 +88,7 @@ public class MonotonicTest {
 
 	private IRI BELSHAZZAR;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(MonotonicTest.class);
 		lf = repo.getValueFactory();
@@ -112,7 +112,7 @@ public class MonotonicTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/RemoveIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/RemoveIsolationTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 
@@ -23,11 +23,11 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test isolation behavior on removal operations
@@ -37,12 +37,12 @@ import org.junit.Test;
  */
 public class RemoveIsolationTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -55,14 +55,14 @@ public class RemoveIsolationTest {
 
 	private final IsolationLevel level = IsolationLevels.SNAPSHOT_READ;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(RemoveIsolationTest.class);
 		con = repo.getConnection();
 		f = con.getValueFactory();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			con.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SerializableTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SerializableTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,11 +32,11 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on behavior of SERIALIZABLE transactions.
@@ -46,12 +46,12 @@ import org.junit.Test;
  */
 public class SerializableTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -98,7 +98,7 @@ public class SerializableTest {
 
 	private IRI BELSHAZZAR;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(SerializableTest.class);
 		lf = repo.getValueFactory();
@@ -122,7 +122,7 @@ public class SerializableTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SnapshotTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SnapshotTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,20 +31,20 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SnapshotTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -91,7 +91,7 @@ public class SnapshotTest {
 
 	private IRI BELSHAZZAR;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(SnapshotTest.class);
 		lf = repo.getValueFactory();
@@ -115,7 +115,7 @@ public class SnapshotTest {
 		b = repo.getConnection();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/rio/pom.xml
+++ b/testsuites/rio/pom.xml
@@ -35,5 +35,11 @@
 			<artifactId>xmlsec</artifactId>
 			<version>1.3.0</version>
 		</dependency>
+		<!-- This module uses legacy test/suite setup, and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testsuites/sail/pom.xml
+++ b/testsuites/sail/pom.xml
@@ -50,5 +50,11 @@
 			<version>${project.version}</version>
 			<scope>runtime</scope>
 		</dependency>
+		<!-- This module uses timeout rule, and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/EvaluationStrategyTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/EvaluationStrategyTest.java
@@ -10,8 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sail;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.util.List;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -34,12 +35,11 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.repository.manager.RepositoryProvider;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test cases for behavior of {@link StrictEvaluationStrategy} and {@link ExtendedEvaluationStrategy} on base Sail
@@ -49,18 +49,18 @@ import org.junit.rules.TemporaryFolder;
  */
 public abstract class EvaluationStrategyTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File tempDir;
 
 	private Repository strictRepo;
 
@@ -71,9 +71,9 @@ public abstract class EvaluationStrategyTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
-		manager = RepositoryProvider.getRepositoryManager(tempDir.newFolder());
+		manager = RepositoryProvider.getRepositoryManager(tempDir);
 
 		BaseSailConfig strictStoreConfig = getBaseSailConfig();
 		strictStoreConfig.setEvaluationStrategyFactoryClassName(StrictEvaluationStrategyFactory.class.getName());

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/InferencingTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/InferencingTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sail;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -28,10 +30,9 @@ import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,12 +40,12 @@ public abstract class InferencingTest {
 
 	private static final Logger logger = LoggerFactory.getLogger(InferencingTest.class);
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -114,10 +115,10 @@ public abstract class InferencingTest {
 			}
 
 			File dumpFile = dumpStatements(name, diff);
-			Assert.fail("Incomplete entailment, diff dumped to file " + dumpFile);
+			fail("Incomplete entailment, diff dumped to file " + dumpFile);
 		} else if (!isPositiveTest && outputEntailed) {
 			File dumpFile = dumpStatements(name, expectedStatements);
-			Assert.fail("Erroneous entailment, unexpected statements dumped to file " + dumpFile);
+			fail("Erroneous entailment, unexpected statements dumped to file " + dumpFile);
 		}
 	}
 

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailConcurrencyTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailConcurrencyTest.java
@@ -10,7 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sail;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -25,11 +26,11 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +68,7 @@ public abstract class SailConcurrencyTest {
 	 * Methods *
 	 *---------*/
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		store = createSail();
 		store.init();
@@ -76,7 +77,7 @@ public abstract class SailConcurrencyTest {
 
 	protected abstract Sail createSail() throws SailException;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		store.shutDown();
 	}
@@ -178,8 +179,8 @@ public abstract class SailConcurrencyTest {
 			long size1 = conn.size(context1);
 			long size2 = conn.size(context2);
 			logger.debug("size 1 = {}, size 2 = {}", size1, size2);
-			Assert.assertEquals("upload into context 1 should have been fully committed", runner1.getSize(), size1);
-			Assert.assertEquals("upload into context 2 should have been fully committed", runner2.getSize(), size2);
+			assertEquals(runner1.getSize(), size1, "upload into context 1 should have been fully committed");
+			assertEquals(runner2.getSize(), size2, "upload into context 2 should have been fully committed");
 		}
 
 	}
@@ -223,14 +224,14 @@ public abstract class SailConcurrencyTest {
 			long size1 = conn.size(context1);
 			long size2 = conn.size(context2);
 			logger.debug("size 1 = {}, size 2 = {}", size1, size2);
-			Assert.assertEquals("upload into context 1 should have been fully committed", runner1.getSize(), size1);
-			Assert.assertEquals("upload into context 2 should have been rolled back", 0, size2);
+			assertEquals(runner1.getSize(), size1, "upload into context 1 should have been fully committed");
+			assertEquals(0, size2, "upload into context 2 should have been rolled back");
 		}
 
 	}
 
 	@Test
-	@Ignore("This test takes a long time and accomplishes little extra")
+	@Disabled("This test takes a long time and accomplishes little extra")
 	public void testGetContextIDs() throws Exception {
 		// Create one thread which writes statements to the repository, on a
 		// number of named graphs.
@@ -300,7 +301,7 @@ public abstract class SailConcurrencyTest {
 		writerThread2.join(1000);
 
 		if (hasFailed()) {
-			Assert.fail("Test Failed");
+			Assertions.fail("Test Failed");
 		} else {
 			logger.info("Test succeeded");
 		}

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailInterruptTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailInterruptTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sail;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Random;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -19,12 +21,11 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests thread interrupts on a Sail implementation.
@@ -33,12 +34,12 @@ import org.junit.Test;
  */
 public abstract class SailInterruptTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -47,7 +48,7 @@ public abstract class SailInterruptTest {
 
 	private ValueFactory vf;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		store = createSail();
 		store.init();
@@ -56,7 +57,7 @@ public abstract class SailInterruptTest {
 
 	protected abstract Sail createSail() throws SailException;
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		store.shutDown();
 	}
@@ -74,7 +75,7 @@ public abstract class SailInterruptTest {
 			con.commit();
 		} catch (Exception e) {
 			con.rollback();
-			Assert.fail(e.getMessage());
+			fail(e.getMessage());
 		} finally {
 			con.close();
 		}

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailIsolationLevelTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/SailIsolationLevelTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sail;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -37,12 +37,12 @@ import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.UnknownSailTransactionStateException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,12 +53,12 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class SailIsolationLevelTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -81,7 +81,7 @@ public abstract class SailIsolationLevelTest {
 	 * Methods *
 	 *---------*/
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		store = createSail();
 		store.init();
@@ -89,7 +89,7 @@ public abstract class SailIsolationLevelTest {
 		failed = null;
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		store.shutDown();
 	}
@@ -287,7 +287,7 @@ public abstract class SailIsolationLevelTest {
 		try (SailConnection con = store.getConnection()) {
 			con.begin(level);
 			con.addStatement(RDF.NIL, RDF.TYPE, RDF.LIST);
-			Assert.assertEquals(1, count(con, RDF.NIL, RDF.TYPE, RDF.LIST, false));
+			assertEquals(1, count(con, RDF.NIL, RDF.TYPE, RDF.LIST, false));
 			con.removeStatements(RDF.NIL, RDF.TYPE, RDF.LIST);
 			con.commit();
 		}
@@ -305,7 +305,7 @@ public abstract class SailIsolationLevelTest {
 					null, true)) {
 				con.begin(level);
 				con.addStatement(RDF.NIL, RDF.TYPE, RDF.LIST);
-				Assert.assertEquals(1, count(con, RDF.NIL, RDF.TYPE, RDF.LIST, false));
+				assertEquals(1, count(con, RDF.NIL, RDF.TYPE, RDF.LIST, false));
 				con.removeStatements(RDF.NIL, RDF.TYPE, RDF.LIST);
 				con.commit();
 			}
@@ -322,7 +322,7 @@ public abstract class SailIsolationLevelTest {
 			con.begin(level);
 			con.addStatement(RDF.NIL, RDF.TYPE, RDF.LIST);
 			con.rollback();
-			Assert.assertEquals(0, count(con, RDF.NIL, RDF.TYPE, RDF.LIST, false));
+			assertEquals(0, count(con, RDF.NIL, RDF.TYPE, RDF.LIST, false));
 		}
 	}
 
@@ -365,7 +365,7 @@ public abstract class SailIsolationLevelTest {
 					return;
 				}
 				// not read if transaction is consistent
-				Assert.assertEquals(0, counted);
+				assertEquals(0, counted);
 			} catch (Throwable e) {
 				fail("Reader failed", e);
 			}
@@ -412,7 +412,7 @@ public abstract class SailIsolationLevelTest {
 				begin.await();
 				read.begin(level);
 				long first = count(read, RDF.NIL, RDF.TYPE, RDF.LIST, false);
-				Assert.assertEquals(1, first);
+				assertEquals(1, first);
 				observed.countDown();
 				changed.await(1, TimeUnit.SECONDS);
 				// observed statements must continue to exist
@@ -426,7 +426,7 @@ public abstract class SailIsolationLevelTest {
 					return;
 				}
 				// statement must continue to exist if transaction consistent
-				Assert.assertEquals(first, second);
+				assertEquals(first, second);
 			} catch (Throwable e) {
 				fail("Reader failed", e);
 			}
@@ -470,7 +470,7 @@ public abstract class SailIsolationLevelTest {
 				e.printStackTrace();
 				return;
 			}
-			Assert.assertEquals(size, counter);
+			assertEquals(size, counter);
 		}
 	}
 
@@ -522,7 +522,7 @@ public abstract class SailIsolationLevelTest {
 					return;
 				}
 				// store must not change if transaction consistent
-				Assert.assertEquals(first, second);
+				assertEquals(first, second);
 			} catch (Throwable e) {
 				fail("Reader failed", e);
 			}
@@ -562,7 +562,7 @@ public abstract class SailIsolationLevelTest {
 			int val = lit.intValue();
 			// val could be 4 or 6 if one transaction was aborted
 			if (val != 4 && val != 6) {
-				Assert.assertEquals(9, val);
+				assertEquals(9, val);
 			}
 			check.commit();
 		}
@@ -622,7 +622,7 @@ public abstract class SailIsolationLevelTest {
 			}
 			Value obj = stmts.next().getObject();
 			if (stmts.hasNext()) {
-				Assert.fail("multiple literals: " + obj + " and " + stmts.next());
+				Assertions.fail("multiple literals: " + obj + " and " + stmts.next());
 			}
 			return (Literal) obj;
 		}

--- a/testsuites/shacl/pom.xml
+++ b/testsuites/shacl/pom.xml
@@ -15,5 +15,11 @@
 			<artifactId>rdf4j-shacl</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<!-- This module uses legacy test/suite setup, and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testsuites/sparql/pom.xml
+++ b/testsuites/sparql/pom.xml
@@ -120,5 +120,11 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
+		<!-- This module uses parameterized tests and legacy test/suite setup, and cannot be fully migrated to JUnit 5 now -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/ComplexSPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/ComplexSPARQLQueryTest.java
@@ -67,11 +67,11 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.testsuite.query.parser.sparql.manifest.SPARQL11ManifestTest;
 import org.eclipse.rdf4j.testsuite.sparql.RepositorySPARQLComplianceTestSuite;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,12 +86,12 @@ import org.slf4j.LoggerFactory;
 @Deprecated(since = "4.0.2", forRemoval = true)
 public abstract class ComplexSPARQLQueryTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -115,7 +115,7 @@ public abstract class ComplexSPARQLQueryTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		logger.debug("setting up test");
 		this.rep = newRepository();
@@ -135,7 +135,7 @@ public abstract class ComplexSPARQLQueryTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			if (conn != null) {

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/SPARQLUpdateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/SPARQLUpdateTest.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.testsuite.query.parser.sparql;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -46,9 +47,9 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,7 @@ public abstract class SPARQLUpdateTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		logger.debug("setting up test");
 
@@ -102,7 +103,7 @@ public abstract class SPARQLUpdateTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		logger.debug("tearing down...");
 		con.close();
@@ -1682,16 +1683,18 @@ public abstract class SPARQLUpdateTest {
 		assertFalse(msg, con.hasStatement(alice, FOAF.MBOX, f.createLiteral("alice@example.org"), true, graph2));
 	}
 
-	@Test(expected = MalformedQueryException.class)
+	@Test
 	public void testInvalidInsertUpdate() {
 		RepositoryConnection connection = rep.getConnection();
-		Update update = connection.prepareUpdate(QueryLanguage.SPARQL, "insert data { ?s ?p ?o }");
+		assertThrows(MalformedQueryException.class,
+				() -> connection.prepareUpdate(QueryLanguage.SPARQL, "insert data { ?s ?p ?o }"));
 	}
 
-	@Test(expected = MalformedQueryException.class)
+	@Test
 	public void testInvalidDeleteUpdate() {
 		RepositoryConnection connection = rep.getConnection();
-		Update delete = connection.prepareUpdate(QueryLanguage.SPARQL, "delete data { ?s ?p ?o }");
+		assertThrows(MalformedQueryException.class,
+				() -> connection.prepareUpdate(QueryLanguage.SPARQL, "delete data { ?s ?p ?o }"));
 	}
 
 	/*

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/AbstractComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/AbstractComplianceTest.java
@@ -47,8 +47,8 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,13 +64,13 @@ public abstract class AbstractComplianceTest {
 	protected Repository repo;
 	protected RepositoryConnection conn;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		repo = RepositorySPARQLComplianceTestSuite.getEmptyInitializedRepository(this.getClass());
 		conn = new RepositoryConnectionWrapper(repo.getConnection());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			conn.close();

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPARQL aggregate function compliance.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ArbitraryLengthPathTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ArbitraryLengthPathTest.java
@@ -24,7 +24,7 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.impl.SimpleDataset;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPARQL property paths involving * or + operators (arbitrary length paths).

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BasicTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BasicTest.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Basic SPARQL functionality tests

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
@@ -32,7 +32,7 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test on SPARQL BIND function.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BuiltinFunctionTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BuiltinFunctionTest.java
@@ -31,7 +31,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on various SPARQL built-in functions.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ConstructTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ConstructTest.java
@@ -32,7 +32,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPARQL CONSTRUCT queries.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/DefaultGraphTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/DefaultGraphTest.java
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on handling default graph identification (DEFAULT keyword, rf4j:nil).

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/DescribeTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/DescribeTest.java
@@ -27,7 +27,7 @@ import org.eclipse.rdf4j.query.GraphQueryResult;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPARQL DESCRIBE queries

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ExistsTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ExistsTest.java
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for queries using EXISTS

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/GroupByTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/GroupByTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertNotNull;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPARQL GROUP BY

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/InTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/InTest.java
@@ -25,7 +25,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on the IN operator.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/MinusTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/MinusTest.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for queries using MINUS

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OptionalTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OptionalTest.java
@@ -31,7 +31,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on OPTIONAL clause behavior.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OrderByTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OrderByTest.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OrderByTest extends AbstractComplianceTest {
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/PropertyPathTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/PropertyPathTest.java
@@ -44,7 +44,7 @@ import org.eclipse.rdf4j.query.impl.SimpleBinding;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPARQL property paths.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/SubselectTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/SubselectTest.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPARQL nested SELECT query handling.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/UnionTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/UnionTest.java
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPRQL UNION clauses.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ValuesTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ValuesTest.java
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests on SPARQL VALUES clauses.

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -195,11 +195,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/common/webapp/navigation/NavigationTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/common/webapp/navigation/NavigationTest.java
@@ -10,23 +10,23 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.webapp.navigation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NavigationTest {
 
 	private NavigationModel model = null;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		model = new NavigationModel();
 		List<String> navigationModelLocations = new ArrayList<>();
@@ -36,28 +36,28 @@ public class NavigationTest {
 
 	@Test
 	public void testParse() {
-		assertNotNull("Parsed model is null", model);
-		assertEquals("Model should have one group", 1, model.getGroups().size());
+		assertNotNull(model, "Parsed model is null");
+		assertEquals(1, model.getGroups().size(), "Model should have one group");
 		Group systemGroup = model.getGroups().get(0);
-		assertEquals("system group should have 1 subgroup", 1, systemGroup.getGroups().size());
-		assertEquals("system group should have 2 views", 2, systemGroup.getViews().size());
+		assertEquals(1, systemGroup.getGroups().size(), "system group should have 1 subgroup");
+		assertEquals(2, systemGroup.getViews().size(), "system group should have 2 views");
 		View loggingView = systemGroup.getViews().get(1);
-		assertFalse("logging view should not be hidden", loggingView.isHidden());
-		assertTrue("logging view should be enabled", loggingView.isEnabled());
-		assertEquals("Path for logging is not correct", "/system/logging.view", loggingView.getPath());
-		assertEquals("Icon for logging is not correct", "/images/icons/system_logging.png", loggingView.getIcon());
-		assertEquals("I18N for logging is not correct", "system.logging.title", loggingView.getI18n());
+		assertFalse(loggingView.isHidden(), "logging view should not be hidden");
+		assertTrue(loggingView.isEnabled(), "logging view should be enabled");
+		assertEquals("/system/logging.view", loggingView.getPath(), "Path for logging is not correct");
+		assertEquals("/images/icons/system_logging.png", loggingView.getIcon(), "Icon for logging is not correct");
+		assertEquals("system.logging.title", loggingView.getI18n(), "I18N for logging is not correct");
 		Group loggingGroup = systemGroup.getGroups().get(0);
-		assertEquals("logging subgroup should have 1 views", 1, loggingGroup.getViews().size());
-		assertTrue("logging subgroup should be hidden", loggingGroup.isHidden());
-		assertTrue("logging subgroup should be enabled", loggingGroup.isEnabled());
+		assertEquals(1, loggingGroup.getViews().size(), "logging subgroup should have 1 views");
+		assertTrue(loggingGroup.isHidden(), "logging subgroup should be hidden");
+		assertTrue(loggingGroup.isEnabled(), "logging subgroup should be enabled");
 		View loggingOverview = loggingGroup.getViews().get(0);
-		assertFalse("logging overview should be disabled", loggingOverview.isEnabled());
+		assertFalse(loggingOverview.isEnabled(), "logging overview should be disabled");
 	}
 
 	@Test
 	public void testFind() {
-		assertNotNull("Find should have succeeded", model.findView("/system/logging/overview.view"));
-		assertNull("Find should not have succeeded", model.findView("/system/logging/bogus.view"));
+		assertNotNull(model.findView("/system/logging/overview.view"), "Find should have succeeded");
+		assertNull(model.findView("/system/logging/bogus.view"), "Find should not have succeeded");
 	}
 }

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/common/webapp/util/HttpServerUtilTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/common/webapp/util/HttpServerUtilTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.common.webapp.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -41,8 +41,8 @@ import javax.servlet.http.Part;
 import org.eclipse.rdf4j.common.lang.FileFormat;
 import org.eclipse.rdf4j.common.lang.service.FileFormatServiceRegistry;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -54,7 +54,7 @@ public class HttpServerUtilTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		FileFormatServiceRegistry<? extends FileFormat, ?> registry = TupleQueryResultWriterRegistry.getInstance();
 

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/RepositoryControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/RepositoryControllerTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.http.server.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -25,8 +25,8 @@ import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
@@ -42,7 +42,7 @@ public class RepositoryControllerTest {
 	private MockHttpServletResponse response;
 	private RepositoryManager manager;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		request = new MockHttpServletRequest();
 		request.setAttribute("repositoryID", repositoryId);

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigControllerTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigControllerTest.java
@@ -25,8 +25,8 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.memory.config.MemoryStoreConfig;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -42,7 +42,7 @@ public class ConfigControllerTest {
 	private MockHttpServletResponse response;
 	private RepositoryManager manager;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		request = new MockHttpServletRequest();
 		request.setAttribute("repositoryID", repositoryId);

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigViewTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/config/ConfigViewTest.java
@@ -22,15 +22,15 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 public class ConfigViewTest {
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 	}
 

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestExportStatementsView.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestExportStatementsView.java
@@ -12,14 +12,17 @@ package org.eclipse.rdf4j.http.server.repository.statements;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Map;
 
 import org.eclipse.rdf4j.http.server.ServerHTTPException;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 import org.springframework.ui.ModelMap;
@@ -29,7 +32,7 @@ public class TestExportStatementsView extends TestStatementsCommon {
 	private final ExportStatementsView exportStatementsView = ExportStatementsView.getInstance();
 	private final Map<String, Object> model = new ModelMap();
 
-	@Before
+	@BeforeEach
 	public void initMocks() {
 		request.setMethod(HttpMethod.GET.name());
 		model.put(ExportStatementsView.FACTORY_KEY, new TurtleWriterFactory());
@@ -44,7 +47,7 @@ public class TestExportStatementsView extends TestStatementsCommon {
 		// act
 		exportStatementsView.render(model, request, response);
 
-		Assert.assertEquals(SC_OK, response.getStatus());
+		assertEquals(SC_OK, response.getStatus());
 	}
 
 	@Test
@@ -62,7 +65,7 @@ public class TestExportStatementsView extends TestStatementsCommon {
 			exception = ex;
 		}
 
-		Assert.assertNotNull(exception);
-		Assert.assertTrue(exception.getMessage().contains(REPOSITORY_ERROR_MSG));
+		assertNotNull(exception);
+		assertTrue(exception.getMessage().contains(REPOSITORY_ERROR_MSG));
 	}
 }

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsCommon.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsCommon.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.http.server.repository.statements;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.rio.ParserConfig;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -25,7 +25,7 @@ public class TestStatementsCommon {
 	protected final RepositoryConnection connectionMock = Mockito.mock(RepositoryConnection.class);
 	private final ParserConfig parserConfigMock = Mockito.mock(ParserConfig.class);
 
-	@Before
+	@BeforeEach
 	public void initMocks() {
 		Mockito.when(repMock.getConnection()).thenReturn(connectionMock);
 		Mockito.when(connectionMock.getParserConfig()).thenReturn(parserConfigMock);

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.rdf4j.http.server.repository.statements;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 
@@ -19,9 +19,9 @@ import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.http.server.ClientHTTPException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.Update;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpMethod;
 
@@ -32,7 +32,7 @@ public class TestStatementsController extends TestStatementsCommon {
 
 	private final StatementsController controller = new StatementsController();
 
-	@Before
+	@BeforeEach
 	public void initMocks() {
 		request.setMethod(HttpMethod.POST.name());
 

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
@@ -14,7 +14,7 @@ package org.eclipse.rdf4j.http.server.repository.transaction;
 import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.Repository;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +34,7 @@ public class TestActiveTransactionRegistry {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		System.setProperty(ActiveTransactionRegistry.CACHE_TIMEOUT_PROPERTY, "1");
 		registry = ActiveTransactionRegistry.INSTANCE;

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -66,8 +66,8 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ProtocolIT.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ProtocolIT.java
@@ -10,16 +10,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.lang.ref.WeakReference;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -57,9 +56,9 @@ import org.eclipse.rdf4j.query.resultio.QueryResultIO;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -71,7 +70,7 @@ public class ProtocolIT {
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new TestServer();
 		try {
@@ -82,7 +81,7 @@ public class ProtocolIT {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 	}
@@ -422,7 +421,7 @@ public class ProtocolIT {
 		Set<Namespace> namespaceDeletions = Sets.difference(namespacesBefore, namespacesAfter);
 		Set<Namespace> namespaceAdditions = Sets.difference(namespacesAfter, namespacesBefore);
 
-		assertTrue("Some namespaces have been deleted", namespaceDeletions.isEmpty());
+		assertTrue(namespaceDeletions.isEmpty(), "Some namespaces have been deleted");
 		assertEquals(Sets.newHashSet(new SimpleNamespace("", "http://example.org/")), namespaceAdditions);
 	}
 

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ShaclValidationReportIT.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ShaclValidationReportIT.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.server;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -28,9 +28,10 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ShaclValidationReportIT {
 
@@ -38,7 +39,7 @@ public class ShaclValidationReportIT {
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new TestServer();
 		try {
@@ -49,7 +50,7 @@ public class ShaclValidationReportIT {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 	}

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/TransactionSettingsIT.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/TransactionSettingsIT.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.http.server;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import java.io.StringReader;
 
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
@@ -27,10 +29,10 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TransactionSettingsIT {
 
@@ -38,7 +40,7 @@ public class TransactionSettingsIT {
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new TestServer();
 		try {
@@ -49,7 +51,7 @@ public class TransactionSettingsIT {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 	}
@@ -72,7 +74,7 @@ public class TransactionSettingsIT {
 			"        sh:path rdfs:label ;\n" +
 			"        sh:minCount 1 .";
 
-	@Before
+	@BeforeEach
 	public void before() {
 		Repository repository = new HTTPRepository(
 				Protocol.getRepositoryLocation(TestServer.SERVER_URL, TestServer.TEST_SHACL_REPO_ID));
@@ -104,7 +106,7 @@ public class TransactionSettingsIT {
 
 	}
 
-	@Test(expected = RemoteShaclValidationException.class)
+	@Test
 	public void testInvalid() throws Throwable {
 
 		Repository repository = new HTTPRepository(
@@ -116,17 +118,15 @@ public class TransactionSettingsIT {
 			connection.add(new StringReader(shacl), "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 
 			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
-			try {
-				connection.commit();
-			} catch (RepositoryException e) {
-				throw e.getCause();
-			}
+			assertThatExceptionOfType(RepositoryException.class)
+					.isThrownBy(() -> connection.commit())
+					.withCauseInstanceOf(RemoteShaclValidationException.class);
 
 		}
 
 	}
 
-	@Test(expected = RemoteShaclValidationException.class)
+	@Test
 	public void testInvalidSnapshot() throws Throwable {
 
 		Repository repository = new HTTPRepository(
@@ -138,11 +138,9 @@ public class TransactionSettingsIT {
 			connection.add(new StringReader(shacl), "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 
 			connection.add(RDFS.RESOURCE, RDF.TYPE, RDFS.RESOURCE);
-			try {
-				connection.commit();
-			} catch (RepositoryException e) {
-				throw e.getCause();
-			}
+			assertThatExceptionOfType(RepositoryException.class)
+					.isThrownBy(() -> connection.commit())
+					.withCauseInstanceOf(RemoteShaclValidationException.class);
 
 		}
 
@@ -177,7 +175,7 @@ public class TransactionSettingsIT {
 
 	}
 
-	@Test(expected = RemoteShaclValidationException.class)
+	@Test
 	public void testValidationDisabled() throws Throwable {
 
 		Repository repository = new HTTPRepository(
@@ -195,11 +193,9 @@ public class TransactionSettingsIT {
 			connection.begin(ShaclSail.TransactionSettings.ValidationApproach.Bulk, IsolationLevels.SNAPSHOT);
 			try (RepositoryConnection connection1 = repository.getConnection()) {
 
-				try {
-					connection.commit();
-				} catch (RepositoryException e) {
-					throw e.getCause();
-				}
+				assertThatExceptionOfType(RepositoryException.class)
+						.isThrownBy(() -> connection.commit())
+						.withCauseInstanceOf(RemoteShaclValidationException.class);
 			}
 
 		}

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/WebXmlValidationTest.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/WebXmlValidationTest.java
@@ -18,8 +18,8 @@ import javax.xml.XMLConstants;
 import javax.xml.validation.SchemaFactory;
 
 import org.eclipse.rdf4j.common.xml.DocumentUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 /**
@@ -28,7 +28,7 @@ import org.xml.sax.SAXException;
 public class WebXmlValidationTest {
 
 	@Test
-	@Ignore("temporarily disabled to avoid problems with downloading of XML Schema on Hudson instance")
+	@Disabled("temporarily disabled to avoid problems with downloading of XML Schema on Hudson instance")
 	public void testValidXml() throws MalformedURLException, IOException, SAXException {
 		File webXml = new File("src/main/webapp/WEB-INF/web.xml");
 

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestCreateServlet.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestCreateServlet.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dale Visser

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestExploreServlet.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestExploreServlet.java
@@ -28,9 +28,9 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.workbench.commands.ExploreServlet.ResultCursor;
 import org.eclipse.rdf4j.workbench.util.TupleResultBuilder;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dale Visser
@@ -54,7 +54,7 @@ public class TestExploreServlet {
 	 * @throws MalformedQueryException  if an issue occurs inserting data
 	 * @throws UpdateExecutionException if an issue occurs inserting data
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws RepositoryException, MalformedQueryException, UpdateExecutionException {
 		Repository repo = new SailRepository(new MemoryStore());
 		connection = repo.getConnection();
@@ -70,7 +70,7 @@ public class TestExploreServlet {
 		builder = mock(TupleResultBuilder.class);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws RepositoryException {
 		connection.close();
 		servlet.destroy();

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestInfoServlet.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestInfoServlet.java
@@ -21,8 +21,8 @@ import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.repository.manager.RepositoryInfo;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author dale
@@ -38,7 +38,7 @@ public class TestInfoServlet {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		servlet.setRepositoryInfo(info);
 		manager = mock(RepositoryManager.class);

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestQueryServlet.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestQueryServlet.java
@@ -27,8 +27,8 @@ import org.eclipse.rdf4j.common.io.ResourceUtil;
 import org.eclipse.rdf4j.workbench.exceptions.BadRequestException;
 import org.eclipse.rdf4j.workbench.util.QueryStorage;
 import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dale Visser
@@ -41,7 +41,7 @@ public class TestQueryServlet {
 
 	private String longQuery;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws IOException {
 		longQuery = ResourceUtil.getString("long.rq");
 	}

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestRemoveServlet.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestRemoveServlet.java
@@ -28,7 +28,7 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.workbench.exceptions.BadRequestException;
 import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit and regression tests for {@link RemoteServlet}.

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/util/TestPagedQuery.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/util/TestPagedQuery.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 
 import org.eclipse.rdf4j.common.io.ResourceUtil;
 import org.eclipse.rdf4j.query.QueryLanguage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Regression test suite for {@link org.eclipse.rdf4j.workbench.util.PagedQuery PagedQuery}.

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/util/TestTupleResultBuilder.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/util/TestTupleResultBuilder.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.workbench.util;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONWriter;
 import org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLBooleanXMLWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Dale Visser

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/util/TestValueDecoder.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/util/TestValueDecoder.java
@@ -11,7 +11,7 @@
 package org.eclipse.rdf4j.workbench.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,10 +25,8 @@ import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.workbench.exceptions.BadRequestException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author dale
@@ -39,13 +37,10 @@ public class TestValueDecoder {
 
 	private ValueFactory factory;
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		factory = SimpleValueFactory.getInstance();
 


### PR DESCRIPTION
GitHub issue resolved: #4384

Briefly describe the changes proposed in this PR:

This PR migrates a lot of our code to JUnit 5 and removes the all-include dependency to junit-vintage-engine. This will make it easier to work in modules without dependency to JUnit 4 by reducing the number of multiple import alternatives.

I've migrated as much as I found reasonable without digging into full rewrites that would make the PR un-reviewable. I will create an issue with a summary of the remaining migration, even if I tried to add comments to the unwanted vintage dependency declarations in POMs.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

