### PR TITLE
GH-4399 adjust docker setup to work with docker compose 2

### DIFF
--- a/docker/README_DEV.md
+++ b/docker/README_DEV.md
@@ -18,35 +18,35 @@ the maven project is assembled and the result is packed in the SDK ZIP-file unde
 2. The SDK ZIP-file is copied and renamed as `ignore/rdf4j.zip` (as required by the Dockerfile script).
 
 3. Building the docker image can be done with a docker command directly, 
-but the script takes an alternative approach and uses docker-compose instead. 
+but the script takes an alternative approach and uses docker compose instead. 
 
 4. Once the image is built, it is tagged as `eclipse/rdf4j-workbench:${maven.project.version}`.
 
 
-### Running up the docker container (docker-compose)
+### Running up the docker container (docker compose)
 
-Use docker-compose to run up the container. This uses the `docker-compose.yml` file to start
+Use `docker compose` to run up the container. This uses the `docker-compose.yml` file to start
 a container with the port mapped to 8080 and persistence using docker volumes.
 
-`docker-compose up -d`
+`docker compose up -d`
 
-#### Other useful docker-compose commands
+#### Other useful docker compose commands
 
 Stop:
 
-`docker-compose stop`
+`docker compose stop`
 
 Follow logs:
 
-`docker-compose logs -f`
+`docker compose logs -f`
 
 Show all logs:
 
-`docker-compose logs --tail="all"`
+`docker compose logs --tail="all"`
 
 Start containers in foreground (prints logs and stops containers with Ctrl-C):
 
-`docker-compose up`
+`docker compose up`
 
 Stop and remove all containers and delete all my volumes (for all containers and all volumes):
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -36,9 +36,9 @@ cd "$CURRENT"
 
 # build
 echo "Building docker image"
-docker-compose build --pull --no-cache
+docker compose build --pull --no-cache
 
-docker tag docker_rdf4j:latest eclipse/rdf4j-workbench:${MVN_VERSION}
+docker tag docker-rdf4j:latest eclipse/rdf4j-workbench:${MVN_VERSION}
 
 echo "
 Docker image tagged as:
@@ -46,7 +46,7 @@ Docker image tagged as:
   eclipse/rdf4j-workbench:${MVN_VERSION}
 
 To start the workbench and server:
-    docker-compose up -d
+    docker compose up -d
 
 Workbench will be available at http://localhost:8080/rdf4j-workbench
 "

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -42,7 +42,7 @@ docker tag docker-rdf4j:latest eclipse/rdf4j-workbench:${MVN_VERSION}
 
 echo "
 Docker image tagged as:
-  docker_rdf4j:latest
+  docker-rdf4j:latest
   eclipse/rdf4j-workbench:${MVN_VERSION}
 
 To start the workbench and server:

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,14 +3,14 @@ set -e
 ./build.sh
 
 echo "Starting the docker container"
-docker-compose up --force-recreate -d
+docker compose up --force-recreate -d
 
 # Wait for the server to be ready. Server is ready when the log contains something like "org.apache.catalina.startup.Catalina.start Server startup in 3400 ms".
 printf '%s' "Waiting for container to be ready"
-while ! docker-compose logs rdf4j | grep -q "Server startup in"; do
+while ! docker compose logs rdf4j | grep -q "Server startup in"; do
   printf '%s' "."
   # Exit with error if we have looped 30 times (e.g. 30 seconds)
-  ((c++)) && ((c == 30)) && echo "" && docker-compose logs | tee && echo "" && docker ps -a | tee && printf '\n%s\n' "Timed out while waiting!" >&2 && exit 1
+  ((c++)) && ((c == 30)) && echo "" && docker compose logs | tee && echo "" && docker ps -a | tee && printf '\n%s\n' "Timed out while waiting!" >&2 && exit 1
   sleep 1
 done
 


### PR DESCRIPTION
GitHub issue resolved: #4399  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- docker compose is a docker plugin now instead of a separate command: all usages of `docker-compose` replaced with `docker compose`.
- docker compose v2 uses a differerent naming convention for the produced image: `docker-rdf4j` instead of `docker_rdf4j`
- tested with Docker version 23.0.0, Docker Compose version v2.15.1

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

