### PR TITLE
GH-4391 dynamic model namespaces

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/impl/DynamicModel.java
@@ -71,38 +71,58 @@ public class DynamicModel extends AbstractSet<Statement> implements Model {
 
 	@Override
 	public Optional<Namespace> getNamespace(String prefix) {
-		for (Namespace nextNamespace : namespaces) {
-			if (prefix.equals(nextNamespace.getPrefix())) {
-				return Optional.of(nextNamespace);
+		if (model == null) {
+			for (Namespace nextNamespace : namespaces) {
+				if (prefix.equals(nextNamespace.getPrefix())) {
+					return Optional.of(nextNamespace);
+				}
 			}
+		} else {
+			return model.getNamespace(prefix);
 		}
 		return Optional.empty();
 	}
 
 	@Override
 	public Set<Namespace> getNamespaces() {
-		return namespaces;
+		if (model == null) {
+			return namespaces;
+		} else {
+			return model.getNamespaces();
+		}
 	}
 
 	@Override
 	public Namespace setNamespace(String prefix, String name) {
-		removeNamespace(prefix);
-		Namespace result = new SimpleNamespace(prefix, name);
-		namespaces.add(result);
-		return result;
+		if (model == null) {
+			removeNamespace(prefix);
+			Namespace result = new SimpleNamespace(prefix, name);
+			namespaces.add(result);
+			return result;
+		} else {
+			return model.setNamespace(prefix, name);
+		}
 	}
 
 	@Override
 	public void setNamespace(Namespace namespace) {
-		removeNamespace(namespace.getPrefix());
-		namespaces.add(namespace);
+		if (model == null) {
+			removeNamespace(namespace.getPrefix());
+			namespaces.add(namespace);
+		} else {
+			model.setNamespace(namespace);
+		}
 	}
 
 	@Override
 	public Optional<Namespace> removeNamespace(String prefix) {
-		Optional<Namespace> result = getNamespace(prefix);
-		result.ifPresent(namespaces::remove);
-		return result;
+		if (model == null) {
+			Optional<Namespace> result = getNamespace(prefix);
+			result.ifPresent(namespaces::remove);
+			return result;
+		} else {
+			return model.removeNamespace(prefix);
+		}
 	}
 
 	@Override
@@ -339,6 +359,7 @@ public class DynamicModel extends AbstractSet<Statement> implements Model {
 			statements = Collections.unmodifiableMap(statements);
 			Model tempModel = modelFactory.createEmptyModel();
 			tempModel.addAll(statements.values());
+			namespaces.forEach(tempModel::setNamespace);
 			model = tempModel;
 		}
 	}

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/DynamicModelTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/DynamicModelTest.java
@@ -11,58 +11,58 @@
 
 package org.eclipse.rdf4j.model.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class DynamicModelTest {
 
-    @Test
-    public void testAddNamespace() {
-        SimpleNamespace ns = new SimpleNamespace("ex", "example:namespace");
+	@Test
+	public void testAddNamespace() {
+		SimpleNamespace ns = new SimpleNamespace("ex", "example:namespace");
 
-        Model model = new DynamicModelFactory().createEmptyModel();
-        model.setNamespace(ns);
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace(ns);
 
-        Model filtered = model.filter(null, null, null);
+		Model filtered = model.filter(null, null, null);
 
-        assertThat(filtered.getNamespace(ns.getPrefix()).get())
-                .isEqualTo(ns);
-    }
+		assertThat(filtered.getNamespace(ns.getPrefix()).get())
+				.isEqualTo(ns);
+	}
 
-    @Test
-    public void testAddNamespacePrefixAndName() {
-        String prefix = "ex";
-        String name = "example:namespace";
+	@Test
+	public void testAddNamespacePrefixAndName() {
+		String prefix = "ex";
+		String name = "example:namespace";
 
-        Model model = new DynamicModelFactory().createEmptyModel();
-        model.setNamespace(prefix, name);
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace(prefix, name);
 
-        Model filtered = model.filter(null, null, null);
+		Model filtered = model.filter(null, null, null);
 
-        assertThat(filtered.getNamespace(prefix).isPresent())
-                .isTrue();
-        assertThat(filtered.getNamespace(prefix).get().getName())
-                .isEqualTo(name);
-    }
+		assertThat(filtered.getNamespace(prefix).isPresent())
+				.isTrue();
+		assertThat(filtered.getNamespace(prefix).get().getName())
+				.isEqualTo(name);
+	}
 
-    @Test
-    public void testRemoveNamespace() {
-        Namespace ns = new SimpleNamespace("ex", "example:namespace");
+	@Test
+	public void testRemoveNamespace() {
+		Namespace ns = new SimpleNamespace("ex", "example:namespace");
 
-        Model model = new DynamicModelFactory().createEmptyModel();
-        model.setNamespace(ns);
+		Model model = new DynamicModelFactory().createEmptyModel();
+		model.setNamespace(ns);
 
-        Model filtered = model.filter(null, null, null);
+		Model filtered = model.filter(null, null, null);
 
-        filtered.removeNamespace(ns.getPrefix());
+		filtered.removeNamespace(ns.getPrefix());
 
-        assertThat(filtered.getNamespace(ns.getPrefix()).isPresent())
-                .isFalse();
-        assertThat(model.getNamespace(ns.getPrefix()).isPresent())
-                .isFalse();
-    }
+		assertThat(filtered.getNamespace(ns.getPrefix()).isPresent())
+				.isFalse();
+		assertThat(model.getNamespace(ns.getPrefix()).isPresent())
+				.isFalse();
+	}
 
 }

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/DynamicModelTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/DynamicModelTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DynamicModelTest {
 

--- a/core/model/src/test/java/org/eclipse/rdf4j/model/impl/DynamicModelTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/impl/DynamicModelTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.model.impl;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Namespace;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DynamicModelTest {
+
+    @Test
+    public void testAddNamespace() {
+        SimpleNamespace ns = new SimpleNamespace("ex", "example:namespace");
+
+        Model model = new DynamicModelFactory().createEmptyModel();
+        model.setNamespace(ns);
+
+        Model filtered = model.filter(null, null, null);
+
+        assertThat(filtered.getNamespace(ns.getPrefix()).get())
+                .isEqualTo(ns);
+    }
+
+    @Test
+    public void testAddNamespacePrefixAndName() {
+        String prefix = "ex";
+        String name = "example:namespace";
+
+        Model model = new DynamicModelFactory().createEmptyModel();
+        model.setNamespace(prefix, name);
+
+        Model filtered = model.filter(null, null, null);
+
+        assertThat(filtered.getNamespace(prefix).isPresent())
+                .isTrue();
+        assertThat(filtered.getNamespace(prefix).get().getName())
+                .isEqualTo(name);
+    }
+
+    @Test
+    public void testRemoveNamespace() {
+        Namespace ns = new SimpleNamespace("ex", "example:namespace");
+
+        Model model = new DynamicModelFactory().createEmptyModel();
+        model.setNamespace(ns);
+
+        Model filtered = model.filter(null, null, null);
+
+        filtered.removeNamespace(ns.getPrefix());
+
+        assertThat(filtered.getNamespace(ns.getPrefix()).isPresent())
+                .isFalse();
+        assertThat(model.getNamespace(ns.getPrefix()).isPresent())
+                .isFalse();
+    }
+
+}


### PR DESCRIPTION
GitHub issue resolved: #4391

Briefly describe the changes proposed in this PR:

Preserves namespace of the `DynamicModel` after an upgrade happened.


