### PR TITLE
GH-4451 dataformat now correctly determined

### DIFF
--- a/core/repository/http/pom.xml
+++ b/core/repository/http/pom.xml
@@ -60,6 +60,17 @@
 			<version>${project.version}</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-rio-turtle</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mock-server</groupId>
+			<artifactId>mockserver-junit-jupiter-no-dependencies</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
+++ b/core/repository/http/src/main/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnection.java
@@ -79,6 +79,7 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParserRegistry;
 import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.eclipse.rdf4j.rio.helpers.StatementCollector;
 
@@ -414,7 +415,10 @@ class HTTPRepositoryConnection extends AbstractRepositoryConnection implements H
 				mimeType = mimeType.substring(0, semiColonIdx);
 			}
 			dataFormat = Rio.getParserFormatForMIMEType(mimeType)
-					.orElse(Rio.getParserFormatForFileName(url.getPath()).orElseThrow(Rio.unsupportedFormat(mimeType)));
+					.orElseGet(() -> Rio.getParserFormatForFileName(url.getPath())
+							.orElseThrow(() -> new UnsupportedRDFormatException(
+									"Could not find RDF format for URL: " + url.toExternalForm())));
+
 		}
 
 		try {

--- a/core/repository/http/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnectionTest.java
+++ b/core/repository/http/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryConnectionTest.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.repository.http;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import java.io.InputStream;
+import java.net.URL;
+
+import org.eclipse.rdf4j.http.client.RDF4JProtocolSession;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.junit.jupiter.MockServerExtension;
+import org.mockserver.model.MediaType;
+
+@ExtendWith(MockServerExtension.class)
+public class HTTPRepositoryConnectionTest {
+
+	static HTTPRepository testRepository;
+	static RDF4JProtocolSession session;
+
+	@BeforeAll
+	static void configureMockServer(MockServerClient client) {
+		client.when(
+				request()
+						.withMethod("GET")
+						.withPath("/Socrates")
+		)
+				.respond(
+						response()
+								.withContentType(MediaType.parse(RDFFormat.TURTLE.getDefaultMIMEType()))
+								.withBody("<http://example.org/Socrates> a <http://xmlns.com/foaf/0.1/Person> .")
+
+				);
+
+		client.when(
+				request()
+						.withMethod("GET")
+						.withPath("/Socrates.ttl")
+		)
+				.respond(
+						response()
+								.withContentType(MediaType.WILDCARD)
+								.withBody("<http://example.org/Socrates> a <http://xmlns.com/foaf/0.1/Person> .")
+
+				);
+
+		client.when(
+				request()
+						.withMethod("GET")
+						.withPath("/Plato")
+		)
+				.respond(
+						response()
+								.withContentType(MediaType.WILDCARD)
+								.withBody("<http://example.org/Socrates> a <http://xmlns.com/foaf/0.1/Person> .")
+
+				);
+	}
+
+	@BeforeAll
+	static void configureHTTPRepository(MockServerClient client) {
+		session = mock(RDF4JProtocolSession.class);
+		testRepository = mock(HTTPRepository.class);
+	}
+
+	@Test
+	public void testAddFromURL_FormatFromMimetype(MockServerClient client) throws Exception {
+		URL url = new URL("http://localhost:" + client.getPort() + "/Socrates");
+		try (HTTPRepositoryConnection repoConn = new HTTPRepositoryConnection(testRepository, session)) {
+			repoConn.add(url);
+		}
+		verify(session).upload(any(InputStream.class), eq(url.toExternalForm()), eq(RDFFormat.TURTLE), anyBoolean(),
+				anyBoolean());
+	}
+
+	@Test
+	public void testAddFromURL_FormatFromFilename(MockServerClient client) throws Exception {
+		URL url = new URL("http://localhost:" + client.getPort() + "/Socrates.ttl");
+		try (HTTPRepositoryConnection repoConn = new HTTPRepositoryConnection(testRepository, session)) {
+			repoConn.add(url);
+		}
+		verify(session).upload(any(InputStream.class), eq(url.toExternalForm()), eq(RDFFormat.TURTLE), anyBoolean(),
+				anyBoolean());
+	}
+
+	@Test
+	public void testAddFromURL_FormatUndetermined(MockServerClient client) throws Exception {
+		URL url = new URL("http://localhost:" + client.getPort() + "/Plato");
+		try (HTTPRepositoryConnection repoConn = new HTTPRepositoryConnection(testRepository, session)) {
+			assertThatExceptionOfType(UnsupportedRDFormatException.class).isThrownBy(() -> {
+				repoConn.add(url);
+			}).withMessageContaining("Could not find RDF format for URL: " + url.toExternalForm());
+		}
+	}
+
+}


### PR DESCRIPTION



GitHub issue resolved: #4451  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- added regression test and fix
- fixed on develop branch instead of main because we recently switched to mockserver (from wiremock) on develop and I didn't want to refactor.
----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

