### PR TITLE
GH-4523 fix for escaped characters in SHACL Shapes

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShapeValidationContainer.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShapeValidationContainer.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.shacl.ast.Shape;
+import org.eclipse.rdf4j.sail.shacl.ast.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.ast.planNodes.SingleCloseablePlanNode;
+import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ValidationExecutionLogger;
+import org.eclipse.rdf4j.sail.shacl.ast.planNodes.ValidationTuple;
+import org.eclipse.rdf4j.sail.shacl.results.lazy.ValidationResultIterator;
+import org.slf4j.Logger;
+
+class ShapeValidationContainer {
+	private final Shape shape;
+	private final boolean logValidationViolations;
+	private final PlanNode planNode;
+	private final ValidationExecutionLogger validationExecutionLogger;
+	private final long effectiveValidationResultsLimitPerConstraint;
+	private final boolean performanceLogging;
+	private final Logger logger;
+
+	public ShapeValidationContainer(Shape shape, Supplier<PlanNode> planNodeSupplier, boolean logValidationExecution,
+			boolean logValidationViolations, long effectiveValidationResultsLimitPerConstraint,
+			boolean performanceLogging, Logger logger) {
+		this.shape = shape;
+		this.logValidationViolations = logValidationViolations;
+		this.effectiveValidationResultsLimitPerConstraint = effectiveValidationResultsLimitPerConstraint;
+		this.performanceLogging = performanceLogging;
+		this.logger = logger;
+		try {
+			PlanNode planNode = planNodeSupplier.get();
+			this.validationExecutionLogger = ValidationExecutionLogger
+					.getInstance(logValidationExecution);
+			if (!(planNode.isGuaranteedEmpty())) {
+				assert planNode instanceof SingleCloseablePlanNode;
+				planNode.receiveLogger(validationExecutionLogger);
+				this.planNode = planNode;
+			} else {
+				this.planNode = planNode;
+			}
+		} catch (Exception e) {
+			throw new SailException("Error processing SHACL Shape " + shape.getId() + "\n" + shape, e);
+		}
+
+	}
+
+	public Shape getShape() {
+		return shape;
+	}
+
+	public boolean hasPlanNode() {
+		return !(planNode.isGuaranteedEmpty());
+	}
+
+	public ValidationResultIterator performValidation() {
+		long before = getTimeStamp();
+		handlePreLogging();
+
+		ValidationResultIterator validationResults = null;
+
+		try (CloseableIteration<? extends ValidationTuple, SailException> iterator = planNode.iterator()) {
+			validationResults = new ValidationResultIterator(iterator, effectiveValidationResultsLimitPerConstraint);
+			return validationResults;
+		} catch (Exception e) {
+			throw new SailException("Error validating SHACL Shape " + shape.getId() + "\n" + shape, e);
+		} finally {
+			handlePostLogging(before, validationResults);
+		}
+	}
+
+	private long getTimeStamp() {
+		if (performanceLogging) {
+			return System.currentTimeMillis();
+		}
+		return 0;
+	}
+
+	private void handlePreLogging() {
+		if (validationExecutionLogger.isEnabled()) {
+			logger.info("Start execution of plan:\n{}\n", getShape().toString());
+		}
+	}
+
+	private void handlePostLogging(long before, ValidationResultIterator validationResults) {
+		if (validationExecutionLogger.isEnabled()) {
+			validationExecutionLogger.flush();
+		}
+
+		if (validationResults != null) {
+
+			if (performanceLogging) {
+				long after = System.currentTimeMillis();
+				logger.info("Execution of plan took {} ms for:\n{}\n",
+						(after - before),
+						getShape().toString());
+			}
+
+			if (validationExecutionLogger.isEnabled()) {
+				logger.info("Finished execution of plan:\n{}\n",
+						getShape().toString());
+			}
+
+			if (logValidationViolations) {
+				if (!validationResults.conforms()) {
+					List<ValidationTuple> tuples = validationResults.getTuples();
+
+					logger.info(
+							"SHACL not valid. The following experimental debug results were produced:\n\t\t{}\n\n{}\n",
+							tuples.stream()
+									.map(ValidationTuple::toString)
+									.collect(Collectors.joining("\n\t\t")),
+							getShape().toString()
+
+					);
+				}
+			}
+
+		}
+
+	}
+
+}

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AbstractConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/AbstractConstraintComponent.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.shacl.ValidationSettings;
@@ -110,6 +112,36 @@ public abstract class AbstractConstraintComponent implements ConstraintComponent
 			s[i] = s[i].trim();
 		}
 		return s;
+	}
+
+	public String stringRepresentationOfValue(Value value) {
+		if (value.isIRI()) {
+			return "<" + value + ">";
+		}
+		if (value.isLiteral()) {
+			IRI datatype = ((Literal) value).getDatatype();
+			if (datatype == null) {
+				return "\"" + value.stringValue()
+						.replace("\\", "\\\\")
+						.replace("\"", "\\\"")
+						.replace("\n", "\\n")
+						+ "\"";
+			}
+			if (((Literal) value).getLanguage().isPresent()) {
+				return "\"" + value.stringValue()
+						.replace("\\", "\\\\")
+						.replace("\"", "\\\"")
+						.replace("\n", "\\n")
+						+ "\"@" + ((Literal) value).getLanguage().get();
+			}
+			return "\"" + value.stringValue()
+					.replace("\\", "\\\\")
+					.replace("\"", "\\\"")
+					.replace("\n", "\\n")
+					+ "\"^^<" + datatype.stringValue() + ">";
+		}
+
+		throw new IllegalStateException(value.getClass().getSimpleName());
 	}
 
 }

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/DashHasValueInConstraintComponent.java
@@ -195,17 +195,9 @@ public class DashHasValueInConstraintComponent extends AbstractConstraintCompone
 
 						statementMatchers.addAll(optimizedStatementMatchers);
 
-						if (value.isIRI()) {
-							return "BIND(<" + value + "> as " + object.asSparqlVariable() + ")\n"
-									+ targetQueryFragment.getFragment();
-						}
-						if (value.isLiteral()) {
-							return "BIND(" + value + " as " + object.asSparqlVariable() + ")\n"
-									+ targetQueryFragment.getFragment();
-						}
+						return "BIND(" + stringRepresentationOfValue(value) + " as " + object.asSparqlVariable() + ")\n"
+								+ targetQueryFragment.getFragment();
 
-						throw new UnsupportedOperationException(
-								"value was unsupported type: " + value.getClass().getSimpleName());
 					})
 					.collect(
 							Collectors.joining("} UNION {\n" + VALUES_INJECTION_POINT + "\n",

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/HasValueConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/HasValueConstraintComponent.java
@@ -165,36 +165,18 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 
 			SparqlFragment targetQueryFragment = path.getTargetQueryFragment(subject, object, rdfsSubClassOfReasoner,
 					stableRandomVariableProvider, Set.of());
-			if (hasValue.isIRI()) {
-				return SparqlFragment.bgp(List.of(),
-						"BIND(<" + hasValue + "> as " + object.asSparqlVariable() + ")\n"
-								+ targetQueryFragment.getFragment(),
-						StatementMatcher.swap(targetQueryFragment.getStatementMatchers(), object,
-								new Variable<>((IRI) hasValue)),
-						null);
-			}
-			if (hasValue.isLiteral()) {
-				return SparqlFragment.bgp(List.of(),
-						"BIND(" + hasValue.toString() + " as " + object.asSparqlVariable() + ")\n"
-								+ targetQueryFragment.getFragment(),
-						StatementMatcher.swap(targetQueryFragment.getStatementMatchers(), object,
-								new Variable<>((Literal) hasValue)),
-						null);
-			}
 
-			throw new UnsupportedOperationException(
-					"value was unsupported type: " + hasValue.getClass().getSimpleName());
+			return SparqlFragment.bgp(List.of(),
+					"BIND(" + stringRepresentationOfValue(hasValue) + " as " + object.asSparqlVariable() + ")\n"
+							+ targetQueryFragment.getFragment(),
+					StatementMatcher.swap(targetQueryFragment.getStatementMatchers(), object,
+							new Variable<>(hasValue)),
+					null);
 
 		} else {
-			if (hasValue.isIRI()) {
-				return SparqlFragment.filterCondition(List.of(), object.asSparqlVariable() + " = <" + hasValue + ">",
-						List.of());
-			} else if (hasValue.isLiteral()) {
-				return SparqlFragment.filterCondition(List.of(), object.asSparqlVariable() + " = " + hasValue,
-						List.of());
-			}
-			throw new UnsupportedOperationException(
-					"value was unsupported type: " + hasValue.getClass().getSimpleName());
+			return SparqlFragment.filterCondition(List.of(),
+					object.asSparqlVariable() + " = " + stringRepresentationOfValue(hasValue),
+					List.of());
 
 		}
 	}
@@ -233,24 +215,6 @@ public class HasValueConstraintComponent extends AbstractConstraintComponent {
 		return new ValidationQuery(getTargetChain().getNamespaces(), query, allTargetVariables, null, scope, this, null,
 				null);
 
-	}
-
-	private String stringRepresentationOfValue(Value value) {
-		if (value.isIRI()) {
-			return "<" + value + ">";
-		}
-		if (value.isLiteral()) {
-			IRI datatype = ((Literal) value).getDatatype();
-			if (datatype == null) {
-				return "\"" + value.stringValue() + "\"";
-			}
-			if (((Literal) value).getLanguage().isPresent()) {
-				return "\"" + value.stringValue() + "\"@" + ((Literal) value).getLanguage().get();
-			}
-			return "\"" + value.stringValue() + "\"^^<" + datatype.stringValue() + ">";
-		}
-
-		throw new IllegalStateException(value.getClass().getSimpleName());
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/PatternConstraintComponent.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/constraintcomponents/PatternConstraintComponent.java
@@ -66,7 +66,7 @@ public class PatternConstraintComponent extends SimpleAbstractConstraintComponen
 	}
 
 	private static String escapeRegexForSparql(String pattern) {
-		return pattern.replace("\\", "\\\\");
+		return pattern.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
 	}
 
 	@Override

--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Select.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ast/planNodes/Select.java
@@ -74,7 +74,9 @@ public class Select implements PlanNode {
 		}
 
 		dataset = PlanNodeHelper.asDefaultGraphDataset(dataGraph);
-
+		if (logger.isDebugEnabled()) {
+			this.stackTrace = Thread.currentThread().getStackTrace();
+		}
 	}
 
 	public Select(SailConnection connection, String query, Function<BindingSet, ValidationTuple> mapper,
@@ -89,6 +91,9 @@ public class Select implements PlanNode {
 		this.dataset = PlanNodeHelper.asDefaultGraphDataset(dataGraph);
 
 		this.sorted = false;
+		if (logger.isDebugEnabled()) {
+			this.stackTrace = Thread.currentThread().getStackTrace();
+		}
 	}
 
 	@Override
@@ -111,6 +116,11 @@ public class Select implements PlanNode {
 						logger.trace("SPARQL query (hasNext={}) \n{}", hasNext, Formatter.formatSparqlQuery(query));
 					}
 				} catch (MalformedQueryException e) {
+					if (stackTrace != null) {
+						Exception rootCause = new Exception("Root cause");
+						rootCause.setStackTrace(stackTrace);
+						logger.debug("Select plan node with malformed query", rootCause);
+					}
 					logger.error("Malformed query:\n{}", query);
 					throw e;
 				}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -95,6 +95,7 @@ import org.topbraid.shacl.vocabulary.SH;
 import com.google.common.collect.Lists;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
 
 /**
  * @author Håvard Ottestad
@@ -1157,20 +1158,17 @@ abstract public class AbstractShaclTest {
 	}
 
 	void runWithAutomaticLogging(Runnable r) {
-		ch.qos.logback.classic.Logger shaclSailConnectionLogger = (ch.qos.logback.classic.Logger) LoggerFactory
-				.getLogger(ShaclSailConnection.class.getName());
-		Level shaclSailConnectionLoggerLevel = shaclSailConnectionLogger.getLevel();
-		ch.qos.logback.classic.Logger shaclSailLogger = (ch.qos.logback.classic.Logger) LoggerFactory
-				.getLogger(ShaclSail.class.getName());
-		Level shaclSailLoggerLevel = shaclSailLogger.getLevel();
+		LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+		ch.qos.logback.classic.Logger shaclPackageLogger = loggerContext.getLogger("org.eclipse.rdf4j.sail.shacl");
+
+		Level originalLogLevel = shaclPackageLogger.getLevel();
 
 		try {
 			r.run();
 		} catch (Throwable t) {
 			fullLogging = true;
 
-			shaclSailConnectionLogger.setLevel(Level.DEBUG);
-			shaclSailLogger.setLevel(Level.DEBUG);
+			shaclPackageLogger.setLevel(Level.DEBUG);
 
 			System.out.println("\n##############################################");
 			System.out.println("###### Re-running test with full logging #####");
@@ -1180,8 +1178,7 @@ abstract public class AbstractShaclTest {
 			throw t;
 		} finally {
 			fullLogging = false;
-			shaclSailConnectionLogger.setLevel(shaclSailConnectionLoggerLevel);
-			shaclSailLogger.setLevel(shaclSailLoggerLevel);
+			shaclPackageLogger.setLevel(originalLogLevel);
 
 		}
 	}

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/results/ShaclValidatorTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/results/ShaclValidatorTest.java
@@ -29,7 +29,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.sail.shacl.ShaclValidator;
-import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case1/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case1/query1.rq
@@ -1,0 +1,13 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+		ex:knows "1234567".
+
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case1/report.ttl
@@ -1,0 +1,23 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:shapesGraph rdf4j:SHACLShapeGraph;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:knows;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:HasValueConstraintComponent;
+      sh:sourceShape [ a sh:PropertyShape;
+          sh:hasValue "\"quoted\nString\"";
+          sh:path ex:knows
+        ]
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case2/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case2/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 	ex:knows "1234567".
+
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case2/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case2/query2.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person .
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case2/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case2/report.ttl
@@ -1,0 +1,23 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:shapesGraph rdf4j:SHACLShapeGraph;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:knows;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:HasValueConstraintComponent;
+      sh:sourceShape [ a sh:PropertyShape;
+          sh:hasValue "\"quoted\nString\"";
+          sh:path ex:knows
+        ]
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case3/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case3/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:knows [], "\"quoted\nString\"".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case3/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case3/query2.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE DATA {
+
+        ex:validPerson1 ex:knows "\"quoted\nString\"".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case3/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case3/report.ttl
@@ -1,0 +1,23 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:shapesGraph rdf4j:SHACLShapeGraph;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:knows;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:HasValueConstraintComponent;
+      sh:sourceShape [ a sh:PropertyShape;
+          sh:hasValue "\"quoted\nString\"";
+          sh:path ex:knows
+        ]
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case4/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case4/query1.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 	ex:knows "1234567".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case4/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case4/query2.rq
@@ -1,0 +1,17 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1
+        ex:knows [], ex:pete ;
+        a ex:Person .
+
+ex:validPerson2
+        ex:knows [] ;
+        a ex:Person .
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case4/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/invalid/case4/report.ttl
@@ -1,0 +1,31 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:shapesGraph rdf4j:SHACLShapeGraph;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:knows;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:HasValueConstraintComponent;
+      sh:sourceShape _:5089a376325a403b926b5c31d5e95e727886
+    ], [ a sh:ValidationResult;
+      rsx:shapesGraph rdf4j:SHACLShapeGraph;
+      sh:focusNode ex:validPerson2;
+      sh:resultPath ex:knows;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:HasValueConstraintComponent;
+      sh:sourceShape _:5089a376325a403b926b5c31d5e95e727886
+    ] .
+
+_:5089a376325a403b926b5c31d5e95e727886 a sh:PropertyShape;
+  sh:hasValue "\"quoted\nString\"";
+  sh:path ex:knows .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/shacl.trig
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/shacl.trig
@@ -1,0 +1,16 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+rdf4j:SHACLShapeGraph {
+  ex:PersonShape a sh:NodeShape;
+    sh:targetClass ex:Person;
+    sh:property [
+        sh:path ex:knows;
+        sh:hasValue "\"quoted\nString\""
+      ].
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case1/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case1/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:knows [], "\"quoted\nString\"","\"quoted\nString\"".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case1/report.ttl
@@ -1,0 +1,12 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms true .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case2/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case2/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:knows "\"quoted\nString\"".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case2/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case2/query2.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 ex:knows [].
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case2/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case2/report.ttl
@@ -1,0 +1,12 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms true .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case3/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case3/query1.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 	ex:knows [].
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case3/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case3/query2.rq
@@ -1,0 +1,13 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson2
+        ex:knows "\"quoted\nString\"" ;
+        a ex:Person .
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case3/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case3/report.ttl
@@ -1,0 +1,12 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms true .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case4/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case4/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:knows "\"quoted\nString\"".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case4/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case4/report.ttl
@@ -1,0 +1,12 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms true .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case5/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case5/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:knows [], "\"quoted\nString\"".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case5/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case5/query2.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE DATA {
+        ex:validPerson1 a ex:Person .
+        ex:validPerson1 ex:knows "\"quoted\nString\"".
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case5/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case5/report.ttl
@@ -1,0 +1,12 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms true .

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case6/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case6/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:knows ex:steve, "\"quoted\nString\"".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case6/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case6/query2.rq
@@ -1,0 +1,10 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE DATA {
+       ex:validPerson1 ex:knows ex:steve.
+}

--- a/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case6/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/hasValue/quotedString/valid/case6/report.ttl
@@ -1,0 +1,12 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms true .

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case1/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case1/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:singleEscapedQuote "aaa1bbb".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case1/report.ttl
@@ -1,0 +1,25 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:dataGraph rdf4j:nil;
+      rsx:shapesGraph rdf4j:nil;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:singleEscapedQuote;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:PatternConstraintComponent;
+      sh:sourceShape [ a sh:PropertyShape;
+          sh:path ex:singleEscapedQuote;
+          sh:pattern "aaa\"bbb\n"
+        ];
+      sh:value "aaa1bbb"
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case2/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case2/query1.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+    ex:validPerson1 a ex:Person ;
+	    ex:singleEscapedQuote "aaa\"bbb\n".
+}

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case2/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case2/query2.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+    ex:validPerson1 ex:singleEscapedQuote "aaa\\\"bbb".
+}
+

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case2/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/invalid/case2/report.ttl
@@ -1,0 +1,25 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms false;
+  sh:result [ a sh:ValidationResult;
+      rsx:dataGraph rdf4j:nil;
+      rsx:shapesGraph rdf4j:nil;
+      sh:focusNode ex:validPerson1;
+      sh:resultPath ex:singleEscapedQuote;
+      sh:resultSeverity sh:Violation;
+      sh:sourceConstraintComponent sh:PatternConstraintComponent;
+      sh:sourceShape [ a sh:PropertyShape;
+          sh:path ex:singleEscapedQuote;
+          sh:pattern "aaa\"bbb\n"
+        ];
+      sh:value "aaa\\\"bbb"
+    ] .

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/shacl.trig
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/shacl.trig
@@ -1,0 +1,21 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+{
+  ex:PersonShape a sh:NodeShape;
+    sh:targetClass ex:Person;
+    sh:property [
+        sh:path ex:singleEscapedQuote;
+        sh:pattern "aaa\"bbb\n"
+      ], [
+        sh:path ex:doubleEscapedQuote;
+        sh:pattern "aaa\\\"bbb"
+      ] .
+  rdf4j:nil sh:shapesGraph rdf4j:nil.
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case1/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case1/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+ex:validPerson1 a ex:Person ;
+	ex:singleEscapedQuote "aaa\"bbb\n".
+
+}

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case1/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case1/report.ttl
@@ -1,0 +1,12 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms true .

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case2/query1.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case2/query1.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+    ex:validPerson1 a ex:Person ;
+	ex:singleEscapedQuote "aaa\"bbb\n".
+}

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case2/query2.rq
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case2/query2.rq
@@ -1,0 +1,11 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+    ex:validPerson1 ex:singleEscapedQuote "baaa\"bbb\nc".
+}
+

--- a/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case2/report.ttl
+++ b/core/sail/shacl/src/test/resources/test-cases/pattern/quotes/valid/case2/report.ttl
@@ -1,0 +1,12 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rsx: <http://rdf4j.org/shacl-extensions#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+
+[] a sh:ValidationReport;
+  rdf4j:truncated false;
+  sh:conforms true .


### PR DESCRIPTION
GitHub issue resolved: #4523 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - fixed by replacing various escaped characters
 - this should really be followed up with a fix where we don't need to inline RDF values but instead can bind them at query time.

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

