### PR TITLE
GH-3396 the elasticsearch-maven-plugin should not run while tests are skipped or while integration tests are skipped

### DIFF
--- a/core/sail/elasticsearch-store/pom.xml
+++ b/core/sail/elasticsearch-store/pom.xml
@@ -130,6 +130,46 @@
 				<java.sec.mgr>-Djava.security.manager=allow</java.sec.mgr>
 			</properties>
 		</profile>
+		<profile>
+			<id>skipIfSkipITs</id>
+			<activation>
+				<property>
+					<name>skipITs</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.alexcojocaru</groupId>
+						<artifactId>elasticsearch-maven-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>skipIfSkipTests</id>
+			<activation>
+				<property>
+					<name>skipTests</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.alexcojocaru</groupId>
+						<artifactId>elasticsearch-maven-plugin</artifactId>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	<build>
 		<plugins>
@@ -145,6 +185,8 @@
 				<artifactId>elasticsearch-maven-plugin</artifactId>
 				<version>6.26</version>
 				<configuration>
+					<skip>${skipITs}</skip>
+					<skip>${skipTests}</skip>
 					<version>${elasticsearch.version}</version>
 					<clusterName>test</clusterName>
 					<transportPort>9300</transportPort>


### PR DESCRIPTION


GitHub issue resolved: #3396 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

Fix after merging branch for GH-3396.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

