### PR TITLE
GH-4610: fix FedX issue with large join (Phaser > 65535)

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerBoundJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ControlledWorkerBoundJoin.java
@@ -91,7 +91,7 @@ public class ControlledWorkerBoundJoin extends ControlledWorkerJoin {
 				throw new RuntimeException("Expr is of unexpected type: " + expr.getClass().getCanonicalName()
 						+ ". Please report this problem.");
 			}
-			phaser.register();
+			currentPhaser.register();
 			scheduler.schedule(
 					new ParallelJoinTask(new PhaserHandlingParallelExecutor(this, currentPhaser), strategy, expr, b));
 		}
@@ -132,7 +132,7 @@ public class ControlledWorkerBoundJoin extends ControlledWorkerJoin {
 
 			totalBindings += count;
 
-			phaser.register();
+			currentPhaser.register();
 			scheduler.schedule(taskCreator.getTask(new PhaserHandlingParallelExecutor(this, currentPhaser), bindings));
 		}
 


### PR DESCRIPTION
GitHub issue resolved: #4610 

Instead of registering to the root phaser, we need to register to the current phaser. Otherwise we may reach the limit of 65535 for large joins.

Note that in ControlledWorkerJoin and ControlledWorkerLeftJoin this was done correctly.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

