### PR TITLE
GH-5291 Add asynchronous fsync to LuceneSail

### DIFF
--- a/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/core/sail/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -290,6 +290,21 @@ public class LuceneSail extends NotifyingSailWrapper {
 	public static final String LUCENE_RAMDIR_KEY = "useramdir";
 
 	/**
+	 * Set the key "fsyncInterval=&lt;t&gt;" as sail parameter to configure the interval in milliseconds in which fsync
+	 * is called on the Lucene index. Set to 0 or a negative value to call fsync synchronously after each operation.
+	 * Default is 0. Setting this parameter to a positive value will improve performance for frequent writes, but may
+	 * cause the loss of the last few operations in case of a crash.
+	 */
+	public static final String FSYNC_INTERVAL_KEY = "fsyncInterval";
+
+	/**
+	 * Set the key "fsyncMaxPendingFiles=&lt;n&gt;" as sail parameter to configure the maximum number of files pending
+	 * to be fsynced. When this number is reached, a fsync is forced to limit memory usage. Default is 5000. This
+	 * parameter only has an effect when {@link #FSYNC_INTERVAL_KEY} is set to a positive value.
+	 */
+	public static final String FSYNC_MAX_PENDING_FILES_KEY = "fsyncMaxPendingFiles";
+
+	/**
 	 * Set the key "defaultNumDocs=&lt;n&gt;" as sail parameter to limit the maximum number of documents to return from
 	 * a search query. The default is to return all documents. NB: this may involve extra cost for some SearchIndex
 	 * implementations as they may have to determine this number.

--- a/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/impl/DelayedSyncDirectoryWrapper.java
+++ b/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/impl/DelayedSyncDirectoryWrapper.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wrapper around a Lucene Directory that batches sync and metadata sync calls to be executed at a fixed interval.
+ *
+ * @author Piotr Sowiński
+ */
+class DelayedSyncDirectoryWrapper extends FilterDirectory {
+
+	final private Logger logger = LoggerFactory.getLogger(getClass());
+
+	final private ScheduledExecutorService scheduler;
+
+	final private AtomicBoolean needsMetadataSync = new AtomicBoolean(false);
+
+	final private AtomicReference<IOException> lastSyncException = new AtomicReference<>(null);
+
+	final private HashSet<String> pendingSyncs = new HashSet<>();
+
+	final private int maxPendingSyncs;
+
+	/**
+	 * Creates a new instance of LuceneDirectoryWrapper.
+	 *
+	 * @param in              the underlying directory
+	 * @param fsyncInterval   the interval in milliseconds writes after which a fsync is performed
+	 * @param maxPendingSyncs the maximum number of pending syncs to accumulate before forcing a sync
+	 */
+	DelayedSyncDirectoryWrapper(Directory in, long fsyncInterval, int maxPendingSyncs) {
+		super(in);
+		assert fsyncInterval > 0;
+		assert maxPendingSyncs > 0;
+		this.maxPendingSyncs = maxPendingSyncs;
+		scheduler = Executors.newScheduledThreadPool(1);
+		scheduler.scheduleAtFixedRate(
+				this::doSync,
+				fsyncInterval,
+				fsyncInterval,
+				TimeUnit.MILLISECONDS
+		);
+	}
+
+	private void doSync() {
+		List<String> toSync;
+		synchronized (pendingSyncs) {
+			toSync = new ArrayList<>(pendingSyncs);
+			pendingSyncs.clear();
+		}
+		if (!toSync.isEmpty()) {
+			try {
+				super.sync(toSync);
+			} catch (IOException e) {
+				lastSyncException.set(e);
+				logger.error("IO error during a periodic sync of Lucene index files", e);
+			}
+		}
+		if (this.needsMetadataSync.getAndSet(false)) {
+			try {
+				super.syncMetaData();
+			} catch (IOException e) {
+				lastSyncException.set(e);
+				logger.error("IO error during a periodic sync of Lucene index metadata", e);
+			}
+		}
+	}
+
+	@Override
+	public void sync(Collection<String> names) throws IOException {
+		final IOException ex = lastSyncException.getAndSet(null);
+		if (ex != null) {
+			// Rethrow the last exception if there was one.
+			// This will fail the current transaction, and not the one that caused the original exception.
+			// But there is no other way to notify the caller of the error, as the sync is done asynchronously.
+			throw ex;
+		}
+		synchronized (pendingSyncs) {
+			pendingSyncs.addAll(names);
+			if (pendingSyncs.size() >= maxPendingSyncs) {
+				// If we have accumulated too many pending syncs, do a sync right away
+				// to avoid excessive memory usage
+				doSync();
+			}
+		}
+	}
+
+	@Override
+	public void syncMetaData() throws IOException {
+		needsMetadataSync.set(true);
+	}
+
+	@Override
+	public void close() throws IOException {
+		// Finish the current sync task, if in progress and then shut down
+		try {
+			scheduler.shutdown();
+		} finally {
+			// Do a final sync of any remaining files
+			try {
+				doSync();
+			} finally {
+				super.close();
+			}
+		}
+	}
+}

--- a/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndex.java
+++ b/core/sail/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneIndex.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -227,6 +226,23 @@ public class LuceneIndex extends AbstractLuceneIndex {
 			throw new IOException("No luceneIndex set, and no '" + LuceneSail.LUCENE_DIR_KEY + "' or '"
 					+ LuceneSail.LUCENE_RAMDIR_KEY + "' parameter given. ");
 		}
+		long fsyncInterval = 0;
+		int maxPendingSyncs = 5000;
+		try {
+			var param = parameters.getProperty(LuceneSail.FSYNC_INTERVAL_KEY, "0");
+			fsyncInterval = Long.parseLong(param);
+		} catch (NumberFormatException e) {
+			logger.warn("Ignoring invalid {} parameter: {}", LuceneSail.FSYNC_INTERVAL_KEY, e.getMessage());
+		}
+		try {
+			var param = parameters.getProperty(LuceneSail.FSYNC_MAX_PENDING_FILES_KEY, "5000");
+			maxPendingSyncs = Integer.parseInt(param);
+		} catch (NumberFormatException e) {
+			logger.warn("Ignoring invalid {} parameter: {}", LuceneSail.FSYNC_MAX_PENDING_FILES_KEY, e.getMessage());
+		}
+		if (fsyncInterval > 0) {
+			dir = new DelayedSyncDirectoryWrapper(dir, fsyncInterval, maxPendingSyncs);
+		}
 		return dir;
 	}
 
@@ -385,10 +401,16 @@ public class LuceneIndex extends AbstractLuceneIndex {
 					}
 				} finally {
 					try {
-						IndexWriter toCloseIndexWriter = indexWriter;
-						indexWriter = null;
-						if (toCloseIndexWriter != null) {
-							toCloseIndexWriter.close();
+						try {
+							IndexWriter toCloseIndexWriter = indexWriter;
+							indexWriter = null;
+							if (toCloseIndexWriter != null) {
+								toCloseIndexWriter.close();
+							}
+						} finally {
+							// Close the directory -- if asynchronous fsync is used, this will clean
+							// up the scheduler thread too.
+							directory.close();
 						}
 					} finally {
 						if (!exceptions.isEmpty()) {

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/DelayedSyncDirectoryWrapperTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/DelayedSyncDirectoryWrapperTest.java
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FilterDirectory;
+import org.apache.lucene.store.RAMDirectory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Piotr Sowiński
+ */
+public class DelayedSyncDirectoryWrapperTest {
+
+	private static final class TrackingDirectory extends FilterDirectory {
+		private AtomicInteger syncCount = new AtomicInteger(0);
+		private AtomicInteger metaSyncCount = new AtomicInteger(0);
+		private AtomicInteger closeCount = new AtomicInteger(0);
+
+		TrackingDirectory(Directory in) {
+			super(in);
+		}
+
+		@Override
+		public void sync(Collection<String> names) throws IOException {
+			syncCount.getAndIncrement();
+			super.sync(names);
+		}
+
+		@Override
+		public void syncMetaData() throws IOException {
+			metaSyncCount.getAndIncrement();
+			super.syncMetaData();
+		}
+
+		@Override
+		public void close() throws IOException {
+			closeCount.getAndIncrement();
+			super.close();
+		}
+
+		public int getSyncCount() {
+			return syncCount.get();
+		}
+
+		public int getMetaSyncCount() {
+			return metaSyncCount.get();
+		}
+
+		public int getCloseCount() {
+			return closeCount.get();
+		}
+	}
+
+	@Test
+	public void testSyncData() throws IOException {
+		final var dir = new TrackingDirectory(new RAMDirectory());
+		final var delayedDir = new DelayedSyncDirectoryWrapper(dir, 500, 100);
+
+		assertEquals(0, dir.getSyncCount());
+		assertEquals(0, dir.getMetaSyncCount());
+
+		delayedDir.sync(List.of("file1", "file2"));
+
+		// The sync should be delayed, so the count should still be 0
+		assertEquals(0, dir.getSyncCount());
+
+		// Wait for more than the fsync interval to allow the scheduled task to run
+		waitFor(700);
+		assertEquals(1, dir.getSyncCount());
+		// Meta sync should still be 0
+		assertEquals(0, dir.getMetaSyncCount());
+
+		delayedDir.close();
+
+		// No additional syncs should have occurred after close
+		assertEquals(1, dir.getSyncCount());
+		assertEquals(0, dir.getMetaSyncCount());
+		assertEquals(1, dir.getCloseCount());
+	}
+
+	@Test
+	public void testSyncMetaData() throws IOException {
+		final var dir = new TrackingDirectory(new RAMDirectory());
+		final var delayedDir = new DelayedSyncDirectoryWrapper(dir, 500, 100);
+
+		assertEquals(0, dir.getSyncCount());
+		assertEquals(0, dir.getMetaSyncCount());
+
+		delayedDir.syncMetaData();
+
+		// The meta sync should be delayed, so the count should still be 0
+		assertEquals(0, dir.getMetaSyncCount());
+
+		// Wait for more than the fsync interval to allow the scheduled task to run
+		waitFor(700);
+		assertEquals(1, dir.getMetaSyncCount());
+		// Regular sync should still be 0
+		assertEquals(0, dir.getSyncCount());
+
+		delayedDir.close();
+
+		// No additional syncs should have occurred after close
+		assertEquals(0, dir.getSyncCount());
+		assertEquals(1, dir.getMetaSyncCount());
+		assertEquals(1, dir.getCloseCount());
+	}
+
+	@Test
+	public void testSyncMixed() throws IOException {
+		final var dir = new TrackingDirectory(new RAMDirectory());
+		final var delayedDir = new DelayedSyncDirectoryWrapper(dir, 500, 100);
+
+		assertEquals(0, dir.getSyncCount());
+		assertEquals(0, dir.getMetaSyncCount());
+
+		delayedDir.sync(List.of("file1", "file2"));
+		delayedDir.sync(List.of("file2", "file456"));
+		delayedDir.syncMetaData();
+		delayedDir.syncMetaData();
+		delayedDir.syncMetaData();
+
+		// The syncs should be delayed, so the counts should still be 0
+		assertEquals(0, dir.getSyncCount());
+		assertEquals(0, dir.getMetaSyncCount());
+
+		// Wait for more than the fsync interval to allow the scheduled task to run
+		waitFor(700);
+		assertEquals(1, dir.getSyncCount());
+		assertEquals(1, dir.getMetaSyncCount());
+
+		delayedDir.sync(List.of("file2", "file456"));
+		delayedDir.syncMetaData();
+
+		waitFor(700);
+		assertEquals(2, dir.getSyncCount());
+		assertEquals(2, dir.getMetaSyncCount());
+
+		// Wait again to ensure no extra syncs occur
+		waitFor(700);
+		assertEquals(2, dir.getSyncCount());
+		assertEquals(2, dir.getMetaSyncCount());
+
+		delayedDir.close();
+
+		// No additional syncs should have occurred after close
+		assertEquals(2, dir.getSyncCount());
+		assertEquals(2, dir.getMetaSyncCount());
+		assertEquals(1, dir.getCloseCount());
+	}
+
+	@Test
+	public void testSyncMixed_afterClose() throws IOException {
+		final var dir = new TrackingDirectory(new RAMDirectory());
+		final var delayedDir = new DelayedSyncDirectoryWrapper(dir, 500, 100);
+
+		assertEquals(0, dir.getSyncCount());
+		assertEquals(0, dir.getMetaSyncCount());
+
+		delayedDir.sync(List.of("file1", "file2"));
+		delayedDir.sync(List.of("file2", "file456"));
+		delayedDir.syncMetaData();
+		delayedDir.syncMetaData();
+		delayedDir.syncMetaData();
+
+		assertEquals(0, dir.getSyncCount());
+		assertEquals(0, dir.getMetaSyncCount());
+
+		delayedDir.close();
+
+		// The syncs should be executed on close
+		assertEquals(1, dir.getSyncCount());
+		assertEquals(1, dir.getMetaSyncCount());
+		assertEquals(1, dir.getCloseCount());
+	}
+
+	@Test
+	public void testCloseOnIndexShutDown() throws IOException {
+		final var dir = new TrackingDirectory(new RAMDirectory());
+		final var delayedDir = new DelayedSyncDirectoryWrapper(dir, 500, 100);
+		final var index = new LuceneIndex(delayedDir, new StandardAnalyzer());
+		assertEquals(0, dir.getCloseCount());
+
+		index.shutDown();
+
+		assertEquals(1, dir.getCloseCount());
+	}
+
+	@Test
+	public void testRethrowLastSyncException() throws IOException {
+		final var dir = new FilterDirectory(new RAMDirectory()) {
+			@Override
+			public void sync(Collection<String> names) throws IOException {
+				throw new IOException("Simulated IO exception during sync");
+			}
+
+			@Override
+			public void syncMetaData() throws IOException {
+				throw new IOException("Simulated IO exception during syncMetaData");
+			}
+		};
+		final var delayedDir = new DelayedSyncDirectoryWrapper(dir, 300, 100);
+
+		// This should not throw immediately
+		delayedDir.sync(List.of("file1", "file2"));
+		waitFor(500);
+		try {
+			delayedDir.syncMetaData();
+		} catch (IOException e) {
+			// The exception from the previous sync should be rethrown here
+			assertEquals("Simulated IO exception during sync", e.getMessage());
+		}
+
+		waitFor(500);
+		try {
+			delayedDir.sync(List.of("file3"));
+		} catch (IOException e) {
+			// The exception from the previous syncMetaData should be rethrown here
+			assertEquals("Simulated IO exception during syncMetaData", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSyncIfOverSyncLimit() throws IOException {
+		final var dir = new TrackingDirectory(new RAMDirectory());
+		final var delayedDir = new DelayedSyncDirectoryWrapper(
+				dir,
+				100_000, // Large interval to prevent scheduled syncs during the test
+				5 // Low max pending syncs to trigger sync quickly
+		);
+
+		assertEquals(0, dir.getSyncCount());
+		delayedDir.sync(List.of("file1", "file2", "file3", "file4"));
+		// Still no sync should have occurred, 4 < 5
+		assertEquals(0, dir.getSyncCount());
+		// Sync the same files again, should still be 4 unique files
+		delayedDir.sync(List.of("file1", "file2", "file3", "file4"));
+		assertEquals(0, dir.getSyncCount());
+		// Sync one more file, should trigger the sync as we now have 5 unique files
+		delayedDir.sync(List.of("file5"));
+		assertEquals(1, dir.getSyncCount());
+	}
+
+	private void waitFor(long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+}

--- a/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneDelayedFsyncTest.java
+++ b/core/sail/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/impl/LuceneDelayedFsyncTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.eclipse.rdf4j.sail.lucene.LuceneSail;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test to verify that when fsync interval is set, the index uses DelayedSyncDirectoryWrapper. It also checks if the
+ * index still works correctly while using the wrapper.
+ *
+ * @author Piotr Sowiński
+ */
+public class LuceneDelayedFsyncTest extends AbstractGenericLuceneTest {
+
+	@TempDir
+	public File dataDir;
+
+	private LuceneIndex index;
+
+	@Override
+	protected void configure(LuceneSail sail) throws IOException {
+		index = new LuceneIndex(new NIOFSDirectory(dataDir.toPath()), new StandardAnalyzer());
+		var params = new Properties();
+		params.setProperty(LuceneSail.FSYNC_INTERVAL_KEY, "5000"); // 5 seconds
+		params.setProperty(LuceneSail.LUCENE_DIR_KEY, dataDir.getAbsolutePath());
+		try {
+			index.initialize(params);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		sail.setLuceneIndex(index);
+	}
+
+	@Test
+	public void testIndexSettings() {
+		assertNotNull(index);
+		assertThat(index.getDirectory()).isInstanceOf(DelayedSyncDirectoryWrapper.class);
+	}
+}


### PR DESCRIPTION
GitHub issue resolved: #5291

Briefly describe the changes proposed in this PR:

As described in the issue, the current setup with an fsync after each transaction is very safe, but also a huge bottleneck when dealing with many small transactions. This PR introduces an option that allows for asynchronous fsyncs in the background, on a fixed interval. If there is nothing to sync, it does nothing.

I tested this with the original workload with which I found the issue. When I set `fsyncInterval` to 5000 ms, it went from ~10–12 TX/s to ~100–150 TX/s, over an HTTP connection. That's basically the same as when I tried removing the fsync entirely. Great :)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

