### PR TITLE
GH-3983 deprecate limitsize strategy + native store impl

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/limited/LimitedSizeEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/limited/LimitedSizeEvaluationStrategy.java
@@ -23,7 +23,10 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 
 /**
  * @author Jerven Bolleman, SIB Swiss Institute of Bioinformatics
+ *
+ * @deprecated since 4.2.4. See https://github.com/eclipse/rdf4j/issues/3983
  */
+@Deprecated(forRemoval = true, since = "4.2.4")
 public class LimitedSizeEvaluationStrategy extends StrictEvaluationStrategy {
 
 	private final AtomicLong used = new AtomicLong();

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/LimitedSizeNativeStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/LimitedSizeNativeStore.java
@@ -18,7 +18,10 @@ import org.eclipse.rdf4j.sail.SailException;
 
 /**
  * @author Jerven Bolleman, SIB Swiss Institute of Bioinformatics
+ *
+ * @deprecated since 4.2.4. See https://github.com/eclipse/rdf4j/issues/3983
  */
+@Deprecated(since = "4.2.4", forRemoval = true)
 public class LimitedSizeNativeStore extends NativeStore {
 
 	/**

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/LimitedSizeNativeStoreConnection.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/LimitedSizeNativeStoreConnection.java
@@ -19,7 +19,10 @@ import org.eclipse.rdf4j.query.algebra.evaluation.limited.LimitedSizeEvaluationS
 
 /**
  * @author Jerven Bolleman, SIB Swiss Institute of Bioinformatics
+ *
+ * @deprecated since 4.2.4. See https://github.com/eclipse/rdf4j/issues/3983
  */
+@Deprecated(since = "4.2.4", forRemoval = true)
 public class LimitedSizeNativeStoreConnection extends NativeStoreConnection {
 
 	private int maxCollectionsSize = Integer.MAX_VALUE;


### PR DESCRIPTION
GitHub issue resolved: #3983  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- deprecate LimitedSizeEvaluationStrategy, and Native Store extensions that make use of it

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

