### PR TITLE
GH-5608: Update Docker images to JDK 21/25

### DIFF
--- a/docker/Dockerfile-jetty
+++ b/docker/Dockerfile-jetty
@@ -11,7 +11,7 @@ WORKDIR /tmp
 RUN unzip -q /tmp/rdf4j.zip
 
 # Final workbench
-FROM jetty:9-jre17-eclipse-temurin
+FROM jetty:9-jdk21-eclipse-temurin
 LABEL org.opencontainers.image.authors="Bart Hanssens (bart.hanssens@bosa.fgov.be)"
 
 USER root

--- a/docker/Dockerfile-tomcat
+++ b/docker/Dockerfile-tomcat
@@ -11,7 +11,7 @@ WORKDIR /tmp
 RUN unzip -q /tmp/rdf4j.zip
 
 # Final workbench
-FROM tomcat:9-jre17-temurin-jammy
+FROM tomcat:9-jre25-temurin-jammy
 MAINTAINER Bart Hanssens (bart.hanssens@bosa.fgov.be)
 
 RUN apt-get clean && apt-get update && apt-get upgrade -y && apt-get clean

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Eclipse RDF4J server and workbench
 
-Docker image for RDF4J server and workbench, based on a Tomcat 9.0 or Jetty 9.4 (JRE 17) image.
+Docker image for RDF4J server and workbench, based on a Tomcat 10 (JDK 25) or Jetty 9.4 (JDK 21) image.
 
 A slightly modified web.mxl is used for Tomcat to fix a known UTF-8 issue 
 (see also http://docs.rdf4j.org/server-workbench-console)


### PR DESCRIPTION
GitHub issue resolved: #5608 

Briefly describe the changes proposed in this PR:

- Upgrade the JDK in Tomcat-based images to 25
- Upgrade the JDK in Jetty-based images to 21
  - Unfortunately, there are no official Jetty 9 Docker images for JDKs newer than 21. Jetty 9 itself is end-of-life and will very soon stop getting security updates, so this is the best we can do at the moment.
  - See: https://github.com/eclipse-rdf4j/rdf4j/issues/4252#issuecomment-3641893866

The images appear to work fine. On Tomcat, we are getting a warning message like this:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.apache.tomcat.jni.Library in an unnamed module (file:/usr/local/tomcat/lib/tomcat-jni.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

But that's only mildly annoying. We can disable this with a proper option if needed.

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

