### PR TITLE
GH-5581 LMDB: remove unneeded volatile keywords

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbBNode.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbBNode.java
@@ -27,11 +27,11 @@ public class LmdbBNode extends SimpleBNode implements LmdbResource {
 	 * Variables *
 	 *-----------*/
 
-	private volatile ValueStoreRevision revision;
+	private ValueStoreRevision revision;
 
-	private volatile long internalID;
+	private long internalID;
 
-	private volatile boolean initialized = false;
+	private boolean initialized = false;
 
 	/*--------------*
 	 * Constructors *

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbIRI.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbIRI.java
@@ -29,11 +29,11 @@ public class LmdbIRI implements LmdbResource, IRI {
 	 * Constants *
 	 *-----------*/
 
-	private volatile ValueStoreRevision revision;
+	private ValueStoreRevision revision;
 
-	private volatile long internalID;
+	private long internalID;
 
-	private volatile boolean initialized = false;
+	private boolean initialized = false;
 	/**
 	 * The IRI string.
 	 */

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
@@ -50,11 +50,11 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	 */
 	private CoreDatatype coreDatatype;
 
-	private volatile ValueStoreRevision revision;
+	private ValueStoreRevision revision;
 
-	private volatile long internalID;
+	private long internalID;
 
-	private volatile boolean initialized = false;
+	private boolean initialized = false;
 
 	/*--------------*
 	 * Constructors *


### PR DESCRIPTION
GitHub issue resolved: #5581 

Briefly describe the changes proposed in this PR:

I was profiling SPARQL queries on top of LMDB again, and I've noticed that creating `LmdbValue` instances and accessing their fields was unusually slow. The reason are the `volatile` keywords on three key fields in each implementation.

I started looking into whether these volatiles are really needed. The following is based on my understanding of how LmdbSail works, which is incomplete, so the reasoning may be flawed.

`volatile` in general is only needed when we need to ensure that when one thread writes a value, other threads immediately see that value. That's expensive, because we need to synchronize cache lines. In the case of `LmdbValue`, I've found the following writes to `volatile` fields:

- `initialized` is only written in the constructor or in a `synchronized` block, where it's double-protected. It therefore has even stronger memory consistency guarantees than `volatile`, so the `volatile` keyword is not needed.
- `internalID` and `revision` are only written to in `setInternalID`.
- `setInternalID` is called from `ValueStoreRevision::resolveValue`, which in turn is only called from within a synchronized block in `init`, so it's well-protected anyway.
- `setInternalID` is also called from the many constructors of `LmdbValue` subclasses. At this point it's impossible to use the object anyway, so this is fine as well.
- `setInternalID` is also called in `ValueStore::getId` from two places.
  - First case: `isOwnValue == true`. In that case we update the revision and internal ID, which is then used in the same thread. Other threads looking at the same value (if there are any) may see a stale revision and internal ID, but they did not request the value to be stored or found in the value store... so I don't see an issue in that.
  - Second case: `isOwnValue == false`. In that case, a new value is constructed, and `setInternalID` is invoked right after the constructor. At this point the value cannot be visible to other threads, so this is fine.

It is possible that I missed something here, though.

I ran into this issue when running queries that count all quads in the store – yes, I know they are not very optimized at the moment, but they are good at surfacing issues with just iterating over a lot of quads without accessing the values. The issue here will be most pronounced in this exact case.

Setup:

```
# JMH version: 1.37
# VM version: JDK 25, Java HotSpot(TM) 64-Bit Server VM, 25+37-LTS-jvmci-b01
# VM invoker: /home/piotr/.jdks/graalvm-jdk-25/bin/java
# VM options: -Xms1G -Xmx1G
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 5 iterations, 10 s each
# Measurement: 8 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.eclipse.rdf4j.sail.lmdb.benchmark.QueryBenchmark.count_all
```

5 forks.

Before:

```
Benchmark                 Mode  Cnt   Score   Error  Units
QueryBenchmark.count_all  avgt   40  27.627 ± 1.260  ms/op
```

After:

```
Benchmark                 Mode  Cnt   Score   Error  Units
QueryBenchmark.count_all  avgt   40  25.442 ± 0.236  ms/op
```

So it's not massive, but still pretty good for a simple change, I think.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

