### PR TITLE
GH-4651 fix log warning by checking if the new vocabulary is in use or not before we compare with the old (legacy) vocabulary

### DIFF
--- a/core/model/src/main/java/org/eclipse/rdf4j/model/util/Configurations.java
+++ b/core/model/src/main/java/org/eclipse/rdf4j/model/util/Configurations.java
@@ -102,7 +102,11 @@ public class Configurations {
 		Set<Value> objects = model.filter(subject, property, null).objects();
 		Set<Value> legacyObjects = model.filter(subject, legacyProperty, null).objects();
 		if (USE_CONFIG) {
-			legacyObjects = Set.of();
+			legacyObjects = objects;
+		} else {
+			if (objects.isEmpty()) {
+				return legacyObjects;
+			}
 		}
 
 		if (!objects.equals(legacyObjects)) {


### PR DESCRIPTION
GitHub issue resolved: GH-4651  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:
 - fix log warning by checking if the new vocabulary is in use or not before we compare with the old (legacy) vocabulary

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

