### PR TITLE
GH-4401 refactor configuration vocabulary to new shared namespace using tag uri scheme

### DIFF
--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -4,7 +4,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/org/documents/edl-v10.php 
+ * http://www.eclipse.org/org/documents/edl-v10.php
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *******************************************************************************/
@@ -14,9 +14,9 @@ import org.eclipse.rdf4j.model.IRI;
 
 /**
  * Shared vocabulary for configuration of RDF4J components: Repositories, SAILs, and so on.
- * 
+ *
  * @author Jeen Broekstra
- * 
+ *
  * @since 4.3.0
  */
 public class CONFIG {
@@ -107,5 +107,14 @@ public class CONFIG {
 	 * <var>tag:rdf4j.org:2023:config/insertContext</var>
 	 */
 	public final static IRI INSERT_CONTEXT = Vocabularies.createIRI(NAMESPACE, "insertContext");
-}
 
+	/**
+	 * <var>tag:rdf4j.org:2023:config/proxiedID</var>
+	 */
+	public final static IRI PROXIED_ID = Vocabularies.createIRI(NAMESPACE, "proxiedID");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/sailImpl</var>
+	 */
+	public final static IRI SAIL_IMPL = Vocabularies.createIRI(NAMESPACE, "sailImpl");
+}

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.model.vocabulary;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
 
 /**
  * Shared vocabulary for configuration of RDF4J components: Repositories, SAILs, and so on.
@@ -32,6 +33,13 @@ public class CONFIG {
 	 * The recommended prefix for the RDF4J config namespace: "config"
 	 */
 	public static final String PREFIX = "config";
+
+	/**
+	 * The RDF4J config namespace (<var>tag:rdf4j.org,2023:config/</var>) as a {@link Namespace} object.
+	 *
+	 * @see <a href="https://tools.ietf.org/html/rfc4151">the 'tag' URI Scheme (RFC 4151)</a>
+	 */
+	public static final Namespace NS = Vocabularies.createNamespace(PREFIX, NAMESPACE);
 
 	/**
 	 * Setting for linking a delegate config to a wrapper in a SAIL or Repository config stack.

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -40,7 +40,6 @@ public class CONFIG {
 	 */
 	public final static IRI delegate = Vocabularies.createIRI(NAMESPACE, "delegate");
 
-
 	/**
 	 * Repository config
 	 */
@@ -190,7 +189,6 @@ public class CONFIG {
 		public static final IRI passThroughEnabled = Vocabularies.createIRI(NAMESPACE, "sparql.passThroughEnabled");
 	}
 
-
 	/**
 	 * Sail config
 	 */
@@ -234,5 +232,40 @@ public class CONFIG {
 
 		/** <var>tag:rdf4j.org,2023:config/mem.syncDelay</var> */
 		public final static IRI syncDelay = Vocabularies.createIRI(NAMESPACE, "mem.syncDelay");
+	}
+
+	/**
+	 * Native Store config
+	 */
+	public static final class Native {
+		/**
+		 * <var>tag:rdf4j.org,2023:config/native.tripleIndexes</var>
+		 */
+		public final static IRI tripleIndexes = Vocabularies.createIRI(NAMESPACE, "native.tripleIndexes");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/native.forceSync</var>
+		 */
+		public final static IRI forceSync = Vocabularies.createIRI(NAMESPACE, "native.forceSync");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/native.valueCacheSize</var>
+		 */
+		public final static IRI valueCacheSize = Vocabularies.createIRI(NAMESPACE, "native.valueCacheSize");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/native.valueIDCacheSize</var>
+		 */
+		public final static IRI valueIDCacheSize = Vocabularies.createIRI(NAMESPACE, "native.valueIDCacheSize");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/native.namespaceCacheSize</var>
+		 */
+		public final static IRI namespaceCacheSize = Vocabularies.createIRI(NAMESPACE, "native.namespaceCacheSize");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/native.namespaceIDCacheSize</var>
+		 */
+		public final static IRI namespaceIDCacheSize = Vocabularies.createIRI(NAMESPACE, "native.namespaceIDCacheSize");
 	}
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.IRI;
  *
  * @since 4.3.0
  */
-public class Config {
+public class CONFIG {
 
 	/**
 	 * The RDF4J config namespace (<var>tag:rdf4j.org,2023:config/</var>).

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php 
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.model.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+
+/**
+ * Shared vocabulary for configuration of RDF4J components: Repositories, SAILs, and so on.
+ * 
+ * @author Jeen Broekstra
+ * 
+ * @since 4.3.0
+ */
+public class CONFIG {
+
+	/**
+	 * The RDF4J config namespace (<var>tag:rdf4j.org:2023:config/</var>).
+	 *
+	 * @see https://tools.ietf.org/html/rfc4151
+	 */
+	public static final String NAMESPACE = "tag:rdf4j.org:2023:config/";
+
+	/**
+	 * The recommended prefix for the RDF4J config namespace: "config"
+	 */
+	public static final String PREFIX = "config";
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/Repository</var>
+	 */
+	public final static IRI REPOSITORY = Vocabularies.createIRI(NAMESPACE, "Repository");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/repositoryID</var>
+	 */
+	public final static IRI REPOSITORY_ID = Vocabularies.createIRI(NAMESPACE, "repositoryID");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/repositoryImpl</var>
+	 */
+	public final static IRI REPOSITORY_IMPL = Vocabularies.createIRI(NAMESPACE, "repositoryImpl");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/repositoryType</var>
+	 */
+	public final static IRI REPOSITORY_TYPE = Vocabularies.createIRI(NAMESPACE, "repositoryType");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/delegate</var>
+	 */
+	public final static IRI DELEGATE = Vocabularies.createIRI(NAMESPACE, "delegate");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/repositoryURL</var>
+	 */
+	public static final IRI REPOSITORY_URL = Vocabularies.createIRI(NAMESPACE, "repositoryURL");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/username</var>
+	 */
+	public final static IRI USERNAME = Vocabularies.createIRI(NAMESPACE, "username");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/password</var>
+	 */
+	public final static IRI PASSWORD = Vocabularies.createIRI(NAMESPACE, "password");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/includeInferred</var>
+	 */
+	public final static IRI INCLUDE_INFERRED = Vocabularies.createIRI(NAMESPACE, "includeInferred");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/maxQueryTime</var>
+	 */
+	public final static IRI MAX_QUERY_TIME = Vocabularies.createIRI(NAMESPACE, "maxQueryTime");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/queryLanguage</var>
+	 */
+	public final static IRI QUERY_LANGUAGE = Vocabularies.createIRI(NAMESPACE, "queryLanguage");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/base</var>
+	 */
+	public final static IRI BASE_URI = Vocabularies.createIRI(NAMESPACE, "base");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/readContext</var>
+	 */
+	public final static IRI READ_CONTEXT = Vocabularies.createIRI(NAMESPACE, "readContext");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/removeContext</var>
+	 */
+	public final static IRI REMOVE_CONTEXT = Vocabularies.createIRI(NAMESPACE, "removeContext");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/insertContext</var>
+	 */
+	public final static IRI INSERT_CONTEXT = Vocabularies.createIRI(NAMESPACE, "insertContext");
+}
+

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -54,23 +54,23 @@ public class CONFIG {
 		/**
 		 * Setting for the repository ID.
 		 *
-		 * <var>tag:rdf4j.org,2023:config/repositoryID</var>
+		 * <var>tag:rdf4j.org,2023:config/rep.id</var>
 		 */
-		public final static IRI repositoryID = Vocabularies.createIRI(NAMESPACE, "repositoryID");
+		public final static IRI id = Vocabularies.createIRI(NAMESPACE, "rep.id");
 
 		/**
 		 * Setting for the repository implementation-specific configuration.
 		 *
-		 * <var>tag:rdf4j.org,2023:config/repositoryImpl</var>
+		 * <var>tag:rdf4j.org,2023:config/rep.impl</var>
 		 */
-		public final static IRI repositoryImpl = Vocabularies.createIRI(NAMESPACE, "repositoryImpl");
+		public final static IRI impl = Vocabularies.createIRI(NAMESPACE, "rep.impl");
 
 		/**
 		 * Setting for the repository type.
 		 *
-		 * <var>tag:rdf4j.org,2023:config/repositoryType</var>
+		 * <var>tag:rdf4j.org,2023:config/rep.type</var>
 		 */
-		public final static IRI repositoryType = Vocabularies.createIRI(NAMESPACE, "repositoryType");
+		public final static IRI type = Vocabularies.createIRI(NAMESPACE, "rep.type");
 	}
 
 	/**
@@ -78,25 +78,25 @@ public class CONFIG {
 	 */
 	public static final class Http {
 		/**
-		 * Setting for a (remote) RDF4J Repository URL.
+		 * Setting for a RDF4J HTTP Repository URL.
 		 *
-		 * <var>tag:rdf4j.org,2023:config/repositoryURL</var>
+		 * <var>tag:rdf4j.org,2023:config/http.url</var>
 		 */
-		public static final IRI repositoryURL = Vocabularies.createIRI(NAMESPACE, "repositoryURL");
+		public static final IRI url = Vocabularies.createIRI(NAMESPACE, "http.url");
 
 		/**
 		 * Setting for a username to use for authentication.
 		 *
-		 * <var>tag:rdf4j.org,2023:config/username</var>
+		 * <var>tag:rdf4j.org,2023:config/http.username</var>
 		 */
-		public final static IRI username = Vocabularies.createIRI(NAMESPACE, "username");
+		public final static IRI username = Vocabularies.createIRI(NAMESPACE, "http.username");
 
 		/**
 		 * Setting for a password to use for authentication.
 		 *
-		 * <var>tag:rdf4j.org,2023:config/password</var>
+		 * <var>tag:rdf4j.org,2023:config/http.password</var>
 		 */
-		public final static IRI password = Vocabularies.createIRI(NAMESPACE, "password");
+		public final static IRI password = Vocabularies.createIRI(NAMESPACE, "http.password");
 	}
 
 	/**
@@ -267,5 +267,71 @@ public class CONFIG {
 		 * <var>tag:rdf4j.org,2023:config/native.namespaceIDCacheSize</var>
 		 */
 		public final static IRI namespaceIDCacheSize = Vocabularies.createIRI(NAMESPACE, "native.namespaceIDCacheSize");
+	}
+
+	/**
+	 * SHACL Sail config
+	 */
+	public static final class Shacl {
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.parallelValidation</code>
+		 */
+		public final static IRI parallelValidation = Vocabularies.createIRI(NAMESPACE, "parallelValidation");
+
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.logValidationPlans</code>
+		 */
+		public final static IRI logValidationPlans = Vocabularies.createIRI(NAMESPACE, "logValidationPlans");
+
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.logValidationViolations</code>
+		 */
+		public final static IRI logValidationViolations = Vocabularies.createIRI(NAMESPACE,
+				"logValidationViolations");
+
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.validationEnabled</code>
+		 */
+		public final static IRI validationEnabled = Vocabularies.createIRI(NAMESPACE, "validationEnabled");
+
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.cacheSelectNodes</code>
+		 */
+		public final static IRI cacheSelectNodes = Vocabularies.createIRI(NAMESPACE, "cacheSelectNodes");
+
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.globalLogValidationExecution</code>
+		 */
+		public final static IRI globalLogValidationExecution = Vocabularies.createIRI(NAMESPACE,
+				"globalLogValidationExecution");
+
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.rdfsSubClassReasoning</code>
+		 */
+		public final static IRI rdfsSubClassReasoning = Vocabularies.createIRI(NAMESPACE, "rdfsSubClassReasoning");
+
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.performanceLogging</code>
+		 */
+		public final static IRI performanceLogging = Vocabularies.createIRI(NAMESPACE, "performanceLogging");
+
+		/**
+		 * <code>tag:rdf4j.org,2023:config/shacl.serializableValidation</code>
+		 */
+		public final static IRI serializableValidation = Vocabularies.createIRI(NAMESPACE, "serializableValidation");
+
+		public final static IRI eclipseRdf4jShaclExtensions = Vocabularies.createIRI(NAMESPACE,
+				"eclipseRdf4jShaclExtensions");
+
+		public final static IRI dashDataShapes = Vocabularies.createIRI(NAMESPACE, "dashDataShapes");
+
+		public final static IRI validationResultsLimitTotal = Vocabularies.createIRI(NAMESPACE,
+				"validationResultsLimitTotal");
+		public final static IRI validationResultsLimitPerConstraint = Vocabularies.createIRI(NAMESPACE,
+				"validationResultsLimitPerConstraint");
+		public final static IRI transactionalValidationLimit = Vocabularies.createIRI(NAMESPACE,
+				"transactionalValidationLimit");
+
+		public final static IRI shapesGraph = Vocabularies.createIRI(NAMESPACE, "shapesGraph");
 	}
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -114,6 +114,30 @@ public class CONFIG {
 	public final static IRI proxiedID = Vocabularies.createIRI(NAMESPACE, "proxiedID");
 
 	/**
+	 * Configuration setting for the SPARQL query endpoint.
+	 *
+	 * <var>tag:rdf4j.org:2023:config/queryEndpoint</var>
+	 */
+	public static final IRI queryEndpoint = Vocabularies.createIRI(NAMESPACE, "queryEndpoint");
+
+	/**
+	 * Configuration setting for the SPARQL update endpoint.
+	 *
+	 * <var>tag:rdf4j.org:2023:config/updateEndpoint</var>
+	 */
+	public static final IRI updateEndpoint = Vocabularies
+			.createIRI(NAMESPACE, "updateEndpoint");
+
+	/**
+	 * Configuration setting for enabling/disabling direct result pass-through.
+	 *
+	 * <var>tag:rdf4j.org:2023:config/passThroughEnabled</var>
+	 *
+	 * @see SPARQLProtocolSession#isPassThroughEnabled()
+	 */
+	public static final IRI passThroughEnabled = Vocabularies.createIRI(NAMESPACE, "passThroughEnabled");
+
+	/**
 	 * <var>tag:rdf4j.org:2023:config/sailImpl</var>
 	 */
 	public final static IRI sailImpl = Vocabularies.createIRI(NAMESPACE, "sailImpl");

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -24,7 +24,7 @@ public class CONFIG {
 	/**
 	 * The RDF4J config namespace (<var>tag:rdf4j.org:2023:config/</var>).
 	 *
-	 * @see https://tools.ietf.org/html/rfc4151
+	 * @see <a href="https://tools.ietf.org/html/rfc4151">the 'tag' URI Scheme (RFC 4151)</a>
 	 */
 	public static final String NAMESPACE = "tag:rdf4j.org:2023:config/";
 
@@ -36,85 +36,109 @@ public class CONFIG {
 	/**
 	 * <var>tag:rdf4j.org:2023:config/Repository</var>
 	 */
-	public final static IRI REPOSITORY = Vocabularies.createIRI(NAMESPACE, "Repository");
+	public final static IRI Repository = Vocabularies.createIRI(NAMESPACE, "Repository");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/repositoryID</var>
 	 */
-	public final static IRI REPOSITORY_ID = Vocabularies.createIRI(NAMESPACE, "repositoryID");
+	public final static IRI repositoryID = Vocabularies.createIRI(NAMESPACE, "repositoryID");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/repositoryImpl</var>
 	 */
-	public final static IRI REPOSITORY_IMPL = Vocabularies.createIRI(NAMESPACE, "repositoryImpl");
+	public final static IRI repositoryImpl = Vocabularies.createIRI(NAMESPACE, "repositoryImpl");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/repositoryType</var>
 	 */
-	public final static IRI REPOSITORY_TYPE = Vocabularies.createIRI(NAMESPACE, "repositoryType");
+	public final static IRI repositoryType = Vocabularies.createIRI(NAMESPACE, "repositoryType");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/delegate</var>
 	 */
-	public final static IRI DELEGATE = Vocabularies.createIRI(NAMESPACE, "delegate");
+	public final static IRI delegate = Vocabularies.createIRI(NAMESPACE, "delegate");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/repositoryURL</var>
 	 */
-	public static final IRI REPOSITORY_URL = Vocabularies.createIRI(NAMESPACE, "repositoryURL");
+	public static final IRI repositoryURL = Vocabularies.createIRI(NAMESPACE, "repositoryURL");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/username</var>
 	 */
-	public final static IRI USERNAME = Vocabularies.createIRI(NAMESPACE, "username");
+	public final static IRI username = Vocabularies.createIRI(NAMESPACE, "username");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/password</var>
 	 */
-	public final static IRI PASSWORD = Vocabularies.createIRI(NAMESPACE, "password");
+	public final static IRI password = Vocabularies.createIRI(NAMESPACE, "password");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/includeInferred</var>
 	 */
-	public final static IRI INCLUDE_INFERRED = Vocabularies.createIRI(NAMESPACE, "includeInferred");
+	public final static IRI includeInferred = Vocabularies.createIRI(NAMESPACE, "includeInferred");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/maxQueryTime</var>
 	 */
-	public final static IRI MAX_QUERY_TIME = Vocabularies.createIRI(NAMESPACE, "maxQueryTime");
+	public final static IRI maxQueryTime = Vocabularies.createIRI(NAMESPACE, "maxQueryTime");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/queryLanguage</var>
 	 */
-	public final static IRI QUERY_LANGUAGE = Vocabularies.createIRI(NAMESPACE, "queryLanguage");
+	public final static IRI queryLanguage = Vocabularies.createIRI(NAMESPACE, "queryLanguage");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/base</var>
 	 */
-	public final static IRI BASE_URI = Vocabularies.createIRI(NAMESPACE, "base");
+	public final static IRI base = Vocabularies.createIRI(NAMESPACE, "base");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/readContext</var>
 	 */
-	public final static IRI READ_CONTEXT = Vocabularies.createIRI(NAMESPACE, "readContext");
+	public final static IRI readContext = Vocabularies.createIRI(NAMESPACE, "readContext");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/removeContext</var>
 	 */
-	public final static IRI REMOVE_CONTEXT = Vocabularies.createIRI(NAMESPACE, "removeContext");
+	public final static IRI removeContext = Vocabularies.createIRI(NAMESPACE, "removeContext");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/insertContext</var>
 	 */
-	public final static IRI INSERT_CONTEXT = Vocabularies.createIRI(NAMESPACE, "insertContext");
+	public final static IRI insertContext = Vocabularies.createIRI(NAMESPACE, "insertContext");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/proxiedID</var>
 	 */
-	public final static IRI PROXIED_ID = Vocabularies.createIRI(NAMESPACE, "proxiedID");
+	public final static IRI proxiedID = Vocabularies.createIRI(NAMESPACE, "proxiedID");
 
 	/**
 	 * <var>tag:rdf4j.org:2023:config/sailImpl</var>
 	 */
-	public final static IRI SAIL_IMPL = Vocabularies.createIRI(NAMESPACE, "sailImpl");
+	public final static IRI sailImpl = Vocabularies.createIRI(NAMESPACE, "sailImpl");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/sailType</var>
+	 */
+	public final static IRI sailType = Vocabularies.createIRI(NAMESPACE, "sailType");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/iterationCacheSyncTreshold</var>
+	 */
+	public final static IRI iterationCacheSyncThreshold = Vocabularies.createIRI(NAMESPACE,
+			"iterationCacheSyncThreshold");
+
+	/**
+	 * <var>tag:rdf4j.org:2023:config/connectionTimeOut</var>
+	 */
+	public final static IRI connectionTimeOut = Vocabularies.createIRI(NAMESPACE, "connectionTimeOut");
+
+	/** <var>tag:rdf4j.org:2023:config/evaluationStrategyFactory</var> */
+	public final static IRI evaluationStrategyFactory = Vocabularies.createIRI(NAMESPACE,
+			"evaluationStrategyFactory");
+
+	/** <var>tag:rdf4j.org:2023:config/defaultQueryEvaluationMode</var> */
+	public final static IRI defaultQueryEvaluationMode = Vocabularies.createIRI(NAMESPACE,
+			"defaultQueryEvaluationMode");
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -34,66 +34,91 @@ public class CONFIG {
 	public static final String PREFIX = "config";
 
 	/**
+	 * Type value for a RepositoryConfig.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/Repository</var>
 	 */
 	public final static IRI Repository = Vocabularies.createIRI(NAMESPACE, "Repository");
 
 	/**
+	 * Setting for the repository ID.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/repositoryID</var>
 	 */
 	public final static IRI repositoryID = Vocabularies.createIRI(NAMESPACE, "repositoryID");
 
 	/**
+	 * Setting for the repository implementation-specific configuration.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/repositoryImpl</var>
 	 */
 	public final static IRI repositoryImpl = Vocabularies.createIRI(NAMESPACE, "repositoryImpl");
 
 	/**
+	 * Setting for the repository type.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/repositoryType</var>
 	 */
 	public final static IRI repositoryType = Vocabularies.createIRI(NAMESPACE, "repositoryType");
 
 	/**
+	 * Setting for linking a delegate config to a wrapper in a SAIL or Repository config stack.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/delegate</var>
 	 */
 	public final static IRI delegate = Vocabularies.createIRI(NAMESPACE, "delegate");
 
 	/**
+	 * Setting for a (remote) RDF4J Repository URL.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/repositoryURL</var>
 	 */
 	public static final IRI repositoryURL = Vocabularies.createIRI(NAMESPACE, "repositoryURL");
 
 	/**
+	 * Setting for a username to use for authentication.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/username</var>
 	 */
 	public final static IRI username = Vocabularies.createIRI(NAMESPACE, "username");
 
 	/**
+	 * Setting for a password to use for authentication.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/password</var>
 	 */
 	public final static IRI password = Vocabularies.createIRI(NAMESPACE, "password");
 
 	/**
+	 * Setting for including inferred statements by default.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/includeInferred</var>
 	 */
 	public final static IRI includeInferred = Vocabularies.createIRI(NAMESPACE, "includeInferred");
 
 	/**
+	 * Setting for the max query time.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/maxQueryTime</var>
 	 */
 	public final static IRI maxQueryTime = Vocabularies.createIRI(NAMESPACE, "maxQueryTime");
 
 	/**
+	 * Setting for the query language to be used.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/queryLanguage</var>
 	 */
 	public final static IRI queryLanguage = Vocabularies.createIRI(NAMESPACE, "queryLanguage");
 
 	/**
+	 * Setting for a base URI.
+	 *
 	 * <var>tag:rdf4j.org:2023:config/base</var>
 	 */
 	public final static IRI base = Vocabularies.createIRI(NAMESPACE, "base");
 
 	/**
+	 *
 	 * <var>tag:rdf4j.org:2023:config/readContext</var>
 	 */
 	public final static IRI readContext = Vocabularies.createIRI(NAMESPACE, "readContext");

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -22,11 +22,11 @@ import org.eclipse.rdf4j.model.IRI;
 public class CONFIG {
 
 	/**
-	 * The RDF4J config namespace (<var>tag:rdf4j.org:2023:config/</var>).
+	 * The RDF4J config namespace (<var>tag:rdf4j.org,2023:config/</var>).
 	 *
 	 * @see <a href="https://tools.ietf.org/html/rfc4151">the 'tag' URI Scheme (RFC 4151)</a>
 	 */
-	public static final String NAMESPACE = "tag:rdf4j.org:2023:config/";
+	public static final String NAMESPACE = "tag:rdf4j.org,2023:config/";
 
 	/**
 	 * The recommended prefix for the RDF4J config namespace: "config"
@@ -34,160 +34,205 @@ public class CONFIG {
 	public static final String PREFIX = "config";
 
 	/**
-	 * Type value for a RepositoryConfig.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/Repository</var>
-	 */
-	public final static IRI Repository = Vocabularies.createIRI(NAMESPACE, "Repository");
-
-	/**
-	 * Setting for the repository ID.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/repositoryID</var>
-	 */
-	public final static IRI repositoryID = Vocabularies.createIRI(NAMESPACE, "repositoryID");
-
-	/**
-	 * Setting for the repository implementation-specific configuration.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/repositoryImpl</var>
-	 */
-	public final static IRI repositoryImpl = Vocabularies.createIRI(NAMESPACE, "repositoryImpl");
-
-	/**
-	 * Setting for the repository type.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/repositoryType</var>
-	 */
-	public final static IRI repositoryType = Vocabularies.createIRI(NAMESPACE, "repositoryType");
-
-	/**
 	 * Setting for linking a delegate config to a wrapper in a SAIL or Repository config stack.
 	 *
-	 * <var>tag:rdf4j.org:2023:config/delegate</var>
+	 * <var>tag:rdf4j.org,2023:config/delegate</var>
 	 */
 	public final static IRI delegate = Vocabularies.createIRI(NAMESPACE, "delegate");
 
+
 	/**
-	 * Setting for a (remote) RDF4J Repository URL.
+	 * Repository config
+	 */
+	public static final class Rep {
+		/**
+		 * Type value for a RepositoryConfig.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/Repository</var>
+		 */
+		public final static IRI Repository = Vocabularies.createIRI(NAMESPACE, "Repository");
+
+		/**
+		 * Setting for the repository ID.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/repositoryID</var>
+		 */
+		public final static IRI repositoryID = Vocabularies.createIRI(NAMESPACE, "repositoryID");
+
+		/**
+		 * Setting for the repository implementation-specific configuration.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/repositoryImpl</var>
+		 */
+		public final static IRI repositoryImpl = Vocabularies.createIRI(NAMESPACE, "repositoryImpl");
+
+		/**
+		 * Setting for the repository type.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/repositoryType</var>
+		 */
+		public final static IRI repositoryType = Vocabularies.createIRI(NAMESPACE, "repositoryType");
+	}
+
+	/**
+	 * HTTP Repository config
+	 */
+	public static final class Http {
+		/**
+		 * Setting for a (remote) RDF4J Repository URL.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/repositoryURL</var>
+		 */
+		public static final IRI repositoryURL = Vocabularies.createIRI(NAMESPACE, "repositoryURL");
+
+		/**
+		 * Setting for a username to use for authentication.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/username</var>
+		 */
+		public final static IRI username = Vocabularies.createIRI(NAMESPACE, "username");
+
+		/**
+		 * Setting for a password to use for authentication.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/password</var>
+		 */
+		public final static IRI password = Vocabularies.createIRI(NAMESPACE, "password");
+	}
+
+	/**
+	 * ContextAwareRepository config
+	 */
+	public static final class ContextAware {
+		/**
+		 * Setting for including inferred statements by default.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/ca.includeInferred</var>
+		 */
+		public final static IRI includeInferred = Vocabularies.createIRI(NAMESPACE, "ca.includeInferred");
+
+		/**
+		 * Setting for the max query time.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/ca.maxQueryTime</var>
+		 */
+		public final static IRI maxQueryTime = Vocabularies.createIRI(NAMESPACE, "ca.maxQueryTime");
+
+		/**
+		 * Setting for the query language to be used.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/ca.queryLanguage</var>
+		 */
+		public final static IRI queryLanguage = Vocabularies.createIRI(NAMESPACE, "ca.queryLanguage");
+		/**
+		 *
+		 * <var>tag:rdf4j.org,2023:config/ca.readContext</var>
+		 */
+		public final static IRI readContext = Vocabularies.createIRI(NAMESPACE, "ca.readContext");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/ca.removeContext</var>
+		 */
+		public final static IRI removeContext = Vocabularies.createIRI(NAMESPACE, "ca.removeContext");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/ca.insertContext</var>
+		 */
+		public final static IRI insertContext = Vocabularies.createIRI(NAMESPACE, "ca.insertContext");
+
+		/**
+		 * Setting for a base URI.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/ca.base</var>
+		 */
+		public final static IRI base = Vocabularies.createIRI(NAMESPACE, "ca.base");
+
+	}
+
+	/**
+	 * ProxyRepository config
 	 *
-	 * <var>tag:rdf4j.org:2023:config/repositoryURL</var>
 	 */
-	public static final IRI repositoryURL = Vocabularies.createIRI(NAMESPACE, "repositoryURL");
+	public static final class Proxy {
+		/**
+		 * <var>tag:rdf4j.org,2023:config/proxy.proxiedID</var>
+		 */
+		public final static IRI proxiedID = Vocabularies.createIRI(NAMESPACE, "proxy.proxiedID");
+
+	}
 
 	/**
-	 * Setting for a username to use for authentication.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/username</var>
+	 * SPARQLRepository config
 	 */
-	public final static IRI username = Vocabularies.createIRI(NAMESPACE, "username");
+	public static final class Sparql {
+		/**
+		 * Configuration setting for the SPARQL query endpoint.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/sparql.queryEndpoint</var>
+		 */
+		public static final IRI queryEndpoint = Vocabularies.createIRI(NAMESPACE, "sparq.queryEndpoint");
+
+		/**
+		 * Configuration setting for the SPARQL update endpoint.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/sparql.updateEndpoint</var>
+		 */
+		public static final IRI updateEndpoint = Vocabularies
+				.createIRI(NAMESPACE, "sparql.updateEndpoint");
+
+		/**
+		 * Configuration setting for enabling/disabling direct result pass-through.
+		 *
+		 * <var>tag:rdf4j.org,2023:config/sparql.passThroughEnabled</var>
+		 *
+		 * @see SPARQLProtocolSession#isPassThroughEnabled()
+		 */
+		public static final IRI passThroughEnabled = Vocabularies.createIRI(NAMESPACE, "sparql.passThroughEnabled");
+	}
+
 
 	/**
-	 * Setting for a password to use for authentication.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/password</var>
+	 * Sail config
 	 */
-	public final static IRI password = Vocabularies.createIRI(NAMESPACE, "password");
+	public static final class Sail {
+		/**
+		 * <var>tag:rdf4j.org,2023:config/sail.type</var>
+		 */
+		public final static IRI type = Vocabularies.createIRI(NAMESPACE, "sail.type");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/sail.impl</var>
+		 */
+		public final static IRI impl = Vocabularies.createIRI(NAMESPACE, "sail.impl");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/sail.iterationCacheSyncTreshold</var>
+		 */
+		public final static IRI iterationCacheSyncThreshold = Vocabularies.createIRI(NAMESPACE,
+				"sail.iterationCacheSyncThreshold");
+
+		/**
+		 * <var>tag:rdf4j.org,2023:config/sail.connectionTimeOut</var>
+		 */
+		public final static IRI connectionTimeOut = Vocabularies.createIRI(NAMESPACE, "sail.connectionTimeOut");
+
+		/** <var>tag:rdf4j.org,2023:config/sail.evaluationStrategyFactory</var> */
+		public final static IRI evaluationStrategyFactory = Vocabularies.createIRI(NAMESPACE,
+				"sail.evaluationStrategyFactory");
+
+		/** <var>tag:rdf4j.org,2023:config/sail.defaultQueryEvaluationMode</var> */
+		public final static IRI defaultQueryEvaluationMode = Vocabularies.createIRI(NAMESPACE,
+				"sail.defaultQueryEvaluationMode");
+	}
 
 	/**
-	 * Setting for including inferred statements by default.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/includeInferred</var>
+	 * Memory Store config
 	 */
-	public final static IRI includeInferred = Vocabularies.createIRI(NAMESPACE, "includeInferred");
+	public static final class Mem {
+		/** <var>tag:rdf4j.org,2023:config/mem.persist</var> */
+		public final static IRI persist = Vocabularies.createIRI(NAMESPACE, "mem.persist");
 
-	/**
-	 * Setting for the max query time.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/maxQueryTime</var>
-	 */
-	public final static IRI maxQueryTime = Vocabularies.createIRI(NAMESPACE, "maxQueryTime");
-
-	/**
-	 * Setting for the query language to be used.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/queryLanguage</var>
-	 */
-	public final static IRI queryLanguage = Vocabularies.createIRI(NAMESPACE, "queryLanguage");
-
-	/**
-	 * Setting for a base URI.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/base</var>
-	 */
-	public final static IRI base = Vocabularies.createIRI(NAMESPACE, "base");
-
-	/**
-	 *
-	 * <var>tag:rdf4j.org:2023:config/readContext</var>
-	 */
-	public final static IRI readContext = Vocabularies.createIRI(NAMESPACE, "readContext");
-
-	/**
-	 * <var>tag:rdf4j.org:2023:config/removeContext</var>
-	 */
-	public final static IRI removeContext = Vocabularies.createIRI(NAMESPACE, "removeContext");
-
-	/**
-	 * <var>tag:rdf4j.org:2023:config/insertContext</var>
-	 */
-	public final static IRI insertContext = Vocabularies.createIRI(NAMESPACE, "insertContext");
-
-	/**
-	 * <var>tag:rdf4j.org:2023:config/proxiedID</var>
-	 */
-	public final static IRI proxiedID = Vocabularies.createIRI(NAMESPACE, "proxiedID");
-
-	/**
-	 * Configuration setting for the SPARQL query endpoint.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/queryEndpoint</var>
-	 */
-	public static final IRI queryEndpoint = Vocabularies.createIRI(NAMESPACE, "queryEndpoint");
-
-	/**
-	 * Configuration setting for the SPARQL update endpoint.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/updateEndpoint</var>
-	 */
-	public static final IRI updateEndpoint = Vocabularies
-			.createIRI(NAMESPACE, "updateEndpoint");
-
-	/**
-	 * Configuration setting for enabling/disabling direct result pass-through.
-	 *
-	 * <var>tag:rdf4j.org:2023:config/passThroughEnabled</var>
-	 *
-	 * @see SPARQLProtocolSession#isPassThroughEnabled()
-	 */
-	public static final IRI passThroughEnabled = Vocabularies.createIRI(NAMESPACE, "passThroughEnabled");
-
-	/**
-	 * <var>tag:rdf4j.org:2023:config/sailImpl</var>
-	 */
-	public final static IRI sailImpl = Vocabularies.createIRI(NAMESPACE, "sailImpl");
-
-	/**
-	 * <var>tag:rdf4j.org:2023:config/sailType</var>
-	 */
-	public final static IRI sailType = Vocabularies.createIRI(NAMESPACE, "sailType");
-
-	/**
-	 * <var>tag:rdf4j.org:2023:config/iterationCacheSyncTreshold</var>
-	 */
-	public final static IRI iterationCacheSyncThreshold = Vocabularies.createIRI(NAMESPACE,
-			"iterationCacheSyncThreshold");
-
-	/**
-	 * <var>tag:rdf4j.org:2023:config/connectionTimeOut</var>
-	 */
-	public final static IRI connectionTimeOut = Vocabularies.createIRI(NAMESPACE, "connectionTimeOut");
-
-	/** <var>tag:rdf4j.org:2023:config/evaluationStrategyFactory</var> */
-	public final static IRI evaluationStrategyFactory = Vocabularies.createIRI(NAMESPACE,
-			"evaluationStrategyFactory");
-
-	/** <var>tag:rdf4j.org:2023:config/defaultQueryEvaluationMode</var> */
-	public final static IRI defaultQueryEvaluationMode = Vocabularies.createIRI(NAMESPACE,
-			"defaultQueryEvaluationMode");
+		/** <var>tag:rdf4j.org,2023:config/mem.syncDelay</var> */
+		public final static IRI syncDelay = Vocabularies.createIRI(NAMESPACE, "mem.syncDelay");
+	}
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/CONFIG.java
@@ -276,62 +276,83 @@ public class CONFIG {
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.parallelValidation</code>
 		 */
-		public final static IRI parallelValidation = Vocabularies.createIRI(NAMESPACE, "parallelValidation");
+		public final static IRI parallelValidation = Vocabularies.createIRI(NAMESPACE, "shacl.parallelValidation");
 
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.logValidationPlans</code>
 		 */
-		public final static IRI logValidationPlans = Vocabularies.createIRI(NAMESPACE, "logValidationPlans");
+		public final static IRI logValidationPlans = Vocabularies.createIRI(NAMESPACE, "shacl.logValidationPlans");
 
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.logValidationViolations</code>
 		 */
 		public final static IRI logValidationViolations = Vocabularies.createIRI(NAMESPACE,
-				"logValidationViolations");
+				"shacl.logValidationViolations");
 
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.validationEnabled</code>
 		 */
-		public final static IRI validationEnabled = Vocabularies.createIRI(NAMESPACE, "validationEnabled");
+		public final static IRI validationEnabled = Vocabularies.createIRI(NAMESPACE, "shacl.validationEnabled");
 
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.cacheSelectNodes</code>
 		 */
-		public final static IRI cacheSelectNodes = Vocabularies.createIRI(NAMESPACE, "cacheSelectNodes");
+		public final static IRI cacheSelectNodes = Vocabularies.createIRI(NAMESPACE, "shacl.cacheSelectNodes");
 
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.globalLogValidationExecution</code>
 		 */
 		public final static IRI globalLogValidationExecution = Vocabularies.createIRI(NAMESPACE,
-				"globalLogValidationExecution");
+				"shacl.globalLogValidationExecution");
 
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.rdfsSubClassReasoning</code>
 		 */
-		public final static IRI rdfsSubClassReasoning = Vocabularies.createIRI(NAMESPACE, "rdfsSubClassReasoning");
+		public final static IRI rdfsSubClassReasoning = Vocabularies.createIRI(NAMESPACE,
+				"shacl.rdfsSubClassReasoning");
 
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.performanceLogging</code>
 		 */
-		public final static IRI performanceLogging = Vocabularies.createIRI(NAMESPACE, "performanceLogging");
+		public final static IRI performanceLogging = Vocabularies.createIRI(NAMESPACE, "shacl.performanceLogging");
 
 		/**
 		 * <code>tag:rdf4j.org,2023:config/shacl.serializableValidation</code>
 		 */
-		public final static IRI serializableValidation = Vocabularies.createIRI(NAMESPACE, "serializableValidation");
+		public final static IRI serializableValidation = Vocabularies.createIRI(NAMESPACE,
+				"shacl.serializableValidation");
 
 		public final static IRI eclipseRdf4jShaclExtensions = Vocabularies.createIRI(NAMESPACE,
-				"eclipseRdf4jShaclExtensions");
+				"shacl.eclipseRdf4jShaclExtensions");
 
-		public final static IRI dashDataShapes = Vocabularies.createIRI(NAMESPACE, "dashDataShapes");
+		public final static IRI dashDataShapes = Vocabularies.createIRI(NAMESPACE, "shacl.dashDataShapes");
 
 		public final static IRI validationResultsLimitTotal = Vocabularies.createIRI(NAMESPACE,
-				"validationResultsLimitTotal");
+				"shacl.validationResultsLimitTotal");
 		public final static IRI validationResultsLimitPerConstraint = Vocabularies.createIRI(NAMESPACE,
-				"validationResultsLimitPerConstraint");
+				"shacl.validationResultsLimitPerConstraint");
 		public final static IRI transactionalValidationLimit = Vocabularies.createIRI(NAMESPACE,
-				"transactionalValidationLimit");
+				"shacl.transactionalValidationLimit");
 
-		public final static IRI shapesGraph = Vocabularies.createIRI(NAMESPACE, "shapesGraph");
+		public final static IRI shapesGraph = Vocabularies.createIRI(NAMESPACE, "shacl.shapesGraph");
+	}
+
+	/**
+	 * Lucene Sail config
+	 *
+	 */
+	public static final class Lucene {
+		public final static IRI indexDir = Vocabularies.createIRI(NAMESPACE, "lucene.indexDir");
+	}
+
+	/**
+	 * Elasticsearch Store config
+	 */
+	public static final class Ess {
+
+		public final static IRI hostname = Vocabularies.createIRI(NAMESPACE, "ess.hostname");
+		public final static IRI port = Vocabularies.createIRI(NAMESPACE, "ess.port");
+		public final static IRI index = Vocabularies.createIRI(NAMESPACE, "ess.index");
+		public final static IRI clusterName = Vocabularies.createIRI(NAMESPACE, "ess.clusterName");
 	}
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/Config.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/Config.java
@@ -355,4 +355,15 @@ public class Config {
 		public final static IRI index = Vocabularies.createIRI(NAMESPACE, "ess.index");
 		public final static IRI clusterName = Vocabularies.createIRI(NAMESPACE, "ess.clusterName");
 	}
+
+	/**
+	 * Custom Graph Query Inferencer config
+	 */
+	public static final class Cgqi {
+		public final static IRI queryLanguage = Vocabularies.createIRI(NAMESPACE, "cgqi.queryLanguage");
+
+		public final static IRI ruleQuery = Vocabularies.createIRI(NAMESPACE, "cgqi.ruleQuery");
+
+		public final static IRI matcherQuery = Vocabularies.createIRI(NAMESPACE, "cgqi.matcherQuery");
+	}
 }

--- a/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/Config.java
+++ b/core/model-vocabulary/src/main/java/org/eclipse/rdf4j/model/vocabulary/Config.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.IRI;
  *
  * @since 4.3.0
  */
-public class CONFIG {
+public class Config {
 
 	/**
 	 * The RDF4J config namespace (<var>tag:rdf4j.org,2023:config/</var>).
@@ -169,7 +169,7 @@ public class CONFIG {
 		 *
 		 * <var>tag:rdf4j.org,2023:config/sparql.queryEndpoint</var>
 		 */
-		public static final IRI queryEndpoint = Vocabularies.createIRI(NAMESPACE, "sparq.queryEndpoint");
+		public static final IRI queryEndpoint = Vocabularies.createIRI(NAMESPACE, "sparql.queryEndpoint");
 
 		/**
 		 * Configuration setting for the SPARQL update endpoint.

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Configurations.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Configurations.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.model.util;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+
+/**
+ * Utility functions for working with RDF4J Models representing configuration settings.
+ *
+ * @author Jeen Broekstra
+ *
+ * @implNote intended for internal use only.
+ */
+@InternalUseOnly
+public class Configurations {
+
+	/**
+	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a supplied
+	 * legacy property .
+	 *
+	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 *
+	 * @param model          the model to retrieve property values from.
+	 * @param subject        the subject of the property.
+	 * @param property       the property to retrieve the value of.
+	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
+	 * @return the resource value for supplied subject and property (or the legacy property ), if present.
+	 */
+	@InternalUseOnly
+	public static Optional<Resource> getResourceValue(Model model, Resource subject, IRI property,
+			IRI legacyProperty) {
+		var result = Models.objectResource(model.getStatements(subject, property, null));
+		if (result.isPresent()) {
+			return result;
+		}
+		return Models.objectResource(model.getStatements(subject, legacyProperty, null));
+	}
+
+	/**
+	 * Retrieve a property value for the supplied subject as a {@link Literal} if present, falling back to a supplied
+	 * legacy property .
+	 *
+	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 *
+	 * @param model          the model to retrieve property values from.
+	 * @param subject        the subject of the property.
+	 * @param property       the property to retrieve the value of.
+	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
+	 * @return the literal value for supplied subject and property (or the legacy property ), if present.
+	 */
+	@InternalUseOnly
+	public static Optional<Literal> getLiteralValue(Model model, Resource subject, IRI property,
+			IRI legacyProperty) {
+
+		var result = Models.objectLiteral(model.getStatements(subject, property, null));
+		if (result.isPresent()) {
+			return result;
+		}
+		return Models.objectLiteral(model.getStatements(subject, legacyProperty, null));
+	}
+
+	/**
+	 * Retrieve all property values for the supplied subject as a Set of values and include all values for any legacy
+	 * property.
+	 *
+	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 *
+	 * @param model          the model to retrieve property values from.
+	 * @param subject        the subject of the property.
+	 * @param property       the property to retrieve the values of.
+	 * @param legacyProperty legacy property to retrieve values of.
+	 * @return the set of values for supplied subject and property (and/or legacy property).
+	 */
+	@InternalUseOnly
+	public static Set<Value> getPropertyValues(Model model, Resource subject, IRI property,
+			IRI legacyProperty) {
+		final Set<Value> results = new HashSet<>();
+		results.addAll(model.filter(subject, property, null).objects());
+		results.addAll(model.filter(subject, legacyProperty, null).objects());
+		return results;
+	}
+
+	/**
+	 * Retrieve a property value for the supplied subject as a {@link IRI} if present, falling back to a supplied legacy
+	 * property .
+	 *
+	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 *
+	 * @param model          the model to retrieve property values from.
+	 * @param subject        the subject of the property.
+	 * @param property       the property to retrieve the value of.
+	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
+	 * @return the IRI value for supplied subject and property (or the legacy property ), if present.
+	 */
+	@InternalUseOnly
+	public static Optional<IRI> getIRIValue(Model model, Resource subject, IRI property,
+			IRI legacyProperty) {
+		var result = Models.objectIRI(model.getStatements(subject, property, null));
+		if (result.isPresent()) {
+			return result;
+		}
+		return Models.objectIRI(model.getStatements(subject, legacyProperty, null));
+	}
+}

--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Configurations.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Configurations.java
@@ -36,7 +36,7 @@ public class Configurations {
 	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a supplied
 	 * legacy property .
 	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 * This method allows querying repository config models with a mix of old and new namespaces.
 	 *
 	 * @param model          the model to retrieve property values from.
 	 * @param subject        the subject of the property.
@@ -58,7 +58,7 @@ public class Configurations {
 	 * Retrieve a property value for the supplied subject as a {@link Literal} if present, falling back to a supplied
 	 * legacy property .
 	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 * This method allows querying repository config models with a mix of old and new namespaces.
 	 *
 	 * @param model          the model to retrieve property values from.
 	 * @param subject        the subject of the property.
@@ -81,7 +81,7 @@ public class Configurations {
 	 * Retrieve all property values for the supplied subject as a Set of values and include all values for any legacy
 	 * property.
 	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 * This method allows querying repository config models with a mix of old and new namespaces.
 	 *
 	 * @param model          the model to retrieve property values from.
 	 * @param subject        the subject of the property.
@@ -102,7 +102,7 @@ public class Configurations {
 	 * Retrieve a property value for the supplied subject as a {@link IRI} if present, falling back to a supplied legacy
 	 * property .
 	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 * This method allows querying repository config models with a mix of old and new namespaces.
 	 *
 	 * @param model          the model to retrieve property values from.
 	 * @param subject        the subject of the property.

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.repository.config;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * @author Herko ter Horst
@@ -69,7 +69,7 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 
 		if (delegate != null) {
 			Resource delegateNode = delegate.export(model);
-			model.add(resource, CONFIG.delegate, delegateNode);
+			model.add(resource, Config.delegate, delegateNode);
 		}
 
 		return resource;
@@ -80,7 +80,7 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 		super.parse(model, resource);
 
 		Configurations
-				.getResourceValue(model, resource, CONFIG.delegate, RepositoryConfigSchema.DELEGATE)
+				.getResourceValue(model, resource, Config.delegate, RepositoryConfigSchema.DELEGATE)
 				.ifPresent(delegate -> setDelegate(create(model, delegate)));
 	}
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
@@ -10,11 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
-import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.DELEGATE;
-
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author Herko ter Horst
@@ -70,7 +68,7 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 
 		if (delegate != null) {
 			Resource delegateNode = delegate.export(model);
-			model.add(resource, DELEGATE, delegateNode);
+			model.add(resource, CONFIG.DELEGATE, delegateNode);
 		}
 
 		return resource;
@@ -80,7 +78,8 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		super.parse(model, resource);
 
-		Models.objectResource(model.getStatements(resource, DELEGATE, null))
+		RepositoryConfigUtil
+				.getPropertyAsResource(model, resource, CONFIG.DELEGATE, RepositoryConfigSchema.NAMESPACE_OBSOLETE)
 				.ifPresent(delegate -> setDelegate(create(model, delegate)));
 	}
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
@@ -68,7 +68,7 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 
 		if (delegate != null) {
 			Resource delegateNode = delegate.export(model);
-			model.add(resource, CONFIG.DELEGATE, delegateNode);
+			model.add(resource, CONFIG.delegate, delegateNode);
 		}
 
 		return resource;
@@ -79,7 +79,7 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 		super.parse(model, resource);
 
 		RepositoryConfigUtil
-				.getPropertyAsResource(model, resource, CONFIG.DELEGATE, RepositoryConfigSchema.NAMESPACE_OBSOLETE)
+				.getPropertyAsResource(model, resource, CONFIG.delegate, RepositoryConfigSchema.NAMESPACE_OBSOLETE)
 				.ifPresent(delegate -> setDelegate(create(model, delegate)));
 	}
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
@@ -79,7 +79,7 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 		super.parse(model, resource);
 
 		RepositoryConfigUtil
-				.getPropertyAsResource(model, resource, CONFIG.delegate, RepositoryConfigSchema.NAMESPACE_OBSOLETE)
+				.getPropertyAsResource(model, resource, CONFIG.delegate, RepositoryConfigSchema.DELEGATE)
 				.ifPresent(delegate -> setDelegate(create(model, delegate)));
 	}
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.repository.config;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author Herko ter Horst
@@ -69,7 +69,7 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 
 		if (delegate != null) {
 			Resource delegateNode = delegate.export(model);
-			model.add(resource, Config.delegate, delegateNode);
+			model.add(resource, CONFIG.delegate, delegateNode);
 		}
 
 		return resource;
@@ -80,7 +80,7 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 		super.parse(model, resource);
 
 		Configurations
-				.getResourceValue(model, resource, Config.delegate, RepositoryConfigSchema.DELEGATE)
+				.getResourceValue(model, resource, CONFIG.delegate, RepositoryConfigSchema.DELEGATE)
 				.ifPresent(delegate -> setDelegate(create(model, delegate)));
 	}
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractDelegatingRepositoryImplConfig.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.repository.config;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
@@ -78,8 +79,8 @@ public abstract class AbstractDelegatingRepositoryImplConfig extends AbstractRep
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		super.parse(model, resource);
 
-		RepositoryConfigUtil
-				.getPropertyAsResource(model, resource, CONFIG.delegate, RepositoryConfigSchema.DELEGATE)
+		Configurations
+				.getResourceValue(model, resource, CONFIG.delegate, RepositoryConfigSchema.DELEGATE)
 				.ifPresent(delegate -> setDelegate(create(model, delegate)));
 	}
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE_OBSOLETE;
-import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYTYPE;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author Herko ter Horst
@@ -64,7 +65,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 		BNode implNode = SimpleValueFactory.getInstance().createBNode();
 
 		if (type != null) {
-			model.add(implNode, REPOSITORYTYPE, SimpleValueFactory.getInstance().createLiteral(type));
+			model.add(implNode, CONFIG.REPOSITORY_TYPE, literal(type));
 		}
 
 		return implNode;
@@ -73,7 +74,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		RepositoryConfigUtil
-				.getPropertyAsLiteral(model, resource, REPOSITORYTYPE, NAMESPACE_OBSOLETE)
+				.getPropertyAsLiteral(model, resource, CONFIG.REPOSITORY_TYPE, NAMESPACE_OBSOLETE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -90,7 +91,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
 			final Literal typeLit = RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, REPOSITORYTYPE, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, resource, CONFIG.REPOSITORY_TYPE, NAMESPACE_OBSOLETE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -65,7 +65,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 		BNode implNode = bnode();
 
 		if (type != null) {
-			model.add(implNode, CONFIG.REPOSITORY_TYPE, literal(type));
+			model.add(implNode, CONFIG.repositoryType, literal(type));
 		}
 
 		return implNode;
@@ -74,7 +74,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		RepositoryConfigUtil
-				.getPropertyAsLiteral(model, resource, CONFIG.REPOSITORY_TYPE, NAMESPACE_OBSOLETE)
+				.getPropertyAsLiteral(model, resource, CONFIG.repositoryType, NAMESPACE_OBSOLETE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -91,7 +91,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
 			final Literal typeLit = RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.REPOSITORY_TYPE, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, resource, CONFIG.repositoryType, NAMESPACE_OBSOLETE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -65,7 +65,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 		BNode implNode = bnode();
 
 		if (type != null) {
-			model.add(implNode, CONFIG.repositoryType, literal(type));
+			model.add(implNode, CONFIG.Rep.repositoryType, literal(type));
 		}
 
 		return implNode;
@@ -74,7 +74,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		Configurations
-				.getLiteralValue(model, resource, CONFIG.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
+				.getLiteralValue(model, resource, CONFIG.Rep.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -91,7 +91,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
 			final Literal typeLit = Configurations
-					.getLiteralValue(model, resource, CONFIG.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
+					.getLiteralValue(model, resource, CONFIG.Rep.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
+import static org.eclipse.rdf4j.model.util.Values.bnode;
 import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE_OBSOLETE;
 
@@ -17,7 +18,6 @@ import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
@@ -62,7 +62,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 
 	@Override
 	public Resource export(Model model) {
-		BNode implNode = SimpleValueFactory.getInstance().createBNode();
+		BNode implNode = bnode();
 
 		if (type != null) {
 			model.add(implNode, CONFIG.REPOSITORY_TYPE, literal(type));

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
+import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE_OBSOLETE;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYTYPE;
 
 import org.eclipse.rdf4j.model.BNode;
@@ -18,7 +19,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
 
 /**
  * @author Herko ter Horst
@@ -72,7 +72,8 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
-		Models.objectLiteral(model.getStatements(resource, REPOSITORYTYPE, null))
+		RepositoryConfigUtil
+				.getPropertyAsLiteral(model, resource, REPOSITORYTYPE, NAMESPACE_OBSOLETE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -88,10 +89,8 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	 */
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
-			// Literal typeLit = GraphUtil.getOptionalObjectLiteral(graph,
-			// implNode, REPOSITORYTYPE);
-
-			final Literal typeLit = Models.objectLiteral(model.getStatements(resource, REPOSITORYTYPE, null))
+			final Literal typeLit = RepositoryConfigUtil
+					.getPropertyAsLiteral(model, resource, REPOSITORYTYPE, NAMESPACE_OBSOLETE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()
@@ -109,4 +108,5 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 			throw new RepositoryConfigException(e.getMessage(), e);
 		}
 	}
+
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * @author Herko ter Horst
@@ -65,7 +65,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 		BNode implNode = bnode();
 
 		if (type != null) {
-			model.add(implNode, CONFIG.Rep.type, literal(type));
+			model.add(implNode, Config.Rep.type, literal(type));
 		}
 
 		return implNode;
@@ -74,7 +74,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		Configurations
-				.getLiteralValue(model, resource, CONFIG.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
+				.getLiteralValue(model, resource, Config.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -91,7 +91,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
 			final Literal typeLit = Configurations
-					.getLiteralValue(model, resource, CONFIG.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
+					.getLiteralValue(model, resource, Config.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author Herko ter Horst
@@ -65,7 +65,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 		BNode implNode = bnode();
 
 		if (type != null) {
-			model.add(implNode, Config.Rep.type, literal(type));
+			model.add(implNode, CONFIG.Rep.type, literal(type));
 		}
 
 		return implNode;
@@ -74,7 +74,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		Configurations
-				.getLiteralValue(model, resource, Config.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
+				.getLiteralValue(model, resource, CONFIG.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -91,7 +91,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
 			final Literal typeLit = Configurations
-					.getLiteralValue(model, resource, Config.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
+					.getLiteralValue(model, resource, CONFIG.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.repository.config;
 
 import static org.eclipse.rdf4j.model.util.Values.bnode;
 import static org.eclipse.rdf4j.model.util.Values.literal;
-import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE_OBSOLETE;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
@@ -74,7 +73,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		RepositoryConfigUtil
-				.getPropertyAsLiteral(model, resource, CONFIG.repositoryType, NAMESPACE_OBSOLETE)
+				.getPropertyAsLiteral(model, resource, CONFIG.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -91,7 +90,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
 			final Literal typeLit = RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.repositoryType, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, resource, CONFIG.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
@@ -72,8 +73,8 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
-		RepositoryConfigUtil
-				.getPropertyAsLiteral(model, resource, CONFIG.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
+		Configurations
+				.getLiteralValue(model, resource, CONFIG.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -89,8 +90,8 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	 */
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
-			final Literal typeLit = RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
+			final Literal typeLit = Configurations
+					.getLiteralValue(model, resource, CONFIG.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/AbstractRepositoryImplConfig.java
@@ -65,7 +65,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 		BNode implNode = bnode();
 
 		if (type != null) {
-			model.add(implNode, CONFIG.Rep.repositoryType, literal(type));
+			model.add(implNode, CONFIG.Rep.type, literal(type));
 		}
 
 		return implNode;
@@ -74,7 +74,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource resource) throws RepositoryConfigException {
 		Configurations
-				.getLiteralValue(model, resource, CONFIG.Rep.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
+				.getLiteralValue(model, resource, CONFIG.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
 				.ifPresent(typeLit -> setType(typeLit.getLabel()));
 	}
 
@@ -91,7 +91,7 @@ public class AbstractRepositoryImplConfig implements RepositoryImplConfig {
 	public static RepositoryImplConfig create(Model model, Resource resource) throws RepositoryConfigException {
 		try {
 			final Literal typeLit = Configurations
-					.getLiteralValue(model, resource, CONFIG.Rep.repositoryType, RepositoryConfigSchema.REPOSITORYTYPE)
+					.getLiteralValue(model, resource, CONFIG.Rep.type, RepositoryConfigSchema.REPOSITORYTYPE)
 					.orElse(null);
 			if (typeLit != null) {
 				RepositoryFactory factory = RepositoryRegistry.getInstance()

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -15,6 +15,7 @@ import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
@@ -146,16 +147,16 @@ public class RepositoryConfig {
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
-			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, repositoryNode, CONFIG.repositoryID,
+			Configurations
+					.getLiteralValue(model, repositoryNode, CONFIG.repositoryID,
 							RepositoryConfigSchema.REPOSITORYID)
 					.ifPresent(lit -> setID(lit.getLabel()));
 
 			Models.objectLiteral(model.getStatements(repositoryNode, RDFS.LABEL, null))
 					.ifPresent(lit -> setTitle(lit.getLabel()));
 
-			RepositoryConfigUtil
-					.getPropertyAsResource(model, repositoryNode, CONFIG.repositoryImpl,
+			Configurations
+					.getResourceValue(model, repositoryNode, CONFIG.repositoryImpl,
 							RepositoryConfigSchema.REPOSITORYIMPL)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -130,25 +130,25 @@ public class RepositoryConfig {
 	public void export(Model model, Resource repositoryNode) {
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
-		model.setNamespace("rep", CONFIG.NAMESPACE);
-		model.add(repositoryNode, RDF.TYPE, CONFIG.Rep.Repository);
+		model.setNamespace("rep", Config.NAMESPACE);
+		model.add(repositoryNode, RDF.TYPE, Config.Rep.Repository);
 
 		if (id != null) {
-			model.add(repositoryNode, CONFIG.Rep.id, literal(id));
+			model.add(repositoryNode, Config.Rep.id, literal(id));
 		}
 		if (title != null) {
 			model.add(repositoryNode, RDFS.LABEL, literal(title));
 		}
 		if (implConfig != null) {
 			Resource implNode = implConfig.export(model);
-			model.add(repositoryNode, CONFIG.Rep.impl, implNode);
+			model.add(repositoryNode, Config.Rep.impl, implNode);
 		}
 	}
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
 			Configurations
-					.getLiteralValue(model, repositoryNode, CONFIG.Rep.id,
+					.getLiteralValue(model, repositoryNode, Config.Rep.id,
 							RepositoryConfigSchema.REPOSITORYID)
 					.ifPresent(lit -> setID(lit.getLabel()));
 
@@ -156,7 +156,7 @@ public class RepositoryConfig {
 					.ifPresent(lit -> setTitle(lit.getLabel()));
 
 			Configurations
-					.getResourceValue(model, repositoryNode, CONFIG.Rep.impl,
+					.getResourceValue(model, repositoryNode, Config.Rep.impl,
 							RepositoryConfigSchema.REPOSITORYIMPL)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -148,7 +148,7 @@ public class RepositoryConfig {
 		try {
 			RepositoryConfigUtil
 					.getPropertyAsLiteral(model, repositoryNode, CONFIG.repositoryID,
-							RepositoryConfigSchema.NAMESPACE_OBSOLETE)
+							RepositoryConfigSchema.REPOSITORYID)
 					.ifPresent(lit -> setID(lit.getLabel()));
 
 			Models.objectLiteral(model.getStatements(repositoryNode, RDFS.LABEL, null))
@@ -156,7 +156,7 @@ public class RepositoryConfig {
 
 			RepositoryConfigUtil
 					.getPropertyAsResource(model, repositoryNode, CONFIG.repositoryImpl,
-							RepositoryConfigSchema.NAMESPACE_OBSOLETE)
+							RepositoryConfigSchema.REPOSITORYIMPL)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
+import static org.eclipse.rdf4j.model.util.Values.bnode;
 import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE_OBSOLETE;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORY;
@@ -23,8 +25,6 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -125,8 +125,7 @@ public class RepositoryConfig {
 	 */
 	@Deprecated
 	public void export(Model model) {
-		ValueFactory vf = SimpleValueFactory.getInstance();
-		export(model, vf.createBNode());
+		export(model, bnode());
 	}
 
 	/**
@@ -137,17 +136,16 @@ public class RepositoryConfig {
 	 * @since 2.3
 	 */
 	public void export(Model model, Resource repositoryNode) {
-		ValueFactory vf = SimpleValueFactory.getInstance();
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
 		model.setNamespace("rep", NAMESPACE);
 		model.add(repositoryNode, RDF.TYPE, REPOSITORY);
 
 		if (id != null) {
-			model.add(repositoryNode, REPOSITORYID, vf.createLiteral(id));
+			model.add(repositoryNode, REPOSITORYID, literal(id));
 		}
 		if (title != null) {
-			model.add(repositoryNode, RDFS.LABEL, vf.createLiteral(title));
+			model.add(repositoryNode, RDFS.LABEL, literal(title));
 		}
 		if (implConfig != null) {
 			Resource implNode = implConfig.export(model);
@@ -169,7 +167,6 @@ public class RepositoryConfig {
 	}
 
 	private Optional<Resource> getResource(Model model, Resource subject, IRI property) {
-
 		return Optional
 				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
 				.orElseGet(() -> {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -130,7 +130,7 @@ public class RepositoryConfig {
 	public void export(Model model, Resource repositoryNode) {
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
-		model.setNamespace("config", CONFIG.NAMESPACE);
+		model.setNamespace(CONFIG.NS);
 		model.add(repositoryNode, RDF.TYPE, CONFIG.Rep.Repository);
 
 		if (id != null) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -12,16 +12,12 @@ package org.eclipse.rdf4j.repository.config;
 
 import static org.eclipse.rdf4j.model.util.Values.bnode;
 import static org.eclipse.rdf4j.model.util.Values.literal;
-import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE;
-import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE_OBSOLETE;
-import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORY;
-import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYID;
-import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYIMPL;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -133,32 +129,34 @@ public class RepositoryConfig {
 	public void export(Model model, Resource repositoryNode) {
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
-		model.setNamespace("rep", NAMESPACE);
-		model.add(repositoryNode, RDF.TYPE, REPOSITORY);
+		model.setNamespace("rep", CONFIG.NAMESPACE);
+		model.add(repositoryNode, RDF.TYPE, CONFIG.REPOSITORY);
 
 		if (id != null) {
-			model.add(repositoryNode, REPOSITORYID, literal(id));
+			model.add(repositoryNode, CONFIG.REPOSITORY_ID, literal(id));
 		}
 		if (title != null) {
 			model.add(repositoryNode, RDFS.LABEL, literal(title));
 		}
 		if (implConfig != null) {
 			Resource implNode = implConfig.export(model);
-			model.add(repositoryNode, REPOSITORYIMPL, implNode);
+			model.add(repositoryNode, CONFIG.REPOSITORY_IMPL, implNode);
 		}
 	}
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, repositoryNode, REPOSITORYID, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, repositoryNode, CONFIG.REPOSITORY_ID,
+							RepositoryConfigSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setID(lit.getLabel()));
 
 			Models.objectLiteral(model.getStatements(repositoryNode, RDFS.LABEL, null))
 					.ifPresent(lit -> setTitle(lit.getLabel()));
 
 			RepositoryConfigUtil
-					.getPropertyAsResource(model, repositoryNode, REPOSITORYIMPL, NAMESPACE_OBSOLETE)
+					.getPropertyAsResource(model, repositoryNode, CONFIG.REPOSITORY_IMPL,
+							RepositoryConfigSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -131,24 +131,24 @@ public class RepositoryConfig {
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
 		model.setNamespace("rep", CONFIG.NAMESPACE);
-		model.add(repositoryNode, RDF.TYPE, CONFIG.Repository);
+		model.add(repositoryNode, RDF.TYPE, CONFIG.Rep.Repository);
 
 		if (id != null) {
-			model.add(repositoryNode, CONFIG.repositoryID, literal(id));
+			model.add(repositoryNode, CONFIG.Rep.repositoryID, literal(id));
 		}
 		if (title != null) {
 			model.add(repositoryNode, RDFS.LABEL, literal(title));
 		}
 		if (implConfig != null) {
 			Resource implNode = implConfig.export(model);
-			model.add(repositoryNode, CONFIG.repositoryImpl, implNode);
+			model.add(repositoryNode, CONFIG.Rep.repositoryImpl, implNode);
 		}
 	}
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
 			Configurations
-					.getLiteralValue(model, repositoryNode, CONFIG.repositoryID,
+					.getLiteralValue(model, repositoryNode, CONFIG.Rep.repositoryID,
 							RepositoryConfigSchema.REPOSITORYID)
 					.ifPresent(lit -> setID(lit.getLabel()));
 
@@ -156,7 +156,7 @@ public class RepositoryConfig {
 					.ifPresent(lit -> setTitle(lit.getLabel()));
 
 			Configurations
-					.getResourceValue(model, repositoryNode, CONFIG.repositoryImpl,
+					.getResourceValue(model, repositoryNode, CONFIG.Rep.repositoryImpl,
 							RepositoryConfigSchema.REPOSITORYIMPL)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -134,21 +134,21 @@ public class RepositoryConfig {
 		model.add(repositoryNode, RDF.TYPE, CONFIG.Rep.Repository);
 
 		if (id != null) {
-			model.add(repositoryNode, CONFIG.Rep.repositoryID, literal(id));
+			model.add(repositoryNode, CONFIG.Rep.id, literal(id));
 		}
 		if (title != null) {
 			model.add(repositoryNode, RDFS.LABEL, literal(title));
 		}
 		if (implConfig != null) {
 			Resource implNode = implConfig.export(model);
-			model.add(repositoryNode, CONFIG.Rep.repositoryImpl, implNode);
+			model.add(repositoryNode, CONFIG.Rep.impl, implNode);
 		}
 	}
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
 			Configurations
-					.getLiteralValue(model, repositoryNode, CONFIG.Rep.repositoryID,
+					.getLiteralValue(model, repositoryNode, CONFIG.Rep.id,
 							RepositoryConfigSchema.REPOSITORYID)
 					.ifPresent(lit -> setID(lit.getLabel()));
 
@@ -156,7 +156,7 @@ public class RepositoryConfig {
 					.ifPresent(lit -> setTitle(lit.getLabel()));
 
 			Configurations
-					.getResourceValue(model, repositoryNode, CONFIG.Rep.repositoryImpl,
+					.getResourceValue(model, repositoryNode, CONFIG.Rep.impl,
 							RepositoryConfigSchema.REPOSITORYIMPL)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
@@ -130,25 +130,25 @@ public class RepositoryConfig {
 	public void export(Model model, Resource repositoryNode) {
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
-		model.setNamespace("rep", Config.NAMESPACE);
-		model.add(repositoryNode, RDF.TYPE, Config.Rep.Repository);
+		model.setNamespace("rep", CONFIG.NAMESPACE);
+		model.add(repositoryNode, RDF.TYPE, CONFIG.Rep.Repository);
 
 		if (id != null) {
-			model.add(repositoryNode, Config.Rep.id, literal(id));
+			model.add(repositoryNode, CONFIG.Rep.id, literal(id));
 		}
 		if (title != null) {
 			model.add(repositoryNode, RDFS.LABEL, literal(title));
 		}
 		if (implConfig != null) {
 			Resource implNode = implConfig.export(model);
-			model.add(repositoryNode, Config.Rep.impl, implNode);
+			model.add(repositoryNode, CONFIG.Rep.impl, implNode);
 		}
 	}
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
 			Configurations
-					.getLiteralValue(model, repositoryNode, Config.Rep.id,
+					.getLiteralValue(model, repositoryNode, CONFIG.Rep.id,
 							RepositoryConfigSchema.REPOSITORYID)
 					.ifPresent(lit -> setID(lit.getLabel()));
 
@@ -156,7 +156,7 @@ public class RepositoryConfig {
 					.ifPresent(lit -> setTitle(lit.getLabel()));
 
 			Configurations
-					.getResourceValue(model, repositoryNode, Config.Rep.impl,
+					.getResourceValue(model, repositoryNode, CONFIG.Rep.impl,
 							RepositoryConfigSchema.REPOSITORYIMPL)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -165,7 +165,6 @@ public class RepositoryConfig {
 		}
 	}
 
-
 	/**
 	 * Creates a new {@link RepositoryConfig} object and initializes it by supplying the {@code model} and
 	 * {@code repositoryNode} to its {@link #parse(Model, Resource) parse} method.

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -11,7 +11,6 @@
 package org.eclipse.rdf4j.repository.config;
 
 import static org.eclipse.rdf4j.model.util.Values.bnode;
-import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE_OBSOLETE;
@@ -19,10 +18,6 @@ import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSIT
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYID;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYIMPL;
 
-import java.util.Optional;
-
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.ModelException;
@@ -155,34 +150,21 @@ public class RepositoryConfig {
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
-			getLiteral(model, repositoryNode, REPOSITORYID)
+			RepositoryConfigUtil
+					.getPropertyAsLiteral(model, repositoryNode, REPOSITORYID, NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setID(lit.getLabel()));
+
 			Models.objectLiteral(model.getStatements(repositoryNode, RDFS.LABEL, null))
 					.ifPresent(lit -> setTitle(lit.getLabel()));
-			getResource(model, repositoryNode, REPOSITORYIMPL)
+
+			RepositoryConfigUtil
+					.getPropertyAsResource(model, repositoryNode, REPOSITORYIMPL, NAMESPACE_OBSOLETE)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);
 		}
 	}
 
-	private Optional<Resource> getResource(Model model, Resource subject, IRI property) {
-		return Optional
-				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					IRI fallback = iri(NAMESPACE_OBSOLETE, property.getLocalName());
-					return Models.objectResource(model.getStatements(subject, fallback, null));
-				});
-	}
-
-	private Optional<Literal> getLiteral(Model model, Resource subject, IRI property) {
-		return Optional
-				.ofNullable(Models.objectLiteral(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					IRI fallback = iri(NAMESPACE_OBSOLETE, property.getLocalName());
-					return Models.objectLiteral(model.getStatements(subject, fallback, null));
-				});
-	}
 
 	/**
 	 * Creates a new {@link RepositoryConfig} object and initializes it by supplying the {@code model} and

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -130,24 +130,24 @@ public class RepositoryConfig {
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
 		model.setNamespace("rep", CONFIG.NAMESPACE);
-		model.add(repositoryNode, RDF.TYPE, CONFIG.REPOSITORY);
+		model.add(repositoryNode, RDF.TYPE, CONFIG.Repository);
 
 		if (id != null) {
-			model.add(repositoryNode, CONFIG.REPOSITORY_ID, literal(id));
+			model.add(repositoryNode, CONFIG.repositoryID, literal(id));
 		}
 		if (title != null) {
 			model.add(repositoryNode, RDFS.LABEL, literal(title));
 		}
 		if (implConfig != null) {
 			Resource implNode = implConfig.export(model);
-			model.add(repositoryNode, CONFIG.REPOSITORY_IMPL, implNode);
+			model.add(repositoryNode, CONFIG.repositoryImpl, implNode);
 		}
 	}
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, repositoryNode, CONFIG.REPOSITORY_ID,
+					.getPropertyAsLiteral(model, repositoryNode, CONFIG.repositoryID,
 							RepositoryConfigSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setID(lit.getLabel()));
 
@@ -155,7 +155,7 @@ public class RepositoryConfig {
 					.ifPresent(lit -> setTitle(lit.getLabel()));
 
 			RepositoryConfigUtil
-					.getPropertyAsResource(model, repositoryNode, CONFIG.REPOSITORY_IMPL,
+					.getPropertyAsResource(model, repositoryNode, CONFIG.repositoryImpl,
 							RepositoryConfigSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -130,7 +130,7 @@ public class RepositoryConfig {
 	public void export(Model model, Resource repositoryNode) {
 		model.setNamespace(RDFS.NS);
 		model.setNamespace(XSD.NS);
-		model.setNamespace("rep", CONFIG.NAMESPACE);
+		model.setNamespace("config", CONFIG.NAMESPACE);
 		model.add(repositoryNode, RDF.TYPE, CONFIG.Rep.Repository);
 
 		if (id != null) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfig.java
@@ -10,11 +10,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE;
+import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.NAMESPACE_OBSOLETE;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORY;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYID;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYIMPL;
 
+import java.util.Optional;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -151,16 +157,34 @@ public class RepositoryConfig {
 
 	public void parse(Model model, Resource repositoryNode) throws RepositoryConfigException {
 		try {
-
-			Models.objectLiteral(model.getStatements(repositoryNode, REPOSITORYID, null))
+			getLiteral(model, repositoryNode, REPOSITORYID)
 					.ifPresent(lit -> setID(lit.getLabel()));
 			Models.objectLiteral(model.getStatements(repositoryNode, RDFS.LABEL, null))
 					.ifPresent(lit -> setTitle(lit.getLabel()));
-			Models.objectResource(model.getStatements(repositoryNode, REPOSITORYIMPL, null))
+			getResource(model, repositoryNode, REPOSITORYIMPL)
 					.ifPresent(res -> setRepositoryImplConfig(AbstractRepositoryImplConfig.create(model, res)));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);
 		}
+	}
+
+	private Optional<Resource> getResource(Model model, Resource subject, IRI property) {
+
+		return Optional
+				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
+				.orElseGet(() -> {
+					IRI fallback = iri(NAMESPACE_OBSOLETE, property.getLocalName());
+					return Models.objectResource(model.getStatements(subject, fallback, null));
+				});
+	}
+
+	private Optional<Literal> getLiteral(Model model, Resource subject, IRI property) {
+		return Optional
+				.ofNullable(Models.objectLiteral(model.getStatements(subject, property, null)))
+				.orElseGet(() -> {
+					IRI fallback = iri(NAMESPACE_OBSOLETE, property.getLocalName());
+					return Models.objectLiteral(model.getStatements(subject, fallback, null));
+				});
 	}
 
 	/**

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -19,44 +19,47 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
  * {@link org.eclipse.rdf4j.repository.manager.RepositoryManager}s.
  *
  * @author Arjohn Kampman
+ * @author Jeen Broekstra
  */
 public class RepositoryConfigSchema {
 
 	/**
-	 * The Repository config schema namespace (<var>http://rdf4j.org/vocabulary/repository#</var>).
+	 * The Repository config schema namespace (<var>tag:rdf4j.org:2023:config/repository#</var>).
+	 * 
+	 * @see tools.ietf.org/html/rfc4151
 	 */
-	public static final String NAMESPACE = "http://rdf4j.org/schema/repository#";
+	public static final String NAMESPACE = "tag:rdf4j.org:2023:config/repository#";
 
-	@Deprecated(forRemoval = true)
+	@Deprecated(since = "4.3.0", forRemoval = true)
 	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository#";
 
 	/**
-	 * <var>"http://rdf4j.org/schema/repository#RepositoryContext</var>
+	 * <var>"tag:rdf4j.org:2023:config/repository#RepositoryContext</var>
 	 */
 	public final static IRI REPOSITORY_CONTEXT;
 
 	/**
-	 * <var>http://rdf4j.org/schema/repository#Repository</var>
+	 * <var>tag:rdf4j.org:2023:config/repository#Repository</var>
 	 */
 	public final static IRI REPOSITORY;
 
 	/**
-	 * <var>http://rdf4j.org/schema/repository#repositoryID</var>
+	 * <var>tag:rdf4j.org:2023:config/repository#repositoryID</var>
 	 */
 	public final static IRI REPOSITORYID;
 
 	/**
-	 * <var>http://rdf4j.org/schema/repository#repositoryImpl</var>
+	 * <var>tag:rdf4j.org:2023:config/repository#repositoryImpl</var>
 	 */
 	public final static IRI REPOSITORYIMPL;
 
 	/**
-	 * <var>http://rdf4j.org/schema/repository#repositoryType</var>
+	 * <var>tag:rdf4j.org:2023:config/repository#repositoryType</var>
 	 */
 	public final static IRI REPOSITORYTYPE;
 
 	/**
-	 * <var>http://rdf4j.org/schema/repository#delegate</var>
+	 * <var>tag:rdf4j.org:2023:config/repository#delegate</var>
 	 */
 	public final static IRI DELEGATE;
 

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -22,14 +22,12 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
  * @author Arjohn Kampman
  * @author Jeen Broekstra
  *
- * @deprecated use {@link CONFIG} instead.
+ * @deprecated use {@link CONFIG} vocabulary instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class RepositoryConfigSchema {
 
-	public static final String NAMESPACE = CONFIG.NAMESPACE;
-
-	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository#";
+	public static final String NAMESPACE = "http://www.openrdf.org/config/repository#";
 
 	/**
 	 * This IRI is not in the CONFIG vocabulary because it is no longer necessary - it was only used in the old-style
@@ -37,13 +35,28 @@ public class RepositoryConfigSchema {
 	 */
 	public final static IRI REPOSITORY_CONTEXT = iri(NAMESPACE, "RepositoryContext");
 
-	public final static IRI REPOSITORY = CONFIG.Repository;
+	/**
+	 * @deprecated use {@link CONFIG#Repository} instead.
+	 */
+	public final static IRI REPOSITORY = iri(NAMESPACE, "Repository");
 
-	public final static IRI REPOSITORYID = CONFIG.repositoryID;
+	/**
+	 * @deprecated use {@link CONFIG#repositoryID} instead.
+	 */
+	public final static IRI REPOSITORYID = iri(NAMESPACE, "repositoryID");
 
-	public final static IRI REPOSITORYIMPL = CONFIG.repositoryImpl;
+	/**
+	 * @deprecated use {@link CONFIG#repositoryImpl} instead.
+	 */
+	public final static IRI REPOSITORYIMPL = iri(NAMESPACE, "repositoryImpl");
 
-	public final static IRI REPOSITORYTYPE = CONFIG.repositoryType;
+	/**
+	 * @deprecated use {@link CONFIG#repositoryType} instead.
+	 */
+	public final static IRI REPOSITORYTYPE = iri(NAMESPACE, "repositoryType");
 
-	public final static IRI DELEGATE = CONFIG.delegate;
+	/**
+	 * @deprecated use {@link CONFIG#delegate} instead.
+	 */
+	public final static IRI DELEGATE = iri(NAMESPACE, "delegate");
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
  *
  * @author Arjohn Kampman
  * @author Jeen Broekstra
- * 
+ *
  * @deprecated use {@link CONFIG} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -23,37 +23,40 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 public class RepositoryConfigSchema {
 
 	/**
-	 * The HTTPRepository schema namespace (<var>http://www.openrdf.org/config/repository#</var>).
+	 * The Repository config schema namespace (<var>http://rdf4j.org/vocabulary/repository#</var>).
 	 */
-	public static final String NAMESPACE = "http://www.openrdf.org/config/repository#";
+	public static final String NAMESPACE = "http://rdf4j.org/schema/repository#";
+
+	@Deprecated(forRemoval = true)
+	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository#";
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository#RepositoryContext</var>
+	 * <var>"http://rdf4j.org/schema/repository#RepositoryContext</var>
 	 */
 	public final static IRI REPOSITORY_CONTEXT;
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository#Repository</var>
+	 * <var>http://rdf4j.org/schema/repository#Repository</var>
 	 */
 	public final static IRI REPOSITORY;
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository#repositoryID</var>
+	 * <var>http://rdf4j.org/schema/repository#repositoryID</var>
 	 */
 	public final static IRI REPOSITORYID;
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository#repositoryImpl</var>
+	 * <var>http://rdf4j.org/schema/repository#repositoryImpl</var>
 	 */
 	public final static IRI REPOSITORYIMPL;
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository#repositoryType</var>
+	 * <var>http://rdf4j.org/schema/repository#repositoryType</var>
 	 */
 	public final static IRI REPOSITORYTYPE;
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository#delegate</var>
+	 * <var>http://rdf4j.org/schema/repository#delegate</var>
 	 */
 	public final static IRI DELEGATE;
 

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -41,17 +41,17 @@ public class RepositoryConfigSchema {
 	public final static IRI REPOSITORY = iri(NAMESPACE, "Repository");
 
 	/**
-	 * @deprecated use {@link CONFIG#repositoryID} instead.
+	 * @deprecated use {@link CONFIG#id} instead.
 	 */
 	public final static IRI REPOSITORYID = iri(NAMESPACE, "repositoryID");
 
 	/**
-	 * @deprecated use {@link CONFIG#repositoryImpl} instead.
+	 * @deprecated use {@link CONFIG#impl} instead.
 	 */
 	public final static IRI REPOSITORYIMPL = iri(NAMESPACE, "repositoryImpl");
 
 	/**
-	 * @deprecated use {@link CONFIG#repositoryType} instead.
+	 * @deprecated use {@link CONFIG#type} instead.
 	 */
 	public final static IRI REPOSITORYTYPE = iri(NAMESPACE, "repositoryType");
 

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.repository.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Defines constants for the repository configuration schema that is used by
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.vocabulary.Config;
  * @author Arjohn Kampman
  * @author Jeen Broekstra
  *
- * @deprecated use {@link Config} vocabulary instead.
+ * @deprecated use {@link CONFIG} vocabulary instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class RepositoryConfigSchema {
@@ -36,27 +36,27 @@ public class RepositoryConfigSchema {
 	public final static IRI REPOSITORY_CONTEXT = iri(NAMESPACE, "RepositoryContext");
 
 	/**
-	 * @deprecated use {@link Config#Repository} instead.
+	 * @deprecated use {@link CONFIG#Repository} instead.
 	 */
 	public final static IRI REPOSITORY = iri(NAMESPACE, "Repository");
 
 	/**
-	 * @deprecated use {@link Config#id} instead.
+	 * @deprecated use {@link CONFIG#id} instead.
 	 */
 	public final static IRI REPOSITORYID = iri(NAMESPACE, "repositoryID");
 
 	/**
-	 * @deprecated use {@link Config#impl} instead.
+	 * @deprecated use {@link CONFIG#impl} instead.
 	 */
 	public final static IRI REPOSITORYIMPL = iri(NAMESPACE, "repositoryImpl");
 
 	/**
-	 * @deprecated use {@link Config#type} instead.
+	 * @deprecated use {@link CONFIG#type} instead.
 	 */
 	public final static IRI REPOSITORYTYPE = iri(NAMESPACE, "repositoryType");
 
 	/**
-	 * @deprecated use {@link Config#delegate} instead.
+	 * @deprecated use {@link CONFIG#delegate} instead.
 	 */
 	public final static IRI DELEGATE = iri(NAMESPACE, "delegate");
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.repository.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * Defines constants for the repository configuration schema that is used by
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
  * @author Arjohn Kampman
  * @author Jeen Broekstra
  *
- * @deprecated use {@link CONFIG} vocabulary instead.
+ * @deprecated use {@link Config} vocabulary instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class RepositoryConfigSchema {
@@ -36,27 +36,27 @@ public class RepositoryConfigSchema {
 	public final static IRI REPOSITORY_CONTEXT = iri(NAMESPACE, "RepositoryContext");
 
 	/**
-	 * @deprecated use {@link CONFIG#Repository} instead.
+	 * @deprecated use {@link Config#Repository} instead.
 	 */
 	public final static IRI REPOSITORY = iri(NAMESPACE, "Repository");
 
 	/**
-	 * @deprecated use {@link CONFIG#id} instead.
+	 * @deprecated use {@link Config#id} instead.
 	 */
 	public final static IRI REPOSITORYID = iri(NAMESPACE, "repositoryID");
 
 	/**
-	 * @deprecated use {@link CONFIG#impl} instead.
+	 * @deprecated use {@link Config#impl} instead.
 	 */
 	public final static IRI REPOSITORYIMPL = iri(NAMESPACE, "repositoryImpl");
 
 	/**
-	 * @deprecated use {@link CONFIG#type} instead.
+	 * @deprecated use {@link Config#type} instead.
 	 */
 	public final static IRI REPOSITORYTYPE = iri(NAMESPACE, "repositoryType");
 
 	/**
-	 * @deprecated use {@link CONFIG#delegate} instead.
+	 * @deprecated use {@link Config#delegate} instead.
 	 */
 	public final static IRI DELEGATE = iri(NAMESPACE, "delegate");
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -37,13 +37,13 @@ public class RepositoryConfigSchema {
 	 */
 	public final static IRI REPOSITORY_CONTEXT = iri(NAMESPACE, "RepositoryContext");
 
-	public final static IRI REPOSITORY = CONFIG.REPOSITORY;
+	public final static IRI REPOSITORY = CONFIG.Repository;
 
-	public final static IRI REPOSITORYID = CONFIG.REPOSITORY_ID;
+	public final static IRI REPOSITORYID = CONFIG.repositoryID;
 
-	public final static IRI REPOSITORYIMPL = CONFIG.REPOSITORY_IMPL;
+	public final static IRI REPOSITORYIMPL = CONFIG.repositoryImpl;
 
-	public final static IRI REPOSITORYTYPE = CONFIG.REPOSITORY_TYPE;
+	public final static IRI REPOSITORYTYPE = CONFIG.repositoryType;
 
-	public final static IRI DELEGATE = CONFIG.DELEGATE;
+	public final static IRI DELEGATE = CONFIG.delegate;
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -25,7 +25,7 @@ public class RepositoryConfigSchema {
 
 	/**
 	 * The Repository config schema namespace (<var>tag:rdf4j.org:2023:config/repository#</var>).
-	 * 
+	 *
 	 * @see tools.ietf.org/html/rfc4151
 	 */
 	public static final String NAMESPACE = "tag:rdf4j.org:2023:config/repository#";

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -10,9 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Defines constants for the repository configuration schema that is used by
@@ -20,56 +21,29 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
  *
  * @author Arjohn Kampman
  * @author Jeen Broekstra
+ * 
+ * @deprecated use {@link CONFIG} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class RepositoryConfigSchema {
 
-	/**
-	 * The Repository config schema namespace (<var>tag:rdf4j.org:2023:config/repository#</var>).
-	 *
-	 * @see tools.ietf.org/html/rfc4151
-	 */
-	public static final String NAMESPACE = "tag:rdf4j.org:2023:config/repository#";
+	public static final String NAMESPACE = CONFIG.NAMESPACE;
 
-	@Deprecated(since = "4.3.0", forRemoval = true)
 	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository#";
 
 	/**
-	 * <var>"tag:rdf4j.org:2023:config/repository#RepositoryContext</var>
+	 * This IRI is not in the CONFIG vocabulary because it is no longer necessary - it was only used in the old-style
+	 * SYSTEM-repo configurations.
 	 */
-	public final static IRI REPOSITORY_CONTEXT;
+	public final static IRI REPOSITORY_CONTEXT = iri(NAMESPACE, "RepositoryContext");
 
-	/**
-	 * <var>tag:rdf4j.org:2023:config/repository#Repository</var>
-	 */
-	public final static IRI REPOSITORY;
+	public final static IRI REPOSITORY = CONFIG.REPOSITORY;
 
-	/**
-	 * <var>tag:rdf4j.org:2023:config/repository#repositoryID</var>
-	 */
-	public final static IRI REPOSITORYID;
+	public final static IRI REPOSITORYID = CONFIG.REPOSITORY_ID;
 
-	/**
-	 * <var>tag:rdf4j.org:2023:config/repository#repositoryImpl</var>
-	 */
-	public final static IRI REPOSITORYIMPL;
+	public final static IRI REPOSITORYIMPL = CONFIG.REPOSITORY_IMPL;
 
-	/**
-	 * <var>tag:rdf4j.org:2023:config/repository#repositoryType</var>
-	 */
-	public final static IRI REPOSITORYTYPE;
+	public final static IRI REPOSITORYTYPE = CONFIG.REPOSITORY_TYPE;
 
-	/**
-	 * <var>tag:rdf4j.org:2023:config/repository#delegate</var>
-	 */
-	public final static IRI DELEGATE;
-
-	static {
-		ValueFactory factory = SimpleValueFactory.getInstance();
-		REPOSITORY_CONTEXT = factory.createIRI(NAMESPACE, "RepositoryContext");
-		REPOSITORY = factory.createIRI(NAMESPACE, "Repository");
-		REPOSITORYID = factory.createIRI(NAMESPACE, "repositoryID");
-		REPOSITORYIMPL = factory.createIRI(NAMESPACE, "repositoryImpl");
-		REPOSITORYTYPE = factory.createIRI(NAMESPACE, "repositoryType");
-		DELEGATE = factory.createIRI(NAMESPACE, "delegate");
-	}
+	public final static IRI DELEGATE = CONFIG.DELEGATE;
 }

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigSchema.java
@@ -41,17 +41,17 @@ public class RepositoryConfigSchema {
 	public final static IRI REPOSITORY = iri(NAMESPACE, "Repository");
 
 	/**
-	 * @deprecated use {@link CONFIG#id} instead.
+	 * @deprecated use {@link CONFIG.Rep#id} instead.
 	 */
 	public final static IRI REPOSITORYID = iri(NAMESPACE, "repositoryID");
 
 	/**
-	 * @deprecated use {@link CONFIG#impl} instead.
+	 * @deprecated use {@link CONFIG.Rep#impl} instead.
 	 */
 	public final static IRI REPOSITORYIMPL = iri(NAMESPACE, "repositoryImpl");
 
 	/**
-	 * @deprecated use {@link CONFIG#type} instead.
+	 * @deprecated use {@link CONFIG.Rep#type} instead.
 	 */
 	public final static IRI REPOSITORYTYPE = iri(NAMESPACE, "repositoryType");
 

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -56,7 +56,7 @@ public class RepositoryConfigUtil {
 
 	public static Set<String> getRepositoryIDs(Model model) throws RepositoryException {
 		Set<String> idSet = new LinkedHashSet<>();
-		model.filter(null, CONFIG.repositoryID, null).forEach(idStatement -> {
+		model.filter(null, CONFIG.Rep.repositoryID, null).forEach(idStatement -> {
 			if (idStatement.getObject() instanceof Literal) {
 				Literal idLiteral = (Literal) idStatement.getObject();
 				idSet.add(idLiteral.getLabel());
@@ -67,7 +67,7 @@ public class RepositoryConfigUtil {
 
 	private static Statement getIDStatement(Model model, String repositoryID) {
 		Literal idLiteral = literal(repositoryID);
-		Model idStatementList = model.filter(null, CONFIG.repositoryID, idLiteral);
+		Model idStatementList = model.filter(null, CONFIG.Rep.repositoryID, idLiteral);
 
 		if (idStatementList.isEmpty()) {
 			idStatementList = model.filter(null, RepositoryConfigSchema.REPOSITORYID, idLiteral);
@@ -87,7 +87,7 @@ public class RepositoryConfigUtil {
 		try (RepositoryConnection con = repository.getConnection()) {
 			Set<String> idSet = new LinkedHashSet<>();
 
-			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, CONFIG.repositoryID, null,
+			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, CONFIG.Rep.repositoryID, null,
 					true)) {
 				while (idStatementIter.hasNext()) {
 					Statement idStatement = idStatementIter.next();
@@ -252,7 +252,7 @@ public class RepositoryConfigUtil {
 			throws RepositoryException, RepositoryConfigException {
 		Literal idLiteral = con.getRepository().getValueFactory().createLiteral(repositoryID);
 		List<Statement> idStatementList = Iterations
-				.asList(con.getStatements(null, CONFIG.repositoryID, idLiteral, true));
+				.asList(con.getStatements(null, CONFIG.Rep.repositoryID, idLiteral, true));
 
 		if (idStatementList.size() == 1) {
 			return idStatementList.get(0);

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
-import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import java.util.HashSet;
@@ -73,99 +72,89 @@ public class RepositoryConfigUtil {
 	}
 
 	/**
-	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a property
-	 * with the same local name in the supplied fallbackNamespace.
+	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a supplied
+	 * legacy property .
 	 *
 	 * This method allows use to query repository config models with a mix of old and new namespaces.
 	 *
-	 * @param model             the model to retrieve property values from.
-	 * @param subject           the subject of the property.
-	 * @param property          the property to retrieve the value of.
-	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
-	 *                          supplied property has no value in the model.
-	 * @return the resource value for supplied subject and property (or the property with the supplied
-	 *         fallbackNamespace), if present.
+	 * @param model          the model to retrieve property values from.
+	 * @param subject        the subject of the property.
+	 * @param property       the property to retrieve the value of.
+	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
+	 * @return the resource value for supplied subject and property (or the legacy property ), if present.
 	 */
 	@InternalUseOnly
 	public static Optional<Resource> getPropertyAsResource(Model model, Resource subject, IRI property,
-			String fallbackNamespace) {
+			IRI legacyProperty) {
 		return Optional
 				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
 				.orElseGet(() -> {
-					IRI fallback = iri(fallbackNamespace, property.getLocalName());
-					return Models.objectResource(model.getStatements(subject, fallback, null));
+					return Models.objectResource(model.getStatements(subject, legacyProperty, null));
 				});
 	}
 
 	/**
-	 * Retrieve a property value for the supplied subject as a {@link Literal} if present, falling back to a property
-	 * with the same local name in the supplied fallbackNamespace.
+	 * Retrieve a property value for the supplied subject as a {@link Literal} if present, falling back to a supplied
+	 * legacy property .
 	 *
 	 * This method allows use to query repository config models with a mix of old and new namespaces.
 	 *
-	 * @param model             the model to retrieve property values from.
-	 * @param subject           the subject of the property.
-	 * @param property          the property to retrieve the value of.
-	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
-	 *                          supplied property has no value in the model.
-	 * @return the literal value for supplied subject and property (or the property with the supplied
-	 *         fallbackNamespace), if present.
+	 * @param model          the model to retrieve property values from.
+	 * @param subject        the subject of the property.
+	 * @param property       the property to retrieve the value of.
+	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
+	 * @return the literal value for supplied subject and property (or the legacy property ), if present.
 	 */
 	@InternalUseOnly
 	public static Optional<Literal> getPropertyAsLiteral(Model model, Resource subject, IRI property,
-			String fallbackNamespace) {
+			IRI legacyProperty) {
 		return Optional
 				.ofNullable(Models.objectLiteral(model.getStatements(subject, property, null)))
 				.orElseGet(() -> {
-					IRI fallback = iri(fallbackNamespace, property.getLocalName());
-					return Models.objectLiteral(model.getStatements(subject, fallback, null));
+					return Models.objectLiteral(model.getStatements(subject, legacyProperty, null));
 				});
 	}
 
 	/**
-	 * Retrieve all property values for the supplied subject as a Set of values and include all values for any property
-	 * with the same local name in the supplied fallbackNamespace.
+	 * Retrieve all property values for the supplied subject as a Set of values and include all values for any legacy
+	 * property.
 	 *
 	 * This method allows use to query repository config models with a mix of old and new namespaces.
 	 *
-	 * @param model             the model to retrieve property values from.
-	 * @param subject           the subject of the property.
-	 * @param property          the property to retrieve the values of.
-	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property.
-	 * @return the set of values for supplied subject and property (and/or the property with the supplied
-	 *         fallbackNamespace).
+	 * @param model          the model to retrieve property values from.
+	 * @param subject        the subject of the property.
+	 * @param property       the property to retrieve the values of.
+	 * @param legacyProperty legacy property to retrieve values of.
+	 * @return the set of values for supplied subject and property (and/or legacy property).
 	 */
 	@InternalUseOnly
 	public static Set<Value> getPropertyValues(Model model, Resource subject, IRI property,
-			String fallbackNamespace) {
+			IRI legacyProperty) {
 		final Set<Value> results = new HashSet<>();
 		results.addAll(model.filter(subject, property, null).objects());
-		results.addAll(model.filter(subject, iri(fallbackNamespace, property.getLocalName()), null).objects());
+		results.addAll(model.filter(subject, legacyProperty, null).objects());
 		return results;
 	}
 
 	/**
-	 * Retrieve a property value for the supplied subject as an {@link IRI} if present, falling back to a property with
-	 * the same local name in the supplied fallbackNamespace.
+	 * Retrieve a property value for the supplied subject as a {@link IRI} if present, falling back to a supplied legacy
+	 * property .
 	 *
 	 * This method allows use to query repository config models with a mix of old and new namespaces.
 	 *
-	 * @param model             the model to retrieve property values from.
-	 * @param subject           the subject of the property.
-	 * @param property          the property to retrieve the value of.
-	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
-	 *                          supplied property has no value in the model.
-	 * @return the IRI value for supplied subject and property (or the property with the supplied fallbackNamespace), if
-	 *         present.
+	 * @param model          the model to retrieve property values from.
+	 * @param subject        the subject of the property.
+	 * @param property       the property to retrieve the value of.
+	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
+	 * @return the IRI value for supplied subject and property (or the legacy property ), if present.
 	 */
 	@InternalUseOnly
 	public static Optional<IRI> getPropertyAsIRI(Model model, Resource subject, IRI property,
-			String fallbackNamespace) {
+			IRI legacyProperty) {
 		return Optional
 				.ofNullable(Models.objectIRI(model.getStatements(subject, property, null)))
 				.orElseGet(() -> {
-					IRI fallback = iri(fallbackNamespace, property.getLocalName());
-					return Models.objectIRI(model.getStatements(subject, fallback, null));
+					return Models.objectIRI(model.getStatements(subject, legacyProperty, null));
 				});
 	}
 
@@ -174,8 +163,7 @@ public class RepositoryConfigUtil {
 		Model idStatementList = model.filter(null, CONFIG.repositoryID, idLiteral);
 
 		if (idStatementList.isEmpty()) {
-			IRI fallback = iri(RepositoryConfigSchema.NAMESPACE_OBSOLETE, CONFIG.repositoryID.getLocalName());
-			idStatementList = model.filter(null, fallback, idLiteral);
+			idStatementList = model.filter(null, RepositoryConfigSchema.REPOSITORYID, idLiteral);
 		}
 
 		if (idStatementList.size() == 1) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORYID;
 import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSITORY_CONTEXT;
 
@@ -18,13 +20,13 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.repository.Repository;
@@ -67,8 +69,13 @@ public class RepositoryConfigUtil {
 	}
 
 	private static Statement getIDStatement(Model model, String repositoryID) {
-		Literal idLiteral = SimpleValueFactory.getInstance().createLiteral(repositoryID);
+		Literal idLiteral = literal(repositoryID);
 		Model idStatementList = model.filter(null, REPOSITORYID, idLiteral);
+
+		if (idStatementList.isEmpty()) {
+			IRI fallback = iri(RepositoryConfigSchema.NAMESPACE_OBSOLETE, REPOSITORYID.getLocalName());
+			idStatementList = model.filter(null, fallback, idLiteral);
+		}
 
 		if (idStatementList.size() == 1) {
 			return idStatementList.iterator().next();

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -17,8 +17,10 @@ import static org.eclipse.rdf4j.repository.config.RepositoryConfigSchema.REPOSIT
 
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -27,6 +29,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.repository.Repository;
@@ -66,6 +69,39 @@ public class RepositoryConfigUtil {
 			}
 		});
 		return idSet;
+	}
+	
+	@InternalUseOnly
+	public static Optional<Resource> getPropertyAsResource(Model model, Resource subject, IRI property,
+			String fallbackNamespace) {
+		return Optional
+				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
+				.orElseGet(() -> {
+					IRI fallback = iri(fallbackNamespace, property.getLocalName());
+					return Models.objectResource(model.getStatements(subject, fallback, null));
+				});
+	}
+
+	@InternalUseOnly
+	public static Optional<Literal> getPropertyAsLiteral(Model model, Resource subject, IRI property,
+			String fallbackNamespace) {
+		return Optional
+				.ofNullable(Models.objectLiteral(model.getStatements(subject, property, null)))
+				.orElseGet(() -> {
+					IRI fallback = iri(fallbackNamespace, property.getLocalName());
+					return Models.objectLiteral(model.getStatements(subject, fallback, null));
+				});
+	}
+
+	@InternalUseOnly
+	public static Optional<IRI> getPropertyAsIRI(Model model, Resource subject, IRI property,
+			String fallbackNamespace) {
+		return Optional
+				.ofNullable(Models.objectIRI(model.getStatements(subject, property, null)))
+				.orElseGet(() -> {
+					IRI fallback = iri(fallbackNamespace, property.getLocalName());
+					return Models.objectIRI(model.getStatements(subject, fallback, null));
+				});
 	}
 
 	private static Statement getIDStatement(Model model, String repositoryID) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -12,23 +12,17 @@ package org.eclipse.rdf4j.repository.config;
 
 import static org.eclipse.rdf4j.model.util.Values.literal;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
-import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.iteration.Iterations;
-import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -69,93 +63,6 @@ public class RepositoryConfigUtil {
 			}
 		});
 		return idSet;
-	}
-
-	/**
-	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a supplied
-	 * legacy property .
-	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
-	 *
-	 * @param model          the model to retrieve property values from.
-	 * @param subject        the subject of the property.
-	 * @param property       the property to retrieve the value of.
-	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
-	 * @return the resource value for supplied subject and property (or the legacy property ), if present.
-	 */
-	@InternalUseOnly
-	public static Optional<Resource> getPropertyAsResource(Model model, Resource subject, IRI property,
-			IRI legacyProperty) {
-		return Optional
-				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					return Models.objectResource(model.getStatements(subject, legacyProperty, null));
-				});
-	}
-
-	/**
-	 * Retrieve a property value for the supplied subject as a {@link Literal} if present, falling back to a supplied
-	 * legacy property .
-	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
-	 *
-	 * @param model          the model to retrieve property values from.
-	 * @param subject        the subject of the property.
-	 * @param property       the property to retrieve the value of.
-	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
-	 * @return the literal value for supplied subject and property (or the legacy property ), if present.
-	 */
-	@InternalUseOnly
-	public static Optional<Literal> getPropertyAsLiteral(Model model, Resource subject, IRI property,
-			IRI legacyProperty) {
-		return Optional
-				.ofNullable(Models.objectLiteral(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					return Models.objectLiteral(model.getStatements(subject, legacyProperty, null));
-				});
-	}
-
-	/**
-	 * Retrieve all property values for the supplied subject as a Set of values and include all values for any legacy
-	 * property.
-	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
-	 *
-	 * @param model          the model to retrieve property values from.
-	 * @param subject        the subject of the property.
-	 * @param property       the property to retrieve the values of.
-	 * @param legacyProperty legacy property to retrieve values of.
-	 * @return the set of values for supplied subject and property (and/or legacy property).
-	 */
-	@InternalUseOnly
-	public static Set<Value> getPropertyValues(Model model, Resource subject, IRI property,
-			IRI legacyProperty) {
-		final Set<Value> results = new HashSet<>();
-		results.addAll(model.filter(subject, property, null).objects());
-		results.addAll(model.filter(subject, legacyProperty, null).objects());
-		return results;
-	}
-
-	/**
-	 * Retrieve a property value for the supplied subject as a {@link IRI} if present, falling back to a supplied legacy
-	 * property .
-	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
-	 *
-	 * @param model          the model to retrieve property values from.
-	 * @param subject        the subject of the property.
-	 * @param property       the property to retrieve the value of.
-	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
-	 * @return the IRI value for supplied subject and property (or the legacy property ), if present.
-	 */
-	@InternalUseOnly
-	public static Optional<IRI> getPropertyAsIRI(Model model, Resource subject, IRI property,
-			IRI legacyProperty) {
-		return Optional
-				.ofNullable(Models.objectIRI(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					return Models.objectIRI(model.getStatements(subject, legacyProperty, null));
-				});
 	}
 
 	private static Statement getIDStatement(Model model, String repositoryID) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -23,7 +23,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.repository.Repository;
@@ -56,7 +56,7 @@ public class RepositoryConfigUtil {
 
 	public static Set<String> getRepositoryIDs(Model model) throws RepositoryException {
 		Set<String> idSet = new LinkedHashSet<>();
-		model.filter(null, Config.Rep.id, null).forEach(idStatement -> {
+		model.filter(null, CONFIG.Rep.id, null).forEach(idStatement -> {
 			if (idStatement.getObject() instanceof Literal) {
 				Literal idLiteral = (Literal) idStatement.getObject();
 				idSet.add(idLiteral.getLabel());
@@ -67,7 +67,7 @@ public class RepositoryConfigUtil {
 
 	private static Statement getIDStatement(Model model, String repositoryID) {
 		Literal idLiteral = literal(repositoryID);
-		Model idStatementList = model.filter(null, Config.Rep.id, idLiteral);
+		Model idStatementList = model.filter(null, CONFIG.Rep.id, idLiteral);
 
 		if (idStatementList.isEmpty()) {
 			idStatementList = model.filter(null, RepositoryConfigSchema.REPOSITORYID, idLiteral);
@@ -87,7 +87,7 @@ public class RepositoryConfigUtil {
 		try (RepositoryConnection con = repository.getConnection()) {
 			Set<String> idSet = new LinkedHashSet<>();
 
-			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, Config.Rep.id, null,
+			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, CONFIG.Rep.id, null,
 					true)) {
 				while (idStatementIter.hasNext()) {
 					Statement idStatement = idStatementIter.next();
@@ -252,7 +252,7 @@ public class RepositoryConfigUtil {
 			throws RepositoryException, RepositoryConfigException {
 		Literal idLiteral = con.getRepository().getValueFactory().createLiteral(repositoryID);
 		List<Statement> idStatementList = Iterations
-				.asList(con.getStatements(null, Config.Rep.id, idLiteral, true));
+				.asList(con.getStatements(null, CONFIG.Rep.id, idLiteral, true));
 
 		if (idStatementList.size() == 1) {
 			return idStatementList.get(0);

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryResults;
@@ -56,17 +57,19 @@ public class RepositoryConfigUtil {
 
 	public static Set<String> getRepositoryIDs(Model model) throws RepositoryException {
 		Set<String> idSet = new LinkedHashSet<>();
-		model.filter(null, CONFIG.Rep.id, null).forEach(idStatement -> {
-			if (idStatement.getObject() instanceof Literal) {
-				Literal idLiteral = (Literal) idStatement.getObject();
-				idSet.add(idLiteral.getLabel());
-			}
-		});
+
+		Configurations.getPropertyValues(model, null, CONFIG.Rep.id, RepositoryConfigSchema.REPOSITORYID)
+				.forEach(value -> {
+					if (value.isLiteral()) {
+						idSet.add(((Literal) value).getLabel());
+					}
+				});
 		return idSet;
 	}
 
 	private static Statement getIDStatement(Model model, String repositoryID) {
 		Literal idLiteral = literal(repositoryID);
+
 		Model idStatementList = model.filter(null, CONFIG.Rep.id, idLiteral);
 
 		if (idStatementList.isEmpty()) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -56,7 +56,7 @@ public class RepositoryConfigUtil {
 
 	public static Set<String> getRepositoryIDs(Model model) throws RepositoryException {
 		Set<String> idSet = new LinkedHashSet<>();
-		model.filter(null, CONFIG.Rep.repositoryID, null).forEach(idStatement -> {
+		model.filter(null, CONFIG.Rep.id, null).forEach(idStatement -> {
 			if (idStatement.getObject() instanceof Literal) {
 				Literal idLiteral = (Literal) idStatement.getObject();
 				idSet.add(idLiteral.getLabel());
@@ -67,7 +67,7 @@ public class RepositoryConfigUtil {
 
 	private static Statement getIDStatement(Model model, String repositoryID) {
 		Literal idLiteral = literal(repositoryID);
-		Model idStatementList = model.filter(null, CONFIG.Rep.repositoryID, idLiteral);
+		Model idStatementList = model.filter(null, CONFIG.Rep.id, idLiteral);
 
 		if (idStatementList.isEmpty()) {
 			idStatementList = model.filter(null, RepositoryConfigSchema.REPOSITORYID, idLiteral);
@@ -87,7 +87,7 @@ public class RepositoryConfigUtil {
 		try (RepositoryConnection con = repository.getConnection()) {
 			Set<String> idSet = new LinkedHashSet<>();
 
-			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, CONFIG.Rep.repositoryID, null,
+			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, CONFIG.Rep.id, null,
 					true)) {
 				while (idStatementIter.hasNext()) {
 					Statement idStatement = idStatementIter.next();
@@ -252,7 +252,7 @@ public class RepositoryConfigUtil {
 			throws RepositoryException, RepositoryConfigException {
 		Literal idLiteral = con.getRepository().getValueFactory().createLiteral(repositoryID);
 		List<Statement> idStatementList = Iterations
-				.asList(con.getStatements(null, CONFIG.Rep.repositoryID, idLiteral, true));
+				.asList(con.getStatements(null, CONFIG.Rep.id, idLiteral, true));
 
 		if (idStatementList.size() == 1) {
 			return idStatementList.get(0);

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -23,7 +23,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.repository.Repository;
@@ -56,7 +56,7 @@ public class RepositoryConfigUtil {
 
 	public static Set<String> getRepositoryIDs(Model model) throws RepositoryException {
 		Set<String> idSet = new LinkedHashSet<>();
-		model.filter(null, CONFIG.Rep.id, null).forEach(idStatement -> {
+		model.filter(null, Config.Rep.id, null).forEach(idStatement -> {
 			if (idStatement.getObject() instanceof Literal) {
 				Literal idLiteral = (Literal) idStatement.getObject();
 				idSet.add(idLiteral.getLabel());
@@ -67,7 +67,7 @@ public class RepositoryConfigUtil {
 
 	private static Statement getIDStatement(Model model, String repositoryID) {
 		Literal idLiteral = literal(repositoryID);
-		Model idStatementList = model.filter(null, CONFIG.Rep.id, idLiteral);
+		Model idStatementList = model.filter(null, Config.Rep.id, idLiteral);
 
 		if (idStatementList.isEmpty()) {
 			idStatementList = model.filter(null, RepositoryConfigSchema.REPOSITORYID, idLiteral);
@@ -87,7 +87,7 @@ public class RepositoryConfigUtil {
 		try (RepositoryConnection con = repository.getConnection()) {
 			Set<String> idSet = new LinkedHashSet<>();
 
-			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, CONFIG.Rep.id, null,
+			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, Config.Rep.id, null,
 					true)) {
 				while (idStatementIter.hasNext()) {
 					Statement idStatement = idStatementIter.next();
@@ -252,7 +252,7 @@ public class RepositoryConfigUtil {
 			throws RepositoryException, RepositoryConfigException {
 		Literal idLiteral = con.getRepository().getValueFactory().createLiteral(repositoryID);
 		List<Statement> idStatementList = Iterations
-				.asList(con.getStatements(null, CONFIG.Rep.id, idLiteral, true));
+				.asList(con.getStatements(null, Config.Rep.id, idLiteral, true));
 
 		if (idStatementList.size() == 1) {
 			return idStatementList.get(0);

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -70,7 +70,21 @@ public class RepositoryConfigUtil {
 		});
 		return idSet;
 	}
-	
+
+	/**
+	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a property
+	 * with the same local name in the supplied fallbackNamespace.
+	 *
+	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 *
+	 * @param model             the model to retrieve property values from.
+	 * @param subject           the subject of the property.
+	 * @param property          the property to retrieve the value of.
+	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
+	 *                          supplied property has no value in the model.
+	 * @return the resource value for supplied subject and property (or the property with the supplied
+	 *         fallbackNamespace), if present.
+	 */
 	@InternalUseOnly
 	public static Optional<Resource> getPropertyAsResource(Model model, Resource subject, IRI property,
 			String fallbackNamespace) {
@@ -82,6 +96,20 @@ public class RepositoryConfigUtil {
 				});
 	}
 
+	/**
+	 * Retrieve a property value for the supplied subject as a {@link Literal} if present, falling back to a property
+	 * with the same local name in the supplied fallbackNamespace.
+	 *
+	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 *
+	 * @param model             the model to retrieve property values from.
+	 * @param subject           the subject of the property.
+	 * @param property          the property to retrieve the value of.
+	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
+	 *                          supplied property has no value in the model.
+	 * @return the literal value for supplied subject and property (or the property with the supplied
+	 *         fallbackNamespace), if present.
+	 */
 	@InternalUseOnly
 	public static Optional<Literal> getPropertyAsLiteral(Model model, Resource subject, IRI property,
 			String fallbackNamespace) {
@@ -93,6 +121,20 @@ public class RepositoryConfigUtil {
 				});
 	}
 
+	/**
+	 * Retrieve a property value for the supplied subject as an {@link IRI} if present, falling back to a property with
+	 * the same local name in the supplied fallbackNamespace.
+	 *
+	 * This method allows use to query repository config models with a mix of old and new namespaces.
+	 *
+	 * @param model             the model to retrieve property values from.
+	 * @param subject           the subject of the property.
+	 * @param property          the property to retrieve the value of.
+	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
+	 *                          supplied property has no value in the model.
+	 * @return the IRI value for supplied subject and property (or the property with the supplied fallbackNamespace), if
+	 *         present.
+	 */
 	@InternalUseOnly
 	public static Optional<IRI> getPropertyAsIRI(Model model, Resource subject, IRI property,
 			String fallbackNamespace) {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryConfigUtil.java
@@ -63,7 +63,7 @@ public class RepositoryConfigUtil {
 
 	public static Set<String> getRepositoryIDs(Model model) throws RepositoryException {
 		Set<String> idSet = new LinkedHashSet<>();
-		model.filter(null, CONFIG.REPOSITORY_ID, null).forEach(idStatement -> {
+		model.filter(null, CONFIG.repositoryID, null).forEach(idStatement -> {
 			if (idStatement.getObject() instanceof Literal) {
 				Literal idLiteral = (Literal) idStatement.getObject();
 				idSet.add(idLiteral.getLabel());
@@ -171,10 +171,10 @@ public class RepositoryConfigUtil {
 
 	private static Statement getIDStatement(Model model, String repositoryID) {
 		Literal idLiteral = literal(repositoryID);
-		Model idStatementList = model.filter(null, CONFIG.REPOSITORY_ID, idLiteral);
+		Model idStatementList = model.filter(null, CONFIG.repositoryID, idLiteral);
 
 		if (idStatementList.isEmpty()) {
-			IRI fallback = iri(RepositoryConfigSchema.NAMESPACE_OBSOLETE, CONFIG.REPOSITORY_ID.getLocalName());
+			IRI fallback = iri(RepositoryConfigSchema.NAMESPACE_OBSOLETE, CONFIG.repositoryID.getLocalName());
 			idStatementList = model.filter(null, fallback, idLiteral);
 		}
 
@@ -192,7 +192,7 @@ public class RepositoryConfigUtil {
 		try (RepositoryConnection con = repository.getConnection()) {
 			Set<String> idSet = new LinkedHashSet<>();
 
-			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, CONFIG.REPOSITORY_ID, null,
+			try (RepositoryResult<Statement> idStatementIter = con.getStatements(null, CONFIG.repositoryID, null,
 					true)) {
 				while (idStatementIter.hasNext()) {
 					Statement idStatement = idStatementIter.next();
@@ -357,7 +357,7 @@ public class RepositoryConfigUtil {
 			throws RepositoryException, RepositoryConfigException {
 		Literal idLiteral = con.getRepository().getValueFactory().createLiteral(repositoryID);
 		List<Statement> idStatementList = Iterations
-				.asList(con.getStatements(null, CONFIG.REPOSITORY_ID, idLiteral, true));
+				.asList(con.getStatements(null, CONFIG.repositoryID, idLiteral, true));
 
 		if (idStatementList.size() == 1) {
 			return idStatementList.get(0);

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryImplConfig.java
@@ -17,7 +17,7 @@ import org.eclipse.rdf4j.repository.Repository;
 /**
  * A {@link RepositoryImplConfig} represents configuration details specific to a particular implementation of the
  * {@link Repository} interface.
- * 
+ *
  * @author Arjohn Kampman
  */
 public interface RepositoryImplConfig {

--- a/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryImplConfig.java
+++ b/core/repository/api/src/main/java/org/eclipse/rdf4j/repository/config/RepositoryImplConfig.java
@@ -12,8 +12,12 @@ package org.eclipse.rdf4j.repository.config;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.repository.Repository;
 
 /**
+ * A {@link RepositoryImplConfig} represents configuration details specific to a particular implementation of the
+ * {@link Repository} interface.
+ * 
  * @author Arjohn Kampman
  */
 public interface RepositoryImplConfig {

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/lmdb.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/lmdb.ttl
@@ -2,15 +2,15 @@
 # Configuration template for an LmdbStore
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-   config:repositoryID "{%Repository ID|lmdb%}" ;
+   config:rep.id "{%Repository ID|lmdb%}" ;
    rdfs:label "{%Repository title|LMDB Store%}" ;
-   config:repositoryImpl [
-      config:repositoryType "openrdf:SailRepository" ;
-      config:sailImpl [
-         config:sailType "rdf4j:LmdbStore" ;
-         config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "rdf4j:LmdbStore" ;
+         config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/lmdb.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/lmdb.ttl
@@ -2,19 +2,15 @@
 # Configuration template for an LmdbStore
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "{%Repository ID|lmdb%}" ;
+[] a config:Repository ;
+   config:repositoryID "{%Repository ID|lmdb%}" ;
    rdfs:label "{%Repository title|LMDB Store%}" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "rdf4j:LmdbStore" ;
-         sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+   config:repositoryImpl [
+      config:repositoryType "openrdf:SailRepository" ;
+      config:sailImpl [
+         config:sailType "rdf4j:LmdbStore" ;
+         config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/lmdb.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/lmdb.ttl
@@ -2,7 +2,7 @@
 # Configuration template for an LmdbStore
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/lmdb.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/lmdb.ttl
@@ -2,7 +2,7 @@
 # Configuration template for an LmdbStore
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-customrule.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-customrule.ttl
@@ -3,34 +3,31 @@
 # a custom graph query inference rule.
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 @prefix sp: <http://spinrdf.org/sp#>.
 
-
 [] a config:Repository ;
-   config:repositoryID "{%Repository ID|memory-customrule%}" ;
+   config:rep.id "{%Repository ID|memory-customrule%}" ;
    rdfs:label "{%Repository title|Memory store with custom graph query inferencing rule%}" ;
-   config:repositoryImpl [
-      config:repositoryType "openrdf:SailRepository" ;
-      config:sailImpl [
-         config:sailType "openrdf:CustomGraphQueryInferencer" ;
-         cgqi:queryLanguage "{%Query Language|SPARQL%}" ;
-         cgqi:ruleQuery [
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "openrdf:CustomGraphQueryInferencer" ;
+         config:cgqi.queryLanguage "{%Query Language|SPARQL%}" ;
+         config:cgqi.ruleQuery [
              a sp:Construct ;
              sp:text '''{%Rule query|insert rule query here%}'''
          ];
-         cgqi:matcherQuery [
+         config:cgqi.matcherQuery [
              a sp:Construct ;
              sp:text '''{%Matcher query (optional)|%}'''
          ];
          config:delegate [
-            config:sailType "openrdf:MemoryStore" ;
-            config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
-            ms:persist {%Persist|true|false%} ;
-            ms:syncDelay {%Sync delay|0%};
-            config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+            config:sail.type "openrdf:MemoryStore" ;
+            config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+            config:mem.persist {%Persist|true|false%} ;
+            config:mem.syncDelay {%Sync delay|0%};
+            config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
          ]
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-customrule.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-customrule.ttl
@@ -3,22 +3,19 @@
 # a custom graph query inference rule.
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
 @prefix sp: <http://spinrdf.org/sp#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
 
-[] a rep:Repository ;
-   rep:repositoryID "{%Repository ID|memory-customrule%}" ;
+[] a config:Repository ;
+   config:repositoryID "{%Repository ID|memory-customrule%}" ;
    rdfs:label "{%Repository title|Memory store with custom graph query inferencing rule%}" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "openrdf:CustomGraphQueryInferencer" ;
+   config:repositoryImpl [
+      config:repositoryType "openrdf:SailRepository" ;
+      config:sailImpl [
+         config:sailType "openrdf:CustomGraphQueryInferencer" ;
          cgqi:queryLanguage "{%Query Language|SPARQL%}" ;
          cgqi:ruleQuery [
              a sp:Construct ;
@@ -28,12 +25,12 @@
              a sp:Construct ;
              sp:text '''{%Matcher query (optional)|%}'''
          ];
-         sail:delegate [
-            sail:sailType "openrdf:MemoryStore" ;
-        sail:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+         config:delegate [
+            config:sailType "openrdf:MemoryStore" ;
+            config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
             ms:persist {%Persist|true|false%} ;
             ms:syncDelay {%Sync delay|0%};
-            sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+            config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
          ]
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-customrule.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-customrule.ttl
@@ -3,7 +3,7 @@
 # a custom graph query inference rule.
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-customrule.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-customrule.ttl
@@ -3,7 +3,7 @@
 # a custom graph query inference rule.
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-lucene.ttl
@@ -1,5 +1,5 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix spin: <http://www.openrdf.org/config/sail/spin#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-lucene.ttl
@@ -1,5 +1,5 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix spin: <http://www.openrdf.org/config/sail/spin#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-lucene.ttl
@@ -1,24 +1,20 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sp: <http://spinrdf.org/sp#>.
-
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|memory-lucene%}" ;
+    config:rep.id "{%Repository ID|memory-lucene%}" ;
     rdfs:label "{%Repository title|Native store with Lucene Support%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "openrdf:LuceneSail";
-            sail-luc:indexDir "index/" ;
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "openrdf:LuceneSail";
+            config:lucene.indexDir "index/" ;
             config:delegate [
-                config:sailType "openrdf:MemoryStore" ;
-                config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
-                ms:persist {%Persist|true|false%} ;
-                ms:syncDelay {%Sync delay|0%};
-                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:sail.type "openrdf:MemoryStore" ;
+                config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+                config:mem.persist {%Persist|true|false%} ;
+                config:mem.syncDelay {%Sync delay|0%};
+                config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-lucene.ttl
@@ -1,29 +1,24 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix spin: <http://www.openrdf.org/config/sail/spin#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
-@prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
 @prefix sp: <http://spinrdf.org/sp#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
 
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|memory-lucene%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|memory-lucene%}" ;
     rdfs:label "{%Repository title|Native store with Lucene Support%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "openrdf:LuceneSail";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "openrdf:LuceneSail";
             sail-luc:indexDir "index/" ;
-            sail:delegate [
-                sail:sailType "openrdf:MemoryStore" ;
-                sail:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+            config:delegate [
+                config:sailType "openrdf:MemoryStore" ;
+                config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
                 ms:persist {%Persist|true|false%} ;
                 ms:syncDelay {%Sync delay|0%};
-                sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
@@ -3,7 +3,7 @@
 # RDF Schema and direct type hierarchy inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
@@ -3,7 +3,7 @@
 # RDF Schema and direct type hierarchy inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
@@ -3,28 +3,24 @@
 # RDF Schema and direct type hierarchy inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
-
-[] a rep:Repository ;
-   rep:repositoryID "{%Repository ID|memory-rdfs-dt%}" ;
+[] a config:Repository ;
+   config:repositoryID "{%Repository ID|memory-rdfs-dt%}" ;
    rdfs:label "{%Repository title|Memory store with RDF Schema and direct type inferencing%}" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "openrdf:DirectTypeHierarchyInferencer" ;
-         sail:delegate [
-            sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
-            sail:delegate [
-                sail:sailType "openrdf:MemoryStore" ;
-                sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+   config:repositoryImpl [
+      config:repositoryType "openrdf:SailRepository" ;
+      config:sailImpl [
+         config:sailType "openrdf:DirectTypeHierarchyInferencer" ;
+         config:delegate [
+            config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+            config:delegate [
+                config:sailType "openrdf:MemoryStore" ;
+                config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
                 ms:persist {%Persist|true|false%} ;
                 ms:syncDelay {%Sync delay|0%};
-                sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
          ]
       ]

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-dt.ttl
@@ -3,24 +3,23 @@
 # RDF Schema and direct type hierarchy inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-   config:repositoryID "{%Repository ID|memory-rdfs-dt%}" ;
+   config:rep.id "{%Repository ID|memory-rdfs-dt%}" ;
    rdfs:label "{%Repository title|Memory store with RDF Schema and direct type inferencing%}" ;
-   config:repositoryImpl [
-      config:repositoryType "openrdf:SailRepository" ;
-      config:sailImpl [
-         config:sailType "openrdf:DirectTypeHierarchyInferencer" ;
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "openrdf:DirectTypeHierarchyInferencer" ;
          config:delegate [
-            config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+            config:sail.type "rdf4j:SchemaCachingRDFSInferencer" ;
             config:delegate [
-                config:sailType "openrdf:MemoryStore" ;
-                config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-                ms:persist {%Persist|true|false%} ;
-                ms:syncDelay {%Sync delay|0%};
-                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:sail.type "openrdf:MemoryStore" ;
+                config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+                config:mem.persist {%Persist|true|false%} ;
+                config:mem.syncDelay {%Sync delay|0%};
+                config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
          ]
       ]

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
@@ -3,7 +3,7 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
@@ -3,7 +3,7 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
@@ -3,23 +3,21 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-   config:repositoryID "{%Repository ID|memory-rdfs-new%}" ;
+   config:rep.id "{%Repository ID|memory-rdfs-new%}" ;
    rdfs:label "{%Repository title|Memory store with RDFS inferencing (legacy reasoner)%}" ;
-   config:repositoryImpl [
-      config:repositoryType "openrdf:SailRepository" ;
-      config:sailImpl [
-         config:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "openrdf:ForwardChainingRDFSInferencer" ;
          config:delegate [
-            config:sailType "openrdf:MemoryStore" ;
-            config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-            ms:persist {%Persist|true|false%} ;
-            ms:syncDelay {%Sync delay|0%};
-            config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+            config:sail.type "openrdf:MemoryStore" ;
+            config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+            config:mem.persist {%Persist|true|false%} ;
+            config:mem.syncDelay {%Sync delay|0%};
+            config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
          ]
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-legacy.ttl
@@ -3,26 +3,23 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
 
-[] a rep:Repository ;
-   rep:repositoryID "{%Repository ID|memory-rdfs-new%}" ;
+[] a config:Repository ;
+   config:repositoryID "{%Repository ID|memory-rdfs-new%}" ;
    rdfs:label "{%Repository title|Memory store with RDFS inferencing (legacy reasoner)%}" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "openrdf:ForwardChainingRDFSInferencer" ;
-         sail:delegate [
-            sail:sailType "openrdf:MemoryStore" ;
-            sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+   config:repositoryImpl [
+      config:repositoryType "openrdf:SailRepository" ;
+      config:sailImpl [
+         config:sailType "openrdf:ForwardChainingRDFSInferencer" ;
+         config:delegate [
+            config:sailType "openrdf:MemoryStore" ;
+            config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
             ms:persist {%Persist|true|false%} ;
             ms:syncDelay {%Sync delay|0%};
-            sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+            config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
          ]
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
@@ -3,7 +3,7 @@
 # RDF Schema inferencing and Lucene index
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
@@ -3,30 +3,27 @@
 # RDF Schema inferencing and Lucene index
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
 
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|memory-rdfs-lucene%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|memory-rdfs-lucene%}" ;
     rdfs:label "{%Repository title|Memory store with RDFS inferencing and Lucene index%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "openrdf:LuceneSail";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "openrdf:LuceneSail";
             sail-luc:indexDir "index/" ;
-            sail:delegate [
-                sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
-                sail:delegate [
-                    sail:sailType "openrdf:MemoryStore" ;
-                    sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+            config:delegate [
+                config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+                config:delegate [
+                    config:sailType "openrdf:MemoryStore" ;
+                    config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
                     ms:persist {%Persist|true|false%} ;
                     ms:syncDelay {%Sync delay|0%};
-                    sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                    config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
                 ]
             ]
         ]

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
@@ -3,7 +3,7 @@
 # RDF Schema inferencing and Lucene index
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs-lucene.ttl
@@ -3,27 +3,24 @@
 # RDF Schema inferencing and Lucene index
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|memory-rdfs-lucene%}" ;
+    config:rep.id "{%Repository ID|memory-rdfs-lucene%}" ;
     rdfs:label "{%Repository title|Memory store with RDFS inferencing and Lucene index%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "openrdf:LuceneSail";
-            sail-luc:indexDir "index/" ;
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "openrdf:LuceneSail";
+            config:lucene.indexDir "index/" ;
             config:delegate [
-                config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+                config:sail.type "rdf4j:SchemaCachingRDFSInferencer" ;
                 config:delegate [
-                    config:sailType "openrdf:MemoryStore" ;
-                    config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-                    ms:persist {%Persist|true|false%} ;
-                    ms:syncDelay {%Sync delay|0%};
-                    config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                    config:sail.type "openrdf:MemoryStore" ;
+                    config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+                    config:mem.persist {%Persist|true|false%} ;
+                    config:mem.syncDelay {%Sync delay|0%};
+                    config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
                 ]
             ]
         ]

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
@@ -3,7 +3,7 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
@@ -3,7 +3,7 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
@@ -3,26 +3,23 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
 
-[] a rep:Repository ;
-   rep:repositoryID "{%Repository ID|memory-rdfs%}" ;
+[] a config:Repository ;
+   config:repositoryID "{%Repository ID|memory-rdfs%}" ;
    rdfs:label "{%Repository title|Memory store with RDFS inferencing%}" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
-         sail:delegate [
-            sail:sailType "openrdf:MemoryStore" ;
-            sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+   config:repositoryImpl [
+      config:repositoryType "openrdf:SailRepository" ;
+      config:sailImpl [
+         config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+         config:delegate [
+            config:sailType "openrdf:MemoryStore" ;
+            config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
             ms:persist {%Persist|true|false%} ;
             ms:syncDelay {%Sync delay|0%};
-            sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+            config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
          ]
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-rdfs.ttl
@@ -3,23 +3,21 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-   config:repositoryID "{%Repository ID|memory-rdfs%}" ;
+   config:rep.id "{%Repository ID|memory-rdfs%}" ;
    rdfs:label "{%Repository title|Memory store with RDFS inferencing%}" ;
-   config:repositoryImpl [
-      config:repositoryType "openrdf:SailRepository" ;
-      config:sailImpl [
-         config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "rdf4j:SchemaCachingRDFSInferencer" ;
          config:delegate [
-            config:sailType "openrdf:MemoryStore" ;
-            config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-            ms:persist {%Persist|true|false%} ;
-            ms:syncDelay {%Sync delay|0%};
-            config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+            config:sail.type "openrdf:MemoryStore" ;
+            config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+            config:mem.persist {%Persist|true|false%} ;
+            config:mem.syncDelay {%Sync delay|0%};
+            config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
          ]
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
@@ -2,23 +2,21 @@
 # RDF4J configuration template for a main-memory repository with SHACL
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|memory-rdfs%}" ;
+    config:rep.id "{%Repository ID|memory-rdfs%}" ;
     rdfs:label "{%Repository title|Memory store with SHACL%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "rdf4j:ShaclSail" ;
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "rdf4j:ShaclSail" ;
             config:delegate [
-                config:sailType "openrdf:MemoryStore" ;
+                config:sail.type "openrdf:MemoryStore" ;
                 config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-                ms:persist {%Persist|true|false%} ;
-                ms:syncDelay {%Sync delay|0%};
-                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:mem.persist {%Persist|true|false%} ;
+                config:mem.syncDelay {%Sync delay|0%};
+                config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a main-memory repository with SHACL
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
@@ -2,26 +2,23 @@
 # RDF4J configuration template for a main-memory repository with SHACL
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
 
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|memory-rdfs%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|memory-rdfs%}" ;
     rdfs:label "{%Repository title|Memory store with SHACL%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "rdf4j:ShaclSail" ;
-            sail:delegate [
-                sail:sailType "openrdf:MemoryStore" ;
-                sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "rdf4j:ShaclSail" ;
+            config:delegate [
+                config:sailType "openrdf:MemoryStore" ;
+                config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
                 ms:persist {%Persist|true|false%} ;
                 ms:syncDelay {%Sync delay|0%};
-                sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a main-memory repository with SHACL
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a main-memory repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory.ttl
@@ -2,19 +2,18 @@
 # RDF4J configuration template for a main-memory repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-   config:repositoryID "{%Repository ID|memory%}" ;
+   config:rep.id "{%Repository ID|memory%}" ;
    rdfs:label "{%Repository title|Memory store%}" ;
-   config:repositoryImpl [
-      config:repositoryType "openrdf:SailRepository" ;
-      config:sailImpl [
-         config:sailType "openrdf:MemoryStore" ;
-         config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
-         ms:persist {%Persist|true|false%} ;
-         ms:syncDelay {%Sync delay|0%} ;
-         config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "openrdf:MemoryStore" ;
+         config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+         config:mem.persist {%Persist|true|false%} ;
+         config:mem.syncDelay {%Sync delay|0%} ;
+         config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a main-memory repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory.ttl
@@ -2,22 +2,19 @@
 # RDF4J configuration template for a main-memory repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
-[] a rep:Repository ;
-   rep:repositoryID "{%Repository ID|memory%}" ;
+[] a config:Repository ;
+   config:repositoryID "{%Repository ID|memory%}" ;
    rdfs:label "{%Repository title|Memory store%}" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "openrdf:MemoryStore" ;
-         sail:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+   config:repositoryImpl [
+      config:repositoryType "openrdf:SailRepository" ;
+      config:sailImpl [
+         config:sailType "openrdf:MemoryStore" ;
+         config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
          ms:persist {%Persist|true|false%} ;
          ms:syncDelay {%Sync delay|0%} ;
-         sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+         config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
       ]
    ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-customrule.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-customrule.ttl
@@ -3,7 +3,7 @@
 # a custom graph query inference rule.
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-customrule.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-customrule.ttl
@@ -3,33 +3,30 @@
 # a custom graph query inference rule.
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 @prefix sp: <http://spinrdf.org/sp#>.
 
-
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|native-customrule%}" ;
+    config:rep.id "{%Repository ID|native-customrule%}" ;
     rdfs:label "{%Repository title|Native store with custom graph query inferencing rule%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "openrdf:CustomGraphQueryInferencer" ;
-            cgqi:queryLanguage "{%Query Language|SPARQL%}" ;
-            cgqi:ruleQuery [
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "openrdf:CustomGraphQueryInferencer" ;
+            config:cgqi.queryLanguage "{%Query Language|SPARQL%}" ;
+            config:cgqi.ruleQuery [
                 a sp:Construct ;
                 sp:text '''{%Rule query|insert rule query here%}'''
             ];
-            cgqi:matcherQuery [
+            config:cgqi.matcherQuery [
                 a sp:Construct ;
                 sp:text '''{%Matcher query (optional)|%}'''
             ];
             config:delegate [
-                config:sailType "openrdf:NativeStore" ;
-                config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
-                ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:sail.type "openrdf:NativeStore" ;
+                config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+                config:native.tripleIndexes "{%Triple indexes|spoc,posc%}";
+                config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-customrule.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-customrule.ttl
@@ -3,7 +3,7 @@
 # a custom graph query inference rule.
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-customrule.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-customrule.ttl
@@ -3,22 +3,19 @@
 # a custom graph query inference rule.
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.
 @prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
 @prefix sp: <http://spinrdf.org/sp#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
 
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|native-customrule%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|native-customrule%}" ;
     rdfs:label "{%Repository title|Native store with custom graph query inferencing rule%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "openrdf:CustomGraphQueryInferencer" ;
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "openrdf:CustomGraphQueryInferencer" ;
             cgqi:queryLanguage "{%Query Language|SPARQL%}" ;
             cgqi:ruleQuery [
                 a sp:Construct ;
@@ -28,11 +25,11 @@
                 a sp:Construct ;
                 sp:text '''{%Matcher query (optional)|%}'''
             ];
-            sail:delegate [
-                sail:sailType "openrdf:NativeStore" ;
-                sail:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+            config:delegate [
+                config:sailType "openrdf:NativeStore" ;
+                config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
                 ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-lucene.ttl
@@ -3,7 +3,7 @@
 # Lucene support
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix spin: <http://www.openrdf.org/config/sail/spin#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-lucene.ttl
@@ -3,30 +3,23 @@
 # Lucene support
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix spin: <http://www.openrdf.org/config/sail/spin#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
-@prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix sp: <http://spinrdf.org/sp#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
-
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|native-lucene%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|native-lucene%}" ;
     rdfs:label "{%Repository title|Native store with Lucene Support%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "openrdf:LuceneSail";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "openrdf:LuceneSail";
             sail-luc:indexDir "index/" ;
-            sail:delegate [
-                sail:sailType "openrdf:NativeStore" ;
-                sail:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+            config:delegate [
+                config:sailType "openrdf:NativeStore" ;
+                config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
                 ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-lucene.ttl
@@ -3,7 +3,7 @@
 # Lucene support
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix spin: <http://www.openrdf.org/config/sail/spin#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-lucene.ttl
@@ -3,23 +3,21 @@
 # Lucene support
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|native-lucene%}" ;
+    config:rep.id "{%Repository ID|native-lucene%}" ;
     rdfs:label "{%Repository title|Native store with Lucene Support%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "openrdf:LuceneSail";
-            sail-luc:indexDir "index/" ;
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "openrdf:LuceneSail";
+            config:lucene.indexDir "index/" ;
             config:delegate [
-                config:sailType "openrdf:NativeStore" ;
-                config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
-                ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:sail.type "openrdf:NativeStore" ;
+                config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+                config:native.tripleIndexes "{%Triple indexes|spoc,posc%}";
+                config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
@@ -3,7 +3,7 @@
 # RDF Schema and direct type hierarchy inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
@@ -3,23 +3,22 @@
 # RDF Schema and direct type hierarchy inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|native-rdfs-dt%}" ;
+    config:rep.id "{%Repository ID|native-rdfs-dt%}" ;
     rdfs:label "{%Repository title|Native store with RDF Schema and direct type inferencing%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "openrdf:DirectTypeHierarchyInferencer" ;
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "openrdf:DirectTypeHierarchyInferencer" ;
             config:delegate [
-                config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+                config:sail.type "rdf4j:SchemaCachingRDFSInferencer" ;
                 config:delegate [
-                    config:sailType "openrdf:NativeStore" ;
-                    config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-                    ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                    config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                    config:sail.type "openrdf:NativeStore" ;
+                    config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+                    config:native.tripleIndexes "{%Triple indexes|spoc,posc%}";
+                    config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
                 ]
             ]
         ]

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
@@ -3,27 +3,23 @@
 # RDF Schema and direct type hierarchy inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
-
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|native-rdfs-dt%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|native-rdfs-dt%}" ;
     rdfs:label "{%Repository title|Native store with RDF Schema and direct type inferencing%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "openrdf:DirectTypeHierarchyInferencer" ;
-            sail:delegate [
-                sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
-                sail:delegate [
-                    sail:sailType "openrdf:NativeStore" ;
-                    sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "openrdf:DirectTypeHierarchyInferencer" ;
+            config:delegate [
+                config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+                config:delegate [
+                    config:sailType "openrdf:NativeStore" ;
+                    config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
                     ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                    sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                    config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
                 ]
             ]
         ]

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-dt.ttl
@@ -3,7 +3,7 @@
 # RDF Schema and direct type hierarchy inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
@@ -3,26 +3,23 @@
 # RDFS support and a Lucene index
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
-@prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|native-rdfs-lucene%}" ;
+    config:rep.id "{%Repository ID|native-rdfs-lucene%}" ;
     rdfs:label "{%Repository title|Native store with RDFS entailment and  Lucene Support%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "openrdf:LuceneSail";
-            sail-luc:indexDir "index/" ;
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "openrdf:LuceneSail";
+            config:lucene.indexDir "index/" ;
             config:delegate [
-                config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+                config:sail.type "rdf4j:SchemaCachingRDFSInferencer" ;
                 config:delegate [
-                    config:sailType "openrdf:NativeStore" ;
-                    config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
-                    ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                    config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                    config:sail.type "openrdf:NativeStore" ;
+                    config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+                    config:native.tripleIndexes "{%Triple indexes|spoc,posc%}";
+                    config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
                 ]
             ]
         ]

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
@@ -3,32 +3,26 @@
 # RDFS support and a Lucene index
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix spin: <http://www.openrdf.org/config/sail/spin#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix sail-luc: <http://www.openrdf.org/config/sail/lucene#>.
 @prefix cgqi: <http://www.openrdf.org/config/sail/customGraphQueryInferencer#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix sp: <http://spinrdf.org/sp#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
-
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|native-rdfs-lucene%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|native-rdfs-lucene%}" ;
     rdfs:label "{%Repository title|Native store with RDFS entailment and  Lucene Support%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "openrdf:LuceneSail";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "openrdf:LuceneSail";
             sail-luc:indexDir "index/" ;
-            sail:delegate [
-                sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
-                sail:delegate [
-                    sail:sailType "openrdf:NativeStore" ;
-                    sail:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+            config:delegate [
+                config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+                config:delegate [
+                    config:sailType "openrdf:NativeStore" ;
+                    config:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
                     ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                    sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                    config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
                 ]
             ]
         ]

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
@@ -3,7 +3,7 @@
 # RDFS support and a Lucene index
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix spin: <http://www.openrdf.org/config/sail/spin#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs-lucene.ttl
@@ -3,7 +3,7 @@
 # RDFS support and a Lucene index
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix spin: <http://www.openrdf.org/config/sail/spin#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
@@ -3,7 +3,7 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
@@ -3,22 +3,20 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
-
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|native-rdfs%}" ;
+    config:rep.id "{%Repository ID|native-rdfs%}" ;
     rdfs:label "{%Repository title|Native store with RDF Schema inferencing%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "rdf4j:SchemaCachingRDFSInferencer" ;
             config:delegate [
-                config:sailType "openrdf:NativeStore" ;
-                config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-                ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:sail.type "openrdf:NativeStore" ;
+                config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+                config:native.tripleIndexes "{%Triple indexes|spoc,posc%}";
+                config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
@@ -3,7 +3,7 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-rdfs.ttl
@@ -3,25 +3,22 @@
 # RDF Schema inferencing
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
 
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|native-rdfs%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|native-rdfs%}" ;
     rdfs:label "{%Repository title|Native store with RDF Schema inferencing%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
-            sail:delegate [
-                sail:sailType "openrdf:NativeStore" ;
-                sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "rdf4j:SchemaCachingRDFSInferencer" ;
+            config:delegate [
+                config:sailType "openrdf:NativeStore" ;
+                config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
                 ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
@@ -3,21 +3,20 @@
 # SHACL
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|native-shacl%}" ;
+    config:rep.id "{%Repository ID|native-shacl%}" ;
     rdfs:label "{%Repository title|Native store with SHACL support%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "rdf4j:ShaclSail" ;
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "rdf4j:ShaclSail" ;
             config:delegate [
-                config:sailType "openrdf:NativeStore" ;
-                config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-                ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:sail.type "openrdf:NativeStore" ;
+                config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+                config:native.tripleIndexes "{%Triple indexes|spoc,posc%}";
+                config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
@@ -3,7 +3,7 @@
 # SHACL
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
@@ -3,25 +3,21 @@
 # SHACL
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
-
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|native-shacl%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|native-shacl%}" ;
     rdfs:label "{%Repository title|Native store with SHACL support%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "rdf4j:ShaclSail" ;
-            sail:delegate [
-                sail:sailType "openrdf:NativeStore" ;
-                sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "rdf4j:ShaclSail" ;
+            config:delegate [
+                config:sailType "openrdf:NativeStore" ;
+                config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
                 ns:tripleIndexes "{%Triple indexes|spoc,posc%}";
-                sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+                config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
             ]
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
@@ -3,7 +3,7 @@
 # SHACL
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native.ttl
@@ -2,21 +2,18 @@
 # RDF4J configuration template for a native RDF repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
 
-[] a rep:Repository ;
-    rep:repositoryID "{%Repository ID|native%}" ;
+[] a config:Repository ;
+    config:repositoryID "{%Repository ID|native%}" ;
     rdfs:label "{%Repository title|Native store%}" ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
-            sail:sailType "openrdf:NativeStore" ;
-            sail:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SailRepository" ;
+        config:sailImpl [
+            config:sailType "openrdf:NativeStore" ;
+            config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
             ns:tripleIndexes "{%Triple indexes|spoc,posc%}" ;
-            sb:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+            config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a native RDF repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native.ttl
@@ -2,18 +2,17 @@
 # RDF4J configuration template for a native RDF repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryID "{%Repository ID|native%}" ;
+    config:rep.id "{%Repository ID|native%}" ;
     rdfs:label "{%Repository title|Native store%}" ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SailRepository" ;
-        config:sailImpl [
-            config:sailType "openrdf:NativeStore" ;
-            config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
-            ns:tripleIndexes "{%Triple indexes|spoc,posc%}" ;
-            config:defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
+    config:rep.impl [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
+            config:sail.type "openrdf:NativeStore" ;
+            config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";
+            config:native.tripleIndexes "{%Triple indexes|spoc,posc%}" ;
+            config:sail.defaultQueryEvaluationMode "{%Query Evaluation Mode|STRICT|STANDARD%}"
         ]
     ].

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a native RDF repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
 @prefix sail: <http://www.openrdf.org/config/sail#>.
 @prefix ns: <http://www.openrdf.org/config/sail/native#>.

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/remote.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/remote.ttl
@@ -2,12 +2,12 @@
 # RDF4J configuration template for a (proxy for a) remote repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:HTTPRepository" ;
-        config:repositoryURL <{%RDF4J Server location|http://localhost:8080/rdf4j-server%}/repositories/{%Remote repository ID|SYSTEM%}>
+    config:rep.impl [
+        config:rep.type "openrdf:HTTPRepository" ;
+        config:http.url <{%RDF4J Server location|http://localhost:8080/rdf4j-server%}/repositories/{%Remote repository ID|SYSTEM%}>
     ];
-    config:repositoryID "{%Local repository ID|SYSTEM@localhost%}" ;
+    config:rep.id "{%Local repository ID|SYSTEM@localhost%}" ;
     rdfs:label "{%Repository title|SYSTEM repository @localhost%}" .

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/remote.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/remote.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a (proxy for a) remote repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix hr: <http://www.openrdf.org/config/repository/http#>.
 
 [] a rep:Repository ;

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/remote.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/remote.ttl
@@ -2,13 +2,12 @@
 # RDF4J configuration template for a (proxy for a) remote repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
-@prefix hr: <http://www.openrdf.org/config/repository/http#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 
-[] a rep:Repository ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:HTTPRepository" ;
-        hr:repositoryURL <{%Sesame server location|http://localhost:8080/openrdf-sesame%}/repositories/{%Remote repository ID|SYSTEM%}>
+[] a config:Repository ;
+    config:repositoryImpl [
+        config:repositoryType "openrdf:HTTPRepository" ;
+        config:repositoryURL <{%RDF4J Server location|http://localhost:8080/rdf4j-server%}/repositories/{%Remote repository ID|SYSTEM%}>
     ];
-    rep:repositoryID "{%Local repository ID|SYSTEM@localhost%}" ;
+    config:repositoryID "{%Local repository ID|SYSTEM@localhost%}" ;
     rdfs:label "{%Repository title|SYSTEM repository @localhost%}" .

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/remote.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/remote.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a (proxy for a) remote repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix hr: <http://www.openrdf.org/config/repository/http#>.
 
 [] a rep:Repository ;

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/sparql.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/sparql.ttl
@@ -2,14 +2,13 @@
 # RDF4J configuration template for a Repository proxy for a SPARQL endpoint
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix config: <tag:rdf4j.org:2023:config/>.
-@prefix sparql: <http://www.openrdf.org/config/repository/sparql#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 [] a config:Repository ;
-    config:repositoryImpl [
-        config:repositoryType "openrdf:SPARQLRepository" ;
-        sparql:query-endpoint <{%SPARQL query endpoint|%}> ;
-        sparql:update-endpoint <{%SPARQL update endpoint|%}> ;
+    config:rep.impl [
+        config:rep.type "openrdf:SPARQLRepository" ;
+        config:sparql.queryEndpoint <{%SPARQL query endpoint|%}> ;
+        config:sparql.updateEndpoint <{%SPARQL update endpoint|%}> ;
     ];
-    config:repositoryID "{%Local repository ID|endpoint@localhost%}" ;
+    config:rep.id "{%Local repository ID|endpoint@localhost%}" ;
     rdfs:label "{%Repository title|SPARQL endpoint repository @localhost%}" .

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/sparql.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/sparql.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a Repository proxy for a SPARQL endpoint
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix rep: <http://rdf4j.org/schema/repository#>.
 @prefix sparql: <http://www.openrdf.org/config/repository/sparql#>.
 
 [] a rep:Repository ;

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/sparql.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/sparql.ttl
@@ -2,14 +2,14 @@
 # RDF4J configuration template for a Repository proxy for a SPARQL endpoint
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
+@prefix config: <tag:rdf4j.org:2023:config/>.
 @prefix sparql: <http://www.openrdf.org/config/repository/sparql#>.
 
-[] a rep:Repository ;
-    rep:repositoryImpl [
-        rep:repositoryType "openrdf:SPARQLRepository" ;
+[] a config:Repository ;
+    config:repositoryImpl [
+        config:repositoryType "openrdf:SPARQLRepository" ;
         sparql:query-endpoint <{%SPARQL query endpoint|%}> ;
         sparql:update-endpoint <{%SPARQL update endpoint|%}> ;
     ];
-    rep:repositoryID "{%Local repository ID|endpoint@localhost%}" ;
+    config:repositoryID "{%Local repository ID|endpoint@localhost%}" ;
     rdfs:label "{%Repository title|SPARQL endpoint repository @localhost%}" .

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/sparql.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/sparql.ttl
@@ -2,7 +2,7 @@
 # RDF4J configuration template for a Repository proxy for a SPARQL endpoint
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://rdf4j.org/schema/repository#>.
+@prefix rep: <tag:rdf4j.org:2023:config/repository#>.
 @prefix sparql: <http://www.openrdf.org/config/repository/sparql#>.
 
 [] a rep:Repository ;

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
@@ -28,7 +28,7 @@ public class RepositoryConfigTest {
 		var repoNode = iri("urn:repo1");
 		Model m = new ModelBuilder()
 				.subject(repoNode)
-				.add(CONFIG.Rep.repositoryID, ID)
+				.add(CONFIG.Rep.id, ID)
 				.build();
 
 		RepositoryConfig config = new RepositoryConfig(ID);

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.junit.jupiter.api.Test;
 
 public class RepositoryConfigTest {
@@ -27,7 +28,7 @@ public class RepositoryConfigTest {
 		var repoNode = iri("urn:repo1");
 		Model m = new ModelBuilder()
 				.subject(repoNode)
-				.add(RepositoryConfigSchema.REPOSITORYID, ID)
+				.add(CONFIG.repositoryID, ID)
 				.build();
 
 		RepositoryConfig config = new RepositoryConfig(ID);
@@ -39,12 +40,10 @@ public class RepositoryConfigTest {
 
 	@Test
 	public void testParse_oldVocabulary() {
-
 		var repoNode = iri("urn:repo1");
 		Model m = new ModelBuilder()
 				.subject(repoNode)
-				.add(iri(RepositoryConfigSchema.NAMESPACE_OBSOLETE, RepositoryConfigSchema.REPOSITORYID.getLocalName()),
-						ID)
+				.add(RepositoryConfigSchema.REPOSITORYID, ID)
 				.build();
 
 		RepositoryConfig config = new RepositoryConfig(ID);

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
@@ -23,17 +23,17 @@ public class RepositoryConfigTest {
 
 	@Test
 	public void testParse_newVocabulary() {
-		
+
 		var repoNode = iri("urn:repo1");
 		Model m = new ModelBuilder()
 				.subject(repoNode)
 				.add(RepositoryConfigSchema.REPOSITORYID, ID)
 				.build();
-		
+
 		RepositoryConfig config = new RepositoryConfig(ID);
 
 		config.parse(m, repoNode);
-		
+
 		assertThat(config.getID()).isEqualTo(ID);
 	}
 

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
@@ -15,7 +15,7 @@ import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.junit.jupiter.api.Test;
 
 public class RepositoryConfigTest {
@@ -28,7 +28,7 @@ public class RepositoryConfigTest {
 		var repoNode = iri("urn:repo1");
 		Model m = new ModelBuilder()
 				.subject(repoNode)
-				.add(CONFIG.Rep.id, ID)
+				.add(Config.Rep.id, ID)
 				.build();
 
 		RepositoryConfig config = new RepositoryConfig(ID);

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
@@ -28,7 +28,7 @@ public class RepositoryConfigTest {
 		var repoNode = iri("urn:repo1");
 		Model m = new ModelBuilder()
 				.subject(repoNode)
-				.add(CONFIG.repositoryID, ID)
+				.add(CONFIG.Rep.repositoryID, ID)
 				.build();
 
 		RepositoryConfig config = new RepositoryConfig(ID);

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.junit.jupiter.api.Test;
+
+public class RepositoryConfigTest {
+
+	public static final String ID = "test";
+
+	@Test
+	public void testParse_newVocabulary() {
+		
+		var repoNode = iri("urn:repo1");
+		Model m = new ModelBuilder()
+				.subject(repoNode)
+				.add(RepositoryConfigSchema.REPOSITORYID, ID)
+				.build();
+		
+		RepositoryConfig config = new RepositoryConfig(ID);
+
+		config.parse(m, repoNode);
+		
+		assertThat(config.getID()).isEqualTo(ID);
+	}
+
+	@Test
+	public void testParse_oldVocabulary() {
+
+		var repoNode = iri("urn:repo1");
+		Model m = new ModelBuilder()
+				.subject(repoNode)
+				.add(iri(RepositoryConfigSchema.NAMESPACE_OBSOLETE, RepositoryConfigSchema.REPOSITORYID.getLocalName()),
+						ID)
+				.build();
+
+		RepositoryConfig config = new RepositoryConfig(ID);
+
+		config.parse(m, repoNode);
+
+		assertThat(config.getID()).isEqualTo(ID);
+	}
+
+}

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/config/RepositoryConfigTest.java
@@ -15,7 +15,7 @@ import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.junit.jupiter.api.Test;
 
 public class RepositoryConfigTest {
@@ -28,7 +28,7 @@ public class RepositoryConfigTest {
 		var repoNode = iri("urn:repo1");
 		Model m = new ModelBuilder()
 				.subject(repoNode)
-				.add(Config.Rep.id, ID)
+				.add(CONFIG.Rep.id, ID)
 				.build();
 
 		RepositoryConfig config = new RepositoryConfig(ID);

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
@@ -21,11 +21,11 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.config.AbstractDelegatingRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
-import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 import org.eclipse.rdf4j.repository.contextaware.ContextAwareConnection;
 
 /**
@@ -221,42 +221,42 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 		super.parse(model, resource);
 
 		try {
-			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.includeInferred,
+			Configurations
+					.getLiteralValue(model, resource, CONFIG.includeInferred,
 							ContextAwareSchema.INCLUDE_INFERRED)
 					.ifPresent(lit -> setIncludeInferred(lit.booleanValue()));
 
-			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.maxQueryTime,
+			Configurations
+					.getLiteralValue(model, resource, CONFIG.maxQueryTime,
 							ContextAwareSchema.MAX_QUERY_TIME)
 					.ifPresent(lit -> setMaxQueryTime(lit.intValue()));
 
-			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.queryLanguage,
+			Configurations
+					.getLiteralValue(model, resource, CONFIG.queryLanguage,
 							ContextAwareSchema.QUERY_LANGUAGE)
 					.ifPresent(lit -> setQueryLanguage(QueryLanguage.valueOf(lit.getLabel())));
 
-			RepositoryConfigUtil
-					.getPropertyAsIRI(model, resource, CONFIG.base,
+			Configurations
+					.getIRIValue(model, resource, CONFIG.base,
 							ContextAwareSchema.BASE_URI)
 					.ifPresent(iri -> setBaseURI(iri.stringValue()));
 
-			Set<Value> objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.readContext,
+			Set<Value> objects = Configurations.getPropertyValues(model, resource, CONFIG.readContext,
 					ContextAwareSchema.READ_CONTEXT);
 			setReadContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = model.filter(resource, ADD_CONTEXT, null).objects();
 			setAddContexts(objects.toArray(new IRI[objects.size()]));
 
-			objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.removeContext,
+			objects = Configurations.getPropertyValues(model, resource, CONFIG.removeContext,
 					ContextAwareSchema.REMOVE_CONTEXT);
 			setRemoveContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = model.filter(resource, ARCHIVE_CONTEXT, null).objects();
 			setArchiveContexts(objects.toArray(new IRI[objects.size()]));
 
-			RepositoryConfigUtil
-					.getPropertyAsIRI(model, resource, CONFIG.insertContext,
+			Configurations
+					.getIRIValue(model, resource, CONFIG.insertContext,
 							ContextAwareSchema.INSERT_CONTEXT)
 					.ifPresent(iri -> setInsertContext(iri));
 		} catch (ArrayStoreException e) {

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
@@ -186,31 +186,31 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 		Resource repImplNode = super.export(model);
 
 		if (includeInferred != null) {
-			model.add(repImplNode, CONFIG.INCLUDE_INFERRED, literal(includeInferred));
+			model.add(repImplNode, CONFIG.includeInferred, literal(includeInferred));
 		}
 		if (maxQueryTime > 0) {
-			model.add(repImplNode, CONFIG.MAX_QUERY_TIME, literal(maxQueryTime));
+			model.add(repImplNode, CONFIG.maxQueryTime, literal(maxQueryTime));
 		}
 		if (queryLanguage != null) {
-			model.add(repImplNode, CONFIG.QUERY_LANGUAGE, literal(queryLanguage.getName()));
+			model.add(repImplNode, CONFIG.queryLanguage, literal(queryLanguage.getName()));
 		}
 		if (baseURI != null) {
-			model.add(repImplNode, CONFIG.BASE_URI, iri(baseURI));
+			model.add(repImplNode, CONFIG.base, iri(baseURI));
 		}
 		for (IRI uri : readContexts) {
-			model.add(repImplNode, CONFIG.READ_CONTEXT, uri);
+			model.add(repImplNode, CONFIG.readContext, uri);
 		}
 		for (IRI resource : addContexts) {
 			model.add(repImplNode, ADD_CONTEXT, resource);
 		}
 		for (IRI resource : removeContexts) {
-			model.add(repImplNode, CONFIG.REMOVE_CONTEXT, resource);
+			model.add(repImplNode, CONFIG.removeContext, resource);
 		}
 		for (IRI resource : archiveContexts) {
 			model.add(repImplNode, ARCHIVE_CONTEXT, resource);
 		}
 		if (insertContext != null) {
-			model.add(repImplNode, CONFIG.INSERT_CONTEXT, insertContext);
+			model.add(repImplNode, CONFIG.insertContext, insertContext);
 		}
 
 		return repImplNode;
@@ -222,33 +222,33 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 
 		try {
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.INCLUDE_INFERRED,
+					.getPropertyAsLiteral(model, resource, CONFIG.includeInferred,
 							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setIncludeInferred(lit.booleanValue()));
 
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.MAX_QUERY_TIME,
+					.getPropertyAsLiteral(model, resource, CONFIG.maxQueryTime,
 							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setMaxQueryTime(lit.intValue()));
 
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, resource, CONFIG.QUERY_LANGUAGE,
+					.getPropertyAsLiteral(model, resource, CONFIG.queryLanguage,
 							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setQueryLanguage(QueryLanguage.valueOf(lit.getLabel())));
 
 			RepositoryConfigUtil
-					.getPropertyAsIRI(model, resource, CONFIG.BASE_URI,
+					.getPropertyAsIRI(model, resource, CONFIG.base,
 							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(iri -> setBaseURI(iri.stringValue()));
 
-			Set<Value> objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.READ_CONTEXT,
+			Set<Value> objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.readContext,
 					ContextAwareSchema.NAMESPACE_OBSOLETE);
 			setReadContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = model.filter(resource, ADD_CONTEXT, null).objects();
 			setAddContexts(objects.toArray(new IRI[objects.size()]));
 
-			objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.REMOVE_CONTEXT,
+			objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.removeContext,
 					ContextAwareSchema.NAMESPACE_OBSOLETE);
 			setRemoveContexts(objects.toArray(new IRI[objects.size()]));
 
@@ -256,7 +256,7 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 			setArchiveContexts(objects.toArray(new IRI[objects.size()]));
 
 			RepositoryConfigUtil
-					.getPropertyAsIRI(model, resource, CONFIG.INSERT_CONTEXT,
+					.getPropertyAsIRI(model, resource, CONFIG.insertContext,
 							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(iri -> setInsertContext(iri));
 		} catch (ArrayStoreException e) {

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
@@ -10,29 +10,22 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.contextaware.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.ADD_CONTEXT;
 import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.ARCHIVE_CONTEXT;
-import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.BASE_URI;
-import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.INCLUDE_INFERRED;
-import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.INSERT_CONTEXT;
-import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.MAX_QUERY_TIME;
-import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.QUERY_LANGUAGE;
-import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.READ_CONTEXT;
-import static org.eclipse.rdf4j.repository.contextaware.config.ContextAwareSchema.REMOVE_CONTEXT;
 
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.config.AbstractDelegatingRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 import org.eclipse.rdf4j.repository.contextaware.ContextAwareConnection;
 
 /**
@@ -192,35 +185,32 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 	public Resource export(Model model) {
 		Resource repImplNode = super.export(model);
 
-		ValueFactory vf = SimpleValueFactory.getInstance();
-
 		if (includeInferred != null) {
-			Literal bool = vf.createLiteral(includeInferred);
-			model.add(repImplNode, INCLUDE_INFERRED, bool);
+			model.add(repImplNode, CONFIG.INCLUDE_INFERRED, literal(includeInferred));
 		}
 		if (maxQueryTime > 0) {
-			model.add(repImplNode, MAX_QUERY_TIME, vf.createLiteral(maxQueryTime));
+			model.add(repImplNode, CONFIG.MAX_QUERY_TIME, literal(maxQueryTime));
 		}
 		if (queryLanguage != null) {
-			model.add(repImplNode, QUERY_LANGUAGE, vf.createLiteral(queryLanguage.getName()));
+			model.add(repImplNode, CONFIG.QUERY_LANGUAGE, literal(queryLanguage.getName()));
 		}
 		if (baseURI != null) {
-			model.add(repImplNode, BASE_URI, vf.createIRI(baseURI));
+			model.add(repImplNode, CONFIG.BASE_URI, iri(baseURI));
 		}
 		for (IRI uri : readContexts) {
-			model.add(repImplNode, READ_CONTEXT, uri);
+			model.add(repImplNode, CONFIG.READ_CONTEXT, uri);
 		}
 		for (IRI resource : addContexts) {
 			model.add(repImplNode, ADD_CONTEXT, resource);
 		}
 		for (IRI resource : removeContexts) {
-			model.add(repImplNode, REMOVE_CONTEXT, resource);
+			model.add(repImplNode, CONFIG.REMOVE_CONTEXT, resource);
 		}
 		for (IRI resource : archiveContexts) {
 			model.add(repImplNode, ARCHIVE_CONTEXT, resource);
 		}
 		if (insertContext != null) {
-			model.add(repImplNode, INSERT_CONTEXT, insertContext);
+			model.add(repImplNode, CONFIG.INSERT_CONTEXT, insertContext);
 		}
 
 		return repImplNode;
@@ -231,31 +221,43 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 		super.parse(model, resource);
 
 		try {
-			Models.objectLiteral(model.getStatements(resource, INCLUDE_INFERRED, null))
+			RepositoryConfigUtil
+					.getPropertyAsLiteral(model, resource, CONFIG.INCLUDE_INFERRED,
+							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setIncludeInferred(lit.booleanValue()));
 
-			Models.objectLiteral(model.getStatements(resource, MAX_QUERY_TIME, null))
+			RepositoryConfigUtil
+					.getPropertyAsLiteral(model, resource, CONFIG.MAX_QUERY_TIME,
+							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setMaxQueryTime(lit.intValue()));
 
-			Models.objectLiteral(model.getStatements(resource, QUERY_LANGUAGE, null))
+			RepositoryConfigUtil
+					.getPropertyAsLiteral(model, resource, CONFIG.QUERY_LANGUAGE,
+							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setQueryLanguage(QueryLanguage.valueOf(lit.getLabel())));
 
-			Models.objectIRI(model.getStatements(resource, QUERY_LANGUAGE, null))
+			RepositoryConfigUtil
+					.getPropertyAsIRI(model, resource, CONFIG.BASE_URI,
+							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(iri -> setBaseURI(iri.stringValue()));
 
-			Set<Value> objects = model.filter(resource, READ_CONTEXT, null).objects();
+			Set<Value> objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.READ_CONTEXT,
+					ContextAwareSchema.NAMESPACE_OBSOLETE);
 			setReadContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = model.filter(resource, ADD_CONTEXT, null).objects();
 			setAddContexts(objects.toArray(new IRI[objects.size()]));
 
-			objects = model.filter(resource, REMOVE_CONTEXT, null).objects();
+			objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.REMOVE_CONTEXT,
+					ContextAwareSchema.NAMESPACE_OBSOLETE);
 			setRemoveContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = model.filter(resource, ARCHIVE_CONTEXT, null).objects();
 			setArchiveContexts(objects.toArray(new IRI[objects.size()]));
 
-			Models.objectIRI(model.getStatements(resource, INSERT_CONTEXT, null))
+			RepositoryConfigUtil
+					.getPropertyAsIRI(model, resource, CONFIG.INSERT_CONTEXT,
+							ContextAwareSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(iri -> setInsertContext(iri));
 		} catch (ArrayStoreException e) {
 			throw new RepositoryConfigException(e);

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.Config.ContextAware;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG.ContextAware;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.config.AbstractDelegatingRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
@@ -223,33 +223,33 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 		try {
 			RepositoryConfigUtil
 					.getPropertyAsLiteral(model, resource, CONFIG.includeInferred,
-							ContextAwareSchema.NAMESPACE_OBSOLETE)
+							ContextAwareSchema.INCLUDE_INFERRED)
 					.ifPresent(lit -> setIncludeInferred(lit.booleanValue()));
 
 			RepositoryConfigUtil
 					.getPropertyAsLiteral(model, resource, CONFIG.maxQueryTime,
-							ContextAwareSchema.NAMESPACE_OBSOLETE)
+							ContextAwareSchema.MAX_QUERY_TIME)
 					.ifPresent(lit -> setMaxQueryTime(lit.intValue()));
 
 			RepositoryConfigUtil
 					.getPropertyAsLiteral(model, resource, CONFIG.queryLanguage,
-							ContextAwareSchema.NAMESPACE_OBSOLETE)
+							ContextAwareSchema.QUERY_LANGUAGE)
 					.ifPresent(lit -> setQueryLanguage(QueryLanguage.valueOf(lit.getLabel())));
 
 			RepositoryConfigUtil
 					.getPropertyAsIRI(model, resource, CONFIG.base,
-							ContextAwareSchema.NAMESPACE_OBSOLETE)
+							ContextAwareSchema.BASE_URI)
 					.ifPresent(iri -> setBaseURI(iri.stringValue()));
 
 			Set<Value> objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.readContext,
-					ContextAwareSchema.NAMESPACE_OBSOLETE);
+					ContextAwareSchema.READ_CONTEXT);
 			setReadContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = model.filter(resource, ADD_CONTEXT, null).objects();
 			setAddContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = RepositoryConfigUtil.getPropertyValues(model, resource, CONFIG.removeContext,
-					ContextAwareSchema.NAMESPACE_OBSOLETE);
+					ContextAwareSchema.REMOVE_CONTEXT);
 			setRemoveContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = model.filter(resource, ARCHIVE_CONTEXT, null).objects();
@@ -257,7 +257,7 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 
 			RepositoryConfigUtil
 					.getPropertyAsIRI(model, resource, CONFIG.insertContext,
-							ContextAwareSchema.NAMESPACE_OBSOLETE)
+							ContextAwareSchema.INSERT_CONTEXT)
 					.ifPresent(iri -> setInsertContext(iri));
 		} catch (ArrayStoreException e) {
 			throw new RepositoryConfigException(e);

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG.ContextAware;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.config.AbstractDelegatingRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
@@ -186,31 +186,31 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 		Resource repImplNode = super.export(model);
 
 		if (includeInferred != null) {
-			model.add(repImplNode, CONFIG.includeInferred, literal(includeInferred));
+			model.add(repImplNode, ContextAware.includeInferred, literal(includeInferred));
 		}
 		if (maxQueryTime > 0) {
-			model.add(repImplNode, CONFIG.maxQueryTime, literal(maxQueryTime));
+			model.add(repImplNode, ContextAware.maxQueryTime, literal(maxQueryTime));
 		}
 		if (queryLanguage != null) {
-			model.add(repImplNode, CONFIG.queryLanguage, literal(queryLanguage.getName()));
+			model.add(repImplNode, ContextAware.queryLanguage, literal(queryLanguage.getName()));
 		}
 		if (baseURI != null) {
-			model.add(repImplNode, CONFIG.base, iri(baseURI));
+			model.add(repImplNode, ContextAware.base, iri(baseURI));
 		}
 		for (IRI uri : readContexts) {
-			model.add(repImplNode, CONFIG.readContext, uri);
+			model.add(repImplNode, ContextAware.readContext, uri);
 		}
 		for (IRI resource : addContexts) {
 			model.add(repImplNode, ADD_CONTEXT, resource);
 		}
 		for (IRI resource : removeContexts) {
-			model.add(repImplNode, CONFIG.removeContext, resource);
+			model.add(repImplNode, ContextAware.removeContext, resource);
 		}
 		for (IRI resource : archiveContexts) {
 			model.add(repImplNode, ARCHIVE_CONTEXT, resource);
 		}
 		if (insertContext != null) {
-			model.add(repImplNode, CONFIG.insertContext, insertContext);
+			model.add(repImplNode, ContextAware.insertContext, insertContext);
 		}
 
 		return repImplNode;
@@ -222,33 +222,33 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 
 		try {
 			Configurations
-					.getLiteralValue(model, resource, CONFIG.includeInferred,
+					.getLiteralValue(model, resource, ContextAware.includeInferred,
 							ContextAwareSchema.INCLUDE_INFERRED)
 					.ifPresent(lit -> setIncludeInferred(lit.booleanValue()));
 
 			Configurations
-					.getLiteralValue(model, resource, CONFIG.maxQueryTime,
+					.getLiteralValue(model, resource, ContextAware.maxQueryTime,
 							ContextAwareSchema.MAX_QUERY_TIME)
 					.ifPresent(lit -> setMaxQueryTime(lit.intValue()));
 
 			Configurations
-					.getLiteralValue(model, resource, CONFIG.queryLanguage,
+					.getLiteralValue(model, resource, ContextAware.queryLanguage,
 							ContextAwareSchema.QUERY_LANGUAGE)
 					.ifPresent(lit -> setQueryLanguage(QueryLanguage.valueOf(lit.getLabel())));
 
 			Configurations
-					.getIRIValue(model, resource, CONFIG.base,
+					.getIRIValue(model, resource, ContextAware.base,
 							ContextAwareSchema.BASE_URI)
 					.ifPresent(iri -> setBaseURI(iri.stringValue()));
 
-			Set<Value> objects = Configurations.getPropertyValues(model, resource, CONFIG.readContext,
+			Set<Value> objects = Configurations.getPropertyValues(model, resource, ContextAware.readContext,
 					ContextAwareSchema.READ_CONTEXT);
 			setReadContexts(objects.toArray(new IRI[objects.size()]));
 
 			objects = model.filter(resource, ADD_CONTEXT, null).objects();
 			setAddContexts(objects.toArray(new IRI[objects.size()]));
 
-			objects = Configurations.getPropertyValues(model, resource, CONFIG.removeContext,
+			objects = Configurations.getPropertyValues(model, resource, ContextAware.removeContext,
 					ContextAwareSchema.REMOVE_CONTEXT);
 			setRemoveContexts(objects.toArray(new IRI[objects.size()]));
 
@@ -256,7 +256,7 @@ public class ContextAwareConfig extends AbstractDelegatingRepositoryImplConfig {
 			setArchiveContexts(objects.toArray(new IRI[objects.size()]));
 
 			Configurations
-					.getIRIValue(model, resource, CONFIG.insertContext,
+					.getIRIValue(model, resource, ContextAware.insertContext,
 							ContextAwareSchema.INSERT_CONTEXT)
 					.ifPresent(iri -> setInsertContext(iri));
 		} catch (ArrayStoreException e) {

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareConfig.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG.ContextAware;
+import org.eclipse.rdf4j.model.vocabulary.Config.ContextAware;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.config.AbstractDelegatingRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
@@ -13,12 +13,12 @@ package org.eclipse.rdf4j.repository.contextaware.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * @author James Leigh
  *
- * @deprecated use {@link CONFIG.ContextAware} vocabulary instead.
+ * @deprecated use {@link Config.ContextAware} vocabulary instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ContextAwareSchema {
@@ -30,27 +30,27 @@ public class ContextAwareSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/contextaware#";
 
 	/**
-	 * @deprecated use {@link CONFIG.ContextAware#includeInferred} instead.
+	 * @deprecated use {@link Config.ContextAware#includeInferred} instead.
 	 */
 	public final static IRI INCLUDE_INFERRED = iri(NAMESPACE, "includeInferrred");
 
 	/**
-	 * @deprecated use {@link CONFIG.ContextAware#maxQueryTime} instead
+	 * @deprecated use {@link Config.ContextAware#maxQueryTime} instead
 	 */
 	public final static IRI MAX_QUERY_TIME = iri(NAMESPACE, "maxQueryTime");
 
 	/**
-	 * @deprecated use {@link CONFIG.ContextAware#queryLanguage} instead.
+	 * @deprecated use {@link Config.ContextAware#queryLanguage} instead.
 	 */
 	public final static IRI QUERY_LANGUAGE = iri(NAMESPACE, "queryLanguage");
 
 	/**
-	 * @deprecated use {@link CONFIG.ContextAware#base} instead
+	 * @deprecated use {@link Config.ContextAware#base} instead
 	 */
 	public final static IRI BASE_URI = iri(NAMESPACE, "base");
 
 	/**
-	 * @deprecated use {@link CONFIG.ContextAware#readContext} instead
+	 * @deprecated use {@link Config.ContextAware#readContext} instead
 	 */
 	public final static IRI READ_CONTEXT = iri(NAMESPACE, "readContext");
 
@@ -58,7 +58,7 @@ public class ContextAwareSchema {
 	public final static IRI ADD_CONTEXT = iri(NAMESPACE, "addContext");
 
 	/**
-	 * @deprecated use {@link CONFIG.ContextAware#removeContext} instead.
+	 * @deprecated use {@link Config.ContextAware#removeContext} instead.
 	 */
 	public final static IRI REMOVE_CONTEXT = iri(NAMESPACE, "removeContext");
 
@@ -66,7 +66,7 @@ public class ContextAwareSchema {
 	public final static IRI ARCHIVE_CONTEXT = iri(NAMESPACE, "archiveContext");
 
 	/**
-	 * @deprecated use {@link CONFIG.ContextAware#insertContext} instead.
+	 * @deprecated use {@link Config.ContextAware#insertContext} instead.
 	 */
 	public final static IRI INSERT_CONTEXT = iri(NAMESPACE, "insertContext");
 }

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 /**
  * @author James Leigh
  *
- * @deprecated use {@link CONFIG} vocabulary instead.
+ * @deprecated use {@link CONFIG.ContextAware} vocabulary instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ContextAwareSchema {
@@ -30,27 +30,27 @@ public class ContextAwareSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/contextaware#";
 
 	/**
-	 * @deprecated use {@link CONFIG#includeInferred} instead.
+	 * @deprecated use {@link CONFIG.ContextAware#includeInferred} instead.
 	 */
 	public final static IRI INCLUDE_INFERRED = iri(NAMESPACE, "includeInferrred");
 
 	/**
-	 * @deprecated use {@link CONFIG#maxQueryTime} instead
+	 * @deprecated use {@link CONFIG.ContextAware#maxQueryTime} instead
 	 */
 	public final static IRI MAX_QUERY_TIME = iri(NAMESPACE, "maxQueryTime");
 
 	/**
-	 * @deprecated use {@link CONFIG#queryLanguage} instead.
+	 * @deprecated use {@link CONFIG.ContextAware#queryLanguage} instead.
 	 */
 	public final static IRI QUERY_LANGUAGE = iri(NAMESPACE, "queryLanguage");
 
 	/**
-	 * @deprecated use {@link CONFIG#base} instead
+	 * @deprecated use {@link CONFIG.ContextAware#base} instead
 	 */
 	public final static IRI BASE_URI = iri(NAMESPACE, "base");
 
 	/**
-	 * @deprecated use {@link CONFIG#readContext} instead
+	 * @deprecated use {@link CONFIG.ContextAware#readContext} instead
 	 */
 	public final static IRI READ_CONTEXT = iri(NAMESPACE, "readContext");
 
@@ -58,7 +58,7 @@ public class ContextAwareSchema {
 	public final static IRI ADD_CONTEXT = iri(NAMESPACE, "addContext");
 
 	/**
-	 * @deprecated use {@link CONFIG#removeContext} instead.
+	 * @deprecated use {@link CONFIG.ContextAware#removeContext} instead.
 	 */
 	public final static IRI REMOVE_CONTEXT = iri(NAMESPACE, "removeContext");
 
@@ -66,7 +66,7 @@ public class ContextAwareSchema {
 	public final static IRI ARCHIVE_CONTEXT = iri(NAMESPACE, "archiveContext");
 
 	/**
-	 * @deprecated use {@link CONFIG#insertContext} instead.
+	 * @deprecated use {@link CONFIG.ContextAware#insertContext} instead.
 	 */
 	public final static IRI INSERT_CONTEXT = iri(NAMESPACE, "insertContext");
 }

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
@@ -17,7 +17,7 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author James Leigh
- * 
+ *
  * @deprecated use {@link CONFIG} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 /**
  * @author James Leigh
  *
- * @deprecated use {@link CONFIG} instead.
+ * @deprecated use {@link CONFIG} vocabulary instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ContextAwareSchema {
@@ -27,25 +27,46 @@ public class ContextAwareSchema {
 	 * The obsolete ContextAwareRepository schema namespace (
 	 * <var>http://www.openrdf.org/config/repository/contextaware#</var>).
 	 */
-	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/contextaware#";
+	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/contextaware#";
 
-	public final static IRI INCLUDE_INFERRED = CONFIG.includeInferred;
+	/**
+	 * @deprecated use {@link CONFIG#includeInferred} instead.
+	 */
+	public final static IRI INCLUDE_INFERRED = iri(NAMESPACE, "includeInferrred");
 
-	public final static IRI MAX_QUERY_TIME = CONFIG.maxQueryTime;
+	/**
+	 * @deprecated use {@link CONFIG#maxQueryTime} instead
+	 */
+	public final static IRI MAX_QUERY_TIME = iri(NAMESPACE, "maxQueryTime");
 
-	public final static IRI QUERY_LANGUAGE = CONFIG.queryLanguage;
+	/**
+	 * @deprecated use {@link CONFIG#queryLanguage} instead.
+	 */
+	public final static IRI QUERY_LANGUAGE = iri(NAMESPACE, "queryLanguage");
 
-	public final static IRI BASE_URI = CONFIG.base;
+	/**
+	 * @deprecated use {@link CONFIG#base} instead
+	 */
+	public final static IRI BASE_URI = iri(NAMESPACE, "base");
 
-	public final static IRI READ_CONTEXT = CONFIG.readContext;
+	/**
+	 * @deprecated use {@link CONFIG#readContext} instead
+	 */
+	public final static IRI READ_CONTEXT = iri(NAMESPACE, "readContext");
 
 	@Deprecated
-	public final static IRI ADD_CONTEXT = iri(NAMESPACE_OBSOLETE, "addContext");
+	public final static IRI ADD_CONTEXT = iri(NAMESPACE, "addContext");
 
-	public final static IRI REMOVE_CONTEXT = CONFIG.removeContext;
+	/**
+	 * @deprecated use {@link CONFIG#removeContext} instead.
+	 */
+	public final static IRI REMOVE_CONTEXT = iri(NAMESPACE, "removeContext");
 
 	@Deprecated
-	public final static IRI ARCHIVE_CONTEXT = iri(NAMESPACE_OBSOLETE, "archiveContext");
+	public final static IRI ARCHIVE_CONTEXT = iri(NAMESPACE, "archiveContext");
 
-	public final static IRI INSERT_CONTEXT = CONFIG.insertContext;
+	/**
+	 * @deprecated use {@link CONFIG#insertContext} instead.
+	 */
+	public final static IRI INSERT_CONTEXT = iri(NAMESPACE, "insertContext");
 }

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
@@ -10,77 +10,42 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.contextaware.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author James Leigh
+ * 
+ * @deprecated use {@link CONFIG} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class ContextAwareSchema {
 
 	/**
-	 * The ContextAwareRepository schema namespace ( <var>http://www.openrdf.org/config/repository/contextaware#</var>).
+	 * The obsolete ContextAwareRepository schema namespace (
+	 * <var>http://www.openrdf.org/config/repository/contextaware#</var>).
 	 */
-	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/contextaware#";
+	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/contextaware#";
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#includeInferred</var>
-	 */
-	public final static IRI INCLUDE_INFERRED;
+	public final static IRI INCLUDE_INFERRED = CONFIG.INCLUDE_INFERRED;
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#maxQueryTime</var>
-	 */
-	public final static IRI MAX_QUERY_TIME;
+	public final static IRI MAX_QUERY_TIME = CONFIG.MAX_QUERY_TIME;
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#queryLanguage</var>
-	 */
-	public final static IRI QUERY_LANGUAGE;
+	public final static IRI QUERY_LANGUAGE = CONFIG.QUERY_LANGUAGE;
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#base</var>
-	 */
-	public final static IRI BASE_URI;
+	public final static IRI BASE_URI = CONFIG.BASE_URI;
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#readContext</var>
-	 */
-	public final static IRI READ_CONTEXT;
+	public final static IRI READ_CONTEXT = CONFIG.READ_CONTEXT;
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#addContext</var>
-	 */
 	@Deprecated
-	public final static IRI ADD_CONTEXT;
+	public final static IRI ADD_CONTEXT = iri(NAMESPACE_OBSOLETE, "addContext");
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#removeContext</var>
-	 */
-	public final static IRI REMOVE_CONTEXT;
+	public final static IRI REMOVE_CONTEXT = CONFIG.REMOVE_CONTEXT;
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#archiveContext</var>
-	 */
 	@Deprecated
-	public final static IRI ARCHIVE_CONTEXT;
+	public final static IRI ARCHIVE_CONTEXT = iri(NAMESPACE_OBSOLETE, "archiveContext");
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/contextaware#insertContext</var>
-	 */
-	public final static IRI INSERT_CONTEXT;
-
-	static {
-		ValueFactory factory = SimpleValueFactory.getInstance();
-		INCLUDE_INFERRED = factory.createIRI(NAMESPACE, "includeInferred");
-		QUERY_LANGUAGE = factory.createIRI(NAMESPACE, "ql");
-		BASE_URI = factory.createIRI(NAMESPACE, "base");
-		READ_CONTEXT = factory.createIRI(NAMESPACE, "readContext");
-		ADD_CONTEXT = factory.createIRI(NAMESPACE, "addContext");
-		REMOVE_CONTEXT = factory.createIRI(NAMESPACE, "removeContext");
-		ARCHIVE_CONTEXT = factory.createIRI(NAMESPACE, "archiveContext");
-		INSERT_CONTEXT = factory.createIRI(NAMESPACE, "insertContext");
-		MAX_QUERY_TIME = factory.createIRI(NAMESPACE, "maxQueryTime");
-	}
+	public final static IRI INSERT_CONTEXT = CONFIG.INSERT_CONTEXT;
 }

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
@@ -29,23 +29,23 @@ public class ContextAwareSchema {
 	 */
 	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/contextaware#";
 
-	public final static IRI INCLUDE_INFERRED = CONFIG.INCLUDE_INFERRED;
+	public final static IRI INCLUDE_INFERRED = CONFIG.includeInferred;
 
-	public final static IRI MAX_QUERY_TIME = CONFIG.MAX_QUERY_TIME;
+	public final static IRI MAX_QUERY_TIME = CONFIG.maxQueryTime;
 
-	public final static IRI QUERY_LANGUAGE = CONFIG.QUERY_LANGUAGE;
+	public final static IRI QUERY_LANGUAGE = CONFIG.queryLanguage;
 
-	public final static IRI BASE_URI = CONFIG.BASE_URI;
+	public final static IRI BASE_URI = CONFIG.base;
 
-	public final static IRI READ_CONTEXT = CONFIG.READ_CONTEXT;
+	public final static IRI READ_CONTEXT = CONFIG.readContext;
 
 	@Deprecated
 	public final static IRI ADD_CONTEXT = iri(NAMESPACE_OBSOLETE, "addContext");
 
-	public final static IRI REMOVE_CONTEXT = CONFIG.REMOVE_CONTEXT;
+	public final static IRI REMOVE_CONTEXT = CONFIG.removeContext;
 
 	@Deprecated
 	public final static IRI ARCHIVE_CONTEXT = iri(NAMESPACE_OBSOLETE, "archiveContext");
 
-	public final static IRI INSERT_CONTEXT = CONFIG.INSERT_CONTEXT;
+	public final static IRI INSERT_CONTEXT = CONFIG.insertContext;
 }

--- a/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
+++ b/core/repository/contextaware/src/main/java/org/eclipse/rdf4j/repository/contextaware/config/ContextAwareSchema.java
@@ -13,12 +13,12 @@ package org.eclipse.rdf4j.repository.contextaware.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author James Leigh
  *
- * @deprecated use {@link Config.ContextAware} vocabulary instead.
+ * @deprecated use {@link CONFIG.ContextAware} vocabulary instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ContextAwareSchema {
@@ -30,27 +30,27 @@ public class ContextAwareSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/contextaware#";
 
 	/**
-	 * @deprecated use {@link Config.ContextAware#includeInferred} instead.
+	 * @deprecated use {@link CONFIG.ContextAware#includeInferred} instead.
 	 */
 	public final static IRI INCLUDE_INFERRED = iri(NAMESPACE, "includeInferrred");
 
 	/**
-	 * @deprecated use {@link Config.ContextAware#maxQueryTime} instead
+	 * @deprecated use {@link CONFIG.ContextAware#maxQueryTime} instead
 	 */
 	public final static IRI MAX_QUERY_TIME = iri(NAMESPACE, "maxQueryTime");
 
 	/**
-	 * @deprecated use {@link Config.ContextAware#queryLanguage} instead.
+	 * @deprecated use {@link CONFIG.ContextAware#queryLanguage} instead.
 	 */
 	public final static IRI QUERY_LANGUAGE = iri(NAMESPACE, "queryLanguage");
 
 	/**
-	 * @deprecated use {@link Config.ContextAware#base} instead
+	 * @deprecated use {@link CONFIG.ContextAware#base} instead
 	 */
 	public final static IRI BASE_URI = iri(NAMESPACE, "base");
 
 	/**
-	 * @deprecated use {@link Config.ContextAware#readContext} instead
+	 * @deprecated use {@link CONFIG.ContextAware#readContext} instead
 	 */
 	public final static IRI READ_CONTEXT = iri(NAMESPACE, "readContext");
 
@@ -58,7 +58,7 @@ public class ContextAwareSchema {
 	public final static IRI ADD_CONTEXT = iri(NAMESPACE, "addContext");
 
 	/**
-	 * @deprecated use {@link Config.ContextAware#removeContext} instead.
+	 * @deprecated use {@link CONFIG.ContextAware#removeContext} instead.
 	 */
 	public final static IRI REMOVE_CONTEXT = iri(NAMESPACE, "removeContext");
 
@@ -66,7 +66,7 @@ public class ContextAwareSchema {
 	public final static IRI ARCHIVE_CONTEXT = iri(NAMESPACE, "archiveContext");
 
 	/**
-	 * @deprecated use {@link Config.ContextAware#insertContext} instead.
+	 * @deprecated use {@link CONFIG.ContextAware#insertContext} instead.
 	 */
 	public final static IRI INSERT_CONTEXT = iri(NAMESPACE, "insertContext");
 }

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 
@@ -76,8 +76,8 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (url != null) {
-			graph.setNamespace(Config.PREFIX, Config.NAMESPACE);
-			graph.add(implNode, Config.Http.url, SimpleValueFactory.getInstance().createIRI(url));
+			graph.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
+			graph.add(implNode, CONFIG.Http.url, SimpleValueFactory.getInstance().createIRI(url));
 		}
 
 		return implNode;
@@ -90,15 +90,15 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		try {
 
 			Configurations
-					.getIRIValue(model, implNode, Config.Http.url, HTTPRepositorySchema.REPOSITORYURL)
+					.getIRIValue(model, implNode, CONFIG.Http.url, HTTPRepositorySchema.REPOSITORYURL)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
 			Configurations
-					.getLiteralValue(model, implNode, Config.Http.username, HTTPRepositorySchema.USERNAME)
+					.getLiteralValue(model, implNode, CONFIG.Http.username, HTTPRepositorySchema.USERNAME)
 					.ifPresent(username -> setUsername(username.getLabel()));
 
 			Configurations
-					.getLiteralValue(model, implNode, Config.Http.password, HTTPRepositorySchema.PASSWORD)
+					.getLiteralValue(model, implNode, CONFIG.Http.password, HTTPRepositorySchema.PASSWORD)
 					.ifPresent(password -> setPassword(password.getLabel()));
 
 		} catch (ModelException e) {

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.repository.http.config;
 
 import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.NAMESPACE;
+import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.NAMESPACE_OBSOLETE;
 import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.PASSWORD;
 import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.REPOSITORYURL;
 import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.USERNAME;
@@ -19,9 +20,9 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 
 /**
  * @author Arjohn Kampman
@@ -83,14 +84,6 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 			graph.setNamespace("http", NAMESPACE);
 			graph.add(implNode, REPOSITORYURL, SimpleValueFactory.getInstance().createIRI(url));
 		}
-		// if (username != null) {
-		// graph.add(implNode, USERNAME,
-		// graph.getValueFactory().createLiteral(username));
-		// }
-		// if (password != null) {
-		// graph.add(implNode, PASSWORD,
-		// graph.getValueFactory().createLiteral(password));
-		// }
 
 		return implNode;
 	}
@@ -100,13 +93,17 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(model, implNode);
 
 		try {
-			Models.objectIRI(model.getStatements(implNode, REPOSITORYURL, null))
+			
+			RepositoryConfigUtil
+					.getPropertyAsIRI(model, implNode, REPOSITORYURL, NAMESPACE_OBSOLETE)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
-			Models.objectLiteral(model.getStatements(implNode, USERNAME, null))
+			RepositoryConfigUtil
+					.getPropertyAsLiteral(model, implNode, USERNAME, NAMESPACE_OBSOLETE)
 					.ifPresent(username -> setUsername(username.getLabel()));
 
-			Models.objectLiteral(model.getStatements(implNode, PASSWORD, null))
+			RepositoryConfigUtil
+					.getPropertyAsLiteral(model, implNode, PASSWORD, NAMESPACE_OBSOLETE)
 					.ifPresent(password -> setPassword(password.getLabel()));
 
 		} catch (ModelException e) {

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -10,16 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.http.config;
 
-import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.NAMESPACE;
 import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.NAMESPACE_OBSOLETE;
-import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.PASSWORD;
-import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.REPOSITORYURL;
-import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.USERNAME;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
@@ -81,8 +78,8 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (url != null) {
-			graph.setNamespace("http", NAMESPACE);
-			graph.add(implNode, REPOSITORYURL, SimpleValueFactory.getInstance().createIRI(url));
+			graph.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
+			graph.add(implNode, CONFIG.REPOSITORY_URL, SimpleValueFactory.getInstance().createIRI(url));
 		}
 
 		return implNode;
@@ -95,15 +92,15 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		try {
 
 			RepositoryConfigUtil
-					.getPropertyAsIRI(model, implNode, REPOSITORYURL, NAMESPACE_OBSOLETE)
+					.getPropertyAsIRI(model, implNode, CONFIG.REPOSITORY_URL, NAMESPACE_OBSOLETE)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, USERNAME, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, implNode, CONFIG.USERNAME, NAMESPACE_OBSOLETE)
 					.ifPresent(username -> setUsername(username.getLabel()));
 
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, PASSWORD, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, implNode, CONFIG.PASSWORD, NAMESPACE_OBSOLETE)
 					.ifPresent(password -> setPassword(password.getLabel()));
 
 		} catch (ModelException e) {

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.http.config;
 
-import static org.eclipse.rdf4j.model.util.Values.iri;
-
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -79,7 +77,7 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		if (url != null) {
 			graph.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
-			graph.add(implNode, CONFIG.repositoryURL, SimpleValueFactory.getInstance().createIRI(url));
+			graph.add(implNode, CONFIG.Http.repositoryURL, SimpleValueFactory.getInstance().createIRI(url));
 		}
 
 		return implNode;
@@ -92,15 +90,15 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		try {
 
 			Configurations
-					.getIRIValue(model, implNode, CONFIG.repositoryURL, HTTPRepositorySchema.REPOSITORYURL)
+					.getIRIValue(model, implNode, CONFIG.Http.repositoryURL, HTTPRepositorySchema.REPOSITORYURL)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
 			Configurations
-					.getLiteralValue(model, implNode, CONFIG.username, HTTPRepositorySchema.USERNAME)
+					.getLiteralValue(model, implNode, CONFIG.Http.username, HTTPRepositorySchema.USERNAME)
 					.ifPresent(username -> setUsername(username.getLabel()));
 
 			Configurations
-					.getLiteralValue(model, implNode, CONFIG.password, HTTPRepositorySchema.PASSWORD)
+					.getLiteralValue(model, implNode, CONFIG.Http.password, HTTPRepositorySchema.PASSWORD)
 					.ifPresent(password -> setPassword(password.getLabel()));
 
 		} catch (ModelException e) {

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.http.config;
 
-import static org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema.NAMESPACE_OBSOLETE;
-
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -92,15 +90,15 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		try {
 
 			RepositoryConfigUtil
-					.getPropertyAsIRI(model, implNode, CONFIG.repositoryURL, NAMESPACE_OBSOLETE)
+					.getPropertyAsIRI(model, implNode, CONFIG.repositoryURL, HTTPRepositorySchema.REPOSITORYURL)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.username, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, implNode, CONFIG.username, HTTPRepositorySchema.USERNAME)
 					.ifPresent(username -> setUsername(username.getLabel()));
 
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.password, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, implNode, CONFIG.password, HTTPRepositorySchema.PASSWORD)
 					.ifPresent(password -> setPassword(password.getLabel()));
 
 		} catch (ModelException e) {

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -93,7 +93,7 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(model, implNode);
 
 		try {
-			
+
 			RepositoryConfigUtil
 					.getPropertyAsIRI(model, implNode, REPOSITORYURL, NAMESPACE_OBSOLETE)
 					.ifPresent(iri -> setURL(iri.stringValue()));

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -10,14 +10,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.http.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
-import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 
 /**
  * @author Arjohn Kampman
@@ -89,16 +91,16 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		try {
 
-			RepositoryConfigUtil
-					.getPropertyAsIRI(model, implNode, CONFIG.repositoryURL, HTTPRepositorySchema.REPOSITORYURL)
+			Configurations
+					.getIRIValue(model, implNode, CONFIG.repositoryURL, HTTPRepositorySchema.REPOSITORYURL)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
-			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.username, HTTPRepositorySchema.USERNAME)
+			Configurations
+					.getLiteralValue(model, implNode, CONFIG.username, HTTPRepositorySchema.USERNAME)
 					.ifPresent(username -> setUsername(username.getLabel()));
 
-			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.password, HTTPRepositorySchema.PASSWORD)
+			Configurations
+					.getLiteralValue(model, implNode, CONFIG.password, HTTPRepositorySchema.PASSWORD)
 					.ifPresent(password -> setPassword(password.getLabel()));
 
 		} catch (ModelException e) {

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 
@@ -76,8 +76,8 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (url != null) {
-			graph.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
-			graph.add(implNode, CONFIG.Http.url, SimpleValueFactory.getInstance().createIRI(url));
+			graph.setNamespace(Config.PREFIX, Config.NAMESPACE);
+			graph.add(implNode, Config.Http.url, SimpleValueFactory.getInstance().createIRI(url));
 		}
 
 		return implNode;
@@ -90,15 +90,15 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		try {
 
 			Configurations
-					.getIRIValue(model, implNode, CONFIG.Http.url, HTTPRepositorySchema.REPOSITORYURL)
+					.getIRIValue(model, implNode, Config.Http.url, HTTPRepositorySchema.REPOSITORYURL)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
 			Configurations
-					.getLiteralValue(model, implNode, CONFIG.Http.username, HTTPRepositorySchema.USERNAME)
+					.getLiteralValue(model, implNode, Config.Http.username, HTTPRepositorySchema.USERNAME)
 					.ifPresent(username -> setUsername(username.getLabel()));
 
 			Configurations
-					.getLiteralValue(model, implNode, CONFIG.Http.password, HTTPRepositorySchema.PASSWORD)
+					.getLiteralValue(model, implNode, Config.Http.password, HTTPRepositorySchema.PASSWORD)
 					.ifPresent(password -> setPassword(password.getLabel()));
 
 		} catch (ModelException e) {

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -79,7 +79,7 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		if (url != null) {
 			graph.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
-			graph.add(implNode, CONFIG.REPOSITORY_URL, SimpleValueFactory.getInstance().createIRI(url));
+			graph.add(implNode, CONFIG.repositoryURL, SimpleValueFactory.getInstance().createIRI(url));
 		}
 
 		return implNode;
@@ -92,15 +92,15 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		try {
 
 			RepositoryConfigUtil
-					.getPropertyAsIRI(model, implNode, CONFIG.REPOSITORY_URL, NAMESPACE_OBSOLETE)
+					.getPropertyAsIRI(model, implNode, CONFIG.repositoryURL, NAMESPACE_OBSOLETE)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.USERNAME, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, implNode, CONFIG.username, NAMESPACE_OBSOLETE)
 					.ifPresent(username -> setUsername(username.getLabel()));
 
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.PASSWORD, NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, implNode, CONFIG.password, NAMESPACE_OBSOLETE)
 					.ifPresent(password -> setPassword(password.getLabel()));
 
 		} catch (ModelException e) {

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositoryConfig.java
@@ -77,7 +77,7 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		if (url != null) {
 			graph.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
-			graph.add(implNode, CONFIG.Http.repositoryURL, SimpleValueFactory.getInstance().createIRI(url));
+			graph.add(implNode, CONFIG.Http.url, SimpleValueFactory.getInstance().createIRI(url));
 		}
 
 		return implNode;
@@ -90,7 +90,7 @@ public class HTTPRepositoryConfig extends AbstractRepositoryImplConfig {
 		try {
 
 			Configurations
-					.getIRIValue(model, implNode, CONFIG.Http.repositoryURL, HTTPRepositorySchema.REPOSITORYURL)
+					.getIRIValue(model, implNode, CONFIG.Http.url, HTTPRepositorySchema.REPOSITORYURL)
 					.ifPresent(iri -> setURL(iri.stringValue()));
 
 			Configurations

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
@@ -31,7 +31,7 @@ public class HTTPRepositorySchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/http#";
 
 	/**
-	 * @deprecated use {@link CONFIG#repositoryURL} instead.
+	 * @deprecated use {@link CONFIG#url} instead.
 	 */
 	public final static IRI REPOSITORYURL = iri(NAMESPACE, "repositoryURL");
 

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.repository.http.HTTPRepository;
  * {@link HTTPRepository}s.
  *
  * @author Arjohn Kampman
- * 
+ *
  * @deprecated since 4.3.0. Use {@link CONFIG} instead.
  *
  */

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
@@ -11,8 +11,7 @@
 package org.eclipse.rdf4j.repository.http.config;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 
 /**
@@ -20,36 +19,20 @@ import org.eclipse.rdf4j.repository.http.HTTPRepository;
  * {@link HTTPRepository}s.
  *
  * @author Arjohn Kampman
+ * 
+ * @deprecated since 4.3.0. Use {@link CONFIG} instead.
+ *
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class HTTPRepositorySchema {
 
-	/**
-	 * The HTTPRepository schema namespace (<var>tag:rdf4j.org:2023:config/http-repository#</var>).
-	 */
-	public static final String NAMESPACE = "tag:rdf4j.org:2023:config/http-repository#";
+	public static final String NAMESPACE = CONFIG.NAMESPACE;
 
-	@Deprecated(since = "4.3.0", forRemoval = true)
 	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/http#";
 
-	/**
-	 * <var>tag:rdf4j.org:2023:config/http-repository#repositoryURL</var>
-	 */
-	public final static IRI REPOSITORYURL;
+	public final static IRI REPOSITORYURL = CONFIG.REPOSITORY_URL;
 
-	/**
-	 * <var>tag:rdf4j.org:2023:config/http-repository#username</var>
-	 */
-	public final static IRI USERNAME;
+	public final static IRI USERNAME = CONFIG.USERNAME;
 
-	/**
-	 * <var>tag:rdf4j.org:2023:config/http-repository#password</var>
-	 */
-	public final static IRI PASSWORD;
-
-	static {
-		ValueFactory factory = SimpleValueFactory.getInstance();
-		REPOSITORYURL = factory.createIRI(NAMESPACE, "repositoryURL");
-		USERNAME = factory.createIRI(NAMESPACE, "username");
-		PASSWORD = factory.createIRI(NAMESPACE, "password");
-	}
+	public final static IRI PASSWORD = CONFIG.PASSWORD;
 }

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.repository.http.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 
 /**
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.repository.http.HTTPRepository;
  *
  * @author Arjohn Kampman
  *
- * @deprecated since 4.3.0. Use {@link CONFIG} instead.
+ * @deprecated since 4.3.0. Use {@link Config} instead.
  *
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
@@ -31,17 +31,17 @@ public class HTTPRepositorySchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/http#";
 
 	/**
-	 * @deprecated use {@link CONFIG#url} instead.
+	 * @deprecated use {@link Config#url} instead.
 	 */
 	public final static IRI REPOSITORYURL = iri(NAMESPACE, "repositoryURL");
 
 	/**
-	 * @deprecated use {@link CONFIG#username} instead.
+	 * @deprecated use {@link Config#username} instead.
 	 */
 	public final static IRI USERNAME = iri(NAMESPACE, "username");
 
 	/**
-	 * @deprecated use {@link CONFIG#password} instead.
+	 * @deprecated use {@link Config#password} instead.
 	 */
 	public final static IRI PASSWORD = iri(NAMESPACE, "password");
 }

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.repository.http.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 
 /**
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.repository.http.HTTPRepository;
  *
  * @author Arjohn Kampman
  *
- * @deprecated since 4.3.0. Use {@link Config} instead.
+ * @deprecated since 4.3.0. Use {@link CONFIG} instead.
  *
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
@@ -31,17 +31,17 @@ public class HTTPRepositorySchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/http#";
 
 	/**
-	 * @deprecated use {@link Config#url} instead.
+	 * @deprecated use {@link CONFIG#url} instead.
 	 */
 	public final static IRI REPOSITORYURL = iri(NAMESPACE, "repositoryURL");
 
 	/**
-	 * @deprecated use {@link Config#username} instead.
+	 * @deprecated use {@link CONFIG#username} instead.
 	 */
 	public final static IRI USERNAME = iri(NAMESPACE, "username");
 
 	/**
-	 * @deprecated use {@link Config#password} instead.
+	 * @deprecated use {@link CONFIG#password} instead.
 	 */
 	public final static IRI PASSWORD = iri(NAMESPACE, "password");
 }

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
@@ -24,22 +24,25 @@ import org.eclipse.rdf4j.repository.http.HTTPRepository;
 public class HTTPRepositorySchema {
 
 	/**
-	 * The HTTPRepository schema namespace (<var>http://www.openrdf.org/config/repository/http#</var>).
+	 * The HTTPRepository schema namespace (<var>tag:rdf4j.org:2023:config/http-repository#</var>).
 	 */
-	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/http#";
+	public static final String NAMESPACE = "tag:rdf4j.org:2023:config/http-repository#";
+
+	@Deprecated(since = "4.3.0", forRemoval = true)
+	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/http#";
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository/http#repositoryURL</var>
+	 * <var>tag:rdf4j.org:2023:config/http-repository#repositoryURL</var>
 	 */
 	public final static IRI REPOSITORYURL;
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository/http#username</var>
+	 * <var>tag:rdf4j.org:2023:config/http-repository#username</var>
 	 */
 	public final static IRI USERNAME;
 
 	/**
-	 * <var>http://www.openrdf.org/config/repository/http#password</var>
+	 * <var>tag:rdf4j.org:2023:config/http-repository#password</var>
 	 */
 	public final static IRI PASSWORD;
 

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.http.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
@@ -26,13 +28,20 @@ import org.eclipse.rdf4j.repository.http.HTTPRepository;
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class HTTPRepositorySchema {
 
-	public static final String NAMESPACE = CONFIG.NAMESPACE;
+	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/http#";
 
-	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/http#";
+	/**
+	 * @deprecated use {@link CONFIG#repositoryURL} instead.
+	 */
+	public final static IRI REPOSITORYURL = iri(NAMESPACE, "repositoryURL");
 
-	public final static IRI REPOSITORYURL = CONFIG.repositoryURL;
+	/**
+	 * @deprecated use {@link CONFIG#username} instead.
+	 */
+	public final static IRI USERNAME = iri(NAMESPACE, "username");
 
-	public final static IRI USERNAME = CONFIG.username;
-
-	public final static IRI PASSWORD = CONFIG.password;
+	/**
+	 * @deprecated use {@link CONFIG#password} instead.
+	 */
+	public final static IRI PASSWORD = iri(NAMESPACE, "password");
 }

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/config/HTTPRepositorySchema.java
@@ -30,9 +30,9 @@ public class HTTPRepositorySchema {
 
 	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/http#";
 
-	public final static IRI REPOSITORYURL = CONFIG.REPOSITORY_URL;
+	public final static IRI REPOSITORYURL = CONFIG.repositoryURL;
 
-	public final static IRI USERNAME = CONFIG.USERNAME;
+	public final static IRI USERNAME = CONFIG.username;
 
-	public final static IRI PASSWORD = CONFIG.PASSWORD;
+	public final static IRI PASSWORD = CONFIG.password;
 }

--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/RepositoryManager.java
@@ -31,6 +31,7 @@ import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModelFactory;
 import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.RepositoryResolver;
@@ -56,12 +57,17 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 	/**
 	 * The {@link org.eclipse.rdf4j.repository.sail.ProxyRepository} schema namespace (
 	 * <var>http://www.openrdf.org/config/repository/proxy#</var>).
+	 *
+	 * @deprecated use {@link CONFIG.Proxy} instead.
 	 */
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/proxy#";
 
 	/**
 	 * <var>http://www.openrdf.org/config/repository/proxy#proxiedID</var>
+	 *
+	 * @deprecated use {@link CONFIG.Proxy#proxiedID} instead.
 	 */
+	@Deprecated(since = "4.3.0", forRemoval = true)
 	public final static IRI PROXIED_ID = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "proxiedID");
 
 	/*-----------*
@@ -256,7 +262,8 @@ public abstract class RepositoryManager implements RepositoryResolver, HttpClien
 			RepositoryConfig config = getRepositoryConfig(id);
 			Model model = new LinkedHashModel();
 			config.export(model, Values.bnode());
-			if (model.contains(null, PROXIED_ID, Values.literal(repositoryID))) {
+			if (model.contains(null, CONFIG.Proxy.proxiedID, Values.literal(repositoryID))
+					|| model.contains(null, PROXIED_ID, Values.literal(repositoryID))) {
 				return false;
 			}
 		}

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 
@@ -53,7 +53,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 	public Resource export(Model model) {
 		Resource implNode = super.export(model);
 		if (null != this.proxiedID) {
-			model.add(implNode, CONFIG.Proxy.proxiedID, literal(this.proxiedID));
+			model.add(implNode, Config.Proxy.proxiedID, literal(this.proxiedID));
 		}
 		return implNode;
 	}
@@ -64,7 +64,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		try {
 			Configurations
-					.getLiteralValue(model, implNode, CONFIG.Proxy.proxiedID, ProxyRepositorySchema.PROXIED_ID)
+					.getLiteralValue(model, implNode, Config.Proxy.proxiedID, ProxyRepositorySchema.PROXIED_ID)
 					.ifPresent(lit -> setProxiedRepositoryID(lit.getLabel()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
@@ -53,7 +53,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 	public Resource export(Model model) {
 		Resource implNode = super.export(model);
 		if (null != this.proxiedID) {
-			model.add(implNode, CONFIG.PROXIED_ID, literal(this.proxiedID));
+			model.add(implNode, CONFIG.proxiedID, literal(this.proxiedID));
 		}
 		return implNode;
 	}
@@ -64,7 +64,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		try {
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.PROXIED_ID, ProxyRepositorySchema.NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, implNode, CONFIG.proxiedID, ProxyRepositorySchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setProxiedRepositoryID(lit.getLabel()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
@@ -53,7 +53,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 	public Resource export(Model model) {
 		Resource implNode = super.export(model);
 		if (null != this.proxiedID) {
-			model.add(implNode, CONFIG.proxiedID, literal(this.proxiedID));
+			model.add(implNode, CONFIG.Proxy.proxiedID, literal(this.proxiedID));
 		}
 		return implNode;
 	}
@@ -64,7 +64,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		try {
 			Configurations
-					.getLiteralValue(model, implNode, CONFIG.proxiedID, ProxyRepositorySchema.PROXIED_ID)
+					.getLiteralValue(model, implNode, CONFIG.Proxy.proxiedID, ProxyRepositorySchema.PROXIED_ID)
 					.ifPresent(lit -> setProxiedRepositoryID(lit.getLabel()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 
@@ -53,7 +53,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 	public Resource export(Model model) {
 		Resource implNode = super.export(model);
 		if (null != this.proxiedID) {
-			model.add(implNode, Config.Proxy.proxiedID, literal(this.proxiedID));
+			model.add(implNode, CONFIG.Proxy.proxiedID, literal(this.proxiedID));
 		}
 		return implNode;
 	}
@@ -64,7 +64,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		try {
 			Configurations
-					.getLiteralValue(model, implNode, Config.Proxy.proxiedID, ProxyRepositorySchema.PROXIED_ID)
+					.getLiteralValue(model, implNode, CONFIG.Proxy.proxiedID, ProxyRepositorySchema.PROXIED_ID)
 					.ifPresent(lit -> setProxiedRepositoryID(lit.getLabel()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
@@ -10,13 +10,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail.config;
 
+import static org.eclipse.rdf4j.model.util.Values.literal;
+
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 
 public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 
@@ -51,9 +53,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 	public Resource export(Model model) {
 		Resource implNode = super.export(model);
 		if (null != this.proxiedID) {
-			model.setNamespace("proxy", ProxyRepositorySchema.NAMESPACE);
-			model.add(implNode, ProxyRepositorySchema.PROXIED_ID,
-					SimpleValueFactory.getInstance().createLiteral(this.proxiedID));
+			model.add(implNode, CONFIG.PROXIED_ID, literal(this.proxiedID));
 		}
 		return implNode;
 	}
@@ -63,7 +63,8 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(model, implNode);
 
 		try {
-			Models.objectLiteral(model.getStatements(implNode, ProxyRepositorySchema.PROXIED_ID, null))
+			RepositoryConfigUtil
+					.getPropertyAsLiteral(model, implNode, CONFIG.PROXIED_ID, ProxyRepositorySchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setProxiedRepositoryID(lit.getLabel()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
@@ -14,11 +14,11 @@ import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
-import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 
 public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 
@@ -63,8 +63,8 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(model, implNode);
 
 		try {
-			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.proxiedID, ProxyRepositorySchema.PROXIED_ID)
+			Configurations
+					.getLiteralValue(model, implNode, CONFIG.proxiedID, ProxyRepositorySchema.PROXIED_ID)
 					.ifPresent(lit -> setProxiedRepositoryID(lit.getLabel()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositoryConfig.java
@@ -64,7 +64,7 @@ public class ProxyRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		try {
 			RepositoryConfigUtil
-					.getPropertyAsLiteral(model, implNode, CONFIG.proxiedID, ProxyRepositorySchema.NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(model, implNode, CONFIG.proxiedID, ProxyRepositorySchema.PROXIED_ID)
 					.ifPresent(lit -> setProxiedRepositoryID(lit.getLabel()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
@@ -23,6 +23,8 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ProxyRepositorySchema {
 
+	public static final String NAMESPACE = CONFIG.NAMESPACE;
+
 	/**
 	 * The obsolete {@link org.eclipse.rdf4j.repository.sail.ProxyRepository} schema namespace (
 	 * <var>http://www.openrdf.org/config/repository/proxy#</var>).

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
@@ -13,14 +13,14 @@ package org.eclipse.rdf4j.repository.sail.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * Defines constants for the HTTPRepository schema which is used by {@link ProxyRepositoryFactory}s to initialize
  * {@link org.eclipse.rdf4j.repository.sail.ProxyRepository}s.
  *
  * @author Dale Visser
- * @deprecated use {@link CONFIG} instead.
+ * @deprecated use {@link Config} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ProxyRepositorySchema {
@@ -32,7 +32,7 @@ public class ProxyRepositorySchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/proxy#";
 
 	/**
-	 * @deprecated use {@link CONFIG#proxiedID} instead.
+	 * @deprecated use {@link Config#proxiedID} instead.
 	 */
 	public final static IRI PROXIED_ID = iri(NAMESPACE, "proxiedID");
 

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
@@ -11,30 +11,24 @@
 package org.eclipse.rdf4j.repository.sail.config;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Defines constants for the HTTPRepository schema which is used by {@link ProxyRepositoryFactory}s to initialize
  * {@link org.eclipse.rdf4j.repository.sail.ProxyRepository}s.
  *
  * @author Dale Visser
+ * @deprecated use {@link CONFIG} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class ProxyRepositorySchema {
 
 	/**
-	 * The {@link org.eclipse.rdf4j.repository.sail.ProxyRepository} schema namespace (
+	 * The obsolete {@link org.eclipse.rdf4j.repository.sail.ProxyRepository} schema namespace (
 	 * <var>http://www.openrdf.org/config/repository/proxy#</var>).
 	 */
-	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/proxy#";
+	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/proxy#";
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/proxy#proxiedID</var>
-	 */
-	public final static IRI PROXIED_ID;
+	public final static IRI PROXIED_ID = CONFIG.PROXIED_ID;
 
-	static {
-		ValueFactory factory = SimpleValueFactory.getInstance();
-		PROXIED_ID = factory.createIRI(NAMESPACE, "proxiedID");
-	}
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
@@ -29,6 +29,6 @@ public class ProxyRepositorySchema {
 	 */
 	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/proxy#";
 
-	public final static IRI PROXIED_ID = CONFIG.PROXIED_ID;
+	public final static IRI PROXIED_ID = CONFIG.proxiedID;
 
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
@@ -13,14 +13,14 @@ package org.eclipse.rdf4j.repository.sail.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Defines constants for the HTTPRepository schema which is used by {@link ProxyRepositoryFactory}s to initialize
  * {@link org.eclipse.rdf4j.repository.sail.ProxyRepository}s.
  *
  * @author Dale Visser
- * @deprecated use {@link Config} instead.
+ * @deprecated use {@link CONFIG} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ProxyRepositorySchema {
@@ -32,7 +32,7 @@ public class ProxyRepositorySchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/proxy#";
 
 	/**
-	 * @deprecated use {@link Config#proxiedID} instead.
+	 * @deprecated use {@link CONFIG#proxiedID} instead.
 	 */
 	public final static IRI PROXIED_ID = iri(NAMESPACE, "proxiedID");
 

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/ProxyRepositorySchema.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
@@ -23,14 +25,15 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ProxyRepositorySchema {
 
-	public static final String NAMESPACE = CONFIG.NAMESPACE;
-
 	/**
 	 * The obsolete {@link org.eclipse.rdf4j.repository.sail.ProxyRepository} schema namespace (
 	 * <var>http://www.openrdf.org/config/repository/proxy#</var>).
 	 */
-	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/proxy#";
+	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/proxy#";
 
-	public final static IRI PROXIED_ID = CONFIG.proxiedID;
+	/**
+	 * @deprecated use {@link CONFIG#proxiedID} instead.
+	 */
+	public final static IRI PROXIED_ID = iri(NAMESPACE, "proxiedID");
 
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -18,7 +18,6 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
@@ -72,7 +71,7 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 		if (sailImplConfig != null) {
 			model.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
 			Resource sailImplNode = sailImplConfig.export(model);
-			model.add(repImplNode, CONFIG.sailImpl, sailImplNode);
+			model.add(repImplNode, CONFIG.Sail.impl, sailImplNode);
 		}
 
 		return repImplNode;
@@ -82,9 +81,10 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 	public void parse(Model model, Resource repImplNode) throws RepositoryConfigException {
 		try {
 			Optional<Resource> sailImplNode = Configurations.getResourceValue(model, repImplNode,
-					CONFIG.sailImpl, SailRepositorySchema.SAILIMPL);
+					CONFIG.Sail.impl, SailRepositorySchema.SAILIMPL);
 			if (sailImplNode.isPresent()) {
-				Models.objectLiteral(model.getStatements(sailImplNode.get(), SAILTYPE, null)).ifPresent(typeLit -> {
+				Configurations.getLiteralValue(model, sailImplNode.get(), CONFIG.Sail.type, SAILTYPE)
+						.ifPresent(typeLit -> {
 					SailFactory factory = SailRegistry.getInstance()
 							.get(typeLit.getLabel())
 							.orElseThrow(() -> new RepositoryConfigException(

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
@@ -69,9 +69,9 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource repImplNode = super.export(model);
 
 		if (sailImplConfig != null) {
-			model.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
+			model.setNamespace(Config.PREFIX, Config.NAMESPACE);
 			Resource sailImplNode = sailImplConfig.export(model);
-			model.add(repImplNode, CONFIG.Sail.impl, sailImplNode);
+			model.add(repImplNode, Config.Sail.impl, sailImplNode);
 		}
 
 		return repImplNode;
@@ -81,9 +81,9 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 	public void parse(Model model, Resource repImplNode) throws RepositoryConfigException {
 		try {
 			Optional<Resource> sailImplNode = Configurations.getResourceValue(model, repImplNode,
-					CONFIG.Sail.impl, SailRepositorySchema.SAILIMPL);
+					Config.Sail.impl, SailRepositorySchema.SAILIMPL);
 			if (sailImplNode.isPresent()) {
-				Configurations.getLiteralValue(model, sailImplNode.get(), CONFIG.Sail.type, SAILTYPE)
+				Configurations.getLiteralValue(model, sailImplNode.get(), Config.Sail.type, SAILTYPE)
 						.ifPresent(typeLit -> {
 							SailFactory factory = SailRegistry.getInstance()
 									.get(typeLit.getLabel())

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -69,7 +69,7 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource repImplNode = super.export(model);
 
 		if (sailImplConfig != null) {
-			model.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
+			model.setNamespace(CONFIG.NS);
 			Resource sailImplNode = sailImplConfig.export(model);
 			model.add(repImplNode, CONFIG.Sail.impl, sailImplNode);
 		}

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -72,7 +72,7 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 		if (sailImplConfig != null) {
 			model.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
 			Resource sailImplNode = sailImplConfig.export(model);
-			model.add(repImplNode, CONFIG.SAIL_IMPL, sailImplNode);
+			model.add(repImplNode, CONFIG.sailImpl, sailImplNode);
 		}
 
 		return repImplNode;
@@ -82,7 +82,7 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 	public void parse(Model model, Resource repImplNode) throws RepositoryConfigException {
 		try {
 			Optional<Resource> sailImplNode = RepositoryConfigUtil.getPropertyAsResource(model, repImplNode,
-					CONFIG.SAIL_IMPL, SailRepositorySchema.NAMESPACE_OBSOLETE);
+					CONFIG.sailImpl, SailRepositorySchema.NAMESPACE_OBSOLETE);
 			if (sailImplNode.isPresent()) {
 				Models.objectLiteral(model.getStatements(sailImplNode.get(), SAILTYPE, null)).ifPresent(typeLit -> {
 					SailFactory factory = SailRegistry.getInstance()

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
@@ -69,9 +69,9 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource repImplNode = super.export(model);
 
 		if (sailImplConfig != null) {
-			model.setNamespace(Config.PREFIX, Config.NAMESPACE);
+			model.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
 			Resource sailImplNode = sailImplConfig.export(model);
-			model.add(repImplNode, Config.Sail.impl, sailImplNode);
+			model.add(repImplNode, CONFIG.Sail.impl, sailImplNode);
 		}
 
 		return repImplNode;
@@ -81,9 +81,9 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 	public void parse(Model model, Resource repImplNode) throws RepositoryConfigException {
 		try {
 			Optional<Resource> sailImplNode = Configurations.getResourceValue(model, repImplNode,
-					Config.Sail.impl, SailRepositorySchema.SAILIMPL);
+					CONFIG.Sail.impl, SailRepositorySchema.SAILIMPL);
 			if (sailImplNode.isPresent()) {
-				Configurations.getLiteralValue(model, sailImplNode.get(), Config.Sail.type, SAILTYPE)
+				Configurations.getLiteralValue(model, sailImplNode.get(), CONFIG.Sail.type, SAILTYPE)
 						.ifPresent(typeLit -> {
 							SailFactory factory = SailRegistry.getInstance()
 									.get(typeLit.getLabel())

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -82,7 +82,7 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 	public void parse(Model model, Resource repImplNode) throws RepositoryConfigException {
 		try {
 			Optional<Resource> sailImplNode = RepositoryConfigUtil.getPropertyAsResource(model, repImplNode,
-					CONFIG.sailImpl, SailRepositorySchema.NAMESPACE_OBSOLETE);
+					CONFIG.sailImpl, SailRepositorySchema.SAILIMPL);
 			if (sailImplNode.isPresent()) {
 				Models.objectLiteral(model.getStatements(sailImplNode.get(), SAILTYPE, null)).ifPresent(typeLit -> {
 					SailFactory factory = SailRegistry.getInstance()

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -85,14 +85,14 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 			if (sailImplNode.isPresent()) {
 				Configurations.getLiteralValue(model, sailImplNode.get(), CONFIG.Sail.type, SAILTYPE)
 						.ifPresent(typeLit -> {
-					SailFactory factory = SailRegistry.getInstance()
-							.get(typeLit.getLabel())
-							.orElseThrow(() -> new RepositoryConfigException(
-									"Unsupported Sail type: " + typeLit.getLabel()));
+							SailFactory factory = SailRegistry.getInstance()
+									.get(typeLit.getLabel())
+									.orElseThrow(() -> new RepositoryConfigException(
+											"Unsupported Sail type: " + typeLit.getLabel()));
 
-					sailImplConfig = factory.getConfig();
-					sailImplConfig.parse(model, sailImplNode.get());
-				});
+							sailImplConfig = factory.getConfig();
+							sailImplConfig.parse(model, sailImplNode.get());
+						});
 			}
 		} catch (ModelException | SailConfigException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -16,12 +16,12 @@ import java.util.Optional;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
-import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.eclipse.rdf4j.sail.config.SailFactory;
 import org.eclipse.rdf4j.sail.config.SailImplConfig;
@@ -81,7 +81,7 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource repImplNode) throws RepositoryConfigException {
 		try {
-			Optional<Resource> sailImplNode = RepositoryConfigUtil.getPropertyAsResource(model, repImplNode,
+			Optional<Resource> sailImplNode = Configurations.getResourceValue(model, repImplNode,
 					CONFIG.sailImpl, SailRepositorySchema.SAILIMPL);
 			if (sailImplNode.isPresent()) {
 				Models.objectLiteral(model.getStatements(sailImplNode.get(), SAILTYPE, null)).ifPresent(typeLit -> {

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositoryConfig.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail.config;
 
-import static org.eclipse.rdf4j.repository.sail.config.SailRepositorySchema.NAMESPACE;
-import static org.eclipse.rdf4j.repository.sail.config.SailRepositorySchema.SAILIMPL;
 import static org.eclipse.rdf4j.sail.config.SailConfigSchema.SAILTYPE;
 
 import java.util.Optional;
@@ -20,8 +18,10 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.eclipse.rdf4j.sail.config.SailFactory;
 import org.eclipse.rdf4j.sail.config.SailImplConfig;
@@ -70,9 +70,9 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 		Resource repImplNode = super.export(model);
 
 		if (sailImplConfig != null) {
-			model.setNamespace("sr", NAMESPACE);
+			model.setNamespace(CONFIG.PREFIX, CONFIG.NAMESPACE);
 			Resource sailImplNode = sailImplConfig.export(model);
-			model.add(repImplNode, SAILIMPL, sailImplNode);
+			model.add(repImplNode, CONFIG.SAIL_IMPL, sailImplNode);
 		}
 
 		return repImplNode;
@@ -81,7 +81,8 @@ public class SailRepositoryConfig extends AbstractRepositoryImplConfig {
 	@Override
 	public void parse(Model model, Resource repImplNode) throws RepositoryConfigException {
 		try {
-			Optional<Resource> sailImplNode = Models.objectResource(model.getStatements(repImplNode, SAILIMPL, null));
+			Optional<Resource> sailImplNode = RepositoryConfigUtil.getPropertyAsResource(model, repImplNode,
+					CONFIG.SAIL_IMPL, SailRepositorySchema.NAMESPACE_OBSOLETE);
 			if (sailImplNode.isPresent()) {
 				Models.objectLiteral(model.getStatements(sailImplNode.get(), SAILTYPE, null)).ifPresent(typeLit -> {
 					SailFactory factory = SailRegistry.getInstance()

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.repository.sail.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
  * {@link SailRepository}s.
  *
  * @author Arjohn Kampman
- * @deprecated use {@link Config} instead.
+ * @deprecated use {@link CONFIG} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class SailRepositorySchema {
@@ -32,7 +32,7 @@ public class SailRepositorySchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/sail#";
 
 	/**
-	 * @deprecated use {@link Config#impl} instead.
+	 * @deprecated use {@link CONFIG#impl} instead.
 	 */
 	public final static IRI SAILIMPL = iri(NAMESPACE, "sailImpl");
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
@@ -29,5 +29,5 @@ public class SailRepositorySchema {
 	 */
 	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/sail#";
 
-	public final static IRI SAILIMPL = CONFIG.SAIL_IMPL;
+	public final static IRI SAILIMPL = CONFIG.sailImpl;
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
@@ -24,6 +24,8 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class SailRepositorySchema {
 
+	public static final String NAMESPACE = CONFIG.NAMESPACE;
+
 	/**
 	 * The SailRepository schema namespace (<var>http://www.openrdf.org/config/repository/sail#</var>).
 	 */

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -24,12 +26,13 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class SailRepositorySchema {
 
-	public static final String NAMESPACE = CONFIG.NAMESPACE;
-
 	/**
 	 * The SailRepository schema namespace (<var>http://www.openrdf.org/config/repository/sail#</var>).
 	 */
-	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/sail#";
+	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/sail#";
 
-	public final static IRI SAILIMPL = CONFIG.sailImpl;
+	/**
+	 * @deprecated use {@link CONFIG#sailImpl} instead.
+	 */
+	public final static IRI SAILIMPL = iri(NAMESPACE, "sailImpl");
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
@@ -11,8 +11,7 @@
 package org.eclipse.rdf4j.repository.sail.config;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 
 /**
@@ -20,21 +19,15 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
  * {@link SailRepository}s.
  *
  * @author Arjohn Kampman
+ * @deprecated use {@link CONFIG} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class SailRepositorySchema {
 
 	/**
 	 * The SailRepository schema namespace (<var>http://www.openrdf.org/config/repository/sail#</var>).
 	 */
-	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/sail#";
+	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/repository/sail#";
 
-	/**
-	 * <var>http://www.openrdf.org/config/repository/sail#sailImpl</var>
-	 */
-	public final static IRI SAILIMPL;
-
-	static {
-		ValueFactory factory = SimpleValueFactory.getInstance();
-		SAILIMPL = factory.createIRI(NAMESPACE, "sailImpl");
-	}
+	public final static IRI SAILIMPL = CONFIG.SAIL_IMPL;
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
@@ -32,7 +32,7 @@ public class SailRepositorySchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/sail#";
 
 	/**
-	 * @deprecated use {@link CONFIG#sailImpl} instead.
+	 * @deprecated use {@link CONFIG#impl} instead.
 	 */
 	public final static IRI SAILIMPL = iri(NAMESPACE, "sailImpl");
 }

--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/config/SailRepositorySchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.repository.sail.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
  * {@link SailRepository}s.
  *
  * @author Arjohn Kampman
- * @deprecated use {@link CONFIG} instead.
+ * @deprecated use {@link Config} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class SailRepositorySchema {
@@ -32,7 +32,7 @@ public class SailRepositorySchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/repository/sail#";
 
 	/**
-	 * @deprecated use {@link CONFIG#impl} instead.
+	 * @deprecated use {@link Config#impl} instead.
 	 */
 	public final static IRI SAILIMPL = iri(NAMESPACE, "sailImpl");
 }

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 
@@ -37,7 +37,7 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	/**
 	 * Configuration setting for the SPARQL query endpoint. Required.
 	 *
-	 * @deprecated use {@link Config#queryEndpoint} instead.
+	 * @deprecated use {@link CONFIG#queryEndpoint} instead.
 	 */
 	public static final IRI QUERY_ENDPOINT = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#query-endpoint");
@@ -45,7 +45,7 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	/**
 	 * Configuration setting for the SPARQL update endpoint. Optional.
 	 *
-	 * @deprecated use {@link Config#updateEndpoint} instead.
+	 * @deprecated use {@link CONFIG#updateEndpoint} instead.
 	 */
 	public static final IRI UPDATE_ENDPOINT = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#update-endpoint");
@@ -55,7 +55,7 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	 *
 	 * @see SPARQLProtocolSession#isPassThroughEnabled()
 	 *
-	 * @deprecated use {@link Config#passThroughEnabled} instead.
+	 * @deprecated use {@link CONFIG#passThroughEnabled} instead.
 	 */
 	public static final IRI PASS_THROUGH_ENABLED = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#pass-through-enabled");
@@ -110,13 +110,13 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		m.setNamespace("sparql", NAMESPACE);
 		if (getQueryEndpointUrl() != null) {
-			m.add(implNode, Config.Sparql.queryEndpoint, vf.createIRI(getQueryEndpointUrl()));
+			m.add(implNode, CONFIG.Sparql.queryEndpoint, vf.createIRI(getQueryEndpointUrl()));
 		}
 		if (getUpdateEndpointUrl() != null) {
-			m.add(implNode, Config.Sparql.updateEndpoint, vf.createIRI(getUpdateEndpointUrl()));
+			m.add(implNode, CONFIG.Sparql.updateEndpoint, vf.createIRI(getUpdateEndpointUrl()));
 		}
 		if (getPassThroughEnabled() != null) {
-			m.add(implNode, Config.Sparql.passThroughEnabled, BooleanLiteral.valueOf(getPassThroughEnabled()));
+			m.add(implNode, CONFIG.Sparql.passThroughEnabled, BooleanLiteral.valueOf(getPassThroughEnabled()));
 		}
 
 		return implNode;
@@ -127,11 +127,11 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(m, implNode);
 
 		try {
-			Configurations.getIRIValue(m, implNode, Config.Sparql.queryEndpoint, QUERY_ENDPOINT)
+			Configurations.getIRIValue(m, implNode, CONFIG.Sparql.queryEndpoint, QUERY_ENDPOINT)
 					.ifPresent(iri -> setQueryEndpointUrl(iri.stringValue()));
-			Configurations.getIRIValue(m, implNode, Config.Sparql.updateEndpoint, UPDATE_ENDPOINT)
+			Configurations.getIRIValue(m, implNode, CONFIG.Sparql.updateEndpoint, UPDATE_ENDPOINT)
 					.ifPresent(iri -> setUpdateEndpointUrl(iri.stringValue()));
-			Configurations.getLiteralValue(m, implNode, Config.Sparql.passThroughEnabled, PASS_THROUGH_ENABLED)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Sparql.passThroughEnabled, PASS_THROUGH_ENABLED)
 					.ifPresent(lit -> setPassThroughEnabled(lit.booleanValue()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
@@ -18,9 +18,10 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 
 /**
  * Configuration for a SPARQL endpoint.
@@ -35,12 +36,16 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 
 	/**
 	 * Configuration setting for the SPARQL query endpoint. Required.
+	 *
+	 * @deprecated use {@link CONFIG#queryEndpoint} instead.
 	 */
 	public static final IRI QUERY_ENDPOINT = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#query-endpoint");
 
 	/**
 	 * Configuration setting for the SPARQL update endpoint. Optional.
+	 *
+	 * @deprecated use {@link CONFIG#updateEndpoint} instead.
 	 */
 	public static final IRI UPDATE_ENDPOINT = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#update-endpoint");
@@ -49,6 +54,8 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	 * Configuration setting for enabling/disabling direct result pass-through. Optional.
 	 *
 	 * @see SPARQLProtocolSession#isPassThroughEnabled()
+	 *
+	 * @deprecated use {@link CONFIG#passThroughEnabled} instead.
 	 */
 	public static final IRI PASS_THROUGH_ENABLED = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#pass-through-enabled");
@@ -103,13 +110,13 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		m.setNamespace("sparql", NAMESPACE);
 		if (getQueryEndpointUrl() != null) {
-			m.add(implNode, QUERY_ENDPOINT, vf.createIRI(getQueryEndpointUrl()));
+			m.add(implNode, CONFIG.queryEndpoint, vf.createIRI(getQueryEndpointUrl()));
 		}
 		if (getUpdateEndpointUrl() != null) {
-			m.add(implNode, UPDATE_ENDPOINT, vf.createIRI(getUpdateEndpointUrl()));
+			m.add(implNode, CONFIG.updateEndpoint, vf.createIRI(getUpdateEndpointUrl()));
 		}
 		if (getPassThroughEnabled() != null) {
-			m.add(implNode, PASS_THROUGH_ENABLED, BooleanLiteral.valueOf(getPassThroughEnabled()));
+			m.add(implNode, CONFIG.passThroughEnabled, BooleanLiteral.valueOf(getPassThroughEnabled()));
 		}
 
 		return implNode;
@@ -120,11 +127,11 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(m, implNode);
 
 		try {
-			Models.objectIRI(m.getStatements(implNode, QUERY_ENDPOINT, null))
+			RepositoryConfigUtil.getPropertyAsIRI(m, implNode, CONFIG.queryEndpoint, QUERY_ENDPOINT)
 					.ifPresent(iri -> setQueryEndpointUrl(iri.stringValue()));
-			Models.objectIRI(m.getStatements(implNode, UPDATE_ENDPOINT, null))
+			RepositoryConfigUtil.getPropertyAsIRI(m, implNode, CONFIG.updateEndpoint, UPDATE_ENDPOINT)
 					.ifPresent(iri -> setUpdateEndpointUrl(iri.stringValue()));
-			Models.objectLiteral(m.getStatements(implNode, PASS_THROUGH_ENABLED, null))
+			RepositoryConfigUtil.getPropertyAsLiteral(m, implNode, CONFIG.passThroughEnabled, PASS_THROUGH_ENABLED)
 					.ifPresent(lit -> setPassThroughEnabled(lit.booleanValue()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 
@@ -37,7 +37,7 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	/**
 	 * Configuration setting for the SPARQL query endpoint. Required.
 	 *
-	 * @deprecated use {@link CONFIG#queryEndpoint} instead.
+	 * @deprecated use {@link Config#queryEndpoint} instead.
 	 */
 	public static final IRI QUERY_ENDPOINT = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#query-endpoint");
@@ -45,7 +45,7 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	/**
 	 * Configuration setting for the SPARQL update endpoint. Optional.
 	 *
-	 * @deprecated use {@link CONFIG#updateEndpoint} instead.
+	 * @deprecated use {@link Config#updateEndpoint} instead.
 	 */
 	public static final IRI UPDATE_ENDPOINT = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#update-endpoint");
@@ -55,7 +55,7 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 	 *
 	 * @see SPARQLProtocolSession#isPassThroughEnabled()
 	 *
-	 * @deprecated use {@link CONFIG#passThroughEnabled} instead.
+	 * @deprecated use {@link Config#passThroughEnabled} instead.
 	 */
 	public static final IRI PASS_THROUGH_ENABLED = vf
 			.createIRI("http://www.openrdf.org/config/repository/sparql#pass-through-enabled");
@@ -110,13 +110,13 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		m.setNamespace("sparql", NAMESPACE);
 		if (getQueryEndpointUrl() != null) {
-			m.add(implNode, CONFIG.Sparql.queryEndpoint, vf.createIRI(getQueryEndpointUrl()));
+			m.add(implNode, Config.Sparql.queryEndpoint, vf.createIRI(getQueryEndpointUrl()));
 		}
 		if (getUpdateEndpointUrl() != null) {
-			m.add(implNode, CONFIG.Sparql.updateEndpoint, vf.createIRI(getUpdateEndpointUrl()));
+			m.add(implNode, Config.Sparql.updateEndpoint, vf.createIRI(getUpdateEndpointUrl()));
 		}
 		if (getPassThroughEnabled() != null) {
-			m.add(implNode, CONFIG.Sparql.passThroughEnabled, BooleanLiteral.valueOf(getPassThroughEnabled()));
+			m.add(implNode, Config.Sparql.passThroughEnabled, BooleanLiteral.valueOf(getPassThroughEnabled()));
 		}
 
 		return implNode;
@@ -127,11 +127,11 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(m, implNode);
 
 		try {
-			Configurations.getIRIValue(m, implNode, CONFIG.Sparql.queryEndpoint, QUERY_ENDPOINT)
+			Configurations.getIRIValue(m, implNode, Config.Sparql.queryEndpoint, QUERY_ENDPOINT)
 					.ifPresent(iri -> setQueryEndpointUrl(iri.stringValue()));
-			Configurations.getIRIValue(m, implNode, CONFIG.Sparql.updateEndpoint, UPDATE_ENDPOINT)
+			Configurations.getIRIValue(m, implNode, Config.Sparql.updateEndpoint, UPDATE_ENDPOINT)
 					.ifPresent(iri -> setUpdateEndpointUrl(iri.stringValue()));
-			Configurations.getLiteralValue(m, implNode, CONFIG.Sparql.passThroughEnabled, PASS_THROUGH_ENABLED)
+			Configurations.getLiteralValue(m, implNode, Config.Sparql.passThroughEnabled, PASS_THROUGH_ENABLED)
 					.ifPresent(lit -> setPassThroughEnabled(lit.booleanValue()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
@@ -17,11 +17,11 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.repository.config.AbstractRepositoryImplConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
-import org.eclipse.rdf4j.repository.config.RepositoryConfigUtil;
 
 /**
  * Configuration for a SPARQL endpoint.
@@ -127,11 +127,11 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(m, implNode);
 
 		try {
-			RepositoryConfigUtil.getPropertyAsIRI(m, implNode, CONFIG.queryEndpoint, QUERY_ENDPOINT)
+			Configurations.getIRIValue(m, implNode, CONFIG.queryEndpoint, QUERY_ENDPOINT)
 					.ifPresent(iri -> setQueryEndpointUrl(iri.stringValue()));
-			RepositoryConfigUtil.getPropertyAsIRI(m, implNode, CONFIG.updateEndpoint, UPDATE_ENDPOINT)
+			Configurations.getIRIValue(m, implNode, CONFIG.updateEndpoint, UPDATE_ENDPOINT)
 					.ifPresent(iri -> setUpdateEndpointUrl(iri.stringValue()));
-			RepositoryConfigUtil.getPropertyAsLiteral(m, implNode, CONFIG.passThroughEnabled, PASS_THROUGH_ENABLED)
+			Configurations.getLiteralValue(m, implNode, CONFIG.passThroughEnabled, PASS_THROUGH_ENABLED)
 					.ifPresent(lit -> setPassThroughEnabled(lit.booleanValue()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/config/SPARQLRepositoryConfig.java
@@ -110,13 +110,13 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 
 		m.setNamespace("sparql", NAMESPACE);
 		if (getQueryEndpointUrl() != null) {
-			m.add(implNode, CONFIG.queryEndpoint, vf.createIRI(getQueryEndpointUrl()));
+			m.add(implNode, CONFIG.Sparql.queryEndpoint, vf.createIRI(getQueryEndpointUrl()));
 		}
 		if (getUpdateEndpointUrl() != null) {
-			m.add(implNode, CONFIG.updateEndpoint, vf.createIRI(getUpdateEndpointUrl()));
+			m.add(implNode, CONFIG.Sparql.updateEndpoint, vf.createIRI(getUpdateEndpointUrl()));
 		}
 		if (getPassThroughEnabled() != null) {
-			m.add(implNode, CONFIG.passThroughEnabled, BooleanLiteral.valueOf(getPassThroughEnabled()));
+			m.add(implNode, CONFIG.Sparql.passThroughEnabled, BooleanLiteral.valueOf(getPassThroughEnabled()));
 		}
 
 		return implNode;
@@ -127,11 +127,11 @@ public class SPARQLRepositoryConfig extends AbstractRepositoryImplConfig {
 		super.parse(m, implNode);
 
 		try {
-			Configurations.getIRIValue(m, implNode, CONFIG.queryEndpoint, QUERY_ENDPOINT)
+			Configurations.getIRIValue(m, implNode, CONFIG.Sparql.queryEndpoint, QUERY_ENDPOINT)
 					.ifPresent(iri -> setQueryEndpointUrl(iri.stringValue()));
-			Configurations.getIRIValue(m, implNode, CONFIG.updateEndpoint, UPDATE_ENDPOINT)
+			Configurations.getIRIValue(m, implNode, CONFIG.Sparql.updateEndpoint, UPDATE_ENDPOINT)
 					.ifPresent(iri -> setUpdateEndpointUrl(iri.stringValue()));
-			Configurations.getLiteralValue(m, implNode, CONFIG.passThroughEnabled, PASS_THROUGH_ENABLED)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Sparql.passThroughEnabled, PASS_THROUGH_ENABLED)
 					.ifPresent(lit -> setPassThroughEnabled(lit.booleanValue()));
 		} catch (ModelException e) {
 			throw new RepositoryConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractDelegatingSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractDelegatingSailImplConfig.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * @author Herko ter Horst
@@ -72,7 +72,7 @@ public abstract class AbstractDelegatingSailImplConfig extends AbstractSailImplC
 
 		if (delegate != null) {
 			Resource delegateNode = delegate.export(m);
-			m.add(implNode, CONFIG.delegate, delegateNode);
+			m.add(implNode, Config.delegate, delegateNode);
 		}
 
 		return implNode;
@@ -83,7 +83,7 @@ public abstract class AbstractDelegatingSailImplConfig extends AbstractSailImplC
 		super.parse(m, implNode);
 
 		try {
-			Configurations.getResourceValue(m, implNode, CONFIG.delegate, DELEGATE)
+			Configurations.getResourceValue(m, implNode, Config.delegate, DELEGATE)
 					.ifPresent(delegate -> setDelegate(SailConfigUtil.parseRepositoryImpl(m, delegate)));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractDelegatingSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractDelegatingSailImplConfig.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author Herko ter Horst
@@ -72,7 +72,7 @@ public abstract class AbstractDelegatingSailImplConfig extends AbstractSailImplC
 
 		if (delegate != null) {
 			Resource delegateNode = delegate.export(m);
-			m.add(implNode, Config.delegate, delegateNode);
+			m.add(implNode, CONFIG.delegate, delegateNode);
 		}
 
 		return implNode;
@@ -83,7 +83,7 @@ public abstract class AbstractDelegatingSailImplConfig extends AbstractSailImplC
 		super.parse(m, implNode);
 
 		try {
-			Configurations.getResourceValue(m, implNode, Config.delegate, DELEGATE)
+			Configurations.getResourceValue(m, implNode, CONFIG.delegate, DELEGATE)
 					.ifPresent(delegate -> setDelegate(SailConfigUtil.parseRepositoryImpl(m, delegate)));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractDelegatingSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractDelegatingSailImplConfig.java
@@ -14,6 +14,7 @@ import static org.eclipse.rdf4j.sail.config.SailConfigSchema.DELEGATE;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
@@ -82,7 +83,7 @@ public abstract class AbstractDelegatingSailImplConfig extends AbstractSailImplC
 		super.parse(m, implNode);
 
 		try {
-			SailConfigUtil.getPropertyAsResource(m, implNode, CONFIG.delegate, DELEGATE)
+			Configurations.getResourceValue(m, implNode, CONFIG.delegate, DELEGATE)
 					.ifPresent(delegate -> setDelegate(SailConfigUtil.parseRepositoryImpl(m, delegate)));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractDelegatingSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractDelegatingSailImplConfig.java
@@ -15,7 +15,7 @@ import static org.eclipse.rdf4j.sail.config.SailConfigSchema.DELEGATE;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * @author Herko ter Horst
@@ -71,7 +71,7 @@ public abstract class AbstractDelegatingSailImplConfig extends AbstractSailImplC
 
 		if (delegate != null) {
 			Resource delegateNode = delegate.export(m);
-			m.add(implNode, DELEGATE, delegateNode);
+			m.add(implNode, CONFIG.delegate, delegateNode);
 		}
 
 		return implNode;
@@ -82,7 +82,7 @@ public abstract class AbstractDelegatingSailImplConfig extends AbstractSailImplC
 		super.parse(m, implNode);
 
 		try {
-			Models.objectResource(m.getStatements(implNode, DELEGATE, null))
+			SailConfigUtil.getPropertyAsResource(m, implNode, CONFIG.delegate, DELEGATE)
 					.ifPresent(delegate -> setDelegate(SailConfigUtil.parseRepositoryImpl(m, delegate)));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
@@ -10,15 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.config;
 
-import static org.eclipse.rdf4j.sail.config.SailConfigSchema.SAILTYPE;
+import static org.eclipse.rdf4j.model.util.Values.bnode;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Base implementation of {@link SailImplConfig}
@@ -64,21 +63,18 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 
 	@Override
 	public Resource export(Model m) {
-		ValueFactory vf = SimpleValueFactory.getInstance();
-		BNode implNode = vf.createBNode();
+		BNode implNode = bnode();
 
-		m.setNamespace("sail", SailConfigSchema.NAMESPACE);
 		if (type != null) {
-			m.add(implNode, SAILTYPE, vf.createLiteral(type));
+			m.add(implNode, CONFIG.sailType, literal(type));
 		}
 
 		if (iterationCacheSyncThreshold > 0) {
-			m.add(implNode, SailConfigSchema.ITERATION_CACHE_SYNC_THRESHOLD,
-					vf.createLiteral(iterationCacheSyncThreshold));
+			m.add(implNode, CONFIG.iterationCacheSyncThreshold, literal(iterationCacheSyncThreshold));
 		}
 
 		if (connectionTimeOut > 0) {
-			m.add(implNode, SailConfigSchema.CONNECTION_TIME_OUT, vf.createLiteral(connectionTimeOut));
+			m.add(implNode, CONFIG.connectionTimeOut, literal(connectionTimeOut));
 		}
 		return implNode;
 	}
@@ -86,10 +82,14 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 	@Override
 	public void parse(Model m, Resource implNode) throws SailConfigException {
 		try {
-			Models.objectLiteral(m.getStatements(implNode, SAILTYPE, null)).ifPresent(lit -> setType(lit.getLabel()));
-			Models.objectLiteral(m.getStatements(implNode, SailConfigSchema.ITERATION_CACHE_SYNC_THRESHOLD, null))
+			SailConfigUtil.getPropertyAsLiteral(m, implNode, CONFIG.sailType, SailConfigSchema.NAMESPACE_OBSOLETE)
+					.ifPresent(lit -> setType(lit.getLabel()));
+			SailConfigUtil
+					.getPropertyAsLiteral(m, implNode, CONFIG.iterationCacheSyncThreshold,
+							SailConfigSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setIterationCacheSyncThreshold(lit.longValue()));
-			Models.objectLiteral(m.getStatements(implNode, SailConfigSchema.CONNECTION_TIME_OUT, null))
+			SailConfigUtil
+					.getPropertyAsLiteral(m, implNode, CONFIG.connectionTimeOut, SailConfigSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(lit -> setConnectionTimeOut(lit.longValue()));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
@@ -67,15 +67,15 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 		BNode implNode = bnode();
 
 		if (type != null) {
-			m.add(implNode, CONFIG.sailType, literal(type));
+			m.add(implNode, CONFIG.Sail.type, literal(type));
 		}
 
 		if (iterationCacheSyncThreshold > 0) {
-			m.add(implNode, CONFIG.iterationCacheSyncThreshold, literal(iterationCacheSyncThreshold));
+			m.add(implNode, CONFIG.Sail.iterationCacheSyncThreshold, literal(iterationCacheSyncThreshold));
 		}
 
 		if (connectionTimeOut > 0) {
-			m.add(implNode, CONFIG.connectionTimeOut, literal(connectionTimeOut));
+			m.add(implNode, CONFIG.Sail.connectionTimeOut, literal(connectionTimeOut));
 		}
 		return implNode;
 	}
@@ -83,14 +83,14 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 	@Override
 	public void parse(Model m, Resource implNode) throws SailConfigException {
 		try {
-			Configurations.getLiteralValue(m, implNode, CONFIG.sailType, SailConfigSchema.SAILTYPE)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Sail.type, SailConfigSchema.SAILTYPE)
 					.ifPresent(lit -> setType(lit.getLabel()));
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.iterationCacheSyncThreshold,
+					.getLiteralValue(m, implNode, CONFIG.Sail.iterationCacheSyncThreshold,
 							SailConfigSchema.ITERATION_CACHE_SYNC_THRESHOLD)
 					.ifPresent(lit -> setIterationCacheSyncThreshold(lit.longValue()));
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
+					.getLiteralValue(m, implNode, CONFIG.Sail.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
 					.ifPresent(lit -> setConnectionTimeOut(lit.longValue()));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
@@ -16,6 +16,7 @@ import static org.eclipse.rdf4j.model.util.Values.literal;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
@@ -82,14 +83,14 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 	@Override
 	public void parse(Model m, Resource implNode) throws SailConfigException {
 		try {
-			SailConfigUtil.getPropertyAsLiteral(m, implNode, CONFIG.sailType, SailConfigSchema.SAILTYPE)
+			Configurations.getLiteralValue(m, implNode, CONFIG.sailType, SailConfigSchema.SAILTYPE)
 					.ifPresent(lit -> setType(lit.getLabel()));
-			SailConfigUtil
-					.getPropertyAsLiteral(m, implNode, CONFIG.iterationCacheSyncThreshold,
+			Configurations
+					.getLiteralValue(m, implNode, CONFIG.iterationCacheSyncThreshold,
 							SailConfigSchema.ITERATION_CACHE_SYNC_THRESHOLD)
 					.ifPresent(lit -> setIterationCacheSyncThreshold(lit.longValue()));
-			SailConfigUtil
-					.getPropertyAsLiteral(m, implNode, CONFIG.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
+			Configurations
+					.getLiteralValue(m, implNode, CONFIG.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
 					.ifPresent(lit -> setConnectionTimeOut(lit.longValue()));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
@@ -82,14 +82,14 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 	@Override
 	public void parse(Model m, Resource implNode) throws SailConfigException {
 		try {
-			SailConfigUtil.getPropertyAsLiteral(m, implNode, CONFIG.sailType, SailConfigSchema.NAMESPACE_OBSOLETE)
+			SailConfigUtil.getPropertyAsLiteral(m, implNode, CONFIG.sailType, SailConfigSchema.SAILTYPE)
 					.ifPresent(lit -> setType(lit.getLabel()));
 			SailConfigUtil
 					.getPropertyAsLiteral(m, implNode, CONFIG.iterationCacheSyncThreshold,
-							SailConfigSchema.NAMESPACE_OBSOLETE)
+							SailConfigSchema.ITERATION_CACHE_SYNC_THRESHOLD)
 					.ifPresent(lit -> setIterationCacheSyncThreshold(lit.longValue()));
 			SailConfigUtil
-					.getPropertyAsLiteral(m, implNode, CONFIG.connectionTimeOut, SailConfigSchema.NAMESPACE_OBSOLETE)
+					.getPropertyAsLiteral(m, implNode, CONFIG.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
 					.ifPresent(lit -> setConnectionTimeOut(lit.longValue()));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Base implementation of {@link SailImplConfig}
@@ -67,15 +67,15 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 		BNode implNode = bnode();
 
 		if (type != null) {
-			m.add(implNode, Config.Sail.type, literal(type));
+			m.add(implNode, CONFIG.Sail.type, literal(type));
 		}
 
 		if (iterationCacheSyncThreshold > 0) {
-			m.add(implNode, Config.Sail.iterationCacheSyncThreshold, literal(iterationCacheSyncThreshold));
+			m.add(implNode, CONFIG.Sail.iterationCacheSyncThreshold, literal(iterationCacheSyncThreshold));
 		}
 
 		if (connectionTimeOut > 0) {
-			m.add(implNode, Config.Sail.connectionTimeOut, literal(connectionTimeOut));
+			m.add(implNode, CONFIG.Sail.connectionTimeOut, literal(connectionTimeOut));
 		}
 		return implNode;
 	}
@@ -83,14 +83,14 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 	@Override
 	public void parse(Model m, Resource implNode) throws SailConfigException {
 		try {
-			Configurations.getLiteralValue(m, implNode, Config.Sail.type, SailConfigSchema.SAILTYPE)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Sail.type, SailConfigSchema.SAILTYPE)
 					.ifPresent(lit -> setType(lit.getLabel()));
 			Configurations
-					.getLiteralValue(m, implNode, Config.Sail.iterationCacheSyncThreshold,
+					.getLiteralValue(m, implNode, CONFIG.Sail.iterationCacheSyncThreshold,
 							SailConfigSchema.ITERATION_CACHE_SYNC_THRESHOLD)
 					.ifPresent(lit -> setIterationCacheSyncThreshold(lit.longValue()));
 			Configurations
-					.getLiteralValue(m, implNode, Config.Sail.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
+					.getLiteralValue(m, implNode, CONFIG.Sail.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
 					.ifPresent(lit -> setConnectionTimeOut(lit.longValue()));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/AbstractSailImplConfig.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * Base implementation of {@link SailImplConfig}
@@ -67,15 +67,15 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 		BNode implNode = bnode();
 
 		if (type != null) {
-			m.add(implNode, CONFIG.Sail.type, literal(type));
+			m.add(implNode, Config.Sail.type, literal(type));
 		}
 
 		if (iterationCacheSyncThreshold > 0) {
-			m.add(implNode, CONFIG.Sail.iterationCacheSyncThreshold, literal(iterationCacheSyncThreshold));
+			m.add(implNode, Config.Sail.iterationCacheSyncThreshold, literal(iterationCacheSyncThreshold));
 		}
 
 		if (connectionTimeOut > 0) {
-			m.add(implNode, CONFIG.Sail.connectionTimeOut, literal(connectionTimeOut));
+			m.add(implNode, Config.Sail.connectionTimeOut, literal(connectionTimeOut));
 		}
 		return implNode;
 	}
@@ -83,14 +83,14 @@ public abstract class AbstractSailImplConfig implements SailImplConfig {
 	@Override
 	public void parse(Model m, Resource implNode) throws SailConfigException {
 		try {
-			Configurations.getLiteralValue(m, implNode, CONFIG.Sail.type, SailConfigSchema.SAILTYPE)
+			Configurations.getLiteralValue(m, implNode, Config.Sail.type, SailConfigSchema.SAILTYPE)
 					.ifPresent(lit -> setType(lit.getLabel()));
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.Sail.iterationCacheSyncThreshold,
+					.getLiteralValue(m, implNode, Config.Sail.iterationCacheSyncThreshold,
 							SailConfigSchema.ITERATION_CACHE_SYNC_THRESHOLD)
 					.ifPresent(lit -> setIterationCacheSyncThreshold(lit.longValue()));
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.Sail.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
+					.getLiteralValue(m, implNode, Config.Sail.connectionTimeOut, SailConfigSchema.CONNECTION_TIME_OUT)
 					.ifPresent(lit -> setConnectionTimeOut(lit.longValue()));
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
@@ -11,46 +11,30 @@
 package org.eclipse.rdf4j.sail.config;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Defines constants for the Sail repository schema which are used to initialize repositories.
  *
  * @author Arjohn Kampman
+ * @deprecated use {@link CONFIG} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class SailConfigSchema {
 
-	/**
-	 * The Sail API schema namespace ( <var>http://www.openrdf.org/config/sail#</var>).
-	 */
-	public static final String NAMESPACE = "http://www.openrdf.org/config/sail#";
+	public static final String NAMESPACE = CONFIG.NAMESPACE;
 
 	/**
-	 * <var>http://www.openrdf.org/config/sail#sailType</var>
+	 * The (Obsolete) Sail API schema namespace ( <var>http://www.openrdf.org/config/sail#</var>).
 	 */
-	public final static IRI SAILTYPE;
+	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/sail#";
 
-	/**
-	 * <var>http://www.openrdf.org/config/sail#delegate</var>
-	 */
-	public final static IRI DELEGATE;
+	public final static IRI SAILTYPE = CONFIG.sailType;
 
-	/**
-	 * <var>http://www.openrdf.org/config/sail#iterationCacheSyncTreshold</var>
-	 */
-	public final static IRI ITERATION_CACHE_SYNC_THRESHOLD;
+	public final static IRI DELEGATE = CONFIG.delegate;
 
-	/**
-	 * <var>http://www.openrdf.org/config/sail#connectionTimeOut</var>
-	 */
-	public final static IRI CONNECTION_TIME_OUT;
+	public final static IRI ITERATION_CACHE_SYNC_THRESHOLD = CONFIG.iterationCacheSyncThreshold;
 
-	static {
-		ValueFactory factory = SimpleValueFactory.getInstance();
-		SAILTYPE = factory.createIRI(NAMESPACE, "sailType");
-		DELEGATE = factory.createIRI(NAMESPACE, "delegate");
-		ITERATION_CACHE_SYNC_THRESHOLD = factory.createIRI(NAMESPACE, "iterationCacheSyncTreshold");
-		CONNECTION_TIME_OUT = factory.createIRI(NAMESPACE, "connectionTimeOut");
-	}
+	public final static IRI CONNECTION_TIME_OUT = CONFIG.connectionTimeOut;
+
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
@@ -22,19 +24,29 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class SailConfigSchema {
 
-	public static final String NAMESPACE = CONFIG.NAMESPACE;
-
 	/**
 	 * The (Obsolete) Sail API schema namespace ( <var>http://www.openrdf.org/config/sail#</var>).
 	 */
-	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/sail#";
+	public static final String NAMESPACE = "http://www.openrdf.org/config/sail#";
 
-	public final static IRI SAILTYPE = CONFIG.sailType;
+	/**
+	 * @deprecated use {@link CONFIG#sailType} instead.
+	 */
+	public final static IRI SAILTYPE = iri(NAMESPACE, "sailType");
 
-	public final static IRI DELEGATE = CONFIG.delegate;
+	/**
+	 * @deprecated use {@link CONFIG#delegate} instead.
+	 */
+	public final static IRI DELEGATE = iri(NAMESPACE, "delegate");
 
-	public final static IRI ITERATION_CACHE_SYNC_THRESHOLD = CONFIG.iterationCacheSyncThreshold;
+	/**
+	 * @deprecated use {@link CONFIG#iterationCacheSyncThreshold} instead.
+	 */
+	public final static IRI ITERATION_CACHE_SYNC_THRESHOLD = iri(NAMESPACE, "iterationCacheSyncThreshold");
 
-	public final static IRI CONNECTION_TIME_OUT = CONFIG.connectionTimeOut;
+	/**
+	 * @deprecated use {@link CONFIG#connectionTimeOut} instead.
+	 */
+	public final static IRI CONNECTION_TIME_OUT = iri(NAMESPACE, "connectionTimeOut");
 
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
@@ -13,13 +13,13 @@ package org.eclipse.rdf4j.sail.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * Defines constants for the Sail repository schema which are used to initialize repositories.
  *
  * @author Arjohn Kampman
- * @deprecated use {@link CONFIG} instead.
+ * @deprecated use {@link Config} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class SailConfigSchema {
@@ -30,22 +30,22 @@ public class SailConfigSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/sail#";
 
 	/**
-	 * @deprecated use {@link CONFIG#type} instead.
+	 * @deprecated use {@link Config#type} instead.
 	 */
 	public final static IRI SAILTYPE = iri(NAMESPACE, "sailType");
 
 	/**
-	 * @deprecated use {@link CONFIG#delegate} instead.
+	 * @deprecated use {@link Config#delegate} instead.
 	 */
 	public final static IRI DELEGATE = iri(NAMESPACE, "delegate");
 
 	/**
-	 * @deprecated use {@link CONFIG#iterationCacheSyncThreshold} instead.
+	 * @deprecated use {@link Config#iterationCacheSyncThreshold} instead.
 	 */
 	public final static IRI ITERATION_CACHE_SYNC_THRESHOLD = iri(NAMESPACE, "iterationCacheSyncThreshold");
 
 	/**
-	 * @deprecated use {@link CONFIG#connectionTimeOut} instead.
+	 * @deprecated use {@link Config#connectionTimeOut} instead.
 	 */
 	public final static IRI CONNECTION_TIME_OUT = iri(NAMESPACE, "connectionTimeOut");
 

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
@@ -30,7 +30,7 @@ public class SailConfigSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/sail#";
 
 	/**
-	 * @deprecated use {@link CONFIG#sailType} instead.
+	 * @deprecated use {@link CONFIG#type} instead.
 	 */
 	public final static IRI SAILTYPE = iri(NAMESPACE, "sailType");
 

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigSchema.java
@@ -13,13 +13,13 @@ package org.eclipse.rdf4j.sail.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Defines constants for the Sail repository schema which are used to initialize repositories.
  *
  * @author Arjohn Kampman
- * @deprecated use {@link Config} instead.
+ * @deprecated use {@link CONFIG} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class SailConfigSchema {
@@ -30,22 +30,22 @@ public class SailConfigSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/sail#";
 
 	/**
-	 * @deprecated use {@link Config#type} instead.
+	 * @deprecated use {@link CONFIG#type} instead.
 	 */
 	public final static IRI SAILTYPE = iri(NAMESPACE, "sailType");
 
 	/**
-	 * @deprecated use {@link Config#delegate} instead.
+	 * @deprecated use {@link CONFIG#delegate} instead.
 	 */
 	public final static IRI DELEGATE = iri(NAMESPACE, "delegate");
 
 	/**
-	 * @deprecated use {@link Config#iterationCacheSyncThreshold} instead.
+	 * @deprecated use {@link CONFIG#iterationCacheSyncThreshold} instead.
 	 */
 	public final static IRI ITERATION_CACHE_SYNC_THRESHOLD = iri(NAMESPACE, "iterationCacheSyncThreshold");
 
 	/**
-	 * @deprecated use {@link Config#connectionTimeOut} instead.
+	 * @deprecated use {@link CONFIG#connectionTimeOut} instead.
 	 */
 	public final static IRI CONNECTION_TIME_OUT = iri(NAMESPACE, "connectionTimeOut");
 

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
@@ -10,20 +10,29 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.config;
 
-import java.util.Optional;
+import static org.eclipse.rdf4j.model.util.Values.iri;
 
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 public class SailConfigUtil {
 
 	public static SailImplConfig parseRepositoryImpl(Model m, Resource implNode) throws SailConfigException {
 		try {
-			Optional<Literal> typeLit = Models
-					.objectLiteral(m.getStatements(implNode, SailConfigSchema.SAILTYPE, null));
+
+			Optional<Literal> typeLit = getPropertyAsLiteral(m, implNode, CONFIG.sailType,
+					SailConfigSchema.NAMESPACE_OBSOLETE);
 
 			if (typeLit.isPresent()) {
 				Optional<SailFactory> factory = SailRegistry.getInstance().get(typeLit.get().getLabel());
@@ -41,5 +50,102 @@ public class SailConfigUtil {
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);
 		}
+	}
+
+	/**
+	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a property
+	 * with the same local name in the supplied fallbackNamespace.
+	 *
+	 * This method allows use to query sail config models with a mix of old and new namespaces.
+	 *
+	 * @param model             the model to retrieve property values from.
+	 * @param subject           the subject of the property.
+	 * @param property          the property to retrieve the value of.
+	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
+	 *                          supplied property has no value in the model.
+	 * @return the resource value for supplied subject and property (or the property with the supplied
+	 *         fallbackNamespace), if present.
+	 */
+	@InternalUseOnly
+	public static Optional<Resource> getPropertyAsResource(Model model, Resource subject, IRI property,
+			String fallbackNamespace) {
+		return Optional
+				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
+				.orElseGet(() -> {
+					IRI fallback = iri(fallbackNamespace, property.getLocalName());
+					return Models.objectResource(model.getStatements(subject, fallback, null));
+				});
+	}
+
+	/**
+	 * Retrieve a property value for the supplied subject as a {@link Literal} if present, falling back to a property
+	 * with the same local name in the supplied fallbackNamespace.
+	 *
+	 * This method allows use to query sail config models with a mix of old and new namespaces.
+	 *
+	 * @param model             the model to retrieve property values from.
+	 * @param subject           the subject of the property.
+	 * @param property          the property to retrieve the value of.
+	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
+	 *                          supplied property has no value in the model.
+	 * @return the literal value for supplied subject and property (or the property with the supplied
+	 *         fallbackNamespace), if present.
+	 */
+	@InternalUseOnly
+	public static Optional<Literal> getPropertyAsLiteral(Model model, Resource subject, IRI property,
+			String fallbackNamespace) {
+		return Optional
+				.ofNullable(Models.objectLiteral(model.getStatements(subject, property, null)))
+				.orElseGet(() -> {
+					IRI fallback = iri(fallbackNamespace, property.getLocalName());
+					return Models.objectLiteral(model.getStatements(subject, fallback, null));
+				});
+	}
+
+	/**
+	 * Retrieve all property values for the supplied subject as a Set of values and include all values for any property
+	 * with the same local name in the supplied fallbackNamespace.
+	 *
+	 * This method allows use to query sail config models with a mix of old and new namespaces.
+	 *
+	 * @param model             the model to retrieve property values from.
+	 * @param subject           the subject of the property.
+	 * @param property          the property to retrieve the values of.
+	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property.
+	 * @return the set of values for supplied subject and property (and/or the property with the supplied
+	 *         fallbackNamespace).
+	 */
+	@InternalUseOnly
+	public static Set<Value> getPropertyValues(Model model, Resource subject, IRI property,
+			String fallbackNamespace) {
+		final Set<Value> results = new HashSet<>();
+		results.addAll(model.filter(subject, property, null).objects());
+		results.addAll(model.filter(subject, iri(fallbackNamespace, property.getLocalName()), null).objects());
+		return results;
+	}
+
+	/**
+	 * Retrieve a property value for the supplied subject as an {@link IRI} if present, falling back to a property with
+	 * the same local name in the supplied fallbackNamespace.
+	 *
+	 * This method allows use to query sail config models with a mix of old and new namespaces.
+	 *
+	 * @param model             the model to retrieve property values from.
+	 * @param subject           the subject of the property.
+	 * @param property          the property to retrieve the value of.
+	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
+	 *                          supplied property has no value in the model.
+	 * @return the IRI value for supplied subject and property (or the property with the supplied fallbackNamespace), if
+	 *         present.
+	 */
+	@InternalUseOnly
+	public static Optional<IRI> getPropertyAsIRI(Model model, Resource subject, IRI property,
+			String fallbackNamespace) {
+		return Optional
+				.ofNullable(Models.objectIRI(model.getStatements(subject, property, null)))
+				.orElseGet(() -> {
+					IRI fallback = iri(fallbackNamespace, property.getLocalName());
+					return Models.objectIRI(model.getStatements(subject, fallback, null));
+				});
 	}
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
@@ -24,7 +24,7 @@ public class SailConfigUtil {
 	public static SailImplConfig parseRepositoryImpl(Model m, Resource implNode) throws SailConfigException {
 		try {
 
-			Optional<Literal> typeLit = Configurations.getLiteralValue(m, implNode, CONFIG.sailType,
+			Optional<Literal> typeLit = Configurations.getLiteralValue(m, implNode, CONFIG.Sail.type,
 					SailConfigSchema.SAILTYPE);
 
 			if (typeLit.isPresent()) {

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
@@ -10,20 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.config;
 
-import static org.eclipse.rdf4j.model.util.Values.iri;
-
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 
-import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
-import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 public class SailConfigUtil {
@@ -31,7 +24,7 @@ public class SailConfigUtil {
 	public static SailImplConfig parseRepositoryImpl(Model m, Resource implNode) throws SailConfigException {
 		try {
 
-			Optional<Literal> typeLit = getPropertyAsLiteral(m, implNode, CONFIG.sailType,
+			Optional<Literal> typeLit = Configurations.getLiteralValue(m, implNode, CONFIG.sailType,
 					SailConfigSchema.SAILTYPE);
 
 			if (typeLit.isPresent()) {
@@ -52,115 +45,4 @@ public class SailConfigUtil {
 		}
 	}
 
-	/**
-	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a property
-	 * with the same local name in the supplied fallbackNamespace.
-	 *
-	 * This method allows use to query sail config models with a mix of old and new namespaces.
-	 *
-	 * @param model             the model to retrieve property values from.
-	 * @param subject           the subject of the property.
-	 * @param property          the property to retrieve the value of.
-	 * @param fallbackNamespace namespace to use in combination with the local name of the supplied property if the
-	 *                          supplied property has no value in the model.
-	 * @return the resource value for supplied subject and property (or the property with the supplied
-	 *         fallbackNamespace), if present.
-	 */
-	@InternalUseOnly
-	public static Optional<Resource> getPropertyAsResource(Model model, Resource subject, IRI property,
-			String fallbackNamespace) {
-		return Optional
-				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					IRI fallback = iri(fallbackNamespace, property.getLocalName());
-					return Models.objectResource(model.getStatements(subject, fallback, null));
-				});
-	}
-
-	/**
-	 * Retrieve a property value for the supplied subject as a {@link Resource} if present, falling back to a supplied
-	 * legacy property .
-	 *
-	 * This method allows use to query repository config models with a mix of old and new namespaces.
-	 *
-	 * @param model          the model to retrieve property values from.
-	 * @param subject        the subject of the property.
-	 * @param property       the property to retrieve the value of.
-	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
-	 * @return the resource value for supplied subject and property (or the legacy property ), if present.
-	 */
-	@InternalUseOnly
-	public static Optional<Resource> getPropertyAsResource(Model model, Resource subject, IRI property,
-			IRI legacyProperty) {
-		return Optional
-				.ofNullable(Models.objectResource(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					return Models.objectResource(model.getStatements(subject, legacyProperty, null));
-				});
-	}
-
-	/**
-	 * Retrieve a property value for the supplied subject as a {@link Literal} if present, falling back to a supplied
-	 * legacy property .
-	 *
-	 * This method allows use to query sail config models with a mix of old and new namespaces.
-	 *
-	 * @param model          the model to retrieve property values from.
-	 * @param subject        the subject of the property.
-	 * @param property       the property to retrieve the value of.
-	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
-	 * @return the literal value for supplied subject and property (or the legacy property ), if present.
-	 */
-	@InternalUseOnly
-	public static Optional<Literal> getPropertyAsLiteral(Model model, Resource subject, IRI property,
-			IRI legacyProperty) {
-		return Optional
-				.ofNullable(Models.objectLiteral(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					return Models.objectLiteral(model.getStatements(subject, legacyProperty, null));
-				});
-	}
-
-	/**
-	 * Retrieve all property values for the supplied subject as a Set of values and include all values for any legacy
-	 * property.
-	 *
-	 * This method allows use to query sail config models with a mix of old and new namespaces.
-	 *
-	 * @param model          the model to retrieve property values from.
-	 * @param subject        the subject of the property.
-	 * @param property       the property to retrieve the values of.
-	 * @param legacyProperty legacy property to retrieve values of.
-	 * @return the set of values for supplied subject and property (and/or legacy property).
-	 */
-	@InternalUseOnly
-	public static Set<Value> getPropertyValues(Model model, Resource subject, IRI property,
-			IRI legacyProperty) {
-		final Set<Value> results = new HashSet<>();
-		results.addAll(model.filter(subject, property, null).objects());
-		results.addAll(model.filter(subject, legacyProperty, null).objects());
-		return results;
-	}
-
-	/**
-	 * Retrieve a property value for the supplied subject as a {@link IRI} if present, falling back to a supplied legacy
-	 * property .
-	 *
-	 * This method allows use to query sail config models with a mix of old and new namespaces.
-	 *
-	 * @param model          the model to retrieve property values from.
-	 * @param subject        the subject of the property.
-	 * @param property       the property to retrieve the value of.
-	 * @param legacyProperty legacy property to use if the supplied property has no value in the model.
-	 * @return the IRI value for supplied subject and property (or the legacy property ), if present.
-	 */
-	@InternalUseOnly
-	public static Optional<IRI> getPropertyAsIRI(Model model, Resource subject, IRI property,
-			IRI legacyProperty) {
-		return Optional
-				.ofNullable(Models.objectIRI(model.getStatements(subject, property, null)))
-				.orElseGet(() -> {
-					return Models.objectIRI(model.getStatements(subject, legacyProperty, null));
-				});
-	}
 }

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
@@ -17,14 +17,14 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 public class SailConfigUtil {
 
 	public static SailImplConfig parseRepositoryImpl(Model m, Resource implNode) throws SailConfigException {
 		try {
 
-			Optional<Literal> typeLit = Configurations.getLiteralValue(m, implNode, CONFIG.Sail.type,
+			Optional<Literal> typeLit = Configurations.getLiteralValue(m, implNode, Config.Sail.type,
 					SailConfigSchema.SAILTYPE);
 
 			if (typeLit.isPresent()) {

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/config/SailConfigUtil.java
@@ -17,14 +17,14 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 public class SailConfigUtil {
 
 	public static SailImplConfig parseRepositoryImpl(Model m, Resource implNode) throws SailConfigException {
 		try {
 
-			Optional<Literal> typeLit = Configurations.getLiteralValue(m, implNode, Config.Sail.type,
+			Optional<Literal> typeLit = Configurations.getLiteralValue(m, implNode, CONFIG.Sail.type,
 					SailConfigSchema.SAILTYPE);
 
 			if (typeLit.isPresent()) {

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
@@ -11,8 +11,6 @@
 package org.eclipse.rdf4j.sail.base.config;
 
 import static org.eclipse.rdf4j.model.util.Values.literal;
-import static org.eclipse.rdf4j.sail.base.config.BaseSailSchema.EVALUATION_STRATEGY_FACTORY;
-import static org.eclipse.rdf4j.sail.base.config.BaseSailSchema.NAMESPACE;
 
 import java.util.Optional;
 
@@ -20,10 +18,11 @@ import org.eclipse.rdf4j.common.transaction.QueryEvaluationMode;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
 import org.eclipse.rdf4j.sail.config.AbstractSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
+import org.eclipse.rdf4j.sail.config.SailConfigUtil;
 
 public abstract class BaseSailConfig extends AbstractSailImplConfig {
 
@@ -64,13 +63,11 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (evalStratFactoryClassName != null) {
-			graph.setNamespace("sb", NAMESPACE);
-			graph.add(implNode, EVALUATION_STRATEGY_FACTORY,
+			graph.add(implNode, CONFIG.evaluationStrategyFactory,
 					literal(evalStratFactoryClassName));
 		}
 		getDefaultQueryEvaluationMode().ifPresent(mode -> {
-			graph.setNamespace("sb", NAMESPACE);
-			graph.add(implNode, BaseSailSchema.DEFAULT_QUERY_EVALUATION_MODE,
+			graph.add(implNode, CONFIG.defaultQueryEvaluationMode,
 					literal(mode.getValue()));
 		});
 
@@ -82,11 +79,15 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		super.parse(graph, implNode);
 
 		try {
-			Models.objectLiteral(graph.getStatements(implNode, BaseSailSchema.DEFAULT_QUERY_EVALUATION_MODE, null))
+			SailConfigUtil
+					.getPropertyAsLiteral(graph, implNode, CONFIG.defaultQueryEvaluationMode,
+							BaseSailSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(qem -> setDefaultQueryEvaluationMode(
 							QueryEvaluationMode.valueOf(qem.stringValue())));
 
-			Models.objectLiteral(graph.getStatements(implNode, EVALUATION_STRATEGY_FACTORY, null))
+			SailConfigUtil
+					.getPropertyAsLiteral(graph, implNode, CONFIG.evaluationStrategyFactory,
+							BaseSailSchema.NAMESPACE_OBSOLETE)
 					.ifPresent(factoryClassName -> {
 						setEvaluationStrategyFactoryClassName(factoryClassName.stringValue());
 					});

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
 import org.eclipse.rdf4j.sail.config.AbstractSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
@@ -63,11 +63,11 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (evalStratFactoryClassName != null) {
-			graph.add(implNode, CONFIG.Sail.evaluationStrategyFactory,
+			graph.add(implNode, Config.Sail.evaluationStrategyFactory,
 					literal(evalStratFactoryClassName));
 		}
 		getDefaultQueryEvaluationMode().ifPresent(mode -> {
-			graph.add(implNode, CONFIG.Sail.defaultQueryEvaluationMode,
+			graph.add(implNode, Config.Sail.defaultQueryEvaluationMode,
 					literal(mode.getValue()));
 		});
 
@@ -79,12 +79,12 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		super.parse(graph, implNode);
 
 		try {
-			Configurations.getLiteralValue(graph, implNode, CONFIG.Sail.defaultQueryEvaluationMode,
+			Configurations.getLiteralValue(graph, implNode, Config.Sail.defaultQueryEvaluationMode,
 					BaseSailSchema.DEFAULT_QUERY_EVALUATION_MODE)
 					.ifPresent(qem -> setDefaultQueryEvaluationMode(
 							QueryEvaluationMode.valueOf(qem.stringValue())));
 
-			Configurations.getLiteralValue(graph, implNode, CONFIG.Sail.evaluationStrategyFactory,
+			Configurations.getLiteralValue(graph, implNode, Config.Sail.evaluationStrategyFactory,
 					BaseSailSchema.EVALUATION_STRATEGY_FACTORY)
 					.ifPresent(factoryClassName -> {
 						setEvaluationStrategyFactoryClassName(factoryClassName.stringValue());

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
@@ -17,12 +17,12 @@ import java.util.Optional;
 import org.eclipse.rdf4j.common.transaction.QueryEvaluationMode;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
 import org.eclipse.rdf4j.sail.config.AbstractSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
-import org.eclipse.rdf4j.sail.config.SailConfigUtil;
 
 public abstract class BaseSailConfig extends AbstractSailImplConfig {
 
@@ -79,15 +79,13 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		super.parse(graph, implNode);
 
 		try {
-			SailConfigUtil
-					.getPropertyAsLiteral(graph, implNode, CONFIG.defaultQueryEvaluationMode,
-							BaseSailSchema.DEFAULT_QUERY_EVALUATION_MODE)
+			Configurations.getLiteralValue(graph, implNode, CONFIG.defaultQueryEvaluationMode,
+					BaseSailSchema.DEFAULT_QUERY_EVALUATION_MODE)
 					.ifPresent(qem -> setDefaultQueryEvaluationMode(
 							QueryEvaluationMode.valueOf(qem.stringValue())));
 
-			SailConfigUtil
-					.getPropertyAsLiteral(graph, implNode, CONFIG.evaluationStrategyFactory,
-							BaseSailSchema.EVALUATION_STRATEGY_FACTORY)
+			Configurations.getLiteralValue(graph, implNode, CONFIG.evaluationStrategyFactory,
+					BaseSailSchema.EVALUATION_STRATEGY_FACTORY)
 					.ifPresent(factoryClassName -> {
 						setEvaluationStrategyFactoryClassName(factoryClassName.stringValue());
 					});

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
@@ -63,11 +63,11 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (evalStratFactoryClassName != null) {
-			graph.add(implNode, CONFIG.evaluationStrategyFactory,
+			graph.add(implNode, CONFIG.Sail.evaluationStrategyFactory,
 					literal(evalStratFactoryClassName));
 		}
 		getDefaultQueryEvaluationMode().ifPresent(mode -> {
-			graph.add(implNode, CONFIG.defaultQueryEvaluationMode,
+			graph.add(implNode, CONFIG.Sail.defaultQueryEvaluationMode,
 					literal(mode.getValue()));
 		});
 
@@ -79,12 +79,12 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		super.parse(graph, implNode);
 
 		try {
-			Configurations.getLiteralValue(graph, implNode, CONFIG.defaultQueryEvaluationMode,
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Sail.defaultQueryEvaluationMode,
 					BaseSailSchema.DEFAULT_QUERY_EVALUATION_MODE)
 					.ifPresent(qem -> setDefaultQueryEvaluationMode(
 							QueryEvaluationMode.valueOf(qem.stringValue())));
 
-			Configurations.getLiteralValue(graph, implNode, CONFIG.evaluationStrategyFactory,
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Sail.evaluationStrategyFactory,
 					BaseSailSchema.EVALUATION_STRATEGY_FACTORY)
 					.ifPresent(factoryClassName -> {
 						setEvaluationStrategyFactoryClassName(factoryClassName.stringValue());

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
 import org.eclipse.rdf4j.sail.config.AbstractSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
@@ -63,11 +63,11 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		Resource implNode = super.export(graph);
 
 		if (evalStratFactoryClassName != null) {
-			graph.add(implNode, Config.Sail.evaluationStrategyFactory,
+			graph.add(implNode, CONFIG.Sail.evaluationStrategyFactory,
 					literal(evalStratFactoryClassName));
 		}
 		getDefaultQueryEvaluationMode().ifPresent(mode -> {
-			graph.add(implNode, Config.Sail.defaultQueryEvaluationMode,
+			graph.add(implNode, CONFIG.Sail.defaultQueryEvaluationMode,
 					literal(mode.getValue()));
 		});
 
@@ -79,12 +79,12 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		super.parse(graph, implNode);
 
 		try {
-			Configurations.getLiteralValue(graph, implNode, Config.Sail.defaultQueryEvaluationMode,
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Sail.defaultQueryEvaluationMode,
 					BaseSailSchema.DEFAULT_QUERY_EVALUATION_MODE)
 					.ifPresent(qem -> setDefaultQueryEvaluationMode(
 							QueryEvaluationMode.valueOf(qem.stringValue())));
 
-			Configurations.getLiteralValue(graph, implNode, Config.Sail.evaluationStrategyFactory,
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Sail.evaluationStrategyFactory,
 					BaseSailSchema.EVALUATION_STRATEGY_FACTORY)
 					.ifPresent(factoryClassName -> {
 						setEvaluationStrategyFactoryClassName(factoryClassName.stringValue());

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailConfig.java
@@ -81,13 +81,13 @@ public abstract class BaseSailConfig extends AbstractSailImplConfig {
 		try {
 			SailConfigUtil
 					.getPropertyAsLiteral(graph, implNode, CONFIG.defaultQueryEvaluationMode,
-							BaseSailSchema.NAMESPACE_OBSOLETE)
+							BaseSailSchema.DEFAULT_QUERY_EVALUATION_MODE)
 					.ifPresent(qem -> setDefaultQueryEvaluationMode(
 							QueryEvaluationMode.valueOf(qem.stringValue())));
 
 			SailConfigUtil
 					.getPropertyAsLiteral(graph, implNode, CONFIG.evaluationStrategyFactory,
-							BaseSailSchema.NAMESPACE_OBSOLETE)
+							BaseSailSchema.EVALUATION_STRATEGY_FACTORY)
 					.ifPresent(factoryClassName -> {
 						setEvaluationStrategyFactoryClassName(factoryClassName.stringValue());
 					});

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailSchema.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailSchema.java
@@ -13,12 +13,12 @@ package org.eclipse.rdf4j.sail.base.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Defines constants for the BaseSail schema.
  *
- * @deprecated use {@link Config} instead.
+ * @deprecated use {@link CONFIG} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class BaseSailSchema {
@@ -29,12 +29,12 @@ public class BaseSailSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/sail/base#";
 
 	/**
-	 * @deprecated use {@link Config#evaluationStrategyFactory} instead.
+	 * @deprecated use {@link CONFIG#evaluationStrategyFactory} instead.
 	 */
 	public final static IRI EVALUATION_STRATEGY_FACTORY = iri(NAMESPACE, "evaluationStrategyFactory");
 
 	/**
-	 * @deprecated use {@link Config#defaultQueryEvaluationMode} instead.
+	 * @deprecated use {@link CONFIG#defaultQueryEvaluationMode} instead.
 	 */
 	public final static IRI DEFAULT_QUERY_EVALUATION_MODE = iri(NAMESPACE, "defaultQueryEvaluationMode");
 

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailSchema.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailSchema.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.base.config;
 
+import static org.eclipse.rdf4j.model.util.Values.iri;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
@@ -21,14 +23,19 @@ import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class BaseSailSchema {
 
-	public static final String NAMESPACE = CONFIG.NAMESPACE;
-
 	/**
 	 * The (obsolete)BaseSail schema namespace (<var>http://www.openrdf.org/config/sail/base#</var>).
 	 */
-	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/sail/base#";
+	public static final String NAMESPACE = "http://www.openrdf.org/config/sail/base#";
 
-	public final static IRI EVALUATION_STRATEGY_FACTORY = CONFIG.evaluationStrategyFactory;
-	public final static IRI DEFAULT_QUERY_EVALUATION_MODE = CONFIG.defaultQueryEvaluationMode;
+	/**
+	 * @deprecated use {@link CONFIG#evaluationStrategyFactory} instead.
+	 */
+	public final static IRI EVALUATION_STRATEGY_FACTORY = iri(NAMESPACE, "evaluationStrategyFactory");
+
+	/**
+	 * @deprecated use {@link CONFIG#defaultQueryEvaluationMode} instead.
+	 */
+	public final static IRI DEFAULT_QUERY_EVALUATION_MODE = iri(NAMESPACE, "defaultQueryEvaluationMode");
 
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailSchema.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailSchema.java
@@ -10,23 +10,25 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.base.config;
 
-import static org.eclipse.rdf4j.model.util.Values.iri;
-
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 
 /**
  * Defines constants for the BaseSail schema.
+ *
+ * @deprecated use {@link CONFIG} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class BaseSailSchema {
 
+	public static final String NAMESPACE = CONFIG.NAMESPACE;
+
 	/**
-	 * The BaseSail schema namespace (<var>http://www.openrdf.org/config/sail/base#</var>).
+	 * The (obsolete)BaseSail schema namespace (<var>http://www.openrdf.org/config/sail/base#</var>).
 	 */
-	public static final String NAMESPACE = "http://www.openrdf.org/config/sail/base#";
+	public static final String NAMESPACE_OBSOLETE = "http://www.openrdf.org/config/sail/base#";
 
-	/** <var>http://www.openrdf.org/config/sail/base#evaluationStrategyFactory</var> */
-	public final static IRI EVALUATION_STRATEGY_FACTORY = iri(NAMESPACE, "evaluationStrategyFactory");
-
-	public final static IRI DEFAULT_QUERY_EVALUATION_MODE = iri(NAMESPACE, "defaultQueryEvaluationMode");
+	public final static IRI EVALUATION_STRATEGY_FACTORY = CONFIG.evaluationStrategyFactory;
+	public final static IRI DEFAULT_QUERY_EVALUATION_MODE = CONFIG.defaultQueryEvaluationMode;
 
 }

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailSchema.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/base/config/BaseSailSchema.java
@@ -13,12 +13,12 @@ package org.eclipse.rdf4j.sail.base.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 
 /**
  * Defines constants for the BaseSail schema.
  *
- * @deprecated use {@link CONFIG} instead.
+ * @deprecated use {@link Config} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class BaseSailSchema {
@@ -29,12 +29,12 @@ public class BaseSailSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/sail/base#";
 
 	/**
-	 * @deprecated use {@link CONFIG#evaluationStrategyFactory} instead.
+	 * @deprecated use {@link Config#evaluationStrategyFactory} instead.
 	 */
 	public final static IRI EVALUATION_STRATEGY_FACTORY = iri(NAMESPACE, "evaluationStrategyFactory");
 
 	/**
-	 * @deprecated use {@link CONFIG#defaultQueryEvaluationMode} instead.
+	 * @deprecated use {@link Config#defaultQueryEvaluationMode} instead.
 	 */
 	public final static IRI DEFAULT_QUERY_EVALUATION_MODE = iri(NAMESPACE, "defaultQueryEvaluationMode");
 

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfig.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfig.java
@@ -10,17 +10,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearchstore.config;
 
-import static org.eclipse.rdf4j.sail.elasticsearchstore.config.ElasticsearchStoreSchema.NAMESPACE;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -28,8 +27,6 @@ import org.eclipse.rdf4j.sail.config.SailConfigException;
  * @author Håvard Mikkelsen Ottestad
  */
 public class ElasticsearchStoreConfig extends BaseSailConfig {
-
-	private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
 	private String hostname;
 	private int port = -1;
@@ -44,18 +41,17 @@ public class ElasticsearchStoreConfig extends BaseSailConfig {
 	public Resource export(Model graph) {
 		Resource implNode = super.export(graph);
 
-		graph.setNamespace(ElasticsearchStoreSchema.PREFIX, NAMESPACE);
 		if (hostname != null) {
-			graph.add(implNode, ElasticsearchStoreSchema.hostname, vf.createLiteral(hostname));
+			graph.add(implNode, CONFIG.Ess.hostname, literal(hostname));
 		}
 		if (clusterName != null) {
-			graph.add(implNode, ElasticsearchStoreSchema.clusterName, vf.createLiteral(clusterName));
+			graph.add(implNode, CONFIG.Ess.clusterName, literal(clusterName));
 		}
 		if (index != null) {
-			graph.add(implNode, ElasticsearchStoreSchema.index, vf.createLiteral(index));
+			graph.add(implNode, CONFIG.Ess.index, literal(index));
 		}
 		if (port != -1) {
-			graph.add(implNode, ElasticsearchStoreSchema.port, vf.createLiteral(port));
+			graph.add(implNode, CONFIG.Ess.port, literal(port));
 		}
 
 		return implNode;
@@ -67,47 +63,48 @@ public class ElasticsearchStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Models.objectLiteral(graph.getStatements(implNode, ElasticsearchStoreSchema.hostname, null))
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.hostname, ElasticsearchStoreSchema.hostname)
 					.ifPresent(value -> {
 						try {
 							setHostname(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + ElasticsearchStoreSchema.hostname
+									"String value required for " + CONFIG.Ess.hostname
 											+ " property, found "
 											+ value);
 						}
 					});
 
-			Models.objectLiteral(graph.getStatements(implNode, ElasticsearchStoreSchema.index, null))
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.index, ElasticsearchStoreSchema.index)
 					.ifPresent(value -> {
 						try {
 							setIndex(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + ElasticsearchStoreSchema.index + " property, found "
+									"String value required for " + CONFIG.Ess.index + " property, found "
 											+ value);
 						}
 					});
 
-			Models.objectLiteral(graph.getStatements(implNode, ElasticsearchStoreSchema.clusterName, null))
+			Configurations
+					.getLiteralValue(graph, implNode, CONFIG.Ess.clusterName, ElasticsearchStoreSchema.clusterName)
 					.ifPresent(value -> {
 						try {
 							setClusterName(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + ElasticsearchStoreSchema.clusterName
+									"String value required for " + CONFIG.Ess.clusterName
 											+ " property, found " + value);
 						}
 					});
 
-			Models.objectLiteral(graph.getStatements(implNode, ElasticsearchStoreSchema.port, null))
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.port, ElasticsearchStoreSchema.port)
 					.ifPresent(value -> {
 						try {
 							setPort(value.intValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"Integer value required for " + ElasticsearchStoreSchema.port + " property, found "
+									"Integer value required for " + CONFIG.Ess.port + " property, found "
 											+ value);
 						}
 					});

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfig.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -42,16 +42,16 @@ public class ElasticsearchStoreConfig extends BaseSailConfig {
 		Resource implNode = super.export(graph);
 
 		if (hostname != null) {
-			graph.add(implNode, Config.Ess.hostname, literal(hostname));
+			graph.add(implNode, CONFIG.Ess.hostname, literal(hostname));
 		}
 		if (clusterName != null) {
-			graph.add(implNode, Config.Ess.clusterName, literal(clusterName));
+			graph.add(implNode, CONFIG.Ess.clusterName, literal(clusterName));
 		}
 		if (index != null) {
-			graph.add(implNode, Config.Ess.index, literal(index));
+			graph.add(implNode, CONFIG.Ess.index, literal(index));
 		}
 		if (port != -1) {
-			graph.add(implNode, Config.Ess.port, literal(port));
+			graph.add(implNode, CONFIG.Ess.port, literal(port));
 		}
 
 		return implNode;
@@ -63,48 +63,48 @@ public class ElasticsearchStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Configurations.getLiteralValue(graph, implNode, Config.Ess.hostname, ElasticsearchStoreSchema.hostname)
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.hostname, ElasticsearchStoreSchema.hostname)
 					.ifPresent(value -> {
 						try {
 							setHostname(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + Config.Ess.hostname
+									"String value required for " + CONFIG.Ess.hostname
 											+ " property, found "
 											+ value);
 						}
 					});
 
-			Configurations.getLiteralValue(graph, implNode, Config.Ess.index, ElasticsearchStoreSchema.index)
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.index, ElasticsearchStoreSchema.index)
 					.ifPresent(value -> {
 						try {
 							setIndex(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + Config.Ess.index + " property, found "
+									"String value required for " + CONFIG.Ess.index + " property, found "
 											+ value);
 						}
 					});
 
 			Configurations
-					.getLiteralValue(graph, implNode, Config.Ess.clusterName, ElasticsearchStoreSchema.clusterName)
+					.getLiteralValue(graph, implNode, CONFIG.Ess.clusterName, ElasticsearchStoreSchema.clusterName)
 					.ifPresent(value -> {
 						try {
 							setClusterName(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + Config.Ess.clusterName
+									"String value required for " + CONFIG.Ess.clusterName
 											+ " property, found " + value);
 						}
 					});
 
-			Configurations.getLiteralValue(graph, implNode, Config.Ess.port, ElasticsearchStoreSchema.port)
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.port, ElasticsearchStoreSchema.port)
 					.ifPresent(value -> {
 						try {
 							setPort(value.intValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"Integer value required for " + Config.Ess.port + " property, found "
+									"Integer value required for " + CONFIG.Ess.port + " property, found "
 											+ value);
 						}
 					});

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfig.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -42,16 +42,16 @@ public class ElasticsearchStoreConfig extends BaseSailConfig {
 		Resource implNode = super.export(graph);
 
 		if (hostname != null) {
-			graph.add(implNode, CONFIG.Ess.hostname, literal(hostname));
+			graph.add(implNode, Config.Ess.hostname, literal(hostname));
 		}
 		if (clusterName != null) {
-			graph.add(implNode, CONFIG.Ess.clusterName, literal(clusterName));
+			graph.add(implNode, Config.Ess.clusterName, literal(clusterName));
 		}
 		if (index != null) {
-			graph.add(implNode, CONFIG.Ess.index, literal(index));
+			graph.add(implNode, Config.Ess.index, literal(index));
 		}
 		if (port != -1) {
-			graph.add(implNode, CONFIG.Ess.port, literal(port));
+			graph.add(implNode, Config.Ess.port, literal(port));
 		}
 
 		return implNode;
@@ -63,48 +63,48 @@ public class ElasticsearchStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.hostname, ElasticsearchStoreSchema.hostname)
+			Configurations.getLiteralValue(graph, implNode, Config.Ess.hostname, ElasticsearchStoreSchema.hostname)
 					.ifPresent(value -> {
 						try {
 							setHostname(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + CONFIG.Ess.hostname
+									"String value required for " + Config.Ess.hostname
 											+ " property, found "
 											+ value);
 						}
 					});
 
-			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.index, ElasticsearchStoreSchema.index)
+			Configurations.getLiteralValue(graph, implNode, Config.Ess.index, ElasticsearchStoreSchema.index)
 					.ifPresent(value -> {
 						try {
 							setIndex(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + CONFIG.Ess.index + " property, found "
+									"String value required for " + Config.Ess.index + " property, found "
 											+ value);
 						}
 					});
 
 			Configurations
-					.getLiteralValue(graph, implNode, CONFIG.Ess.clusterName, ElasticsearchStoreSchema.clusterName)
+					.getLiteralValue(graph, implNode, Config.Ess.clusterName, ElasticsearchStoreSchema.clusterName)
 					.ifPresent(value -> {
 						try {
 							setClusterName(value.stringValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"String value required for " + CONFIG.Ess.clusterName
+									"String value required for " + Config.Ess.clusterName
 											+ " property, found " + value);
 						}
 					});
 
-			Configurations.getLiteralValue(graph, implNode, CONFIG.Ess.port, ElasticsearchStoreSchema.port)
+			Configurations.getLiteralValue(graph, implNode, Config.Ess.port, ElasticsearchStoreSchema.port)
 					.ifPresent(value -> {
 						try {
 							setPort(value.intValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"Integer value required for " + CONFIG.Ess.port + " property, found "
+									"Integer value required for " + Config.Ess.port + " property, found "
 											+ value);
 						}
 					});

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreSchema.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreSchema.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 
 /**
@@ -20,7 +21,9 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
  * {@link ElasticsearchStore}s.
  *
  * @author Håvard Mikkelsen Ottestad
+ * @deprecated since 4.3.0. Use {@link CONFIG.Ess} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class ElasticsearchStoreSchema {
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();
@@ -31,9 +34,24 @@ public class ElasticsearchStoreSchema {
 	public static final String NAMESPACE = "http://rdf4j.org/config/sail/elasticsearchstore#";
 	public static final String PREFIX = "ess";
 
+	/**
+	 * @deprecated use {@link CONFIG.Ess#hostname} instead.
+	 */
 	public final static IRI hostname = vf.createIRI(NAMESPACE, "hostname");
+
+	/**
+	 * @deprecated use {@link CONFIG.Ess#port} instead.
+	 */
 	public final static IRI port = vf.createIRI(NAMESPACE, "port");
+
+	/**
+	 * @deprecated use {@link CONFIG.Ess#index} instead.
+	 */
 	public final static IRI index = vf.createIRI(NAMESPACE, "index");
+
+	/**
+	 * @deprecated use {@link CONFIG.Ess#clusterName} instead.
+	 */
 	public final static IRI clusterName = vf.createIRI(NAMESPACE, "clusterName");
 
 }

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreSchema.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
  * {@link ElasticsearchStore}s.
  *
  * @author Håvard Mikkelsen Ottestad
- * @deprecated since 4.3.0. Use {@link CONFIG.Ess} instead.
+ * @deprecated since 4.3.0. Use {@link Config.Ess} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ElasticsearchStoreSchema {
@@ -35,22 +35,22 @@ public class ElasticsearchStoreSchema {
 	public static final String PREFIX = "ess";
 
 	/**
-	 * @deprecated use {@link CONFIG.Ess#hostname} instead.
+	 * @deprecated use {@link Config.Ess#hostname} instead.
 	 */
 	public final static IRI hostname = vf.createIRI(NAMESPACE, "hostname");
 
 	/**
-	 * @deprecated use {@link CONFIG.Ess#port} instead.
+	 * @deprecated use {@link Config.Ess#port} instead.
 	 */
 	public final static IRI port = vf.createIRI(NAMESPACE, "port");
 
 	/**
-	 * @deprecated use {@link CONFIG.Ess#index} instead.
+	 * @deprecated use {@link Config.Ess#index} instead.
 	 */
 	public final static IRI index = vf.createIRI(NAMESPACE, "index");
 
 	/**
-	 * @deprecated use {@link CONFIG.Ess#clusterName} instead.
+	 * @deprecated use {@link Config.Ess#clusterName} instead.
 	 */
 	public final static IRI clusterName = vf.createIRI(NAMESPACE, "clusterName");
 

--- a/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreSchema.java
+++ b/core/sail/elasticsearch-store/src/main/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
  * {@link ElasticsearchStore}s.
  *
  * @author Håvard Mikkelsen Ottestad
- * @deprecated since 4.3.0. Use {@link Config.Ess} instead.
+ * @deprecated since 4.3.0. Use {@link CONFIG.Ess} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ElasticsearchStoreSchema {
@@ -35,22 +35,22 @@ public class ElasticsearchStoreSchema {
 	public static final String PREFIX = "ess";
 
 	/**
-	 * @deprecated use {@link Config.Ess#hostname} instead.
+	 * @deprecated use {@link CONFIG.Ess#hostname} instead.
 	 */
 	public final static IRI hostname = vf.createIRI(NAMESPACE, "hostname");
 
 	/**
-	 * @deprecated use {@link Config.Ess#port} instead.
+	 * @deprecated use {@link CONFIG.Ess#port} instead.
 	 */
 	public final static IRI port = vf.createIRI(NAMESPACE, "port");
 
 	/**
-	 * @deprecated use {@link Config.Ess#index} instead.
+	 * @deprecated use {@link CONFIG.Ess#index} instead.
 	 */
 	public final static IRI index = vf.createIRI(NAMESPACE, "index");
 
 	/**
-	 * @deprecated use {@link Config.Ess#clusterName} instead.
+	 * @deprecated use {@link CONFIG.Ess#clusterName} instead.
 	 */
 	public final static IRI clusterName = vf.createIRI(NAMESPACE, "clusterName");
 

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfigTest.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/config/ElasticsearchStoreConfigTest.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,10 +54,10 @@ public class ElasticsearchStoreConfigTest {
 		// FIXME we need to set formatting guidelines for this kind of thing
 		// @formatter:off
 		mb
-			.add(ElasticsearchStoreSchema.hostname, "host1")
-			.add(ElasticsearchStoreSchema.clusterName, "cluster1")
-			.add(ElasticsearchStoreSchema.index, "index1")
-			.add(ElasticsearchStoreSchema.port, 9300);
+			.add(CONFIG.Ess.hostname, "host1")
+			.add(CONFIG.Ess.clusterName, "cluster1")
+			.add(CONFIG.Ess.index, "index1")
+			.add(CONFIG.Ess.port, 9300);
 		// @formatter:on
 
 		subject.parse(mb.build(), implNode);
@@ -71,8 +72,8 @@ public class ElasticsearchStoreConfigTest {
 	@Test
 	public void parseFromPartialModelSetValuesCorrectly() {
 		mb
-				.add(ElasticsearchStoreSchema.hostname, "host1")
-				.add(ElasticsearchStoreSchema.port, 9300);
+				.add(CONFIG.Ess.hostname, "host1")
+				.add(CONFIG.Ess.port, 9300);
 
 		subject.parse(mb.build(), implNode);
 
@@ -84,7 +85,7 @@ public class ElasticsearchStoreConfigTest {
 	public void parseInvalidModelGivesCorrectException() {
 
 		mb
-				.add(ElasticsearchStoreSchema.port, "port1");
+				.add(CONFIG.Ess.port, "port1");
 
 		assertThrows(SailConfigException.class, () -> subject.parse(mb.build(), implNode));
 
@@ -94,10 +95,10 @@ public class ElasticsearchStoreConfigTest {
 	public void exportAddsAllConfigData() {
 
 		mb
-				.add(ElasticsearchStoreSchema.hostname, "host1")
-				.add(ElasticsearchStoreSchema.clusterName, "cluster1")
-				.add(ElasticsearchStoreSchema.index, "index1")
-				.add(ElasticsearchStoreSchema.port, 9300);
+				.add(CONFIG.Ess.hostname, "host1")
+				.add(CONFIG.Ess.clusterName, "cluster1")
+				.add(CONFIG.Ess.index, "index1")
+				.add(CONFIG.Ess.port, 9300);
 		// @formatter:on
 
 		subject.parse(mb.build(), implNode);
@@ -105,10 +106,10 @@ public class ElasticsearchStoreConfigTest {
 		Model m = new TreeModel();
 		Resource node = subject.export(m);
 
-		assertThat(m.contains(node, ElasticsearchStoreSchema.hostname, null)).isTrue();
-		assertThat(m.contains(node, ElasticsearchStoreSchema.clusterName, null)).isTrue();
-		assertThat(m.contains(node, ElasticsearchStoreSchema.index, null)).isTrue();
-		assertThat(m.contains(node, ElasticsearchStoreSchema.port, null)).isTrue();
+		assertThat(m.contains(node, CONFIG.Ess.hostname, null)).isTrue();
+		assertThat(m.contains(node, CONFIG.Ess.clusterName, null)).isTrue();
+		assertThat(m.contains(node, CONFIG.Ess.index, null)).isTrue();
+		assertThat(m.contains(node, CONFIG.Ess.port, null)).isTrue();
 
 	}
 

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerConfig.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerConfig.java
@@ -29,7 +29,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SP;
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -100,28 +100,28 @@ public final class CustomGraphQueryInferencerConfig extends AbstractDelegatingSa
 
 		try {
 
-			Optional<Literal> language = Configurations.getLiteralValue(m, implNode, Config.Cgqi.queryLanguage,
+			Optional<Literal> language = Configurations.getLiteralValue(m, implNode, CONFIG.Cgqi.queryLanguage,
 					QUERY_LANGUAGE);
 
 			if (language.isPresent()) {
 				setQueryLanguage(QueryLanguage.valueOf(language.get().stringValue()));
 				if (null == getQueryLanguage()) {
 					throw new SailConfigException(
-							"Valid value required for " + Config.Cgqi.queryLanguage + " property, found "
+							"Valid value required for " + CONFIG.Cgqi.queryLanguage + " property, found "
 									+ language.get());
 				}
 			} else {
 				setQueryLanguage(QueryLanguage.SPARQL);
 			}
 
-			Optional<Resource> object = Configurations.getResourceValue(m, implNode, Config.Cgqi.ruleQuery,
+			Optional<Resource> object = Configurations.getResourceValue(m, implNode, CONFIG.Cgqi.ruleQuery,
 					RULE_QUERY);
 			if (object.isPresent()) {
 				Models.objectLiteral(m.getStatements(object.get(), SP.TEXT_PROPERTY, null))
 						.ifPresent(lit -> setRuleQuery(lit.stringValue()));
 			}
 
-			object = Configurations.getResourceValue(m, implNode, Config.Cgqi.matcherQuery,
+			object = Configurations.getResourceValue(m, implNode, CONFIG.Cgqi.matcherQuery,
 					MATCHER_QUERY);
 			if (object.isPresent()) {
 				Models.objectLiteral(m.getStatements(object.get(), SP.TEXT_PROPERTY, null))
@@ -161,10 +161,10 @@ public final class CustomGraphQueryInferencerConfig extends AbstractDelegatingSa
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
 		if (null != language) {
-			m.add(implNode, Config.Cgqi.queryLanguage, literal(language.getName()));
+			m.add(implNode, CONFIG.Cgqi.queryLanguage, literal(language.getName()));
 		}
-		addQueryNode(m, implNode, Config.Cgqi.ruleQuery, ruleQuery);
-		addQueryNode(m, implNode, Config.Cgqi.matcherQuery, matcherQuery);
+		addQueryNode(m, implNode, CONFIG.Cgqi.ruleQuery, ruleQuery);
+		addQueryNode(m, implNode, CONFIG.Cgqi.matcherQuery, matcherQuery);
 		return implNode;
 	}
 

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerConfig.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerConfig.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.inferencer.fc.config;
 
+import static org.eclipse.rdf4j.model.util.Values.bnode;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.sail.inferencer.fc.config.CustomGraphQueryInferencerSchema.MATCHER_QUERY;
 import static org.eclipse.rdf4j.sail.inferencer.fc.config.CustomGraphQueryInferencerSchema.QUERY_LANGUAGE;
 import static org.eclipse.rdf4j.sail.inferencer.fc.config.CustomGraphQueryInferencerSchema.RULE_QUERY;
@@ -24,10 +26,10 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
 import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SP;
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -98,25 +100,29 @@ public final class CustomGraphQueryInferencerConfig extends AbstractDelegatingSa
 
 		try {
 
-			Optional<Literal> language = Models.objectLiteral(m.getStatements(implNode, QUERY_LANGUAGE, null));
+			Optional<Literal> language = Configurations.getLiteralValue(m, implNode, Config.Cgqi.queryLanguage,
+					QUERY_LANGUAGE);
 
 			if (language.isPresent()) {
 				setQueryLanguage(QueryLanguage.valueOf(language.get().stringValue()));
 				if (null == getQueryLanguage()) {
 					throw new SailConfigException(
-							"Valid value required for " + QUERY_LANGUAGE + " property, found " + language.get());
+							"Valid value required for " + Config.Cgqi.queryLanguage + " property, found "
+									+ language.get());
 				}
 			} else {
 				setQueryLanguage(QueryLanguage.SPARQL);
 			}
 
-			Optional<Resource> object = Models.objectResource(m.getStatements(implNode, RULE_QUERY, null));
+			Optional<Resource> object = Configurations.getResourceValue(m, implNode, Config.Cgqi.ruleQuery,
+					RULE_QUERY);
 			if (object.isPresent()) {
 				Models.objectLiteral(m.getStatements(object.get(), SP.TEXT_PROPERTY, null))
 						.ifPresent(lit -> setRuleQuery(lit.stringValue()));
 			}
 
-			object = Models.objectResource(m.getStatements(implNode, MATCHER_QUERY, null));
+			object = Configurations.getResourceValue(m, implNode, Config.Cgqi.matcherQuery,
+					MATCHER_QUERY);
 			if (object.isPresent()) {
 				Models.objectLiteral(m.getStatements(object.get(), SP.TEXT_PROPERTY, null))
 						.ifPresent(lit -> setMatcherQuery(lit.stringValue()));
@@ -154,12 +160,11 @@ public final class CustomGraphQueryInferencerConfig extends AbstractDelegatingSa
 	@Override
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
-		m.setNamespace("cgqi", CustomGraphQueryInferencerSchema.NAMESPACE);
 		if (null != language) {
-			m.add(implNode, QUERY_LANGUAGE, SimpleValueFactory.getInstance().createLiteral(language.getName()));
+			m.add(implNode, Config.Cgqi.queryLanguage, literal(language.getName()));
 		}
-		addQueryNode(m, implNode, RULE_QUERY, ruleQuery);
-		addQueryNode(m, implNode, MATCHER_QUERY, matcherQuery);
+		addQueryNode(m, implNode, Config.Cgqi.ruleQuery, ruleQuery);
+		addQueryNode(m, implNode, Config.Cgqi.matcherQuery, matcherQuery);
 		return implNode;
 	}
 
@@ -179,11 +184,10 @@ public final class CustomGraphQueryInferencerConfig extends AbstractDelegatingSa
 
 	private void addQueryNode(Model m, Resource implNode, IRI predicate, String queryText) {
 		if (null != queryText) {
-			ValueFactory factory = SimpleValueFactory.getInstance();
-			BNode queryNode = factory.createBNode();
+			BNode queryNode = bnode();
 			m.add(implNode, predicate, queryNode);
 			m.add(queryNode, RDF.TYPE, SP.CONSTRUCT_CLASS);
-			m.add(queryNode, SP.TEXT_PROPERTY, factory.createLiteral(queryText));
+			m.add(queryNode, SP.TEXT_PROPERTY, literal(queryText));
 		}
 	}
 }

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerSchema.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerSchema.java
@@ -13,12 +13,15 @@ package org.eclipse.rdf4j.sail.inferencer.fc.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.inferencer.fc.CustomGraphQueryInferencer;
 
 /**
  * Configuration schema URI's for {@link CustomGraphQueryInferencer}.
  *
  * @author Dale Visser
+ * 
+ * @deprecated since 4.3.0. Use {@link Config.Cgqi} instead.
  */
 public class CustomGraphQueryInferencerSchema {
 
@@ -30,16 +33,22 @@ public class CustomGraphQueryInferencerSchema {
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#queryLanguage</var>
+	 * 
+	 * @deprecated use {@link Config.Cgqi#queryLanguage} instead.
 	 */
 	public final static IRI QUERY_LANGUAGE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#ruleQuery</var>
+	 * 
+	 * @deprecated use {@link Config.Cgqi#ruleQuery} instead.
 	 */
 	public final static IRI RULE_QUERY;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#matcherQuery</var>
+	 * 
+	 * @deprecated use {@link Config.Cgqi#matcherQuery} instead.
 	 */
 	public final static IRI MATCHER_QUERY;
 

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerSchema.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.inferencer.fc.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.inferencer.fc.CustomGraphQueryInferencer;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.sail.inferencer.fc.CustomGraphQueryInferencer;
  *
  * @author Dale Visser
  * 
- * @deprecated since 4.3.0. Use {@link Config.Cgqi} instead.
+ * @deprecated since 4.3.0. Use {@link CONFIG.Cgqi} instead.
  */
 public class CustomGraphQueryInferencerSchema {
 
@@ -34,21 +34,21 @@ public class CustomGraphQueryInferencerSchema {
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#queryLanguage</var>
 	 * 
-	 * @deprecated use {@link Config.Cgqi#queryLanguage} instead.
+	 * @deprecated use {@link CONFIG.Cgqi#queryLanguage} instead.
 	 */
 	public final static IRI QUERY_LANGUAGE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#ruleQuery</var>
 	 * 
-	 * @deprecated use {@link Config.Cgqi#ruleQuery} instead.
+	 * @deprecated use {@link CONFIG.Cgqi#ruleQuery} instead.
 	 */
 	public final static IRI RULE_QUERY;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#matcherQuery</var>
 	 * 
-	 * @deprecated use {@link Config.Cgqi#matcherQuery} instead.
+	 * @deprecated use {@link CONFIG.Cgqi#matcherQuery} instead.
 	 */
 	public final static IRI MATCHER_QUERY;
 

--- a/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerSchema.java
+++ b/core/sail/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/CustomGraphQueryInferencerSchema.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.sail.inferencer.fc.CustomGraphQueryInferencer;
  * Configuration schema URI's for {@link CustomGraphQueryInferencer}.
  *
  * @author Dale Visser
- * 
+ *
  * @deprecated since 4.3.0. Use {@link CONFIG.Cgqi} instead.
  */
 public class CustomGraphQueryInferencerSchema {
@@ -33,21 +33,21 @@ public class CustomGraphQueryInferencerSchema {
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#queryLanguage</var>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Cgqi#queryLanguage} instead.
 	 */
 	public final static IRI QUERY_LANGUAGE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#ruleQuery</var>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Cgqi#ruleQuery} instead.
 	 */
 	public final static IRI RULE_QUERY;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/customGraphQueryInferencer#matcherQuery</var>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Cgqi#matcherQuery} instead.
 	 */
 	public final static IRI MATCHER_QUERY;

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/AbstractLuceneSailConfig.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/AbstractLuceneSailConfig.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.config.AbstractDelegatingSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.eclipse.rdf4j.sail.config.SailImplConfig;
@@ -89,11 +89,11 @@ public abstract class AbstractLuceneSailConfig extends AbstractDelegatingSailImp
 		Resource implNode = super.export(m);
 
 		if (indexDir != null) {
-			m.add(implNode, Config.Lucene.indexDir, literal(indexDir));
+			m.add(implNode, CONFIG.Lucene.indexDir, literal(indexDir));
 		}
 
 		for (String key : getParameterNames()) {
-			m.add(implNode, iri(Config.NAMESPACE, PARAMETER_PREFIX + key), literal(getParameter(key)));
+			m.add(implNode, iri(CONFIG.NAMESPACE, PARAMETER_PREFIX + key), literal(getParameter(key)));
 		}
 
 		return implNode;
@@ -103,13 +103,13 @@ public abstract class AbstractLuceneSailConfig extends AbstractDelegatingSailImp
 	public void parse(Model graph, Resource implNode) throws SailConfigException {
 		super.parse(graph, implNode);
 
-		Literal indexDirLit = Configurations.getLiteralValue(graph, implNode, Config.Lucene.indexDir, INDEX_DIR)
-				.orElseThrow(() -> new SailConfigException("no value found for " + Config.Lucene.indexDir));
+		Literal indexDirLit = Configurations.getLiteralValue(graph, implNode, CONFIG.Lucene.indexDir, INDEX_DIR)
+				.orElseThrow(() -> new SailConfigException("no value found for " + CONFIG.Lucene.indexDir));
 
 		setIndexDir(indexDirLit.getLabel());
 
 		for (Statement stmt : graph.getStatements(implNode, null, null)) {
-			if (stmt.getPredicate().getNamespace().equals(Config.NAMESPACE)
+			if (stmt.getPredicate().getNamespace().equals(CONFIG.NAMESPACE)
 					|| stmt.getPredicate().getNamespace().equals(LuceneSailConfigSchema.NAMESPACE)) {
 				if (stmt.getObject().isLiteral()) {
 					String key = stmt.getPredicate().getLocalName();

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/AbstractLuceneSailConfig.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/AbstractLuceneSailConfig.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.config.AbstractDelegatingSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.eclipse.rdf4j.sail.config.SailImplConfig;
@@ -89,11 +89,11 @@ public abstract class AbstractLuceneSailConfig extends AbstractDelegatingSailImp
 		Resource implNode = super.export(m);
 
 		if (indexDir != null) {
-			m.add(implNode, CONFIG.Lucene.indexDir, literal(indexDir));
+			m.add(implNode, Config.Lucene.indexDir, literal(indexDir));
 		}
 
 		for (String key : getParameterNames()) {
-			m.add(implNode, iri(CONFIG.NAMESPACE, PARAMETER_PREFIX + key), literal(getParameter(key)));
+			m.add(implNode, iri(Config.NAMESPACE, PARAMETER_PREFIX + key), literal(getParameter(key)));
 		}
 
 		return implNode;
@@ -103,13 +103,13 @@ public abstract class AbstractLuceneSailConfig extends AbstractDelegatingSailImp
 	public void parse(Model graph, Resource implNode) throws SailConfigException {
 		super.parse(graph, implNode);
 
-		Literal indexDirLit = Configurations.getLiteralValue(graph, implNode, CONFIG.Lucene.indexDir, INDEX_DIR)
-				.orElseThrow(() -> new SailConfigException("no value found for " + CONFIG.Lucene.indexDir));
+		Literal indexDirLit = Configurations.getLiteralValue(graph, implNode, Config.Lucene.indexDir, INDEX_DIR)
+				.orElseThrow(() -> new SailConfigException("no value found for " + Config.Lucene.indexDir));
 
 		setIndexDir(indexDirLit.getLabel());
 
 		for (Statement stmt : graph.getStatements(implNode, null, null)) {
-			if (stmt.getPredicate().getNamespace().equals(CONFIG.NAMESPACE)
+			if (stmt.getPredicate().getNamespace().equals(Config.NAMESPACE)
 					|| stmt.getPredicate().getNamespace().equals(LuceneSailConfigSchema.NAMESPACE)) {
 				if (stmt.getObject().isLiteral()) {
 					String key = stmt.getPredicate().getLocalName();

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/AbstractLuceneSailConfig.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/AbstractLuceneSailConfig.java
@@ -88,6 +88,7 @@ public abstract class AbstractLuceneSailConfig extends AbstractDelegatingSailImp
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
 
+		m.setNamespace(CONFIG.NS);
 		if (indexDir != null) {
 			m.add(implNode, CONFIG.Lucene.indexDir, literal(indexDir));
 		}

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/LuceneSailConfigSchema.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/LuceneSailConfigSchema.java
@@ -13,12 +13,16 @@ package org.eclipse.rdf4j.sail.lucene.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 
 /**
  * Defines constants for the LuceneSail schema which is used by
  * {@link org.eclipse.rdf4j.sail.lucene.config.LuceneSailFactory}s to initialize {@link LuceneSail}s.
+ *
+ * @deprecated use {@link CONFIG.Lucene} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class LuceneSailConfigSchema {
 
 	/**
@@ -26,6 +30,9 @@ public class LuceneSailConfigSchema {
 	 */
 	public static final String NAMESPACE = "http://www.openrdf.org/config/sail/lucene#";
 
+	/**
+	 * @deprecated use {@link CONFIG.Lucene#indexDir} instead.
+	 */
 	public static final IRI INDEX_DIR;
 
 	static {

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/LuceneSailConfigSchema.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/LuceneSailConfigSchema.java
@@ -13,14 +13,14 @@ package org.eclipse.rdf4j.sail.lucene.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 
 /**
  * Defines constants for the LuceneSail schema which is used by
  * {@link org.eclipse.rdf4j.sail.lucene.config.LuceneSailFactory}s to initialize {@link LuceneSail}s.
  *
- * @deprecated use {@link CONFIG.Lucene} instead.
+ * @deprecated use {@link Config.Lucene} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class LuceneSailConfigSchema {
@@ -31,7 +31,7 @@ public class LuceneSailConfigSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/sail/lucene#";
 
 	/**
-	 * @deprecated use {@link CONFIG.Lucene#indexDir} instead.
+	 * @deprecated use {@link Config.Lucene#indexDir} instead.
 	 */
 	public static final IRI INDEX_DIR;
 

--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/LuceneSailConfigSchema.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/config/LuceneSailConfigSchema.java
@@ -13,14 +13,14 @@ package org.eclipse.rdf4j.sail.lucene.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 
 /**
  * Defines constants for the LuceneSail schema which is used by
  * {@link org.eclipse.rdf4j.sail.lucene.config.LuceneSailFactory}s to initialize {@link LuceneSail}s.
  *
- * @deprecated use {@link Config.Lucene} instead.
+ * @deprecated use {@link CONFIG.Lucene} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class LuceneSailConfigSchema {
@@ -31,7 +31,7 @@ public class LuceneSailConfigSchema {
 	public static final String NAMESPACE = "http://www.openrdf.org/config/sail/lucene#";
 
 	/**
-	 * @deprecated use {@link Config.Lucene#indexDir} instead.
+	 * @deprecated use {@link CONFIG.Lucene#indexDir} instead.
 	 */
 	public static final IRI INDEX_DIR;
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -67,11 +67,11 @@ public class MemoryStoreConfig extends BaseSailConfig {
 		Resource implNode = super.export(graph);
 
 		if (persist) {
-			graph.add(implNode, CONFIG.Mem.persist, BooleanLiteral.TRUE);
+			graph.add(implNode, Config.Mem.persist, BooleanLiteral.TRUE);
 		}
 
 		if (syncDelay != 0) {
-			graph.add(implNode, CONFIG.Mem.syncDelay, literal(syncDelay));
+			graph.add(implNode, Config.Mem.syncDelay, literal(syncDelay));
 		}
 
 		return implNode;
@@ -83,22 +83,22 @@ public class MemoryStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Configurations.getLiteralValue(graph, implNode, CONFIG.Mem.persist, PERSIST).ifPresent(persistValue -> {
+			Configurations.getLiteralValue(graph, implNode, Config.Mem.persist, PERSIST).ifPresent(persistValue -> {
 				try {
 					setPersist((persistValue).booleanValue());
 				} catch (IllegalArgumentException e) {
 					throw new SailConfigException(
-							"Boolean value required for " + CONFIG.Mem.persist + " property, found " + persistValue);
+							"Boolean value required for " + Config.Mem.persist + " property, found " + persistValue);
 				}
 			});
 
-			Configurations.getLiteralValue(graph, implNode, CONFIG.Mem.syncDelay, SYNC_DELAY)
+			Configurations.getLiteralValue(graph, implNode, Config.Mem.syncDelay, SYNC_DELAY)
 					.ifPresent(syncDelayValue -> {
 						try {
 							setSyncDelay((syncDelayValue).longValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Long integer value required for " + CONFIG.Mem.syncDelay + " property, found "
+									"Long integer value required for " + Config.Mem.syncDelay + " property, found "
 											+ syncDelayValue);
 						}
 					});

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
@@ -94,14 +94,14 @@ public class MemoryStoreConfig extends BaseSailConfig {
 
 			Configurations.getLiteralValue(graph, implNode, CONFIG.Mem.syncDelay, SYNC_DELAY)
 					.ifPresent(syncDelayValue -> {
-				try {
-					setSyncDelay((syncDelayValue).longValue());
-				} catch (NumberFormatException e) {
-					throw new SailConfigException(
+						try {
+							setSyncDelay((syncDelayValue).longValue());
+						} catch (NumberFormatException e) {
+							throw new SailConfigException(
 									"Long integer value required for " + CONFIG.Mem.syncDelay + " property, found "
-									+ syncDelayValue);
-				}
-			});
+											+ syncDelayValue);
+						}
+					});
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);
 		}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
@@ -10,16 +10,16 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory.config;
 
-import static org.eclipse.rdf4j.sail.memory.config.MemoryStoreSchema.NAMESPACE;
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.sail.memory.config.MemoryStoreSchema.PERSIST;
 import static org.eclipse.rdf4j.sail.memory.config.MemoryStoreSchema.SYNC_DELAY;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -66,13 +66,12 @@ public class MemoryStoreConfig extends BaseSailConfig {
 	public Resource export(Model graph) {
 		Resource implNode = super.export(graph);
 
-		graph.setNamespace("ms", NAMESPACE);
 		if (persist) {
-			graph.add(implNode, PERSIST, BooleanLiteral.TRUE);
+			graph.add(implNode, CONFIG.Mem.persist, BooleanLiteral.TRUE);
 		}
 
 		if (syncDelay != 0) {
-			graph.add(implNode, SYNC_DELAY, SimpleValueFactory.getInstance().createLiteral(syncDelay));
+			graph.add(implNode, CONFIG.Mem.syncDelay, literal(syncDelay));
 		}
 
 		return implNode;
@@ -84,21 +83,23 @@ public class MemoryStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Models.objectLiteral(graph.getStatements(implNode, PERSIST, null)).ifPresent(persistValue -> {
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Mem.persist, PERSIST).ifPresent(persistValue -> {
 				try {
 					setPersist((persistValue).booleanValue());
 				} catch (IllegalArgumentException e) {
 					throw new SailConfigException(
-							"Boolean value required for " + PERSIST + " property, found " + persistValue);
+							"Boolean value required for " + CONFIG.Mem.persist + " property, found " + persistValue);
 				}
 			});
 
-			Models.objectLiteral(graph.getStatements(implNode, SYNC_DELAY, null)).ifPresent(syncDelayValue -> {
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Mem.syncDelay, SYNC_DELAY)
+					.ifPresent(syncDelayValue -> {
 				try {
 					setSyncDelay((syncDelayValue).longValue());
 				} catch (NumberFormatException e) {
 					throw new SailConfigException(
-							"Long integer value required for " + SYNC_DELAY + " property, found " + syncDelayValue);
+									"Long integer value required for " + CONFIG.Mem.syncDelay + " property, found "
+									+ syncDelayValue);
 				}
 			});
 		} catch (ModelException e) {

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
@@ -65,6 +65,7 @@ public class MemoryStoreConfig extends BaseSailConfig {
 	@Override
 	public Resource export(Model graph) {
 		Resource implNode = super.export(graph);
+		graph.setNamespace(CONFIG.NS);
 
 		if (persist) {
 			graph.add(implNode, CONFIG.Mem.persist, BooleanLiteral.TRUE);

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreConfig.java
@@ -19,7 +19,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -67,11 +67,11 @@ public class MemoryStoreConfig extends BaseSailConfig {
 		Resource implNode = super.export(graph);
 
 		if (persist) {
-			graph.add(implNode, Config.Mem.persist, BooleanLiteral.TRUE);
+			graph.add(implNode, CONFIG.Mem.persist, BooleanLiteral.TRUE);
 		}
 
 		if (syncDelay != 0) {
-			graph.add(implNode, Config.Mem.syncDelay, literal(syncDelay));
+			graph.add(implNode, CONFIG.Mem.syncDelay, literal(syncDelay));
 		}
 
 		return implNode;
@@ -83,22 +83,22 @@ public class MemoryStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Configurations.getLiteralValue(graph, implNode, Config.Mem.persist, PERSIST).ifPresent(persistValue -> {
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Mem.persist, PERSIST).ifPresent(persistValue -> {
 				try {
 					setPersist((persistValue).booleanValue());
 				} catch (IllegalArgumentException e) {
 					throw new SailConfigException(
-							"Boolean value required for " + Config.Mem.persist + " property, found " + persistValue);
+							"Boolean value required for " + CONFIG.Mem.persist + " property, found " + persistValue);
 				}
 			});
 
-			Configurations.getLiteralValue(graph, implNode, Config.Mem.syncDelay, SYNC_DELAY)
+			Configurations.getLiteralValue(graph, implNode, CONFIG.Mem.syncDelay, SYNC_DELAY)
 					.ifPresent(syncDelayValue -> {
 						try {
 							setSyncDelay((syncDelayValue).longValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Long integer value required for " + Config.Mem.syncDelay + " property, found "
+									"Long integer value required for " + CONFIG.Mem.syncDelay + " property, found "
 											+ syncDelayValue);
 						}
 					});

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreSchema.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.memory.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
  * {@link MemoryStore}s.
  *
  * @author Arjohn Kampman
- * @deprecated use {@link Config.Mem} instead.
+ * @deprecated use {@link CONFIG.Mem} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class MemoryStoreSchema {
@@ -34,14 +34,14 @@ public class MemoryStoreSchema {
 	/**
 	 * <var>http://www.openrdf.org/config/sail/memory#persist</var>
 	 *
-	 * @deprecated use {@link Config.Mem#persist} instead.
+	 * @deprecated use {@link CONFIG.Mem#persist} instead.
 	 */
 	public final static IRI PERSIST;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/memory#syncDelay</var>
 	 *
-	 * @deprecated use {@link Config.Mem#syncDelay} instead.
+	 * @deprecated use {@link CONFIG.Mem#syncDelay} instead.
 	 */
 	public final static IRI SYNC_DELAY;
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreSchema.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.memory.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
  * {@link MemoryStore}s.
  *
  * @author Arjohn Kampman
- * @deprecated use {@link CONFIG.Mem} instead.
+ * @deprecated use {@link Config.Mem} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class MemoryStoreSchema {
@@ -34,14 +34,14 @@ public class MemoryStoreSchema {
 	/**
 	 * <var>http://www.openrdf.org/config/sail/memory#persist</var>
 	 *
-	 * @deprecated use {@link CONFIG.Mem#persist} instead.
+	 * @deprecated use {@link Config.Mem#persist} instead.
 	 */
 	public final static IRI PERSIST;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/memory#syncDelay</var>
 	 *
-	 * @deprecated use {@link CONFIG.Mem#syncDelay} instead.
+	 * @deprecated use {@link Config.Mem#syncDelay} instead.
 	 */
 	public final static IRI SYNC_DELAY;
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreSchema.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreSchema.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sail.memory.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 /**
@@ -20,7 +21,9 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
  * {@link MemoryStore}s.
  *
  * @author Arjohn Kampman
+ * @deprecated use {@link CONFIG.Mem} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class MemoryStoreSchema {
 
 	/**
@@ -30,11 +33,15 @@ public class MemoryStoreSchema {
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/memory#persist</var>
+	 *
+	 * @deprecated use {@link CONFIG.Mem#persist} instead.
 	 */
 	public final static IRI PERSIST;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/memory#syncDelay</var>
+	 * 
+	 * @deprecated use {@link CONFIG.Mem#syncDelay} instead.
 	 */
 	public final static IRI SYNC_DELAY;
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreSchema.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/config/MemoryStoreSchema.java
@@ -40,7 +40,7 @@ public class MemoryStoreSchema {
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/memory#syncDelay</var>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Mem#syncDelay} instead.
 	 */
 	public final static IRI SYNC_DELAY;

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf.config;
 
+import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.FORCE_SYNC;
-import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.NAMESPACE;
 import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.NAMESPACE_CACHE_SIZE;
 import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.NAMESPACE_ID_CACHE_SIZE;
 import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.TRIPLE_INDEXES;
@@ -20,10 +20,9 @@ import static org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreSchema.VALUE_ID
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -121,26 +120,24 @@ public class NativeStoreConfig extends BaseSailConfig {
 	@Override
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
-		ValueFactory vf = SimpleValueFactory.getInstance();
 
-		m.setNamespace("ns", NAMESPACE);
 		if (tripleIndexes != null) {
-			m.add(implNode, TRIPLE_INDEXES, vf.createLiteral(tripleIndexes));
+			m.add(implNode, CONFIG.Native.tripleIndexes, literal(tripleIndexes));
 		}
 		if (forceSync) {
-			m.add(implNode, FORCE_SYNC, vf.createLiteral(forceSync));
+			m.add(implNode, CONFIG.Native.forceSync, literal(forceSync));
 		}
 		if (valueCacheSize >= 0) {
-			m.add(implNode, VALUE_CACHE_SIZE, vf.createLiteral(valueCacheSize));
+			m.add(implNode, CONFIG.Native.valueCacheSize, literal(valueCacheSize));
 		}
 		if (valueIDCacheSize >= 0) {
-			m.add(implNode, VALUE_ID_CACHE_SIZE, vf.createLiteral(valueIDCacheSize));
+			m.add(implNode, CONFIG.Native.valueIDCacheSize, literal(valueIDCacheSize));
 		}
 		if (namespaceCacheSize >= 0) {
-			m.add(implNode, NAMESPACE_CACHE_SIZE, vf.createLiteral(namespaceCacheSize));
+			m.add(implNode, CONFIG.Native.namespaceCacheSize, literal(namespaceCacheSize));
 		}
 		if (namespaceIDCacheSize >= 0) {
-			m.add(implNode, NAMESPACE_ID_CACHE_SIZE, vf.createLiteral(namespaceIDCacheSize));
+			m.add(implNode, CONFIG.Native.namespaceIDCacheSize, literal(namespaceIDCacheSize));
 		}
 
 		return implNode;
@@ -152,52 +149,63 @@ public class NativeStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Models.objectLiteral(m.getStatements(implNode, TRIPLE_INDEXES, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.tripleIndexes, TRIPLE_INDEXES)
 					.ifPresent(lit -> setTripleIndexes(lit.getLabel()));
-			Models.objectLiteral(m.getStatements(implNode, FORCE_SYNC, null)).ifPresent(lit -> {
-				try {
-					setForceSync(lit.booleanValue());
-				} catch (IllegalArgumentException e) {
-					throw new SailConfigException(
-							"Boolean value required for " + FORCE_SYNC + " property, found " + lit);
-				}
-			});
 
-			Models.objectLiteral(m.getStatements(implNode, VALUE_CACHE_SIZE, null)).ifPresent(lit -> {
-				try {
-					setValueCacheSize(lit.intValue());
-				} catch (NumberFormatException e) {
-					throw new SailConfigException(
-							"Integer value required for " + VALUE_CACHE_SIZE + " property, found " + lit);
-				}
-			});
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.forceSync, FORCE_SYNC)
+					.ifPresent(lit -> {
+						try {
+							setForceSync(lit.booleanValue());
+						} catch (IllegalArgumentException e) {
+							throw new SailConfigException(
+									"Boolean value required for " + CONFIG.Native.forceSync + " property, found "
+											+ lit);
+						}
+					});
 
-			Models.objectLiteral(m.getStatements(implNode, VALUE_ID_CACHE_SIZE, null)).ifPresent(lit -> {
-				try {
-					setValueIDCacheSize(lit.intValue());
-				} catch (NumberFormatException e) {
-					throw new SailConfigException(
-							"Integer value required for " + VALUE_ID_CACHE_SIZE + " property, found " + lit);
-				}
-			});
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.valueCacheSize, VALUE_CACHE_SIZE)
+					.ifPresent(lit -> {
+						try {
+							setValueCacheSize(lit.intValue());
+						} catch (NumberFormatException e) {
+							throw new SailConfigException(
+									"Integer value required for " + CONFIG.Native.valueCacheSize + " property, found "
+											+ lit);
+						}
+					});
 
-			Models.objectLiteral(m.getStatements(implNode, NAMESPACE_CACHE_SIZE, null)).ifPresent(lit -> {
-				try {
-					setNamespaceCacheSize(lit.intValue());
-				} catch (NumberFormatException e) {
-					throw new SailConfigException(
-							"Integer value required for " + NAMESPACE_CACHE_SIZE + " property, found " + lit);
-				}
-			});
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.valueIDCacheSize, VALUE_ID_CACHE_SIZE)
+					.ifPresent(lit -> {
+						try {
+							setValueIDCacheSize(lit.intValue());
+						} catch (NumberFormatException e) {
+							throw new SailConfigException(
+									"Integer value required for " + CONFIG.Native.valueIDCacheSize + " property, found "
+											+ lit);
+						}
+					});
 
-			Models.objectLiteral(m.getStatements(implNode, NAMESPACE_ID_CACHE_SIZE, null)).ifPresent(lit -> {
-				try {
-					setNamespaceIDCacheSize(lit.intValue());
-				} catch (NumberFormatException e) {
-					throw new SailConfigException(
-							"Integer value required for " + NAMESPACE_ID_CACHE_SIZE + " property, found " + lit);
-				}
-			});
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.namespaceCacheSize, NAMESPACE_CACHE_SIZE)
+					.ifPresent(lit -> {
+						try {
+							setNamespaceCacheSize(lit.intValue());
+						} catch (NumberFormatException e) {
+							throw new SailConfigException(
+									"Integer value required for " + CONFIG.Native.namespaceCacheSize
+											+ " property, found " + lit);
+						}
+					});
+
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.namespaceIDCacheSize, NAMESPACE_ID_CACHE_SIZE)
+					.ifPresent(lit -> {
+						try {
+							setNamespaceIDCacheSize(lit.intValue());
+						} catch (NumberFormatException e) {
+							throw new SailConfigException(
+									"Integer value required for " + CONFIG.Native.namespaceIDCacheSize
+											+ " property, found " + lit);
+						}
+					});
 		} catch (ModelException e) {
 			throw new SailConfigException(e.getMessage(), e);
 		}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -122,22 +122,22 @@ public class NativeStoreConfig extends BaseSailConfig {
 		Resource implNode = super.export(m);
 
 		if (tripleIndexes != null) {
-			m.add(implNode, Config.Native.tripleIndexes, literal(tripleIndexes));
+			m.add(implNode, CONFIG.Native.tripleIndexes, literal(tripleIndexes));
 		}
 		if (forceSync) {
-			m.add(implNode, Config.Native.forceSync, literal(forceSync));
+			m.add(implNode, CONFIG.Native.forceSync, literal(forceSync));
 		}
 		if (valueCacheSize >= 0) {
-			m.add(implNode, Config.Native.valueCacheSize, literal(valueCacheSize));
+			m.add(implNode, CONFIG.Native.valueCacheSize, literal(valueCacheSize));
 		}
 		if (valueIDCacheSize >= 0) {
-			m.add(implNode, Config.Native.valueIDCacheSize, literal(valueIDCacheSize));
+			m.add(implNode, CONFIG.Native.valueIDCacheSize, literal(valueIDCacheSize));
 		}
 		if (namespaceCacheSize >= 0) {
-			m.add(implNode, Config.Native.namespaceCacheSize, literal(namespaceCacheSize));
+			m.add(implNode, CONFIG.Native.namespaceCacheSize, literal(namespaceCacheSize));
 		}
 		if (namespaceIDCacheSize >= 0) {
-			m.add(implNode, Config.Native.namespaceIDCacheSize, literal(namespaceIDCacheSize));
+			m.add(implNode, CONFIG.Native.namespaceIDCacheSize, literal(namespaceIDCacheSize));
 		}
 
 		return implNode;
@@ -149,60 +149,60 @@ public class NativeStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Configurations.getLiteralValue(m, implNode, Config.Native.tripleIndexes, TRIPLE_INDEXES)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.tripleIndexes, TRIPLE_INDEXES)
 					.ifPresent(lit -> setTripleIndexes(lit.getLabel()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Native.forceSync, FORCE_SYNC)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.forceSync, FORCE_SYNC)
 					.ifPresent(lit -> {
 						try {
 							setForceSync(lit.booleanValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"Boolean value required for " + Config.Native.forceSync + " property, found "
+									"Boolean value required for " + CONFIG.Native.forceSync + " property, found "
 											+ lit);
 						}
 					});
 
-			Configurations.getLiteralValue(m, implNode, Config.Native.valueCacheSize, VALUE_CACHE_SIZE)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.valueCacheSize, VALUE_CACHE_SIZE)
 					.ifPresent(lit -> {
 						try {
 							setValueCacheSize(lit.intValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Integer value required for " + Config.Native.valueCacheSize + " property, found "
+									"Integer value required for " + CONFIG.Native.valueCacheSize + " property, found "
 											+ lit);
 						}
 					});
 
-			Configurations.getLiteralValue(m, implNode, Config.Native.valueIDCacheSize, VALUE_ID_CACHE_SIZE)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.valueIDCacheSize, VALUE_ID_CACHE_SIZE)
 					.ifPresent(lit -> {
 						try {
 							setValueIDCacheSize(lit.intValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Integer value required for " + Config.Native.valueIDCacheSize + " property, found "
+									"Integer value required for " + CONFIG.Native.valueIDCacheSize + " property, found "
 											+ lit);
 						}
 					});
 
-			Configurations.getLiteralValue(m, implNode, Config.Native.namespaceCacheSize, NAMESPACE_CACHE_SIZE)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.namespaceCacheSize, NAMESPACE_CACHE_SIZE)
 					.ifPresent(lit -> {
 						try {
 							setNamespaceCacheSize(lit.intValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Integer value required for " + Config.Native.namespaceCacheSize
+									"Integer value required for " + CONFIG.Native.namespaceCacheSize
 											+ " property, found " + lit);
 						}
 					});
 
-			Configurations.getLiteralValue(m, implNode, Config.Native.namespaceIDCacheSize, NAMESPACE_ID_CACHE_SIZE)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Native.namespaceIDCacheSize, NAMESPACE_ID_CACHE_SIZE)
 					.ifPresent(lit -> {
 						try {
 							setNamespaceIDCacheSize(lit.intValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Integer value required for " + Config.Native.namespaceIDCacheSize
+									"Integer value required for " + CONFIG.Native.namespaceIDCacheSize
 											+ " property, found " + lit);
 						}
 					});

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Configurations;
 import org.eclipse.rdf4j.model.util.ModelException;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.base.config.BaseSailConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 
@@ -122,22 +122,22 @@ public class NativeStoreConfig extends BaseSailConfig {
 		Resource implNode = super.export(m);
 
 		if (tripleIndexes != null) {
-			m.add(implNode, CONFIG.Native.tripleIndexes, literal(tripleIndexes));
+			m.add(implNode, Config.Native.tripleIndexes, literal(tripleIndexes));
 		}
 		if (forceSync) {
-			m.add(implNode, CONFIG.Native.forceSync, literal(forceSync));
+			m.add(implNode, Config.Native.forceSync, literal(forceSync));
 		}
 		if (valueCacheSize >= 0) {
-			m.add(implNode, CONFIG.Native.valueCacheSize, literal(valueCacheSize));
+			m.add(implNode, Config.Native.valueCacheSize, literal(valueCacheSize));
 		}
 		if (valueIDCacheSize >= 0) {
-			m.add(implNode, CONFIG.Native.valueIDCacheSize, literal(valueIDCacheSize));
+			m.add(implNode, Config.Native.valueIDCacheSize, literal(valueIDCacheSize));
 		}
 		if (namespaceCacheSize >= 0) {
-			m.add(implNode, CONFIG.Native.namespaceCacheSize, literal(namespaceCacheSize));
+			m.add(implNode, Config.Native.namespaceCacheSize, literal(namespaceCacheSize));
 		}
 		if (namespaceIDCacheSize >= 0) {
-			m.add(implNode, CONFIG.Native.namespaceIDCacheSize, literal(namespaceIDCacheSize));
+			m.add(implNode, Config.Native.namespaceIDCacheSize, literal(namespaceIDCacheSize));
 		}
 
 		return implNode;
@@ -149,60 +149,60 @@ public class NativeStoreConfig extends BaseSailConfig {
 
 		try {
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Native.tripleIndexes, TRIPLE_INDEXES)
+			Configurations.getLiteralValue(m, implNode, Config.Native.tripleIndexes, TRIPLE_INDEXES)
 					.ifPresent(lit -> setTripleIndexes(lit.getLabel()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Native.forceSync, FORCE_SYNC)
+			Configurations.getLiteralValue(m, implNode, Config.Native.forceSync, FORCE_SYNC)
 					.ifPresent(lit -> {
 						try {
 							setForceSync(lit.booleanValue());
 						} catch (IllegalArgumentException e) {
 							throw new SailConfigException(
-									"Boolean value required for " + CONFIG.Native.forceSync + " property, found "
+									"Boolean value required for " + Config.Native.forceSync + " property, found "
 											+ lit);
 						}
 					});
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Native.valueCacheSize, VALUE_CACHE_SIZE)
+			Configurations.getLiteralValue(m, implNode, Config.Native.valueCacheSize, VALUE_CACHE_SIZE)
 					.ifPresent(lit -> {
 						try {
 							setValueCacheSize(lit.intValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Integer value required for " + CONFIG.Native.valueCacheSize + " property, found "
+									"Integer value required for " + Config.Native.valueCacheSize + " property, found "
 											+ lit);
 						}
 					});
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Native.valueIDCacheSize, VALUE_ID_CACHE_SIZE)
+			Configurations.getLiteralValue(m, implNode, Config.Native.valueIDCacheSize, VALUE_ID_CACHE_SIZE)
 					.ifPresent(lit -> {
 						try {
 							setValueIDCacheSize(lit.intValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Integer value required for " + CONFIG.Native.valueIDCacheSize + " property, found "
+									"Integer value required for " + Config.Native.valueIDCacheSize + " property, found "
 											+ lit);
 						}
 					});
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Native.namespaceCacheSize, NAMESPACE_CACHE_SIZE)
+			Configurations.getLiteralValue(m, implNode, Config.Native.namespaceCacheSize, NAMESPACE_CACHE_SIZE)
 					.ifPresent(lit -> {
 						try {
 							setNamespaceCacheSize(lit.intValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Integer value required for " + CONFIG.Native.namespaceCacheSize
+									"Integer value required for " + Config.Native.namespaceCacheSize
 											+ " property, found " + lit);
 						}
 					});
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Native.namespaceIDCacheSize, NAMESPACE_ID_CACHE_SIZE)
+			Configurations.getLiteralValue(m, implNode, Config.Native.namespaceIDCacheSize, NAMESPACE_ID_CACHE_SIZE)
 					.ifPresent(lit -> {
 						try {
 							setNamespaceIDCacheSize(lit.intValue());
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
-									"Integer value required for " + CONFIG.Native.namespaceIDCacheSize
+									"Integer value required for " + Config.Native.namespaceIDCacheSize
 											+ " property, found " + lit);
 						}
 					});

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreConfig.java
@@ -120,6 +120,7 @@ public class NativeStoreConfig extends BaseSailConfig {
 	@Override
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
+		m.setNamespace(CONFIG.NS);
 
 		if (tripleIndexes != null) {
 			m.add(implNode, CONFIG.Native.tripleIndexes, literal(tripleIndexes));

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreSchema.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreSchema.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sail.nativerdf.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 
 /**
@@ -20,7 +21,9 @@ import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
  * {@link NativeStore}s.
  *
  * @author Arjohn Kampman
+ * @deprecated use {@link CONFIG.Native} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class NativeStoreSchema {
 
 	/**
@@ -30,31 +33,43 @@ public class NativeStoreSchema {
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#tripleIndexes</var>
+	 *
+	 * @deprecated use {@link CONFIG.Native#tripleIndexes} instead.
 	 */
 	public final static IRI TRIPLE_INDEXES;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#forceSync</var>
+	 *
+	 * @deprecated use {@link CONFIG.Native#forceSync} instead.
 	 */
 	public final static IRI FORCE_SYNC;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#valueCacheSize</var>
+	 *
+	 * @deprecated use {@link CONFIG.Native#valueCacheSize} instead.
 	 */
 	public final static IRI VALUE_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#valueIDCacheSize</var>
+	 *
+	 * @deprecated use {@link CONFIG.Native#valueIDCacheSize} instead.
 	 */
 	public final static IRI VALUE_ID_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#namespaceCacheSize</var>
+	 *
+	 * @deprecated use {@link CONFIG.Native#namespaceCacheSize} instead.
 	 */
 	public final static IRI NAMESPACE_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#namespaceIDCacheSize</var>
+	 *
+	 * @deprecated use {@link CONFIG.Native#namespaceIDCacheSize} instead.
 	 */
 	public final static IRI NAMESPACE_ID_CACHE_SIZE;
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreSchema.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.nativerdf.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
  * {@link NativeStore}s.
  *
  * @author Arjohn Kampman
- * @deprecated use {@link CONFIG.Native} instead.
+ * @deprecated use {@link Config.Native} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class NativeStoreSchema {
@@ -34,42 +34,42 @@ public class NativeStoreSchema {
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#tripleIndexes</var>
 	 *
-	 * @deprecated use {@link CONFIG.Native#tripleIndexes} instead.
+	 * @deprecated use {@link Config.Native#tripleIndexes} instead.
 	 */
 	public final static IRI TRIPLE_INDEXES;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#forceSync</var>
 	 *
-	 * @deprecated use {@link CONFIG.Native#forceSync} instead.
+	 * @deprecated use {@link Config.Native#forceSync} instead.
 	 */
 	public final static IRI FORCE_SYNC;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#valueCacheSize</var>
 	 *
-	 * @deprecated use {@link CONFIG.Native#valueCacheSize} instead.
+	 * @deprecated use {@link Config.Native#valueCacheSize} instead.
 	 */
 	public final static IRI VALUE_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#valueIDCacheSize</var>
 	 *
-	 * @deprecated use {@link CONFIG.Native#valueIDCacheSize} instead.
+	 * @deprecated use {@link Config.Native#valueIDCacheSize} instead.
 	 */
 	public final static IRI VALUE_ID_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#namespaceCacheSize</var>
 	 *
-	 * @deprecated use {@link CONFIG.Native#namespaceCacheSize} instead.
+	 * @deprecated use {@link Config.Native#namespaceCacheSize} instead.
 	 */
 	public final static IRI NAMESPACE_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#namespaceIDCacheSize</var>
 	 *
-	 * @deprecated use {@link CONFIG.Native#namespaceIDCacheSize} instead.
+	 * @deprecated use {@link Config.Native#namespaceIDCacheSize} instead.
 	 */
 	public final static IRI NAMESPACE_ID_CACHE_SIZE;
 

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreSchema.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/config/NativeStoreSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.nativerdf.config;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 
 /**
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
  * {@link NativeStore}s.
  *
  * @author Arjohn Kampman
- * @deprecated use {@link Config.Native} instead.
+ * @deprecated use {@link CONFIG.Native} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class NativeStoreSchema {
@@ -34,42 +34,42 @@ public class NativeStoreSchema {
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#tripleIndexes</var>
 	 *
-	 * @deprecated use {@link Config.Native#tripleIndexes} instead.
+	 * @deprecated use {@link CONFIG.Native#tripleIndexes} instead.
 	 */
 	public final static IRI TRIPLE_INDEXES;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#forceSync</var>
 	 *
-	 * @deprecated use {@link Config.Native#forceSync} instead.
+	 * @deprecated use {@link CONFIG.Native#forceSync} instead.
 	 */
 	public final static IRI FORCE_SYNC;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#valueCacheSize</var>
 	 *
-	 * @deprecated use {@link Config.Native#valueCacheSize} instead.
+	 * @deprecated use {@link CONFIG.Native#valueCacheSize} instead.
 	 */
 	public final static IRI VALUE_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#valueIDCacheSize</var>
 	 *
-	 * @deprecated use {@link Config.Native#valueIDCacheSize} instead.
+	 * @deprecated use {@link CONFIG.Native#valueIDCacheSize} instead.
 	 */
 	public final static IRI VALUE_ID_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#namespaceCacheSize</var>
 	 *
-	 * @deprecated use {@link Config.Native#namespaceCacheSize} instead.
+	 * @deprecated use {@link CONFIG.Native#namespaceCacheSize} instead.
 	 */
 	public final static IRI NAMESPACE_CACHE_SIZE;
 
 	/**
 	 * <var>http://www.openrdf.org/config/sail/native#namespaceIDCacheSize</var>
 	 *
-	 * @deprecated use {@link Config.Native#namespaceIDCacheSize} instead.
+	 * @deprecated use {@link CONFIG.Native#namespaceIDCacheSize} instead.
 	 */
 	public final static IRI NAMESPACE_ID_CACHE_SIZE;
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
@@ -211,6 +211,7 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	@Override
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
+		m.setNamespace(CONFIG.NS);
 
 		m.add(implNode, CONFIG.Shacl.parallelValidation, BooleanLiteral.valueOf(isParallelValidation()));
 		m.add(implNode, CONFIG.Shacl.logValidationPlans, BooleanLiteral.valueOf(isLogValidationPlans()));

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
@@ -30,7 +30,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.sail.config.AbstractDelegatingSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
@@ -212,30 +212,30 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
 
-		m.add(implNode, CONFIG.Shacl.parallelValidation, BooleanLiteral.valueOf(isParallelValidation()));
-		m.add(implNode, CONFIG.Shacl.logValidationPlans, BooleanLiteral.valueOf(isLogValidationPlans()));
-		m.add(implNode, CONFIG.Shacl.logValidationViolations, BooleanLiteral.valueOf(isLogValidationViolations()));
-		m.add(implNode, CONFIG.Shacl.validationEnabled, BooleanLiteral.valueOf(isValidationEnabled()));
-		m.add(implNode, CONFIG.Shacl.cacheSelectNodes, BooleanLiteral.valueOf(isCacheSelectNodes()));
-		m.add(implNode, CONFIG.Shacl.globalLogValidationExecution,
+		m.add(implNode, Config.Shacl.parallelValidation, BooleanLiteral.valueOf(isParallelValidation()));
+		m.add(implNode, Config.Shacl.logValidationPlans, BooleanLiteral.valueOf(isLogValidationPlans()));
+		m.add(implNode, Config.Shacl.logValidationViolations, BooleanLiteral.valueOf(isLogValidationViolations()));
+		m.add(implNode, Config.Shacl.validationEnabled, BooleanLiteral.valueOf(isValidationEnabled()));
+		m.add(implNode, Config.Shacl.cacheSelectNodes, BooleanLiteral.valueOf(isCacheSelectNodes()));
+		m.add(implNode, Config.Shacl.globalLogValidationExecution,
 				BooleanLiteral.valueOf(isGlobalLogValidationExecution()));
-		m.add(implNode, CONFIG.Shacl.rdfsSubClassReasoning, BooleanLiteral.valueOf(isRdfsSubClassReasoning()));
-		m.add(implNode, CONFIG.Shacl.performanceLogging, BooleanLiteral.valueOf(isPerformanceLogging()));
-		m.add(implNode, CONFIG.Shacl.serializableValidation, BooleanLiteral.valueOf(isSerializableValidation()));
-		m.add(implNode, CONFIG.Shacl.eclipseRdf4jShaclExtensions,
+		m.add(implNode, Config.Shacl.rdfsSubClassReasoning, BooleanLiteral.valueOf(isRdfsSubClassReasoning()));
+		m.add(implNode, Config.Shacl.performanceLogging, BooleanLiteral.valueOf(isPerformanceLogging()));
+		m.add(implNode, Config.Shacl.serializableValidation, BooleanLiteral.valueOf(isSerializableValidation()));
+		m.add(implNode, Config.Shacl.eclipseRdf4jShaclExtensions,
 				BooleanLiteral.valueOf(isEclipseRdf4jShaclExtensions()));
-		m.add(implNode, CONFIG.Shacl.dashDataShapes, BooleanLiteral.valueOf(isDashDataShapes()));
+		m.add(implNode, Config.Shacl.dashDataShapes, BooleanLiteral.valueOf(isDashDataShapes()));
 
-		m.add(implNode, CONFIG.Shacl.validationResultsLimitTotal,
+		m.add(implNode, Config.Shacl.validationResultsLimitTotal,
 				literal(getValidationResultsLimitTotal()));
-		m.add(implNode, CONFIG.Shacl.validationResultsLimitPerConstraint,
+		m.add(implNode, Config.Shacl.validationResultsLimitPerConstraint,
 				literal(getValidationResultsLimitPerConstraint()));
 
-		m.add(implNode, CONFIG.Shacl.transactionalValidationLimit,
+		m.add(implNode, Config.Shacl.transactionalValidationLimit,
 				literal(getTransactionalValidationLimit()));
 
 		for (IRI shapesGraph : shapesGraphs) {
-			m.add(implNode, CONFIG.Shacl.shapesGraph, shapesGraph);
+			m.add(implNode, Config.Shacl.shapesGraph, shapesGraph);
 		}
 
 		return implNode;
@@ -246,61 +246,61 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 		super.parse(m, implNode);
 
 		try {
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.parallelValidation, PARALLEL_VALIDATION)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.parallelValidation, PARALLEL_VALIDATION)
 					.ifPresent(l -> setParallelValidation(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.logValidationPlans, LOG_VALIDATION_PLANS)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.logValidationPlans, LOG_VALIDATION_PLANS)
 					.ifPresent(l -> setLogValidationPlans(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.logValidationViolations, LOG_VALIDATION_VIOLATIONS)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.logValidationViolations, LOG_VALIDATION_VIOLATIONS)
 					.ifPresent(l -> setLogValidationViolations(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.validationEnabled, VALIDATION_ENABLED)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.validationEnabled, VALIDATION_ENABLED)
 					.ifPresent(l -> setValidationEnabled(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.cacheSelectNodes, CACHE_SELECT_NODES)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.cacheSelectNodes, CACHE_SELECT_NODES)
 					.ifPresent(l -> setCacheSelectNodes(l.booleanValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.Shacl.globalLogValidationExecution,
+					.getLiteralValue(m, implNode, Config.Shacl.globalLogValidationExecution,
 							GLOBAL_LOG_VALIDATION_EXECUTION)
 					.ifPresent(l -> setGlobalLogValidationExecution(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.rdfsSubClassReasoning, RDFS_SUB_CLASS_REASONING)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.rdfsSubClassReasoning, RDFS_SUB_CLASS_REASONING)
 					.ifPresent(l -> setRdfsSubClassReasoning(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.performanceLogging, PERFORMANCE_LOGGING)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.performanceLogging, PERFORMANCE_LOGGING)
 					.ifPresent(l -> setPerformanceLogging(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.serializableValidation, SERIALIZABLE_VALIDATION)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.serializableValidation, SERIALIZABLE_VALIDATION)
 					.ifPresent(l -> setSerializableValidation(l.booleanValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.Shacl.eclipseRdf4jShaclExtensions,
+					.getLiteralValue(m, implNode, Config.Shacl.eclipseRdf4jShaclExtensions,
 							ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS)
 					.ifPresent(l -> setEclipseRdf4jShaclExtensions(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.dashDataShapes, ShaclSailSchema.DASH_DATA_SHAPES)
+			Configurations.getLiteralValue(m, implNode, Config.Shacl.dashDataShapes, ShaclSailSchema.DASH_DATA_SHAPES)
 					.ifPresent(l -> setDashDataShapes(l.booleanValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.Shacl.validationResultsLimitTotal,
+					.getLiteralValue(m, implNode, Config.Shacl.validationResultsLimitTotal,
 							ShaclSailSchema.VALIDATION_RESULTS_LIMIT_TOTAL)
 					.ifPresent(l -> setValidationResultsLimitTotal(l.longValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.Shacl.validationResultsLimitPerConstraint,
+					.getLiteralValue(m, implNode, Config.Shacl.validationResultsLimitPerConstraint,
 							ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT)
 					.ifPresent(l -> setValidationResultsLimitPerConstraint(l.longValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, CONFIG.Shacl.transactionalValidationLimit,
+					.getLiteralValue(m, implNode, Config.Shacl.transactionalValidationLimit,
 							ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT)
 					.ifPresent(l -> setTransactionalValidationLimit(l.longValue()));
 
 			setShapesGraphs(
 					Configurations
-							.getPropertyValues(m, implNode, CONFIG.Shacl.shapesGraph, ShaclSailSchema.SHAPES_GRAPH)
+							.getPropertyValues(m, implNode, Config.Shacl.shapesGraph, ShaclSailSchema.SHAPES_GRAPH)
 							.stream()
 							.peek(v -> {
 								if (!v.isIRI()) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
@@ -30,7 +30,7 @@ import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.util.Configurations;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.sail.config.AbstractDelegatingSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
@@ -212,30 +212,30 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
 
-		m.add(implNode, Config.Shacl.parallelValidation, BooleanLiteral.valueOf(isParallelValidation()));
-		m.add(implNode, Config.Shacl.logValidationPlans, BooleanLiteral.valueOf(isLogValidationPlans()));
-		m.add(implNode, Config.Shacl.logValidationViolations, BooleanLiteral.valueOf(isLogValidationViolations()));
-		m.add(implNode, Config.Shacl.validationEnabled, BooleanLiteral.valueOf(isValidationEnabled()));
-		m.add(implNode, Config.Shacl.cacheSelectNodes, BooleanLiteral.valueOf(isCacheSelectNodes()));
-		m.add(implNode, Config.Shacl.globalLogValidationExecution,
+		m.add(implNode, CONFIG.Shacl.parallelValidation, BooleanLiteral.valueOf(isParallelValidation()));
+		m.add(implNode, CONFIG.Shacl.logValidationPlans, BooleanLiteral.valueOf(isLogValidationPlans()));
+		m.add(implNode, CONFIG.Shacl.logValidationViolations, BooleanLiteral.valueOf(isLogValidationViolations()));
+		m.add(implNode, CONFIG.Shacl.validationEnabled, BooleanLiteral.valueOf(isValidationEnabled()));
+		m.add(implNode, CONFIG.Shacl.cacheSelectNodes, BooleanLiteral.valueOf(isCacheSelectNodes()));
+		m.add(implNode, CONFIG.Shacl.globalLogValidationExecution,
 				BooleanLiteral.valueOf(isGlobalLogValidationExecution()));
-		m.add(implNode, Config.Shacl.rdfsSubClassReasoning, BooleanLiteral.valueOf(isRdfsSubClassReasoning()));
-		m.add(implNode, Config.Shacl.performanceLogging, BooleanLiteral.valueOf(isPerformanceLogging()));
-		m.add(implNode, Config.Shacl.serializableValidation, BooleanLiteral.valueOf(isSerializableValidation()));
-		m.add(implNode, Config.Shacl.eclipseRdf4jShaclExtensions,
+		m.add(implNode, CONFIG.Shacl.rdfsSubClassReasoning, BooleanLiteral.valueOf(isRdfsSubClassReasoning()));
+		m.add(implNode, CONFIG.Shacl.performanceLogging, BooleanLiteral.valueOf(isPerformanceLogging()));
+		m.add(implNode, CONFIG.Shacl.serializableValidation, BooleanLiteral.valueOf(isSerializableValidation()));
+		m.add(implNode, CONFIG.Shacl.eclipseRdf4jShaclExtensions,
 				BooleanLiteral.valueOf(isEclipseRdf4jShaclExtensions()));
-		m.add(implNode, Config.Shacl.dashDataShapes, BooleanLiteral.valueOf(isDashDataShapes()));
+		m.add(implNode, CONFIG.Shacl.dashDataShapes, BooleanLiteral.valueOf(isDashDataShapes()));
 
-		m.add(implNode, Config.Shacl.validationResultsLimitTotal,
+		m.add(implNode, CONFIG.Shacl.validationResultsLimitTotal,
 				literal(getValidationResultsLimitTotal()));
-		m.add(implNode, Config.Shacl.validationResultsLimitPerConstraint,
+		m.add(implNode, CONFIG.Shacl.validationResultsLimitPerConstraint,
 				literal(getValidationResultsLimitPerConstraint()));
 
-		m.add(implNode, Config.Shacl.transactionalValidationLimit,
+		m.add(implNode, CONFIG.Shacl.transactionalValidationLimit,
 				literal(getTransactionalValidationLimit()));
 
 		for (IRI shapesGraph : shapesGraphs) {
-			m.add(implNode, Config.Shacl.shapesGraph, shapesGraph);
+			m.add(implNode, CONFIG.Shacl.shapesGraph, shapesGraph);
 		}
 
 		return implNode;
@@ -246,61 +246,61 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 		super.parse(m, implNode);
 
 		try {
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.parallelValidation, PARALLEL_VALIDATION)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.parallelValidation, PARALLEL_VALIDATION)
 					.ifPresent(l -> setParallelValidation(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.logValidationPlans, LOG_VALIDATION_PLANS)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.logValidationPlans, LOG_VALIDATION_PLANS)
 					.ifPresent(l -> setLogValidationPlans(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.logValidationViolations, LOG_VALIDATION_VIOLATIONS)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.logValidationViolations, LOG_VALIDATION_VIOLATIONS)
 					.ifPresent(l -> setLogValidationViolations(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.validationEnabled, VALIDATION_ENABLED)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.validationEnabled, VALIDATION_ENABLED)
 					.ifPresent(l -> setValidationEnabled(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.cacheSelectNodes, CACHE_SELECT_NODES)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.cacheSelectNodes, CACHE_SELECT_NODES)
 					.ifPresent(l -> setCacheSelectNodes(l.booleanValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, Config.Shacl.globalLogValidationExecution,
+					.getLiteralValue(m, implNode, CONFIG.Shacl.globalLogValidationExecution,
 							GLOBAL_LOG_VALIDATION_EXECUTION)
 					.ifPresent(l -> setGlobalLogValidationExecution(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.rdfsSubClassReasoning, RDFS_SUB_CLASS_REASONING)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.rdfsSubClassReasoning, RDFS_SUB_CLASS_REASONING)
 					.ifPresent(l -> setRdfsSubClassReasoning(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.performanceLogging, PERFORMANCE_LOGGING)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.performanceLogging, PERFORMANCE_LOGGING)
 					.ifPresent(l -> setPerformanceLogging(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.serializableValidation, SERIALIZABLE_VALIDATION)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.serializableValidation, SERIALIZABLE_VALIDATION)
 					.ifPresent(l -> setSerializableValidation(l.booleanValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, Config.Shacl.eclipseRdf4jShaclExtensions,
+					.getLiteralValue(m, implNode, CONFIG.Shacl.eclipseRdf4jShaclExtensions,
 							ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS)
 					.ifPresent(l -> setEclipseRdf4jShaclExtensions(l.booleanValue()));
 
-			Configurations.getLiteralValue(m, implNode, Config.Shacl.dashDataShapes, ShaclSailSchema.DASH_DATA_SHAPES)
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.dashDataShapes, ShaclSailSchema.DASH_DATA_SHAPES)
 					.ifPresent(l -> setDashDataShapes(l.booleanValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, Config.Shacl.validationResultsLimitTotal,
+					.getLiteralValue(m, implNode, CONFIG.Shacl.validationResultsLimitTotal,
 							ShaclSailSchema.VALIDATION_RESULTS_LIMIT_TOTAL)
 					.ifPresent(l -> setValidationResultsLimitTotal(l.longValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, Config.Shacl.validationResultsLimitPerConstraint,
+					.getLiteralValue(m, implNode, CONFIG.Shacl.validationResultsLimitPerConstraint,
 							ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT)
 					.ifPresent(l -> setValidationResultsLimitPerConstraint(l.longValue()));
 
 			Configurations
-					.getLiteralValue(m, implNode, Config.Shacl.transactionalValidationLimit,
+					.getLiteralValue(m, implNode, CONFIG.Shacl.transactionalValidationLimit,
 							ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT)
 					.ifPresent(l -> setTransactionalValidationLimit(l.longValue()));
 
 			setShapesGraphs(
 					Configurations
-							.getPropertyValues(m, implNode, Config.Shacl.shapesGraph, ShaclSailSchema.SHAPES_GRAPH)
+							.getPropertyValues(m, implNode, CONFIG.Shacl.shapesGraph, ShaclSailSchema.SHAPES_GRAPH)
 							.stream()
 							.peek(v -> {
 								if (!v.isIRI()) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
@@ -15,7 +15,6 @@ import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.CACHE_SELECT_N
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.GLOBAL_LOG_VALIDATION_EXECUTION;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.LOG_VALIDATION_PLANS;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.LOG_VALIDATION_VIOLATIONS;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.NAMESPACE;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PARALLEL_VALIDATION;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PERFORMANCE_LOGGING;
 import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.RDFS_SUB_CLASS_REASONING;
@@ -24,15 +23,14 @@ import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_ENA
 
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.eclipse.rdf4j.common.annotation.Experimental;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
-import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.util.Configurations;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.sail.config.AbstractDelegatingSailImplConfig;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
@@ -214,30 +212,30 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
 
-		m.setNamespace("sail-shacl", NAMESPACE);
-		m.add(implNode, PARALLEL_VALIDATION, BooleanLiteral.valueOf(isParallelValidation()));
-		m.add(implNode, LOG_VALIDATION_PLANS, BooleanLiteral.valueOf(isLogValidationPlans()));
-		m.add(implNode, LOG_VALIDATION_VIOLATIONS, BooleanLiteral.valueOf(isLogValidationViolations()));
-		m.add(implNode, VALIDATION_ENABLED, BooleanLiteral.valueOf(isValidationEnabled()));
-		m.add(implNode, CACHE_SELECT_NODES, BooleanLiteral.valueOf(isCacheSelectNodes()));
-		m.add(implNode, GLOBAL_LOG_VALIDATION_EXECUTION, BooleanLiteral.valueOf(isGlobalLogValidationExecution()));
-		m.add(implNode, RDFS_SUB_CLASS_REASONING, BooleanLiteral.valueOf(isRdfsSubClassReasoning()));
-		m.add(implNode, PERFORMANCE_LOGGING, BooleanLiteral.valueOf(isPerformanceLogging()));
-		m.add(implNode, SERIALIZABLE_VALIDATION, BooleanLiteral.valueOf(isSerializableValidation()));
-		m.add(implNode, ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS,
+		m.add(implNode, CONFIG.Shacl.parallelValidation, BooleanLiteral.valueOf(isParallelValidation()));
+		m.add(implNode, CONFIG.Shacl.logValidationPlans, BooleanLiteral.valueOf(isLogValidationPlans()));
+		m.add(implNode, CONFIG.Shacl.logValidationViolations, BooleanLiteral.valueOf(isLogValidationViolations()));
+		m.add(implNode, CONFIG.Shacl.validationEnabled, BooleanLiteral.valueOf(isValidationEnabled()));
+		m.add(implNode, CONFIG.Shacl.cacheSelectNodes, BooleanLiteral.valueOf(isCacheSelectNodes()));
+		m.add(implNode, CONFIG.Shacl.globalLogValidationExecution,
+				BooleanLiteral.valueOf(isGlobalLogValidationExecution()));
+		m.add(implNode, CONFIG.Shacl.rdfsSubClassReasoning, BooleanLiteral.valueOf(isRdfsSubClassReasoning()));
+		m.add(implNode, CONFIG.Shacl.performanceLogging, BooleanLiteral.valueOf(isPerformanceLogging()));
+		m.add(implNode, CONFIG.Shacl.serializableValidation, BooleanLiteral.valueOf(isSerializableValidation()));
+		m.add(implNode, CONFIG.Shacl.eclipseRdf4jShaclExtensions,
 				BooleanLiteral.valueOf(isEclipseRdf4jShaclExtensions()));
-		m.add(implNode, ShaclSailSchema.DASH_DATA_SHAPES, BooleanLiteral.valueOf(isDashDataShapes()));
+		m.add(implNode, CONFIG.Shacl.dashDataShapes, BooleanLiteral.valueOf(isDashDataShapes()));
 
-		m.add(implNode, ShaclSailSchema.VALIDATION_RESULTS_LIMIT_TOTAL,
+		m.add(implNode, CONFIG.Shacl.validationResultsLimitTotal,
 				literal(getValidationResultsLimitTotal()));
-		m.add(implNode, ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT,
+		m.add(implNode, CONFIG.Shacl.validationResultsLimitPerConstraint,
 				literal(getValidationResultsLimitPerConstraint()));
 
-		m.add(implNode, ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT,
+		m.add(implNode, CONFIG.Shacl.transactionalValidationLimit,
 				literal(getTransactionalValidationLimit()));
 
 		for (IRI shapesGraph : shapesGraphs) {
-			m.add(implNode, ShaclSailSchema.SHAPES_GRAPH, shapesGraph);
+			m.add(implNode, CONFIG.Shacl.shapesGraph, shapesGraph);
 		}
 
 		return implNode;
@@ -248,63 +246,72 @@ public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
 		super.parse(m, implNode);
 
 		try {
-			Models.objectLiteral(m.getStatements(implNode, PARALLEL_VALIDATION, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.parallelValidation, PARALLEL_VALIDATION)
 					.ifPresent(l -> setParallelValidation(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, LOG_VALIDATION_PLANS, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.logValidationPlans, LOG_VALIDATION_PLANS)
 					.ifPresent(l -> setLogValidationPlans(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, LOG_VALIDATION_VIOLATIONS, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.logValidationViolations, LOG_VALIDATION_VIOLATIONS)
 					.ifPresent(l -> setLogValidationViolations(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, VALIDATION_ENABLED, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.validationEnabled, VALIDATION_ENABLED)
 					.ifPresent(l -> setValidationEnabled(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, CACHE_SELECT_NODES, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.cacheSelectNodes, CACHE_SELECT_NODES)
 					.ifPresent(l -> setCacheSelectNodes(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, GLOBAL_LOG_VALIDATION_EXECUTION, null))
+			Configurations
+					.getLiteralValue(m, implNode, CONFIG.Shacl.globalLogValidationExecution,
+							GLOBAL_LOG_VALIDATION_EXECUTION)
 					.ifPresent(l -> setGlobalLogValidationExecution(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, RDFS_SUB_CLASS_REASONING, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.rdfsSubClassReasoning, RDFS_SUB_CLASS_REASONING)
 					.ifPresent(l -> setRdfsSubClassReasoning(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, PERFORMANCE_LOGGING, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.performanceLogging, PERFORMANCE_LOGGING)
 					.ifPresent(l -> setPerformanceLogging(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, SERIALIZABLE_VALIDATION, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.serializableValidation, SERIALIZABLE_VALIDATION)
 					.ifPresent(l -> setSerializableValidation(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS, null))
+			Configurations
+					.getLiteralValue(m, implNode, CONFIG.Shacl.eclipseRdf4jShaclExtensions,
+							ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS)
 					.ifPresent(l -> setEclipseRdf4jShaclExtensions(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, ShaclSailSchema.DASH_DATA_SHAPES, null))
+			Configurations.getLiteralValue(m, implNode, CONFIG.Shacl.dashDataShapes, ShaclSailSchema.DASH_DATA_SHAPES)
 					.ifPresent(l -> setDashDataShapes(l.booleanValue()));
 
-			Models.objectLiteral(m.getStatements(implNode, ShaclSailSchema.VALIDATION_RESULTS_LIMIT_TOTAL, null))
+			Configurations
+					.getLiteralValue(m, implNode, CONFIG.Shacl.validationResultsLimitTotal,
+							ShaclSailSchema.VALIDATION_RESULTS_LIMIT_TOTAL)
 					.ifPresent(l -> setValidationResultsLimitTotal(l.longValue()));
 
-			Models.objectLiteral(
-					m.getStatements(implNode, ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT, null))
+			Configurations
+					.getLiteralValue(m, implNode, CONFIG.Shacl.validationResultsLimitPerConstraint,
+							ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT)
 					.ifPresent(l -> setValidationResultsLimitPerConstraint(l.longValue()));
 
-			Models.objectLiteral(
-					m.getStatements(implNode, ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT, null))
+			Configurations
+					.getLiteralValue(m, implNode, CONFIG.Shacl.transactionalValidationLimit,
+							ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT)
 					.ifPresent(l -> setTransactionalValidationLimit(l.longValue()));
 
-			if (m.contains(implNode, ShaclSailSchema.SHAPES_GRAPH, null)) {
-				setShapesGraphs(StreamSupport
-						.stream(m.getStatements(implNode, ShaclSailSchema.SHAPES_GRAPH, null).spliterator(), false)
-						.peek(statement -> {
-							if (!statement.getObject().isIRI()) {
-								throw new IllegalArgumentException("Expected IRI but found "
-										+ statement.getObject().getClass().getSimpleName() + " at " + statement);
-							}
-						})
-						.map(Statement::getObject)
-						.map(o -> ((IRI) o))
-						.collect(Collectors.toUnmodifiableSet()));
-			}
+			setShapesGraphs(
+					Configurations
+							.getPropertyValues(m, implNode, CONFIG.Shacl.shapesGraph, ShaclSailSchema.SHAPES_GRAPH)
+							.stream()
+							.peek(v -> {
+								if (!v.isIRI()) {
+									throw new IllegalArgumentException(
+											"Expected IRI but found " + v.getClass().getSimpleName() + "for value "
+													+ v.stringValue());
+								}
+							})
+							.map(o -> ((IRI) o))
+							.collect(Collectors.toUnmodifiableSet())
+			);
 
 		} catch (IllegalArgumentException e) {
 			throw new SailConfigException("error parsing Sail configuration", e);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
@@ -13,6 +13,7 @@ package org.eclipse.rdf4j.sail.shacl.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
 
 /**
@@ -20,7 +21,10 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSail;
  * {@link ShaclSail}s.
  *
  * @author Jeen Broekstra
+ * 
+ * @deprecated since 4.3.0. Use {@link CONFIG.Shacl} instead.
  */
+@Deprecated(since = "4.3.0", forRemoval = true)
 public class ShaclSailSchema {
 
 	/**
@@ -30,57 +34,95 @@ public class ShaclSailSchema {
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#parallelValidation</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#parallelValidation} instead.
 	 */
 	public final static IRI PARALLEL_VALIDATION = create("parallelValidation");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#logValidationPlans</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#logValidationPlans} instead.
 	 */
 	public final static IRI LOG_VALIDATION_PLANS = create("logValidationPlans");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#logValidationViolations</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#logValidationViolations} instead.
 	 */
 	public final static IRI LOG_VALIDATION_VIOLATIONS = create("logValidationViolations");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#validationEnabled</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#validationEnabled} instead.
 	 */
 	public final static IRI VALIDATION_ENABLED = create("validationEnabled");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#cacheSelectNodes</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#cacheSelectNodes} instead.
 	 */
 	public final static IRI CACHE_SELECT_NODES = create("cacheSelectNodes");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#globalLogValidationExecution</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#globalLogValidationExecution} instead.
 	 */
 	public final static IRI GLOBAL_LOG_VALIDATION_EXECUTION = create("globalLogValidationExecution");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#rdfsSubClassReasoning</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#rdfsSubClassReasoning} instead.
 	 */
 	public final static IRI RDFS_SUB_CLASS_REASONING = create("rdfsSubClassReasoning");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#performanceLogging</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#performanceLogging} instead.
 	 */
 	public final static IRI PERFORMANCE_LOGGING = create("performanceLogging");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#serializableValidation</code>
+	 * 
+	 * @deprecated use {@link CONFIG.Shacl#serializableValidation} instead.
 	 */
 	public final static IRI SERIALIZABLE_VALIDATION = create("serializableValidation");
 
+	/**
+	 * @deprecated use {@link CONFIG.Shacl#eclipseRdf4jShaclExtensions} instead.
+	 */
 	public final static IRI ECLIPSE_RDF4J_SHACL_EXTENSIONS = create("eclipseRdf4jShaclExtensions");
 
+	/**
+	 * @deprecated use {@link CONFIG.Shacl#dashDataShapes} instead.
+	 */
 	public final static IRI DASH_DATA_SHAPES = create("dashDataShapes");
 
+	/**
+	 * @deprecated use {@link CONFIG.Shacl#validationResultsLimitTotal} instead.
+	 */
 	public final static IRI VALIDATION_RESULTS_LIMIT_TOTAL = create("validationResultsLimitTotal");
+
+	/**
+	 * @deprecated use {@link CONFIG.Shacl#validationResultsLimitPerConstraint} instead.
+	 */
 	public final static IRI VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT = create("validationResultsLimitPerConstraint");
+
+	/**
+	 * @deprecated use {@link CONFIG.Shacl#transactionalValidationLimit} instead.
+	 */
 	public final static IRI TRANSACTIONAL_VALIDATION_LIMIT = create("transactionalValidationLimit");
 
+	/**
+	 * @deprecated use {@link CONFIG.Shacl#shapesGraph} instead.
+	 */
 	public final static IRI SHAPES_GRAPH = create("shapesGraph");
 
 	private static IRI create(String localName) {

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.shacl.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
 
 /**
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSail;
  *
  * @author Jeen Broekstra
  *
- * @deprecated since 4.3.0. Use {@link Config.Shacl} instead.
+ * @deprecated since 4.3.0. Use {@link CONFIG.Shacl} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ShaclSailSchema {
@@ -35,93 +35,93 @@ public class ShaclSailSchema {
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#parallelValidation</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#parallelValidation} instead.
+	 * @deprecated use {@link CONFIG.Shacl#parallelValidation} instead.
 	 */
 	public final static IRI PARALLEL_VALIDATION = create("parallelValidation");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#logValidationPlans</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#logValidationPlans} instead.
+	 * @deprecated use {@link CONFIG.Shacl#logValidationPlans} instead.
 	 */
 	public final static IRI LOG_VALIDATION_PLANS = create("logValidationPlans");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#logValidationViolations</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#logValidationViolations} instead.
+	 * @deprecated use {@link CONFIG.Shacl#logValidationViolations} instead.
 	 */
 	public final static IRI LOG_VALIDATION_VIOLATIONS = create("logValidationViolations");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#validationEnabled</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#validationEnabled} instead.
+	 * @deprecated use {@link CONFIG.Shacl#validationEnabled} instead.
 	 */
 	public final static IRI VALIDATION_ENABLED = create("validationEnabled");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#cacheSelectNodes</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#cacheSelectNodes} instead.
+	 * @deprecated use {@link CONFIG.Shacl#cacheSelectNodes} instead.
 	 */
 	public final static IRI CACHE_SELECT_NODES = create("cacheSelectNodes");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#globalLogValidationExecution</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#globalLogValidationExecution} instead.
+	 * @deprecated use {@link CONFIG.Shacl#globalLogValidationExecution} instead.
 	 */
 	public final static IRI GLOBAL_LOG_VALIDATION_EXECUTION = create("globalLogValidationExecution");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#rdfsSubClassReasoning</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#rdfsSubClassReasoning} instead.
+	 * @deprecated use {@link CONFIG.Shacl#rdfsSubClassReasoning} instead.
 	 */
 	public final static IRI RDFS_SUB_CLASS_REASONING = create("rdfsSubClassReasoning");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#performanceLogging</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#performanceLogging} instead.
+	 * @deprecated use {@link CONFIG.Shacl#performanceLogging} instead.
 	 */
 	public final static IRI PERFORMANCE_LOGGING = create("performanceLogging");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#serializableValidation</code>
 	 *
-	 * @deprecated use {@link Config.Shacl#serializableValidation} instead.
+	 * @deprecated use {@link CONFIG.Shacl#serializableValidation} instead.
 	 */
 	public final static IRI SERIALIZABLE_VALIDATION = create("serializableValidation");
 
 	/**
-	 * @deprecated use {@link Config.Shacl#eclipseRdf4jShaclExtensions} instead.
+	 * @deprecated use {@link CONFIG.Shacl#eclipseRdf4jShaclExtensions} instead.
 	 */
 	public final static IRI ECLIPSE_RDF4J_SHACL_EXTENSIONS = create("eclipseRdf4jShaclExtensions");
 
 	/**
-	 * @deprecated use {@link Config.Shacl#dashDataShapes} instead.
+	 * @deprecated use {@link CONFIG.Shacl#dashDataShapes} instead.
 	 */
 	public final static IRI DASH_DATA_SHAPES = create("dashDataShapes");
 
 	/**
-	 * @deprecated use {@link Config.Shacl#validationResultsLimitTotal} instead.
+	 * @deprecated use {@link CONFIG.Shacl#validationResultsLimitTotal} instead.
 	 */
 	public final static IRI VALIDATION_RESULTS_LIMIT_TOTAL = create("validationResultsLimitTotal");
 
 	/**
-	 * @deprecated use {@link Config.Shacl#validationResultsLimitPerConstraint} instead.
+	 * @deprecated use {@link CONFIG.Shacl#validationResultsLimitPerConstraint} instead.
 	 */
 	public final static IRI VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT = create("validationResultsLimitPerConstraint");
 
 	/**
-	 * @deprecated use {@link Config.Shacl#transactionalValidationLimit} instead.
+	 * @deprecated use {@link CONFIG.Shacl#transactionalValidationLimit} instead.
 	 */
 	public final static IRI TRANSACTIONAL_VALIDATION_LIMIT = create("transactionalValidationLimit");
 
 	/**
-	 * @deprecated use {@link Config.Shacl#shapesGraph} instead.
+	 * @deprecated use {@link CONFIG.Shacl#shapesGraph} instead.
 	 */
 	public final static IRI SHAPES_GRAPH = create("shapesGraph");
 

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSail;
  * {@link ShaclSail}s.
  *
  * @author Jeen Broekstra
- * 
+ *
  * @deprecated since 4.3.0. Use {@link CONFIG.Shacl} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
@@ -34,63 +34,63 @@ public class ShaclSailSchema {
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#parallelValidation</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#parallelValidation} instead.
 	 */
 	public final static IRI PARALLEL_VALIDATION = create("parallelValidation");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#logValidationPlans</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#logValidationPlans} instead.
 	 */
 	public final static IRI LOG_VALIDATION_PLANS = create("logValidationPlans");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#logValidationViolations</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#logValidationViolations} instead.
 	 */
 	public final static IRI LOG_VALIDATION_VIOLATIONS = create("logValidationViolations");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#validationEnabled</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#validationEnabled} instead.
 	 */
 	public final static IRI VALIDATION_ENABLED = create("validationEnabled");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#cacheSelectNodes</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#cacheSelectNodes} instead.
 	 */
 	public final static IRI CACHE_SELECT_NODES = create("cacheSelectNodes");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#globalLogValidationExecution</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#globalLogValidationExecution} instead.
 	 */
 	public final static IRI GLOBAL_LOG_VALIDATION_EXECUTION = create("globalLogValidationExecution");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#rdfsSubClassReasoning</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#rdfsSubClassReasoning} instead.
 	 */
 	public final static IRI RDFS_SUB_CLASS_REASONING = create("rdfsSubClassReasoning");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#performanceLogging</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#performanceLogging} instead.
 	 */
 	public final static IRI PERFORMANCE_LOGGING = create("performanceLogging");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#serializableValidation</code>
-	 * 
+	 *
 	 * @deprecated use {@link CONFIG.Shacl#serializableValidation} instead.
 	 */
 	public final static IRI SERIALIZABLE_VALIDATION = create("serializableValidation");

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
@@ -13,7 +13,7 @@ package org.eclipse.rdf4j.sail.shacl.config;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.vocabulary.CONFIG;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
 
 /**
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSail;
  *
  * @author Jeen Broekstra
  *
- * @deprecated since 4.3.0. Use {@link CONFIG.Shacl} instead.
+ * @deprecated since 4.3.0. Use {@link Config.Shacl} instead.
  */
 @Deprecated(since = "4.3.0", forRemoval = true)
 public class ShaclSailSchema {
@@ -35,93 +35,93 @@ public class ShaclSailSchema {
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#parallelValidation</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#parallelValidation} instead.
+	 * @deprecated use {@link Config.Shacl#parallelValidation} instead.
 	 */
 	public final static IRI PARALLEL_VALIDATION = create("parallelValidation");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#logValidationPlans</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#logValidationPlans} instead.
+	 * @deprecated use {@link Config.Shacl#logValidationPlans} instead.
 	 */
 	public final static IRI LOG_VALIDATION_PLANS = create("logValidationPlans");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#logValidationViolations</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#logValidationViolations} instead.
+	 * @deprecated use {@link Config.Shacl#logValidationViolations} instead.
 	 */
 	public final static IRI LOG_VALIDATION_VIOLATIONS = create("logValidationViolations");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#validationEnabled</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#validationEnabled} instead.
+	 * @deprecated use {@link Config.Shacl#validationEnabled} instead.
 	 */
 	public final static IRI VALIDATION_ENABLED = create("validationEnabled");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#cacheSelectNodes</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#cacheSelectNodes} instead.
+	 * @deprecated use {@link Config.Shacl#cacheSelectNodes} instead.
 	 */
 	public final static IRI CACHE_SELECT_NODES = create("cacheSelectNodes");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#globalLogValidationExecution</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#globalLogValidationExecution} instead.
+	 * @deprecated use {@link Config.Shacl#globalLogValidationExecution} instead.
 	 */
 	public final static IRI GLOBAL_LOG_VALIDATION_EXECUTION = create("globalLogValidationExecution");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#rdfsSubClassReasoning</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#rdfsSubClassReasoning} instead.
+	 * @deprecated use {@link Config.Shacl#rdfsSubClassReasoning} instead.
 	 */
 	public final static IRI RDFS_SUB_CLASS_REASONING = create("rdfsSubClassReasoning");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#performanceLogging</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#performanceLogging} instead.
+	 * @deprecated use {@link Config.Shacl#performanceLogging} instead.
 	 */
 	public final static IRI PERFORMANCE_LOGGING = create("performanceLogging");
 
 	/**
 	 * <code>http://rdf4j.org/config/sail/shacl#serializableValidation</code>
 	 *
-	 * @deprecated use {@link CONFIG.Shacl#serializableValidation} instead.
+	 * @deprecated use {@link Config.Shacl#serializableValidation} instead.
 	 */
 	public final static IRI SERIALIZABLE_VALIDATION = create("serializableValidation");
 
 	/**
-	 * @deprecated use {@link CONFIG.Shacl#eclipseRdf4jShaclExtensions} instead.
+	 * @deprecated use {@link Config.Shacl#eclipseRdf4jShaclExtensions} instead.
 	 */
 	public final static IRI ECLIPSE_RDF4J_SHACL_EXTENSIONS = create("eclipseRdf4jShaclExtensions");
 
 	/**
-	 * @deprecated use {@link CONFIG.Shacl#dashDataShapes} instead.
+	 * @deprecated use {@link Config.Shacl#dashDataShapes} instead.
 	 */
 	public final static IRI DASH_DATA_SHAPES = create("dashDataShapes");
 
 	/**
-	 * @deprecated use {@link CONFIG.Shacl#validationResultsLimitTotal} instead.
+	 * @deprecated use {@link Config.Shacl#validationResultsLimitTotal} instead.
 	 */
 	public final static IRI VALIDATION_RESULTS_LIMIT_TOTAL = create("validationResultsLimitTotal");
 
 	/**
-	 * @deprecated use {@link CONFIG.Shacl#validationResultsLimitPerConstraint} instead.
+	 * @deprecated use {@link Config.Shacl#validationResultsLimitPerConstraint} instead.
 	 */
 	public final static IRI VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT = create("validationResultsLimitPerConstraint");
 
 	/**
-	 * @deprecated use {@link CONFIG.Shacl#transactionalValidationLimit} instead.
+	 * @deprecated use {@link Config.Shacl#transactionalValidationLimit} instead.
 	 */
 	public final static IRI TRANSACTIONAL_VALIDATION_LIMIT = create("transactionalValidationLimit");
 
 	/**
-	 * @deprecated use {@link CONFIG.Shacl#shapesGraph} instead.
+	 * @deprecated use {@link Config.Shacl#shapesGraph} instead.
 	 */
 	public final static IRI SHAPES_GRAPH = create("shapesGraph");
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
@@ -11,21 +11,6 @@
 package org.eclipse.rdf4j.sail.shacl.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.CACHE_SELECT_NODES;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.DASH_DATA_SHAPES;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.ECLIPSE_RDF4J_SHACL_EXTENSIONS;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.GLOBAL_LOG_VALIDATION_EXECUTION;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.LOG_VALIDATION_PLANS;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.LOG_VALIDATION_VIOLATIONS;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PARALLEL_VALIDATION;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PERFORMANCE_LOGGING;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.RDFS_SUB_CLASS_REASONING;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.SERIALIZABLE_VALIDATION;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.SHAPES_GRAPH;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.TRANSACTIONAL_VALIDATION_LIMIT;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_ENABLED;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT;
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_RESULTS_LIMIT_TOTAL;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Set;
@@ -38,6 +23,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.Config;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.junit.jupiter.api.Assertions;
@@ -75,25 +61,25 @@ public class ShaclSailConfigTest {
 		BNode implNode = vf.createBNode();
 		ModelBuilder mb = new ModelBuilder().subject(implNode);
 
-		mb.add(PARALLEL_VALIDATION, true);
-		mb.add(LOG_VALIDATION_PLANS, true);
-		mb.add(LOG_VALIDATION_VIOLATIONS, true);
-		mb.add(VALIDATION_ENABLED, true);
-		mb.add(CACHE_SELECT_NODES, true);
-		mb.add(GLOBAL_LOG_VALIDATION_EXECUTION, true);
-		mb.add(RDFS_SUB_CLASS_REASONING, false);
-		mb.add(PERFORMANCE_LOGGING, true);
-		mb.add(ECLIPSE_RDF4J_SHACL_EXTENSIONS, true);
-		mb.add(DASH_DATA_SHAPES, true);
-		mb.add(SERIALIZABLE_VALIDATION, false);
+		mb.add(Config.Shacl.parallelValidation, true);
+		mb.add(Config.Shacl.logValidationPlans, true);
+		mb.add(Config.Shacl.logValidationViolations, true);
+		mb.add(Config.Shacl.validationEnabled, true);
+		mb.add(Config.Shacl.cacheSelectNodes, true);
+		mb.add(Config.Shacl.globalLogValidationExecution, true);
+		mb.add(Config.Shacl.rdfsSubClassReasoning, false);
+		mb.add(Config.Shacl.performanceLogging, true);
+		mb.add(Config.Shacl.eclipseRdf4jShaclExtensions, true);
+		mb.add(Config.Shacl.dashDataShapes, true);
+		mb.add(Config.Shacl.serializableValidation, false);
 
-		mb.add(VALIDATION_RESULTS_LIMIT_TOTAL, 100);
-		mb.add(VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT, 3);
-		mb.add(TRANSACTIONAL_VALIDATION_LIMIT, 9);
+		mb.add(Config.Shacl.validationResultsLimitTotal, 100);
+		mb.add(Config.Shacl.validationResultsLimitPerConstraint, 3);
+		mb.add(Config.Shacl.transactionalValidationLimit, 9);
 
 		Set<IRI> shapesGraphs = Set.of(Values.iri("http://example.com/ex1"), Values.iri("http://example.com/ex2"));
 		for (IRI shapesGraph : shapesGraphs) {
-			mb.add(SHAPES_GRAPH, shapesGraph);
+			mb.add(Config.Shacl.shapesGraph, shapesGraph);
 		}
 
 		shaclSailConfig.parse(mb.build(), implNode);
@@ -122,7 +108,7 @@ public class ShaclSailConfigTest {
 		BNode implNode = SimpleValueFactory.getInstance().createBNode();
 		ModelBuilder mb = new ModelBuilder().subject(implNode);
 
-		mb.add(PARALLEL_VALIDATION, false);
+		mb.add(Config.Shacl.parallelValidation, false);
 
 		shaclSailConfig.parse(mb.build(), implNode);
 
@@ -136,7 +122,7 @@ public class ShaclSailConfigTest {
 		BNode implNode = SimpleValueFactory.getInstance().createBNode();
 		ModelBuilder mb = new ModelBuilder().subject(implNode);
 
-		mb.add(PARALLEL_VALIDATION, "I'm not a boolean");
+		mb.add(Config.Shacl.parallelValidation, "I'm not a boolean");
 
 		assertThrows(SailConfigException.class, () -> {
 			shaclSailConfig.parse(mb.build(), implNode);
@@ -149,7 +135,7 @@ public class ShaclSailConfigTest {
 		BNode implNode = SimpleValueFactory.getInstance().createBNode();
 		ModelBuilder mb = new ModelBuilder().subject(implNode);
 
-		mb.add(SHAPES_GRAPH, Values.bnode());
+		mb.add(Config.Shacl.shapesGraph, Values.bnode());
 
 		assertThrows(SailConfigException.class, () -> {
 			shaclSailConfig.parse(mb.build(), implNode);
@@ -162,21 +148,21 @@ public class ShaclSailConfigTest {
 
 		Model m = new TreeModel();
 		Resource node = shaclSailConfig.export(m);
-		Assertions.assertTrue(m.contains(node, PARALLEL_VALIDATION, null));
-		Assertions.assertTrue(m.contains(node, LOG_VALIDATION_PLANS, null));
-		Assertions.assertTrue(m.contains(node, LOG_VALIDATION_VIOLATIONS, null));
-		Assertions.assertTrue(m.contains(node, VALIDATION_ENABLED, null));
-		Assertions.assertTrue(m.contains(node, CACHE_SELECT_NODES, null));
-		Assertions.assertTrue(m.contains(node, GLOBAL_LOG_VALIDATION_EXECUTION, null));
-		Assertions.assertTrue(m.contains(node, RDFS_SUB_CLASS_REASONING, null));
-		Assertions.assertTrue(m.contains(node, PERFORMANCE_LOGGING, null));
-		Assertions.assertTrue(m.contains(node, SERIALIZABLE_VALIDATION, null));
-		Assertions.assertTrue(m.contains(node, ECLIPSE_RDF4J_SHACL_EXTENSIONS, null));
-		Assertions.assertTrue(m.contains(node, DASH_DATA_SHAPES, null));
-		Assertions.assertTrue(m.contains(node, VALIDATION_RESULTS_LIMIT_TOTAL, null));
-		Assertions.assertTrue(m.contains(node, VALIDATION_RESULTS_LIMIT_PER_CONSTRAINT, null));
-		Assertions.assertTrue(m.contains(node, TRANSACTIONAL_VALIDATION_LIMIT, null));
-		Assertions.assertTrue(m.contains(node, SHAPES_GRAPH, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.parallelValidation, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.logValidationPlans, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.logValidationViolations, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.validationEnabled, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.cacheSelectNodes, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.globalLogValidationExecution, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.rdfsSubClassReasoning, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.performanceLogging, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.serializableValidation, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.eclipseRdf4jShaclExtensions, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.dashDataShapes, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.validationResultsLimitTotal, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.validationResultsLimitPerConstraint, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.transactionalValidationLimit, null));
+		Assertions.assertTrue(m.contains(node, Config.Shacl.shapesGraph, null));
 
 	}
 

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
@@ -23,7 +23,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.Values;
-import org.eclipse.rdf4j.model.vocabulary.Config;
+import org.eclipse.rdf4j.model.vocabulary.CONFIG;
 import org.eclipse.rdf4j.model.vocabulary.RDF4J;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.junit.jupiter.api.Assertions;
@@ -61,25 +61,25 @@ public class ShaclSailConfigTest {
 		BNode implNode = vf.createBNode();
 		ModelBuilder mb = new ModelBuilder().subject(implNode);
 
-		mb.add(Config.Shacl.parallelValidation, true);
-		mb.add(Config.Shacl.logValidationPlans, true);
-		mb.add(Config.Shacl.logValidationViolations, true);
-		mb.add(Config.Shacl.validationEnabled, true);
-		mb.add(Config.Shacl.cacheSelectNodes, true);
-		mb.add(Config.Shacl.globalLogValidationExecution, true);
-		mb.add(Config.Shacl.rdfsSubClassReasoning, false);
-		mb.add(Config.Shacl.performanceLogging, true);
-		mb.add(Config.Shacl.eclipseRdf4jShaclExtensions, true);
-		mb.add(Config.Shacl.dashDataShapes, true);
-		mb.add(Config.Shacl.serializableValidation, false);
+		mb.add(CONFIG.Shacl.parallelValidation, true);
+		mb.add(CONFIG.Shacl.logValidationPlans, true);
+		mb.add(CONFIG.Shacl.logValidationViolations, true);
+		mb.add(CONFIG.Shacl.validationEnabled, true);
+		mb.add(CONFIG.Shacl.cacheSelectNodes, true);
+		mb.add(CONFIG.Shacl.globalLogValidationExecution, true);
+		mb.add(CONFIG.Shacl.rdfsSubClassReasoning, false);
+		mb.add(CONFIG.Shacl.performanceLogging, true);
+		mb.add(CONFIG.Shacl.eclipseRdf4jShaclExtensions, true);
+		mb.add(CONFIG.Shacl.dashDataShapes, true);
+		mb.add(CONFIG.Shacl.serializableValidation, false);
 
-		mb.add(Config.Shacl.validationResultsLimitTotal, 100);
-		mb.add(Config.Shacl.validationResultsLimitPerConstraint, 3);
-		mb.add(Config.Shacl.transactionalValidationLimit, 9);
+		mb.add(CONFIG.Shacl.validationResultsLimitTotal, 100);
+		mb.add(CONFIG.Shacl.validationResultsLimitPerConstraint, 3);
+		mb.add(CONFIG.Shacl.transactionalValidationLimit, 9);
 
 		Set<IRI> shapesGraphs = Set.of(Values.iri("http://example.com/ex1"), Values.iri("http://example.com/ex2"));
 		for (IRI shapesGraph : shapesGraphs) {
-			mb.add(Config.Shacl.shapesGraph, shapesGraph);
+			mb.add(CONFIG.Shacl.shapesGraph, shapesGraph);
 		}
 
 		shaclSailConfig.parse(mb.build(), implNode);
@@ -108,7 +108,7 @@ public class ShaclSailConfigTest {
 		BNode implNode = SimpleValueFactory.getInstance().createBNode();
 		ModelBuilder mb = new ModelBuilder().subject(implNode);
 
-		mb.add(Config.Shacl.parallelValidation, false);
+		mb.add(CONFIG.Shacl.parallelValidation, false);
 
 		shaclSailConfig.parse(mb.build(), implNode);
 
@@ -122,7 +122,7 @@ public class ShaclSailConfigTest {
 		BNode implNode = SimpleValueFactory.getInstance().createBNode();
 		ModelBuilder mb = new ModelBuilder().subject(implNode);
 
-		mb.add(Config.Shacl.parallelValidation, "I'm not a boolean");
+		mb.add(CONFIG.Shacl.parallelValidation, "I'm not a boolean");
 
 		assertThrows(SailConfigException.class, () -> {
 			shaclSailConfig.parse(mb.build(), implNode);
@@ -135,7 +135,7 @@ public class ShaclSailConfigTest {
 		BNode implNode = SimpleValueFactory.getInstance().createBNode();
 		ModelBuilder mb = new ModelBuilder().subject(implNode);
 
-		mb.add(Config.Shacl.shapesGraph, Values.bnode());
+		mb.add(CONFIG.Shacl.shapesGraph, Values.bnode());
 
 		assertThrows(SailConfigException.class, () -> {
 			shaclSailConfig.parse(mb.build(), implNode);
@@ -148,21 +148,21 @@ public class ShaclSailConfigTest {
 
 		Model m = new TreeModel();
 		Resource node = shaclSailConfig.export(m);
-		Assertions.assertTrue(m.contains(node, Config.Shacl.parallelValidation, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.logValidationPlans, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.logValidationViolations, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.validationEnabled, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.cacheSelectNodes, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.globalLogValidationExecution, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.rdfsSubClassReasoning, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.performanceLogging, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.serializableValidation, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.eclipseRdf4jShaclExtensions, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.dashDataShapes, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.validationResultsLimitTotal, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.validationResultsLimitPerConstraint, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.transactionalValidationLimit, null));
-		Assertions.assertTrue(m.contains(node, Config.Shacl.shapesGraph, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.parallelValidation, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.logValidationPlans, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.logValidationViolations, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.validationEnabled, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.cacheSelectNodes, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.globalLogValidationExecution, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.rdfsSubClassReasoning, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.performanceLogging, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.serializableValidation, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.eclipseRdf4jShaclExtensions, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.dashDataShapes, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.validationResultsLimitTotal, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.validationResultsLimitPerConstraint, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.transactionalValidationLimit, null));
+		Assertions.assertTrue(m.contains(node, CONFIG.Shacl.shapesGraph, null));
 
 	}
 

--- a/site/content/documentation/programming/federation.md
+++ b/site/content/documentation/programming/federation.md
@@ -110,12 +110,12 @@ The following snippet depicts an example repository configuration that defines a
 # RDF4J configuration template for a FedX Repository
 #
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 @prefix fedx: <http://rdf4j.org/config/federation#>.
 
-[] a rep:Repository ;
-   rep:repositoryImpl [
-      rep:repositoryType "fedx:FedXRepository" ;
+[] a config:Repository ;
+   config:rep.impl [
+      config:rep.type "fedx:FedXRepository" ;
       fedx:member [
          fedx:store "ResolvableRepository" ;
          fedx:repositoryName "my-repository-1"
@@ -125,7 +125,7 @@ The following snippet depicts an example repository configuration that defines a
          fedx:repositoryName "my-repository-2"
       ]
    ];
-   rep:repositoryID "my-federation" ;
+   config:rep.id "my-federation" ;
    rdfs:label "FedX Federation" .
 ```
 

--- a/site/content/documentation/reference/configuration.md
+++ b/site/content/documentation/reference/configuration.md
@@ -11,24 +11,24 @@ RDF4J repositories and SAIL configuration can be set up and changed by means of 
 
 ## Repository configuration
 
-A Repository configuration consists of a single RDF subject of type `rep:Repository`. Typically this subject is a blank node (`[]` in Turtle syntax), and is assigned its configuration parameters through use of RDF properties.
+A Repository configuration consists of a single RDF subject of type `config:Repository`. Typically this subject is a blank node (`[]` in Turtle syntax), and is assigned its configuration parameters through use of RDF properties.
 
-The parameter namespace is `http://www.openrdf.org/config/repository#`, commonly abbreviated to `rep`.
-It takes following configuration parameters:
+The configuration namespace is `tag:rdf4j.org,2023:config/`, commonly abbreviated to `config`.
+A Repository takes a following configuration parameters:
 
-- `rep:repositoryID` (String): the repository identifier (required). This must be unique within the running system.
+- `config:rep.id` (String): the repository identifier (required). This must be unique within the running system.
 - `rdfs:label` (String): a human-readable name or short description of the repository (optional).
-- `rep:repositoryImpl`: this specifies and configures the specific repository implementation (required). This is typically supplied as a nested blank node, which in turns has the implementation-specific configuration parameter. Every repository implemenation _must_ specify a `rep:repositoryType`.
+- `config:rep.impl`: this specifies and configures the specific repository implementation (required). This is typically supplied as a nested blank node, which in turns has the implementation-specific configuration parameter. Every repository implemenation _must_ specify a `config:rep.type`.
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "SPARQL endpoint at http://example.org/" ;
-   rep:repositoryImpl [ rep:repositoryType "example:repositoryType";
+   config:rep.impl [ config:rep.type "example:repositoryType";
                         # your implementation config here
    ].
 ```
@@ -36,28 +36,26 @@ It takes following configuration parameters:
 ### SPARQLRepository
 
 The `SPARQLRepository` repository implementation is a client interface for a remote SPARQL endpoint.
-Its `rep:repositoryType` value is `"openrdf:SPARQLRepository"`.
+Its `config.rep.type` value is `"openrdf:SPARQLRepository"`.
 
-The parameter namespace is `http://www.openrdf.org/config/repository/sparql#`, commonly abbreviated to `sparql`.
 It takes the following configuration parameters:
 
-- `sparql:query-endpoint` (IRI): the SPARQL _query_ endpoint URL (required).
-- `sparql:update-endpoint` (IRI): the SPARQL _update_ endpoint URL (optional). Only needs to be defined if different from the query endpoint.
+- `config:sparql.queryEndpoint` (IRI): the SPARQL _query_ endpoint URL (required).
+- `config:sparql.updateEndpoint` (IRI): the SPARQL _update_ endpoint URL (optional). Only needs to be defined if different from the query endpoint.
 
 #### Example configuration
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sparql: <http://www.openrdf.org/config/repository/sparql#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "SPARQL endpoint at http://example.org/" .
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SPARQLRepository" ;
-      sparql:query-endpoint <http://example.org/sparql> ;
-      sparql:update-endpoint <http://example.org/sparql/update> ;
+   config:rep.impl [
+      config:repositoryType "openrdf:SPARQLRepository" ;
+      config:sparql.queryEndpoint <http://example.org/sparql> ;
+      config:sparql.updateEndpoint <http://example.org/sparql/update> ;
    ];
 ```
 
@@ -67,39 +65,36 @@ The `HTTPRepository` repository implementation is a client interface for a
 store on a (remote) RDF4J Server. It differs from `SPARQLRepository` in that it
 implements several RDF4J-specific  extensions to the standard SPARQL Protocol
 which enhance transactional support and general performance.  Its
-`rep:repositoryType` value is `"openrdf:HTTPRepository"`.
+`config:rep.type` value is `"openrdf:HTTPRepository"`.
 
-The parameter namespace is `http://www.openrdf.org/config/repository/http#`, commonly abbreviated to `hr`.
 It takes the following configuration parameters:
 
-- `hr:repositoryURL` (IRI): the location of the repository on an RDF4J Server (required).
-- `hr:username` (string): username for basic authentication (optional).
-- `hr:password` (string): password for basic authentication (optional).
+- `config:http.url` (IRI): the location of the repository on an RDF4J Server (required).
+- `config:http.username` (string): username for basic authentication (optional).
+- `config:http.password` (string): password for basic authentication (optional).
 
 #### Example configuration
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix hr: <http://www.openrdf.org/config/repository/http#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "example repository on locally running RDF4J Server" .
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:HTTPRepository" ;
-      hr:repositoryURL <http://localhost:8080/rdf4j-server/repositories/test>
+   config:rep.impl [
+      config:rep.type "openrdf:HTTPRepository" ;
+      config:http.url <http://localhost:8080/rdf4j-server/repositories/test>
    ];
 ```
 
 ### SailRepository
 
-The {{< javadoc "SailRepository" "repository/sail/SailRepository.html" >}} repository implementation is the main implementation for direct access to a local RDF database (a SAIL implementation). Its `rep:repositoryType` is `openrdf:SailRepository`.
+The {{< javadoc "SailRepository" "repository/sail/SailRepository.html" >}} repository implementation is the main implementation for direct access to a local RDF database (a SAIL implementation). Its `config:rep.type` is `openrdf:SailRepository`.
 
-The parameter namespace is `http://www.openrdf.org/config/repository/sail#`, commonly abbreviated to `sr`.
 It takes the following configuration parameters:
 
-- `sr:sailImpl`: this specifies and configures the specific SAIL implementation (required). This is typically supplied as a nested blank node, which in turns has the SAIL-specific configuration parameters. Every SAIL implementation _must_ specify a `sail:sailType` property.
+- `config:sail.impl`: this specifies and configures the specific SAIL implementation (required). This is typically supplied as a nested blank node, which in turns has the SAIL-specific configuration parameters. Every SAIL implementation _must_ specify a `config:sail.type` property.
 
 #### Example configuration
 
@@ -107,23 +102,19 @@ In this example we configure a simple SailRepository using a MemoryStore SAIL. S
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example Memory store" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "openrdf:MemoryStore" ;
-         sail:iterationCacheSyncThreshold "10000";
-         ms:persist true;
-         ms:syncDelay 0;
-         sb:evaluationStrategyFactory "org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory"
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "openrdf:MemoryStore" ;
+         config:sail.iterationCacheSyncThreshold "10000";
+         config:mem.persist true;
+         config:mem.syncDelay 0;
+         config:sail.defaultQueryEvaluationMode "STANDARD"
       ]
    ].
 ```
@@ -136,17 +127,16 @@ The {{< javadoc "DatasetRepository" "repository/dataset/DatasetRepository.html" 
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example Dataset Repository" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:DatasetRepository" ;
-      rep:delegate [
-        rep:repositoryType "openrdf:SailRepository" ;
-        sr:sailImpl [
+   config:rep.impl [
+      config:rep.type "openrdf:DatasetRepository" ;
+      config:delegate [
+        config:rep.type "openrdf:SailRepository" ;
+        config:sail.impl [
           ...
         ]
       ]
@@ -157,30 +147,28 @@ The {{< javadoc "DatasetRepository" "repository/dataset/DatasetRepository.html" 
 
 The {{< javadoc "ContextAwareRepository" "repository/contextaware/ContextAwareRepository.html" >}} is a wrapper around any other `Repository`. It can be used to configure the default context(s) on which query, update, or delete operations operate per default.
 
-The parameter namespace is `http://www.openrdf.org/config/repository/contextaware#`, commonly abbreviated to `car`.
 It takes the following parameters:
 
-- `car:readContext`. Specifies the context(s) used per default when executing read operations (including SPARQL queries). Can be specified with multiple values to include more than one context;
-- `car:insertContext`. Specifies the context used for insertion operations.
-- `car:removeContext`. Specifies the context(s) used for delete operations. Can be specified with multiple values to include more than one context.
+- `config:ca.readContext`. Specifies the context(s) used per default when executing read operations (including SPARQL queries). Can be specified with multiple values to include more than one context;
+- `config:ca.insertContext`. Specifies the context used for insertion operations.
+- `config:ca.removeContext`. Specifies the context(s) used for delete operations. Can be specified with multiple values to include more than one context.
 
 #### Example configuration
 
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix car: <http://www.openrdf.org/config/repository/contextaware#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 @prefix ex: <http://example.org/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example Context-aware repository" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:ContextAwareRepository" ;
-      car:readContext ex:namedGraph1, ex:namedGraph2;
-      rep:delegate [
-        rep:repositoryType "openrdf:HTTPRepository" ;
+   config:rep.impl [
+      config:rep.type "openrdf:ContextAwareRepository" ;
+      config:ca.readContext ex:namedGraph1, ex:namedGraph2;
+      config:delegate [
+        config:rep.type "openrdf:HTTPRepository" ;
       ]
    ].
 ```
@@ -191,76 +179,67 @@ Sail implementations come in two basic types: _base_ Sails, and Sail wrappers / 
 
 Each Sail configuration identifies one base Sail, which typically functions as the actual database layer. This base Sail configuration can optionally be wrapped in one or more Stackable Sail configurations. The entire "Sail stack" is then usually wrapped as part of a [SailRepository configuration](#SailRepository).
 
-The parameter namespace is `http://www.openrdf.org/config/sail#`, commonly abbreviated to `sail`.
 Every Sail in a Sail configuration has at least one required parameter:
 
-- `sail:sailType` - this identifies the type of Sail being configured.
-- `sail:iterationCacheSyncThreshold` (integer). Specifies the size of the internal cache for query result iterations before on-disk overflow is enabled.
+- `config:sail.type` - this identifies the type of Sail being configured.
+- `config:sail.iterationCacheSyncThreshold` (integer). Specifies the size of the internal cache for query result iterations before on-disk overflow is enabled.
 
 ### Base Sails
 
 Base Sail implementations are responsible for persistence of data and handling of queries, transactions and update operations on that data. A base Sail is typically a database.
 
-The parameter namespace for common parameters of base Sails is `http://www.openrdf.org/config/sail/base#`, commonly abbreviated to `sb`.
-
 Base Sails commonly take the following parameter:
 
-- `sb:evaluationStrategyFactory` (string). Specifies the full classname of the `EvaluationStrategyFactory` implementation used for this store. This controls how SPARQL queries are evaluated.
+- `config:sail.defaultQueryEvaluationMode` (string). Specifies the default query evaluation mode used for SPARQL queries on this store. Expected values are `STRICT` or `STANDARD`. 
 
 #### Memory Store
 
-A Memory Store is an RDF4J database that keeps all data in main memory, with optional persistence on disk. Its `sail:sailType` value is `"openrdf:MemoryStore"`.
+A Memory Store is an RDF4J database that keeps all data in main memory, with optional persistence on disk. Its `config:sail.type` value is `"openrdf:MemoryStore"`.
 
-The parameter namespace for Memory Store  is `http://www.openrdf.org/config/sail/memory#`, commonly abbreviated to `ms`.
 It takes the following configuration options:
 
-- `ms:persist` (boolean). Specifies if the store persists its data to disk (required). Persistent memory stores write their data to disk before being shut down and read this data back in the next time they are initialized. Non-persistent memory stores are always empty upon initialization.
-- `ms:syncDelay` (integer). Specifies the amount of time (in milliseconds) between an update operation completing and the store syncing its contents to disk (optional). By default, the memory store persistence mechanism synchronizes the disk backup directly upon any change to the contents of the store. Setting a delay on this synchronization can be useful if your application performs several transactions in sequence and you want to prevent disk synchronization in the middle of this sequence to improve update performance.
+- `config:mem.persist` (boolean). Specifies if the store persists its data to disk (required). Persistent memory stores write their data to disk before being shut down and read this data back in the next time they are initialized. Non-persistent memory stores are always empty upon initialization.
+- `config:mem.syncDelay` (integer). Specifies the amount of time (in milliseconds) between an update operation completing and the store syncing its contents to disk (optional). By default, the memory store persistence mechanism synchronizes the disk backup directly upon any change to the contents of the store. Setting a delay on this synchronization can be useful if your application performs several transactions in sequence and you want to prevent disk synchronization in the middle of this sequence to improve update performance.
 
 ##### Example configuration
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example Memory store" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "openrdf:MemoryStore" ;
-         sail:iterationCacheSyncThreshold "10000";
-         ms:persist true;
-         ms:syncDelay 0;
-         sb:evaluationStrategyFactory "org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory"
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "openrdf:MemoryStore" ;
+         config:sail.iterationCacheSyncThreshold "10000";
+         config:mem.persist true;
+         config:mem.syncDelay 0;
+         config:sail.defaultQueryEvaluationMode "STANDARD"
       ]
    ].
 ```
 
 #### Native Store
 
-A Native Store is an RDF4J database that persists all data directly on disk in an indexed binary format. Its `sail:sailType` value is `"openrdf:NativeStore"`.
+A Native Store is an RDF4J database that persists all data directly on disk in an indexed binary format. Its `config:sail.type` value is `"openrdf:NativeStore"`.
 
-The parameter namespace for Native Store  is `http://www.openrdf.org/config/sail/native#`, commonly abbreviated to `ns`.
 It takes the following configuration options:
 
-- `ns:tripleIndex` (string).  Specifices a comma-separated list of indexes for the store to use (optional).
-- `ns:forceSync` (boolean). Specifies if an OS-level force sync should be executed after every update (optional).
-- `ns:valueCacheSize` (integer). Specifies the size of the value cache (optional).
-- `ns:valueIDCacheSize` (integer). Specifices the size of the value ID cache (optional).
-- `ns:namespaceCacheSize` (integer). Specifies the size of the namespace cache (optional).
-- `ns:namespaceIDCacheSize` (integer). Specifies the size of the namespace ID cache (optional).
+- `config:native.tripleIndex` (string).  Specifices a comma-separated list of indexes for the store to use (optional).
+- `config:native.forceSync` (boolean). Specifies if an OS-level force sync should be executed after every update (optional).
+- `config:native.valueCacheSize` (integer). Specifies the size of the value cache (optional).
+- `config:native.valueIDCacheSize` (integer). Specifices the size of the value ID cache (optional).
+- `config:native.namespaceCacheSize` (integer). Specifies the size of the namespace cache (optional).
+- `config:native.namespaceIDCacheSize` (integer). Specifies the size of the namespace ID cache (optional).
 
 ##### Native store indexes
 
 The native store uses on-disk indexes to speed up querying. It uses B-Trees for indexing statements, where the index key consists of four fields: subject (s), predicate (p), object (o) and context (c). The order in which each of these fields is used in the key determines the usability of an index on a specify statement query pattern: searching statements with a specific subject in an index that has the subject as the first field is significantly faster than searching these same statements in an index where the subject field is second or third. In the worst case, the ‘wrong’ statement pattern will result in a sequential scan over the entire set of statements.
 
-By default, the native repository only uses two indexes, one with a subject-predicate-object-context (spoc) key pattern and one with a predicate-object-subject-context (posc) key pattern. However, it is possible to define more or other indexes for the native repository, using the `ns:tripleIndex` parameter. This can be used to optimize performance for query patterns that occur frequently.
+By default, the native repository only uses two indexes, one with a subject-predicate-object-context (spoc) key pattern and one with a predicate-object-subject-context (posc) key pattern. However, it is possible to define more or other indexes for the native repository, using the `config:native.tripleIndex` parameter. This can be used to optimize performance for query patterns that occur frequently.
 
 The subject, predicate, object and context fields are represented by the characters ‘s’, ‘p’, ‘o’ and ‘c’ respectively. Indexes can be specified by creating 4-letter words from these four characters. Multiple indexes can be specified by separating these words with commas, spaces and/or tabs. For example, the string “spoc, posc” specifies two indexes; a subject-predicate-object-context index and a predicate-object-subject-context index.
 
@@ -272,60 +251,52 @@ The native store automatically creates/drops indexes upon (re)initialization, so
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ns: <http://www.openrdf.org/config/sail/native#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example Native store" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "openrdf:NativeStore" ;
-         sail:iterationCacheSyncThreshold "10000";
-         sb:evaluationStrategyFactory "org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory" ;
-         ns:tripleIndexes "spoc,posc"
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+        config:sail.type "openrdf:NativeStore" ;
+         config:sail.iterationCacheSyncThreshold "10000";
+         config:sail.defaultQueryEvaluationMode "STANDARD";
+         config:native.tripleIndexes "spoc,posc"
       ]
    ].
 ```
 
 #### Elasticsearch Store
 
-The Elasticsearch Store is an RDF4J database that persists all data directly in Elasticsearch (not to be confused with the Elasticsearch Fulltext Search Sail, which is an adapter Sail implementation to provided full-text search indexing on top of other RDF databases). Its `sail:sailType` value is `"rdf4j:ElasticsearchStore"`.
+The Elasticsearch Store is an RDF4J database that persists all data directly in Elasticsearch (not to be confused with the Elasticsearch Fulltext Search Sail, which is an adapter Sail implementation to provided full-text search indexing on top of other RDF databases). Its `config:sail.type` value is `"rdf4j:ElasticsearchStore"`.
 
-The parameter namespace for Elasticsearch Store is `http://rdf4j.org/config/sail/elasticsearchstore`, commonly abbreviated to `ess`. It takes the following configuration options:
+The ElasticsearchStore takes the following configuration options:
 
-- `ess:hostname` (string). Specifies the hostname to use for connecting to Elasticsearch (required).
-- `ess:port` (int). Specifies the port number to use for connecting to Elasticsearch (optional).
-- `ess:clusterName` (string). Specifies the Elasticsearch cluster name (optional).
-- `ess:index` (string). Specifies the index name to use for storage and  retrieval of data (optional).
+- `config:ess.hostname` (string). Specifies the hostname to use for connecting to Elasticsearch (required).
+- `config:ess.port` (int). Specifies the port number to use for connecting to Elasticsearch (optional).
+- `config:ess.clusterName` (string). Specifies the Elasticsearch cluster name (optional).
+- `config:ess.index` (string). Specifies the index name to use for storage and  retrieval of data (optional).
 
 ##### Example configuration
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ess: <http://rdf4j.org/config/sail/elasticsearchstore#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example Elasticsearch store" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "rdf4j:ElasticsearchStore" ;
-         sail:iterationCacheSyncThreshold "10000";
-         ess:hostname "localhost";
-         ess:port 9200;
-         ess:clusterName "myCluster";
-         ess:index "myIndex";
-         sb:evaluationStrategyFactory "org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory"
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "rdf4j:ElasticsearchStore" ;
+         config:sail.iterationCacheSyncThreshold "10000";
+         config:ess.hostname "localhost";
+         config:ess.port 9200;
+         config:ess.clusterName "myCluster";
+         config:ess.index "myIndex";
+         config:sail.defaultQueryEvaluationMode "STANDARD"
       ]
    ].
 ```
@@ -336,37 +307,33 @@ Sail Adapters, or "Stackable Sails", are Sail implementations that implement int
 
 Every Sail Adapter has at least one required parameter:
 
-- `sail:delegate`. Specifies and configures the wrapped Sail implementation (required). This is typically supplied as a nested blank node, which in turns has the implementation-specific configuration parameter.
+- `config:delegate`. Specifies and configures the wrapped Sail implementation (required). This is typically supplied as a nested blank node, which in turns has the implementation-specific configuration parameter.
 
 #### RDF Schema inferencer
 
 The RDF Schema inferencer is an Sail Adapter that performs rule-based entailment as defined in the [RDF 1.1 Semantics](https://www.w3.org/TR/rdf11-mt/) recommendation. Reasoning happens in a forward-chaining manner on update operations, and the entailed statements are sent to be persisted by the wrapped Sail. The inferencer also caches RDF Schema statements to speed up entailment and retrieval operations.
 
-The `sail:sailType` value for the RDF Schema inferencer is `"rdf4j:SchemaCachingRDFSInferencer"`.
+The `config:sail.type` value for the RDF Schema inferencer is `"rdf4j:SchemaCachingRDFSInferencer"`.
 
 ##### Example configuration
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example memory store with RDF Schema entailment" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "rdf4j:SchemaCachingRDFSInferencer";
-         sail:delegate [
-             sail:sailType "openrdf:MemoryStore" ;
-             sail:iterationCacheSyncThreshold "10000";
-             ms:persist true;
-             ms:syncDelay 0;
-             sb:evaluationStrategyFactory "org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory"
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "rdf4j:SchemaCachingRDFSInferencer";
+         config:delegate [
+             config:sail.type "openrdf:MemoryStore" ;
+             config:sail.iterationCacheSyncThreshold "10000";
+             config:mem.persist true;
+             config:mem.syncDelay 0;
+             config:sail.defaultQueryEvaluationMode "STANDARD"
          ];
       ]
    ].
@@ -382,27 +349,23 @@ subclass of a resource.  Reasoning happens in a forward-chaining manner on
 update operations, and the entailed statements are sent to be persisted by the
 wrapped Sail.
 
-The `sail:sailType` value is `"openrdf:DirectTypeHierarchyInferencer"`.
+The `config:sail.type` value is `"openrdf:DirectTypeHierarchyInferencer"`.
 
 ##### Example configuration
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example Memory store with direct type entailment" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "openrdf:DirectTypeHierarchyInferencer";
-         sail:delegate [
-             sail:sailType "openrdf:MemoryStore" ;
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+         config:sail.type "openrdf:DirectTypeHierarchyInferencer";
+         config:delegate [
+             config:sail.type "openrdf:MemoryStore" ;
              ...
          ];
       ]
@@ -413,47 +376,42 @@ The `sail:sailType` value is `"openrdf:DirectTypeHierarchyInferencer"`.
 
 The SHACL Sail is a Sail Adapter that performs transaction validation using the Shapes Constraint Language [SHACL](https://www.w3.org/TR/shacl/). More information about the use of the SHACL Sail can be found in [Validation with SHACL](/documentation/programming/shacl).
 
-The `sail:sailType` value of the SHACL Sail is `"rdf4j:ShaclSail"`. Its parameter namespace is `http://rdf4j.org/config/sail/shacl#`, commonly abbreviated to `ssc`. It takes the following configuration options:
+The `config:sail.type` value of the SHACL Sail is `"rdf4j:ShaclSail"`. It takes the following configuration options:
 
-- `ssc:parallelValidation` (boolean): Enables parallel validation (optional).
-- `ssc:undefinedTargetValidatesAllSubjects` (boolean):
+- `config:shacl.parallelValidation` (boolean): Enables parallel validation (optional).
+- `config:shacl.undefinedTargetValidatesAllSubjects` (boolean):
 Specifies if an undefined target in a shape leads to validating all subjects (optional) {{< tag "deprecated" >}} .
-- `ssc:logValidationPlans` (boolean): Specifies if validation plans are sent to the logging framework (optional).
-- `ssc:logValidationViolations` (boolean): Specifies if shape violations are sent to the logging framework (optional).
-- `ssc:ignoreNoShapesLoadedException` (boolean): Specifies if the "no shapes loaded" error is ignored (optional) {{< tag "deprecated" >}}.
-- `ssc:validationEnabled` (boolean): Specifies if transaction valudation is enabled by default (optional).
-- `ssc:cacheSelectNodes` (boolean): Specifies if select nodes are cached (optional).
-- `ssc:globalLogValidationExecution` (boolean): Specifies if validation execution details are sent to the logging framework (optional).
-- `ssc:rdfsSubClassReasoning` (boolean): Enables RDF Schema Subclass entailment (optional).
-- `ssc:performanceLogging` (boolean): Enables performance logging (optional).
-- `ssc:serializableValidation` (boolean): When enabled, combined with transactions using isolation level `SNAPSHOT` the validation guarantee is equivalent to using `SERIALIZABLE` without the performance impact.
-- `ssc:eclipseRdf4jShaclExtensions` (boolean): Enables [RDF4J-specific SHACL extensions](/shacl-extensions/)  (optional).
-- `ssc:dashDataShapes` (boolean): Enables use of [DASH data shapes](https://datashapes.org/dash) (optional).
-- `ssc:validationResultsLimitTotal` (integer): Specifies a limit on the total number of validation results sent in a validation report (optional). A values of -1 indicates no limit.
-- `ssc:validationResultsLimitPerConstraint` (integer): Specifies a limit on the number of validation results sent per constraint in a validation report (optional). A values of -1 indicates no limit.
+- `config:shacl.logValidationPlans` (boolean): Specifies if validation plans are sent to the logging framework (optional).
+- `config:shacl.logValidationViolations` (boolean): Specifies if shape violations are sent to the logging framework (optional).
+- `config:shacl.ignoreNoShapesLoadedException` (boolean): Specifies if the "no shapes loaded" error is ignored (optional) {{< tag "deprecated" >}}.
+- `config:shacl.validationEnabled` (boolean): Specifies if transaction valudation is enabled by default (optional).
+- `config:shacl.cacheSelectNodes` (boolean): Specifies if select nodes are cached (optional).
+- `config:shacl.globalLogValidationExecution` (boolean): Specifies if validation execution details are sent to the logging framework (optional).
+- `config:shacl.rdfsSubClassReasoning` (boolean): Enables RDF Schema Subclass entailment (optional).
+- `config:shacl.performanceLogging` (boolean): Enables performance logging (optional).
+- `config:shacl.serializableValidation` (boolean): When enabled, combined with transactions using isolation level `SNAPSHOT` the validation guarantee is equivalent to using `SERIALIZABLE` without the performance impact.
+- `config:shacl.eclipseRdf4jShaclExtensions` (boolean): Enables [RDF4J-specific SHACL extensions](/shacl-extensions/)  (optional).
+- `config:shacl.dashDataShapes` (boolean): Enables use of [DASH data shapes](https://datashapes.org/dash) (optional).
+- `config:shacl.validationResultsLimitTotal` (integer): Specifies a limit on the total number of validation results sent in a validation report (optional). A values of -1 indicates no limit.
+- `config:shacl.validationResultsLimitPerConstraint` (integer): Specifies a limit on the number of validation results sent per constraint in a validation report (optional). A values of -1 indicates no limit.
 
 ##### Example configuration
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
-@prefix sb: <http://www.openrdf.org/config/sail/base#>.
-@prefix ssc: <http://rdf4j.org/config/sail/shacl#> .
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "example" ;
+[] a config:Repository ;
+   config:rep.id "example" ;
    rdfs:label "Example Memory store with SHACL validation" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-         sail:sailType "rdf4j:ShaclSail";
-         ssc:parallelValidation true;
-         ssc:validationResultsLimitTotal 300;
-         sail:delegate [
-             sail:sailType "openrdf:MemoryStore" ;
+   config:rep.impl [
+      config:rep.id "openrdf:SailRepository" ;
+      sr:sail.impl [
+         config:sail.type "rdf4j:ShaclSail";
+         config:shacl.parallelValidation true;
+         config:shacl.validationResultsLimitTotal 300;
+         config:delegate [
+             config:sail.type "openrdf:MemoryStore" ;
              ...
          ];
       ]

--- a/site/content/documentation/reference/rest-api.md
+++ b/site/content/documentation/reference/rest-api.md
@@ -227,20 +227,17 @@ An example payload, containing a repository configuration for an in-memory store
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "test" ;
+[] a config:Repository ;
+   config:repositoryID "test" ;
    rdfs:label "test memory store" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-	 sail:sailType "openrdf:MemoryStore" ;
-	 ms:persist true ;
-	 ms:syncDelay 120
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+	      config:sail.type "openrdf:MemoryStore" ;
+	      config:mem.persist true ;
+	      config:mem.syncDelay 120
       ]
    ].
 ```
@@ -285,20 +282,17 @@ An example payload, containing a repository configuration for an in-memory store
 
 ```turtle
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix rep: <http://www.openrdf.org/config/repository#>.
-@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-@prefix sail: <http://www.openrdf.org/config/sail#>.
-@prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+@prefix config: <tag:rdf4j.org,2023:config/>.
 
-[] a rep:Repository ;
-   rep:repositoryID "test" ;
+[] a config:Repository ;
+   config:rep.id "test" ;
    rdfs:label "test memory store" ;
-   rep:repositoryImpl [
-      rep:repositoryType "openrdf:SailRepository" ;
-      sr:sailImpl [
-	 sail:sailType "openrdf:MemoryStore" ;
-	 ms:persist true ;
-	 ms:syncDelay 120
+   config:rep.impl [
+      config:rep.type "openrdf:SailRepository" ;
+      config:sail.impl [
+	      config:sail.type "openrdf:MemoryStore" ;
+	        config:mem.persist true ;
+	        config:mem.syncDelay 120
       ]
    ].
 ```

--- a/site/content/documentation/tools/repository-configuration.md
+++ b/site/content/documentation/tools/repository-configuration.md
@@ -13,27 +13,24 @@ The [RDF4J Console](/documentation/tools/console/) comes with a number of defaul
 To create your own templates, it’s easiest to start with an existing template and modify that to your needs. The default “memory.ttl” template looks like this:
 
     #
-    # Rdf4j configuration template for a main-memory repository
+    # RDF4J configuration template for a main-memory repository
     #
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-    @prefix rep: <http://www.openrdf.org/config/repository#>.
-    @prefix sr: <http://www.openrdf.org/config/repository/sail#>.
-    @prefix sail: <http://www.openrdf.org/config/sail#>.
-    @prefix ms: <http://www.openrdf.org/config/sail/memory#>.
+    @prefix config: <tag:rdf4j.org,2023:config/>.
 
-    [] a rep:Repository ;
-       rep:repositoryID "{%Repository ID|memory%}" ;
+    [] a config:Repository ;
+       config:rep.id "{%Repository ID|memory%}" ;
        rdfs:label "{%Repository title|Memory store%}" ;
-       rep:repositoryImpl [
-          rep:repositoryType "openrdf:SailRepository" ;
-          sr:sailImpl [
-             sail:sailType "openrdf:MemoryStore" ;
-             ms:persist {%Persist|true|false%} ;
-             ms:syncDelay {%Sync delay|0%}
+       config:rep.impl [
+          config:rep.type "openrdf:SailRepository" ;
+          config:sail.impl [
+             config:sail.type "openrdf:MemoryStore" ;
+             config:mem.persist {%Persist|true|false%} ;
+             config:mem.syncDelay {%Sync delay|0%}
           ]
        ].
 
 Template variables are written down as `{%var name%}` and can specify zero or more values, seperated by vertical bars (“|”). If one value is specified then this value is interpreted as the default value for the variable. The Console will use this default value when the user simply hits the Enter key. If multiple variable values are specified, e.g. `{%Persist|true|false%}`, then this is interpreted as set of all possible values. If the user enters an unspecified value then that is considered to be an error. The value that is specified first is used as the default value.
 
-The URIs that are used in the templates are the URIs that are specified by the `RepositoryConfig` and `SailConfig` classes of RDF4J’s repository configuration mechanism. The relevant namespaces and URIs can be found in the javadoc of these classes, or in [Repository and Sail Configuration](/documentation/reference/configuration/).
+The URIs that are used in the templates are terms defined in the RDF4J Config vocabulary. The relevant namespace and URIs can be found in the {{< javadoc "CONFIG" "model/vocabulary/config.html" >}} vocabulary javadoc, or in [Repository and Sail Configuration](/documentation/reference/configuration/).
 


### PR DESCRIPTION
GitHub issue resolved: #4401  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Update of configuration vocabularies to use a single namespace following the tag URI scheme. Aims are to 

- simplify configuration and make config files easier to read
- remove references to obsolete openrdf.org domain
- introduce new vocabulary in backward-compatible manner: the code should be able to read both the new config format and the old (or even a mix). 

We will likely want a followup at some point to create automatic migration of existing configs, before we can fully remove the old vocabulary. 

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

