### PR TITLE
GH-4431: Replace WireMock with MockServer

### DIFF
--- a/core/http/client/pom.xml
+++ b/core/http/client/pom.xml
@@ -71,8 +71,8 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -121,6 +121,11 @@
 		<!-- shared test dependencies -->
 		<!-- Testing: JUnit -->
 		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>

--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -41,8 +41,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/util/RDFLoaderTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/util/RDFLoaderTest.java
@@ -10,10 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.util;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.permanentRedirect;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.eclipse.rdf4j.model.util.Statements.statement;
 import static org.eclipse.rdf4j.model.util.Values.getValueFactory;
 import static org.eclipse.rdf4j.model.util.Values.iri;
@@ -24,6 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 import java.net.ProtocolException;
 import java.net.URL;
@@ -45,18 +43,68 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandler;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.jupiter.MockServerExtension;
+import org.mockserver.model.MediaType;
 
 /**
  * Unit tests for {@link RDFLoader}.
  *
  * @author Manuel Fiorelli
  */
-@WireMockTest
+@ExtendWith(MockServerExtension.class)
 public class RDFLoaderTest {
+	@BeforeAll
+	static void defineMockServerBehavior(MockServerClient client) {
+		client.when(
+				request()
+						.withMethod("GET")
+						.withPath("/Socrates.ttl")
+		)
+				.respond(
+						response()
+								.withContentType(MediaType.parse(RDFFormat.TURTLE.getDefaultMIMEType()))
+								.withBody("<http://example.org/Socrates> a <http://xmlns.com/foaf/0.1/Person> .")
+
+				);
+		client.when(
+				request()
+						.withMethod("GET")
+						.withPath("/Socrates")
+		)
+				.respond(
+						response()
+								.withStatusCode(301)
+								.withHeader("Location", "/Socrates.ttl")
+
+				);
+		client.when(
+				request()
+						.withMethod("GET")
+						.withPath("/Socrates1")
+		)
+				.respond(
+						response()
+								.withStatusCode(301)
+								.withHeader("Location", "/Socrates2")
+
+				);
+		client.when(
+				request()
+						.withMethod("GET")
+						.withPath("/Socrates2")
+		)
+				.respond(
+						response()
+								.withStatusCode(301)
+								.withHeader("Location", "/Socrates.ttl")
+
+				);
+	}
+
 	@Test
 	public void testTurtleJavaResource() throws Exception {
 		RDFLoader rdfLoader = new RDFLoader(new ParserConfig(), getValueFactory());
@@ -74,18 +122,12 @@ public class RDFLoaderTest {
 	}
 
 	@Test
-	public void testTurtleDocument(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-		stubFor(get("/Socrates.ttl")
-				.willReturn(aResponse()
-						.withStatus(200)
-						.withHeader("Content-Type", RDFFormat.TURTLE.getDefaultMIMEType())
-						.withBody("<http://example.org/Socrates> a <http://xmlns.com/foaf/0.1/Person> .")));
-
+	public void testTurtleDocument(MockServerClient client) throws Exception {
 		RDFLoader rdfLoader = new RDFLoader(new ParserConfig(), getValueFactory());
 
 		RDFHandler rdfHandler = mock(RDFHandler.class);
 
-		rdfLoader.load(new URL("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/Socrates.ttl"), null, null,
+		rdfLoader.load(new URL("http://localhost:" + client.getPort() + "/Socrates.ttl"), null, null,
 				rdfHandler);
 
 		verify(rdfHandler).startRDF();
@@ -97,24 +139,12 @@ public class RDFLoaderTest {
 	}
 
 	@Test
-	public void testMultipleRedirects(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-		stubFor(get("/Socrates")
-				.willReturn(permanentRedirect("/Socrates2")));
-		stubFor(get("/Socrates2")
-				.willReturn(permanentRedirect("/Socrates3")));
-		stubFor(get("/Socrates3")
-				.willReturn(permanentRedirect("/Socrates.ttl")));
-		stubFor(get("/Socrates.ttl")
-				.willReturn(aResponse()
-						.withStatus(200)
-						.withHeader("Content-Type", RDFFormat.TURTLE.getDefaultMIMEType())
-						.withBody("<http://example.org/Socrates> a <http://xmlns.com/foaf/0.1/Person> .")));
-
+	public void testMultipleRedirects(MockServerClient client) throws Exception {
 		RDFLoader rdfLoader = new RDFLoader(new ParserConfig(), getValueFactory());
 
 		RDFHandler rdfHandler = mock(RDFHandler.class);
 
-		rdfLoader.load(new URL("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/Socrates"), null, null,
+		rdfLoader.load(new URL("http://localhost:" + client.getPort() + "/Socrates1"), null, null,
 				rdfHandler);
 
 		verify(rdfHandler).startRDF();
@@ -126,17 +156,7 @@ public class RDFLoaderTest {
 	}
 
 	@Test
-	public void testAbortOverMaxRedirects(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-		stubFor(get("/Socrates1")
-				.willReturn(permanentRedirect("/Socrates2")));
-		stubFor(get("/Socrates2")
-				.willReturn(permanentRedirect("/Socrates3")));
-		stubFor(get("/Socrates3")
-				.willReturn(aResponse()
-						.withStatus(200)
-						.withHeader("Content-Type", RDFFormat.TURTLE.getDefaultMIMEType())
-						.withBody("<http://example.org/Socrates> a <http://xmlns.com/foaf/0.1/Person> .")));
-
+	public void testAbortOverMaxRedirects(MockServerClient client) throws Exception {
 		/* nullable */
 		String oldMaxRedirects = System.getProperty("http.maxRedirects");
 		try {
@@ -148,7 +168,7 @@ public class RDFLoaderTest {
 
 			RDFHandler rdfHandler = mock(RDFHandler.class);
 			try {
-				rdfLoader.load(new URL("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/Socrates1"), null, null,
+				rdfLoader.load(new URL("http://localhost:" + client.getPort() + "/Socrates1"), null, null,
 						rdfHandler);
 			} catch (ProtocolException e) {
 				actualException = e;
@@ -166,27 +186,16 @@ public class RDFLoaderTest {
 	}
 
 	@Test
-	public void testNonInformationResource(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+	public void testNonInformationResource(MockServerClient client) throws Exception {
 		final SSLSocketFactory toRestoreSocketFactory = disableSSLCertificatCheck();
 		try {
 			final HostnameVerifier toRestoreHostnameVerifier = disableHostnameVerifier();
 			try {
-				stubFor(get("/Socrates")
-						.willReturn(
-								permanentRedirect(
-										"http://localhost:" + wmRuntimeInfo.getHttpPort() + "/Socrates.ttl")));
-
-				stubFor(get("/Socrates.ttl")
-						.willReturn(aResponse()
-								.withStatus(200)
-								.withHeader("Content-Type", RDFFormat.TURTLE.getDefaultMIMEType())
-								.withBody("<http://example.org/Socrates> a <http://xmlns.com/foaf/0.1/Person> .")));
-
 				RDFLoader rdfLoader = new RDFLoader(new ParserConfig(), getValueFactory());
 
 				RDFHandler rdfHandler = mock(RDFHandler.class);
 
-				rdfLoader.load(new URL("http://localhost:" + wmRuntimeInfo.getHttpPort() + "/Socrates"), null, null,
+				rdfLoader.load(new URL("http://localhost:" + client.getPort() + "/Socrates"), null, null,
 						rdfHandler);
 
 				verify(rdfHandler).startRDF();

--- a/core/repository/manager/pom.xml
+++ b/core/repository/manager/pom.xml
@@ -56,14 +56,8 @@
 		</dependency>
 		<!-- testing dependencies -->
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>${servlet.version}</version>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -589,9 +589,9 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>com.github.tomakehurst</groupId>
-				<artifactId>wiremock-jre8</artifactId>
-				<version>2.35.0</version>
+				<groupId>org.mock-server</groupId>
+				<artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
+				<version>5.15.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>

--- a/spring-components/rdf4j-spring/pom.xml
+++ b/spring-components/rdf4j-spring/pom.xml
@@ -66,8 +66,8 @@
 			<version>2.8.1</version>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
GitHub issue resolved: #4431 

Briefly describe the changes proposed in this PR:

This PR migrates all use of WireMock in the codebase to MockServer. MockServer is built on Netty, and provides no-dependency shaded jars, which will ease upgrading Jetty (https://github.com/eclipse/rdf4j/issues/4252), upgrade Java/Jakarta EE and migrate from Java EE to Jakarta EE (https://github.com/eclipse/rdf4j/issues/3559).

The MockServer code is a bit more verbose, but fairly equivalent to WireMock. MockServer lacks the ability to load mocked response bodies from file, so in order to not change "everything" in this PR, I added small utility methods to adapt this missing feature. This can be changed/improved in a follow-up PR.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

