### PR TITLE
GH-4403: Migrate WireMock tests to JUnit 5

### DIFF
--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -68,12 +68,6 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- This module uses WireMock in tests and cannot be fully migrated to JUnit 5 now -->
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/repository/manager/pom.xml
+++ b/core/repository/manager/pom.xml
@@ -71,12 +71,6 @@
 			<artifactId>jcl-over-slf4j</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- This module uses WireMock in tests and cannot be fully migrated to JUnit 5 now -->
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManagerTest.java
+++ b/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManagerTest.java
@@ -19,11 +19,10 @@ import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Unit tests for {@link LocalRepositoryManager}.
@@ -36,18 +35,11 @@ import org.junit.rules.TemporaryFolder;
  */
 public class LocalRepositoryManagerTest extends RepositoryManagerTest {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-
-	private File datadir;
-
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
-	@Override
-	public void setUp() throws Exception {
-		datadir = tempDir.newFolder("local-repositorysubject-test");
+	@BeforeEach
+	public void setUp(@TempDir File datadir) throws Exception {
 		subject = new LocalRepositoryManager(datadir);
 		subject.init();
 	}
@@ -55,7 +47,7 @@ public class LocalRepositoryManagerTest extends RepositoryManagerTest {
 	/**
 	 * @throws IOException if a problem occurs deleting temporary resources
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws IOException {
 		subject.shutDown();
 	}

--- a/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RepositoryManagerTest.java
+++ b/core/repository/manager/src/test/java/org/eclipse/rdf4j/repository/manager/RepositoryManagerTest.java
@@ -24,8 +24,8 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link RepositoryManager}. May be extended by specific {@link RepositoryManager} implementations.
@@ -36,7 +36,7 @@ public class RepositoryManagerTest {
 
 	protected RepositoryManager subject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		subject = new RepositoryManager() {
 

--- a/pom.xml
+++ b/pom.xml
@@ -586,7 +586,7 @@
 			<dependency>
 				<groupId>com.github.tomakehurst</groupId>
 				<artifactId>wiremock-jre8</artifactId>
-				<version>2.27.2</version>
+				<version>2.35.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>


### PR DESCRIPTION
GitHub issue resolved: #4403 

Briefly describe the changes proposed in this PR:

This migrates WireMock tests to JUnit 5 using the documented approach: https://wiremock.org/docs/junit-jupiter/.

Also upgrading WireMock to latest stable version to make the JUnit 5 integration available.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

