### PR TITLE
GH-4714 be more defensive in case a bug results in value being null

### DIFF
--- a/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
+++ b/core/sail/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/results/ValidationResult.java
@@ -38,6 +38,8 @@ import org.eclipse.rdf4j.sail.shacl.ast.Shape;
 import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.ConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ast.constraintcomponents.SparqlConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.ast.paths.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The ValidationResult represents the results from a SHACL validation in an easy-to-use Java API.
@@ -47,6 +49,8 @@ import org.eclipse.rdf4j.sail.shacl.ast.paths.Path;
  */
 @Deprecated
 public class ValidationResult {
+
+	private static final Logger logger = LoggerFactory.getLogger(ValidationResult.class);
 
 	private Resource id;
 	private final Optional<Value> value;
@@ -73,7 +77,18 @@ public class ValidationResult {
 
 		if (sourceConstraintComponent.producesValidationResultValue()) {
 			assert value != null;
-			this.value = Optional.of(value);
+
+			// value could be null if assertions are disabled
+			// noinspection ConstantValue
+			if (value == null) {
+				logger.error(
+						"Source constraint component {} was expected to produce a value, but value is null! Shape: {}",
+						sourceConstraintComponent, shape);
+			}
+
+			// value could be null if assertions are disabled
+			// noinspection OptionalOfNullableMisuse
+			this.value = Optional.ofNullable(value);
 		} else {
 			assert scope != ConstraintComponent.Scope.propertyShape || value == null;
 			this.value = Optional.empty();


### PR DESCRIPTION
GitHub issue resolved: #4714 <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

