### PR TITLE
GH-5663: add deprecation notices for FedX

### DIFF
--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/api/FedXApi.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/api/FedXApi.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryResult;
 
+@Deprecated(forRemoval = true)
 public interface FedXApi {
 
 	TupleQueryResult evaluate(String query) throws QueryEvaluationException;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/FederationEvalStrategy.java
@@ -61,8 +61,6 @@ import org.eclipse.rdf4j.federated.evaluation.iterator.FilteringIteration;
 import org.eclipse.rdf4j.federated.evaluation.iterator.SingleBindingSetIteration;
 import org.eclipse.rdf4j.federated.evaluation.join.ControlledWorkerBindJoin;
 import org.eclipse.rdf4j.federated.evaluation.join.ControlledWorkerJoin;
-import org.eclipse.rdf4j.federated.evaluation.join.SynchronousBoundJoin;
-import org.eclipse.rdf4j.federated.evaluation.join.SynchronousJoin;
 import org.eclipse.rdf4j.federated.evaluation.union.ControlledWorkerUnion;
 import org.eclipse.rdf4j.federated.evaluation.union.ParallelGetStatementsTask;
 import org.eclipse.rdf4j.federated.evaluation.union.ParallelPreparedAlgebraUnionTask;
@@ -889,8 +887,6 @@ public abstract class FederationEvalStrategy extends StrictEvaluationStrategy {
 	 * Join executors are for instance:
 	 *
 	 * <ul>
-	 * <li>{@link SynchronousJoin}</li>
-	 * <li>{@link SynchronousBoundJoin}</li>
 	 * <li>{@link ControlledWorkerJoin}</li>
 	 * <li>{@link ControlledWorkerBindJoin}</li>
 	 * </ul>

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailFederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SailFederationEvalStrategy.java
@@ -48,6 +48,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
  * @author Andreas Schwarte
  *
  */
+@Deprecated(forRemoval = true) // will be replaced with single unified federation eval strategy
 public class SailFederationEvalStrategy extends FederationEvalStrategy {
 
 	public SailFederationEvalStrategy(FederationContext federationContext) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/SparqlFederationEvalStrategy.java
@@ -62,6 +62,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
  * @author Andreas Schwarte
  *
  */
+@Deprecated(forRemoval = true) // will be replaced with single unified federation eval strategy
 public class SparqlFederationEvalStrategy extends FederationEvalStrategy {
 
 	public SparqlFederationEvalStrategy(FederationContext federationContext) {

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/CloseDependentConnectionIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/CloseDependentConnectionIteration.java
@@ -14,8 +14,6 @@ import org.eclipse.rdf4j.common.iteration.AbstractCloseableIteration;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A wrapping iteration that attempts to close the dependent {@link RepositoryConnection} after consumption.
@@ -23,8 +21,6 @@ import org.slf4j.LoggerFactory;
  * @author Andreas Schwarte
  */
 public class CloseDependentConnectionIteration<T> extends AbstractCloseableIteration<T> {
-
-	private static final Logger logger = LoggerFactory.getLogger(CloseDependentConnectionIteration.class);
 
 	protected final CloseableIteration<T> inner;
 	protected final RepositoryConnection dependentConn;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/IndependentJoingroupBindingsIteration.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/IndependentJoingroupBindingsIteration.java
@@ -25,6 +25,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
  *
  * @author Andreas Schwarte
  */
+@Deprecated(forRemoval = true)
 public class IndependentJoingroupBindingsIteration extends LookAheadIteration<BindingSet> {
 
 	protected final BindingSet bindings;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/IndependentJoingroupBindingsIteration2.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/IndependentJoingroupBindingsIteration2.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
  *
  * @author Andreas Schwarte
  */
+@Deprecated(forRemoval = true)
 public class IndependentJoingroupBindingsIteration2 extends LookAheadIteration<BindingSet> {
 
 	// a pattern matcher for the binding resolver, pattern: myVar_%outerID%#bindingId, e.g. name_0#0

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/IndependentJoingroupBindingsIteration3.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/iterator/IndependentJoingroupBindingsIteration3.java
@@ -29,6 +29,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
  *
  * @author Andreas Schwarte
  */
+@Deprecated(forRemoval = true)
 public class IndependentJoingroupBindingsIteration3 extends LookAheadIteration<BindingSet> {
 
 	// a pattern matcher for the binding resolver, pattern: myVar_%outerID%#bindingId, e.g. name_0#0

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoin.java
@@ -36,6 +36,7 @@ import org.eclipse.rdf4j.repository.sparql.federation.CollectionIteration;
  * @author Andreas Schwarte
  * @since 6.0
  */
+@Deprecated(forRemoval = true)
 public class HashJoin extends JoinExecutorBase<BindingSet> {
 
 	private final QueryEvaluationStep rightPrepared;

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousBoundJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousBoundJoin.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andreas Schwarte
  */
+@Deprecated(forRemoval = true) // only support controlled worker bind join
 public class SynchronousBoundJoin extends SynchronousJoin {
 
 	private static final Logger log = LoggerFactory.getLogger(SynchronousBoundJoin.class);

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousJoin.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/evaluation/join/SynchronousJoin.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
  *
  * @author Andreas Schwarte
  */
+@Deprecated(forRemoval = true) // only support controlled worker bind join
 public class SynchronousJoin extends JoinExecutorBase<BindingSet> {
 
 	public SynchronousJoin(FederationEvalStrategy strategy,

--- a/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/Version.java
+++ b/tools/federation/src/main/java/org/eclipse/rdf4j/federated/util/Version.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
  * @author Andreas Schwarte
  *
  */
+@Deprecated(forRemoval = true)
 public class Version {
 
 	protected static final Logger log = LoggerFactory.getLogger(Version.class);

--- a/tools/federation/src/test/java/demos/Demo.java
+++ b/tools/federation/src/test/java/demos/Demo.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 
+@Deprecated(forRemoval = true)
 public class Demo {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/Demo2.java
+++ b/tools/federation/src/test/java/demos/Demo2.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 
+@Deprecated(forRemoval = true)
 public class Demo2 {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/Demo3.java
+++ b/tools/federation/src/test/java/demos/Demo3.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.federated.repository.FedXRepository;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 
+@Deprecated(forRemoval = true)
 public class Demo3 {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/Demo4.java
+++ b/tools/federation/src/test/java/demos/Demo4.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.federated.repository.FedXRepository;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 
+@Deprecated(forRemoval = true)
 public class Demo4 {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/Demo5.java
+++ b/tools/federation/src/test/java/demos/Demo5.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.federated.repository.FedXRepository;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 
+@Deprecated(forRemoval = true)
 public class Demo5 {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/FedXWithRemoteRepositoryManager.java
+++ b/tools/federation/src/test/java/demos/FedXWithRemoteRepositoryManager.java
@@ -27,6 +27,7 @@ import org.eclipse.rdf4j.repository.manager.RepositoryManager;
  * @author Andreas Schwarte
  *
  */
+@Deprecated(forRemoval = true)
 public class FedXWithRemoteRepositoryManager {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/GettingStartedDemo.java
+++ b/tools/federation/src/test/java/demos/GettingStartedDemo.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 
+@Deprecated(forRemoval = true)
 public class GettingStartedDemo {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/GettingStartedDemoMinimal.java
+++ b/tools/federation/src/test/java/demos/GettingStartedDemoMinimal.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryResults;
 import org.eclipse.rdf4j.repository.util.Repositories;
 
+@Deprecated(forRemoval = true)
 public class GettingStartedDemoMinimal {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/MonitorRequestsDemo.java
+++ b/tools/federation/src/test/java/demos/MonitorRequestsDemo.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 
+@Deprecated(forRemoval = true)
 public class MonitorRequestsDemo {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/demos/QueryPlanLogDemo.java
+++ b/tools/federation/src/test/java/demos/QueryPlanLogDemo.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 
+@Deprecated(forRemoval = true)
 public class QueryPlanLogDemo {
 
 	public static void main(String[] args) {

--- a/tools/federation/src/test/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoinTest.java
+++ b/tools/federation/src/test/java/org/eclipse/rdf4j/federated/evaluation/join/HashJoinTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+@Deprecated(forRemoval = true)
 public class HashJoinTest {
 
 	@Test


### PR DESCRIPTION
GitHub issue resolved: #5663 


- deprecation notices for obsolete classes / structures to allow for cleanup in RDF4J 6.0
- preparation for unification of evaluation strategies

----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

