### PR TITLE
GH-4549 javadocs aggregate goal is brittle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
 								<inherited>false</inherited>
 								<phase>package</phase>
 								<goals>
-									<goal>aggregate</goal>
+									<goal>aggregate-no-fork</goal>
 								</goals>
 								<configuration>
 									<overview>src/main/javadoc/overview.html</overview>


### PR DESCRIPTION


GitHub issue resolved: #4549 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

The aggregate goal uses forking, and there are some issues with how dependent modules are built. Switching to the aggregate-no-fork goal fixes this.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

