### PR TITLE
GH-4425: Migrate tests with timeout config to JUnit 5

### DIFF
--- a/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
+++ b/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -20,8 +22,7 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.util.Repositories;
 import org.eclipse.rdf4j.sail.lucene.impl.LuceneIndex;
 import org.eclipse.testsuite.rdf4j.sail.lucene.AbstractLuceneSailTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author jeen
@@ -56,7 +57,7 @@ public class LuceneSailTest extends AbstractLuceneSailTest {
 
 		// expected empty result => no data in the index
 		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
-		Assert.assertEquals(Collections.emptyList(), res);
+		assertEquals(Collections.emptyList(), res);
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 			connection.add(SUBJECT_1, PREDICATE_1, vf.createLiteral("one"));
@@ -64,14 +65,14 @@ public class LuceneSailTest extends AbstractLuceneSailTest {
 
 		// expected single result
 		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
-		Assert.assertEquals(1, res.size());
+		assertEquals(1, res.size());
 
 		// re-index
 		this.sail.reindex();
 
 		// expected single result
 		res = Repositories.tupleQuery(repository, query, t -> Iterations.asList(t));
-		Assert.assertEquals(1, res.size());
+		assertEquals(1, res.size());
 	}
 
 }

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTest.java
@@ -27,15 +27,16 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.RepositoryTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class HTTPRepositoryTest extends RepositoryTest {
 
 	private static HTTPMemServer server;
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new HTTPMemServer();
 		try {
@@ -46,7 +47,7 @@ public class HTTPRepositoryTest extends RepositoryTest {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 	}
@@ -56,7 +57,8 @@ public class HTTPRepositoryTest extends RepositoryTest {
 		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
 	}
 
-	@Test(timeout = 10_000)
+	@Test
+	@Timeout(value = 10)
 	public void testSubqueryDeadlock() throws Exception {
 		String mainQueryStr = "SELECT ?property WHERE { ?property a rdf:Property . }";
 		String subQueryStr = "SELECT ?range WHERE { ?property rdfs:range ?range . }";

--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositoryTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLRepositoryTest.java
@@ -14,9 +14,9 @@ import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.http.HTTPMemServer;
 import org.eclipse.rdf4j.testsuite.repository.RepositoryTest;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Jeen Broekstra
@@ -25,7 +25,7 @@ public class SPARQLRepositoryTest extends RepositoryTest {
 
 	private static HTTPMemServer server;
 
-	@BeforeClass
+	@BeforeAll
 	public static void startServer() throws Exception {
 		server = new HTTPMemServer();
 		try {
@@ -37,7 +37,7 @@ public class SPARQLRepositoryTest extends RepositoryTest {
 
 	}
 
-	@Before
+	@BeforeEach
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
@@ -49,7 +49,7 @@ public class SPARQLRepositoryTest extends RepositoryTest {
 
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void stopServer() throws Exception {
 		server.stop();
 		server = null;

--- a/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrSailTest.java
+++ b/compliance/solr/src/test/java/org/eclipse/rdf4j/sail/solr/SolrSailTest.java
@@ -18,8 +18,9 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.solr.SolrIndexTest.PropertiesReader;
 import org.eclipse.testsuite.rdf4j.sail.lucene.AbstractLuceneSailTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 
 public class SolrSailTest extends AbstractLuceneSailTest {
 
@@ -27,7 +28,7 @@ public class SolrSailTest extends AbstractLuceneSailTest {
 
 	private static String toRestoreSolrHome = null;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		toRestoreSolrHome = System.getProperty("solr.solr.home");
 		PropertiesReader reader = new PropertiesReader("maven-config.properties");
@@ -35,7 +36,7 @@ public class SolrSailTest extends AbstractLuceneSailTest {
 		System.setProperty("solr.solr.home", testSolrHome);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDownClass() throws Exception {
 		System.setProperty("solr.solr.home", toRestoreSolrHome == null ? "" : toRestoreSolrHome);
 		toRestoreSolrHome = null;
@@ -47,9 +48,8 @@ public class SolrSailTest extends AbstractLuceneSailTest {
 		sail.setParameter(SolrIndex.SERVER_KEY, "embedded:");
 	}
 
-	@Override
-	public void tearDown() throws IOException, RepositoryException {
-		super.tearDown();
+	@AfterEach
+	public void deleteDataDir() throws IOException, RepositoryException {
 		FileUtils.deleteDirectory(new File(DATA_DIR));
 	}
 }

--- a/core/rio/trig/pom.xml
+++ b/core/rio/trig/pom.xml
@@ -56,11 +56,5 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- This module uses timeout rule, and cannot be fully migrated to JUnit 5 now -->
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
+++ b/core/rio/trig/src/test/java/org/eclipse/rdf4j/rio/trig/TriGParserCustomTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.rio.trig;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.util.concurrent.TimeUnit;
@@ -33,21 +33,17 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Custom (non-manifest) tests for TriG parser.
  *
  * @author Peter Ansell
  */
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
 public class TriGParserCustomTest {
-
-	@Rule
-	public Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
-
 	private ValueFactory vf;
 
 	private ParserConfig settingsNoVerifyLangTag;
@@ -61,7 +57,7 @@ public class TriGParserCustomTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		vf = SimpleValueFactory.getInstance();
 		settingsNoVerifyLangTag = new ParserConfig();

--- a/core/rio/turtle/pom.xml
+++ b/core/rio/turtle/pom.xml
@@ -61,11 +61,5 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<!-- This module uses timeout rule, and cannot be fully migrated to JUnit 5 now -->
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
+++ b/core/rio/turtle/src/test/java/org/eclipse/rdf4j/rio/turtle/CustomTurtleParserTest.java
@@ -11,10 +11,10 @@
 package org.eclipse.rdf4j.rio.turtle;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -40,10 +40,9 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorCollector;
 import org.eclipse.rdf4j.rio.helpers.ParseErrorLogger;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,10 +51,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Peter Ansell
  */
+@Timeout(1000)
 public class CustomTurtleParserTest {
-
-	@Rule
-	public Timeout timeout = Timeout.millis(1000000);
 
 	private ValueFactory vf;
 
@@ -72,7 +69,7 @@ public class CustomTurtleParserTest {
 	/**
 	 * @throws java.lang.Exception
 	 */
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		vf = SimpleValueFactory.getInstance();
 		settingsNoVerifyLangTag = new ParserConfig();
@@ -182,8 +179,8 @@ public class CustomTurtleParserTest {
 
 		String str = out.toString();
 
-		assertTrue("okLiteralString not found", str.contains(okLiteralString));
-		assertTrue("errLiteralString not found", str.contains(errLiteralString));
+		assertTrue(str.contains(okLiteralString), "okLiteralString not found");
+		assertTrue(str.contains(errLiteralString), "errLiteralString not found");
 	}
 
 	@Test

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreContextIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreContextIT.java
@@ -21,8 +21,8 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.sail.RDFNotifyingStoreTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * An extension of RDFStoreTest for testing the class
@@ -34,13 +34,13 @@ public class ElasticsearchStoreContextIT extends RDFNotifyingStoreTest {
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreIT.java
@@ -22,8 +22,8 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.sail.RDFNotifyingStoreTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 /**
  * An extension of RDFStoreTest for testing the class
@@ -39,13 +39,13 @@ public class ElasticsearchStoreIT extends RDFNotifyingStoreTest {
 	private static ElasticsearchClusterRunner runner;
 	static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreRepositoryIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreRepositoryIT.java
@@ -21,9 +21,9 @@ import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
 import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
 import org.eclipse.rdf4j.testsuite.repository.RepositoryTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 
 public class ElasticsearchStoreRepositoryIT extends RepositoryTest {
 
@@ -31,13 +31,13 @@ public class ElasticsearchStoreRepositoryIT extends RepositoryTest {
 	private static ElasticsearchClusterRunner runner;
 	private static SingletonClientProvider clientPool;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws IOException, InterruptedException {
 		runner = TestHelpers.startElasticsearch(installLocation);
 		clientPool = new SingletonClientProvider("localhost", TestHelpers.getPort(runner), TestHelpers.CLUSTER);
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		clientPool.close();
 		TestHelpers.stopElasticsearch(runner);
@@ -50,7 +50,7 @@ public class ElasticsearchStoreRepositoryIT extends RepositoryTest {
 		return sailRepository;
 	}
 
-	@Ignore
+	@Disabled
 	@Override
 	public void testShutdownFollowedByInit() throws Exception {
 		// ignore test

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreContextTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreContextTest.java
@@ -10,14 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.sail.RDFNotifyingStoreTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of RDFStoreTest for testing the class {@link LmdbStore}.
@@ -28,8 +27,8 @@ public class LmdbStoreContextTest extends RDFNotifyingStoreTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -37,12 +36,8 @@ public class LmdbStoreContextTest extends RDFNotifyingStoreTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			NotifyingSail sail = new LmdbStore(tempDir.newFolder(), new LmdbStoreConfig("spoc,posc"));
-			sail.init();
-			return sail;
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		NotifyingSail sail = new LmdbStore(dataDir, new LmdbStoreConfig("spoc,posc"));
+		sail.init();
+		return sail;
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreRepositoryTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreRepositoryTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
@@ -17,14 +18,15 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.repository.RepositoryTest;
 import org.junit.Rule;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.rules.TemporaryFolder;
 
 public class LmdbStoreRepositoryTest extends RepositoryTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	public File dataDir;
 
 	@Override
 	protected Repository createRepository() throws IOException {
-		return new SailRepository(new LmdbStore(tmpDir.getRoot(), new LmdbStoreConfig("spoc")));
+		return new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig("spoc")));
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStoreTest.java
@@ -11,11 +11,10 @@
 package org.eclipse.rdf4j.sail.lmdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -24,9 +23,8 @@ import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.eclipse.rdf4j.testsuite.sail.RDFNotifyingStoreTest;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of RDFStoreTest for testing the class {@link LmdbStore}.
@@ -37,9 +35,8 @@ public class LmdbStoreTest extends RDFNotifyingStoreTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-	private File dataDir;
+	@TempDir
+	public File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -47,18 +44,13 @@ public class LmdbStoreTest extends RDFNotifyingStoreTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			dataDir = tempDir.newFolder();
-			NotifyingSail sail = new LmdbStore(dataDir, new LmdbStoreConfig("spoc,posc"));
-			sail.init();
-			return sail;
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		NotifyingSail sail = new LmdbStore(dataDir, new LmdbStoreConfig("spoc,posc"));
+		sail.init();
+		return sail;
 	}
 
 	// Test for SES-542
-	@Test()
+	@Test
 	public void testGetNamespacePersistence() throws Exception {
 		con.begin();
 		con.setNamespace("rdf", RDF.NAMESPACE);

--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -73,11 +73,5 @@
 			<groupId>org.locationtech.jts</groupId>
 			<artifactId>jts-core</artifactId>
 		</dependency>
-		<!-- This module uses timeout rule, and cannot be fully migrated to JUnit 5 now -->
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/AbstractGenericLuceneTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/AbstractGenericLuceneTest.java
@@ -14,11 +14,11 @@ import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.PROPERTY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.QUERY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SCORE;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SNIPPET;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -61,19 +61,15 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.lucene.LuceneSailSchema;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
 public abstract class AbstractGenericLuceneTest {
-
-	@Rule
-	public Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
-
 	protected static final ValueFactory vf = SimpleValueFactory.getInstance();
 
 	public static final String QUERY_STRING;
@@ -121,7 +117,7 @@ public abstract class AbstractGenericLuceneTest {
 
 	protected abstract void configure(LuceneSail sail) throws IOException;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set logging, uncomment this to get better logging for debugging
 		// org.apache.log4j.BasicConfigurator.configure();
@@ -152,7 +148,7 @@ public abstract class AbstractGenericLuceneTest {
 		connection.commit();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws IOException, RepositoryException {
 		try {
 			if (connection != null) {
@@ -267,10 +263,10 @@ public abstract class AbstractGenericLuceneTest {
 
 			// the number of matched expected results must be equal to the number
 			// of actual results
-			assertEquals("How many expected results were retrieved for query #" + queryID + "?",
-					expectedResultSet.size(), matched.size());
-			assertEquals("How many actual results were retrieved for query #" + queryID + "?", expectedResultSet.size(),
-					actualResults);
+			assertEquals(expectedResultSet.size(), matched.size(),
+					"How many expected results were retrieved for query #" + queryID + "?");
+			assertEquals(expectedResultSet.size(), actualResults,
+					"How many actual results were retrieved for query #" + queryID + "?");
 		}
 	}
 
@@ -454,9 +450,9 @@ public abstract class AbstractGenericLuceneTest {
 			}
 
 			// we found all
-			assertTrue("These were expected but not found: " + expectedSnippetPart, expectedSnippetPart.isEmpty());
+			assertTrue(expectedSnippetPart.isEmpty(), "These were expected but not found: " + expectedSnippetPart);
 
-			assertEquals("there should have been 2 results", 2, results);
+			assertEquals(2, results, "there should have been 2 results");
 		}
 	}
 
@@ -523,9 +519,9 @@ public abstract class AbstractGenericLuceneTest {
 			}
 
 			// we found all
-			assertTrue("These were expected but not found: " + expectedSnippetPart, expectedSnippetPart.isEmpty());
+			assertTrue(expectedSnippetPart.isEmpty(), "These were expected but not found: " + expectedSnippetPart);
 
-			assertEquals("there should have been 3 results", 3, results);
+			assertEquals(3, results, "there should have been 3 results");
 		}
 	}
 
@@ -763,7 +759,7 @@ public abstract class AbstractGenericLuceneTest {
 				// remove it from the set
 				Value subject = bindings.getValue("Resource");
 				IRI expectedProperty = expectedSubject.remove(subject);
-				assertEquals("For subject " + subject, expectedProperty, bindings.getValue("Property"));
+				assertEquals(expectedProperty, bindings.getValue("Property"), "For subject " + subject);
 			}
 
 			// there should have been 3 results
@@ -803,7 +799,7 @@ public abstract class AbstractGenericLuceneTest {
 		for (Throwable e : exceptions) {
 			e.printStackTrace(System.err);
 		}
-		assertEquals("Exceptions occurred during testMultithreadedAdd, see stacktraces above", 0, exceptions.size());
+		assertEquals(0, exceptions.size(), "Exceptions occurred during testMultithreadedAdd, see stacktraces above");
 	}
 
 	@Test
@@ -830,11 +826,11 @@ public abstract class AbstractGenericLuceneTest {
 		TupleQuery query = connection.prepareTupleQuery(queryString);
 		try (TupleQueryResult result = query.evaluate()) {
 			// check the result
-			assertTrue("query for literal '" + literal + " did not return any results, expected was " + resultUri,
-					result.hasNext());
+			assertTrue(result.hasNext(),
+					"query for literal '" + literal + " did not return any results, expected was " + resultUri);
 			BindingSet bindings = result.next();
-			assertEquals("query for literal '" + literal + " did not return the expected resource", resultUri,
-					bindings.getValue("Resource"));
+			assertEquals(resultUri, bindings.getValue("Resource"),
+					"query for literal '" + literal + " did not return the expected resource");
 			assertFalse(result.hasNext());
 		}
 	}
@@ -846,8 +842,8 @@ public abstract class AbstractGenericLuceneTest {
 		TupleQuery query = connection.prepareTupleQuery(queryString);
 		try (TupleQueryResult result = query.evaluate()) {
 			// check the result
-			assertFalse("query for literal '" + literal + " did return results, which was not expected.",
-					result.hasNext());
+			assertFalse(result.hasNext(),
+					"query for literal '" + literal + " did return results, which was not expected.");
 		}
 	}
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.memory;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
@@ -24,7 +26,7 @@ import org.eclipse.rdf4j.query.parser.QueryParserUtil;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.testsuite.sail.RDFNotifyingStoreTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * An extension of RDFStoreTest for testing the class <var>org.eclipse.rdf4j.sesame.sail.memory.MemoryStore</var>.
@@ -56,17 +58,17 @@ public class MemoryStoreTest extends RDFNotifyingStoreTest {
 				"http://example.org/");
 		CloseableIteration<? extends BindingSet, QueryEvaluationException> res = con.evaluate(tupleQuery.getTupleExpr(),
 				null, EmptyBindingSet.getInstance(), false);
-		assertTrue("expect a result", res.hasNext());
+		assertTrue(res.hasNext(), "expect a result");
 		int count = 0;
 		while (res.hasNext()) {
 			BindingSet bs = res.next();
 			Value v = bs.getValue("resource");
-			assertTrue("expect non-null value", v != null);
-			assertTrue("expect IRI", v instanceof IRI);
-			assertTrue("expect <http://unexisting_resource>", "http://unexisting_resource".equals(v.stringValue()));
+			assertNotNull(v, "expect non-null value");
+			assertTrue(v instanceof IRI, "expect IRI");
+			assertEquals("http://unexisting_resource", v.stringValue(), "expect <http://unexisting_resource>");
 			count++;
 		}
-		assertTrue("expect single solution", count == 1);
+		assertEquals(1, count, "expect single solution");
 	}
 
 }

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/PersistentMemoryStoreTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/PersistentMemoryStoreTest.java
@@ -11,31 +11,26 @@
 
 package org.eclipse.rdf4j.sail.memory;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.testsuite.sail.RDFNotifyingStoreTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of RDFStoreTest for testing the class <var>org.eclipse.rdf4j.sesame.sail.memory.MemoryStore</var>.
  */
 public class PersistentMemoryStoreTest extends RDFNotifyingStoreTest {
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File dataDir;
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			NotifyingSail sail = new MemoryStore(tempDir.newFolder(PersistentMemoryStoreTest.class.getSimpleName()));
-			sail.init();
-			return sail;
-		} catch (IOException e) {
-			throw new SailException(e);
-		}
+		NotifyingSail sail = new MemoryStore(dataDir);
+		sail.init();
+		return sail;
 	}
-
 }

--- a/core/sail/nativerdf/pom.xml
+++ b/core/sail/nativerdf/pom.xml
@@ -91,11 +91,6 @@
 			<version>${jmhVersion}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/DefaultIndexTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/DefaultIndexTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.util.Properties;
 
 import org.eclipse.rdf4j.common.io.FileUtil;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStoreTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStoreTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -72,9 +72,9 @@ public class NativeSailStoreTest {
 			conn.remove((IRI) null, null, null, CTX_1);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
-			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
-			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+			assertTrue(conn.hasStatement(S0, false), "Statement 0 incorrectly removed");
+			assertFalse(conn.hasStatement(S1, false, CTX_1), "Statement 1 still not removed");
+			assertTrue(conn.hasStatement(S2, false, CTX_2), "Statement 2 incorrectly removed");
 		}
 	}
 
@@ -84,9 +84,9 @@ public class NativeSailStoreTest {
 			conn.remove((IRI) null, null, null, (Resource) null);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertFalse("Statement 0 still not removed", conn.hasStatement(S0, false));
-			assertTrue("Statement 1 incorrectly removed", conn.hasStatement(S1, false, CTX_1));
-			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+			assertFalse(conn.hasStatement(S0, false), "Statement 0 still not removed");
+			assertTrue(conn.hasStatement(S1, false, CTX_1), "Statement 1 incorrectly removed");
+			assertTrue(conn.hasStatement(S2, false, CTX_2), "Statement 2 incorrectly removed");
 		}
 	}
 
@@ -96,9 +96,9 @@ public class NativeSailStoreTest {
 			conn.remove((IRI) null, null, null, CTX_INV);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
-			assertTrue("Statement 1 incorrectly removed", conn.hasStatement(S1, false, CTX_1));
-			assertTrue("Statement 2 incorrectly removed", conn.hasStatement(S2, false, CTX_2));
+			assertTrue(conn.hasStatement(S0, false), "Statement 0 incorrectly removed");
+			assertTrue(conn.hasStatement(S1, false, CTX_1), "Statement 1 incorrectly removed");
+			assertTrue(conn.hasStatement(S2, false, CTX_2), "Statement 2 incorrectly removed");
 		}
 	}
 
@@ -108,9 +108,9 @@ public class NativeSailStoreTest {
 			conn.remove((IRI) null, null, null, CTX_1, CTX_2);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
-			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
-			assertFalse("Statement 2 still not removed", conn.hasStatement(S2, false, CTX_2));
+			assertTrue(conn.hasStatement(S0, false), "Statement 0 incorrectly removed");
+			assertFalse(conn.hasStatement(S1, false, CTX_1), "Statement 1 still not removed");
+			assertFalse(conn.hasStatement(S2, false, CTX_2), "Statement 2 still not removed");
 		}
 	}
 
@@ -120,9 +120,9 @@ public class NativeSailStoreTest {
 			conn.clear(CTX_1, CTX_2);
 		}
 		try (RepositoryConnection conn = repo.getConnection()) {
-			assertTrue("Statement 0 incorrectly removed", conn.hasStatement(S0, false));
-			assertFalse("Statement 1 still not removed", conn.hasStatement(S1, false, CTX_1));
-			assertFalse("Statement 2 still not removed", conn.hasStatement(S2, false, CTX_2));
+			assertTrue(conn.hasStatement(S0, false), "Statement 0 incorrectly removed");
+			assertFalse(conn.hasStatement(S1, false, CTX_1), "Statement 1 still not removed");
+			assertFalse(conn.hasStatement(S2, false, CTX_2), "Statement 2 still not removed");
 		}
 	}
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnectionTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConnectionTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConsistencyIT.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreConsistencyIT.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.List;

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreContextTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreContextTest.java
@@ -10,13 +10,12 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import java.io.IOException;
+import java.io.File;
 
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.testsuite.sail.RDFNotifyingStoreTest;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of RDFStoreTest for testing the class {@link NativeStore}.
@@ -27,8 +26,8 @@ public class NativeStoreContextTest extends RDFNotifyingStoreTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
+	@TempDir
+	public File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -36,12 +35,8 @@ public class NativeStoreContextTest extends RDFNotifyingStoreTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			NotifyingSail sail = new NativeStore(tempDir.newFolder(), "spoc,posc");
-			sail.init();
-			return sail;
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		NotifyingSail sail = new NativeStore(dataDir, "spoc,posc");
+		sail.init();
+		return sail;
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreDirLockTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreDirLockTest.java
@@ -10,12 +10,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 
 import org.eclipse.rdf4j.sail.SailLockedException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreRepositoryTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreRepositoryTest.java
@@ -10,20 +10,22 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.testsuite.repository.RepositoryTest;
 import org.junit.Rule;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.rules.TemporaryFolder;
 
 public class NativeStoreRepositoryTest extends RepositoryTest {
-	@Rule
-	public final TemporaryFolder tmpDir = new TemporaryFolder();
+	@TempDir
+	public File dataDir;
 
 	@Override
 	protected Repository createRepository() throws IOException {
-		return new SailRepository(new NativeStore(tmpDir.getRoot(), "spoc"));
+		return new SailRepository(new NativeStore(dataDir, "spoc"));
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTest.java
@@ -11,11 +11,10 @@
 package org.eclipse.rdf4j.sail.nativerdf;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.assertj.core.util.Files;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -23,9 +22,8 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.testsuite.sail.RDFNotifyingStoreTest;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * An extension of RDFStoreTest for testing the class {@link NativeStore}.
@@ -36,9 +34,8 @@ public class NativeStoreTest extends RDFNotifyingStoreTest {
 	 * Variables *
 	 *-----------*/
 
-	@Rule
-	public TemporaryFolder tempDir = new TemporaryFolder();
-	private File dataDir;
+	@TempDir
+	public File dataDir;
 
 	/*---------*
 	 * Methods *
@@ -46,18 +43,13 @@ public class NativeStoreTest extends RDFNotifyingStoreTest {
 
 	@Override
 	protected NotifyingSail createSail() throws SailException {
-		try {
-			dataDir = tempDir.newFolder();
-			NotifyingSail sail = new NativeStore(dataDir, "spoc,posc");
-			sail.init();
-			return sail;
-		} catch (IOException e) {
-			throw new AssertionError(e);
-		}
+		NotifyingSail sail = new NativeStore(dataDir, "spoc,posc");
+		sail.init();
+		return sail;
 	}
 
 	// Test for SES-542
-	@Test()
+	@Test
 	public void testGetNamespacePersistence() throws Exception {
 		con.begin();
 		con.setNamespace("rdf", RDF.NAMESPACE);

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTmpDatadirTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTmpDatadirTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -28,10 +28,10 @@ public class NativeStoreTmpDatadirTest {
 		NativeStore store = new NativeStore(dataDir);
 
 		store.init();
-		assertTrue("Data dir not set correctly", dataDir.equals(store.getDataDir()));
+		assertTrue(dataDir.equals(store.getDataDir()), "Data dir not set correctly");
 
 		store.shutDown();
-		assertTrue("Data dir does not exist anymore", dataDir.exists());
+		assertTrue(dataDir.exists(), "Data dir does not exist anymore");
 	}
 
 	@Test
@@ -39,10 +39,10 @@ public class NativeStoreTmpDatadirTest {
 		NativeStore store = new NativeStore();
 		store.init();
 		File dataDir = store.getDataDir();
-		assertTrue("Temp data dir not created", dataDir != null && dataDir.exists());
+		assertTrue(dataDir != null && dataDir.exists(), "Temp data dir not created");
 
 		store.shutDown();
-		assertFalse("Temp data dir still exists", dataDir.exists());
+		assertFalse(dataDir.exists(), "Temp data dir still exists");
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class NativeStoreTmpDatadirTest {
 		store.init();
 		File dataDir2 = store.getDataDir();
 		store.shutDown();
-		assertFalse("Temp data dirs are the same", dataDir1.equals(dataDir2));
+		assertFalse(dataDir1.equals(dataDir2), "Temp data dirs are the same");
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class NativeStoreTmpDatadirTest {
 		File tmpDataDir = store.getDataDir();
 		store.shutDown();
 
-		assertFalse("Temp data dir still exists", tmpDataDir.exists());
-		assertTrue("Data dir does not exist anymore", dataDir.exists());
+		assertFalse(tmpDataDir.exists(), "Temp data dir still exists");
+		assertTrue(dataDir.exists(), "Data dir does not exist anymore");
 	}
 }

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/QueryBenchmarkTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/QueryBenchmarkTest.java
@@ -29,7 +29,7 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * @author Håvard Ottestad
@@ -37,8 +37,6 @@ import org.junit.rules.TemporaryFolder;
 public class QueryBenchmarkTest {
 
 	private static SailRepository repository;
-
-	public static TemporaryFolder tempDir = new TemporaryFolder();
 
 	private static final String query1;
 	private static final String query2;
@@ -61,11 +59,9 @@ public class QueryBenchmarkTest {
 	static List<Statement> statementList;
 
 	@BeforeAll
-	public static void beforeClass() throws IOException {
-		tempDir.create();
-		File file = tempDir.newFolder();
+	public static void beforeClass(@TempDir File dataDir) throws IOException {
 
-		repository = new SailRepository(new NativeStore(file, "spoc,ospc,psoc"));
+		repository = new SailRepository(new NativeStore(dataDir, "spoc,ospc,psoc"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			connection.begin(IsolationLevels.NONE);
@@ -88,9 +84,7 @@ public class QueryBenchmarkTest {
 
 	@AfterAll
 	public static void afterClass() throws IOException {
-		tempDir.delete();
 		repository.shutDown();
-		tempDir = null;
 		repository = null;
 		statementList = null;
 	}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreUpgrade.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TestNativeStoreUpgrade.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/TripleStoreRecoveryTest.java
@@ -10,13 +10,14 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.nativerdf;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 
 import org.eclipse.rdf4j.sail.nativerdf.TxnStatusFile.TxnStatus;
 import org.eclipse.rdf4j.sail.nativerdf.btree.RecordIterator;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/testsuites/lucene/src/main/java/org/eclipse/testsuite/rdf4j/sail/lucene/AbstractLuceneSailTest.java
+++ b/testsuites/lucene/src/main/java/org/eclipse/testsuite/rdf4j/sail/lucene/AbstractLuceneSailTest.java
@@ -13,11 +13,11 @@ import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.PROPERTY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.QUERY;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SCORE;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.SNIPPET;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,16 +55,13 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.lucene.LuceneSailSchema;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
 public abstract class AbstractLuceneSailTest {
-
-	@Rule
-	public Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
 
 	protected static final ValueFactory vf = SimpleValueFactory.getInstance();
 
@@ -109,7 +106,7 @@ public abstract class AbstractLuceneSailTest {
 
 	protected abstract void configure(LuceneSail sail) throws IOException;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		// set logging, uncomment this to get better logging for debugging
 		// org.apache.log4j.BasicConfigurator.configure();
@@ -141,7 +138,7 @@ public abstract class AbstractLuceneSailTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws IOException, RepositoryException {
 		if (repository != null) {
 			repository.shutDown();
@@ -489,10 +486,10 @@ public abstract class AbstractLuceneSailTest {
 
 					// the number of matched expected results must be equal to the number
 					// of actual results
-					assertEquals("How many expected results were retrieved for query #" + queryID + "?",
-							expectedResultSet.size(), matched.size());
-					assertEquals("How many actual results were retrieved for query #" + queryID + "?",
-							expectedResultSet.size(), actualResults);
+					assertEquals(expectedResultSet.size(), matched.size(),
+							"How many expected results were retrieved for query #" + queryID + "?");
+					assertEquals(expectedResultSet.size(), actualResults,
+							"How many actual results were retrieved for query #" + queryID + "?");
 				}
 			}
 		}
@@ -682,10 +679,10 @@ public abstract class AbstractLuceneSailTest {
 					}
 
 					// we found all
-					assertTrue("These were expected but not found: " + expectedSnippetPart,
-							expectedSnippetPart.isEmpty());
+					assertTrue(expectedSnippetPart.isEmpty(),
+							"These were expected but not found: " + expectedSnippetPart);
 
-					assertEquals("there should have been 2 results", 2, results);
+					assertEquals(2, results, "there should have been 2 results");
 				}
 			}
 		}
@@ -744,10 +741,10 @@ public abstract class AbstractLuceneSailTest {
 					}
 
 					// we found all
-					assertTrue("These were expected but not found: " + expectedSnippetPart,
-							expectedSnippetPart.isEmpty());
+					assertTrue(expectedSnippetPart.isEmpty(),
+							"These were expected but not found: " + expectedSnippetPart);
 
-					assertEquals("there should have been 3 results", 3, results);
+					assertEquals(3, results, "there should have been 3 results");
 
 				}
 			}
@@ -1040,7 +1037,7 @@ public abstract class AbstractLuceneSailTest {
 					// remove it from the set
 					Value subject = bindings.getValue("Resource");
 					IRI expectedProperty = expectedSubject.remove(subject);
-					assertEquals("For subject " + subject, expectedProperty, bindings.getValue("Property"));
+					assertEquals(expectedProperty, bindings.getValue("Property"), "For subject " + subject);
 				}
 
 				// there should have been 3 results
@@ -1081,7 +1078,7 @@ public abstract class AbstractLuceneSailTest {
 		for (Throwable e : exceptions) {
 			e.printStackTrace(System.err);
 		}
-		assertEquals("Exceptions occurred during testMultithreadedAdd, see stacktraces above", 0, exceptions.size());
+		assertEquals(0, exceptions.size(), "Exceptions occurred during testMultithreadedAdd, see stacktraces above");
 	}
 
 	protected void assertQueryResult(String literal, IRI predicate, Resource resultUri) throws Exception {
@@ -1092,11 +1089,11 @@ public abstract class AbstractLuceneSailTest {
 			TupleQuery query = connection.prepareTupleQuery(queryString);
 			try (TupleQueryResult result = query.evaluate()) {
 				// check the result
-				assertTrue("query for literal '" + literal + " did not return any results, expected was " + resultUri,
-						result.hasNext());
+				assertTrue(result.hasNext(),
+						"query for literal '" + literal + " did not return any results, expected was " + resultUri);
 				BindingSet bindings = result.next();
-				assertEquals("query for literal '" + literal + " did not return the expected resource", resultUri,
-						bindings.getValue("Resource"));
+				assertEquals(resultUri, bindings.getValue("Resource"),
+						"query for literal '" + literal + " did not return the expected resource");
 				assertFalse(result.hasNext());
 			}
 		}
@@ -1111,8 +1108,8 @@ public abstract class AbstractLuceneSailTest {
 			try (TupleQueryResult result = query.evaluate()) {
 
 				// check the result
-				assertFalse("query for literal '" + literal + " did return results, which was not expected.",
-						result.hasNext());
+				assertFalse(result.hasNext(),
+						"query for literal '" + literal + " did return results, which was not expected.");
 			}
 		}
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/RepositoryTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/RepositoryTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
@@ -21,36 +21,30 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Integration test suite for implementations of Repository.
  *
  * @author Jeen Broekstra
  */
+@Timeout(value = 1, unit = TimeUnit.MINUTES)
 public abstract class RepositoryTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
-
-	/**
-	 * Timeout all individual tests after 1 minute.
-	 */
-	@Rule
-	public Timeout to = new Timeout(1, TimeUnit.MINUTES);
 
 	private static final String MBOX = "mbox";
 
@@ -92,7 +86,7 @@ public abstract class RepositoryTest {
 
 	protected Literal Александър;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		testRepository = createRepository();
 
@@ -113,7 +107,7 @@ public abstract class RepositoryTest {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		testRepository.shutDown();
 	}

--- a/testsuites/sail/pom.xml
+++ b/testsuites/sail/pom.xml
@@ -50,10 +50,9 @@
 			<version>${project.version}</version>
 			<scope>runtime</scope>
 		</dependency>
-		<!-- This module uses timeout rule, and cannot be fully migrated to JUnit 5 now -->
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/RDFNotifyingStoreTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/RDFNotifyingStoreTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.testsuite.sail;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
@@ -18,8 +19,8 @@ import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.SailChangedEvent;
 import org.eclipse.rdf4j.sail.SailChangedListener;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * A JUnit test for testing Sail implementations that store RDF data. This is purely a test for data storage and
@@ -49,10 +50,8 @@ public abstract class RDFNotifyingStoreTest extends RDFStoreTest implements Sail
 	@Override
 	protected abstract NotifyingSail createSail() throws SailException;
 
-	@Override
-	public void setUp() throws Exception {
-		super.setUp();
-
+	@BeforeEach
+	public void addSailChangedListener() throws Exception {
 		// set self as listener
 		((NotifyingSail) sail).addSailChangedListener(this);
 
@@ -74,9 +73,9 @@ public abstract class RDFNotifyingStoreTest extends RDFStoreTest implements Sail
 		con.removeStatements(painting, RDF.TYPE, RDFS.CLASS);
 		con.commit();
 
-		Assert.assertEquals("Repository should contain 4 statements in total", 4, countAllElements());
+		assertEquals(4, countAllElements(), "Repository should contain 4 statements in total");
 
-		Assert.assertEquals("Named context should contain 3 statements", 3, countContext1Elements());
+		assertEquals(3, countContext1Elements(), "Named context should contain 3 statements");
 
 		assertThat(con.hasStatement(painting, RDF.TYPE, RDFS.CLASS, true)).isFalse();
 
@@ -84,20 +83,20 @@ public abstract class RDFNotifyingStoreTest extends RDFStoreTest implements Sail
 		con.removeStatements(null, null, null, context1);
 		con.commit();
 
-		Assert.assertEquals("Repository should contain 1 statement in total", 1, countAllElements());
+		assertEquals(1, countAllElements(), "Repository should contain 1 statement in total");
 
-		Assert.assertEquals("Named context should be empty", 0, countContext1Elements());
+		assertEquals(0, countContext1Elements(), "Named context should be empty");
 
 		con.begin();
 		con.clear();
 		con.commit();
 
-		Assert.assertEquals("Repository should no longer contain any statements", 0, countAllElements());
+		assertEquals(0, countAllElements(), "Repository should no longer contain any statements");
 
 		// test if event listener works properly.
-		Assert.assertEquals("There should have been 1 event in which statements were added", 1, addEventCount);
+		assertEquals(1, addEventCount, "There should have been 1 event in which statements were added");
 
-		Assert.assertEquals("There should have been 3 events in which statements were removed", 3, removeEventCount);
+		assertEquals(3, removeEventCount, "There should have been 3 events in which statements were removed");
 	}
 
 	@Override

--- a/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/RDFStoreTest.java
+++ b/testsuites/sail/src/main/java/org/eclipse/rdf4j/testsuite/sail/RDFStoreTest.java
@@ -12,13 +12,18 @@ package org.eclipse.rdf4j.testsuite.sail;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Iterator;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
@@ -48,37 +53,30 @@ import org.eclipse.rdf4j.query.parser.QueryParserUtil;
 import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * A JUnit test for testing Sail implementations that store RDF data. This is purely a test for data storage and
  * retrieval which assumes that no inferencing or whatsoever is performed. This is an abstract class that should be
  * extended for specific Sail implementations.
  */
+@Timeout(value = 60)
 public abstract class RDFStoreTest {
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
-
-	/**
-	 * Timeout all individual tests after 1 minute.
-	 */
-	@Rule
-	public Timeout to = new Timeout(60, TimeUnit.SECONDS);
 
 	/*-----------*
 	 * Constants *
@@ -150,7 +148,7 @@ public abstract class RDFStoreTest {
 	 */
 	protected abstract Sail createSail();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		sail = createSail();
 
@@ -172,7 +170,7 @@ public abstract class RDFStoreTest {
 
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		try {
 			if (con.isOpen()) {
@@ -193,15 +191,15 @@ public abstract class RDFStoreTest {
 	@Test
 	public void testEmptyRepository() throws Exception {
 		// repository should be empty
-		Assert.assertEquals("Empty repository should not return any statements", 0, countAllElements());
+		assertEquals(0, countAllElements(), "Empty repository should not return any statements");
 
-		Assert.assertEquals("Named context should be empty", 0, countContext1Elements());
+		assertEquals(0, countContext1Elements(), "Named context should be empty");
 
-		Assert.assertEquals("Empty repository should not return any context identifiers", 0,
-				countElements(con.getContextIDs()));
+		assertEquals(0, countElements(con.getContextIDs()),
+				"Empty repository should not return any context identifiers");
 
-		Assert.assertEquals("Empty repository should not return any query results", 0,
-				countQueryResults("select * where { ?s ?p ?o}"));
+		assertEquals(0, countQueryResults("select * where { ?s ?p ?o}"),
+				"Empty repository should not return any query results");
 	}
 
 	@Test
@@ -332,13 +330,13 @@ public abstract class RDFStoreTest {
 
 		try (CloseableIteration<? extends Statement, SailException> stIter = con.getStatements(null, null, null,
 				false)) {
-			Assert.assertTrue(stIter.hasNext());
+			assertTrue(stIter.hasNext());
 
 			Statement st = stIter.next();
-			Assert.assertEquals(subj, st.getSubject());
-			Assert.assertEquals(pred, st.getPredicate());
-			Assert.assertEquals(obj, st.getObject());
-			Assert.assertFalse(stIter.hasNext());
+			assertEquals(subj, st.getSubject());
+			assertEquals(pred, st.getPredicate());
+			assertEquals(obj, st.getObject());
+			assertFalse(stIter.hasNext());
 		}
 
 		ParsedTupleQuery tupleQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL,
@@ -348,13 +346,13 @@ public abstract class RDFStoreTest {
 		iter = con.evaluate(tupleQuery.getTupleExpr(), null, EmptyBindingSet.getInstance(), false);
 
 		try {
-			Assert.assertTrue(iter.hasNext());
+			assertTrue(iter.hasNext());
 
 			BindingSet bindings = iter.next();
-			Assert.assertEquals(subj, bindings.getValue("S"));
-			Assert.assertEquals(pred, bindings.getValue("P"));
-			Assert.assertEquals(obj, bindings.getValue("O"));
-			Assert.assertTrue(!iter.hasNext());
+			assertEquals(subj, bindings.getValue("S"));
+			assertEquals(pred, bindings.getValue("P"));
+			assertEquals(obj, bindings.getValue("O"));
+			assertTrue(!iter.hasNext());
 		} finally {
 			iter.close();
 		}
@@ -369,7 +367,7 @@ public abstract class RDFStoreTest {
 		con.addStatement(picasso2, paints, guernica);
 		con.commit();
 
-		Assert.assertEquals("createURI(Sring) and createURI(String, String) should create equal URIs", 1, con.size());
+		assertEquals(1, con.size(), "createURI(Sring) and createURI(String, String) should create equal URIs");
 	}
 
 	@Test
@@ -381,7 +379,7 @@ public abstract class RDFStoreTest {
 		con.addStatement(picasso2, paints, guernica);
 		con.commit();
 
-		Assert.assertEquals("createURI(Sring) and createURI(String, String) should create equal URIs", 1, con.size());
+		assertEquals(1, con.size(), "createURI(Sring) and createURI(String, String) should create equal URIs");
 	}
 
 	@Test
@@ -389,12 +387,12 @@ public abstract class RDFStoreTest {
 		// SES-711
 		Literal date1 = vf.createLiteral("2004-12-20", XSD.DATETIME);
 		Literal date2 = vf.createLiteral("2004-12-20", CoreDatatype.XSD.DATETIME);
-		Assert.assertEquals(date1, date2);
+		assertEquals(date1, date2);
 	}
 
 	@Test
 	public void testSize() {
-		Assert.assertEquals("Size of empty repository should be 0", 0, con.size());
+		assertEquals(0, con.size(), "Size of empty repository should be 0");
 
 		// Add some data to the repository
 		con.begin();
@@ -405,16 +403,16 @@ public abstract class RDFStoreTest {
 		con.addStatement(picasso, paints, guernica, context1);
 		con.commit();
 
-		Assert.assertEquals("Size of repository should be 5", 5, con.size());
-		Assert.assertEquals("Size of named context should be 3", 3, con.size(context1));
+		assertEquals(5, con.size(), "Size of repository should be 5");
+		assertEquals(3, con.size(context1), "Size of named context should be 3");
 
 		IRI unknownContext = vf.createIRI(EXAMPLE_NS + "unknown");
 
-		Assert.assertEquals("Size of unknown context should be 0", 0, con.size(unknownContext));
+		assertEquals(0, con.size(unknownContext), "Size of unknown context should be 0");
 
 		IRI uriImplContext1 = vf.createIRI(context1.toString());
 
-		Assert.assertEquals("Size of named context (defined as URIImpl) should be 3", 3, con.size(uriImplContext1));
+		assertEquals(3, con.size(uriImplContext1), "Size of named context (defined as URIImpl) should be 3");
 	}
 
 	@Test
@@ -428,14 +426,14 @@ public abstract class RDFStoreTest {
 		con.addStatement(picasso, paints, guernica, context1);
 		con.commit();
 
-		Assert.assertEquals("Repository should contain 5 statements in total", 5, countAllElements());
+		assertEquals(5, countAllElements(), "Repository should contain 5 statements in total");
 
-		Assert.assertEquals("Named context should contain 3 statements", 3, countContext1Elements());
+		assertEquals(3, countContext1Elements(), "Named context should contain 3 statements");
 
-		Assert.assertEquals("Repository should have 1 context identifier", 1, countElements(con.getContextIDs()));
+		assertEquals(1, countElements(con.getContextIDs()), "Repository should have 1 context identifier");
 
-		Assert.assertEquals("Repository should contain 5 statements in total", 5,
-				countQueryResults("select * where {?s ?p ?o}"));
+		assertEquals(5, countQueryResults("select * where {?s ?p ?o}"),
+				"Repository should contain 5 statements in total");
 
 		// Check for presence of the added statements
 
@@ -449,20 +447,20 @@ public abstract class RDFStoreTest {
 		assertThat(con.hasStatement(painter, paints, painting, true)).isFalse();
 
 		// Various other checks
-		Assert.assertEquals("Repository should contain 2 statements matching (picasso, _, _)", 2,
-				countQueryResults("select * where { ex:picasso ?P ?O}"));
+		assertEquals(2, countQueryResults("select * where { ex:picasso ?P ?O}"),
+				"Repository should contain 2 statements matching (picasso, _, _)");
 
-		Assert.assertEquals("Repository should contain 1 statement matching (picasso, paints, _)", 1,
-				countQueryResults("select * where {ex:picasso ex:paints ?O}"));
+		assertEquals(1, countQueryResults("select * where {ex:picasso ex:paints ?O}"),
+				"Repository should contain 1 statement matching (picasso, paints, _)");
 
-		Assert.assertEquals("Repository should contain 4 statements matching (_, type, _)", 4,
-				countQueryResults("select * where {?S rdf:type ?O}"));
+		assertEquals(4, countQueryResults("select * where {?S rdf:type ?O}"),
+				"Repository should contain 4 statements matching (_, type, _)");
 
-		Assert.assertEquals("Repository should contain 2 statements matching (_, _, Class)", 2,
-				countQueryResults("select * where { ?S ?P rdfs:Class }"));
+		assertEquals(2, countQueryResults("select * where { ?S ?P rdfs:Class }"),
+				"Repository should contain 2 statements matching (_, _, Class)");
 
-		Assert.assertEquals("Repository should contain 0 statements matching (_, _, type)", 0,
-				countQueryResults("select * where {?S ?P rdf:type}"));
+		assertEquals(0, countQueryResults("select * where {?S ?P rdf:type}"),
+				"Repository should contain 0 statements matching (_, _, type)");
 	}
 
 	/**
@@ -521,7 +519,7 @@ public abstract class RDFStoreTest {
 
 		con.commit();
 
-		Assert.assertEquals(3, countElements(con.getStatements(null, RDF.TYPE, RDFS.CLASS, false)));
+		assertEquals(3, countElements(con.getStatements(null, RDF.TYPE, RDFS.CLASS, false)));
 
 		// simulate auto-commit
 		tupleQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL, "SELECT ?P WHERE { [] ?P [] .}", null);
@@ -537,7 +535,7 @@ public abstract class RDFStoreTest {
 			}
 		}
 
-		Assert.assertEquals(2, countElements(con.getStatements(null, RDF.TYPE, RDF.PROPERTY, false)));
+		assertEquals(2, countElements(con.getStatements(null, RDF.TYPE, RDF.PROPERTY, false)));
 	}
 
 	@Test
@@ -556,9 +554,9 @@ public abstract class RDFStoreTest {
 		con.removeStatements(painting, RDF.TYPE, RDFS.CLASS);
 		con.commit();
 
-		Assert.assertEquals("Repository should contain 4 statements in total", 4, countAllElements());
+		assertEquals(4, countAllElements(), "Repository should contain 4 statements in total");
 
-		Assert.assertEquals("Named context should contain 3 statements", 3, countContext1Elements());
+		assertEquals(3, countContext1Elements(), "Named context should contain 3 statements");
 
 		assertThat(con.hasStatement(painting, RDF.TYPE, RDFS.CLASS, true)).isFalse();
 
@@ -566,15 +564,15 @@ public abstract class RDFStoreTest {
 		con.removeStatements(null, null, null, context1);
 		con.commit();
 
-		Assert.assertEquals("Repository should contain 1 statement in total", 1, countAllElements());
+		assertEquals(1, countAllElements(), "Repository should contain 1 statement in total");
 
-		Assert.assertEquals("Named context should be empty", 0, countContext1Elements());
+		assertEquals(0, countContext1Elements(), "Named context should be empty");
 
 		con.begin();
 		con.clear();
 		con.commit();
 
-		Assert.assertEquals("Repository should no longer contain any statements", 0, countAllElements());
+		assertEquals(0, countAllElements(), "Repository should no longer contain any statements");
 	}
 
 	@Test
@@ -582,11 +580,11 @@ public abstract class RDFStoreTest {
 		try {
 			con.close();
 			con.addStatement(painter, RDF.TYPE, RDFS.CLASS);
-			Assert.fail("Operation on connection after close should result in IllegalStateException");
+			fail("Operation on connection after close should result in IllegalStateException");
 		} catch (IllegalStateException e) {
 			// do nothing, this is expected
 		} catch (SailException e) {
-			Assert.fail(e.getMessage());
+			fail(e.getMessage());
 		}
 	}
 
@@ -609,39 +607,39 @@ public abstract class RDFStoreTest {
 
 		con.commit();
 
-		Assert.assertEquals("context1 should contain 3 statements", 3, countContext1Elements());
-		Assert.assertEquals("context2 should contain 3 statements", 3,
-				countElements(con.getStatements(null, null, null, false, context2)));
-		Assert.assertEquals("Repository should contain 8 statements", 8, countAllElements());
-		Assert.assertEquals("statements without context should equal 2", 2,
-				countElements(con.getStatements(null, null, null, false, (Resource) null)));
+		assertEquals(3, countContext1Elements(), "context1 should contain 3 statements");
+		assertEquals(3, countElements(con.getStatements(null, null, null, false, context2)),
+				"context2 should contain 3 statements");
+		assertEquals(8, countAllElements(), "Repository should contain 8 statements");
+		assertEquals(2, countElements(con.getStatements(null, null, null, false, (Resource) null)),
+				"statements without context should equal 2");
 
-		Assert.assertEquals("Statements without context and statements in context 1 together should total 5", 5,
-				countElements(con.getStatements(null, null, null, false, null, context1)));
+		assertEquals(5, countElements(con.getStatements(null, null, null, false, null, context1)),
+				"Statements without context and statements in context 1 together should total 5");
 
-		Assert.assertEquals("Statements without context and statements in context 2 together should total 5", 5,
-				countElements(con.getStatements(null, null, null, false, null, context2)));
+		assertEquals(5, countElements(con.getStatements(null, null, null, false, null, context2)),
+				"Statements without context and statements in context 2 together should total 5");
 
-		Assert.assertEquals("Statements in context 1 and in context 2 together should total 6", 6,
-				countElements(con.getStatements(null, null, null, false, context1, context2)));
+		assertEquals(6, countElements(con.getStatements(null, null, null, false, context1, context2)),
+				"Statements in context 1 and in context 2 together should total 6");
 
 		// remove two statements from context1.
 		con.begin();
 		con.removeStatements(picasso, null, null, context1);
 		con.commit();
 
-		Assert.assertEquals("context1 should contain 1 statements", 1, countContext1Elements());
+		assertEquals(1, countContext1Elements(), "context1 should contain 1 statements");
 
-		Assert.assertEquals("Repository should contain 6 statements", 6, countAllElements());
+		assertEquals(6, countAllElements(), "Repository should contain 6 statements");
 
-		Assert.assertEquals("Statements without context and statements in context 1 together should total 3", 3,
-				countElements(con.getStatements(null, null, null, false, null, context1)));
+		assertEquals(3, countElements(con.getStatements(null, null, null, false, null, context1)),
+				"Statements without context and statements in context 1 together should total 3");
 
-		Assert.assertEquals("Statements without context and statements in context 2 together should total 5", 5,
-				countElements(con.getStatements(null, null, null, false, context2, null)));
+		assertEquals(5, countElements(con.getStatements(null, null, null, false, context2, null)),
+				"Statements without context and statements in context 2 together should total 5");
 
-		Assert.assertEquals("Statements in context 1 and in context 2 together should total 4", 4,
-				countElements(con.getStatements(null, null, null, false, context1, context2)));
+		assertEquals(4, countElements(con.getStatements(null, null, null, false, context1, context2)),
+				"Statements in context 1 and in context 2 together should total 4");
 	}
 
 	@Test
@@ -665,22 +663,22 @@ public abstract class RDFStoreTest {
 
 		iter = con.evaluate(tupleExpr, null, bindings, false);
 		int resultCount = verifyQueryResult(iter, 1);
-		Assert.assertEquals("Wrong number of query results", 2, resultCount);
+		assertEquals(2, resultCount, "Wrong number of query results");
 
 		bindings.addBinding("Y", painter);
 		iter = con.evaluate(tupleExpr, null, bindings, false);
 		resultCount = verifyQueryResult(iter, 1);
-		Assert.assertEquals("Wrong number of query results", 1, resultCount);
+		assertEquals(1, resultCount, "Wrong number of query results");
 
 		bindings.addBinding("Z", painting);
 		iter = con.evaluate(tupleExpr, null, bindings, false);
 		resultCount = verifyQueryResult(iter, 1);
-		Assert.assertEquals("Wrong number of query results", 1, resultCount);
+		assertEquals(1, resultCount, "Wrong number of query results");
 
 		bindings.removeBinding("Y");
 		iter = con.evaluate(tupleExpr, null, bindings, false);
 		resultCount = verifyQueryResult(iter, 1);
-		Assert.assertEquals("Wrong number of query results", 2, resultCount);
+		assertEquals(2, resultCount, "Wrong number of query results");
 
 		// Query 2
 		tupleQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL,
@@ -690,20 +688,20 @@ public abstract class RDFStoreTest {
 
 		iter = con.evaluate(tupleExpr, null, bindings, false);
 		resultCount = verifyQueryResult(iter, 1);
-		Assert.assertEquals("Wrong number of query results", 0, resultCount);
+		assertEquals(0, resultCount, "Wrong number of query results");
 
 		bindings.addBinding("Z", painter);
 		iter = con.evaluate(tupleExpr, null, bindings, false);
 		resultCount = verifyQueryResult(iter, 1);
-		Assert.assertEquals("Wrong number of query results", 1, resultCount);
+		assertEquals(1, resultCount, "Wrong number of query results");
 	}
 
 	@Test
 	public void testStatementEquals() {
 		Statement st = vf.createStatement(picasso, RDF.TYPE, painter);
-		Assert.assertEquals(st, vf.createStatement(picasso, RDF.TYPE, painter));
-		Assert.assertNotEquals(st, vf.createStatement(picasso, RDF.TYPE, painter, context1));
-		Assert.assertNotEquals(st, vf.createStatement(picasso, RDF.TYPE, painter, context2));
+		assertEquals(st, vf.createStatement(picasso, RDF.TYPE, painter));
+		assertNotEquals(st, vf.createStatement(picasso, RDF.TYPE, painter, context1));
+		assertNotEquals(st, vf.createStatement(picasso, RDF.TYPE, painter, context2));
 	}
 
 	@Test
@@ -720,7 +718,7 @@ public abstract class RDFStoreTest {
 		Statement deserializedStatement = (Statement) in.readObject();
 		in.close();
 
-		Assert.assertTrue(st.equals(deserializedStatement));
+		assertTrue(st.equals(deserializedStatement));
 	}
 
 	@Test
@@ -730,11 +728,11 @@ public abstract class RDFStoreTest {
 		con.commit();
 
 		try (CloseableIteration<? extends Namespace, SailException> namespaces = con.getNamespaces()) {
-			Assert.assertTrue(namespaces.hasNext());
+			assertTrue(namespaces.hasNext());
 			Namespace rdf = namespaces.next();
-			Assert.assertEquals("rdf", rdf.getPrefix());
-			Assert.assertEquals(RDF.NAMESPACE, rdf.getName());
-			Assert.assertFalse(namespaces.hasNext());
+			assertEquals("rdf", rdf.getPrefix());
+			assertEquals(RDF.NAMESPACE, rdf.getName());
+			assertFalse(namespaces.hasNext());
 		}
 	}
 
@@ -743,7 +741,7 @@ public abstract class RDFStoreTest {
 		con.begin();
 		con.setNamespace("rdf", RDF.NAMESPACE);
 		con.commit();
-		Assert.assertEquals(RDF.NAMESPACE, con.getNamespace("rdf"));
+		assertEquals(RDF.NAMESPACE, con.getNamespace("rdf"));
 	}
 
 	@Test
@@ -753,7 +751,7 @@ public abstract class RDFStoreTest {
 		con.setNamespace("rdfs", RDFS.NAMESPACE);
 		con.clearNamespaces();
 		con.commit();
-		Assert.assertTrue(!con.getNamespaces().hasNext());
+		assertTrue(!con.getNamespaces().hasNext());
 	}
 
 	@Test
@@ -762,14 +760,14 @@ public abstract class RDFStoreTest {
 		con.setNamespace("rdf", RDF.NAMESPACE);
 		con.removeNamespace("rdf");
 		con.commit();
-		Assert.assertNull(con.getNamespace("rdf"));
+		assertNull(con.getNamespace("rdf"));
 	}
 
 	@Test
 	public void testNullNamespaceDisallowed() {
 		try {
 			con.setNamespace("foo", null);
-			Assert.fail("Expected NullPointerException");
+			fail("Expected NullPointerException");
 		} catch (NullPointerException e) {
 			// expected
 		}
@@ -779,19 +777,19 @@ public abstract class RDFStoreTest {
 	public void testNullPrefixDisallowed() {
 		try {
 			con.setNamespace(null, "foo");
-			Assert.fail("Expected NullPointerException");
+			fail("Expected NullPointerException");
 		} catch (NullPointerException e) {
 			// expected
 		}
 		try {
 			con.getNamespace(null);
-			Assert.fail("Expected NullPointerException");
+			fail("Expected NullPointerException");
 		} catch (NullPointerException e) {
 			// expected
 		}
 		try {
 			con.removeNamespace(null);
-			Assert.fail("Expected NullPointerException");
+			fail("Expected NullPointerException");
 		} catch (NullPointerException e) {
 			// expected
 		}
@@ -799,37 +797,37 @@ public abstract class RDFStoreTest {
 
 	@Test
 	public void testGetContextIDs() {
-		Assert.assertEquals(0, countElements(con.getContextIDs()));
+		assertEquals(0, countElements(con.getContextIDs()));
 
 		// load data
 		con.begin();
 		con.addStatement(picasso, paints, guernica, context1);
-		Assert.assertEquals(1, countElements(con.getContextIDs()));
-		Assert.assertEquals(context1, first(con.getContextIDs()));
+		assertEquals(1, countElements(con.getContextIDs()));
+		assertEquals(context1, first(con.getContextIDs()));
 
 		con.removeStatements(picasso, paints, guernica, context1);
-		Assert.assertEquals(0, countElements(con.getContextIDs()));
+		assertEquals(0, countElements(con.getContextIDs()));
 		con.commit();
 
-		Assert.assertEquals(0, countElements(con.getContextIDs()));
+		assertEquals(0, countElements(con.getContextIDs()));
 
 		con.begin();
 		con.addStatement(picasso, paints, guernica, context2);
-		Assert.assertEquals(1, countElements(con.getContextIDs()));
-		Assert.assertEquals(context2, first(con.getContextIDs()));
+		assertEquals(1, countElements(con.getContextIDs()));
+		assertEquals(context2, first(con.getContextIDs()));
 		con.commit();
 	}
 
 	@Test
 	public void testOldURI() throws Exception {
-		Assert.assertEquals(0, countAllElements());
+		assertEquals(0, countAllElements());
 		con.begin();
 		con.addStatement(painter, RDF.TYPE, RDFS.CLASS);
 		con.addStatement(painting, RDF.TYPE, RDFS.CLASS);
 		con.addStatement(picasso, RDF.TYPE, painter, context1);
 		con.addStatement(guernica, RDF.TYPE, painting, context1);
 		con.addStatement(picasso, paints, guernica, context1);
-		Assert.assertEquals(5, countAllElements());
+		assertEquals(5, countAllElements());
 		con.commit();
 
 		con.begin();
@@ -839,25 +837,25 @@ public abstract class RDFStoreTest {
 		con.begin();
 		con.addStatement(picasso, paints, guernica, context1);
 		con.commit();
-		Assert.assertEquals(1, countAllElements());
+		assertEquals(1, countAllElements());
 	}
 
 	@Test
 	public void testDualConnections() throws Exception {
 		try (SailConnection con2 = sail.getConnection()) {
-			Assert.assertEquals(0, countAllElements());
+			assertEquals(0, countAllElements());
 			con.begin();
 			con.addStatement(painter, RDF.TYPE, RDFS.CLASS);
 			con.addStatement(painting, RDF.TYPE, RDFS.CLASS);
 			con.addStatement(picasso, RDF.TYPE, painter, context1);
 			con.addStatement(guernica, RDF.TYPE, painting, context1);
 			con.commit();
-			Assert.assertEquals(4, countAllElements());
+			assertEquals(4, countAllElements());
 			con2.begin();
 			con2.addStatement(RDF.NIL, RDF.TYPE, RDF.LIST);
 			String query = "SELECT * WHERE { ?S ?P ?O }";
 			ParsedTupleQuery tupleQuery = QueryParserUtil.parseTupleQuery(QueryLanguage.SPARQL, query, null);
-			Assert.assertEquals(5, countElements(
+			assertEquals(5, countElements(
 					con2.evaluate(tupleQuery.getTupleExpr(), null, EmptyBindingSet.getInstance(), false)));
 			Runnable clearer = () -> {
 				try {
@@ -881,15 +879,15 @@ public abstract class RDFStoreTest {
 	public void testBNodeReuse() {
 		con.begin();
 		con.addStatement(RDF.VALUE, RDF.VALUE, RDF.VALUE);
-		Assert.assertEquals(1, con.size());
+		assertEquals(1, con.size());
 		BNode b1 = vf.createBNode();
 		con.addStatement(b1, RDF.VALUE, b1);
 		con.removeStatements(b1, RDF.VALUE, b1);
-		Assert.assertEquals(1, con.size());
+		assertEquals(1, con.size());
 		BNode b2 = vf.createBNode();
 		con.addStatement(b2, RDF.VALUE, b2);
 		con.addStatement(b1, RDF.VALUE, b1);
-		Assert.assertEquals(3, con.size());
+		assertEquals(3, con.size());
 		con.commit();
 	}
 
@@ -901,7 +899,7 @@ public abstract class RDFStoreTest {
 		con.commit();
 		con.begin();
 		con.addStatement(RDF.SUBJECT, RDF.PREDICATE, RDF.OBJECT);
-		Assert.assertEquals("Statement should appear once", 1, con.size());
+		assertEquals(1, con.size(), "Statement should appear once");
 		con.commit();
 
 	}
@@ -916,7 +914,7 @@ public abstract class RDFStoreTest {
 		con.addStatement(RDF.SUBJECT, RDF.PREDICATE, RDF.OBJECT);
 		try (Stream<? extends Statement> stream = con.getStatements(null, null, null, false).stream()) {
 			long count = stream.count();
-			Assert.assertEquals("Statement should appear once", 1, count);
+			assertEquals(1, count, "Statement should appear once");
 		}
 		con.commit();
 	}
@@ -932,7 +930,7 @@ public abstract class RDFStoreTest {
 		con.commit();
 		try (Stream<? extends Statement> stream = con.getStatements(null, null, null, false).stream()) {
 			long count = stream.count();
-			Assert.assertEquals("Statement should appear once", 1, count);
+			assertEquals(1, count, "Statement should appear once");
 
 		}
 	}
@@ -947,7 +945,7 @@ public abstract class RDFStoreTest {
 		con.addStatement(RDF.SUBJECT, RDF.PREDICATE, RDF.OBJECT);
 		con.commit();
 
-		Assert.assertEquals("Statement should appear once", 1, con.size());
+		assertEquals(1, con.size(), "Statement should appear once");
 	}
 
 	@Test
@@ -958,9 +956,9 @@ public abstract class RDFStoreTest {
 		con.commit();
 		con.begin();
 		con.addStatement(RDF.SUBJECT, RDF.PREDICATE, RDF.OBJECT);
-		Assert.assertEquals("Statement should appear once", 1, con.size());
-		Assert.assertEquals("Statement should appear once", 1, con.size());
-		Assert.assertEquals("Statement should appear once", 1, con.size());
+		assertEquals(1, con.size(), "Statement should appear once");
+		assertEquals(1, con.size(), "Statement should appear once");
+		assertEquals(1, con.size(), "Statement should appear once");
 		con.commit();
 	}
 
@@ -1010,8 +1008,8 @@ public abstract class RDFStoreTest {
 			BindingSet resultBindings = resultIter.next();
 			resultCount++;
 
-			Assert.assertEquals("Wrong number of binding names for binding set", expectedBindingCount,
-					resultBindings.getBindingNames().size());
+			assertEquals(expectedBindingCount, resultBindings.getBindingNames().size(),
+					"Wrong number of binding names for binding set");
 
 			int bindingCount = 0;
 			Iterator<Binding> bindingIter = resultBindings.iterator();
@@ -1020,7 +1018,7 @@ public abstract class RDFStoreTest {
 				bindingCount++;
 			}
 
-			Assert.assertEquals("Wrong number of bindings in binding set", expectedBindingCount, bindingCount);
+			assertEquals(expectedBindingCount, bindingCount, "Wrong number of bindings in binding set");
 		}
 
 		return resultCount;


### PR DESCRIPTION
GitHub issue resolved: #4425

Briefly describe the changes proposed in this PR:

In https://github.com/eclipse/rdf4j/pull/4385 I left out some tests with timeout configuration - to reduce the number of total changes in the PR. This PR migrates all tests using timeout configuration (Timeout rule) to JUnit 5. Also fixing some leftover asserts to be able to remove junit-vintage dependency from affected modules.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

