### PR TITLE
GH-4589 Enable japicmp for all modules by default

### DIFF
--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -173,6 +173,13 @@
 					</includes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/collection-factory/api/pom.xml
+++ b/core/collection-factory/api/pom.xml
@@ -30,10 +30,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/collection-factory/mapdb/pom.xml
+++ b/core/collection-factory/mapdb/pom.xml
@@ -46,10 +46,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/common/annotation/pom.xml
+++ b/core/common/annotation/pom.xml
@@ -14,10 +14,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/common/exception/pom.xml
+++ b/core/common/exception/pom.xml
@@ -26,10 +26,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/common/io/pom.xml
+++ b/core/common/io/pom.xml
@@ -42,10 +42,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/common/iterator/pom.xml
+++ b/core/common/iterator/pom.xml
@@ -37,10 +37,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/common/text/pom.xml
+++ b/core/common/text/pom.xml
@@ -43,10 +43,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/common/transaction/pom.xml
+++ b/core/common/transaction/pom.xml
@@ -42,10 +42,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/common/util/pom.xml
+++ b/core/common/util/pom.xml
@@ -37,10 +37,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/common/xml/pom.xml
+++ b/core/common/xml/pom.xml
@@ -47,10 +47,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/http/client/pom.xml
+++ b/core/http/client/pom.xml
@@ -111,12 +111,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/model-api/pom.xml
+++ b/core/model-api/pom.xml
@@ -29,10 +29,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/model-vocabulary/pom.xml
+++ b/core/model-vocabulary/pom.xml
@@ -16,12 +16,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -75,12 +75,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/query/pom.xml
+++ b/core/query/pom.xml
@@ -42,12 +42,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/queryalgebra/evaluation/pom.xml
+++ b/core/queryalgebra/evaluation/pom.xml
@@ -83,10 +83,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/queryalgebra/model/pom.xml
+++ b/core/queryalgebra/model/pom.xml
@@ -21,12 +21,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/queryparser/api/pom.xml
+++ b/core/queryparser/api/pom.xml
@@ -21,12 +21,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/queryresultio/api/pom.xml
+++ b/core/queryresultio/api/pom.xml
@@ -31,12 +31,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -68,12 +68,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/repository/http/pom.xml
+++ b/core/repository/http/pom.xml
@@ -72,12 +72,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/repository/sail/pom.xml
+++ b/core/repository/sail/pom.xml
@@ -68,12 +68,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/repository/sparql/pom.xml
+++ b/core/repository/sparql/pom.xml
@@ -38,12 +38,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/rio/api/pom.xml
+++ b/core/rio/api/pom.xml
@@ -61,10 +61,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/sail/api/pom.xml
+++ b/core/sail/api/pom.xml
@@ -52,12 +52,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/sail/base/pom.xml
+++ b/core/sail/base/pom.xml
@@ -52,12 +52,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/sail/inferencer/pom.xml
+++ b/core/sail/inferencer/pom.xml
@@ -90,12 +90,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/sail/lmdb/pom.xml
+++ b/core/sail/lmdb/pom.xml
@@ -196,10 +196,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/sail/memory/pom.xml
+++ b/core/sail/memory/pom.xml
@@ -87,10 +87,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/core/sail/model/pom.xml
+++ b/core/sail/model/pom.xml
@@ -37,12 +37,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/core/sail/nativerdf/pom.xml
+++ b/core/sail/nativerdf/pom.xml
@@ -102,10 +102,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1058,6 +1058,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 		<extensions>
 			<extension>

--- a/tools/runtime-osgi/pom.xml
+++ b/tools/runtime-osgi/pom.xml
@@ -89,6 +89,13 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -122,6 +122,13 @@
 					</webApp>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -81,6 +81,13 @@
 					</contextHandlers>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
~~GitHub issue resolved: #4588~~<!-- add a Github issue number here, e.g #123. -->
GitHub issue resolved: #4589 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

