### PR TITLE
GH-4465: Partial revert of "GH-4384 Migration to JUnit 5 (#4385)" to …

### DIFF
--- a/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryOptimisticIsolationTest.java
+++ b/compliance/repository/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryOptimisticIsolationTest.java
@@ -14,8 +14,8 @@ import org.eclipse.rdf4j.repository.config.RepositoryImplConfig;
 import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryConfig;
 import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 /**
  * @author jeen
@@ -24,7 +24,7 @@ public class HTTPRepositoryOptimisticIsolationTest extends OptimisticIsolationTe
 
 	private static HTTPMemServer server;
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 
@@ -46,7 +46,7 @@ public class HTTPRepositoryOptimisticIsolationTest extends OptimisticIsolationTe
 		});
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 		server.stop();

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbOptimisticIsolationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbOptimisticIsolationTest.java
@@ -15,12 +15,12 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 public class LmdbOptimisticIsolationTest extends OptimisticIsolationTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -30,7 +30,7 @@ public class LmdbOptimisticIsolationTest extends OptimisticIsolationTest {
 		});
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeOptimisticIsolationTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeOptimisticIsolationTest.java
@@ -15,12 +15,12 @@ import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
 import org.eclipse.rdf4j.sail.nativerdf.config.NativeStoreFactory;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 public class NativeOptimisticIsolationTest extends OptimisticIsolationTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		setRepositoryFactory(new SailRepositoryFactory() {
 			@Override
@@ -30,7 +30,7 @@ public class NativeOptimisticIsolationTest extends OptimisticIsolationTest {
 		});
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void tearDown() throws Exception {
 		setRepositoryFactory(null);
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/OptimisticIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/OptimisticIsolationTest.java
@@ -28,8 +28,8 @@ import org.eclipse.rdf4j.testsuite.repository.optimistic.MonotonicTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.RemoveIsolationTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.SerializableTest;
 import org.eclipse.rdf4j.testsuite.repository.optimistic.SnapshotTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -43,12 +43,12 @@ import org.junit.runners.Suite.SuiteClasses;
 		SerializableTest.class })
 public abstract class OptimisticIsolationTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeadLockTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeadLockTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -22,20 +22,20 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class DeadLockTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -56,7 +56,7 @@ public class DeadLockTest {
 
 	private IRI REMBRANDT;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(DeadLockTest.class);
 		ValueFactory uf = repo.getValueFactory();
@@ -67,7 +67,7 @@ public class DeadLockTest {
 		b = repo.getConnection();
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeleteInsertTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/DeleteInsertTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.common.transaction.IsolationLevel;
@@ -19,11 +19,11 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test that a complex delete-insert SPARQL query gets correctly executed.
@@ -31,12 +31,12 @@ import org.junit.jupiter.api.Test;
  */
 public class DeleteInsertTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -51,13 +51,13 @@ public class DeleteInsertTest {
 
 	private final ClassLoader cl = getClass().getClassLoader();
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(DeleteInsertTest.class);
 		con = repo.getConnection();
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			con.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/IsolationLevelTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/IsolationLevelTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -31,11 +31,11 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.UnknownTransactionStateException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,12 +46,12 @@ import org.slf4j.LoggerFactory;
  */
 public class IsolationLevelTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -72,13 +72,13 @@ public class IsolationLevelTest {
 	 * Methods *
 	 *---------*/
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		store = OptimisticIsolationTest.getEmptyInitializedRepository(IsolationLevelTest.class);
 		failed = null;
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		store.shutDown();
 	}
@@ -480,7 +480,7 @@ public class IsolationLevelTest {
 			}
 			Value obj = stmts.next().getObject();
 			if (stmts.hasNext()) {
-				org.junit.jupiter.api.Assertions.fail("multiple literals: " + obj + " and " + stmts.next());
+				org.junit.Assert.fail("multiple literals: " + obj + " and " + stmts.next());
 			}
 			return (Literal) obj;
 		}

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/LinearTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/LinearTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,11 +31,11 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Various tests on linear execution of updates.
@@ -43,12 +43,12 @@ import org.junit.jupiter.api.Test;
  */
 public class LinearTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -95,7 +95,7 @@ public class LinearTest {
 
 	private IRI BELSHAZZAR;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(LinearTest.class);
 		lf = repo.getValueFactory();
@@ -119,7 +119,7 @@ public class LinearTest {
 		b = repo.getConnection();
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/ModificationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/ModificationTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.rdf4j.common.transaction.IsolationLevel;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
@@ -22,20 +22,20 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class ModificationTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -52,7 +52,7 @@ public class ModificationTest {
 
 	private IRI PICASSO;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(ModificationTest.class);
 		ValueFactory uf = repo.getValueFactory();
@@ -61,7 +61,7 @@ public class ModificationTest {
 		con = repo.getConnection();
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			con.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/MonotonicTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/MonotonicTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,20 +28,20 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class MonotonicTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -88,7 +88,7 @@ public class MonotonicTest {
 
 	private IRI BELSHAZZAR;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(MonotonicTest.class);
 		lf = repo.getValueFactory();
@@ -112,7 +112,7 @@ public class MonotonicTest {
 		b = repo.getConnection();
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/RemoveIsolationTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/RemoveIsolationTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 
@@ -23,11 +23,11 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test isolation behavior on removal operations
@@ -37,12 +37,12 @@ import org.junit.jupiter.api.Test;
  */
 public class RemoveIsolationTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -55,14 +55,14 @@ public class RemoveIsolationTest {
 
 	private final IsolationLevel level = IsolationLevels.SNAPSHOT_READ;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(RemoveIsolationTest.class);
 		con = repo.getConnection();
 		f = con.getValueFactory();
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			con.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SerializableTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SerializableTest.java
@@ -10,9 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,11 +32,11 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Tests on behavior of SERIALIZABLE transactions.
@@ -46,12 +46,12 @@ import org.junit.jupiter.api.Test;
  */
 public class SerializableTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -98,7 +98,7 @@ public class SerializableTest {
 
 	private IRI BELSHAZZAR;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(SerializableTest.class);
 		lf = repo.getValueFactory();
@@ -122,7 +122,7 @@ public class SerializableTest {
 		b = repo.getConnection();
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SnapshotTest.java
+++ b/testsuites/repository/src/main/java/org/eclipse/rdf4j/testsuite/repository/optimistic/SnapshotTest.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.repository.optimistic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,20 +31,20 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.SailConflictException;
 import org.eclipse.rdf4j.testsuite.repository.OptimisticIsolationTest;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class SnapshotTest {
 
-	@BeforeAll
+	@BeforeClass
 	public static void setUpClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "true");
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void afterClass() throws Exception {
 		System.setProperty("org.eclipse.rdf4j.repository.debug", "false");
 	}
@@ -91,7 +91,7 @@ public class SnapshotTest {
 
 	private IRI BELSHAZZAR;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = OptimisticIsolationTest.getEmptyInitializedRepository(SnapshotTest.class);
 		lf = repo.getValueFactory();
@@ -115,7 +115,7 @@ public class SnapshotTest {
 		b = repo.getConnection();
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			a.close();

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/AbstractComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/AbstractComplianceTest.java
@@ -47,8 +47,8 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.After;
+import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,13 +64,13 @@ public abstract class AbstractComplianceTest {
 	protected Repository repo;
 	protected RepositoryConnection conn;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		repo = RepositorySPARQLComplianceTestSuite.getEmptyInitializedRepository(this.getClass());
 		conn = new RepositoryConnectionWrapper(repo.getConnection());
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		try {
 			conn.close();

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/AggregateTest.java
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPARQL aggregate function compliance.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ArbitraryLengthPathTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ArbitraryLengthPathTest.java
@@ -24,7 +24,7 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.query.impl.SimpleDataset;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPARQL property paths involving * or + operators (arbitrary length paths).

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BasicTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BasicTest.java
@@ -18,7 +18,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Basic SPARQL functionality tests

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
@@ -32,7 +32,7 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Test on SPARQL BIND function.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BuiltinFunctionTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BuiltinFunctionTest.java
@@ -31,7 +31,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on various SPARQL built-in functions.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ConstructTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ConstructTest.java
@@ -32,7 +32,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPARQL CONSTRUCT queries.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/DefaultGraphTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/DefaultGraphTest.java
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on handling default graph identification (DEFAULT keyword, rf4j:nil).

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/DescribeTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/DescribeTest.java
@@ -27,7 +27,7 @@ import org.eclipse.rdf4j.query.GraphQueryResult;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPARQL DESCRIBE queries

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ExistsTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ExistsTest.java
@@ -21,7 +21,7 @@ import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Test for queries using EXISTS

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/GroupByTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/GroupByTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertNotNull;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPARQL GROUP BY

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/InTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/InTest.java
@@ -25,7 +25,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on the IN operator.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/MinusTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/MinusTest.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Test for queries using MINUS

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OptionalTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OptionalTest.java
@@ -31,7 +31,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on OPTIONAL clause behavior.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OrderByTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/OrderByTest.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class OrderByTest extends AbstractComplianceTest {
 

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/PropertyPathTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/PropertyPathTest.java
@@ -44,7 +44,7 @@ import org.eclipse.rdf4j.query.impl.SimpleBinding;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.eclipse.rdf4j.testsuite.sparql.vocabulary.EX;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPARQL property paths.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/SubselectTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/SubselectTest.java
@@ -22,7 +22,7 @@ import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPARQL nested SELECT query handling.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/UnionTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/UnionTest.java
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPRQL UNION clauses.

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ValuesTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/ValuesTest.java
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 /**
  * Tests on SPARQL VALUES clauses.


### PR DESCRIPTION
…fix JUnit 4 suite tests


GitHub issue resolved: #4465

Briefly describe the changes proposed in this PR:

Revert tests migrated to JUnit 5 that are included in a JUnit 4 suite. This does not work, but somehow the CI does not detect this.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

