### PR TITLE
GH-4540 NOW() should always evaluate to a single value per query. 

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DefaultEvaluationStrategy.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/DefaultEvaluationStrategy.java
@@ -1115,7 +1115,9 @@ public class DefaultEvaluationStrategy implements EvaluationStrategy, FederatedS
 	@Override
 	public Value evaluate(ValueExpr expr, BindingSet bindings)
 			throws QueryEvaluationException {
-		return precompile(expr, new QueryEvaluationContext.Minimal(dataset)).evaluate(bindings);
+		return precompile(expr,
+				new QueryEvaluationContext.Minimal(DefaultEvaluationStrategy.this.sharedValueOfNow, dataset))
+				.evaluate(bindings);
 	}
 
 	@Deprecated(forRemoval = true)

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
@@ -227,4 +227,27 @@ public class StrictEvaluationStrategyTest {
 			fail(e.getMessage());
 		}
 	}
+
+	@Test
+	public void testSES869ValueOfNow() {
+
+		ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL,
+				"SELECT ?p ( NOW() as ?n ) { BIND (NOW() as ?p ) }", null);
+		QueryEvaluationStep prepared = strategy.precompile(pq.getTupleExpr());
+
+		try (CloseableIteration<BindingSet, QueryEvaluationException> result = prepared
+				.evaluate(EmptyBindingSet.getInstance())) {
+			assertNotNull(result);
+			assertTrue(result.hasNext());
+
+			BindingSet bs = result.next();
+			Value p = bs.getValue("p");
+			Value n = bs.getValue("n");
+
+			assertNotNull(p);
+			assertNotNull(n);
+			assertEquals(p, n);
+			assertTrue(p == n);
+		}
+	}
 }

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BuiltinFunctionTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BuiltinFunctionTest.java
@@ -111,6 +111,7 @@ public class BuiltinFunctionTest extends AbstractComplianceTest {
 			assertNotNull(p);
 			assertNotNull(n);
 			assertEquals(p, n);
+			assertTrue(p == n);
 		}
 	}
 


### PR DESCRIPTION
Test identity not just equality


GitHub issue resolved: #4540 

Briefly describe the changes proposed in this PR:

ConstantOptimizer uses a QueryEvaluationContext to avoid this breakage.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

