### PR TITLE
GH-4499 fix BIND + FILTER EXISTS by simplifying code

### DIFF
--- a/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
+++ b/core/queryparser/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/GraphPattern.java
@@ -98,6 +98,13 @@ public class GraphPattern {
 		requiredTEs.add(te);
 	}
 
+	/**
+	 * Remove all values for required tuple expressions in this {@link GraphPattern}
+	 */
+	void clearRequiredTEs() {
+		requiredTEs.clear();
+	}
+
 	public void addRequiredSP(Var subjVar, Var predVar, Var objVar) {
 
 		addRequiredTE(new StatementPattern(spScope, subjVar, predVar, objVar,
@@ -164,18 +171,7 @@ public class GraphPattern {
 	 * @return A tuple expression for this graph pattern.
 	 */
 	public TupleExpr buildTupleExpr() {
-		TupleExpr result;
-
-		if (requiredTEs.isEmpty()) {
-			result = new SingletonSet();
-		} else {
-			result = requiredTEs.get(0);
-
-			for (int i = 1; i < requiredTEs.size(); i++) {
-				TupleExpr te = requiredTEs.get(i);
-				result = new Join(result, te);
-			}
-		}
+		TupleExpr result = buildJoinFromRequiredTEs();
 
 		for (Map.Entry<TupleExpr, List<ValueExpr>> entry : optionalTEs) {
 			List<ValueExpr> constraints = entry.getValue();
@@ -198,4 +194,22 @@ public class GraphPattern {
 		return result;
 	}
 
+	/**
+	 * Build a single tuple expression representing _only_ the basic graph pattern, by joining the required TEs
+	 */
+	TupleExpr buildJoinFromRequiredTEs() {
+		TupleExpr result;
+
+		if (requiredTEs.isEmpty()) {
+			result = new SingletonSet();
+		} else {
+			result = requiredTEs.get(0);
+
+			for (int i = 1; i < requiredTEs.size(); i++) {
+				TupleExpr te = requiredTEs.get(i);
+				result = new Join(result, te);
+			}
+		}
+		return result;
+	}
 }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
@@ -228,7 +228,6 @@ public class BindTest extends AbstractComplianceTest {
 		assertThat(bs.getValue("a").stringValue()).isEqualTo("http://example.org/a");
 		assertThat(bs.getValue("c").stringValue()).isEqualTo("http://example.org/c2");
 		assertThat(bs.getValue("d")).isNull();
-
 	}
 
 	@Test

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
@@ -31,7 +31,6 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
-import org.eclipse.rdf4j.query.explanation.Explanation.Level;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.junit.Test;
 
@@ -220,7 +219,6 @@ public class BindTest extends AbstractComplianceTest {
 				+ "            FILTER NOT EXISTS { ?c ex:q ?d}\n"
 				+ "}";
 
-		System.out.println(conn.prepareTupleQuery(query).explain(Level.Executed));
 		List<BindingSet> result = QueryResults.asList(conn.prepareTupleQuery(query).evaluate());
 
 		assertThat(result).hasSize(1);
@@ -252,13 +250,12 @@ public class BindTest extends AbstractComplianceTest {
 				+ "SELECT *\n"
 				+ "    WHERE {\n"
 				+ "            FILTER EXISTS { ?c rdf:type ex:T }\n"
-				+ "            FILTER NOT EXISTS { ?c ex:q ?d}\n"
+				+ "            FILTER NOT EXISTS { ?c ex:q ?d }\n"
 				+ "            BIND ( ex:a AS ?a )\n"
 				+ "            BIND ( ex:b AS ?b )\n"
 				+ "            ?a ex:p* ?c .\n"
 				+ "}";
 
-		System.out.println(conn.prepareTupleQuery(query).explain(Level.Executed));
 		List<BindingSet> result = QueryResults.asList(conn.prepareTupleQuery(query).evaluate());
 
 		assertThat(result).hasSize(1);

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BindTest.java
@@ -31,6 +31,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.explanation.Explanation.Level;
 import org.eclipse.rdf4j.testsuite.sparql.AbstractComplianceTest;
 import org.junit.Test;
 
@@ -192,5 +193,81 @@ public class BindTest extends AbstractComplianceTest {
 		List<BindingSet> result = QueryResults.asList(conn.prepareTupleQuery(query).evaluate());
 
 		assertThat(result).isEmpty();
+	}
+
+	@Test
+	public void testGH4499BindFilterNotExist1() {
+		Model testData = new ModelBuilder().setNamespace("ex", "http://example.org/")
+				.subject("ex:a")
+				.add("ex:p", "ex:c1")
+				.add("ex:p", "ex:c2")
+				.add("ex:p", "ex:c3")
+				.subject("ex:c1")
+				.add(RDF.TYPE, "ex:T")
+				.add("ex:q", "something")
+				.subject("ex:c2")
+				.add(RDF.TYPE, "ex:T")
+				.build();
+		conn.add(testData);
+
+		String query = "PREFIX ex: <http://example.org/>\n"
+				+ "SELECT *\n"
+				+ "    WHERE {\n"
+				+ "            BIND ( ex:a AS ?a )\n"
+				+ "            BIND ( ex:b AS ?b )\n"
+				+ "            ?a ex:p* ?c .\n"
+				+ "            FILTER EXISTS { ?c rdf:type ex:T }\n"
+				+ "            FILTER NOT EXISTS { ?c ex:q ?d}\n"
+				+ "}";
+
+		System.out.println(conn.prepareTupleQuery(query).explain(Level.Executed));
+		List<BindingSet> result = QueryResults.asList(conn.prepareTupleQuery(query).evaluate());
+
+		assertThat(result).hasSize(1);
+
+		var bs = result.get(0);
+
+		assertThat(bs.getValue("a").stringValue()).isEqualTo("http://example.org/a");
+		assertThat(bs.getValue("c").stringValue()).isEqualTo("http://example.org/c2");
+		assertThat(bs.getValue("d")).isNull();
+
+	}
+
+	@Test
+	public void testGH4499BindFilterNotExist2() {
+		Model testData = new ModelBuilder().setNamespace("ex", "http://example.org/")
+				.subject("ex:a")
+				.add("ex:p", "ex:c1")
+				.add("ex:p", "ex:c2")
+				.add("ex:p", "ex:c3")
+				.subject("ex:c1")
+				.add(RDF.TYPE, "ex:T")
+				.add("ex:q", "something")
+				.subject("ex:c2")
+				.add(RDF.TYPE, "ex:T")
+				.build();
+		conn.add(testData);
+
+		String query = "PREFIX ex: <http://example.org/>\n"
+				+ "SELECT *\n"
+				+ "    WHERE {\n"
+				+ "            FILTER EXISTS { ?c rdf:type ex:T }\n"
+				+ "            FILTER NOT EXISTS { ?c ex:q ?d}\n"
+				+ "            BIND ( ex:a AS ?a )\n"
+				+ "            BIND ( ex:b AS ?b )\n"
+				+ "            ?a ex:p* ?c .\n"
+				+ "}";
+
+		System.out.println(conn.prepareTupleQuery(query).explain(Level.Executed));
+		List<BindingSet> result = QueryResults.asList(conn.prepareTupleQuery(query).evaluate());
+
+		assertThat(result).hasSize(1);
+
+		var bs = result.get(0);
+
+		assertThat(bs.getValue("a").stringValue()).isEqualTo("http://example.org/a");
+		assertThat(bs.getValue("c").stringValue()).isEqualTo("http://example.org/c2");
+		assertThat(bs.getValue("d")).isNull();
+
 	}
 }


### PR DESCRIPTION
GitHub issue resolved: #4499  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added regression tests
- previous handling of BIND involved it completely replacing/encapsulating the _group_ graph pattern (instead of only the basic graph pattern)
- fix simplifies code and clarifies the distinction between a group graph pattern (the full contents of the GraphPattern class) and a basic graph pattern (only the required TEs)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

