### PR TITLE
GH-4414 fix junit in benchmarks

### DIFF
--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/NowTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/NowTest.java
@@ -20,7 +20,6 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trigstar/TriGStarParserTest.java
@@ -33,7 +33,6 @@ import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.SimpleParseLocationListener;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
@@ -18,7 +18,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.Resource;
@@ -28,8 +30,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -61,9 +61,6 @@ public class QueryBenchmark {
 
 	private SailRepository repository;
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-
 	private static final String query1;
 	private static final String query2;
 	private static final String query3;
@@ -86,6 +83,7 @@ public class QueryBenchmark {
 	}
 
 	List<Statement> statementList;
+	private File file;
 
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
@@ -98,8 +96,8 @@ public class QueryBenchmark {
 
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException {
-		tempDir.create();
-		File file = tempDir.newFolder();
+
+		file = Files.newTemporaryFolder();
 
 		repository = new SailRepository(new LmdbStore(file, ConfigUtil.createConfig()));
 
@@ -124,8 +122,8 @@ public class QueryBenchmark {
 
 	@TearDown(Level.Trial)
 	public void afterClass() throws IOException {
-		tempDir.delete();
 		repository.shutDown();
+		FileUtils.deleteDirectory(file);
 	}
 
 	@Benchmark

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryBenchmark.java
@@ -17,14 +17,14 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -53,9 +53,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class QueryBenchmark {
-
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
 
 	private SailRepository repository;
 
@@ -108,6 +105,8 @@ public class QueryBenchmark {
 		}
 	}
 
+	private File file;
+
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
 				.include("QueryBenchmark") // adapt to run other benchmark tests
@@ -119,8 +118,7 @@ public class QueryBenchmark {
 
 	@Setup(Level.Trial)
 	public void beforeClass() throws IOException, InterruptedException {
-		tempDir.create();
-		File file = tempDir.newFolder();
+		file = Files.newTemporaryFolder();
 
 		repository = new SailRepository(new NativeStore(file, "spoc,ospc,psoc"));
 
@@ -134,9 +132,9 @@ public class QueryBenchmark {
 	}
 
 	@TearDown(Level.Trial)
-	public void afterClass() {
+	public void afterClass() throws IOException {
 		repository.shutDown();
-		tempDir.delete();
+		FileUtils.deleteDirectory(file);
 	}
 
 	@Benchmark

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryWriteBenchmark.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/benchmark/QueryWriteBenchmark.java
@@ -18,7 +18,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.Model;
@@ -30,8 +32,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -61,9 +61,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class QueryWriteBenchmark {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-
 	private SailRepository repository;
 
 	private static final String query2;
@@ -85,6 +82,8 @@ public class QueryWriteBenchmark {
 		}
 	}
 
+	private File file;
+
 	public static void main(String[] args) throws RunnerException {
 		Options opt = new OptionsBuilder()
 				.include("QueryWriteBenchmark") // adapt to run other benchmark tests
@@ -96,8 +95,7 @@ public class QueryWriteBenchmark {
 
 	@Setup(Level.Invocation)
 	public void beforeClass() throws IOException, InterruptedException {
-		tempDir.create();
-		File file = tempDir.newFolder();
+		file = Files.newTemporaryFolder();
 
 		repository = new SailRepository(new NativeStore(file, "spoc,ospc,psoc"));
 
@@ -118,9 +116,10 @@ public class QueryWriteBenchmark {
 	}
 
 	@TearDown(Level.Invocation)
-	public void afterClass() {
+	public void afterClass() throws IOException {
 		repository.shutDown();
-		tempDir.delete();
+		FileUtils.deleteDirectory(file);
+
 	}
 
 	@Benchmark

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ExpressionsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/constraint/ExpressionsTest.java
@@ -18,7 +18,6 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ExpressionsTest {

--- a/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/QueryOrderBenchmark.java
+++ b/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/QueryOrderBenchmark.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -23,11 +25,6 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -47,8 +44,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 /**
  * Designed to test the performance of ORDER BY queries.
  *
- * @see <a href="https://github.com/eclipse/rdf4j/issues/971">https://github.com/eclipse/rdf4j/issues/971</a>
  * @author James Leigh
+ * @see <a href="https://github.com/eclipse/rdf4j/issues/971">https://github.com/eclipse/rdf4j/issues/971</a>
  */
 @Fork(1)
 @State(Scope.Thread)
@@ -57,8 +54,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class QueryOrderBenchmark {
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+
 	private File dataDir;
 
 	private final Random random = new Random(43252333);
@@ -77,9 +73,8 @@ public class QueryOrderBenchmark {
 	public int syncThreshold = 10;
 
 	@Setup
-	@Before
 	public void setup() throws Exception {
-		dataDir = tempDir.newFolder();
+		dataDir = Files.newTemporaryFolder();
 		NativeStore sail = new NativeStore(dataDir, "spoc,posc");
 		sail.setIterationCacheSyncThreshold(syncThreshold);
 		repository = new SailRepository(sail);
@@ -103,13 +98,12 @@ public class QueryOrderBenchmark {
 	}
 
 	@TearDown
-	@After
 	public void tearDown() throws Exception {
 		conn.close();
 		repository.shutDown();
+		FileUtils.deleteDirectory(dataDir);
 	}
 
-	@Test
 	@Benchmark
 	public void selectAll() throws Exception {
 		StringBuilder rq = new StringBuilder("SELECT * { ?s ?p ?o } ORDER BY ?o");
@@ -135,7 +129,6 @@ public class QueryOrderBenchmark {
 		}
 	}
 
-	@Test
 	@Benchmark
 	public void selectDistinct() throws Exception {
 		StringBuilder rq = new StringBuilder("SELECT DISTINCT ?s ?o { ?s ?p ?o } ORDER BY ?o");

--- a/tools/config/src/main/java/org/eclipse/rdf4j/common/logging/file/logback/MultipleFileLogReader.java
+++ b/tools/config/src/main/java/org/eclipse/rdf4j/common/logging/file/logback/MultipleFileLogReader.java
@@ -23,7 +23,6 @@ import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.eclipse.rdf4j.common.logging.LogReader;
 import org.eclipse.rdf4j.common.logging.LogRecord;
 import org.eclipse.rdf4j.common.logging.base.AbstractLogReader;
 

--- a/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ShaclValidationReportIT.java
+++ b/tools/server/src/test/java/org/eclipse/rdf4j/http/server/ShaclValidationReportIT.java
@@ -29,7 +29,6 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
GitHub issue resolved: #4414 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - swap out use of junit rules with explicit creation and deletion of temporary folders in benchmark files where junit isn't in use anyways


<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

