### PR TITLE
GH-4711 Improve chances that iterations are closed on time in FedX

### DIFF
--- a/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/Iterations.java
+++ b/core/common/iterator/src/main/java/org/eclipse/rdf4j/common/iteration/Iterations.java
@@ -50,11 +50,13 @@ public class Iterations {
 	 * @return a List containing all elements obtained from the specified iteration.
 	 */
 	public static <E, X extends Exception> List<E> asList(CloseableIteration<? extends E, X> iter) throws X {
-		// stream.collect is slightly slower than addAll for lists
-		List<E> list = new ArrayList<>();
+		try (iter) {
+			// stream.collect is slightly slower than addAll for lists
+			List<E> list = new ArrayList<>();
 
-		// addAll closes the iteration
-		return addAll(iter, list);
+			// addAll closes the iteration
+			return addAll(iter, list);
+		}
 	}
 
 	/**
@@ -115,15 +117,12 @@ public class Iterations {
 	 */
 	public static <E, X extends Exception, C extends Collection<E>> C addAll(CloseableIteration<? extends E, X> iter,
 			C collection) throws X {
-		try {
+		try (iter) {
 			while (iter.hasNext()) {
 				collection.add(iter.next());
 			}
-		} finally {
-			closeCloseable(iter);
+			return collection;
 		}
-
-		return collection;
 	}
 
 	/**
@@ -215,9 +214,11 @@ public class Iterations {
 	 * @return A String representation of the objects provided by the supplied iteration.
 	 */
 	public static <X extends Exception> String toString(CloseableIteration<?, X> iteration, String separator) throws X {
-		StringBuilder sb = new StringBuilder();
-		toString(iteration, separator, sb);
-		return sb.toString();
+		try (iteration) {
+			StringBuilder sb = new StringBuilder();
+			toString(iteration, separator, sb);
+			return sb.toString();
+		}
 	}
 
 	/**
@@ -253,11 +254,13 @@ public class Iterations {
 	public static <X extends Exception> void toString(CloseableIteration<?, X> iteration, String separator,
 			StringBuilder sb)
 			throws X {
-		while (iteration.hasNext()) {
-			sb.append(iteration.next());
+		try (iteration) {
+			while (iteration.hasNext()) {
+				sb.append(iteration.next());
 
-			if (iteration.hasNext()) {
-				sb.append(separator);
+				if (iteration.hasNext()) {
+					sb.append(separator);
+				}
 			}
 		}
 
@@ -295,4 +298,5 @@ public class Iterations {
 		}
 		return set;
 	}
+
 }

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelServiceExecutor.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelServiceExecutor.java
@@ -164,7 +164,9 @@ public class ParallelServiceExecutor extends LookAheadIteration<BindingSet, Quer
 			// Note: in order two avoid deadlocks we consume the SERVICE result.
 			// This is basically required to avoid processing background tuple
 			// request (i.e. HTTP slots) in the correct order.
-			return new CollectionIteration<>(Iterations.asList(strategy.evaluate(service.getService(), bindings)));
+			try (var evaluate = strategy.evaluate(service.getService(), bindings)) {
+				return new CollectionIteration<>(Iterations.asList(evaluate));
+			}
 		}
 
 		@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelTaskBase.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/concurrent/ParallelTaskBase.java
@@ -107,7 +107,23 @@ public abstract class ParallelTaskBase<T> implements ParallelTask<T> {
 						logger.debug("Attempting to cancel task {}", this);
 						boolean successfullyCanceled = scheduledFuture.cancel(true);
 						if (!successfullyCanceled) {
-							logger.debug("Task {} could not be cancelled properly.", this);
+							logger.debug("Task {} could not be cancelled properly. Maybe it has already completed.",
+									this);
+						}
+
+						int timeout = 100;
+						for (int i = 0; i < timeout && !scheduledFuture.isDone(); i++) {
+							try {
+								Thread.sleep(1);
+							} catch (InterruptedException e) {
+								Thread.currentThread().interrupt();
+								break;
+							}
+						}
+
+						if (!scheduledFuture.isDone()) {
+							logger.error("Timeout while waiting for task {} to terminate after it was cancelled.",
+									this);
 						}
 					}
 				}

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/CloseDependentConnectionIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/CloseDependentConnectionIteration.java
@@ -38,6 +38,12 @@ public class CloseDependentConnectionIteration<T> extends AbstractCloseableItera
 	@Override
 	public boolean hasNext() throws QueryEvaluationException {
 		try {
+			if (Thread.interrupted()) {
+				Thread.currentThread().interrupt();
+				close();
+				return false;
+			}
+
 			boolean res = inner.hasNext();
 			if (!res) {
 				close();

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/ConsumingIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/ConsumingIteration.java
@@ -55,6 +55,11 @@ public class ConsumingIteration implements CloseableIteration<BindingSet, QueryE
 		try {
 			while (consumed.size() < max && iter.hasNext()) {
 				consumed.add(iter.next());
+				if (Thread.interrupted()) {
+					Thread.currentThread().interrupt();
+					close();
+					return;
+				}
 			}
 			if (!iter.hasNext()) {
 				iter.close();
@@ -62,7 +67,7 @@ public class ConsumingIteration implements CloseableIteration<BindingSet, QueryE
 			completed = true;
 		} finally {
 			if (!completed) {
-				iter.close();
+				close();
 			}
 		}
 
@@ -70,6 +75,12 @@ public class ConsumingIteration implements CloseableIteration<BindingSet, QueryE
 
 	@Override
 	public boolean hasNext() throws QueryEvaluationException {
+		if (Thread.interrupted()) {
+			Thread.currentThread().interrupt();
+			close();
+			return false;
+		}
+
 		return currentIndex < consumed.size() || innerIter.hasNext();
 	}
 

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelServiceJoinTask.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/ParallelServiceJoinTask.java
@@ -49,7 +49,9 @@ public class ParallelServiceJoinTask extends ParallelTaskBase<BindingSet> {
 		// Note: in order two avoid deadlocks we consume the SERVICE result.
 		// This is basically required to avoid processing background tuple
 		// request (i.e. HTTP slots) in the correct order.
-		return new CollectionIteration<>(Iterations.asList(strategy.evaluateService(expr, bindings)));
+		try (var iter = strategy.evaluateService(expr, bindings)) {
+			return new CollectionIteration<>(Iterations.asList(iter));
+		}
 	}
 
 	@Override

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/optimizer/SourceSelection.java
@@ -321,8 +321,8 @@ public class SourceSelection {
 		protected CloseableIteration<BindingSet, QueryEvaluationException> performTaskInternal() throws Exception {
 			try {
 				TripleSource t = endpoint.getTripleSource();
-				boolean hasResults;
-				hasResults = t.hasStatements(stmt, EmptyBindingSet.getInstance(), queryInfo, queryInfo.getDataset());
+				boolean hasResults = t.hasStatements(stmt, EmptyBindingSet.getInstance(), queryInfo,
+						queryInfo.getDataset());
 
 				SourceSelection sourceSelection = control.sourceSelection;
 				sourceSelection.cache.updateInformation(new SubQuery(stmt, queryInfo.getDataset()), endpoint,


### PR DESCRIPTION
GitHub issue resolved: #4711 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

