### PR TITLE
GH-5581: Only use value cache on value resolution

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbBNode.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbBNode.java
@@ -68,6 +68,16 @@ public class LmdbBNode extends SimpleBNode implements LmdbResource {
 	}
 
 	@Override
+	public void setFromInitializedValue(LmdbValue initializedValue) {
+		if (initializedValue instanceof LmdbBNode) {
+			LmdbBNode lmdbBNode = (LmdbBNode) initializedValue;
+			super.setID(lmdbBNode.getID());
+		} else {
+			throw new IllegalArgumentException("Initialized value is not of type LmdbBNode");
+		}
+	}
+
+	@Override
 	public long getInternalID() {
 		return internalID;
 	}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbIRI.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbIRI.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.util.URIUtil;
+import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.ValueStoreRevision;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,6 +85,17 @@ public class LmdbIRI implements LmdbResource, IRI {
 	@Override
 	public ValueStoreRevision getValueStoreRevision() {
 		return revision;
+	}
+
+	@Override
+	public void setFromInitializedValue(LmdbValue initializedValue) {
+		if (initializedValue instanceof LmdbIRI) {
+			LmdbIRI initializedIRI = (LmdbIRI) initializedValue;
+			this.iriString = initializedIRI.iriString;
+			this.localNameIdx = initializedIRI.localNameIdx;
+		} else {
+			throw new SailException("Trying to initialize LmdbIRI from non-IRI value");
+		}
 	}
 
 	@Override

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbLiteral.java
@@ -148,6 +148,19 @@ public class LmdbLiteral extends AbstractLiteral implements LmdbValue {
 	}
 
 	@Override
+	public void setFromInitializedValue(LmdbValue initializedValue) {
+		if (initializedValue instanceof LmdbLiteral) {
+			LmdbLiteral lmdbLiteral = (LmdbLiteral) initializedValue;
+			this.label = lmdbLiteral.label;
+			this.language = lmdbLiteral.language;
+			this.datatype = lmdbLiteral.datatype;
+			this.coreDatatype = lmdbLiteral.coreDatatype;
+		} else {
+			throw new IllegalArgumentException("Initialized value is not of type LmdbLiteral");
+		}
+	}
+
+	@Override
 	public long getInternalID() {
 		return internalID;
 	}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbValue.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/model/LmdbValue.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb.model;
 
+import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.lmdb.ValueStoreRevision;
 
@@ -41,4 +42,14 @@ public interface LmdbValue extends Value {
 	 * @return The revision of the value store that created this value at the time it last set the value's internal ID.
 	 */
 	ValueStoreRevision getValueStoreRevision();
+
+	/**
+	 * Sets this value's data from an initialized value.
+	 * <p>
+	 * This must be only called within a synchronized block in the init() method of the uninitialized value.
+	 *
+	 * @param initializedValue the initialized value to copy data from
+	 */
+	@InternalUseOnly
+	void setFromInitializedValue(LmdbValue initializedValue);
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/ValueStoreCacheTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/ValueStoreCacheTest.java
@@ -10,7 +10,9 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import java.io.File;
@@ -38,12 +40,19 @@ class ValueStoreCacheTest {
 			IRI iri = vf.createIRI("urn:example:foo");
 			long id = vs.getId(iri, true);
 
-			// Populate cache via lazy retrieval
+			// On lazy retrieval, the cache should not be touched
 			LmdbValue v1 = vs.getLazyValue(id);
+			assertNotNull(v1);
+			LmdbValue cached1 = vs.cachedValue(id);
+			assertNull(cached1);
+
+			// After initializing the value, it should be cached
+			assertEquals(v1.stringValue(), "urn:example:foo");
+			LmdbValue cached2 = vs.cachedValue(id);
+			assertSame(v1, cached2);
+
 			// Direct cache hit
 			LmdbValue v2 = vs.cachedValue(id);
-
-			assertNotNull(v1);
 			assertSame(v1, v2);
 		} finally {
 			store.shutDown();

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
@@ -79,6 +79,7 @@ public class QueryBenchmark {
 	private static final String wild_card_chain_with_common_ends;
 	private static final String sub_select;
 	private static final String multiple_sub_select;
+	private static final String count_all;
 
 	static {
 		try {
@@ -116,6 +117,7 @@ public class QueryBenchmark {
 			sub_select = IOUtils.toString(getResourceAsStream("benchmarkFiles/sub-select.qr"), StandardCharsets.UTF_8);
 			multiple_sub_select = IOUtils.toString(
 					getResourceAsStream("benchmarkFiles/multiple-sub-select.qr"), StandardCharsets.UTF_8);
+			count_all = "SELECT (COUNT(*) as ?c) WHERE { ?s ?p ?o }";
 
 		} catch (IOException e) {
 			throw new RuntimeException(e);
@@ -411,6 +413,15 @@ public class QueryBenchmark {
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			return count(connection
 					.prepareTupleQuery(multiple_sub_select)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public long count_all() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return count(connection
+					.prepareTupleQuery(count_all)
 					.evaluate());
 		}
 	}


### PR DESCRIPTION
GitHub issue resolved: #5581

This is a solution that instead of accessing the value cache in `getLazyValue`, instead always contructs a new uninitialized value. The caching was moved to `resolveValue`. The reasoning here is that often many more values will be scanned than those that actually need to be resolved, so this will dramatically reduce the number of times we have to access the cache, reducing false sharing by a lot. I ran both multi-threaded benchmarks (the original repro case) as well as single-threaded benchmarks to show that this does not slow down single-thread workloads.

### Before:

Single-threaded test:

```
Benchmark                                                     Mode  Cnt    Score   Error  Units
QueryBenchmark.complexQuery                                   avgt    5    3.564 ± 0.011  ms/op
QueryBenchmark.different_datasets_with_similar_distributions  avgt    5    1.856 ± 0.032  ms/op
QueryBenchmark.groupByQuery                                   avgt    5    0.698 ± 0.006  ms/op
QueryBenchmark.long_chain                                     avgt    5  565.910 ± 3.086  ms/op
QueryBenchmark.lots_of_optional                               avgt    5  178.545 ± 1.783  ms/op
QueryBenchmark.minus                                          avgt    5    9.007 ± 0.145  ms/op
QueryBenchmark.multiple_sub_select                            avgt    5   49.699 ± 0.610  ms/op
QueryBenchmark.nested_optionals                               avgt    5  133.586 ± 0.402  ms/op
QueryBenchmark.optional_lhs_filter                            avgt    5   34.991 ± 0.362  ms/op
QueryBenchmark.optional_rhs_filter                            avgt    5   48.030 ± 0.359  ms/op
QueryBenchmark.ordered_union_limit                            avgt    5   57.674 ± 0.718  ms/op
QueryBenchmark.pathExpressionQuery1                           avgt    5   17.614 ± 0.290  ms/op
QueryBenchmark.pathExpressionQuery2                           avgt    5    3.280 ± 0.040  ms/op
QueryBenchmark.query_distinct_predicates                      avgt    5   42.575 ± 0.413  ms/op
QueryBenchmark.simple_filter_not                              avgt    5    5.242 ± 0.041  ms/op
QueryBenchmark.sub_select                                     avgt    5   65.373 ± 1.059  ms/op
QueryBenchmarkFoaf.groupByCount                               avgt    5  638.972 ± 9.315  ms/op
QueryBenchmarkFoaf.groupByCountSorted                         avgt    5  561.962 ± 8.249  ms/op
QueryBenchmarkFoaf.personsAndFriends                          avgt    5  172.741 ± 1.140  ms/op
```

Multi-threaded test (8 threads):

```
Benchmark                 Mode  Cnt    Score   Error  Units
QueryBenchmark.count_all  avgt    5  135.211 ± 2.664  ms/op
```


### After (with these changes):

Single-threaded test:

```
Benchmark                                                     Mode  Cnt    Score    Error  Units
QueryBenchmark.complexQuery                                   avgt    5    3.435 ±  0.021  ms/op
QueryBenchmark.different_datasets_with_similar_distributions  avgt    5    1.828 ±  0.018  ms/op
QueryBenchmark.groupByQuery                                   avgt    5    0.756 ±  0.007  ms/op
QueryBenchmark.long_chain                                     avgt    5  547.629 ±  6.772  ms/op
QueryBenchmark.lots_of_optional                               avgt    5  187.523 ±  1.659  ms/op
QueryBenchmark.minus                                          avgt    5    9.111 ±  0.382  ms/op
QueryBenchmark.multiple_sub_select                            avgt    5   50.125 ±  0.342  ms/op
QueryBenchmark.nested_optionals                               avgt    5  128.847 ±  0.808  ms/op
QueryBenchmark.optional_lhs_filter                            avgt    5   36.356 ±  0.403  ms/op
QueryBenchmark.optional_rhs_filter                            avgt    5   47.652 ±  0.370  ms/op
QueryBenchmark.ordered_union_limit                            avgt    5   57.352 ±  0.894  ms/op
QueryBenchmark.pathExpressionQuery1                           avgt    5   17.692 ±  0.327  ms/op
QueryBenchmark.pathExpressionQuery2                           avgt    5    3.293 ±  0.018  ms/op
QueryBenchmark.query_distinct_predicates                      avgt    5   40.898 ±  0.269  ms/op
QueryBenchmark.simple_filter_not                              avgt    5    5.090 ±  0.063  ms/op
QueryBenchmark.sub_select                                     avgt    5   65.731 ±  0.582  ms/op
QueryBenchmarkFoaf.groupByCount                               avgt    5  650.806 ± 14.192  ms/op
QueryBenchmarkFoaf.groupByCountSorted                         avgt    5  577.371 ± 14.822  ms/op
QueryBenchmarkFoaf.personsAndFriends                          avgt    5  167.739 ±  1.640  ms/op
```

Multi-threaded test (8 threads):

```
Benchmark                 Mode  Cnt   Score   Error  Units
QueryBenchmark.count_all  avgt    5  47.777 ± 4.670  ms/op
```

### Analysis:

My original issue is mostly solved now – the code is more than 2x faster. Anecdotally I saw similar speedups for other queries with 8 parallel threads, but gathering these results is very time consuming, so I hope you believe my word. Now the parallel queries are bottlenecked by another contention issue, but that's a topic for a separate PR.

A few single-threaded queries are slightly slower – for example `groupByQuery`. I disassembled the C2-compiled binary for this particular query using `perfasm`. The code was profiled instruction-by-instruction using precise hardware counters ([AMD IBS](https://man7.org/linux/man-pages/man1/perf-amd-ibs.1.html)). It was pretty normal overall, aside from this hot section:


<details>
    <summary>x86-64 assembly dump</summary>

    ```
    0.05%                 0x00007f3ea85b5290:   mov    r10,QWORD PTR [rsp]
    0.05%                 0x00007f3ea85b5294:   mov    DWORD PTR [r10+0x20],r8d
    0.06%                 0x00007f3ea85b5298:   mov    r11,r8
    0.05%                 0x00007f3ea85b529b:   xor    r11,r10
    0.05%                 0x00007f3ea85b529e:   shr    r11,0x14
    0.06%                 0x00007f3ea85b52a2:   test   r11,r11
                    ╭       0x00007f3ea85b52a5:   je     0x00007f3ea85b52c6
    0.04%         │       0x00007f3ea85b52a7:   test   r8d,r8d
    0.00%         │╭      0x00007f3ea85b52aa:   je     0x00007f3ea85b52c6
    0.04%         ││      0x00007f3ea85b52ac:   shr    r10,0x9
    0.04%         ││      0x00007f3ea85b52b0:   movabs rdi,0x7f3e9f600000
    0.04%         ││      0x00007f3ea85b52ba:   add    rdi,r10
    0.09%         ││      0x00007f3ea85b52bd:   cmp    BYTE PTR [rdi],0x2
    0.00%         ││      0x00007f3ea85b52c0:   jne    0x00007f3ea85b56d9
    0.06%         ↘↘      0x00007f3ea85b52c6:   mov    r10d,DWORD PTR [r13+0xc]
    0.05%                 0x00007f3ea85b52ca:   mov    r11,QWORD PTR [rsp]
    0.05%                 0x00007f3ea85b52ce:   mov    DWORD PTR [r11+0xc],r10d
    0.09%                 0x00007f3ea85b52d2:   mov    r10,QWORD PTR [rsp]
    0.06%                 0x00007f3ea85b52d6:   mov    QWORD PTR [r10+0x10],rbx
    0.12%                 0x00007f3ea85b52da:   lock add DWORD PTR [rsp-0x40],0x0   ;*putfield iriString {reexecute=0 rethrow=0 return_oop=0}
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::setFromInitializedValue@17 (line 94)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.ValueStore::resolveValue@40 (line 583)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.ValueStoreRevision$Lazy::resolveValue@6 (line 93)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::init@34 (line 152)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::hashCode@16 (line 221)
    0.09%                 0x00007f3ea85b52e0:   cmp    BYTE PTR [r15+0x38],0x0
    0.11%                 0x00007f3ea85b52e5:   jne    0x00007f3ea85b561a           ;*putfield revision {reexecute=0 rethrow=0 return_oop=0}
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::setInternalID@7 (line 82)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.ValueStoreRevision$Lazy::resolveValue@18 (line 95)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::init@34 (line 152)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::hashCode@16 (line 221)
    0.06%                 0x00007f3ea85b52eb:   mov    r10d,DWORD PTR [r14+0xc]     ;*getfield revision {reexecute=0 rethrow=0 return_oop=0}
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.ValueStoreRevision$Lazy::resolveValue@15 (line 95)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::init@34 (line 152)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::hashCode@16 (line 221)
    0.05%                 0x00007f3ea85b52ef:   mov    r11,QWORD PTR [rsp]
    0.06%                 0x00007f3ea85b52f3:   mov    DWORD PTR [r11+0x1c],r10d
    0.05%                 0x00007f3ea85b52f7:   mov    r8,r10
    0.06%                 0x00007f3ea85b52fa:   xor    r8,r11
    0.05%                 0x00007f3ea85b52fd:   shr    r8,0x14
    0.06%                 0x00007f3ea85b5301:   test   r8,r8
                    ╭     0x00007f3ea85b5304:   je     0x00007f3ea85b5326
    0.10%           │     0x00007f3ea85b5306:   test   r10d,r10d
                    │╭    0x00007f3ea85b5309:   je     0x00007f3ea85b5326
    0.10%           ││    0x00007f3ea85b530b:   shr    r11,0x9
    0.10%           ││    0x00007f3ea85b530f:   movabs r8,0x7f3e9f600000
    0.07%           ││    0x00007f3ea85b5319:   add    r8,r11
    0.16%           ││    0x00007f3ea85b531c:   cmp    BYTE PTR [r8],0x2
                    ││    0x00007f3ea85b5320:   jne    0x00007f3ea85b5684
    0.11%           ↘↘    0x00007f3ea85b5326:   mov    r10,QWORD PTR [rsp]
    0.08%                 0x00007f3ea85b532a:   mov    BYTE PTR [r10+0x18],0x1
    0.21%                 0x00007f3ea85b532f:   lock add DWORD PTR [rsp-0x40],0x0   ;*monitorexit {reexecute=0 rethrow=0 return_oop=0}
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::init@60 (line 158)
                                                                                    ; - org.eclipse.rdf4j.sail.lmdb.model.LmdbIRI::hashCode@16 (line 221)
    ```
</details>
    
This is writing to a volatile fields in `setInternalID`. Unfortunately perfasm got a bit confused with all the optimizations that C2 introduced, so the mapping to original lines of code is a bit broken... but still, that's certainly the volatile write, although it seems my JVM decided to obtain some sort of a mutex instead of flushing caches. In the disassembly there is one more (outer) lock for the `synchronized` keyword, so that's also accounted for.

In the previous version this was not an issue because we were passing the entire cached value by reference, and not copying its contents. In the optimistic case where the value was cached, no volatile reads/writes had to happen. This is however fully solved by #5580 which I submitted a few days ago. If we merge them together, there should be no performance decrease even in single-threaded workloads.

### Benchmark setup:

```
# JMH version: 1.37
# VM version: JDK 25, Java HotSpot(TM) 64-Bit Server VM, 25+37-LTS-jvmci-b01
# VM invoker: /home/piotr/.jdks/graalvm-jdk-25/bin/java
# VM options: -Xms1G -Xmx1G
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 5 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
```

(for count_all of course I used 8 threads)

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [x] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

