### PR TITLE
GH-4659 Fix for shared var name between context and subject in StatementPatternQueryEvaluationStep

### DIFF
--- a/core/query/src/main/java/org/eclipse/rdf4j/query/explanation/GenericPlanNode.java
+++ b/core/query/src/main/java/org/eclipse/rdf4j/query/explanation/GenericPlanNode.java
@@ -39,6 +39,8 @@ public class GenericPlanNode {
 	private final static String uniqueIdPrefix = UUID.randomUUID().toString().replace("-", "");
 	private final static AtomicLong uniqueIdSuffix = new AtomicLong();
 
+	private static final String spoc[] = { "s", "p", "o", "c" };
+
 	private final static String newLine = System.getProperty("line.separator");
 
 	private final String id = "UUID_" + uniqueIdPrefix + uniqueIdSuffix.incrementAndGet();
@@ -292,9 +294,14 @@ public class GenericPlanNode {
 
 			String left = plans.get(0).getHumanReadable(prettyBoxDrawingType + 1);
 			String right = plans.get(1).getHumanReadable(prettyBoxDrawingType + 1);
+			boolean join = type.contains("Join");
+
 			{
 				String[] split = left.split(newLine);
-				sb.append(start).append(horizontal).append(split[0]).append(newLine);
+				sb.append(start).append(horizontal).append(" ").append(split[0]);
+				if (join)
+					sb.append(" [left]");
+				sb.append(newLine);
 				for (int i = 1; i < split.length; i++) {
 					sb.append(vertical).append("  ").append(split[i]).append(newLine);
 				}
@@ -302,18 +309,32 @@ public class GenericPlanNode {
 
 			{
 				String[] split = right.split(newLine);
-				sb.append(end).append(horizontal).append(split[0]).append(newLine);
+				sb.append(end).append(horizontal).append(" ").append(split[0]);
+				if (join)
+					sb.append(" [right]");
+				sb.append(newLine);
+
 				for (int i = 1; i < split.length; i++) {
 					sb.append("   ").append(split[i]).append(newLine);
 				}
 			}
 
 		} else {
-			plans.forEach(
-					child -> sb.append(Arrays.stream(child.getHumanReadable(prettyBoxDrawingType + 1).split(newLine))
-							.map(c -> "   " + c)
-							.reduce((a, b) -> a + newLine + b)
-							.orElse("") + newLine));
+
+			for (int i = 0; i < plans.size(); i++) {
+				GenericPlanNode child = plans.get(i);
+				int j = i;
+				sb.append(Arrays.stream(child.getHumanReadable(prettyBoxDrawingType + 1).split(newLine))
+						.map(c -> {
+							if (type.startsWith("StatementPattern") && child.type.startsWith("Var")) {
+								return spoc[j] + ": " + c;
+							}
+							return c;
+						})
+						.map(c -> "   " + c)
+						.reduce((a, b) -> a + newLine + b)
+						.orElse("")).append(newLine);
+			}
 		}
 
 		return sb.toString();

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
@@ -94,6 +94,16 @@ public class StatementPatternQueryEvaluationStep implements QueryEvaluationStep 
 		Var objVar = statementPattern.getObjectVar();
 		Var conVar = statementPattern.getContextVar();
 
+		// First create the getters before removing duplicate vars since we need the getters when creating
+		// JoinStatementWithBindingSetIterator. If there are duplicate vars, for instance ?v1 as both subject and
+		// context then we still need to bind the value from ?v1 in the subject and context arguments of
+		// getStatement(...).
+		getContextVar = makeGetVarValue(conVar, context);
+		getSubjectVar = makeGetVarValue(subjVar, context);
+		getPredicateVar = makeGetVarValue(predVar, context);
+		getObjectVar = makeGetVarValue(objVar, context);
+
+		// then remove duplicate vars
 		if (subjVar != null) {
 			if (predVar != null && predVar.getName().equals(subjVar.getName())) {
 				predVar = null;
@@ -124,11 +134,6 @@ public class StatementPatternQueryEvaluationStep implements QueryEvaluationStep 
 		converter = makeConverter(context, subjVar, predVar, objVar, conVar);
 
 		unboundTest = getUnboundTest(context, subjVar, predVar, objVar, conVar);
-
-		getContextVar = makeGetVarValue(conVar, context);
-		getSubjectVar = makeGetVarValue(subjVar, context);
-		getPredicateVar = makeGetVarValue(predVar, context);
-		getObjectVar = makeGetVarValue(objVar, context);
 
 	}
 

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/QueryPlanRetrievalTest.java
@@ -87,41 +87,39 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Unoptimized).toString();
 			String expected = "Projection\n" +
-					"╠══ProjectionElemList\n" +
+					"╠══ ProjectionElemList\n" +
 					"║     ProjectionElem \"a\"\n" +
-					"╚══Filter\n" +
-					"   ├──And\n" +
-					"   │  ╠══Compare (!=)\n" +
+					"╚══ Filter\n" +
+					"   ├── And\n" +
+					"   │  ╠══ Compare (!=)\n" +
 					"   │  ║     Var (name=c)\n" +
 					"   │  ║     Var (name=d)\n" +
-					"   │  ╚══Compare (!=)\n" +
+					"   │  ╚══ Compare (!=)\n" +
 					"   │        Var (name=c)\n" +
 					"   │        ValueConstant (value=\"<\")\n" +
-					"   └──LeftJoin\n" +
-					"      ╠══Join\n" +
-					"      ║  ├──LeftJoin (new scope)\n" +
-					"      ║  │  ╠══SingletonSet\n" +
-					"      ║  │  ╚══StatementPattern\n" +
-					"      ║  │        Var (name=d)\n" +
-					"      ║  │        Var (name=e)\n" +
-					"      ║  │        Var (name=f)\n" +
-					"      ║  └──Join\n" +
-					"      ║     ╠══StatementPattern\n" +
-					"      ║     ║     Var (name=a)\n" +
-					"      ║     ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"   └── LeftJoin\n" +
+					"      ╠══ Join [left]\n" +
+					"      ║  ├── LeftJoin (new scope) [left]\n" +
+					"      ║  │  ╠══ SingletonSet [left]\n" +
+					"      ║  │  ╚══ StatementPattern [right]\n" +
+					"      ║  │        s: Var (name=d)\n" +
+					"      ║  │        p: Var (name=e)\n" +
+					"      ║  │        o: Var (name=f)\n" +
+					"      ║  └── Join [right]\n" +
+					"      ║     ╠══ StatementPattern [left]\n" +
+					"      ║     ║     s: Var (name=a)\n" +
+					"      ║     ║     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"      ║     ║     Var (name=c)\n" +
-					"      ║     ╚══StatementPattern\n" +
-					"      ║           Var (name=a)\n" +
-					"      ║           Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"      ║     ║     o: Var (name=c)\n" +
+					"      ║     ╚══ StatementPattern [right]\n" +
+					"      ║           s: Var (name=a)\n" +
+					"      ║           p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"      ║           Var (name=d)\n" +
-					"      ╚══StatementPattern\n" +
-					"            Var (name=d)\n" +
-					"            Var (name=e)\n" +
-					"            Var (name=f)\n";
+					"      ║           o: Var (name=d)\n" +
+					"      ╚══ StatementPattern [right]\n" +
+					"            s: Var (name=d)\n" +
+					"            p: Var (name=e)\n" +
+					"            o: Var (name=f)\n";
 
 			assertThat(actual).isEqualToNormalizingNewlines(expected);
 
@@ -138,41 +136,39 @@ public class QueryPlanRetrievalTest {
 			TupleQuery query = connection.prepareTupleQuery(TUPLE_QUERY);
 			String actual = query.explain(Explanation.Level.Optimized).toString();
 			String expected = "Projection\n" +
-					"╠══ProjectionElemList\n" +
+					"╠══ ProjectionElemList\n" +
 					"║     ProjectionElem \"a\"\n" +
-					"╚══LeftJoin (LeftJoinIterator)\n" +
-					"   ├──Join (JoinIterator)\n" +
-					"   │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4)\n" +
-					"   │  ║     Var (name=a)\n" +
-					"   │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"╚══ LeftJoin (LeftJoinIterator)\n" +
+					"   ├── Join (JoinIterator) [left]\n" +
+					"   │  ╠══ StatementPattern (costEstimate=1, resultSizeEstimate=4) [left]\n" +
+					"   │  ║     s: Var (name=a)\n" +
+					"   │  ║     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │  ║     Var (name=d)\n" +
-					"   │  ╚══Filter\n" +
-					"   │     ├──Compare (!=)\n" +
+					"   │  ║     o: Var (name=d)\n" +
+					"   │  ╚══ Filter [right]\n" +
+					"   │     ├── Compare (!=)\n" +
 					"   │     │     Var (name=c)\n" +
 					"   │     │     Var (name=d)\n" +
-					"   │     └──Join (HashJoinIteration)\n" +
-					"   │        ╠══Filter\n" +
-					"   │        ║  ├──Compare (!=)\n" +
+					"   │     └── Join (HashJoinIteration)\n" +
+					"   │        ╠══ Filter [left]\n" +
+					"   │        ║  ├── Compare (!=)\n" +
 					"   │        ║  │     Var (name=c)\n" +
 					"   │        ║  │     ValueConstant (value=\"<\")\n" +
-					"   │        ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=4)\n" +
-					"   │        ║        Var (name=a)\n" +
-					"   │        ║        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"   │        ║  └── StatementPattern (costEstimate=2, resultSizeEstimate=4)\n" +
+					"   │        ║        s: Var (name=a)\n" +
+					"   │        ║        p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │        ║        Var (name=c)\n" +
-					"   │        ╚══LeftJoin (new scope) (costEstimate=5, resultSizeEstimate=12)\n" +
-					"   │           ├──SingletonSet\n" +
-					"   │           └──StatementPattern (resultSizeEstimate=12)\n" +
-					"   │                 Var (name=d)\n" +
-					"   │                 Var (name=e)\n" +
-					"   │                 Var (name=f)\n" +
-					"   └──StatementPattern (resultSizeEstimate=12)\n" +
-					"         Var (name=d)\n" +
-					"         Var (name=e)\n" +
-					"         Var (name=f)\n";
+					"   │        ║        o: Var (name=c)\n" +
+					"   │        ╚══ LeftJoin (new scope) (costEstimate=5, resultSizeEstimate=12) [right]\n" +
+					"   │           ├── SingletonSet [left]\n" +
+					"   │           └── StatementPattern (resultSizeEstimate=12) [right]\n" +
+					"   │                 s: Var (name=d)\n" +
+					"   │                 p: Var (name=e)\n" +
+					"   │                 o: Var (name=f)\n" +
+					"   └── StatementPattern (resultSizeEstimate=12) [right]\n" +
+					"         s: Var (name=d)\n" +
+					"         p: Var (name=e)\n" +
+					"         o: Var (name=f)\n";
 			assertThat(actual).isEqualToNormalizingNewlines(expected);
 
 		}
@@ -218,44 +214,40 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
 			String expected = "Projection (resultSizeActual=2)\n" +
-					"╠══ProjectionElemList\n" +
+					"╠══ ProjectionElemList\n" +
 					"║     ProjectionElem \"a\"\n" +
-					"╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
-					"   ├──Join (JoinIterator) (resultSizeActual=2)\n" +
-					"   │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"   │  ║     Var (name=a)\n" +
-					"   │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"╚══ LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
+					"   ├── Join (JoinIterator) (resultSizeActual=2) [left]\n" +
+					"   │  ╠══ StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4) [left]\n" +
+					"   │  ║     s: Var (name=a)\n" +
+					"   │  ║     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │  ║     Var (name=d)\n" +
-					"   │  ╚══Filter (resultSizeActual=2)\n" +
-					"   │     ├──Compare (!=)\n" +
+					"   │  ║     o: Var (name=d)\n" +
+					"   │  ╚══ Filter (resultSizeActual=2) [right]\n" +
+					"   │     ├── Compare (!=)\n" +
 					"   │     │     Var (name=c)\n" +
 					"   │     │     Var (name=d)\n" +
-					"   │     └──Join (HashJoinIteration) (resultSizeActual=6)\n" +
-					"   │        ╠══Filter (resultSizeActual=6)\n" +
-					"   │        ║  ├──Compare (!=)\n" +
+					"   │     └── Join (HashJoinIteration) (resultSizeActual=6)\n" +
+					"   │        ╠══ Filter (resultSizeActual=6) [left]\n" +
+					"   │        ║  ├── Compare (!=)\n" +
 					"   │        ║  │     Var (name=c)\n" +
 					"   │        ║  │     ValueConstant (value=\"<\")\n" +
-					"   │        ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)"
-					+ "\n" +
-					"   │        ║        Var (name=a)\n" +
-					"   │        ║        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"   │        ║  └── StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n" +
+					"   │        ║        s: Var (name=a)\n" +
+					"   │        ║        p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │        ║        Var (name=c)\n" +
-					"   │        ╚══LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)"
-					+ "\n"
+					"   │        ║        o: Var (name=c)\n" +
+					"   │        ╚══ LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4) [right]\n"
 					+
-					"   │           ├──SingletonSet (resultSizeActual=4)\n" +
-					"   │           └──StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
-					"   │                 Var (name=d)\n" +
-					"   │                 Var (name=e)\n" +
-					"   │                 Var (name=f)\n" +
-					"   └──StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n" +
-					"         Var (name=d)\n" +
-					"         Var (name=e)\n" +
-					"         Var (name=f)\n";
+					"   │           ├── SingletonSet (resultSizeActual=4) [left]\n" +
+					"   │           └── StatementPattern (resultSizeEstimate=12, resultSizeActual=48) [right]\n" +
+					"   │                 s: Var (name=d)\n" +
+					"   │                 p: Var (name=e)\n" +
+					"   │                 o: Var (name=f)\n" +
+					"   └── StatementPattern (resultSizeEstimate=12, resultSizeActual=2) [right]\n" +
+					"         s: Var (name=d)\n" +
+					"         p: Var (name=e)\n" +
+					"         o: Var (name=f)\n";
 			assertThat(actual).isEqualToNormalizingNewlines(expected);
 
 		}
@@ -273,44 +265,40 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Executed).toGenericPlanNode().toString();
 			String expected = "Projection (resultSizeActual=2)\n" +
-					"╠══ProjectionElemList\n" +
+					"╠══ ProjectionElemList\n" +
 					"║     ProjectionElem \"a\"\n" +
-					"╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
-					"   ├──Join (JoinIterator) (resultSizeActual=2)\n" +
-					"   │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"   │  ║     Var (name=a)\n" +
-					"   │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"╚══ LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
+					"   ├── Join (JoinIterator) (resultSizeActual=2) [left]\n" +
+					"   │  ╠══ StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4) [left]\n" +
+					"   │  ║     s: Var (name=a)\n" +
+					"   │  ║     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │  ║     Var (name=d)\n" +
-					"   │  ╚══Filter (resultSizeActual=2)\n" +
-					"   │     ├──Compare (!=)\n" +
+					"   │  ║     o: Var (name=d)\n" +
+					"   │  ╚══ Filter (resultSizeActual=2) [right]\n" +
+					"   │     ├── Compare (!=)\n" +
 					"   │     │     Var (name=c)\n" +
 					"   │     │     Var (name=d)\n" +
-					"   │     └──Join (HashJoinIteration) (resultSizeActual=6)\n" +
-					"   │        ╠══Filter (resultSizeActual=6)\n" +
-					"   │        ║  ├──Compare (!=)\n" +
+					"   │     └── Join (HashJoinIteration) (resultSizeActual=6)\n" +
+					"   │        ╠══ Filter (resultSizeActual=6) [left]\n" +
+					"   │        ║  ├── Compare (!=)\n" +
 					"   │        ║  │     Var (name=c)\n" +
 					"   │        ║  │     ValueConstant (value=\"<\")\n" +
-					"   │        ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)"
-					+ "\n" +
-					"   │        ║        Var (name=a)\n" +
-					"   │        ║        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"   │        ║  └── StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n" +
+					"   │        ║        s: Var (name=a)\n" +
+					"   │        ║        p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │        ║        Var (name=c)\n" +
-					"   │        ╚══LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)"
-					+ "\n"
+					"   │        ║        o: Var (name=c)\n" +
+					"   │        ╚══ LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4) [right]\n"
 					+
-					"   │           ├──SingletonSet (resultSizeActual=4)\n" +
-					"   │           └──StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n" +
-					"   │                 Var (name=d)\n" +
-					"   │                 Var (name=e)\n" +
-					"   │                 Var (name=f)\n" +
-					"   └──StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n" +
-					"         Var (name=d)\n" +
-					"         Var (name=e)\n" +
-					"         Var (name=f)\n";
+					"   │           ├── SingletonSet (resultSizeActual=4) [left]\n" +
+					"   │           └── StatementPattern (resultSizeEstimate=12, resultSizeActual=48) [right]\n" +
+					"   │                 s: Var (name=d)\n" +
+					"   │                 p: Var (name=e)\n" +
+					"   │                 o: Var (name=f)\n" +
+					"   └── StatementPattern (resultSizeEstimate=12, resultSizeActual=2) [right]\n" +
+					"         s: Var (name=d)\n" +
+					"         p: Var (name=e)\n" +
+					"         o: Var (name=f)\n";
 			assertThat(actual).isEqualToNormalizingNewlines(expected);
 
 		}
@@ -453,37 +441,37 @@ public class QueryPlanRetrievalTest {
 			String actual = query.explain(Explanation.Level.Executed).toString();
 			String expected = "Slice (limit=1) (resultSizeActual=1)\n" +
 					"   LeftJoin (LeftJoinIterator) (resultSizeActual=1)\n" +
-					"   ├──Join (JoinIterator) (resultSizeActual=1)\n" +
-					"   │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=3)\n" +
-					"   │  ║     Var (name=a)\n" +
-					"   │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"   ├── Join (JoinIterator) (resultSizeActual=1) [left]\n" +
+					"   │  ╠══ StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=3) [left]\n" +
+					"   │  ║     s: Var (name=a)\n" +
+					"   │  ║     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │  ║     Var (name=d)\n" +
-					"   │  ╚══Filter (resultSizeActual=1)\n" +
-					"   │     ├──Compare (!=)\n" +
+					"   │  ║     o: Var (name=d)\n" +
+					"   │  ╚══ Filter (resultSizeActual=1) [right]\n" +
+					"   │     ├── Compare (!=)\n" +
 					"   │     │     Var (name=c)\n" +
 					"   │     │     Var (name=d)\n" +
-					"   │     └──Join (HashJoinIteration) (resultSizeActual=4)\n" +
-					"   │        ╠══Filter (resultSizeActual=4)\n" +
-					"   │        ║  ├──Compare (!=)\n" +
+					"   │     └── Join (HashJoinIteration) (resultSizeActual=4)\n" +
+					"   │        ╠══ Filter (resultSizeActual=4) [left]\n" +
+					"   │        ║  ├── Compare (!=)\n" +
 					"   │        ║  │     Var (name=c)\n" +
 					"   │        ║  │     ValueConstant (value=\"<\")\n" +
-					"   │        ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n" +
-					"   │        ║        Var (name=a)\n" +
-					"   │        ║        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					"   │        ║  └── StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=4)\n" +
+					"   │        ║        s: Var (name=a)\n" +
+					"   │        ║        p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │        ║        Var (name=c)\n" +
-					"   │        ╚══LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=3)\n"
+					"   │        ║        o: Var (name=c)\n" +
+					"   │        ╚══ LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=3) [right]\n"
 					+
-					"   │           ├──SingletonSet (resultSizeActual=3)\n" +
-					"   │           └──StatementPattern (resultSizeEstimate=12, resultSizeActual=36)\n" +
-					"   │                 Var (name=d)\n" +
-					"   │                 Var (name=e)\n" +
-					"   │                 Var (name=f)\n" +
-					"   └──StatementPattern (resultSizeEstimate=12, resultSizeActual=1)\n" +
-					"         Var (name=d)\n" +
-					"         Var (name=e)\n" +
-					"         Var (name=f)\n";
+					"   │           ├── SingletonSet (resultSizeActual=3) [left]\n" +
+					"   │           └── StatementPattern (resultSizeEstimate=12, resultSizeActual=36) [right]\n" +
+					"   │                 s: Var (name=d)\n" +
+					"   │                 p: Var (name=e)\n" +
+					"   │                 o: Var (name=f)\n" +
+					"   └── StatementPattern (resultSizeEstimate=12, resultSizeActual=1) [right]\n" +
+					"         s: Var (name=d)\n" +
+					"         p: Var (name=e)\n" +
+					"         o: Var (name=f)\n";
 			assertThat(actual).isEqualToNormalizingNewlines(expected);
 
 		}
@@ -501,53 +489,53 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
 
-			String expected = "Reduced (resultSizeActual=3)\n"
-					+ "   MultiProjection (resultSizeActual=4)\n"
-					+ "      ProjectionElemList\n"
-					+ "         ProjectionElem \"a\" AS \"subject\"\n"
-					+ "         ProjectionElem \"_const_f5e5585a_uri\" AS \"predicate\"\n"
-					+ "         ProjectionElem \"c\" AS \"object\"\n"
-					+ "      ProjectionElemList\n"
-					+ "         ProjectionElem \"a\" AS \"subject\"\n"
-					+ "         ProjectionElem \"_const_f5e5585a_uri\" AS \"predicate\"\n"
-					+ "         ProjectionElem \"d\" AS \"object\"\n"
-					+ "      Extension (resultSizeActual=2)\n"
-					+ "      ╠══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n"
-					+ "      ║  ├──Join (JoinIterator) (resultSizeActual=2)\n"
-					+ "      ║  │  ╠══StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)"
-					+ "\n"
-					+ "      ║  │  ║     Var (name=a)\n"
-					+ "      ║  │  ║     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
-					+ "      ║  │  ║     Var (name=d)\n"
-					+ "      ║  │  ╚══Filter (resultSizeActual=2)\n"
-					+ "      ║  │     ├──Compare (!=)\n"
-					+ "      ║  │     │     Var (name=c)\n"
-					+ "      ║  │     │     Var (name=d)\n"
-					+ "      ║  │     └──Join (HashJoinIteration) (resultSizeActual=6)\n"
-					+ "      ║  │        ╠══Filter (resultSizeActual=6)\n"
-					+ "      ║  │        ║  ├──Compare (!=)\n"
-					+ "      ║  │        ║  │     Var (name=c)\n"
-					+ "      ║  │        ║  │     ValueConstant (value=\"<\")\n"
-					+ "      ║  │        ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)"
-					+ "\n"
-					+ "      ║  │        ║        Var (name=a)\n"
-					+ "      ║  │        ║        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
-					+ "      ║  │        ║        Var (name=c)\n"
-					+ "      ║  │        ╚══LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)"
-					+ "\n"
-					+ "      ║  │           ├──SingletonSet (resultSizeActual=4)\n"
-					+ "      ║  │           └──StatementPattern (resultSizeEstimate=12, resultSizeActual=48)\n"
-					+ "      ║  │                 Var (name=d)\n"
-					+ "      ║  │                 Var (name=e)\n"
-					+ "      ║  │                 Var (name=f)\n"
-					+ "      ║  └──StatementPattern (resultSizeEstimate=12, resultSizeActual=2)\n"
-					+ "      ║        Var (name=d)\n"
-					+ "      ║        Var (name=e)\n"
-					+ "      ║        Var (name=f)\n"
-					+ "      ╚══ExtensionElem (_const_f5e5585a_uri)\n"
-					+ "            ValueConstant (value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type)\n";
+			String expected = "Reduced (resultSizeActual=3)\n" +
+					"   MultiProjection (resultSizeActual=4)\n" +
+					"      ProjectionElemList\n" +
+					"         ProjectionElem \"a\" AS \"subject\"\n" +
+					"         ProjectionElem \"_const_f5e5585a_uri\" AS \"predicate\"\n" +
+					"         ProjectionElem \"c\" AS \"object\"\n" +
+					"      ProjectionElemList\n" +
+					"         ProjectionElem \"a\" AS \"subject\"\n" +
+					"         ProjectionElem \"_const_f5e5585a_uri\" AS \"predicate\"\n" +
+					"         ProjectionElem \"d\" AS \"object\"\n" +
+					"      Extension (resultSizeActual=2)\n" +
+					"      ╠══ LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
+					"      ║  ├── Join (JoinIterator) (resultSizeActual=2) [left]\n" +
+					"      ║  │  ╠══ StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4) [left]\n"
+					+
+					"      ║  │  ║     s: Var (name=a)\n" +
+					"      ║  │  ║     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+
+					"      ║  │  ║     o: Var (name=d)\n" +
+					"      ║  │  ╚══ Filter (resultSizeActual=2) [right]\n" +
+					"      ║  │     ├── Compare (!=)\n" +
+					"      ║  │     │     Var (name=c)\n" +
+					"      ║  │     │     Var (name=d)\n" +
+					"      ║  │     └── Join (HashJoinIteration) (resultSizeActual=6)\n" +
+					"      ║  │        ╠══ Filter (resultSizeActual=6) [left]\n" +
+					"      ║  │        ║  ├── Compare (!=)\n" +
+					"      ║  │        ║  │     Var (name=c)\n" +
+					"      ║  │        ║  │     ValueConstant (value=\"<\")\n" +
+					"      ║  │        ║  └── StatementPattern (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)\n"
+					+
+					"      ║  │        ║        s: Var (name=a)\n" +
+					"      ║  │        ║        p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+
+					"      ║  │        ║        o: Var (name=c)\n" +
+					"      ║  │        ╚══ LeftJoin (new scope) (BadlyDesignedLeftJoinIterator) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4) [right]\n"
+					+
+					"      ║  │           ├── SingletonSet (resultSizeActual=4) [left]\n" +
+					"      ║  │           └── StatementPattern (resultSizeEstimate=12, resultSizeActual=48) [right]\n" +
+					"      ║  │                 s: Var (name=d)\n" +
+					"      ║  │                 p: Var (name=e)\n" +
+					"      ║  │                 o: Var (name=f)\n" +
+					"      ║  └── StatementPattern (resultSizeEstimate=12, resultSizeActual=2) [right]\n" +
+					"      ║        s: Var (name=d)\n" +
+					"      ║        p: Var (name=e)\n" +
+					"      ║        o: Var (name=f)\n" +
+					"      ╚══ ExtensionElem (_const_f5e5585a_uri)\n" +
+					"            ValueConstant (value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type)\n";
 
 			assertThat(actual).isEqualToNormalizingNewlines(expected);
 
@@ -591,54 +579,51 @@ public class QueryPlanRetrievalTest {
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
 			String expected = "Projection (resultSizeActual=4)\n" +
-					"╠══ProjectionElemList\n" +
+					"╠══ ProjectionElemList\n" +
 					"║     ProjectionElem \"a\"\n" +
-					"╚══Join (HashJoinIteration) (resultSizeActual=4)\n" +
-					"   ├──Projection (new scope) (resultSizeActual=4)\n" +
-					"   │  ╠══ProjectionElemList\n" +
+					"╚══ Join (HashJoinIteration) (resultSizeActual=4)\n" +
+					"   ├── Projection (new scope) (resultSizeActual=4) [left]\n" +
+					"   │  ╠══ ProjectionElemList\n" +
 					"   │  ║     ProjectionElem \"a\"\n" +
-					"   │  ╚══StatementPattern (resultSizeActual=4)\n" +
-					"   │        Var (name=a)\n" +
-					"   │        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"   │  ╚══ StatementPattern (resultSizeActual=4)\n" +
+					"   │        s: Var (name=a)\n" +
+					"   │        p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"   │        Var (name=type)\n" +
-					"   └──Projection (new scope) (resultSizeActual=2)\n" +
-					"      ╠══ProjectionElemList\n" +
+					"   │        o: Var (name=type)\n" +
+					"   └── Projection (new scope) (resultSizeActual=2) [right]\n" +
+					"      ╠══ ProjectionElemList\n" +
 					"      ║     ProjectionElem \"a\"\n" +
-					"      ╚══LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
-					"         ├──Join (JoinIterator) (resultSizeActual=2)\n" +
-					"         │  ╠══LeftJoin (new scope) (LeftJoinIterator) (resultSizeActual=12)\n" +
-					"         │  ║  ├──SingletonSet (resultSizeActual=1)\n" +
-					"         │  ║  └──StatementPattern (resultSizeActual=12)\n" +
-					"         │  ║        Var (name=d)\n" +
-					"         │  ║        Var (name=e)\n" +
-					"         │  ║        Var (name=f)\n" +
-					"         │  ╚══Filter (resultSizeActual=2)\n" +
-					"         │     ├──Compare (!=)\n" +
+					"      ╚══ LeftJoin (LeftJoinIterator) (resultSizeActual=2)\n" +
+					"         ├── Join (JoinIterator) (resultSizeActual=2) [left]\n" +
+					"         │  ╠══ LeftJoin (new scope) (LeftJoinIterator) (resultSizeActual=12) [left]\n" +
+					"         │  ║  ├── SingletonSet (resultSizeActual=1) [left]\n" +
+					"         │  ║  └── StatementPattern (resultSizeActual=12) [right]\n" +
+					"         │  ║        s: Var (name=d)\n" +
+					"         │  ║        p: Var (name=e)\n" +
+					"         │  ║        o: Var (name=f)\n" +
+					"         │  ╚══ Filter (resultSizeActual=2) [right]\n" +
+					"         │     ├── Compare (!=)\n" +
 					"         │     │     Var (name=c)\n" +
 					"         │     │     Var (name=d)\n" +
-					"         │     └──Join (JoinIterator) (resultSizeActual=6)\n" +
-					"         │        ╠══Filter (resultSizeActual=48)\n" +
-					"         │        ║  ├──Compare (!=)\n" +
+					"         │     └── Join (JoinIterator) (resultSizeActual=6)\n" +
+					"         │        ╠══ Filter (resultSizeActual=48) [left]\n" +
+					"         │        ║  ├── Compare (!=)\n" +
 					"         │        ║  │     Var (name=c)\n" +
 					"         │        ║  │     ValueConstant (value=\"<\")\n" +
-					"         │        ║  └──StatementPattern (resultSizeActual=48)\n" +
-					"         │        ║        Var (name=a)\n" +
-					"         │        ║        Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"         │        ║  └── StatementPattern (resultSizeActual=48)\n" +
+					"         │        ║        s: Var (name=a)\n" +
+					"         │        ║        p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"         │        ║        Var (name=c)\n" +
-					"         │        ╚══StatementPattern (resultSizeActual=6)\n" +
-					"         │              Var (name=a)\n" +
-					"         │              Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
+					"         │        ║        o: Var (name=c)\n" +
+					"         │        ╚══ StatementPattern (resultSizeActual=6) [right]\n" +
+					"         │              s: Var (name=a)\n" +
+					"         │              p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
 					+
-					"         │              Var (name=d)\n" +
-					"         └──StatementPattern (resultSizeActual=2)\n" +
-					"               Var (name=d)\n" +
-					"               Var (name=e)\n" +
-					"               Var (name=f)\n";
+					"         │              o: Var (name=d)\n" +
+					"         └── StatementPattern (resultSizeActual=2) [right]\n" +
+					"               s: Var (name=d)\n" +
+					"               p: Var (name=e)\n" +
+					"               o: Var (name=f)\n";
 
 			assertThat(actual).isEqualToNormalizingNewlines(expected);
 
@@ -657,52 +642,52 @@ public class QueryPlanRetrievalTest {
 			Query query = connection.prepareTupleQuery(UNION_QUERY);
 
 			String actual = query.explain(Explanation.Level.Executed).toString();
-			String expected = "Projection (resultSizeActual=24)\n"
-					+ "╠══ProjectionElemList\n"
-					+ "║     ProjectionElem \"a\"\n"
-					+ "╚══Join (JoinIterator) (resultSizeActual=24)\n"
-					+ "   ├──StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4)\n"
-					+ "   │     Var (name=a)\n"
-					+ "   │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
-					+ "   │     Var (name=type)\n"
-					+ "   └──Union (resultSizeActual=24)\n"
-					+ "      ╠══Join (JoinIterator) (resultSizeActual=20)\n"
-					+ "      ║  ├──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=6)"
-					+ "\n"
-					+ "      ║  │     Var (name=a)\n"
-					+ "      ║  │     Var (name=b)\n"
-					+ "      ║  │     Var (name=c2)\n"
-					+ "      ║  └──Union (resultSizeActual=20)\n"
-					+ "      ║     ╠══Join (JoinIterator) (resultSizeActual=10)\n"
-					+ "      ║     ║  ├──StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)"
-					+ "\n"
-					+ "      ║     ║  │     Var (name=c2)\n"
-					+ "      ║     ║  │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
-					+ "      ║     ║  │     Var (name=type1)\n"
-					+ "      ║     ║  └──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=10)"
-					+ "\n"
-					+ "      ║     ║        Var (name=a)\n"
-					+ "      ║     ║        Var (name=b)\n"
-					+ "      ║     ║        Var (name=c)\n"
-					+ "      ║     ╚══Join (JoinIterator) (resultSizeActual=10)\n"
-					+ "      ║        ├──StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6)"
-					+ "\n"
-					+ "      ║        │     Var (name=c2)\n"
-					+ "      ║        │     Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)"
-					+ "\n"
-					+ "      ║        │     Var (name=type2)\n"
-					+ "      ║        └──StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=10)"
-					+ "\n"
-					+ "      ║              Var (name=a)\n"
-					+ "      ║              Var (name=b)\n"
-					+ "      ║              Var (name=c)\n"
-					+ "      ╚══StatementPattern (new scope) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)"
-					+ "\n"
-					+ "            Var (name=type)\n"
-					+ "            Var (name=d)\n"
-					+ "            Var (name=c)\n";
+			String expected = "Projection (resultSizeActual=24)\n" +
+					"╠══ ProjectionElemList\n" +
+					"║     ProjectionElem \"a\"\n" +
+					"╚══ Join (JoinIterator) (resultSizeActual=24)\n" +
+					"   ├── StatementPattern (costEstimate=1, resultSizeEstimate=4, resultSizeActual=4) [left]\n" +
+					"   │     s: Var (name=a)\n" +
+					"   │     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+
+					"   │     o: Var (name=type)\n" +
+					"   └── Union (resultSizeActual=24) [right]\n" +
+					"      ╠══ Join (JoinIterator) (resultSizeActual=20)\n" +
+					"      ║  ├── StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=6) [left]\n"
+					+
+					"      ║  │     s: Var (name=a)\n" +
+					"      ║  │     p: Var (name=b)\n" +
+					"      ║  │     o: Var (name=c2)\n" +
+					"      ║  └── Union (resultSizeActual=20) [right]\n" +
+					"      ║     ╠══ Join (JoinIterator) (resultSizeActual=10)\n" +
+					"      ║     ║  ├── StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6) [left]\n"
+					+
+					"      ║     ║  │     s: Var (name=c2)\n" +
+					"      ║     ║  │     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+
+					"      ║     ║  │     o: Var (name=type1)\n" +
+					"      ║     ║  └── StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=10) [right]\n"
+					+
+					"      ║     ║        s: Var (name=a)\n" +
+					"      ║     ║        p: Var (name=b)\n" +
+					"      ║     ║        o: Var (name=c)\n" +
+					"      ║     ╚══ Join (JoinIterator) (resultSizeActual=10)\n" +
+					"      ║        ├── StatementPattern (new scope) (costEstimate=2, resultSizeEstimate=4, resultSizeActual=6) [left]\n"
+					+
+					"      ║        │     s: Var (name=c2)\n" +
+					"      ║        │     p: Var (name=_const_f5e5585a_uri, value=http://www.w3.org/1999/02/22-rdf-syntax-ns#type, anonymous)\n"
+					+
+					"      ║        │     o: Var (name=type2)\n" +
+					"      ║        └── StatementPattern (costEstimate=2, resultSizeEstimate=12, resultSizeActual=10) [right]\n"
+					+
+					"      ║              s: Var (name=a)\n" +
+					"      ║              p: Var (name=b)\n" +
+					"      ║              o: Var (name=c)\n" +
+					"      ╚══ StatementPattern (new scope) (costEstimate=5, resultSizeEstimate=12, resultSizeActual=4)\n"
+					+
+					"            s: Var (name=type)\n" +
+					"            p: Var (name=d)\n" +
+					"            o: Var (name=c)\n";
 
 			assertThat(actual).isEqualToNormalizingNewlines(expected);
 
@@ -935,14 +920,14 @@ public class QueryPlanRetrievalTest {
 	public void testWildcard() {
 
 		String expected = "Projection\n" +
-				"╠══ProjectionElemList\n" +
+				"╠══ ProjectionElemList\n" +
 				"║     ProjectionElem \"a\"\n" +
 				"║     ProjectionElem \"b\"\n" +
 				"║     ProjectionElem \"c\"\n" +
-				"╚══StatementPattern (resultSizeEstimate=12)\n" +
-				"      Var (name=a)\n" +
-				"      Var (name=b)\n" +
-				"      Var (name=c)\n";
+				"╚══ StatementPattern (resultSizeEstimate=12)\n" +
+				"      s: Var (name=a)\n" +
+				"      p: Var (name=b)\n" +
+				"      o: Var (name=c)\n";
 		SailRepository sailRepository = new SailRepository(new MemoryStore());
 		addData(sailRepository);
 
@@ -960,22 +945,22 @@ public class QueryPlanRetrievalTest {
 	public void testArbitraryLengthPath() {
 
 		String expected = "Projection\n" +
-				"╠══ProjectionElemList\n" +
+				"╠══ ProjectionElemList\n" +
 				"║     ProjectionElem \"a\"\n" +
 				"║     ProjectionElem \"b\"\n" +
 				"║     ProjectionElem \"c\"\n" +
 				"║     ProjectionElem \"d\"\n" +
-				"╚══Join (JoinIterator)\n" +
-				"   ├──StatementPattern (costEstimate=6, resultSizeEstimate=12)\n" +
-				"   │     Var (name=a)\n" +
-				"   │     Var (name=b)\n" +
-				"   │     Var (name=c)\n" +
-				"   └──ArbitraryLengthPath (costEstimate=5, resultSizeEstimate=24)\n" +
+				"╚══ Join (JoinIterator)\n" +
+				"   ├── StatementPattern (costEstimate=6, resultSizeEstimate=12) [left]\n" +
+				"   │     s: Var (name=a)\n" +
+				"   │     p: Var (name=b)\n" +
+				"   │     o: Var (name=c)\n" +
+				"   └── ArbitraryLengthPath (costEstimate=5, resultSizeEstimate=24) [right]\n" +
 				"         Var (name=c)\n" +
 				"         StatementPattern (resultSizeEstimate=0)\n" +
-				"            Var (name=c)\n" +
-				"            Var (name=_const_f804988f_uri, value=http://a, anonymous)\n" +
-				"            Var (name=d)\n" +
+				"            s: Var (name=c)\n" +
+				"            p: Var (name=_const_f804988f_uri, value=http://a, anonymous)\n" +
+				"            o: Var (name=d)\n" +
 				"         Var (name=d)\n" +
 				"";
 		SailRepository sailRepository = new SailRepository(new MemoryStore());

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryComplianceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/query/parser/sparql/manifest/SPARQLQueryComplianceTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.StringWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.common.io.IOUtil;
@@ -52,6 +54,7 @@ import org.eclipse.rdf4j.query.resultio.QueryResultIO;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultParser;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -304,6 +307,17 @@ public abstract class SPARQLQueryComplianceTest extends SPARQLComplianceTest {
 
 			message.append("# Query:\n\n");
 			message.append(readQueryString().trim()).append("\n");
+			message.append(footer).append("\n");
+
+			message.append("# Data:\n\n");
+			try (RepositoryConnection connection = dataRepository.getConnection()) {
+				try (RepositoryResult<Statement> statements = connection.getStatements(null, null, null)) {
+					List<Statement> collect = statements.stream().collect(Collectors.toList());
+					StringWriter stringWriter = new StringWriter();
+					Rio.write(collect, stringWriter, RDFFormat.TRIG);
+					message.append(stringWriter.toString().trim()).append("\n");
+				}
+			}
 			message.append(footer).append("\n");
 
 			message.append("# Expected bindings:\n\n");

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BasicTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/testsuite/sparql/tests/BasicTest.java
@@ -10,9 +10,17 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.testsuite.sparql.tests;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.DC;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.AbstractTupleQueryResultHandler;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryLanguage;
@@ -43,6 +51,30 @@ public class BasicTest extends AbstractComplianceTest {
 						fail("nobody is self published");
 					}
 				});
+	}
+
+	@Test
+	public void testIdenticalVariablesSubjectContextInStatementPattern() {
+		conn.add(EX.ALICE, FOAF.KNOWS, EX.BOB, EX.ALICE);
+		conn.add(EX.ALICE, RDF.TYPE, FOAF.PERSON, EX.ALICE);
+		conn.add(EX.ALICE, FOAF.KNOWS, EX.A, EX.BOB);
+		conn.add(EX.ALICE, FOAF.KNOWS, EX.B, EX.BOB);
+		conn.add(EX.ALICE, FOAF.KNOWS, EX.C, EX.BOB);
+		conn.add(EX.ALICE, FOAF.KNOWS, EX.MARY, EX.BOB);
+
+		String queryBuilder = "SELECT ?knows { " +
+				"	graph ?alice {" +
+				"		?alice a <" + FOAF.PERSON + ">; " +
+				"			<" + FOAF.KNOWS + "> ?knows ." +
+				"		}" +
+				"}";
+
+		try (Stream<BindingSet> stream = conn.prepareTupleQuery(QueryLanguage.SPARQL, queryBuilder)
+				.evaluate()
+				.stream()) {
+			List<Value> knows = stream.map(b -> b.getValue("knows")).collect(Collectors.toList());
+			assertEquals(List.of(EX.BOB), knows);
+		}
 	}
 
 }


### PR DESCRIPTION
GitHub issue resolved: #4659 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

 - add test
 - reorder code so that the getters are always created in the StatementPatternQueryEvaluationStep, even if they are duplicates
 - also slightly improve the human readable format of the query plans explanation

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

