### PR TITLE
GH-4577 fix: using deprecated (moved) JSONLDMode enum

### DIFF
--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -132,7 +132,13 @@ public class JSONLDWriter extends AbstractRDFWriter implements CharSink {
 
 			Object output = JsonLdProcessor.fromRDF(model, opts, serialiser);
 
-			final JSONLDMode mode = getWriterConfig().get(JSONLDSettings.JSONLD_MODE);
+			final JSONLDMode mode;
+			Object obj = getWriterConfig().get(JSONLDSettings.JSONLD_MODE);
+			if (obj instanceof JSONLDMode) {
+				mode = (JSONLDMode) obj;
+			} else {
+				mode = JSONLDMode.valueOf(((org.eclipse.rdf4j.rio.helpers.JSONLDMode) obj).name());
+			}
 
 			if (writerConfig.get(JSONLDSettings.HIERARCHICAL_VIEW)) {
 				output = JSONLDHierarchicalProcessor.fromJsonLdObject(output);

--- a/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterCompatabilityTest.java
+++ b/core/rio/jsonld/src/test/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriterCompatabilityTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.rio.jsonld;
+
+import java.io.StringWriter;
+
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.junit.jupiter.api.Test;
+
+public class JSONLDWriterCompatabilityTest {
+	@Test
+	void testUseLegacySettings() throws Exception {
+		final RDFWriter writer = Rio.createWriter(RDFFormat.JSONLD, new StringWriter(), "http://example.org/")
+				.set(BasicWriterSettings.INLINE_BLANK_NODES, true)
+				.set(org.eclipse.rdf4j.rio.helpers.JSONLDSettings.OPTIMIZE, true)
+				.set(org.eclipse.rdf4j.rio.helpers.JSONLDSettings.USE_NATIVE_TYPES, true)
+				.set(org.eclipse.rdf4j.rio.helpers.JSONLDSettings.JSONLD_MODE,
+						org.eclipse.rdf4j.rio.helpers.JSONLDMode.COMPACT);
+		Rio.write(new LinkedHashModel(), writer);
+	}
+
+	@Test
+	void testUseMovedSettings() throws Exception {
+		final RDFWriter writer = Rio.createWriter(RDFFormat.JSONLD, new StringWriter(), "http://example.org/")
+				.set(BasicWriterSettings.INLINE_BLANK_NODES, true)
+				.set(JSONLDSettings.OPTIMIZE, true)
+				.set(JSONLDSettings.USE_NATIVE_TYPES, true)
+				.set(JSONLDSettings.JSONLD_MODE, JSONLDMode.COMPACT);
+		Rio.write(new LinkedHashModel(), writer);
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #4577

Briefly describe the changes proposed in this PR:

This fixes the breaking change introduced in https://github.com/eclipse/rdf4j/pull/4332. The fix is not pretty, but Java enums are painful.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

