### PR TITLE
GH-4482 Replace Datatype IRI to CoreDatatype in AbstractLiteral

### DIFF
--- a/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
+++ b/core/model-api/src/main/java/org/eclipse/rdf4j/model/base/AbstractLiteral.java
@@ -188,14 +188,8 @@ public abstract class AbstractLiteral implements Literal {
 
 				.map(language -> label + '@' + language)
 
-				.orElseGet(() -> {
-
-					final IRI datatype = getDatatype();
-
-					return datatype.equals(CoreDatatype.XSD.STRING) ? label
-							: label + "^^<" + datatype.stringValue() + ">";
-
-				});
+				.orElseGet(() -> CoreDatatype.XSD.STRING == getCoreDatatype() ? label
+						: label + "^^<" + getDatatype().stringValue() + ">");
 	}
 
 	private boolean equals(Optional<String> x, Optional<String> y) {

--- a/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVCustomTest.java
+++ b/core/queryresultio/text/src/test/java/org/eclipse/rdf4j/query/resultio/text/tsv/SPARQLTSVCustomTest.java
@@ -52,7 +52,7 @@ public class SPARQLTSVCustomTest {
 				List.of(new ListBindingSet(bindingNames,
 						SimpleValueFactory.getInstance().createLiteral("1", XSD.STRING))));
 		String result = writeTupleResult(tqr);
-		assertEquals("?test\n\"1\"^^<http://www.w3.org/2001/XMLSchema#string>\n", result);
+		assertEquals("?test\n\"1\"\n", result);
 	}
 
 	/**

--- a/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
+++ b/core/rio/rdfxml/src/test/java/org/eclipse/rdf4j/rio/rdfxml/RDFXMLParserTest.java
@@ -220,7 +220,7 @@ public class RDFXMLParserTest {
 				"  <test:datapart xmlns:test=\"http://test.org/testing/\">0</test:datapart>\n" +
 				"  <test:datapart xmlns:test=\"http://test.org/testing/\">0</test:datapart>\n" +
 				"  \"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral>)";
-		String s2 = "(http://mycorp.example.com/papers/NobelPaper1, http://purl.org/metadata/dublin_core#Creator, \"David Hume\"^^<http://www.w3.org/2001/XMLSchema#string>)";
+		String s2 = "(http://mycorp.example.com/papers/NobelPaper1, http://purl.org/metadata/dublin_core#Creator, \"David Hume\")";
 		expectedLiteral[0] = s1;
 		expectedLiteral[1] = s2;
 


### PR DESCRIPTION
GitHub issue resolved: #4482

Briefly describe the changes proposed in this PR:

I replace the IRI by CoreDatatype, I hope it is fine without any test knowing how trivial it is.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

