### PR TITLE
GH-4556: properly escape single quotes in generated federation queries

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/QueryStringUtil.java
@@ -893,7 +893,7 @@ public class QueryStringUtil {
 	 */
 	protected static StringBuilder appendLiteral(StringBuilder sb, Literal lit) {
 		sb.append("'''");
-		sb.append(lit.getLabel().replace("\"", "\\\""));
+		sb.append(lit.getLabel().replace("\"", "\\\"").replace("'", "\\'"));
 		sb.append("'''");
 
 		if (lit.getLanguage().isPresent()) {


### PR DESCRIPTION
GitHub issue resolved: #4556 

When creating federation sub-queries from intermediate bindings sets, we need to make sure to properly escape single quotes in literal string.

Example literal: "'A quoted literal'"

When not escaping such single quotes, query parsing fails.

Issue is covered by an integration unit test.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

