### PR TITLE
GH-4547 Improve autogrow of LmdbStore.

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbUtil.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbUtil.java
@@ -48,11 +48,6 @@ final class LmdbUtil {
 	 */
 	static final long MIN_FREE_SPACE = 524_288; // 512 KiB
 
-	/**
-	 * Minimum size an LMDB db is automatically grown.
-	 */
-	static final long MIN_AUTOGROW_SIZE = 1_048_576; // 1024 KiB
-
 	private LmdbUtil() {
 	}
 
@@ -160,7 +155,7 @@ final class LmdbUtil {
 	 */
 	static boolean requiresResize(long mapSize, long pageSize, long txn, long requiredSize) {
 		long nextPageNo = mdbTxnMtNextPgno(txn);
-		return mapSize - nextPageNo * pageSize < Math.max(requiredSize, LmdbUtil.MIN_FREE_SPACE);
+		return mapSize - nextPageNo * pageSize < Math.max(requiredSize, MIN_FREE_SPACE);
 	}
 
 	/**
@@ -172,7 +167,7 @@ final class LmdbUtil {
 	 * @return the new map size
 	 */
 	static long autoGrowMapSize(long mapSize, long pageSize, long requiredSize) {
-		mapSize = Math.max(mapSize * 2, Math.max(requiredSize, MIN_AUTOGROW_SIZE));
+		mapSize = Math.max(mapSize * 2, Math.max(requiredSize, MIN_FREE_SPACE));
 		// align map size to page size
 		return mapSize % pageSize == 0 ? mapSize : mapSize + (mapSize / pageSize + 1) * pageSize;
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreAutoGrowTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreAutoGrowTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.io.File;
+import java.util.Random;
+
+import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Logger;
+
+/**
+ * Low-level tests for {@link TripleStore}.
+ */
+public class TripleStoreAutoGrowTest {
+
+	protected TripleStore tripleStore;
+
+	@BeforeEach
+	public void before(@TempDir File dataDir) throws Exception {
+		var config = new LmdbStoreConfig("spoc,posc");
+		config.setTripleDBSize(4096 * 10);
+		tripleStore = new TripleStore(dataDir, config);
+		((Logger) LoggerFactory
+				.getLogger(TripleStore.class.getName()))
+				.setLevel(ch.qos.logback.classic.Level.DEBUG);
+	}
+
+	@Test
+	public void testAutoGrowLargeCommits() throws Exception {
+		Random rnd = new Random(1337);
+
+		Txn[] readTxns = new Txn[20];
+		for (int i = 0; i < readTxns.length; i++) {
+			readTxns[i] = tripleStore.getTxnManager().createReadTxn();
+		}
+		for (int subj = 1; subj < 50; subj++) {
+			tripleStore.startTransaction();
+			for (int pred = 1; pred < 100; pred++) {
+				for (int obj = 1; obj < 100; obj++) {
+					tripleStore.storeTriple(1 + rnd.nextInt(1000), 1 + rnd.nextInt(1000),
+							1 + rnd.nextInt(1000), 3, true);
+				}
+			}
+			tripleStore.commit();
+		}
+		for (int i = 0; i < readTxns.length; i++) {
+			readTxns[i].close();
+		}
+	}
+
+	@Test
+	public void testAutoGrowSmallCommits() throws Exception {
+		Random rnd = new Random(1337);
+
+		Txn[] readTxns = new Txn[20];
+		for (int i = 0; i < readTxns.length; i++) {
+			readTxns[i] = tripleStore.getTxnManager().createReadTxn();
+		}
+		for (int subj = 1; subj < 50; subj++) {
+			for (int pred = 1; pred < 100; pred++) {
+				tripleStore.startTransaction();
+				for (int obj = 1; obj < 100; obj++) {
+					tripleStore.storeTriple(1 + rnd.nextInt(1000), 1 + rnd.nextInt(1000),
+							1 + rnd.nextInt(1000), 3, true);
+				}
+				tripleStore.commit();
+			}
+		}
+		for (int i = 0; i < readTxns.length; i++) {
+			readTxns[i].close();
+		}
+	}
+
+	@AfterEach
+	public void after() throws Exception {
+		tripleStore.close();
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #4547 

Briefly describe the changes proposed in this PR:

Improve the autogrow feature of LmdbStore.

- directly renew stale transactions instead of using a list
- abort triple store transaction if commit fails
- add debug log for resize operations
- add simple test for triple store autogrow

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

