### PR TITLE
GH-4430: Provide more user-friendly error message in BinaryQueryResultParser

### DIFF
--- a/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultParser.java
+++ b/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultParser.java
@@ -304,9 +304,9 @@ public class BinaryQueryResultParser extends AbstractTupleQueryResultParser {
 	}
 
 	/**
-	 * Used when trying to parse some invalid content. Reads the remaining bytes as string in order to provide more user-friendly error message.
-	 * Sets the max limit of the returned string, if its length > INVALID_CONTENT_LIMIT, the returned string is trimmed and
-	 * "..." is appended in order to prevent displaying too long result.
+	 * Used when trying to parse some invalid content. Reads the remaining bytes as string in order to provide more
+	 * user-friendly error message. Sets the max limit of the returned string, if its length > INVALID_CONTENT_LIMIT,
+	 * the returned string is trimmed and "..." is appended in order to prevent displaying too long result.
 	 */
 	private String extractInvalidContentAsString(int recordTypeMarker) throws IOException {
 		byte[] remainingBytes = new byte[INVALID_CONTENT_LIMIT];

--- a/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultParser.java
+++ b/core/queryresultio/binary/src/main/java/org/eclipse/rdf4j/query/resultio/binary/BinaryQueryResultParser.java
@@ -195,7 +195,7 @@ public class BinaryQueryResultParser extends AbstractTupleQueryResultParser {
 					break;
 				default:
 					logger.error(extractInvalidContentAsString(recordTypeMarker));
-					throw new IOException("Could not parse the query result.");
+					throw new QueryResultParseException("Could not parse the query result.");
 				}
 
 				currentTuple.add(value);


### PR DESCRIPTION


GitHub issue resolved: #4430  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
Provide more user-friendly error message when trying to parse invalid content with BinaryQueryResultParser.
When BinaryQueryResultParser gets unknown symbol, the remaining bytes from the result are parsed as string in order to provide more user-friendly error message. Also, introduced limit of the returned string, if its length > INVALID_CONTENT_LIMIT, it is trimmed and "..." is appended in order to prevent displaying too long result.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

