### PR TITLE
GH-4441: Bump Solr to latest version 8.x

### DIFF
--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/cloud/Factory.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/cloud/Factory.java
@@ -23,6 +23,6 @@ public class Factory implements SolrClientFactory {
 	@Override
 	public SolrClient create(String spec) {
 		List<String> zkHosts = Lists.newArrayList(spec.substring("cloud:".length()));
-		return new CloudSolrClient.Builder().withZkHost(zkHosts).build();
+		return new CloudSolrClient.Builder(zkHosts).build();
 	}
 }

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/embedded/Factory.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/embedded/Factory.java
@@ -23,6 +23,8 @@ public class Factory implements SolrClientFactory {
 
 	@Override
 	public SolrClient create(String spec) {
+		// FIXME: We need a new way of obtaining Solr home directory.
+		// The following method is deprecated in version 8 and removed in version 9.
 		Path solrHome = SolrResourceLoader.locateSolrHome();
 		Path configFile = solrHome.resolve(SolrXmlConfig.SOLR_XML_FILE);
 		return new EmbeddedSolrServer(CoreContainer.createAndLoad(solrHome, configFile), "embedded");

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
 		<jaxb.version>2.3.3</jaxb.version>
 		<lucene.version>8.5.1</lucene.version>
 		<lwjgl.version>3.3.1</lwjgl.version>
-		<solr.version>8.4.1</solr.version>
+		<solr.version>8.11.2</solr.version>
 		<elasticsearch.version>7.8.1</elasticsearch.version>
 		<spring.version>5.3.24</spring.version>
 		<guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
GitHub issue resolved: #4441

Briefly describe the changes proposed in this PR:

This bumps Solr dependencies to latest version 8.x and fixes usage of deprecated Solr APIs.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

