### PR TITLE
GH-5433 Use RWLockManager in LmdbStore

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -78,6 +78,8 @@ import java.util.StringTokenizer;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 
+import org.eclipse.rdf4j.common.concurrent.locks.Lock;
+import org.eclipse.rdf4j.common.concurrent.locks.ReadWriteLockManager;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.TxnManager.Mode;
 import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
@@ -1081,8 +1083,13 @@ class TripleStore implements Closeable {
 					try {
 						E(mdb_txn_commit(writeTxn));
 						if (recordCache != null) {
-							StampedLock lock = txnManager.lock();
-							long stamp = lock.writeLock();
+							ReadWriteLockManager lockManager = txnManager.lockManager();
+							Lock lock;
+							try {
+								lock = lockManager.getReadLock();
+							} catch (InterruptedException e) {
+								throw new SailException(e);
+							}
 							try {
 								txnManager.deactivate();
 								mapSize = LmdbUtil.autoGrowMapSize(mapSize, pageSize, 0);
@@ -1102,7 +1109,7 @@ class TripleStore implements Closeable {
 								try {
 									txnManager.activate();
 								} finally {
-									lock.unlockWrite(stamp);
+									lock.release();
 								}
 							}
 						} else {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/RecordIteratorBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/RecordIteratorBenchmark.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.util.Files;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @author Piotr Sowiński
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 4, jvmArgs = { "-Xms1G", "-Xmx1G" })
+@Threads(value = 8)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class RecordIteratorBenchmark {
+
+	private File dataDir;
+	private TripleStore tripleStore;
+
+	@Setup(Level.Trial)
+	public void setup() throws IOException {
+		dataDir = Files.newTemporaryFolder();
+		tripleStore = new TripleStore(dataDir, new LmdbStoreConfig("spoc,posc"));
+
+		final int statements = 1_000_000;
+		tripleStore.startTransaction();
+		for (int i = 0; i < statements; i++) {
+			tripleStore.storeTriple(i, i + 1, i + 2, 1, true);
+		}
+		tripleStore.commit();
+	}
+
+	@TearDown(Level.Trial)
+	public void tearDown() throws IOException {
+		tripleStore.close();
+		FileUtils.deleteDirectory(dataDir);
+	}
+
+	@Benchmark
+	public void iterateAll(Blackhole blackhole) throws IOException {
+		try (TxnManager.Txn txn = tripleStore.getTxnManager().createReadTxn()) {
+			try (RecordIterator it = tripleStore.getTriples(txn, 0, 0, 0, 1, true)) {
+				long[] item;
+				while ((item = it.next()) != null) {
+					blackhole.consume(item);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #5433

Sister PR of #5434 – that one focuses on ValueStore, this one tackles record iteration.

Briefly describe the changes proposed in this PR:

I followed the suggestion from @hmottestad to use `ReadPrefReadWriteLockManager` instead of `StampedLock` for record iterators in LmdbStore, as we were running into lock contention issues. Unfortunately, for this case optimistic read locks are not really a solution, as there is complex state that needs to be managed... well, at least I don't feel qualified enough to solve that.

Instead this uses a more scalable locking mechanism. I made a benchmark specifically focusing on long parallel iterations (because that's what I was struggling with originally), with a configurable number of reader threads and no writers.

Results – milliseconds per iteration (scanning 1 million records) (details are below in a dropdown):

| Variant / Threads | 1 | 4 | 8 |
|---|---:|---:|---:|
| Current (`StampedLock`) | 40.481 | 120.504 | 700.674 |
| `ReadPrefReadWriteLockManager`, default sett. | 71.937 | 91.528 | 126.223 |
| `ReadPrefReadWriteLockManager`, no tracking | 45.579 | 62.173 | 97.217 |

With the current setup, performance falls of a cliff very quickly as we increase the number of threads – with 8 parallel iterations, the code is ~17x slower than with just one iteration. When I tried the fancy `ReadPrefReadWriteLockManager` with default settings, it was *way faster* for 8 threads (126 vs 700 ms...), a bit faster for 4, and much slower for 1. I profiled this and the reason was the stuff around lock cleaners, which are used to get rid of locks that we somehow forgot to release.

The original code had no such protections, so I reconfigured the manager to ignore this and this yielded even better perf for 4 and 8 threads, while with 1 thread, this is only 5ms slower than the original.

It's a trade-off – slightly slower single-threaded perf for much better multi-threaded. It's an open question if this is worth it for you. For me it is, but I *really* need parallel SPARQL queries.

I profiled the last variant, and there is really not much to trim out there. I think the best solution would be to simply acquire the lock less frequently and process batches of records in each lock. This would amortize the cost nicely. But I think that's out of scope for this PR.

<details>
  <summary>JMH results</summary>

  CPU: AMD Ryzen 9 7900 12-Core Processor, 5.0 GHz, with plenty of cooling (the thing can run 5.0 GHz sustained on all cores without throttling).

  All benchmarks were run with 4 forks (sequentially) to reduce variance.

  ### 1-thread benchmark

  Setup:

  ```
  # JMH version: 1.37
  # VM version: JDK 23.0.1, OpenJDK 64-Bit Server VM, 23.0.1+11-39
  # VM invoker: /home/piotr/.jdks/openjdk-23.0.1/bin/java
  # VM options: -Xms1G -Xmx1G
  # Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
  # Warmup: 5 iterations, 10 s each
  # Measurement: 10 iterations, 10 s each
  # Timeout: 10 min per iteration
  # Threads: 1 thread, will synchronize iterations
  # Benchmark mode: Average time, time/op
  # Benchmark: org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll
  ```

  Original:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    40.481 ?(99.9%) 0.170 ms/op [Average]
    (min, avg, max) = (39.778, 40.481, 41.120), stdev = 0.303
    CI (99.9%): [40.310, 40.651] (assumes normal distribution)

  Benchmark                           Mode  Cnt   Score   Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  40.481 ? 0.170  ms/op
  ```

  With `ReadPrefReadWriteLockManager`:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    71.937 ?(99.9%) 0.209 ms/op [Average]
    (min, avg, max) = (71.410, 71.937, 72.984), stdev = 0.372
    CI (99.9%): [71.728, 72.147] (assumes normal distribution)

  Benchmark                           Mode  Cnt   Score   Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  71.937 ? 0.209  ms/op
  ```

  With `ReadPrefReadWriteLockManager`, lock tracking disabled:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    45.579 ?(99.9%) 0.138 ms/op [Average]
    (min, avg, max) = (45.235, 45.579, 46.009), stdev = 0.245
    CI (99.9%): [45.441, 45.716] (assumes normal distribution)

  Benchmark                           Mode  Cnt   Score   Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  45.579 ? 0.138  ms/op
  ```

  ### 4-thread benchmark

  Setup:

  ```
  # Threads: 4 threads, will synchronize iterations
  (other settings identical)
  ```

  Original:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    120.504 ?(99.9%) 4.500 ms/op [Average]
    (min, avg, max) = (101.650, 120.504, 131.451), stdev = 7.999
    CI (99.9%): [116.004, 125.004] (assumes normal distribution)

  Benchmark                           Mode  Cnt    Score   Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  120.504 ? 4.500  ms/op
  ```

  With `ReadPrefReadWriteLockManager`:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    91.528 ?(99.9%) 3.002 ms/op [Average]
    (min, avg, max) = (82.396, 91.528, 100.214), stdev = 5.336
    CI (99.9%): [88.526, 94.530] (assumes normal distribution)

  Benchmark                           Mode  Cnt   Score   Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  91.528 ? 3.002  ms/op
  ```

  With `ReadPrefReadWriteLockManager`, lock tracking disabled:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    62.173 ?(99.9%) 1.802 ms/op [Average]
    (min, avg, max) = (53.231, 62.173, 66.771), stdev = 3.202
    CI (99.9%): [60.371, 63.974] (assumes normal distribution)

  Benchmark                           Mode  Cnt   Score   Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  62.173 ? 1.802  ms/op
  ```

  ### 8-thread benchmark

  ```
  # Threads: 8 threads, will synchronize iterations
  (other settings identical)
  ```

  Original:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    700.674 ?(99.9%) 54.522 ms/op [Average]
    (min, avg, max) = (550.567, 700.674, 910.088), stdev = 96.913
    CI (99.9%): [646.152, 755.196] (assumes normal distribution)

  Benchmark                           Mode  Cnt    Score    Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  700.674 ? 54.522  ms/op
  ```

  With `ReadPrefReadWriteLockManager`:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    126.223 ?(99.9%) 6.659 ms/op [Average]
    (min, avg, max) = (97.537, 126.223, 138.715), stdev = 11.837
    CI (99.9%): [119.563, 132.882] (assumes normal distribution)

  Benchmark                           Mode  Cnt    Score   Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  126.223 ? 6.659  ms/op
  ```

  With `ReadPrefReadWriteLockManager`, lock tracking disabled:

  ```
  Result "org.eclipse.rdf4j.sail.lmdb.RecordIteratorBenchmark.iterateAll":
    97.217 ?(99.9%) 4.828 ms/op [Average]
    (min, avg, max) = (80.622, 97.217, 112.429), stdev = 8.582
    CI (99.9%): [92.388, 102.045] (assumes normal distribution)
  
  Benchmark                           Mode  Cnt   Score   Error  Units
  RecordIteratorBenchmark.iterateAll  avgt   40  97.217 ? 4.828  ms/op
  ```

</details>

*Oh, I couldn't place the new benchmark in the `.benchmark` package, because `TripleStore` is not public – not sure what to do with that.*

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

