### PR TITLE
GH-4532 fix breaking changes caused by merge conflict

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -43,7 +43,7 @@ public class QueryJoinOptimizer extends org.eclipse.rdf4j.query.algebra.evaluati
 		implements QueryOptimizer {
 
 	public QueryJoinOptimizer() {
-		this(null);
+		this(new EvaluationStatistics());
 	}
 
 	public QueryJoinOptimizer(EvaluationStatistics statistics) {


### PR DESCRIPTION
GitHub issue resolved: #4532 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Fixes a merge conflict that resulted in the old QueryJoinOptimizer to throw a NullPointerException.

We don't have any tests for the old QueryJoinOptimizer, so that's why it wasn't caught earlier. I don't think it's worth it to make a test now though since the class will be removed in 5.0.0.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

