### PR TITLE
GH-4446: Replace tomcat7-maven-plugin with jetty-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,7 @@
 		<jmhVersion>1.35</jmhVersion>
 		<servlet.version>3.1.0</servlet.version>
 		<junit.version>5.8.2</junit.version>
+		<jetty.version>9.4.50.v20221201</jetty.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -368,7 +369,7 @@
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-bom</artifactId>
-				<version>9.4.50.v20221201</version>
+				<version>${jetty.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -871,9 +872,9 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.tomcat.maven</groupId>
-					<artifactId>tomcat7-maven-plugin</artifactId>
-					<version>2.2</version>
+					<groupId>org.eclipse.jetty</groupId>
+					<artifactId>jetty-maven-plugin</artifactId>
+					<version>${jetty.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>com.github.siom79.japicmp</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -66,16 +66,6 @@
 				<version>1.2</version>
 			</dependency>
 			<dependency>
-				<groupId>taglibs</groupId>
-				<artifactId>standard</artifactId>
-				<version>1.1.2</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.activation</groupId>
-				<artifactId>activation</artifactId>
-				<version>1.1</version>
-			</dependency>
-			<dependency>
 				<groupId>org.ebaysf.web</groupId>
 				<artifactId>cors-filter</artifactId>
 				<version>1.0.1</version>

--- a/tools/server-spring/pom.xml
+++ b/tools/server-spring/pom.xml
@@ -33,20 +33,6 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet.jsp</groupId>
-			<artifactId>jsp-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>jstl</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>taglibs</groupId>
-			<artifactId>standard</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-aop</artifactId>
 			<scope>runtime</scope>

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -32,6 +32,16 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>javax.servlet.jsp</groupId>
+			<artifactId>jsp-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>jstl</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.ebaysf.web</groupId>
 			<artifactId>cors-filter</artifactId>
 		</dependency>
@@ -49,20 +59,11 @@
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-nop</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>javax.servlet</groupId>
-					<artifactId>servlet-api</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -78,24 +79,6 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>apache-jsp</artifactId>
-			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.glassfish</groupId>
-					<artifactId>javax.el</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<!--		Jetty-jsp is including a snapshot version of javax.el, thid breaks the build-->
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
-			<version>3.0.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -130,12 +113,12 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.tomcat.maven</groupId>
-				<artifactId>tomcat7-maven-plugin</artifactId>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
 				<configuration>
-					<warFile>${project.build.directory}/rdf4j-server.war</warFile>
-					<server>tomcat</server>
-					<path>/rdf4j-server</path>
+					<webApp>
+						<contextPath>/rdf4j-server</contextPath>
+					</webApp>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -28,7 +28,7 @@
 			<artifactId>rdf4j-config</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!-- TODO rather include into rdf4j-storage, however, 
+		<!-- TODO rather include into rdf4j-storage, however,
 		requires resolving cyclic dependency on test scope -->
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
@@ -38,6 +38,7 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<!-- Required for CommonsMultipartResolver from the Spring Framework -->
 		<dependency>
@@ -76,12 +77,18 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.tomcat.maven</groupId>
-				<artifactId>tomcat7-maven-plugin</artifactId>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-maven-plugin</artifactId>
 				<configuration>
-					<warFile>${project.build.directory}/rdf4j-workbench.war</warFile>
-					<path>/rdf4j-workbench</path>
-					<server>tomcat</server>
+					<webApp>
+						<contextPath>/rdf4j-workbench</contextPath>
+					</webApp>
+					<contextHandlers>
+						<contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
+							<war>${project.basedir}/../server/target/rdf4j-server.war</war>
+							<contextPath>/rdf4j-server</contextPath>
+						</contextHandler>
+					</contextHandlers>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
GitHub issue resolved: #4446

Briefly describe the changes proposed in this PR:

This PR replaces the maven plugin that can be used to run server/workbench in a local development environment. I am now able to run server in standalone mode by executing `mvn jetty:run` from the server module, and workbench+server if running from the workbench module.

Also cleaning up some dependency issues detected by duplicate class detection on Jetty startup. There is still a problem with duplicate commons-logging classes, but that requires more delicate work to fix. Please let me know if you want the dep-changes in a dedicated PR. I have made an attempt in https://github.com/eclipse/rdf4j/pull/4443, but IMO it makes more sense to do it here - when actually running the applications.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

