### PR TITLE
Propagate iteration cache sync threshold to LMDB store

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
@@ -133,6 +133,9 @@ public class LmdbStore extends AbstractNotifyingSail implements FederatedService
 				IsolationLevels.SNAPSHOT, IsolationLevels.SERIALIZABLE);
 		setDefaultIsolationLevel(IsolationLevels.SNAPSHOT_READ);
 		config.getDefaultQueryEvaluationMode().ifPresent(this::setDefaultQueryEvaluationMode);
+		if (config.getIterationCacheSyncThreshold() > 0) {
+			setIterationCacheSyncThreshold(config.getIterationCacheSyncThreshold());
+		}
 		EvaluationStrategyFactory evalStrategyFactory = config.getEvaluationStrategyFactory();
 		if (evalStrategyFactory != null) {
 			setEvaluationStrategyFactory(evalStrategyFactory);

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfigTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfigTest.java
@@ -22,6 +22,8 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -64,6 +66,17 @@ class LmdbStoreConfigTest {
 	}
 
 	// TODO: Add more tests for other properties
+
+	@Test
+	void setIterationCacheSyncThresholdShouldApplyToCreatedStore() {
+		final long threshold = 42;
+		final LmdbStoreConfig config = new LmdbStoreConfig();
+		config.setIterationCacheSyncThreshold(threshold);
+
+		final LmdbStore store = new LmdbStore(config);
+
+		assertThat(store.getIterationCacheSyncThreshold()).isEqualTo(threshold);
+	}
 
 	/**
 	 * Generic method to test parsing and exporting of config properties.


### PR DESCRIPTION
GitHub issue resolved: #3898  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

