### PR TITLE
GH-4421: Eliminate dependencies to javax.xml.bind from core libraries

### DIFF
--- a/core/http/protocol/pom.xml
+++ b/core/http/protocol/pom.xml
@@ -31,9 +31,9 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>jakarta.xml.bind</groupId>
-			<artifactId>jakarta.xml.bind-api</artifactId>
-			<version>${jaxb.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionSAXParser.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionSAXParser.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.http.protocol.transaction;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +94,7 @@ class TransactionSAXParser extends SimpleSAXAdapter {
 			String encoding = atts.get(TransactionXMLConstants.ENCODING_ATT);
 
 			if (encoding != null && "base64".equalsIgnoreCase(encoding)) {
-				text = new String(javax.xml.bind.DatatypeConverter.parseBase64Binary(text));
+				text = new String(Base64.getDecoder().decode(text));
 			}
 			Literal lit;
 			if (lang != null) {

--- a/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriter.java
+++ b/core/http/protocol/src/main/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriter.java
@@ -13,8 +13,7 @@ package org.eclipse.rdf4j.http.protocol.transaction;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 import org.eclipse.rdf4j.common.xml.XMLUtil;
 import org.eclipse.rdf4j.common.xml.XMLWriter;
@@ -299,7 +298,7 @@ public class TransactionWriter {
 
 			if (!valid) {
 				xmlWriter.setAttribute(TransactionXMLConstants.ENCODING_ATT, "base64");
-				label = DatatypeConverter.printBase64Binary(label.getBytes(StandardCharsets.UTF_8));
+				label = Base64.getEncoder().encodeToString(label.getBytes(StandardCharsets.UTF_8));
 			}
 
 			xmlWriter.textElement(TransactionXMLConstants.LITERAL_TAG, label);

--- a/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriterTest.java
+++ b/core/http/protocol/src/test/java/org/eclipse/rdf4j/http/protocol/transaction/TransactionWriterTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.protocol.transaction;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.eclipse.rdf4j.model.util.Values.literal;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.StringWriter;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.common.xml.XMLWriter;
+import org.eclipse.rdf4j.model.Literal;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TransactionWriterTest {
+	private static Stream<Arguments> serializedLiterals() {
+		return Stream.of(
+				arguments(literal("Hello World"),
+						"<literal datatype='http://www.w3.org/2001/XMLSchema#string'>Hello World</literal>"),
+				arguments(literal(42), "<literal datatype='http://www.w3.org/2001/XMLSchema#int'>42</literal>"),
+				arguments(literal("with special <> char"),
+						"<literal datatype='http://www.w3.org/2001/XMLSchema#string'>with special &lt;&gt; char</literal>"),
+				arguments(literal("non valid char" + '\u0001'),
+						"<literal datatype='http://www.w3.org/2001/XMLSchema#string' encoding='base64'>bm9uIHZhbGlkIGNoYXIB</literal>")
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("serializedLiterals")
+	public void testSerializeLiteral(Literal literal, String expectedString) throws Exception {
+		TransactionWriter writer = new TransactionWriter();
+
+		StringWriter sw = new StringWriter();
+		XMLWriter xmlWriter = new XMLWriter(sw);
+		writer.serialize(literal, xmlWriter);
+
+		assertThat(sw.toString())
+				.isEqualTo(expectedString);
+	}
+}

--- a/core/rio/api/pom.xml
+++ b/core/rio/api/pom.xml
@@ -21,9 +21,8 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>jakarta.xml.bind</groupId>
-			<artifactId>jakarta.xml.bind-api</artifactId>
-			<version>${jaxb.version}</version>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.jsonld-java</groupId>

--- a/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
+++ b/core/rio/api/src/main/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParser.java
@@ -21,8 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
-
+import org.apache.commons.codec.binary.Hex;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -410,7 +409,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 				// we use an MD5 hash rather than the node ID itself to get a
 				// fixed-length generated id, rather than
 				// an ever-growing one (see SES-2171)
-				toAppend = (new HexBinaryAdapter()).marshal(md5.digest(chars));
+				toAppend = Hex.encodeHexString(md5.digest(chars), false);
 			}
 
 			ParsedIRI skolem = getCachedSkolemOrigin();
@@ -461,7 +460,7 @@ public abstract class AbstractRDFParser implements RDFParser {
 				// we use an MD5 hash rather than the node ID itself to get a
 				// fixed-length generated id, rather than
 				// an ever-growing one (see SES-2171)
-				toAppend = (new HexBinaryAdapter()).marshal(md5.digest(chars));
+				toAppend = Hex.encodeHexString(md5.digest(chars), false);
 			}
 
 			return valueFactory.createBNode("genid-" + nextBNodePrefix + toAppend);

--- a/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParserTest.java
+++ b/core/rio/api/src/test/java/org/eclipse/rdf4j/rio/helpers/AbstractRDFParserTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.rio.helpers;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -76,5 +77,17 @@ public class AbstractRDFParserTest {
 		assertFalse(parser.getBNode().toString().startsWith("http://www.example.com"));
 		assertTrue(parser.getBNode().toString().startsWith("_"));
 		assertTrue(parser.getBNode("12").toString().endsWith("12"));
+	}
+
+	@Test
+	public void testNodeIdHashing() throws Exception {
+		// node ids look like "genid_.*-suffix
+		assertThat(parser.createNode("someid").stringValue())
+				.endsWith("-someid");
+
+		// some long id (length > 32) => suffix is hashed
+		String longNodeId = "someverylongnodeidwithmorethan32characters";
+		assertThat(parser.createNode(longNodeId).stringValue())
+				.endsWith("2A372A91878F0980C8F53341D2D8A944");
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #4421

Briefly describe the changes proposed in this PR:

This PR eliminates dependencies to` javax.xml.bind` from core libraries. Main motivation being to ease the javax->jakarta migration, ref. #3559.

- Base64 encoding now uses the standard Java library support added in Java 8
- To perform Hex encoding, I am proposing to use commons-codec for now,. But it should be fairly simple to write our own utility method if that is an unwanted dependency. And migrate to the standard Java library support added in Java 17 - once Java 17 becomes the minimum supported version.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

Kudos to @aschwarte10 for the test additions.