### PR TITLE
GH-4512 error code must be set on uncommitted response - do not autoclose the outputstream

### DIFF
--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/GraphQueryResultView.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/GraphQueryResultView.java
@@ -71,25 +71,22 @@ public class GraphQueryResultView extends QueryResultView {
 		boolean headersOnly = (Boolean) model.get(HEADERS_ONLY);
 
 		if (!headersOnly) {
-			OutputStream out = response.getOutputStream();
-			try {
-
-				RDFWriter rdfWriter = rdfWriterFactory.getWriter(out);
-				GraphQueryResult graphQueryResult = (GraphQueryResult) model.get(QUERY_RESULT_KEY);
-				QueryResults.report(graphQueryResult, rdfWriter);
-
-				// Using explicit close because using a try-with-resources would commit the response before the
-				// catch clause handling, resulting in no error being sent. See GH-4512
-				out.close();
-			} catch (QueryInterruptedException e) {
-				logger.error("Query interrupted", e);
-				response.sendError(SC_SERVICE_UNAVAILABLE, "Query evaluation took too long");
-			} catch (QueryEvaluationException e) {
-				logger.error("Query evaluation error", e);
-				response.sendError(SC_INTERNAL_SERVER_ERROR, "Query evaluation error: " + e.getMessage());
-			} catch (RDFHandlerException e) {
-				logger.error("Serialization error", e);
-				response.sendError(SC_INTERNAL_SERVER_ERROR, "Serialization error: " + e.getMessage());
+			try (OutputStream out = response.getOutputStream()) {
+				// ensure we handle exceptions _before_ closing the stream
+				try {
+					RDFWriter rdfWriter = rdfWriterFactory.getWriter(out);
+					GraphQueryResult graphQueryResult = (GraphQueryResult) model.get(QUERY_RESULT_KEY);
+					QueryResults.report(graphQueryResult, rdfWriter);
+				} catch (QueryInterruptedException e) {
+					logger.error("Query interrupted", e);
+					response.sendError(SC_SERVICE_UNAVAILABLE, "Query evaluation took too long");
+				} catch (QueryEvaluationException e) {
+					logger.error("Query evaluation error", e);
+					response.sendError(SC_INTERNAL_SERVER_ERROR, "Query evaluation error: " + e.getMessage());
+				} catch (RDFHandlerException e) {
+					logger.error("Serialization error", e);
+					response.sendError(SC_INTERNAL_SERVER_ERROR, "Serialization error: " + e.getMessage());
+				}
 			}
 		}
 		logEndOfRequest(request);

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/GraphQueryResultView.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/GraphQueryResultView.java
@@ -71,7 +71,8 @@ public class GraphQueryResultView extends QueryResultView {
 		boolean headersOnly = (Boolean) model.get(HEADERS_ONLY);
 
 		if (!headersOnly) {
-			try (OutputStream out = response.getOutputStream()) {
+			OutputStream out = response.getOutputStream();
+			try {
 				RDFWriter rdfWriter = rdfWriterFactory.getWriter(out);
 				GraphQueryResult graphQueryResult = (GraphQueryResult) model.get(QUERY_RESULT_KEY);
 				QueryResults.report(graphQueryResult, rdfWriter);
@@ -84,6 +85,10 @@ public class GraphQueryResultView extends QueryResultView {
 			} catch (RDFHandlerException e) {
 				logger.error("Serialization error", e);
 				response.sendError(SC_INTERNAL_SERVER_ERROR, "Serialization error: " + e.getMessage());
+			} finally {
+				// Using explicit close because using a try-with-resources would commit the response before the
+				// catch clause handling, resulting in no error being sent. See GH-4512
+				out.close();
 			}
 		}
 		logEndOfRequest(request);

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/TupleQueryResultView.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/TupleQueryResultView.java
@@ -101,6 +101,10 @@ public class TupleQueryResultView extends QueryResultView {
 				}
 
 				QueryResults.report(tupleQueryResult, qrWriter);
+
+				// Using explicit close because using a try-with-resources would commit the response before the
+				// catch clause handling, resulting in no error being sent. See GH-4512
+				out.close();
 			} catch (QueryInterruptedException e) {
 				logger.error("Query interrupted", e);
 				response.sendError(SC_SERVICE_UNAVAILABLE, "Query evaluation took too long");
@@ -110,10 +114,6 @@ public class TupleQueryResultView extends QueryResultView {
 			} catch (TupleQueryResultHandlerException e) {
 				logger.error("Serialization error", e);
 				response.sendError(SC_INTERNAL_SERVER_ERROR, "Serialization error: " + e.getMessage());
-			} finally {
-				// Using explicit close because using a try-with-resources would commit the response before the
-				// catch clause handling, resulting in no error being sent. See GH-4512
-				out.close();
 			}
 		}
 		logEndOfRequest(request);

--- a/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/TupleQueryResultView.java
+++ b/tools/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/TupleQueryResultView.java
@@ -75,7 +75,8 @@ public class TupleQueryResultView extends QueryResultView {
 
 		final Boolean headersOnly = (Boolean) model.get(HEADERS_ONLY);
 		if (headersOnly == null || !headersOnly.booleanValue()) {
-			try (OutputStream out = response.getOutputStream()) {
+			OutputStream out = response.getOutputStream();
+			try {
 				TupleQueryResultWriter qrWriter = qrWriterFactory.getWriter(out);
 				TupleQueryResult tupleQueryResult = (TupleQueryResult) model.get(QUERY_RESULT_KEY);
 
@@ -109,6 +110,10 @@ public class TupleQueryResultView extends QueryResultView {
 			} catch (TupleQueryResultHandlerException e) {
 				logger.error("Serialization error", e);
 				response.sendError(SC_INTERNAL_SERVER_ERROR, "Serialization error: " + e.getMessage());
+			} finally {
+				// Using explicit close because using a try-with-resources would commit the response before the
+				// catch clause handling, resulting in no error being sent. See GH-4512
+				out.close();
 			}
 		}
 		logEndOfRequest(request);

--- a/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/TupleQueryResultViewTest.java
+++ b/tools/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/TupleQueryResultViewTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.http.server.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONWriterFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class TupleQueryResultViewTest {
+
+	private static TupleQueryResultView view = TupleQueryResultView.getInstance();
+
+	@Test
+	public void testRender_QueryEvaluationError1() throws Exception {
+		var request = new MockHttpServletRequest();
+		var response = new MockHttpServletResponse();
+
+		TupleQueryResult queryResult = mock(TupleQueryResult.class);
+		when(queryResult.hasNext()).thenThrow(QueryEvaluationException.class);
+
+		Map<String, Object> model = new HashMap<>();
+		model.put(TupleQueryResultView.FACTORY_KEY, new SPARQLResultsJSONWriterFactory());
+		model.put(TupleQueryResultView.QUERY_RESULT_KEY, queryResult);
+
+		view.render(model, request, response);
+
+		assertThat(response.getStatus()).isEqualTo(500);
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #4512  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

- change try-with-resource to regular try-catch-finally to ensure closing the outputstream (and committing the response) happens _after_ potentially setting an error code (in the catch clause)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

