### PR TITLE
Stabilize server boot signal readiness for test

### DIFF
--- a/tools/server-boot/src/test/java/org/eclipse/rdf4j/tools/serverboot/ServerBootSignalIT.java
+++ b/tools/server-boot/src/test/java/org/eclipse/rdf4j/tools/serverboot/ServerBootSignalIT.java
@@ -170,8 +170,8 @@ class ServerBootSignalIT {
 					synchronized (outputBuffer) {
 						outputBuffer.append(line).append(System.lineSeparator());
 					}
-					if (!signalLogged.get() && (line.contains("Tomcat initialized with port")
-							|| line.contains("Started Rdf4jServerWorkbenchApplication"))) {
+					if (!signalLogged.get() && (line.contains("Started Rdf4jServerWorkbenchApplication")
+							|| line.contains("Initializing Spring DispatcherServlet 'rdf4jServer'"))) {
 						started.countDown();
 						signalLogged.set(true);
 					}


### PR DESCRIPTION
GitHub issue resolved: # <!-- add a Github issue number here, e.g #123. -->

Briefly describe the changes proposed in this PR:

<!-- short description of your change goes here -->

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [ ] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [ ] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [ ] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [ ] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

