### PR TITLE
WIP: Migrate to Jakarta EE 8

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPMemServer.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPMemServer.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.util.Properties;
 
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.ClassMatcher;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -66,7 +67,7 @@ public class HTTPMemServer {
 		WebAppContext webapp = new WebAppContext();
 		webapp.setContextPath(RDF4J_CONTEXT);
 		webapp.setWar(webappDir);
-		webapp.getServerClasspathPattern().add("org.slf4j.", "ch.qos.logback.");
+		webapp.addServerClassMatcher(new ClassMatcher("org.slf4j.", "ch.qos.logback."));
 		jetty.setHandler(webapp);
 
 		manager = RemoteRepositoryManager.getInstance(SERVER_URL);

--- a/compliance/solr/pom.xml
+++ b/compliance/solr/pom.xml
@@ -63,6 +63,10 @@
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>javax.servlet-api</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
 					<artifactId>*</artifactId>
 				</exclusion>

--- a/compliance/solr/pom.xml
+++ b/compliance/solr/pom.xml
@@ -10,6 +10,10 @@
 	<name>RDF4J: Solr Sail Tests</name>
 	<description>Tests for Solr Sail.</description>
 	<properties>
+		<!-- FIXME: Delete; Jetty 10.x requires Solr 9.x -->
+		<jetty.version>9.4.50.v20221201</jetty.version>
+		<!-- FIXME: Delete; Jetty 10.x requires Solr 9.x -->
+		<enforce-no-javax-dependencies.fail>false</enforce-no-javax-dependencies.fail>
 		<!-- used to set up embedded solr server in integration tests -->
 		<test.solr.home>${project.basedir}/solr</test.solr.home>
 	</properties>
@@ -62,10 +66,11 @@
 			<version>${solr.version}</version>
 			<scope>test</scope>
 			<exclusions>
-				<exclusion>
+				<!-- FIXME: Uncomment; Jetty 10.x requires Solr 9.x -->
+				<!--exclusion>
 					<groupId>javax.servlet</groupId>
 					<artifactId>javax.servlet-api</artifactId>
-				</exclusion>
+				</exclusion -->
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
 					<artifactId>*</artifactId>

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLEmbeddedServer.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLEmbeddedServer.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.ClassMatcher;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -64,7 +65,7 @@ public class SPARQLEmbeddedServer {
 		jetty = new Server(PORT);
 
 		WebAppContext webapp = new WebAppContext();
-		webapp.getServerClasspathPattern().add("org.slf4j.", "ch.qos.logback.");
+		webapp.addServerClassMatcher(new ClassMatcher("org.slf4j.", "ch.qos.logback."));
 		webapp.setContextPath(SERVER_CONTEXT);
 		// warPath configured in pom.xml maven-war-plugin configuration
 		webapp.setWar(webappDir);

--- a/core/sail/solr/pom.xml
+++ b/core/sail/solr/pom.xml
@@ -38,6 +38,10 @@
 			<optional>true</optional>
 			<exclusions>
 				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>javax.servlet-api</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
 					<artifactId>*</artifactId>
 				</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<enforce-javaee-provided.fail>true</enforce-javaee-provided.fail>
+		<jakartaee.version>8.0.0</jakartaee.version>
+		<!-- Jakarta XML Binding is part of Jakarta EE BOM from version 9 -->
+		<jaxb.version>2.3.3</jaxb.version>
+		<jetty.version>10.0.15</jetty.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<logback.version>1.2.11</logback.version>
 		<log4j.version>2.17.2</log4j.version>
@@ -377,12 +381,23 @@
 		<spring.version>5.3.23</spring.version>
 		<guava.version>30.1.1-jre</guava.version>
 		<jmhVersion>1.35</jmhVersion>
-		<servlet.version>3.1.0</servlet.version>
 		<junit.version>5.8.2</junit.version>
-		<jetty.version>9.4.50.v20221201</jetty.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>jakarta.platform</groupId>
+				<artifactId>jakarta.jakartaee-bom</artifactId>
+				<version>${jakartaee.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<!-- Jakarta XML Binding is part of Jakarta EE BOM from version 9 -->
+			<dependency>
+				<groupId>jakarta.xml.bind</groupId>
+				<artifactId>jakarta.xml.bind-api</artifactId>
+				<version>${jaxb.version}</version>
+			</dependency>
 			<!-- Jackson Bill-of-Materials -->
 			<dependency>
 				<groupId>com.fasterxml.jackson</groupId>
@@ -943,6 +958,22 @@
 									<requireMavenVersion>
 										<version>3.6.0</version>
 									</requireMavenVersion>
+								</rules>
+								<fail>true</fail>
+							</configuration>
+						</execution>
+						<execution>
+							<id>enforce-banned-dependencies</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<bannedDependencies>
+										<excludes>
+											<exclude>javax.*</exclude>
+										</excludes>
+									</bannedDependencies>
 								</rules>
 								<fail>true</fail>
 							</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<enforce-javaee-provided.fail>true</enforce-javaee-provided.fail>
+		<enforce-no-javax-dependencies.fail>true</enforce-no-javax-dependencies.fail>
 		<jakartaee.version>8.0.0</jakartaee.version>
 		<!-- Jakarta XML Binding is part of Jakarta EE BOM from version 9 -->
 		<jaxb.version>2.3.3</jaxb.version>
@@ -975,7 +976,7 @@
 										</excludes>
 									</bannedDependencies>
 								</rules>
-								<fail>true</fail>
+								<fail>${enforce-no-javax-dependencies.fail}</fail>
 							</configuration>
 						</execution>
 						<execution>

--- a/site/content/documentation/tools/server-workbench.md
+++ b/site/content/documentation/tools/server-workbench.md
@@ -12,8 +12,8 @@ In this chapter, we explain how you can install RDF4J Server (the actual databas
 
 RDF4J Server and RDF4J Workbench requires the following software:
 
-- Java 8 Runtime Environment (either [OpenJDK](https://openjdk.java.net/) or [Oracle Java](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html))
-- A Java Servlet Container that supports Java Servlet API 3.1 and Java Server Pages (JSP) 2.2, or newer.
+- Java 11 Runtime Environment (either [OpenJDK](https://openjdk.java.net/) or [Oracle Java](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html))
+- A Java Servlet Container that supports Java Servlet API 4.0 and Java Server Pages (JSP) 2.3, or newer.
 
 We recommend using a recent, stable version of [Apache Tomcat](https://tomcat.apache.org/) ([version 9.0](https://tomcat.apache.org/download-90.cgi) at the time of writing).
 

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -101,7 +101,7 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- TODO ideally reuse repository-compliace -->
+		<!-- TODO ideally reuse repository-compliance -->
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/server/EmbeddedServer.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/server/EmbeddedServer.java
@@ -14,6 +14,7 @@ import java.io.File;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.webapp.ClassMatcher;
 import org.eclipse.jetty.webapp.WebAppContext;
 
 public class EmbeddedServer {
@@ -39,7 +40,7 @@ public class EmbeddedServer {
 		jetty.addConnector(conn);
 
 		WebAppContext webapp = new WebAppContext();
-		webapp.getServerClasspathPattern().add("org.slf4j.", "ch.qos.logback.");
+		webapp.addServerClassMatcher(new ClassMatcher("org.slf4j.", "ch.qos.logback."));
 		webapp.setContextPath(contextPath);
 		webapp.setTempDirectory(new File("temp/webapp/"));
 		webapp.setWar(warPath);

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -49,22 +49,6 @@
 	</profiles>
 	<dependencyManagement>
 		<dependencies>
-			<!-- Java Enterprise Edition -->
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>javax.servlet-api</artifactId>
-				<version>${servlet.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.servlet.jsp</groupId>
-				<artifactId>jsp-api</artifactId>
-				<version>2.2</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>jstl</artifactId>
-				<version>1.2</version>
-			</dependency>
 			<dependency>
 				<groupId>org.ebaysf.web</groupId>
 				<artifactId>cors-filter</artifactId>

--- a/tools/server-spring/pom.xml
+++ b/tools/server-spring/pom.xml
@@ -28,8 +28,8 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -32,13 +32,13 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet.jsp</groupId>
-			<artifactId>jsp-api</artifactId>
+			<groupId>jakarta.servlet.jsp</groupId>
+			<artifactId>jakarta.servlet.jsp-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>jstl</artifactId>
+			<groupId>jakarta.servlet.jsp.jstl</groupId>
+			<artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/TestServer.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/TestServer.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.webapp.ClassMatcher;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.repository.RepositoryException;
@@ -69,7 +70,7 @@ public class TestServer {
 		jetty.addConnector(conn);
 
 		WebAppContext webapp = new WebAppContext();
-		webapp.getServerClasspathPattern().add("org.slf4j.", "ch.qos.logback.");
+		webapp.addServerClassMatcher(new ClassMatcher("org.slf4j.", "ch.qos.logback."));
 		webapp.setContextPath(RDF4J_CONTEXT);
 		// warPath configured in pom.xml maven-war-plugin configuration
 		webapp.setWar("./target/rdf4j-server");

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -36,8 +36,8 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This is a **draft** PR suggesting migration to Jakarta EE 8, which is the first Jakarta EE release and the only one compatible with Java EE. I think this is a good first step towards migrating to Jakarta EE 9, which adds the additional complexity of the javax->jakarta API namespace move - which is what I am actually looking for. 😄 

Relates to https://github.com/eclipse/rdf4j/issues/3559

CC: @abrokenjester @hmottestad 

Could this really be this simple, or are there some hidden complexities that I cannot see?

GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

