### PR TITLE
GH-4452: Add Dash license-check CI

### DIFF
--- a/.github/workflows/dash-license.yml
+++ b/.github/workflows/dash-license.yml
@@ -1,0 +1,30 @@
+name: dash license
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  license-check:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '19'
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-jdk19-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-jdk19-maven-
+      - name: Run license-check
+        run: mvn -B -Plicence-check org.eclipse.dash:license-tool-plugin:license-check -Ddash.summary=DEPENDENCIES
+      - name: Print Dash Summary
+        if: always()
+        run: cat DEPENDENCIES

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,32 @@
 			</repositories>
 		</profile>
 		<profile>
+			<id>licence-check</id>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>dash-licenses-snapshots</id>
+					<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+				</pluginRepository>
+			</pluginRepositories>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.dash</groupId>
+						<artifactId>license-tool-plugin</artifactId>
+						<version>0.0.1-SNAPSHOT</version>
+						<configuration>
+							<failWhenReviewNeeded>true</failWhenReviewNeeded>
+							<!-- TODO: maven/mavencentral/org.openjdk.jmh/jmh-generator-annprocess/1.35, GPL-2.0-only WITH Classpath-exception-2.0, restricted, #3045 -->
+							<excludeGroupIds>org.openjdk.jmh</excludeGroupIds>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>formatting</id>
 			<activation>
 				<!-- active on all Java 11 and higher builds by default -->


### PR DESCRIPTION
GitHub issue resolved: #4452

Briefly describe the changes proposed in this PR:

This adds an initial workflow that runs Dash license-check. If have haven't done anything wrong, I had to add an exclude to make CI pass. The artifact `org.openjdk.jmh:jmh-generator-annprocess` is reported as restricted.

I suggest a separate workflow since we eventually will migrate to the [Dash License reusable workflow](https://github.com/eclipse/dash-licenses#reusable-github-workflow-for-automatic-license-check-and-ip-team-review-requests).

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

