### PR TITLE
GH-4638 revert dependency so that the server doesn't throw an exception on startup due to a missing class

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 # Temp to reduce image size
 FROM ubuntu:jammy AS temp
 
-RUN apt-get update && apt-get install unzip
+RUN  apt-get clean && apt-get update && apt-get install -y unzip
+
 
 COPY ignore/rdf4j.zip /tmp/rdf4j.zip
 
@@ -13,7 +14,7 @@ RUN unzip -q /tmp/rdf4j.zip
 FROM tomcat:8.5-jre11-temurin
 MAINTAINER Bart Hanssens (bart.hanssens@bosa.fgov.be)
 
-RUN apt-get update && apt-get upgrade -y && apt-get clean
+RUN apt-get clean && apt-get update && apt-get upgrade -y && apt-get clean
 
 ENV JAVA_OPTS="-Xmx2g"
 ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -24,7 +24,7 @@
 			<artifactId>rdf4j-config</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!-- TODO rather include into rdf4j-storage, however, 
+		<!-- TODO rather include into rdf4j-storage, however,
 		requires resolving cyclic dependency on test scope -->
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
@@ -67,6 +67,12 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<!-- See https://github.com/eclipse/rdf4j/issues/4638 -->
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
@@ -89,11 +95,6 @@
 		<dependency>
 			<groupId>com.opencsv</groupId>
 			<artifactId>opencsv</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
GitHub issue resolved: #4638 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

