### PR TITLE
GH-5732: fix application specific thread context in federated service

### DIFF
--- a/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
+++ b/core/repository/sparql/src/main/java/org/eclipse/rdf4j/repository/sparql/federation/RepositoryFederatedService.java
@@ -86,7 +86,7 @@ public class RepositoryFederatedService implements FederatedService {
 			// See: https://github.com/eclipse-rdf4j/rdf4j/discussions/5120
 			// Test case: https://github.com/tkuhn/rdf4j-timeout-test
 			try {
-				querySubmissionTask = threadExecutor.submit(this::run);
+				querySubmissionTask = threadExecutor.submit(wrap(this::run));
 			} catch (Exception e) {
 				throw new QueryEvaluationException("Failed to start a thread for batched federated query submission",
 						e);
@@ -660,5 +660,16 @@ public class RepositoryFederatedService implements FederatedService {
 			logger.warn("Failed to close connection:" + t.getMessage());
 			logger.debug("Details: ", t);
 		}
+	}
+
+	/**
+	 * Callback to wrap the runnable prior to passing it to the background Executor. Can be used by specializations to
+	 * apply context.
+	 *
+	 * @param runnable the runnable
+	 * @return the runnable
+	 */
+	protected Runnable wrap(Runnable runnable) {
+		return runnable;
 	}
 }


### PR DESCRIPTION

GitHub issue resolved: #5732 

RepositoryFederatedService uses a background thread for processing and may miss application specific thread context.

This change adds a callback protected method that allows to wrap the runnable, prior to passing it to the executor

---

Note: for our application this is a regression introduced in RDF4J 5.2.2


----
PR Author Checklist (see the [contributor guidelines](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md) for more details):

 - [x] my pull request is [self-contained](https://rdf4j.org/documentation/developer/merge-strategy/#self-contained-changes-pull-requests-and-commits)
 - [ ] I've added tests for the changes I made
 - [x] I've applied [code formatting](https://github.com/eclipse/rdf4j/blob/main/CONTRIBUTING.md#code-formatting) (you can use `mvn process-resources` to format from the command line)
 - [x] I've [squashed](https://rdf4j.org/documentation/developer/squashing) my commits where necessary 
 - [x] every commit message starts with the issue number (GH-xxxx) followed by a meaningful description of the change

