### PR TITLE
GH-5561 ensure that FILTER NOT EXIST is not lost when adding to an empty GroupGraphPattern

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java
@@ -58,7 +58,14 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 	@Override
 	public GroupGraphPattern and(GraphPattern... patterns) {
 		if (isEmpty() && patterns.length == 1 && (isGGP(patterns[0]))) {
-			copy(GraphPatterns.extractOrConvertToGGP(patterns[0]));
+			GroupGraphPattern ggp = GraphPatterns.extractOrConvertToGGP(patterns[0]);
+			// Only copy if it's a plain GroupGraphPattern, not a specialized subclass
+			// like FilterExistsGraphPattern or MinusGraphPattern which override getQueryString()
+			if (ggp.getClass() == GroupGraphPattern.class) {
+				copy(ggp);
+			} else {
+				addElements(patterns);
+			}
 		} else {
 			addElements(patterns);
 		}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQueryTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQueryTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatternNotTriples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
@@ -52,5 +53,69 @@ public class ModifyQueryTest extends BaseExamples {
 				"?subject ?predicate <http://my-example.com/anyIRI/> . }\n" +
 				"WHERE { OPTIONAL { ?subject ?predicate <http://my-example.com/anyIRI/> . }\n" +
 				"OPTIONAL { ?subject <http://my-example.com/anyIRI/> ?object . } }");
+	}
+
+	@Test
+	public void example_broken_filter_not_exists() {
+		// given
+		Iri subjectIri = iri("http://my-example.com/anyIRI/");
+		Iri classIri = iri("http://my-example.com/SomeClass/");
+		TriplePattern triple = subjectIri.isA(classIri);
+
+		String queryString = Queries.MODIFY()
+				.insert(triple)
+				.where(GraphPatterns.filterNotExists(triple))
+				.getQueryString();
+
+		assertEquals("INSERT { <http://my-example.com/anyIRI/> a <http://my-example.com/SomeClass/> . }\n" +
+		// the WHERE clause is incorrectly generated:
+		// "WHERE { <http://my-example.com/anyIRI/> a <http://my-example.com/SomeClass/> . }",
+		// should be:
+				"WHERE { FILTER NOT EXISTS { <http://my-example.com/anyIRI/> a <http://my-example.com/SomeClass/> . } }",
+				queryString
+		);
+	}
+
+	@Test
+	public void test_GraphPatternNotTriples_getQueryString() {
+		// given
+		Iri subjectIri = iri("http://my-example.com/anyIRI/");
+		Iri classIri = iri("http://my-example.com/SomeClass/");
+		TriplePattern triple = subjectIri.isA(classIri);
+
+		String queryString = GraphPatterns.filterNotExists(triple).getQueryString();
+
+		assertEquals(
+				"FILTER NOT EXISTS { <http://my-example.com/anyIRI/> a <http://my-example.com/SomeClass/> . }",
+				queryString
+		);
+	}
+
+	@Test
+	public void test_GraphPatterns_and_getQueryString() {
+		GraphPatternNotTriples actual = GraphPatterns.and();
+		assertEquals("{}", actual.getQueryString());
+	}
+
+	@Test
+	public void test_GraphPatterns_and_FilterExistsGraphPattern_getQueryString() {
+
+		TriplePattern triple = iri("http://my-example.com/anyIRI/").isA(iri("http://my-example.com/SomeClass/"));
+
+		// emptyGraphPattern by itself yields "{}", see test_GraphPatterns_and_getQueryString
+		GraphPatternNotTriples emptyGraphPattern = GraphPatterns.and();
+
+		// filterNotExists by itself yields "FILTER NOT EXISTS { ... }", see test_GraphPatternNotTriples_getQueryString
+		GraphPatternNotTriples filterNotExists = GraphPatterns.filterNotExists(triple);
+
+		// this is the cause oft the failing example_broken_filter_not_exists test
+		GraphPatternNotTriples withFilterNotExists = emptyGraphPattern.and(filterNotExists);
+
+		String actual = withFilterNotExists.getQueryString();
+
+		assertEquals(
+				"{ FILTER NOT EXISTS { <http://my-example.com/anyIRI/> a <http://my-example.com/SomeClass/> . } }",
+				actual
+		);
 	}
 }


### PR DESCRIPTION

GitHub issue resolved: #5561

Briefly describe the changes proposed in this PR:

Fix bug by ensuring specialized subclasses are only added not extracted when adding to a GroupGraphPattern.

Add example test for wrongly rendered FILTER NOT EXISTS query use cases.


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

