### PR TITLE
GH-4388 solstice theme upstream -> gitlab, removed inline js (CSP)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "site/themes/hugo-solstice-theme"]
 	path = site/themes/hugo-solstice-theme
-	url = https://github.com/EclipseFdn/hugo-solstice-theme.git
+	url = https://gitlab.eclipse.org/eclipsefdn/it/webdev/hugo-solstice-theme.git

--- a/site/layouts/partials/head_variables.html
+++ b/site/layouts/partials/head_variables.html
@@ -1,0 +1,8 @@
+<!-- avoiding usage of inline javascript; we currently use the third option so only making that one external for now -->
+{{ if isset .Params "table_classes" }}
+<script>var tableClasses = {{ .Params.table_classes }};</script>
+{{ else if isset .Site.Params "table_classes" }}
+<script>var tableClasses = {{ .Site.Params.table_classes }};</script>
+{{ else }}
+<script src="js/hugo-solstice-headvars.js"></script>
+{{ end }}

--- a/site/static/js/hugo-solstice-headvars.js
+++ b/site/static/js/hugo-solstice-headvars.js
@@ -1,0 +1,1 @@
+var tableClasses = "table";


### PR DESCRIPTION
Website security hardening: removing use of inline javascript.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

