### PR TITLE
GH-4427: Don't use deprecated Mockito API

### DIFF
--- a/core/common/iterator/src/test/java/org/eclipse/rdf4j/common/iteration/SilentIterationTest.java
+++ b/core/common/iterator/src/test/java/org/eclipse/rdf4j/common/iteration/SilentIterationTest.java
@@ -12,19 +12,24 @@ package org.eclipse.rdf4j.common.iteration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class SilentIterationTest {
 
-	@SuppressWarnings("unchecked")
-	private final CloseableIteration<Object, Exception> delegate = mock(CloseableIteration.class);
+	@Mock
+	private CloseableIteration<Object, Exception> delegate;
 
-	private final SilentIteration<Object, Exception> subject = new SilentIteration<>(delegate);
+	@InjectMocks
+	private SilentIteration<Object, Exception> subject;
 
 	@Test
 	public void hasNextSwallowsException() throws Exception {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -136,6 +136,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
@@ -12,7 +12,6 @@ package org.eclipse.rdf4j.console.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.startsWith;
 import static org.mockito.Mockito.verify;
@@ -22,7 +21,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
-import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
@@ -48,9 +46,8 @@ public class DropTest extends AbstractCommandTest {
 		addRepositories("drop", MEMORY_MEMBER_ID1);
 		manager.addRepositoryConfig(new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));
 
-		ConsoleState state = mock(ConsoleState.class);
-		when(state.getManager()).thenReturn(manager);
-		drop = new Drop(mockConsoleIO, state, new Close(mockConsoleIO, state));
+		when(mockConsoleState.getManager()).thenReturn(manager);
+		drop = new Drop(mockConsoleIO, mockConsoleState, new Close(mockConsoleIO, mockConsoleState));
 	}
 
 	private void setUserDropConfirm(boolean confirm) throws IOException {

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/LoadTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/LoadTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.rdf4j.console.command;
 
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -21,7 +20,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
-import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.manager.LocalRepositoryManager;
@@ -47,9 +45,8 @@ public class LoadTest extends AbstractCommandTest {
 		addRepositories("load", MEMORY_MEMBER_ID1);
 		manager.addRepositoryConfig(new RepositoryConfig(PROXY_ID, new ProxyRepositoryConfig(MEMORY_MEMBER_ID1)));
 
-		ConsoleState state = mock(ConsoleState.class);
-		when(state.getManager()).thenReturn(manager);
-		cmd = new Load(mockConsoleIO, state, defaultSettings);
+		when(mockConsoleState.getManager()).thenReturn(manager);
+		cmd = new Load(mockConsoleIO, mockConsoleState, defaultSettings);
 	}
 
 	@Test

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -26,7 +26,6 @@ import java.nio.file.Files;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.console.ConsoleIO;
-import org.eclipse.rdf4j.console.ConsoleState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,10 +42,9 @@ public class VerifyTest extends AbstractCommandTest {
 	public void setUp() throws IOException, RDF4JException {
 		InputStream input = mock(InputStream.class);
 		OutputStream out = mock(OutputStream.class);
-		ConsoleState info = mock(ConsoleState.class);
-		when(info.getDataDirectory()).thenReturn(locationFile);
+		when(mockConsoleState.getDataDirectory()).thenReturn(locationFile);
 
-		io = new ConsoleIO(input, out, info);
+		io = new ConsoleIO(input, out, mockConsoleState);
 
 		cmd = new Verify(io, defaultSettings);
 	}

--- a/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
+++ b/tools/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
@@ -17,14 +17,16 @@ import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.command.SetParameters;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Abstract class for settings
  *
  * @author Bart Hanssens
  */
+@ExtendWith(MockitoExtension.class)
 public abstract class AbstractSettingTest {
 	@Mock
 	protected ConsoleIO mockConsoleIO;
@@ -37,7 +39,6 @@ public abstract class AbstractSettingTest {
 
 	@BeforeEach
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
 		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);
 	}
 }

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategyTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/write/RepositoryWriteStrategyTest.java
@@ -20,22 +20,23 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class RepositoryWriteStrategyTest {
 
+	@InjectMocks
 	private RepositoryWriteStrategy strategy;
+	@Mock
 	private Repository writeRepository;
+	@Mock
 	private RepositoryConnection connection;
 
 	@BeforeEach
 	public void setUp() {
-		writeRepository = mock(Repository.class);
-		connection = mock(RepositoryConnection.class);
 		when(writeRepository.getConnection()).thenReturn(connection);
-
-		strategy = new RepositoryWriteStrategy(writeRepository);
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #4427 

Briefly describe the changes proposed in this PR:

The initial motivation was to remove usage of deprecated Mockito API. But during my investigation, I found some obvious migrations to the Mockito JUnit 5 integration - that's fixing warnings suppressions.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

