### PR TITLE
GH-5393: prevent the configuration migration routine to be invoked with an already open input stream for `config.ttl`

### DIFF
--- a/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
+++ b/core/repository/manager/src/main/java/org/eclipse/rdf4j/repository/manager/LocalRepositoryManager.java
@@ -263,6 +263,7 @@ public class LocalRepositoryManager extends RepositoryManager {
 			File configFile = new File(dataDir, CFG_FILE);
 			try {
 				Model model;
+				// We read the input and close it so that it may be reopend by the migration process
 				try (InputStream input = new FileInputStream(configFile)) {
 					model = Rio.parse(input, configFile.toURI().toString(), CONFIG_FORMAT);
 				}


### PR DESCRIPTION
GitHub issue resolved: #5393

Briefly describe the changes proposed in this PR:

The proposed fix is to reduce the scope of the try-with-resources construct, so that the migration routine is called outside of it.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

