### PR TITLE
GH-5573: support to refine the @context of a JSON-LD document

### DIFF
--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDSettings.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDSettings.java
@@ -63,6 +63,11 @@ public class JSONLDSettings {
 	public static final RioSetting<Document> FRAME = new ClassRioSetting<>(
 			"org.eclipse.rdf4j.rio.jsonld.frame_document",
 			"A no.hasmac.jsonld.document.Document that contains the frame used for framing as specified in https://www.w3.org/TR/json-ld11-framing/",
+			null);
+
+	public static final RioSetting<Document> CONTEXT = new ClassRioSetting<>(
+			"org.eclipse.rdf4j.rio.jsonld.context_document",
+			"A no.hasmac.jsonld.document.Document that contains the JSON-LD context as specified in https://www.w3.org/TR/json-ld11/#the-context. If not defined, the context is created using the namespaces defined in the model",
 			null);;
 
 	/**

--- a/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
+++ b/core/rio/jsonld/src/main/java/org/eclipse/rdf4j/rio/jsonld/JSONLDWriter.java
@@ -267,15 +267,24 @@ public class JSONLDWriter extends AbstractRDFWriter implements CharSink {
 				jsonld = JsonLd.flatten(JsonDocument.of(jsonld)).options(opts).get();
 				break;
 			case COMPACT:
-				JsonObjectBuilder context = Json.createObjectBuilder();
-				for (Namespace namespace : model.getNamespaces()) {
-					if (namespace.getPrefix().isEmpty()) {
-						context.add("@vocab", namespace.getName());
-					} else {
-						context.add(namespace.getPrefix(), namespace.getName());
+				Document context = writerConfig.get(JSONLDSettings.CONTEXT);
+				if (context == null) {
+
+					// define a default context using namespaces provided in the
+					// model if none is provided to the writer settings
+					JsonObjectBuilder contextBuilder = Json.createObjectBuilder();
+					for (Namespace namespace : model.getNamespaces()) {
+						if (namespace.getPrefix().isEmpty()) {
+							contextBuilder.add("@vocab", namespace.getName());
+						} else {
+							contextBuilder.add(namespace.getPrefix(), namespace.getName());
+						}
 					}
+
+					context = JsonDocument.of(contextBuilder.build());
 				}
-				jsonld = JsonLd.compact(JsonDocument.of(jsonld), JsonDocument.of(context.build())).options(opts).get();
+
+				jsonld = JsonLd.compact(JsonDocument.of(jsonld), context).options(opts).get();
 				break;
 			}
 


### PR DESCRIPTION
This change introduces a new setting for the JSONLDWriter, that allows
to configure a JSON-LD Context as Hasmac JsonDocument.


GitHub issue resolved: #5573 

With such JSONLDContextProvider it is possible to refine the JSON-LD @context in an application.

Example:

```
{
    "@id": "https://example.com/bob",
    "@type": "Person",
    "label": {
        "en": "Bob"
    },
    "name": "Bob",
    "@context": {
        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
        "foaf": "http://xmlns.com/foaf/0.1/",
        "@vocab": "https://example.com/",
        "label": {
            "@id": "rdfs:label",
            "@container": "@language"
        },
        "name": "foaf:name",
        "Person": "foaf:Person"
    }
}
```

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

