### PR TITLE
GH-5532 Add resilient javadoc packaging to release script

### DIFF
--- a/scripts/lib/javadoc.sh
+++ b/scripts/lib/javadoc.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+resolve_javadoc_dir() {
+  local base_dir=${1:-.}
+  local candidates=("target/reports/apidocs" "target/site/apidocs")
+  local candidate
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -d "${base_dir}/${candidate}" ]]; then
+      printf '%s\n' "${base_dir}/${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}

--- a/scripts/tests/test_resolve_javadoc_dir.sh
+++ b/scripts/tests/test_resolve_javadoc_dir.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/../lib"
+
+# shellcheck disable=SC1090
+source "${LIB_DIR}/javadoc.sh"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+mkdir -p "${workdir}/target/reports/apidocs"
+resolved="$(resolve_javadoc_dir "${workdir}")"
+if [[ "${resolved}" != "${workdir}/target/reports/apidocs" ]]; then
+  echo "Expected reports directory but got ${resolved}" >&2
+  exit 1
+fi
+
+rm -rf "${workdir}/target"
+mkdir -p "${workdir}/target/site/apidocs"
+resolved="$(resolve_javadoc_dir "${workdir}")"
+if [[ "${resolved}" != "${workdir}/target/site/apidocs" ]]; then
+  echo "Expected site directory but got ${resolved}" >&2
+  exit 1
+fi
+
+mkdir -p "${workdir}/target/reports/apidocs"
+resolved="$(resolve_javadoc_dir "${workdir}")"
+if [[ "${resolved}" != "${workdir}/target/reports/apidocs" ]]; then
+  echo "Expected reports to take precedence but got ${resolved}" >&2
+  exit 1
+fi
+
+rm -rf "${workdir}/target"
+if resolve_javadoc_dir "${workdir}"; then
+  echo "Expected failure when no javadoc directory exists" >&2
+  exit 1
+else
+  echo "resolve_javadoc_dir correctly fails when directories are missing" >&2
+fi


### PR DESCRIPTION
GitHub issue resolved: #5532  <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

