### PR TITLE
GH-4459: Replace usage of Hamcrest with AssertJ

### DIFF
--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -50,12 +50,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-rio-rdfxml</artifactId>
 			<version>${project.version}</version>

--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -35,9 +35,8 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>1.3</version>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/util/RDFLoaderTest.java
+++ b/core/repository/api/src/test/java/org/eclipse/rdf4j/repository/util/RDFLoaderTest.java
@@ -10,14 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.util;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.model.util.Statements.statement;
 import static org.eclipse.rdf4j.model.util.Values.getValueFactory;
 import static org.eclipse.rdf4j.model.util.Values.iri;
-import static org.hamcrest.CoreMatchers.both;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasProperty;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockserver.model.HttpRequest.request;
@@ -174,8 +170,8 @@ public class RDFLoaderTest {
 				actualException = e;
 			}
 
-			assertThat(actualException, both(notNullValue())
-					.and(hasProperty("message", startsWith("Server redirected too many times"))));
+			assertThat(actualException)
+					.hasMessageStartingWith("Server redirected too many times");
 		} finally {
 			if (oldMaxRedirects != null) {
 				System.setProperty("http.maxRedirects", oldMaxRedirects);

--- a/core/sparqlbuilder/pom.xml
+++ b/core/sparqlbuilder/pom.xml
@@ -17,8 +17,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<artifactId>hamcrest-core</artifactId>
 			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
@@ -11,8 +11,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.core;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -21,7 +21,6 @@ import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatternNotTriples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -50,7 +49,8 @@ public class SparqlBuilderTest {
 								Expressions.gt(price, Rdf.literalOf(30)))))
 				.optional();
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		assertThat(query.getQueryString(), CoreMatchers.containsString("( ?price < 50 && ?price > 30 )"));
+		assertThat(query.getQueryString())
+				.contains("( ?price < 50 && ?price > 30 )");
 	}
 
 	@Test
@@ -66,8 +66,8 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		assertThat(query.getQueryString(), CoreMatchers.containsString("( ?price < 20 || ( ?price > 50 &&" +
-				" ( ?price > 60 || ?price < 70 ) ) )"));
+		assertThat(query.getQueryString())
+				.contains("( ?price < 20 || ( ?price > 50 && ( ?price > 60 || ?price < 70 ) ) )");
 	}
 
 	@Test
@@ -82,7 +82,8 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 - ( 2 * 5 ) )"));
+		assertThat(query.getQueryString())
+				.contains("( 20 - ( 2 * 5 ) )");
 	}
 
 	@Test
@@ -97,7 +98,8 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 + ( 10 / 5 ) )"));
+		assertThat(query.getQueryString())
+				.contains("( 20 + ( 10 / 5 ) )");
 	}
 
 	@Test
@@ -111,7 +113,8 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		assertThat(query.getQueryString(), CoreMatchers.containsString("( ( 20 - 2 ) * 5 ) )"));
+		assertThat(query.getQueryString())
+				.contains("( ( 20 - 2 ) * 5 ) )");
 	}
 
 	@Test
@@ -126,7 +129,8 @@ public class SparqlBuilderTest {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		assertThat(query.getQueryString(), CoreMatchers.containsString("( 20 + ( 10 / 5 ) ) || 30 < 50 )"));
+		assertThat(query.getQueryString())
+				.contains("( 20 + ( 10 / 5 ) ) || 30 < 50 )");
 	}
 
 	@Test
@@ -142,8 +146,10 @@ public class SparqlBuilderTest {
 				.select(title, price)
 				.where(x.has(dc.iri("title"), title),
 						pricePattern);
-		assertThat(query.getQueryString(), CoreMatchers.containsString("FILTER ( ?price < 50 )"));
-		assertThat(query.getQueryString(), CoreMatchers.containsString("FILTER ( ?price > 30 )"));
+		assertThat(query.getQueryString())
+				.contains("FILTER ( ?price < 50 )");
+		assertThat(query.getQueryString())
+				.contains("FILTER ( ?price > 30 )");
 	}
 
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/BaseExamples.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/BaseExamples.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples;
 
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.HamcrestCondition;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DC;
@@ -19,7 +21,6 @@ import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
 import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
@@ -65,9 +66,9 @@ public class BaseExamples {
 		return s.toLowerCase().replaceAll("[\n\\s]", "");
 	}
 
-	protected Matcher<? super String> stringEqualsIgnoreCaseAndWhitespace(String expected) {
+	protected Condition<String> stringEqualsIgnoreCaseAndWhitespace(String expected) {
 		final String expectedConverted = toLowerRemoveWhitespace(expected);
-		return new BaseMatcher<>() {
+		return new HamcrestCondition<>(new BaseMatcher<>() {
 			private String aroundString = null;
 
 			@Override
@@ -94,7 +95,7 @@ public class BaseExamples {
 				description.appendText(
 						"Expected: was \"" + expected.replaceAll("\n", "\\\\n").replaceAll("\\s+", " ") + "\"");
 			}
-		};
+		});
 	}
 
 	private String getFirstDifference(String expected, String actual, int length) {

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section11Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section11Test.java
@@ -11,8 +11,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
@@ -43,7 +43,7 @@ public class Section11Test extends BaseExamples {
 						book.has(base.iri("price"), lprice))
 				.groupBy(org)
 				.having(Expressions.gt(sum, 10));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://books.example/>\n"
 						+ "SELECT (SUM(?lprice) AS ?totalPrice)\n"
 						+ "WHERE {\n"
@@ -76,7 +76,7 @@ public class Section11Test extends BaseExamples {
 				.where(org.has(affiliates, auth), auth.has(writesBook, book), book.has(price, lprice))
 				.groupBy(org)
 				.having(Expressions.gt(sum, 10));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://books.example/>\n"
 						+ "SELECT (SUM(?lprice) AS ?totalPrice)\n"
 						+ "WHERE {\n"
@@ -97,7 +97,7 @@ public class Section11Test extends BaseExamples {
 		query.select(SparqlBuilder.as(Expressions.avg(y), avg))
 				.where(a.has(base.iri("x"), x).andHas(base.iri("y"), y))
 				.groupBy(x);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT (AVG(?y) AS ?avg)\n"
 						+ "WHERE {\n"
 						+ "  ?a :x ?x ;\n"
@@ -117,7 +117,7 @@ public class Section11Test extends BaseExamples {
 				.where(x.has(base.iri("size"), size))
 				.groupBy(x)
 				.having(Expressions.gt(avgSize, 10));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://data.example/>\n"
 						+ "SELECT (AVG(?size) AS ?asize)\n"
 						+ "WHERE {\n"
@@ -138,7 +138,7 @@ public class Section11Test extends BaseExamples {
 				.select(x, twiceMin.as(min))
 				.where(x.has(base.iri("p"), y), x.has(base.iri("q"), z))
 				.groupBy(x, Expressions.str(z));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example.com/data/#>\n"
 						+ "SELECT ?x ((MIN(?y) * 2) AS ?min)\n"
 						+ "WHERE {\n"
@@ -159,7 +159,7 @@ public class Section11Test extends BaseExamples {
 				.select(g, Expressions.avg(p).as(avg), midRange.as(c))
 				.where(g.has(base.iri("p"), p))
 				.groupBy(g);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example.com/data/#>\n"
 						+ "SELECT ?g (AVG(?p) AS ?avg) (((MIN(?p) + MAX(?p)) / 2) AS ?c)\n"
 						+ "WHERE {\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section12Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section12Test.java
@@ -11,8 +11,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -38,7 +38,7 @@ public class Section12Test extends BaseExamples {
 		query.prefix(base, base) // SparqlBuilder even fixes typos for you ;)
 				.select(y, minName)
 				.where(base.iri("alice").has(base.iri("knows"), y), sub);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://people.example/>\n"
 						+ "SELECT ?y ?minName\n"
 						+ "WHERE {\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section13Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section13Test.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.Dataset;
 import org.eclipse.rdf4j.sparqlbuilder.core.From;
@@ -33,7 +33,7 @@ public class Section13Test extends BaseExamples {
 		Variable x = var("x");
 		From defaultGraph = SparqlBuilder.from(iri("http://example.org/foaf/aliceFoaf"));
 		query.prefix(foaf).select(name).from(defaultGraph).where(x.has(foaf.iri("name"), name));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT  ?name\n"
 						+ "FROM    <http://example.org/foaf/aliceFoaf>\n"
@@ -44,7 +44,7 @@ public class Section13Test extends BaseExamples {
 	public void example_13_2_2() {
 		Dataset dataset = SparqlBuilder.dataset(SparqlBuilder.fromNamed(iri("http://example.org/alice")),
 				SparqlBuilder.fromNamed(iri("http://example.org/bob")));
-		assertThat(dataset.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(""
+		assertThat(dataset.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(""
 				+ "FROM NAMED <http://example.org/alice>\n"
 				+ "FROM NAMED <http://example.org/bob>"));
 	}
@@ -65,7 +65,7 @@ public class Section13Test extends BaseExamples {
 				.select(who, g, mbox)
 				.from(defaultGraph, aliceGraph, bobGraph)
 				.where(g.has(dc.iri("publisher"), who), namedGraph);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX dc: <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"
@@ -94,7 +94,7 @@ public class Section13Test extends BaseExamples {
 						.and(x.has(foaf.iri("mbox"), iri("mailto:bob@work.example")),
 								x.has(foaf.iri("nick"), bobNick))
 						.from(src));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "SELECT ?src ?bobNick\n"
@@ -122,7 +122,7 @@ public class Section13Test extends BaseExamples {
 						.and(x.has(foaf.iri("mbox"), iri("mailto:bob@work.example")),
 								x.has(foaf.iri("nick"), nick))
 						.from(data.iri("bobFoaf")));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX data: <http://example.org/foaf/>\n"
 						+ "\n"
@@ -161,7 +161,7 @@ public class Section13Test extends BaseExamples {
 				.from(SparqlBuilder.fromNamed(iri("http://example.org/foaf/aliceFoaf")),
 						SparqlBuilder.fromNamed(iri("http://example.org/foaf/bobFoaf")))
 				.where(aliceFoafGraph, ppdGraph);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  data:  <http://example.org/foaf/>\n"
 						+ "PREFIX  foaf:  <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX  rdfs:  <http://www.w3.org/2000/01/rdf-schema#>\n"
@@ -201,7 +201,7 @@ public class Section13Test extends BaseExamples {
 				.where(g.has(dc.iri("publisher"), name).andHas(dc.iri("date"), date),
 						GraphPatterns.and(person.has(foaf.iri("name"), name)
 								.andHas(foaf.iri("mbox"), mbox)).from(g));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX dc:   <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section15Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section15Test.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.OrderBy;
 import org.eclipse.rdf4j.sparqlbuilder.core.OrderCondition;
@@ -33,7 +33,7 @@ public class Section15Test extends BaseExamples {
 
 		TriplePattern employeePattern = x.has(foaf.iri("name"), name);
 		query.prefix(foaf).select(name).where(employeePattern).orderBy(name);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "SELECT ?name\n"
@@ -59,7 +59,7 @@ public class Section15Test extends BaseExamples {
 		// than Orderable instances) replaces (rather than augments)
 		// the query's order conditions
 		query.orderBy(SparqlBuilder.orderBy(empDesc));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX     :    <http://example.org/ns#>\n"
 						+ "PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
@@ -70,7 +70,7 @@ public class Section15Test extends BaseExamples {
 
 		OrderBy order = SparqlBuilder.orderBy(name, empDesc);
 		query.orderBy(order);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX     :    <http://example.org/ns#>\n"
 						+ "PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
@@ -86,7 +86,7 @@ public class Section15Test extends BaseExamples {
 		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).distinct().where(x.has(foaf.iri("name"), name));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT DISTINCT ?name WHERE { ?x foaf:name ?name .}"
 		));
@@ -103,7 +103,7 @@ public class Section15Test extends BaseExamples {
 		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).where(x.has(foaf.iri("name"), name)).orderBy(name).limit(5).offset(10);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "SELECT  ?name\n"
@@ -120,7 +120,7 @@ public class Section15Test extends BaseExamples {
 		Variable name = var("name"), x = var("x");
 
 		query.prefix(foaf).select(name).where(x.has(foaf.iri("name"), name)).limit(20);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "SELECT ?name\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section16Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section16Test.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -57,7 +57,7 @@ public class Section16Test extends BaseExamples {
 		query.prefix(dc, ns)
 				.select(title, discountedPrice)
 				.where(x.has(ns.iri("price"), p), x.has(dc.iri("title"), title), x.has(ns.iri("discount"), discount));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX  ns:  <https://example.org/ns#>\n"
 						+ "SELECT  ?title ((?p*(1-?discount)) AS ?price) WHERE\n"
@@ -75,7 +75,7 @@ public class Section16Test extends BaseExamples {
 		// (rather than Projectable instances) replaces (rather than augments)
 		// the query's projections
 		query.select(newProjection);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX  ns:  <https://example.org/ns#>\n"
 						+ "SELECT  ?title (?p AS ?fullPrice) ((?fullPrice*(1-?discount)) AS ?customerPrice) WHERE\n"
@@ -95,13 +95,13 @@ public class Section16Test extends BaseExamples {
 		assertThat(Queries.CONSTRUCT(aliceIri.has(vcard.iri("FN"), name))
 				.where(x.has(foaf.iri("name"), name))
 				.prefix(foaf, vcard)
-				.getQueryString(),
-				stringEqualsIgnoreCaseAndWhitespace(
-						"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
-								+ "PREFIX vcard:   <http://www.w3.org/2001/vcard-rdf/3.0#>\n"
-								+ "CONSTRUCT   { <http://example.org/person#Alice> vcard:FN ?name .}\n"
-								+ "WHERE       { ?x foaf:name ?name . }"
-				));
+				.getQueryString()
+		).is(stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
+						+ "PREFIX vcard:   <http://www.w3.org/2001/vcard-rdf/3.0#>\n"
+						+ "CONSTRUCT   { <http://example.org/person#Alice> vcard:FN ?name .}\n"
+						+ "WHERE       { ?x foaf:name ?name . }"
+		));
 	}
 
 	@Test
@@ -120,7 +120,7 @@ public class Section16Test extends BaseExamples {
 				.where(x.has(foaf.iri("firstName"), gname).union(x.has(foaf.iri("givenname"), gname)),
 						x.has(foaf.iri("surname"), fname).union(x.has(foaf.iri("family_name"), fname)));
 
-		assertThat(cQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(cQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX vcard:   <http://www.w3.org/2001/vcard-rdf/3.0#>\n"
 						+ "\n"
@@ -153,7 +153,7 @@ public class Section16Test extends BaseExamples {
 
 		ConstructQuery query = Queries.CONSTRUCT(s.has(p, o)).where(where).prefix(dc, app, xsd);
 
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc: <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX app: <http://example.org/ns#>\n"
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
@@ -180,7 +180,7 @@ public class Section16Test extends BaseExamples {
 				.where(subject.has(foaf.iri("name"), name).andHas(site.iri("hits"), hits))
 				.orderBy(hits.desc())
 				.limit(2);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX site: <http://example.org/stats#>\n"
 						+ "\n"
@@ -202,7 +202,7 @@ public class Section16Test extends BaseExamples {
 		ConstructQuery query = Queries.CONSTRUCT(x.has(foaf.iri("name"), name))
 				.where(x.has(foaf.iri("name"), name))
 				.prefix(foaf);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
 						+ "CONSTRUCT { ?x foaf:name ?name .} \n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section17Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section17Test.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -29,7 +29,7 @@ public class Section17Test extends BaseExamples {
 		Variable attributeIRI = SparqlBuilder.var("attribute_iri");
 		Iri type = rdf.iri("type");
 		Expression in = Expressions.in(attributeIRI, type);
-		assertThat(in.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(in.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"?attribute_iri IN ( rdf:type )"
 		));
 	}
@@ -40,7 +40,7 @@ public class Section17Test extends BaseExamples {
 		Variable attributeIRI = SparqlBuilder.var("attribute_iri");
 		Iri type = rdf.iri("type");
 		Expression notIn = Expressions.notIn(attributeIRI, type);
-		assertThat(notIn.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(notIn.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"?attribute_iri NOT IN ( rdf:type )"
 		));
 	}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section2Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section2Test.java
@@ -11,8 +11,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -42,7 +42,7 @@ public class Section2Test extends BaseExamples {
 				title);
 
 		query.select(title).where(book1_has_title);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?title\n"
 						+ "WHERE\n"
 						+ "{\n"
@@ -61,7 +61,7 @@ public class Section2Test extends BaseExamples {
 
 		query.select(title).where(book1_has_title);
 
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?title\n"
 						+ "WHERE\n"
 						+ "{\n"
@@ -84,7 +84,7 @@ public class Section2Test extends BaseExamples {
 
 		query.prefix(foaf).select(name, mbox).where(x_hasFoafName_name, x_hasFoafMbox_mbox);
 
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE\n"
@@ -107,7 +107,7 @@ public class Section2Test extends BaseExamples {
 
 		query.prefix(foaf).select(name, mbox).where(x_hasFoafName_name, x_hasFoafMbox_mbox);
 
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE\n"
@@ -123,13 +123,13 @@ public class Section2Test extends BaseExamples {
 		TriplePattern v_hasP_cat = GraphPatterns.tp(v, p, Rdf.literalOf("cat"));
 
 		query.select(v).where(v_hasP_cat);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p \"cat\" .}"
 		));
 
 		TriplePattern v_hasP_cat_en = GraphPatterns.tp(v, p, Rdf.literalOfLanguage("cat", "en"));
 		SelectQuery queryWithLangTag = Queries.SELECT(v).where(v_hasP_cat_en);
-		assertThat(queryWithLangTag.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(queryWithLangTag.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p \"cat\"@en . }"
 		));
 	}
@@ -141,7 +141,7 @@ public class Section2Test extends BaseExamples {
 		TriplePattern v_hasP_42 = GraphPatterns.tp(v, p, Rdf.literalOf(42));
 
 		query.select(v).where(v_hasP_42);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p 42 . }"
 		));
 	}
@@ -154,7 +154,7 @@ public class Section2Test extends BaseExamples {
 				Rdf.literalOfType("abc", Rdf.iri(EXAMPLE_DATATYPE_NS, datatype)));
 
 		query.select(v).where(v_hasP_abc_dt);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p \"abc\"^^<http://example.org/datatype#specialDatatype> .}"
 		));
 	}
@@ -169,7 +169,7 @@ public class Section2Test extends BaseExamples {
 		TriplePattern v_hasP_abc_dt = GraphPatterns.tp(v, p, lit);
 
 		query.select(v).where(v_hasP_abc_dt);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?v WHERE { ?v ?p \"abc\"^^<http://example.org/datatype#specialDatatype> .}"
 		));
 
@@ -181,7 +181,7 @@ public class Section2Test extends BaseExamples {
 
 		Variable x = var("x"), name = var("name");
 		query.prefix(foaf).select(x, name).where(x.has(foaf.iri("name"), name));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?x ?name\n"
 						+ "WHERE  { ?x foaf:name ?name . }"
@@ -199,7 +199,7 @@ public class Section2Test extends BaseExamples {
 		query.prefix(foaf)
 				.select(concatAsName)
 				.where(GraphPatterns.tp(P, foaf.iri("givenName"), G).andHas(foaf.iri("surname"), S));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ( CONCAT(?G, \" \", ?S) AS ?name )\n"
 						+ "WHERE  { ?P foaf:givenName ?G ; foaf:surname ?S .}"
@@ -213,7 +213,7 @@ public class Section2Test extends BaseExamples {
 								.andHas(foaf.iri("surname"), S),
 						Expressions.bind(Expressions.concat(G, Rdf.literalOf(" "), S), name));
 
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name\n"
 						+ "WHERE  { \n"
@@ -237,7 +237,7 @@ public class Section2Test extends BaseExamples {
 		TriplePattern orgName = GraphPatterns.tp(x, org.iri("employeeName"), name);
 
 		graphQuery.prefix(prefixes).construct(foafName).where(orgName);
-		assertThat(graphQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(graphQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "PREFIX org:    <https://example.com/ns#>\n"
 						+ "\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section3Test.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -40,7 +40,7 @@ public class Section3Test extends BaseExamples {
 		GraphPattern where = xTitle.filter(regex);
 
 		query.prefix(dc).select(title).where(where);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "SELECT  ?title\n"
 						+ "WHERE   { ?x dc:title ?title .\n"
@@ -49,7 +49,7 @@ public class Section3Test extends BaseExamples {
 		));
 		query = Queries.SELECT();
 		query.prefix(dc).select(title).where(xTitle.filter(Expressions.regex(title, "web", "i")));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "SELECT  ?title\n"
 						+ "WHERE   { ?x dc:title ?title .\n"
@@ -71,7 +71,7 @@ public class Section3Test extends BaseExamples {
 		query.prefix(dc, ns).select(title, price).where(where);
 		// NOTE: had to move FILTER to the end of the group graph pattern (in the original, it's between the two triple
 		// patterns).
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX  ns:  <https://example.com/ns#>\n"
 						+ "SELECT  ?title ?price\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section4Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section4Test.java
@@ -11,8 +11,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
@@ -38,30 +38,30 @@ public class Section4Test extends BaseExamples {
 
 		// [ :p "v" ] .
 		PropertiesBlankNode bnode = Rdf.bNode(defPrefix.iri("p"), Rdf.literalOf("v"));
-		assertThat(bnode.toTp().getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\"] ."));
+		assertThat(bnode.toTp().getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\"] ."));
 
 		// [] :p "v" .
 		TriplePattern tp = Rdf.bNode().has(defPrefix.iri("p"), Rdf.literalOf("v"));
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[] :p \"v\" ."));
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace("[] :p \"v\" ."));
 
 		// [ :p "v" ] :q "w" .
 		tp = bnode.has(defPrefix.iri("q"), Rdf.literalOf("w"));
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\" ] :q \"w\" ."));
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace("[ :p \"v\" ] :q \"w\" ."));
 
 		// :x :q [ :p "v" ] .
 		tp = defPrefix.iri("x").has(defPrefix.iri("q"), bnode);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(":x :q [ :p \"v\" ] ."));
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(":x :q [ :p \"v\" ] ."));
 
 		RdfBlankNode labelledNode = Rdf.bNode("b57");
 		tp = defPrefix.iri("x").has(defPrefix.iri("q"), labelledNode);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(":x :q _:b57 ."));
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(":x :q _:b57 ."));
 		tp = labelledNode.has(defPrefix.iri("p"), "v");
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("_:b57 :p \"v\". "));
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace("_:b57 :p \"v\". "));
 
 		// [ foaf:name ?name ;
 		// foaf:mbox <mailto:alice@example.org> ]
 		bnode = Rdf.bNode(foaf.iri("name"), name).andHas(foaf.iri("mbox"), iri("mailto:alice@example.org"));
-		assertThat(bnode.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(bnode.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"[ foaf:name ?name ;"
 						+ "foaf:mbox <mailto:alice@example.org> ]"
 		));
@@ -72,7 +72,7 @@ public class Section4Test extends BaseExamples {
 		Variable mbox = SparqlBuilder.var("mbox");
 
 		TriplePattern tp = GraphPatterns.tp(x, foaf.iri("name"), name).andHas(foaf.iri("mbox"), mbox);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"    ?x  foaf:name  ?name ;\n"
 						+ "        foaf:mbox  ?mbox ."
 		));
@@ -86,12 +86,12 @@ public class Section4Test extends BaseExamples {
 		StringLiteral aliceNick = Rdf.literalOf("Alice"), alice_Nick = Rdf.literalOf("Alice_");
 
 		TriplePattern tp = GraphPatterns.tp(x, nick, aliceNick, alice_Nick);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"?x foaf:nick  \"Alice\" , \"Alice_\" ."
 		));
 
 		tp = x.has(foaf.iri("name"), name).andHas(nick, aliceNick, alice_Nick);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"?x  foaf:name ?name ; foaf:nick  \"Alice\" , \"Alice_\" ."
 		));
 	}
@@ -102,11 +102,11 @@ public class Section4Test extends BaseExamples {
 
 		// isA() is a shortcut method to create triples using the "a" keyword
 		TriplePattern tp = SparqlBuilder.var("x").isA(defPrefix.iri("Class1"));
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace("?x  a  :Class1 ."));
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace("?x  a  :Class1 ."));
 
 		// the isA predicate is a static member of RdfPredicate
 		tp = Rdf.bNode(RdfPredicate.a, defPrefix.iri("appClass")).has(defPrefix.iri("p"), "v");
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"  [ a :appClass ] :p \"v\" ."
 		));
 	}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section5Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section5Test.java
@@ -10,10 +10,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -31,7 +31,7 @@ public class Section5Test extends BaseExamples {
 		Variable name = var("name"), mbox = var("mbox");
 		Variable x = var("x");
 		query.prefix(foaf).select(name, mbox).where(x.has(foaf.iri("name"), name), x.has(foaf.iri("mbox"), mbox));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE  {\n"
@@ -43,7 +43,7 @@ public class Section5Test extends BaseExamples {
 		GraphPattern mboxPattern = and(x.has(foaf.iri("mbox"), mbox));
 		QueryPattern where = SparqlBuilder.where(and(namePattern, mboxPattern));
 		query.where(where);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE  { { ?x foaf:name ?name . }\n"
@@ -56,7 +56,7 @@ public class Section5Test extends BaseExamples {
 	public void example_5_2_1() {
 		Variable x = var("x");
 		query.select(x);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"SELECT ?x\n"
 						+ "WHERE {}"));
 	}
@@ -70,13 +70,13 @@ public class Section5Test extends BaseExamples {
 						.and(x.has(foaf.iri("mbox"), mbox))
 						.and()
 						.filter(Expressions.regex(name, "Smith"))
-						.getQueryString(),
-				stringEqualsIgnoreCaseAndWhitespace(
-						" {  ?x foaf:name ?name .\n"
-								+ "    ?x foaf:mbox ?mbox .\n"
-								+ "    FILTER ( regex(?name, \"Smith\"))\n"
-								+ " }\n"
-				));
+						.getQueryString()
+		).is(stringEqualsIgnoreCaseAndWhitespace(
+				" {  ?x foaf:name ?name .\n"
+						+ "    ?x foaf:mbox ?mbox .\n"
+						+ "    FILTER ( regex(?name, \"Smith\"))\n"
+						+ " }\n"
+		));
 		// NOTE: removed the other two examples in which the filter expression is before or between the
 		// triple patterns, respectively. The SparqlBuilder cannot generate this without additional curly
 		// braces, and the point of the examples is to show that all these versions are equivalent, so

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section6Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section6Test.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -36,7 +36,7 @@ public class Section6Test extends BaseExamples {
 				GraphPatterns.optional(x.has(foaf.iri("mbox"), mbox)));
 
 		query.prefix(foaf).select(name, mbox).where(where);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox\n"
 						+ "WHERE  { ?x foaf:name  ?name .\n"
@@ -55,7 +55,7 @@ public class Section6Test extends BaseExamples {
 				.optional();
 
 		query.prefix(dc, ns).select(title, price).where(x.has(dc.iri("title"), title), pricePattern);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "PREFIX  ns:  <https://example.org/ns#>\n"
 						+ "SELECT  ?title ?price\n"
@@ -77,7 +77,7 @@ public class Section6Test extends BaseExamples {
 				.select(name, mbox, hpage)
 				.where(namePattern, GraphPatterns.and(x.has(foaf.iri("mbox"), mbox)).optional(),
 						GraphPatterns.and(x.has(foaf.iri("homepage"), hpage)).optional());
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "SELECT ?name ?mbox ?hpage\n"
 						+ "WHERE  { ?x foaf:name  ?name .\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section7Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section7Test.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
@@ -37,7 +37,7 @@ public class Section7Test extends BaseExamples {
 		GraphPattern titlePattern = GraphPatterns.union(book.has(dc10TitleIri, title), book.has(dc11TitleIri, title));
 
 		query.prefix(dc10).prefix(dc11).select(title).where(titlePattern);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
 						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"
@@ -49,7 +49,7 @@ public class Section7Test extends BaseExamples {
 		Variable x = var("x"), y = var("y"), author = var("author");
 		GraphPattern dc10Title = book.has(dc10TitleIri, x), dc11Title = book.has(dc11TitleIri, y);
 		query.prefix(dc10, dc11).select(x, y).where(GraphPatterns.union(dc10Title, dc11Title));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
 						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"
@@ -65,7 +65,7 @@ public class Section7Test extends BaseExamples {
 		query.prefix(dc10, dc11)
 				.select(title, author)
 				.where(GraphPatterns.and(dc10Title, dc10Author).union(GraphPatterns.and(dc11Title, dc11Author)));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc10:  <http://purl.org/dc/elements/1.0/>\n"
 						+ "PREFIX dc11:  <http://purl.org/dc/elements/1.1/>\n"
 						+ "\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section8Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section8Test.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -40,7 +40,7 @@ public class Section8Test extends BaseExamples {
 		GraphPattern personWithName = person.has(foaf.iri("name"), var("name"));
 		GraphPatternNotTriples personOfTypePerson = GraphPatterns.and(person.has(rdf.iri("type"), foaf.iri("Person")));
 		query.prefix(rdf, foaf).select(person).where(personOfTypePerson.filterNotExists(personWithName));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n"
 						+ "PREFIX  foaf:   <http://xmlns.com/foaf/0.1/> \n"
 						+ "\n"
@@ -63,7 +63,7 @@ public class Section8Test extends BaseExamples {
 		GraphPattern personWithName = person.has(foaf.iri("name"), var("name"));
 		GraphPatternNotTriples personOfTypePerson = GraphPatterns.and(person.has(rdf.iri("type"), foaf.iri("Person")));
 		query.prefix(rdf, foaf).select(person).where(personOfTypePerson.filterExists(personWithName));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n"
 						+ "PREFIX  foaf:   <http://xmlns.com/foaf/0.1/> \n"
 						+ "\n"
@@ -87,7 +87,7 @@ public class Section8Test extends BaseExamples {
 		GraphPattern allNotNamedBob = GraphPatterns.and(s.has(p, o))
 				.minus(s.has(foaf.iri("givenName"), Rdf.literalOf("Bob")));
 		query.prefix(base, foaf).select(s).distinct().where(allNotNamedBob);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX :       <http://example/>\n"
 						+ "PREFIX foaf:   <http://xmlns.com/foaf/0.1/>\n"
 						+ "\n"
@@ -108,7 +108,7 @@ public class Section8Test extends BaseExamples {
 		Iri a = base.iri("a"), b = base.iri("b"), c = base.iri("c");
 
 		query.prefix(base).all().where(GraphPatterns.and(s.has(p, o)).filterNotExists(GraphPatterns.tp(a, b, c)));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example/>\n"
 						+ "SELECT * WHERE \n"
 						+ "{ \n"
@@ -123,7 +123,7 @@ public class Section8Test extends BaseExamples {
 		// pattern(s)) replaces (rather than augments) the query's
 		// query pattern. This allows reuse of the other elements of the query.
 		query.where(where);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example/>\n"
 						+ "SELECT * WHERE \n"
 						+ "{ \n"
@@ -143,7 +143,7 @@ public class Section8Test extends BaseExamples {
 				.filterNotExists(GraphPatterns.and(x.has(base.iri("q"), m)).filter(filter));
 
 		query.prefix(base).select().all().where(notExistsFilter);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example.com/>\n"
 						+ "SELECT * WHERE {\n"
 						+ "        ?x :p ?n . \n"
@@ -157,7 +157,7 @@ public class Section8Test extends BaseExamples {
 		QueryPattern where = SparqlBuilder.where(GraphPatterns.and(x.has(base.iri("p"), n))
 				.minus(GraphPatterns.and(x.has(base.iri("q"), m)).filter(filter)));
 		query.where(where);
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX : <http://example.com/>\n"
 						+ "SELECT * WHERE {\n"
 						+ "        ?x :p ?n . \n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section9Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section9Test.java
@@ -11,11 +11,11 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.notEquals;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
@@ -65,7 +65,7 @@ public class Section9Test extends BaseExamples {
 				.pred(dc.iri("title"))
 				.or(rdfs.iri("label")), displayString);
 		// NOTE: changed example: removed curly braces around, added brackets in path, added dot at end
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				":book1 ( dc:title | rdfs:label ) ?displayString ."
 		));
 	}
@@ -74,7 +74,7 @@ public class Section9Test extends BaseExamples {
 	public void example_9_2__2_alt_noprefix() {
 		TriplePattern tp = book1.has(path -> path.pred(DC.TITLE).or(RDFS.LABEL), displayString);
 		// NOTE: changed example: removed curly braces around, added brackets in path, added dot at end
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				":book1 ( <http://purl.org/dc/elements/1.1/title> | <http://www.w3.org/2000/01/rdf-schema#label> ) ?displayString ."
 		));
 	}
@@ -85,7 +85,7 @@ public class Section9Test extends BaseExamples {
 				.and(x.has(path -> path
 						.pred(foaf.iri("knows"))
 						.then(foaf.iri("name")), name));
-		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"{\n"
 						+ "    ?x foaf:mbox <mailto:alice@example> .\n"
 						+ "    ?x foaf:knows / foaf:name ?name .\n"
@@ -101,7 +101,7 @@ public class Section9Test extends BaseExamples {
 						.pred(foaf.iri("knows"))
 						.then(foaf.iri("knows"))
 						.then(foaf.iri("name")), name));
-		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"{\n"
 						+ "    ?x foaf:mbox <mailto:alice@example> .\n"
 						+ "    ?x foaf:knows / foaf:knows / foaf:name ?name .\n"
@@ -119,7 +119,7 @@ public class Section9Test extends BaseExamples {
 				.filter(notEquals(x, y))
 				.and(y.has(foaf.iri("name"), name));
 		// NOTE: changed example: moved FILTER to end of graph pattern, added dot
-		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"  { ?x foaf:mbox <mailto:alice@example> .\n"
 						+ "    ?x foaf:knows / foaf:knows ?y .\n"
 						+ "    ?y foaf:name ?name .\n"
@@ -132,7 +132,7 @@ public class Section9Test extends BaseExamples {
 	public void example_9_2__6_inverse() {
 		TriplePattern tp = mailto.has(path -> path.pred(foaf.iri("mbox")).inv(), x);
 		// NOTE: changed example: removed curly braces, added dot, added brackets in path
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				" <mailto:alice@example> ^ ( foaf:mbox ) ?x ."
 		));
 	}
@@ -146,7 +146,7 @@ public class Section9Test extends BaseExamples {
 				y)
 				.filter(notEquals(x, y));
 		// NOTE: changed example: added brackets in path
-		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"{\n"
 						+ "    ?x foaf:knows/^ ( foaf:knows ) ?y .  \n"
 						+ "    FILTER(?x != ?y)\n"
@@ -163,7 +163,7 @@ public class Section9Test extends BaseExamples {
 						.then(foaf.iri("name")), name
 				));
 		// NOTE: changed example: added brackets in path
-		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"  {\n"
 						+ "    ?x foaf:mbox <mailto:alice@example> .\n"
 						+ "    ?x foaf:knows+/foaf:name ?name .\n"
@@ -178,7 +178,7 @@ public class Section9Test extends BaseExamples {
 				.or(ex.iri("fatherOf"))
 				.oneOrMore(), me);
 		// NOTE: changed example: remove curly braces, added dot
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"?ancestor (ex:motherOf|ex:fatherOf)+ <#me> ."
 		));
 	}
@@ -191,7 +191,7 @@ public class Section9Test extends BaseExamples {
 				.then(s -> s.pred(rdfs.iri("subClassOf"))
 						.zeroOrMore()),
 				type);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"<http://example/thing> rdf:type / rdfs:subClassOf * ?type ."
 		));
 	}
@@ -204,7 +204,7 @@ public class Section9Test extends BaseExamples {
 				.then(s -> s.pred(rdfs.iri("subClassOf"))
 						.zeroOrMore()),
 				type);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"?x rdf:type / rdfs:subClassOf * ?type ."
 		));
 	}
@@ -217,7 +217,7 @@ public class Section9Test extends BaseExamples {
 						.pred(rdfs.iri("subPropertyOf"))
 						.zeroOrMore(),
 						property));
-		assertThat(gp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(gp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"{ ?x ?p ?v . ?p rdfs:subPropertyOf* :property . }"
 		));
 	}
@@ -228,7 +228,7 @@ public class Section9Test extends BaseExamples {
 				.negProp()
 				.pred(rdf.iri("type"))
 				.invPred(rdf.iri("type")), y);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				" ?x !(rdf:type|^rdf:type) ?y ."
 		));
 	}
@@ -240,7 +240,7 @@ public class Section9Test extends BaseExamples {
 				.pred(rdf.iri("rest"))
 				.zeroOrMore()
 				.then(rdf.iri("first")), element);
-		assertThat(tp.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(tp.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				":list rdf:rest*/rdf:first ?element ."
 		));
 	}
@@ -254,7 +254,7 @@ public class Section9Test extends BaseExamples {
 				.where(s.has(p -> p
 						.pred(base.iri("item"))
 						.then(base.iri("price")), x));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX :   <http://example/>\n"
 						+ "SELECT * \n"
 						+ "WHERE {  ?s :item/:price ?x . }"
@@ -270,7 +270,7 @@ public class Section9Test extends BaseExamples {
 				.prefix(base)
 				.where(s.has(base.iri("item"), _a)
 						.and(_a.has(base.iri("price"), x)));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX :   <http://example/>\n"
 						+ "SELECT * \n"
 						+ "WHERE {"
@@ -289,7 +289,7 @@ public class Section9Test extends BaseExamples {
 				.prefix(base)
 				.where(s.has(base.iri("item"), _a)
 						.and(_a.has(base.iri("price"), x)));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX :   <http://example/>\n"
 						+ "SELECT * \n"
 						+ "WHERE {"
@@ -307,7 +307,7 @@ public class Section9Test extends BaseExamples {
 				.where(order.has(p -> p
 						.pred(base.iri("item"))
 						.then(base.iri("price")), x));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				" PREFIX :   <http://example/>\n"
 						+ "  SELECT (sum(?x) AS ?total)\n"
 						+ "  WHERE { \n"
@@ -327,7 +327,7 @@ public class Section9Test extends BaseExamples {
 						.then(RDFS.SUBCLASSOF)
 						.zeroOrMore(),
 						type));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX  rdfs:   <http://www.w3.org/2000/01/rdf-schema#> \n"
 						+ "  PREFIX  rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
 						+ "  SELECT ?x ?type\n"
@@ -348,7 +348,7 @@ public class Section9Test extends BaseExamples {
 								.pred(FOAF.KNOWS)
 								.oneOrMore(),
 								person));
-		assertThat(query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "  PREFIX :     <http://example/>\n"
 						+ "  SELECT ?person\n"

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/updatespec/Section3Test.java
@@ -11,9 +11,9 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.examples.updatespec;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
@@ -59,7 +59,7 @@ public class Section3Test extends BaseExamples {
 		insertDataQuery.prefix(dc)
 				.insertData(iri("http://example/book1").has(dc.iri("title"), Rdf.literalOf("A new book"))
 						.andHas(dc.iri("creator"), Rdf.literalOf("A.N.Other")));
-		assertThat(insertDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertDataQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "INSERT DATA { "
 						+ "<http://example/book1> dc:title \"A new book\" ;\n"
@@ -80,7 +80,7 @@ public class Section3Test extends BaseExamples {
 				.insertData(iri("http://example/book1").has(ns.iri("price"), Rdf.literalOf(42)))
 				.into(iri("http://example/bookStore"));
 
-		assertThat(insertDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertDataQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "PREFIX ns: <https://example.org/ns#> "
 						+ "INSERT DATA { GRAPH "
@@ -101,7 +101,7 @@ public class Section3Test extends BaseExamples {
 		deleteDataQuery.deleteData(iri("http://example/book2").has(dc.iri("title"), Rdf.literalOf("David Copperfield"))
 				.andHas(dc.iri("creator"), Rdf.literalOf("Edmund Wells")));
 
-		assertThat(deleteDataQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(deleteDataQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/>\n"
 						+ "DELETE DATA { "
 						+ "<http://example/book2> dc:title \"David Copperfield\" ; "
@@ -126,7 +126,7 @@ public class Section3Test extends BaseExamples {
 				.prefix(dc)
 				.deleteData(exampleBook.has(title, "Fundamentals of Compiler Desing"))
 				.from(bookStore);
-		assertThat(deleteTypoQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(deleteTypoQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "DELETE DATA { "
 						+ "GRAPH <http://example/bookStore> {\n"
@@ -137,7 +137,7 @@ public class Section3Test extends BaseExamples {
 				.prefix(dc)
 				.insertData(exampleBook.has(title, "Fundamentals of Compiler Design"))
 				.into(bookStore);
-		assertThat(insertFixedTitleQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertFixedTitleQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "INSERT DATA { "
 						+ "GRAPH <http://example/bookStore> {\n"
@@ -156,14 +156,14 @@ public class Section3Test extends BaseExamples {
 
 		// WITH <g1> DELETE { a b c } INSERT { x y z } WHERE { ... }
 		modify.with(g1).delete(abc).insert(xyz).where(examplePattern);
-		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"WITH <g1> DELETE { ?a ?b ?c . } INSERT { ?x ?y ?z . } where { ... }"
 		));
 
 		// DELETE { GRAPH <g1> { a b c } } INSERT { GRAPH <g1> { x y z } } USING <g1>
 		// WHERE { ... }
 		modify.with((Iri) null).delete(abc).from(g1).insert(xyz).into(g1).using(g1).where(examplePattern);
-		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"DELETE { GRAPH <g1> {?a ?b ?c . } } "
 						+ "INSERT { GRAPH <g1> { ?x ?y ?z .} } "
 						+ "USING <g1> WHERE { ... }"
@@ -187,7 +187,7 @@ public class Section3Test extends BaseExamples {
 				.insert(person.has(foaf.iri("givenName"), "William"))
 				.where(person.has(foaf.iri("givenName"), "Bill"));
 
-		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "WITH <http://example/addresses> "
 						+ "DELETE { ?person foaf:givenName \"Bill\" .} "
@@ -214,7 +214,7 @@ public class Section3Test extends BaseExamples {
 				.where(GraphPatterns.and(book.has(dc.iri("date"), date), book.has(p, v))
 						.filter(Expressions.gt(date,
 								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
-		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
 						+ "DELETE { ?book ?p ?v . } "
@@ -243,7 +243,7 @@ public class Section3Test extends BaseExamples {
 				.delete(person.has(property, value))
 				.where(person.has(property, value).andHas(foaf.iri("givenName"), "Fred"));
 
-		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "WITH <http://example/addresses> "
 						+ "DELETE { ?person ?property ?value .} "
@@ -272,7 +272,7 @@ public class Section3Test extends BaseExamples {
 				.where(and(book.has(dc.iri("date"), date), book.has(p, v)).from(iri("http://example/bookStore"))
 						.filter(Expressions.gt(date,
 								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
-		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
 						+ "INSERT { "
@@ -306,7 +306,7 @@ public class Section3Test extends BaseExamples {
 				.where(and(personNameTriple, GraphPatterns.optional(personEmailTriple))
 						.from(iri("http://example/people")));
 
-		assertThat(insertAddressesQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertAddressesQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/> "
 						+ "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
 						+ "INSERT { "
@@ -347,7 +347,7 @@ public class Section3Test extends BaseExamples {
 				.where(and(book.has(dc.iri("date"), date), book.has(p, v)).from(iri("http://example/bookStore"))
 						.filter(Expressions.lt(date,
 								Rdf.literalOfType("1970-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
-		assertThat(insertIntobookStore2Query.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(insertIntobookStore2Query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX dc: <http://purl.org/dc/elements/1.1/> "
 						+ "PREFIX dcmitype: <http://purl.org/dc/dcmitype/> "
 						+ "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
@@ -372,7 +372,7 @@ public class Section3Test extends BaseExamples {
 						.filter(Expressions.lt(date,
 								Rdf.literalOfType("2000-01-01T00:00:00-02:00", xsd.iri("dateTime")))));
 
-		assertThat(deleteFromBookStoreQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(deleteFromBookStoreQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"WITH <http://example/bookStore>\n"
 						+ "DELETE { ?book ?p ?v . }\n"
 						+ "WHERE { ?book dc:date ?date ;\n"
@@ -396,7 +396,7 @@ public class Section3Test extends BaseExamples {
 				.prefix(foaf)
 				.delete()
 				.where(person.has(foaf.iri("givenName"), "Fred").andHas(property, value));
-		assertThat(modify.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(modify.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "DELETE WHERE {"
 						+ " ?person foaf:givenName \"Fred\";"
@@ -424,7 +424,7 @@ public class Section3Test extends BaseExamples {
 				.where(and(person.has(foaf.iri("givenName"), "Fred").andHas(property1, value1)).from(namesGraph),
 						and(person.has(property2, value2)).from(addressesGraph));
 
-		assertThat(deleteFredFromNamesAndAddressesQuery.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(deleteFredFromNamesAndAddressesQuery.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n"
 						+ "DELETE WHERE { "
 						+ "GRAPH <http://example.com/names> { "
@@ -441,11 +441,11 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_load() {
 		LoadQuery load = Queries.LOAD().from(iri(EXAMPLE_ORG_NS));
-		assertThat(load.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(load.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"LOAD <https://example.org/ns#>"
 		));
 		load = Queries.LOAD().silent().from(iri(EXAMPLE_ORG_NS)).to(iri(EXAMPLE_COM_NS));
-		assertThat(load.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(load.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"LOAD SILENT <https://example.org/ns#> INTO GRAPH <https://example.com/ns#>"
 		));
 	}
@@ -453,11 +453,11 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_clear() {
 		ClearQuery clear = Queries.CLEAR().def();
-		assertThat(clear.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(clear.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"CLEAR DEFAULT"
 		));
 		clear = Queries.CLEAR().silent().graph(iri(EXAMPLE_ORG_NS));
-		assertThat(clear.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(clear.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"CLEAR SILENT GRAPH <https://example.org/ns#>"
 		));
 	}
@@ -465,11 +465,11 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_create() {
 		CreateQuery create = Queries.CREATE().graph(iri(EXAMPLE_ORG_NS));
-		assertThat(create.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(create.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"CREATE GRAPH <https://example.org/ns#>"
 		));
 		create = Queries.CREATE().silent().graph(iri(EXAMPLE_ORG_NS));
-		assertThat(create.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(create.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"CREATE SILENT GRAPH <https://example.org/ns#>"
 		));
 	}
@@ -477,11 +477,11 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_drop() {
 		DropQuery drop = Queries.DROP().def();
-		assertThat(drop.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(drop.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"DROP DEFAULT"
 		));
 		drop = Queries.DROP().silent().graph(iri(EXAMPLE_ORG_NS));
-		assertThat(drop.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(drop.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"DROP SILENT GRAPH <https://example.org/ns#>"
 		));
 	}
@@ -492,7 +492,7 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_13() {
 		CopyQuery copy = Queries.COPY().fromDefault().to(iri("http://example.org/named"));
-		assertThat(copy.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(copy.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"COPY DEFAULT TO <http://example.org/named>"
 		));
 	}
@@ -503,7 +503,7 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_14() {
 		MoveQuery move = Queries.MOVE().fromDefault().to(iri("http://example.org/named"));
-		assertThat(move.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(move.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"MOVE DEFAULT TO <http://example.org/named>"
 		));
 	}
@@ -514,7 +514,7 @@ public class Section3Test extends BaseExamples {
 	@Test
 	public void example_15() {
 		AddQuery add = Queries.ADD().fromDefault().to(iri("http://example.org/named"));
-		assertThat(add.getQueryString(), stringEqualsIgnoreCaseAndWhitespace(
+		assertThat(add.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
 				"ADD DEFAULT TO <http://example.org/named>"
 		));
 	}

--- a/tools/console/pom.xml
+++ b/tools/console/pom.xml
@@ -58,7 +58,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<!-- needs extra dependencies: objenesis & hamcrest -->
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -60,7 +60,6 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<!-- needs extra dependencies: objenesis & hamcrest -->
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
GitHub issue resolved: #4459

Briefly describe the changes proposed in this PR:

This removes almost all usage of Hamcrest from our codebase. There is a single custom Hamcrest matcher left, which is now encapsulated by an AssertJ Condition. I did an attempt to fix this also, but I could not make a custom AssertJ condition behave exactly like the current Hamcrest matcher - especially in the error description area.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

