### PR TITLE
GH-3950 Validation report should never conform if it has results

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -1115,7 +1115,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 			try (CloseableIteration<? extends ValidationTuple, SailException> iterator = planNode.iterator()) {
 				validationResults = new ValidationResultIterator(iterator,
-						sail.getEffectiveValidationResultsLimitPerConstraint(), shape.getSeverity());
+						sail.getEffectiveValidationResultsLimitPerConstraint());
 				return validationResults;
 			} finally {
 				handlePostLogging(before, validationResults);

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclValidator.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclValidator.java
@@ -40,8 +40,9 @@ public class ShaclValidator {
 
 	private static final Resource[] ALL_CONTEXTS = {};
 
-	// protected so that tests can override
-	protected static Resource[] CONTEXTS = {};
+	// tests can write to this field using reflection
+	@SuppressWarnings("FieldMayBeFinal")
+	private static Resource[] CONTEXTS = {};
 
 	public static ValidationReport validate(Sail dataRepo, Sail shapesRepo) {
 
@@ -97,7 +98,7 @@ public class ShaclValidator {
 
 				.map(planNode -> {
 					try (CloseableIteration<? extends ValidationTuple, SailException> iterator = planNode.iterator()) {
-						return new ValidationResultIterator(iterator, 1000, planNode.getShape().getSeverity());
+						return new ValidationResultIterator(iterator, 1000);
 					}
 				})
 				.collect(Collectors.toList());

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
@@ -190,13 +190,6 @@ public class ValidationResult {
 	}
 
 	/**
-	 * @return conforms
-	 */
-	public boolean conforms() {
-		return severity != Severity.Violation;
-	}
-
-	/**
 	 * @return the type of the source constraint that caused the violation
 	 */
 	public SourceConstraintComponent getSourceConstraintComponent() {
@@ -238,5 +231,29 @@ public class ValidationResult {
 
 	public void setPathIri(Value path) {
 		this.pathIri = path;
+	}
+
+	protected Optional<Value> getValue() {
+		return value;
+	}
+
+	protected Shape getShape() {
+		return shape;
+	}
+
+	protected ConstraintComponent getSourceConstraint() {
+		return sourceConstraint;
+	}
+
+	protected Severity getSeverity() {
+		return severity;
+	}
+
+	protected Resource[] getDataGraphs() {
+		return dataGraphs;
+	}
+
+	protected Resource[] getShapesGraphs() {
+		return shapesGraphs;
 	}
 }

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.riot.RDFDataMgr;
@@ -289,7 +290,7 @@ abstract public class AbstractShaclTest {
 	}
 
 	@BeforeAll
-	static void beforeAll() {
+	static void beforeAll() throws IllegalAccessException {
 		IRI[] shapesGraphs = SHAPE_GRAPHS.stream()
 				.map(g -> {
 					if (g.equals(RDF4J.NIL)) {
@@ -299,7 +300,7 @@ abstract public class AbstractShaclTest {
 				})
 				.toArray(IRI[]::new);
 
-		ShaclValidator.CONTEXTS = shapesGraphs;
+		FieldUtils.writeDeclaredStaticField(ShaclValidator.class, "CONTEXTS", shapesGraphs, true);
 	}
 
 	@AfterEach

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/results/ShaclValidatorTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/results/ShaclValidatorTest.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  ******************************************************************************/
 
-package org.eclipse.rdf4j.sail.shacl;
+package org.eclipse.rdf4j.sail.shacl.results;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -18,14 +18,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.io.StringReader;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.shacl.ShaclValidator;
 import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -38,8 +41,8 @@ import org.junit.jupiter.api.parallel.Isolated;
 public class ShaclValidatorTest {
 
 	@BeforeAll
-	static void afterAll() {
-		ShaclValidator.CONTEXTS = new Resource[] {};
+	static void beforeAll() throws IllegalAccessException {
+		FieldUtils.writeDeclaredStaticField(ShaclValidator.class, "CONTEXTS", new Resource[] {}, true);
 	}
 
 	@Test
@@ -86,8 +89,10 @@ public class ShaclValidatorTest {
 		}
 
 		ValidationReport validate = ShaclValidator.validate(data.getSail(), shapes.getSail());
-		assertTrue(validate.conforms());
+		assertFalse(validate.conforms());
 		assertEquals(1, validate.getValidationResult().size());
+		assertEquals(SHACL.WARNING, validate.getValidationResult().get(0).getSeverity().getIri());
+
 	}
 
 	@Test
@@ -102,8 +107,9 @@ public class ShaclValidatorTest {
 		}
 
 		ValidationReport validate = ShaclValidator.validate(data.getSail(), shapes.getSail());
-		assertTrue(validate.conforms());
+		assertFalse(validate.conforms());
 		assertEquals(1, validate.getValidationResult().size());
+		assertEquals(SHACL.INFO, validate.getValidationResult().get(0).getSeverity().getIri());
 	}
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #3950 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

This is more of a bug fix for the code to support ShaclValidator and severity, so tacking it onto the same issue since it hasn't been released yet.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

